### PR TITLE
Change DockerRegistrySuite and DockerTrustSuite to use an independent daemon and delete all images between tests and delete all images between tests

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -1,10 +1,18 @@
 package main
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/go-check/check"
 )
+
+// CmdMaker is an interface implemented by test suites. It's used so that
+// testsuites which create their own daemon instance can make commands which
+// target that daemon.
+type CmdMaker interface {
+	MakeCmd(arg ...string) *exec.Cmd
+}
 
 func Test(t *testing.T) {
 	check.TestingT(t)
@@ -18,44 +26,25 @@ type DockerSuite struct {
 }
 
 func (s *DockerSuite) TearDownTest(c *check.C) {
-	deleteAllContainers()
-	deleteAllImages()
+	deleteAllContainers(s)
+	deleteAllImages(s)
 	deleteAllVolumes()
 }
 
-func init() {
-	check.Suite(&DockerRegistrySuite{
-		ds: &DockerSuite{},
-	})
-}
-
-type DockerRegistrySuite struct {
-	ds  *DockerSuite
-	reg *testRegistryV2
-}
-
-func (s *DockerRegistrySuite) SetUpTest(c *check.C) {
-	s.reg = setupRegistry(c)
-}
-
-func (s *DockerRegistrySuite) TearDownTest(c *check.C) {
-	if s.reg != nil {
-		s.reg.Close()
-	}
-	if s.ds != nil {
-		s.ds.TearDownTest(c)
-	}
+// MakeCmd returns a exec.Cmd command to run against the suite daemon.
+func (s *DockerSuite) MakeCmd(arg ...string) *exec.Cmd {
+	return exec.Command(dockerBinary, arg...)
 }
 
 func init() {
 	check.Suite(&DockerDaemonSuite{
-		ds: &DockerSuite{},
+		DockerSuite: &DockerSuite{},
 	})
 }
 
 type DockerDaemonSuite struct {
-	ds *DockerSuite
-	d  *Daemon
+	*DockerSuite
+	d *Daemon
 }
 
 func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
@@ -66,28 +55,5 @@ func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
 func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	s.d.Stop()
-	s.ds.TearDownTest(c)
-}
-
-func init() {
-	check.Suite(&DockerTrustSuite{
-		ds: &DockerSuite{},
-	})
-}
-
-type DockerTrustSuite struct {
-	ds  *DockerSuite
-	reg *testRegistryV2
-	not *testNotary
-}
-
-func (s *DockerTrustSuite) SetUpTest(c *check.C) {
-	s.reg = setupRegistry(c)
-	s.not = setupNotary(c)
-}
-
-func (s *DockerTrustSuite) TearDownTest(c *check.C) {
-	s.reg.Close()
-	s.not.Close()
-	s.ds.TearDownTest(c)
+	s.DockerSuite.TearDownTest(c)
 }

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -46,7 +46,7 @@ func (s *DockerSuite) TestBuildApiDockerfilePath(c *check.C) {
 
 func (s *DockerSuite) TestBuildApiDockerFileRemote(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"testD": `FROM busybox
 COPY * /tmp/
 RUN find / -name ba*
@@ -95,7 +95,7 @@ func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
 		c.Fatalf("failed to close tar archive: %v", err)
 	}
 
-	server, err := fakeBinaryStorage(map[string]*bytes.Buffer{
+	server, err := fakeBinaryStorage(s, map[string]*bytes.Buffer{
 		"testT.tar": buffer,
 	})
 	c.Assert(err, check.IsNil)
@@ -143,7 +143,7 @@ RUN echo 'right'
 		c.Fatalf("failed to close tar archive: %v", err)
 	}
 
-	server, err := fakeBinaryStorage(map[string]*bytes.Buffer{
+	server, err := fakeBinaryStorage(s, map[string]*bytes.Buffer{
 		"testT.tar": buffer,
 	})
 	c.Assert(err, check.IsNil)
@@ -165,7 +165,7 @@ RUN echo 'right'
 
 func (s *DockerSuite) TestBuildApiLowerDockerfile(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	git, err := newFakeGit("repo", map[string]string{
+	git, err := newFakeGit(s, "repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
 	}, false)
@@ -191,7 +191,7 @@ RUN echo from dockerfile`,
 
 func (s *DockerSuite) TestBuildApiBuildGitWithF(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	git, err := newFakeGit("repo", map[string]string{
+	git, err := newFakeGit(s, "repo", map[string]string{
 		"baz": `FROM busybox
 RUN echo from baz`,
 		"Dockerfile": `FROM busybox
@@ -220,7 +220,7 @@ RUN echo from Dockerfile`,
 
 func (s *DockerSuite) TestBuildApiDoubleDockerfile(c *check.C) {
 	testRequires(c, UnixCli) // dockerfile overwrites Dockerfile on Windows
-	git, err := newFakeGit("repo", map[string]string{
+	git, err := newFakeGit(s, "repo", map[string]string{
 		"Dockerfile": `FROM busybox
 RUN echo from Dockerfile`,
 		"dockerfile": `FROM busybox

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -52,7 +52,7 @@ func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
-	out, err := buildImage("saveandload", "FROM hello-world\nENV FOO bar", false)
+	out, err := buildImage(s, "saveandload", "FROM hello-world\nENV FOO bar", false)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
 	name := "test-api-images-delete"
-	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
+	out, err := buildImage(s, name, "FROM hello-world\nENV FOO bar", false)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func (s *DockerSuite) TestApiImagesHistory(c *check.C) {
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
 	name := "test-api-images-history"
-	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
+	out, err := buildImage(s, name, "FROM hello-world\nENV FOO bar", false)
 	c.Assert(err, check.IsNil)
 
 	id := strings.TrimSpace(out)

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -15,7 +15,7 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 1; done")
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	type logOut struct {
 		out string

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -18,7 +18,7 @@ func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
 
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	resp, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "")
 	c.Assert(err, check.IsNil)
@@ -81,7 +81,7 @@ func (s *DockerSuite) TestApiNetworkStats(c *check.C) {
 	// Run container for 30 secs
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	// Retrieve the container address
 	contIP := findContainerIP(c, id)

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -22,7 +22,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 	endGroup.Add(3)
 	startGroup.Add(3)
 
-	if err := waitForContainer("attacher", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 1; echo hello; done"); err != nil {
+	if err := waitForContainer(s, "attacher", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 1; echo hello; done"); err != nil {
 		c.Fatal(err)
 	}
 
@@ -92,7 +92,7 @@ func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	defer func() {
 		cmd := exec.Command(dockerBinary, "kill", id)
@@ -166,7 +166,7 @@ func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
 	}
 
 	// Expect container to still be running after stdin is closed
-	running, err := inspectField(id, "State.Running")
+	running, err := inspectField(s, id, "State.Running")
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -19,7 +19,7 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-dti", "busybox", "sleep", "2")
 
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	errChan := make(chan error)
 	go func() {
@@ -71,7 +71,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 		close(errChan)
 	}()
 
-	c.Assert(waitRun(name), check.IsNil)
+	c.Assert(waitRun(s, name), check.IsNil)
 
 	cpty.Write([]byte{16})
 	time.Sleep(100 * time.Millisecond)
@@ -133,7 +133,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 func (s *DockerSuite) TestAttachDetach(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	cpty, tty, err := pty.Open()
 	if err != nil {
@@ -151,7 +151,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 	if err := cmd.Start(); err != nil {
 		c.Fatal(err)
 	}
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	if _, err := cpty.Write([]byte("hello\n")); err != nil {
 		c.Fatal(err)
@@ -179,7 +179,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 		ch <- struct{}{}
 	}()
 
-	running, err := inspectField(id, "State.Running")
+	running, err := inspectField(s, id, "State.Running")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 func (s *DockerSuite) TestAttachDetachTruncatedID(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
 	id := stringid.TruncateID(strings.TrimSpace(out))
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	cpty, tty, err := pty.Open()
 	if err != nil {
@@ -248,7 +248,7 @@ func (s *DockerSuite) TestAttachDetachTruncatedID(c *check.C) {
 		ch <- struct{}{}
 	}()
 
-	running, err := inspectField(id, "State.Running")
+	running, err := inspectField(s, id, "State.Running")
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -29,7 +29,7 @@ func (s *DockerSuite) TestBuildJSONEmptyRun(c *check.C) {
 	name := "testbuildjsonemptyrun"
 
 	_, err := buildImage(
-		name,
+		s, name,
 		`
     FROM busybox
     RUN []
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestBuildEmptyWhitespace(c *check.C) {
 	name := "testbuildemptywhitespace"
 
 	_, err := buildImage(
-		name,
+		s, name,
 		`
     FROM busybox
     COPY
@@ -67,7 +67,7 @@ func (s *DockerSuite) TestBuildShCmdJSONEntrypoint(c *check.C) {
 	name := "testbuildshcmdjsonentrypoint"
 
 	_, err := buildImage(
-		name,
+		s, name,
 		`
     FROM busybox
     ENTRYPOINT ["/bin/echo"]
@@ -91,7 +91,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementUser(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM scratch
   ENV user foo
   USER ${user}
@@ -100,7 +100,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementUser(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.User")
+	res, err := inspectFieldJSON(s, name, "Config.User")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM scratch
   ENV volume /quux
   VOLUME ${volume}
@@ -124,7 +124,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Volumes")
+	res, err := inspectFieldJSON(s, name, "Config.Volumes")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM scratch
   ENV port 80
   EXPOSE ${port}
@@ -154,7 +154,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.ExposedPorts")
+	res, err := inspectFieldJSON(s, name, "Config.ExposedPorts")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementWorkdir(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM busybox
   ENV MYWORKDIR /work
   RUN mkdir ${MYWORKDIR}
@@ -217,7 +217,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementAddCopy(c *check.C) {
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -227,7 +227,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementEnv(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`
   FROM busybox
   ENV foo zzz
@@ -247,7 +247,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementEnv(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Env")
+	res, err := inspectFieldJSON(s, name, "Config.Env")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -295,7 +295,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildhandleescapes"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`
   FROM scratch
   ENV FOO bar
@@ -308,7 +308,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 
 	var result map[string]map[string]struct{}
 
-	res, err := inspectFieldJSON(name, "Config.Volumes")
+	res, err := inspectFieldJSON(s, name, "Config.Volumes")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -321,9 +321,9 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 		c.Fatal("Could not find volume bar set from env foo in volumes table")
 	}
 
-	deleteImages(name)
+	deleteImages(s, name)
 
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		`
   FROM scratch
   ENV FOO bar
@@ -334,7 +334,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err = inspectFieldJSON(name, "Config.Volumes")
+	res, err = inspectFieldJSON(s, name, "Config.Volumes")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -347,13 +347,13 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 		c.Fatal("Could not find volume ${FOO} set from env foo in volumes table")
 	}
 
-	deleteImages(name)
+	deleteImages(s, name)
 
 	// this test in particular provides *7* backslashes and expects 6 to come back.
 	// Like above, the first escape is swallowed and the rest are treated as
 	// literals, this one is just less obvious because of all the character noise.
 
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		`
   FROM scratch
   ENV FOO bar
@@ -364,7 +364,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err = inspectFieldJSON(name, "Config.Volumes")
+	res, err = inspectFieldJSON(s, name, "Config.Volumes")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func (s *DockerSuite) TestBuildOnBuildLowercase(c *check.C) {
 	name := "testbuildonbuildlowercase"
 	name2 := "testbuildonbuildlowercase2"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`
   FROM busybox
   onbuild run echo quux
@@ -394,7 +394,7 @@ func (s *DockerSuite) TestBuildOnBuildLowercase(c *check.C) {
 		c.Fatal(err)
 	}
 
-	_, out, err := buildImageWithOut(name2, fmt.Sprintf(`
+	_, out, err := buildImageWithOut(s, name2, fmt.Sprintf(`
   FROM %s
   `, name), true)
 
@@ -415,7 +415,7 @@ func (s *DockerSuite) TestBuildOnBuildLowercase(c *check.C) {
 func (s *DockerSuite) TestBuildEnvEscapes(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvescapes"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`
     FROM busybox
     ENV TEST foo
@@ -439,7 +439,7 @@ func (s *DockerSuite) TestBuildEnvOverwrite(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvoverwrite"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`
     FROM busybox
     ENV TEST foo
@@ -469,7 +469,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainerInSourceImage(c *check.
 
 	dockerCmd(c, "commit", "--run", "{\"OnBuild\":[\"MAINTAINER docker.io\"]}", cleanedContainerID, "onbuild")
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM onbuild`,
 		true)
 	if err != nil {
@@ -492,7 +492,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenFromInSourceImage(c *check.C) {
 
 	dockerCmd(c, "commit", "--run", "{\"OnBuild\":[\"FROM busybox\"]}", cleanedContainerID, "onbuild")
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM onbuild`,
 		true)
 	if err != nil {
@@ -515,7 +515,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenChainedInSourceImage(c *check.C) 
 
 	dockerCmd(c, "commit", "--run", "{\"OnBuild\":[\"ONBUILD RUN ls\"]}", cleanedContainerID, "onbuild")
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM onbuild`,
 		true)
 	if err != nil {
@@ -533,7 +533,7 @@ func (s *DockerSuite) TestBuildOnBuildCmdEntrypointJSON(c *check.C) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	_, err := buildImage(name1, `
+	_, err := buildImage(s, name1, `
 FROM busybox
 ONBUILD CMD ["hello world"]
 ONBUILD ENTRYPOINT ["echo"]
@@ -544,7 +544,7 @@ ONBUILD RUN ["true"]`,
 		c.Fatal(err)
 	}
 
-	_, err = buildImage(name2, fmt.Sprintf(`FROM %s`, name1), false)
+	_, err = buildImage(s, name2, fmt.Sprintf(`FROM %s`, name1), false)
 
 	if err != nil {
 		c.Fatal(err)
@@ -563,7 +563,7 @@ func (s *DockerSuite) TestBuildOnBuildEntrypointJSON(c *check.C) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	_, err := buildImage(name1, `
+	_, err := buildImage(s, name1, `
 FROM busybox
 ONBUILD ENTRYPOINT ["echo"]`,
 		false)
@@ -572,7 +572,7 @@ ONBUILD ENTRYPOINT ["echo"]`,
 		c.Fatal(err)
 	}
 
-	_, err = buildImage(name2, fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1), false)
+	_, err = buildImage(s, name2, fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1), false)
 
 	if err != nil {
 		c.Fatal(err)
@@ -589,7 +589,7 @@ ONBUILD ENTRYPOINT ["echo"]`,
 func (s *DockerSuite) TestBuildCacheAdd(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildtwoimageswithadd"
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"robots.txt": "hello",
 		"index.html": "world",
 	})
@@ -598,7 +598,7 @@ func (s *DockerSuite) TestBuildCacheAdd(c *check.C) {
 	}
 	defer server.Close()
 
-	if _, err := buildImage(name,
+	if _, err := buildImage(s, name,
 		fmt.Sprintf(`FROM scratch
 		ADD %s/robots.txt /`, server.URL()),
 		true); err != nil {
@@ -607,8 +607,8 @@ func (s *DockerSuite) TestBuildCacheAdd(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	deleteImages(name)
-	_, out, err := buildImageWithOut(name,
+	deleteImages(s, name)
+	_, out, err := buildImageWithOut(s, name,
 		fmt.Sprintf(`FROM scratch
 		ADD %s/index.html /`, server.URL()),
 		true)
@@ -625,7 +625,7 @@ func (s *DockerSuite) TestBuildLastModified(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildlastmodified"
 
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"file": "hello",
 	})
 	if err != nil {
@@ -641,7 +641,7 @@ RUN ls -le /file`
 
 	dockerfile := fmt.Sprintf(dFmt, server.URL())
 
-	if _, out, err = buildImageWithOut(name, dockerfile, false); err != nil {
+	if _, out, err = buildImageWithOut(s, name, dockerfile, false); err != nil {
 		c.Fatal(err)
 	}
 
@@ -655,7 +655,7 @@ RUN ls -le /file`
 	// Wait a few seconds to make sure the time changed enough to notice
 	time.Sleep(2 * time.Second)
 
-	if _, out2, err = buildImageWithOut(name, dockerfile, false); err != nil {
+	if _, out2, err = buildImageWithOut(s, name, dockerfile, false); err != nil {
 		c.Fatal(err)
 	}
 
@@ -666,7 +666,7 @@ RUN ls -le /file`
 
 	// Now 'touch' the file and make sure the timestamp DID change this time
 	// Create a new fakeStorage instead of just using Add() to help windows
-	server, err = fakeStorage(map[string]string{
+	server, err = fakeStorage(s, map[string]string{
 		"file": "hello",
 	})
 	if err != nil {
@@ -676,7 +676,7 @@ RUN ls -le /file`
 
 	dockerfile = fmt.Sprintf(dFmt, server.URL())
 
-	if _, out2, err = buildImageWithOut(name, dockerfile, false); err != nil {
+	if _, out2, err = buildImageWithOut(s, name, dockerfile, false); err != nil {
 		c.Fatal(err)
 	}
 
@@ -699,7 +699,7 @@ func (s *DockerSuite) TestBuildSixtySteps(c *check.C) {
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -724,7 +724,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -745,7 +745,7 @@ ADD test_file .`,
 
 	errChan := make(chan error)
 	go func() {
-		_, err := buildImageFromContext(name, ctx, true)
+		_, err := buildImageFromContext(s, name, ctx, true)
 		errChan <- err
 		close(errChan)
 	}()
@@ -778,14 +778,14 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
 
 func (s *DockerSuite) TestBuildCopyAddMultipleFiles(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"robots.txt": "hello",
 	})
 	if err != nil {
@@ -823,7 +823,7 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 		c.Fatal(err)
 	}
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -844,7 +844,7 @@ func (s *DockerSuite) TestBuildAddMultipleFilesToFile(c *check.C) {
 	}
 
 	expected := "When using ADD with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -866,7 +866,7 @@ func (s *DockerSuite) TestBuildJSONAddMultipleFilesToFile(c *check.C) {
 	}
 
 	expected := "When using ADD with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -888,7 +888,7 @@ func (s *DockerSuite) TestBuildAddMultipleFilesToFileWild(c *check.C) {
 	}
 
 	expected := "When using ADD with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -910,7 +910,7 @@ func (s *DockerSuite) TestBuildJSONAddMultipleFilesToFileWild(c *check.C) {
 	}
 
 	expected := "When using ADD with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -932,7 +932,7 @@ func (s *DockerSuite) TestBuildCopyMultipleFilesToFile(c *check.C) {
 	}
 
 	expected := "When using COPY with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -954,7 +954,7 @@ func (s *DockerSuite) TestBuildJSONCopyMultipleFilesToFile(c *check.C) {
 	}
 
 	expected := "When using COPY with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -991,7 +991,7 @@ RUN [ $(cat "/test dir/test_file6") = 'test6' ]`,
 		c.Fatal(err)
 	}
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1027,7 +1027,7 @@ RUN [ $(cat "/test dir/test_file6") = 'test6' ]`,
 		c.Fatal(err)
 	}
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1048,7 +1048,7 @@ func (s *DockerSuite) TestBuildAddMultipleFilesToFileWithWhitespace(c *check.C) 
 	}
 
 	expected := "When using ADD with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -1070,7 +1070,7 @@ func (s *DockerSuite) TestBuildCopyMultipleFilesToFileWithWhitespace(c *check.C)
 	}
 
 	expected := "When using COPY with more than one source file, the destination must be a directory and end with a /"
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain %q) got:\n%v", expected, err)
 	}
 
@@ -1079,7 +1079,7 @@ func (s *DockerSuite) TestBuildCopyMultipleFilesToFileWithWhitespace(c *check.C)
 func (s *DockerSuite) TestBuildCopyWildcard(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testcopywildcard"
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"robots.txt": "hello",
 		"index.html": "world",
 	})
@@ -1110,13 +1110,13 @@ func (s *DockerSuite) TestBuildCopyWildcard(c *check.C) {
 	}
 	defer ctx.Close()
 
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
 
 	// Now make sure we use a cache the 2nd time
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -1138,7 +1138,7 @@ func (s *DockerSuite) TestBuildCopyWildcardNoFind(c *check.C) {
 		c.Fatal(err)
 	}
 
-	_, err = buildImageFromContext(name, ctx, true)
+	_, err = buildImageFromContext(s, name, ctx, true)
 	if err == nil {
 		c.Fatal("should have failed to find a file")
 	}
@@ -1167,7 +1167,7 @@ func (s *DockerSuite) TestBuildCopyWildcardInName(c *check.C) {
 	}
 	defer ctx.Close()
 
-	_, err = buildImageFromContext(name, ctx, true)
+	_, err = buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatalf("should have built: %q", err)
 	}
@@ -1186,7 +1186,7 @@ func (s *DockerSuite) TestBuildCopyWildcardCache(c *check.C) {
 		c.Fatal(err)
 	}
 
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -1196,7 +1196,7 @@ func (s *DockerSuite) TestBuildCopyWildcardCache(c *check.C) {
 	ctx.Add("Dockerfile", `FROM busybox
 	COPY file*.txt /tmp/`)
 
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -1227,7 +1227,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -1252,7 +1252,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1278,7 +1278,7 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1305,7 +1305,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1324,7 +1324,7 @@ ADD . /`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1348,7 +1348,7 @@ RUN [ $(ls -l /usr/bin/suidbin | awk '{print $1}') = '-rwsr-xr-x' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1373,7 +1373,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1394,7 +1394,7 @@ COPY test_file .`,
 
 	errChan := make(chan error)
 	go func() {
-		_, err := buildImageFromContext(name, ctx, true)
+		_, err := buildImageFromContext(s, name, ctx, true)
 		errChan <- err
 		close(errChan)
 	}()
@@ -1427,7 +1427,7 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1452,7 +1452,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1476,7 +1476,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1502,7 +1502,7 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1529,7 +1529,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1547,7 +1547,7 @@ COPY . /`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -1555,7 +1555,7 @@ COPY . /`,
 func (s *DockerSuite) TestBuildCopyDisallowRemote(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testcopydisallowremote"
-	_, out, err := buildImageWithOut(name, `FROM scratch
+	_, out, err := buildImageWithOut(s, name, `FROM scratch
 COPY https://index.docker.io/robots.txt /`,
 		true)
 	if err == nil || !strings.Contains(out, "Source can't be a URL for COPY") {
@@ -1640,7 +1640,7 @@ func (s *DockerSuite) TestBuildAddBadLinks(c *check.C) {
 		c.Fatal(err)
 	}
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -1691,7 +1691,7 @@ func (s *DockerSuite) TestBuildAddBadLinksVolume(c *check.C) {
 		c.Fatal(err)
 	}
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -1792,7 +1792,7 @@ func (s *DockerSuite) TestBuildWithInaccessibleFilesInContext(c *check.C) {
 		defer os.Remove(target)
 		// This is used to ensure we don't follow links when checking if everything in the context is accessible
 		// This test doesn't require that we run commands as an unprivileged user
-		if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 			c.Fatal(err)
 		}
 	}
@@ -1831,7 +1831,7 @@ func (s *DockerSuite) TestBuildWithInaccessibleFilesInContext(c *check.C) {
 
 func (s *DockerSuite) TestBuildForceRm(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	containerCountBefore, err := getContainerCount()
+	containerCountBefore, err := getContainerCount(s)
 	if err != nil {
 		c.Fatalf("failed to get the container count: %s", err)
 	}
@@ -1844,7 +1844,7 @@ func (s *DockerSuite) TestBuildForceRm(c *check.C) {
 
 	dockerCmdInDir(c, ctx.Dir, "build", "-t", name, "--force-rm", ".")
 
-	containerCountAfter, err := getContainerCount()
+	containerCountAfter, err := getContainerCount(s)
 	if err != nil {
 		c.Fatalf("failed to get the container count: %s", err)
 	}
@@ -1973,7 +1973,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 	}
 	defer ctx.Close()
 	{
-		containerCountBefore, err := getContainerCount()
+		containerCountBefore, err := getContainerCount(s)
 		if err != nil {
 			c.Fatalf("failed to get the container count: %s", err)
 		}
@@ -1984,7 +1984,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 			c.Fatal("failed to build the image", out)
 		}
 
-		containerCountAfter, err := getContainerCount()
+		containerCountAfter, err := getContainerCount(s)
 		if err != nil {
 			c.Fatalf("failed to get the container count: %s", err)
 		}
@@ -1992,11 +1992,11 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 		if containerCountBefore != containerCountAfter {
 			c.Fatalf("-rm shouldn't have left containers behind")
 		}
-		deleteImages(name)
+		deleteImages(s, name)
 	}
 
 	{
-		containerCountBefore, err := getContainerCount()
+		containerCountBefore, err := getContainerCount(s)
 		if err != nil {
 			c.Fatalf("failed to get the container count: %s", err)
 		}
@@ -2007,7 +2007,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 			c.Fatal("failed to build the image", out)
 		}
 
-		containerCountAfter, err := getContainerCount()
+		containerCountAfter, err := getContainerCount(s)
 		if err != nil {
 			c.Fatalf("failed to get the container count: %s", err)
 		}
@@ -2015,11 +2015,11 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 		if containerCountBefore != containerCountAfter {
 			c.Fatalf("--rm shouldn't have left containers behind")
 		}
-		deleteImages(name)
+		deleteImages(s, name)
 	}
 
 	{
-		containerCountBefore, err := getContainerCount()
+		containerCountBefore, err := getContainerCount(s)
 		if err != nil {
 			c.Fatalf("failed to get the container count: %s", err)
 		}
@@ -2030,7 +2030,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 			c.Fatal("failed to build the image", out)
 		}
 
-		containerCountAfter, err := getContainerCount()
+		containerCountAfter, err := getContainerCount(s)
 		if err != nil {
 			c.Fatalf("failed to get the container count: %s", err)
 		}
@@ -2038,7 +2038,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 		if containerCountBefore == containerCountAfter {
 			c.Fatalf("--rm=false should have left containers behind")
 		}
-		deleteImages(name)
+		deleteImages(s, name)
 
 	}
 
@@ -2061,7 +2061,7 @@ func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
 			"/test8]": emptyMap,
 		}
 	)
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
 		VOLUME /test1
 		VOLUME /test2
@@ -2073,7 +2073,7 @@ func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Volumes")
+	res, err := inspectFieldJSON(s, name, "Config.Volumes")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2095,14 +2095,14 @@ func (s *DockerSuite) TestBuildMaintainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildmaintainer"
 	expected := "dockerio"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
         MAINTAINER dockerio`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Author")
+	res, err := inspectField(s, name, "Author")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2115,7 +2115,7 @@ func (s *DockerSuite) TestBuildUser(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuilduser"
 	expected := "dockerio"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		USER dockerio
@@ -2124,7 +2124,7 @@ func (s *DockerSuite) TestBuildUser(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.User")
+	res, err := inspectField(s, name, "Config.User")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2137,7 +2137,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildrelativeworkdir"
 	expected := "/test2/test3"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		RUN [ "$PWD" = '/' ]
 		WORKDIR test1
@@ -2150,7 +2150,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.WorkingDir")
+	res, err := inspectField(s, name, "Config.WorkingDir")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2163,7 +2163,7 @@ func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildworkdirwithenvvariables"
 	expected := "/test1/test2"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		ENV DIRPATH /test1
 		ENV SUBDIRNAME test2
@@ -2173,7 +2173,7 @@ func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.WorkingDir")
+	res, err := inspectField(s, name, "Config.WorkingDir")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2215,7 +2215,7 @@ func (s *DockerSuite) TestBuildRelativeCopy(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	_, err = buildImageFromContext(name, ctx, false)
+	_, err = buildImageFromContext(s, name, ctx, false)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2225,7 +2225,7 @@ func (s *DockerSuite) TestBuildEnv(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildenv"
 	expected := "[PATH=/test:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		ENV PATH /test:$PATH
         ENV PORT 2375
@@ -2234,7 +2234,7 @@ func (s *DockerSuite) TestBuildEnv(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Env")
+	res, err := inspectField(s, name, "Config.Env")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2252,7 +2252,7 @@ func (s *DockerSuite) TestBuildContextCleanup(c *check.C) {
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		`FROM scratch
         ENTRYPOINT ["/bin/echo"]`,
 		true)
@@ -2278,7 +2278,7 @@ func (s *DockerSuite) TestBuildContextCleanupFailedBuild(c *check.C) {
 	if err != nil {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		`FROM scratch
 	RUN /non/existing/command`,
 		true)
@@ -2299,14 +2299,14 @@ func (s *DockerSuite) TestBuildCmd(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmd"
 	expected := "{[/bin/echo Hello World]}"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
         CMD ["/bin/echo", "Hello World"]`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Cmd")
+	res, err := inspectField(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2319,14 +2319,14 @@ func (s *DockerSuite) TestBuildExpose(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildexpose"
 	expected := "map[2375/tcp:{}]"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
         EXPOSE 2375`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.ExposedPorts")
+	res, err := inspectField(s, name, "Config.ExposedPorts")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2362,13 +2362,13 @@ func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
 	tmpl.Execute(buf, portList)
 
 	name := "testbuildexpose"
-	_, err := buildImage(name, buf.String(), true)
+	_, err := buildImage(s, name, buf.String(), true)
 	if err != nil {
 		c.Fatal(err)
 	}
 
 	// check if all the ports are saved inside Config.ExposedPorts
-	res, err := inspectFieldJSON(name, "Config.ExposedPorts")
+	res, err := inspectFieldJSON(s, name, "Config.ExposedPorts")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2393,12 +2393,12 @@ func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
 func (s *DockerSuite) TestBuildExposeOrder(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	buildID := func(name, exposed string) string {
-		_, err := buildImage(name, fmt.Sprintf(`FROM scratch
+		_, err := buildImage(s, name, fmt.Sprintf(`FROM scratch
 		EXPOSE %s`, exposed), true)
 		if err != nil {
 			c.Fatal(err)
 		}
-		id, err := inspectField(name, "Id")
+		id, err := inspectField(s, name, "Id")
 		if err != nil {
 			c.Fatal(err)
 		}
@@ -2416,14 +2416,14 @@ func (s *DockerSuite) TestBuildExposeUpperCaseProto(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildexposeuppercaseproto"
 	expected := "map[5678/udp:{}]"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
         EXPOSE 5678/UDP`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.ExposedPorts")
+	res, err := inspectField(s, name, "Config.ExposedPorts")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2437,14 +2437,14 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 	name := "testbuildentrypointinheritance"
 	name2 := "testbuildentrypointinheritance2"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
         ENTRYPOINT ["/bin/echo"]`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Entrypoint")
+	res, err := inspectField(s, name, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2454,14 +2454,14 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
 
-	_, err = buildImage(name2,
+	_, err = buildImage(s, name2,
 		fmt.Sprintf(`FROM %s
         ENTRYPOINT []`, name),
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err = inspectField(name2, "Config.Entrypoint")
+	res, err = inspectField(s, name2, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2479,14 +2479,14 @@ func (s *DockerSuite) TestBuildEmptyEntrypoint(c *check.C) {
 	name := "testbuildentrypoint"
 	expected := "{[]}"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
         ENTRYPOINT []`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Entrypoint")
+	res, err := inspectField(s, name, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2500,14 +2500,14 @@ func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildentrypoint"
 	expected := "{[/bin/echo]}"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
         ENTRYPOINT ["/bin/echo"]`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Entrypoint")
+	res, err := inspectField(s, name, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2590,7 +2590,7 @@ func (s *DockerSuite) TestBuildOnBuildLimitedInheritence(c *check.C) {
 func (s *DockerSuite) TestBuildWithCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildwithcache"
-	id1, err := buildImage(name,
+	id1, err := buildImage(s, name,
 		`FROM scratch
 		MAINTAINER dockerio
 		EXPOSE 5432
@@ -2599,7 +2599,7 @@ func (s *DockerSuite) TestBuildWithCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImage(name,
+	id2, err := buildImage(s, name,
 		`FROM scratch
 		MAINTAINER dockerio
 		EXPOSE 5432
@@ -2617,7 +2617,7 @@ func (s *DockerSuite) TestBuildWithoutCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildwithoutcache"
 	name2 := "testbuildwithoutcache2"
-	id1, err := buildImage(name,
+	id1, err := buildImage(s, name,
 		`FROM scratch
 		MAINTAINER dockerio
 		EXPOSE 5432
@@ -2627,7 +2627,7 @@ func (s *DockerSuite) TestBuildWithoutCache(c *check.C) {
 		c.Fatal(err)
 	}
 
-	id2, err := buildImage(name2,
+	id2, err := buildImage(s, name2,
 		`FROM scratch
 		MAINTAINER dockerio
 		EXPOSE 5432
@@ -2656,7 +2656,7 @@ func (s *DockerSuite) TestBuildConditionalCache(c *check.C) {
 	}
 	defer ctx.Close()
 
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatalf("Error building #1: %s", err)
 	}
@@ -2665,7 +2665,7 @@ func (s *DockerSuite) TestBuildConditionalCache(c *check.C) {
 		c.Fatalf("Error modifying foo: %s", err)
 	}
 
-	id2, err := buildImageFromContext(name, ctx, false)
+	id2, err := buildImageFromContext(s, name, ctx, false)
 	if err != nil {
 		c.Fatalf("Error building #2: %s", err)
 	}
@@ -2673,7 +2673,7 @@ func (s *DockerSuite) TestBuildConditionalCache(c *check.C) {
 		c.Fatal("Should not have used the cache")
 	}
 
-	id3, err := buildImageFromContext(name, ctx, true)
+	id3, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatalf("Error building #3: %s", err)
 	}
@@ -2698,11 +2698,11 @@ func (s *DockerSuite) TestBuildAddLocalFileWithCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, true)
+	id2, err := buildImageFromContext(s, name2, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2727,11 +2727,11 @@ func (s *DockerSuite) TestBuildAddMultipleLocalFileWithCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, true)
+	id2, err := buildImageFromContext(s, name2, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2756,11 +2756,11 @@ func (s *DockerSuite) TestBuildAddLocalFileWithoutCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, false)
+	id2, err := buildImageFromContext(s, name2, ctx, false)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2783,7 +2783,7 @@ func (s *DockerSuite) TestBuildCopyDirButNotFile(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2791,7 +2791,7 @@ func (s *DockerSuite) TestBuildCopyDirButNotFile(c *check.C) {
 	if err := ctx.Add("dir_file", "hello2"); err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, true)
+	id2, err := buildImageFromContext(s, name2, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2817,7 +2817,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2825,7 +2825,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithCache(c *check.C) {
 	if err := ctx.Add("bar", "hello2"); err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, true)
+	id2, err := buildImageFromContext(s, name2, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2836,7 +2836,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithCache(c *check.C) {
 	if err := ctx.Add("foo", "hello1"); err != nil {
 		c.Fatal(err)
 	}
-	id3, err := buildImageFromContext(name3, ctx, true)
+	id3, err := buildImageFromContext(s, name3, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2849,7 +2849,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithCache(c *check.C) {
 	if err := ctx.Add("foo", "hello1"); err != nil {
 		c.Fatal(err)
 	}
-	id4, err := buildImageFromContext(name4, ctx, true)
+	id4, err := buildImageFromContext(s, name4, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2873,11 +2873,11 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithoutCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, false)
+	id2, err := buildImageFromContext(s, name2, ctx, false)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2889,7 +2889,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithoutCache(c *check.C) {
 func (s *DockerSuite) TestBuildAddRemoteFileWithCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddremotefilewithcache"
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"baz": "hello",
 	})
 	if err != nil {
@@ -2897,7 +2897,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithCache(c *check.C) {
 	}
 	defer server.Close()
 
-	id1, err := buildImage(name,
+	id1, err := buildImage(s, name,
 		fmt.Sprintf(`FROM scratch
         MAINTAINER dockerio
         ADD %s/baz /usr/lib/baz/quux`, server.URL()),
@@ -2905,7 +2905,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImage(name,
+	id2, err := buildImage(s, name,
 		fmt.Sprintf(`FROM scratch
         MAINTAINER dockerio
         ADD %s/baz /usr/lib/baz/quux`, server.URL()),
@@ -2922,7 +2922,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithoutCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddremotefilewithoutcache"
 	name2 := "testbuildaddremotefilewithoutcache2"
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"baz": "hello",
 	})
 	if err != nil {
@@ -2930,7 +2930,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithoutCache(c *check.C) {
 	}
 	defer server.Close()
 
-	id1, err := buildImage(name,
+	id1, err := buildImage(s, name,
 		fmt.Sprintf(`FROM scratch
         MAINTAINER dockerio
         ADD %s/baz /usr/lib/baz/quux`, server.URL()),
@@ -2938,7 +2938,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithoutCache(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImage(name2,
+	id2, err := buildImage(s, name2,
 		fmt.Sprintf(`FROM scratch
         MAINTAINER dockerio
         ADD %s/baz /usr/lib/baz/quux`, server.URL()),
@@ -2958,7 +2958,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
 	name3 := name + "3"
 
 	files := map[string]string{"baz": "hello"}
-	server, err := fakeStorage(files)
+	server, err := fakeStorage(s, files)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2972,12 +2972,12 @@ func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
 	}
 	defer ctx.Close()
 
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	id2, err := buildImageFromContext(name2, ctx, true)
+	id2, err := buildImageFromContext(s, name2, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -2991,7 +2991,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
 	// allow some time for clock to pass as mtime precision is only 1s
 	time.Sleep(2 * time.Second)
 
-	server2, err := fakeStorage(files)
+	server2, err := fakeStorage(s, files)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3004,7 +3004,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
 		c.Fatal(err)
 	}
 	defer ctx2.Close()
-	id3, err := buildImageFromContext(name3, ctx2, true)
+	id3, err := buildImageFromContext(s, name3, ctx2, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3016,7 +3016,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
 func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddlocalandremotefilewithcache"
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"baz": "hello",
 	})
 	if err != nil {
@@ -3035,11 +3035,11 @@ func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithCache(c *check.C) {
 		c.Fatal(err)
 	}
 	defer ctx.Close()
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3102,7 +3102,7 @@ func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithoutCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddlocalandremotefilewithoutcache"
 	name2 := "testbuildaddlocalandremotefilewithoutcache2"
-	server, err := fakeStorage(map[string]string{
+	server, err := fakeStorage(s, map[string]string{
 		"baz": "hello",
 	})
 	if err != nil {
@@ -3121,11 +3121,11 @@ func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithoutCache(c *check.C) {
 		c.Fatal(err)
 	}
 	defer ctx.Close()
-	id1, err := buildImageFromContext(name, ctx, true)
+	id1, err := buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name2, ctx, false)
+	id2, err := buildImageFromContext(s, name2, ctx, false)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3138,7 +3138,7 @@ func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildimg"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox:latest
         RUN mkdir /test && chown daemon:daemon /test && chmod 0600 /test
         VOLUME /test`,
@@ -3165,7 +3165,7 @@ func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
 func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdcleanup"
-	if _, err := buildImage(name,
+	if _, err := buildImage(s, name,
 		`FROM busybox
         RUN echo "hello"`,
 		true); err != nil {
@@ -3183,10 +3183,10 @@ func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Cmd")
+	res, err := inspectField(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3212,7 +3212,7 @@ func (s *DockerSuite) TestBuildForbiddenContextPath(c *check.C) {
 	}
 
 	expected := "Forbidden path outside the build context: ../../ "
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+	if _, err := buildImageFromContext(s, name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
 		c.Fatalf("Wrong error: (should contain \"%s\") got:\n%v", expected, err)
 	}
 
@@ -3228,7 +3228,7 @@ func (s *DockerSuite) TestBuildAddFileNotFound(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		if !strings.Contains(err.Error(), "foo: no such file or directory") {
 			c.Fatalf("Wrong error %v, must be about missing foo file or directory", err)
 		}
@@ -3241,19 +3241,19 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildinheritance"
 
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM scratch
 		EXPOSE 2375`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	ports1, err := inspectField(name, "Config.ExposedPorts")
+	ports1, err := inspectField(s, name, "Config.ExposedPorts")
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["/bin/echo"]`, name),
 		true)
@@ -3261,14 +3261,14 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectField(name, "Config.Entrypoint")
+	res, err := inspectField(s, name, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err)
 	}
 	if expected := "{[/bin/echo]}"; res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
-	ports2, err := inspectField(name, "Config.ExposedPorts")
+	ports2, err := inspectField(s, name, "Config.ExposedPorts")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3280,7 +3280,7 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 func (s *DockerSuite) TestBuildFails(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildfails"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		RUN sh -c "exit 23"`,
 		true)
@@ -3295,7 +3295,7 @@ func (s *DockerSuite) TestBuildFails(c *check.C) {
 
 func (s *DockerSuite) TestBuildFailsDockerfileEmpty(c *check.C) {
 	name := "testbuildfails"
-	_, err := buildImage(name, ``, true)
+	_, err := buildImage(s, name, ``, true)
 	if err != nil {
 		if !strings.Contains(err.Error(), "The Dockerfile (Dockerfile) cannot be empty") {
 			c.Fatalf("Wrong error %v, must be about empty Dockerfile", err)
@@ -3308,14 +3308,14 @@ func (s *DockerSuite) TestBuildFailsDockerfileEmpty(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuild"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		ONBUILD RUN touch foobar`,
 		true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		fmt.Sprintf(`FROM %s
 		RUN [ -f foobar ]`, name),
 		true)
@@ -3327,7 +3327,7 @@ func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuildForbiddenChained(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenchained"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		ONBUILD ONBUILD RUN touch foobar`,
 		true)
@@ -3343,7 +3343,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenChained(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuildForbiddenFrom(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenfrom"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		ONBUILD FROM scratch`,
 		true)
@@ -3359,7 +3359,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenFrom(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenmaintainer"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		ONBUILD MAINTAINER docker.io`,
 		true)
@@ -3389,7 +3389,7 @@ func (s *DockerSuite) TestBuildAddToSymlinkDest(c *check.C) {
 		c.Fatal(err)
 	}
 	defer ctx.Close()
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -3398,7 +3398,7 @@ func (s *DockerSuite) TestBuildEscapeWhitespace(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildescaping"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM busybox
   MAINTAINER "Docker \
 IO <io@\
@@ -3408,7 +3408,7 @@ docker.com>"
 		c.Fatal(err)
 	}
 
-	res, err := inspectField(name, "Author")
+	res, err := inspectField(s, name, "Author")
 
 	if err != nil {
 		c.Fatal(err)
@@ -3425,7 +3425,7 @@ func (s *DockerSuite) TestBuildVerifyIntString(c *check.C) {
 	// Verify that strings that look like ints are still passed as strings
 	name := "testbuildstringing"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM busybox
   MAINTAINER 123
   `, true)
@@ -3476,7 +3476,7 @@ dir`,
 		c.Fatal(err)
 	}
 	defer ctx.Close()
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -3498,7 +3498,7 @@ func (s *DockerSuite) TestBuildDockerignoreCleanPaths(c *check.C) {
 		c.Fatal(err)
 	}
 	defer ctx.Close()
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -3547,7 +3547,7 @@ dir
 		c.Fatal(err)
 	}
 	defer ctx.Close()
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -3569,13 +3569,13 @@ func (s *DockerSuite) TestBuildDockerignoringDockerfile(c *check.C) {
 	}
 	defer ctx.Close()
 
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't ignore Dockerfile correctly:%s", err)
 	}
 
 	// now try it with ./Dockerfile
 	ctx.Add(".dockerignore", "./Dockerfile\n")
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't ignore ./Dockerfile correctly:%s", err)
 	}
 
@@ -3600,13 +3600,13 @@ func (s *DockerSuite) TestBuildDockerignoringRenamedDockerfile(c *check.C) {
 	}
 	defer ctx.Close()
 
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't ignore MyDockerfile correctly:%s", err)
 	}
 
 	// now try it with ./MyDockerfile
 	ctx.Add(".dockerignore", "./MyDockerfile\n")
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't ignore ./MyDockerfile correctly:%s", err)
 	}
 
@@ -3628,7 +3628,7 @@ func (s *DockerSuite) TestBuildDockerignoringDockerignore(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't ignore .dockerignore correctly:%s", err)
 	}
 }
@@ -3651,11 +3651,11 @@ func (s *DockerSuite) TestBuildDockerignoreTouchDockerfile(c *check.C) {
 		c.Fatal(err)
 	}
 
-	if id1, err = buildImageFromContext(name, ctx, true); err != nil {
+	if id1, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't build it correctly:%s", err)
 	}
 
-	if id2, err = buildImageFromContext(name, ctx, true); err != nil {
+	if id2, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't build it correctly:%s", err)
 	}
 	if id1 != id2 {
@@ -3666,7 +3666,7 @@ func (s *DockerSuite) TestBuildDockerignoreTouchDockerfile(c *check.C) {
 	if err = ctx.Add("Dockerfile", dockerfile+"\n# hi"); err != nil {
 		c.Fatalf("Didn't add Dockerfile: %s", err)
 	}
-	if id2, err = buildImageFromContext(name, ctx, true); err != nil {
+	if id2, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't build it correctly:%s", err)
 	}
 	if id1 != id2 {
@@ -3677,7 +3677,7 @@ func (s *DockerSuite) TestBuildDockerignoreTouchDockerfile(c *check.C) {
 	if err = ctx.Add("Dockerfile", dockerfile+"\n# hi"); err != nil {
 		c.Fatalf("Didn't add Dockerfile: %s", err)
 	}
-	if id2, err = buildImageFromContext(name, ctx, true); err != nil {
+	if id2, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("Didn't build it correctly:%s", err)
 	}
 	if id1 != id2 {
@@ -3702,22 +3702,22 @@ func (s *DockerSuite) TestBuildDockerignoringWholeDir(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	defer ctx.Close()
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
 	c.Assert(ctx.Add(".dockerfile", "*"), check.IsNil)
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
 	c.Assert(ctx.Add(".dockerfile", "."), check.IsNil)
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
 	c.Assert(ctx.Add(".dockerfile", "?"), check.IsNil)
-	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 }
@@ -3738,7 +3738,7 @@ func (s *DockerSuite) TestBuildDockerignoringBadExclusion(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	defer ctx.Close()
-	if _, err = buildImageFromContext(name, ctx, true); err == nil {
+	if _, err = buildImageFromContext(s, name, ctx, true); err == nil {
 		c.Fatalf("Build was supposed to fail but didn't")
 	}
 
@@ -3750,7 +3750,7 @@ func (s *DockerSuite) TestBuildDockerignoringBadExclusion(c *check.C) {
 func (s *DockerSuite) TestBuildLineBreak(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildlinebreak"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM  busybox
 RUN    sh -c 'echo root:testpass \
 	> /tmp/passwd'
@@ -3766,7 +3766,7 @@ RUN    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]`,
 func (s *DockerSuite) TestBuildEOLInLine(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildeolinline"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM   busybox
 RUN    sh -c 'echo root:testpass > /tmp/passwd'
 RUN    echo "foo \n bar"; echo "baz"
@@ -3782,7 +3782,7 @@ RUN    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]`,
 func (s *DockerSuite) TestBuildCommentsShebangs(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcomments"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 # This is an ordinary comment.
 RUN { echo '#!/bin/sh'; echo 'echo hello world'; } > /hello.sh
@@ -3801,7 +3801,7 @@ RUN [ "$(/hello.sh)" = "hello world" ]`,
 func (s *DockerSuite) TestBuildUsersAndGroups(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildusers"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 
 # Make sure our defaults work
@@ -3891,7 +3891,7 @@ RUN    [ "$ghi" = "def" ]
 	}
 	defer ctx.Close()
 
-	_, err = buildImageFromContext(name, ctx, true)
+	_, err = buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -3994,7 +3994,7 @@ RUN    [ "$eee1,$eee2,$eee3,$eee4" = 'foo,foo,foo,foo' ]
 	}
 	defer ctx.Close()
 
-	_, err = buildImageFromContext(name, ctx, true)
+	_, err = buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4017,7 +4017,7 @@ RUN [ "$(cat /testfile)" = 'test!' ]`
 	}
 	defer ctx.Close()
 
-	_, err = buildImageFromContext(name, ctx, true)
+	_, err = buildImageFromContext(s, name, ctx, true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4072,7 +4072,7 @@ RUN cat /existing-directory-trailing-slash/test/foo | grep Hi`
 	}()
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("build failed to complete for TestBuildAddTar: %v", err)
 	}
 
@@ -4125,7 +4125,7 @@ func (s *DockerSuite) TestBuildAddTarXz(c *check.C) {
 
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("build failed to complete for TestBuildAddTarXz: %v", err)
 	}
 
@@ -4184,7 +4184,7 @@ func (s *DockerSuite) TestBuildAddTarXzGz(c *check.C) {
 
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatalf("build failed to complete for TestBuildAddTarXz: %v", err)
 	}
 
@@ -4193,7 +4193,7 @@ func (s *DockerSuite) TestBuildAddTarXzGz(c *check.C) {
 func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromgit"
-	git, err := newFakeGit("repo", map[string]string{
+	git, err := newFakeGit(s, "repo", map[string]string{
 		"Dockerfile": `FROM busybox
 					ADD first /first
 					RUN [ -f /first ]
@@ -4205,11 +4205,11 @@ func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
 	}
 	defer git.Close()
 
-	_, err = buildImageFromPath(name, git.RepoURL, true)
+	_, err = buildImageFromPath(s, name, git.RepoURL, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Author")
+	res, err := inspectField(s, name, "Author")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4221,7 +4221,7 @@ func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
 func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromgit"
-	git, err := newFakeGit("repo", map[string]string{
+	git, err := newFakeGit(s, "repo", map[string]string{
 		"docker/Dockerfile": `FROM busybox
 					ADD first /first
 					RUN [ -f /first ]
@@ -4234,11 +4234,11 @@ func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
 	defer git.Close()
 
 	u := fmt.Sprintf("%s#master:docker", git.RepoURL)
-	_, err = buildImageFromPath(name, u, true)
+	_, err = buildImageFromPath(s, name, u, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Author")
+	res, err := inspectField(s, name, "Author")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4250,7 +4250,7 @@ func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
 func (s *DockerSuite) TestBuildFromGITwithF(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromgitwithf"
-	git, err := newFakeGit("repo", map[string]string{
+	git, err := newFakeGit(s, "repo", map[string]string{
 		"myApp/myDockerfile": `FROM busybox
 					RUN echo hi from Dockerfile`,
 	}, true)
@@ -4292,17 +4292,17 @@ func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
 		c.Fatalf("failed to close tar archive: %v", err)
 	}
 
-	server, err := fakeBinaryStorage(map[string]*bytes.Buffer{
+	server, err := fakeBinaryStorage(s, map[string]*bytes.Buffer{
 		"testT.tar": buffer,
 	})
 	c.Assert(err, check.IsNil)
 
 	defer server.Close()
 
-	_, err = buildImageFromPath(name, server.URL()+"/testT.tar", true)
+	_, err = buildImageFromPath(s, name, server.URL()+"/testT.tar", true)
 	c.Assert(err, check.IsNil)
 
-	res, err := inspectField(name, "Author")
+	res, err := inspectField(s, name, "Author")
 	c.Assert(err, check.IsNil)
 
 	if res != "docker" {
@@ -4313,20 +4313,20 @@ func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
 func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdcleanuponentrypoint"
-	if _, err := buildImage(name,
+	if _, err := buildImage(s, name,
 		`FROM scratch
         CMD ["test"]
 		ENTRYPOINT ["echo"]`,
 		true); err != nil {
 		c.Fatal(err)
 	}
-	if _, err := buildImage(name,
+	if _, err := buildImage(s, name,
 		fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["cat"]`, name),
 		true); err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Cmd")
+	res, err := inspectField(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4334,7 +4334,7 @@ func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 		c.Fatalf("Cmd %s, expected nil", res)
 	}
 
-	res, err = inspectField(name, "Config.Entrypoint")
+	res, err = inspectField(s, name, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4346,7 +4346,7 @@ func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildclearcmd"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`From scratch
    ENTRYPOINT ["/bin/bash"]
    CMD []`,
@@ -4354,7 +4354,7 @@ func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Cmd")
+	res, err := inspectFieldJSON(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4366,10 +4366,10 @@ func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildemptycmd"
-	if _, err := buildImage(name, "FROM scratch\nMAINTAINER quux\n", true); err != nil {
+	if _, err := buildImage(s, name, "FROM scratch\nMAINTAINER quux\n", true); err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Cmd")
+	res, err := inspectFieldJSON(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4381,11 +4381,11 @@ func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildparent"
-	if _, err := buildImage(name, "FROM busybox\nONBUILD RUN echo foo\n", true); err != nil {
+	if _, err := buildImage(s, name, "FROM busybox\nONBUILD RUN echo foo\n", true); err != nil {
 		c.Fatal(err)
 	}
 
-	_, out, err := buildImageWithOut(name, "FROM "+name+"\nMAINTAINER quux\n", true)
+	_, out, err := buildImageWithOut(s, name, "FROM "+name+"\nMAINTAINER quux\n", true)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4398,7 +4398,7 @@ func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
 func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "abcd:" + stringutils.GenerateRandomAlphaOnlyString(200)
-	_, out, err := buildImageWithOut(name, "FROM scratch\nMAINTAINER quux\n", true)
+	_, out, err := buildImageWithOut(s, name, "FROM scratch\nMAINTAINER quux\n", true)
 	// if the error doesnt check for illegal tag name, or the image is built
 	// then this should fail
 	if !strings.Contains(out, "Illegal tag name") || strings.Contains(out, "Sending build context to Docker daemon") {
@@ -4409,11 +4409,11 @@ func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
 func (s *DockerSuite) TestBuildCmdShDashC(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdshc"
-	if _, err := buildImage(name, "FROM busybox\nCMD echo cmd\n", true); err != nil {
+	if _, err := buildImage(s, name, "FROM busybox\nCMD echo cmd\n", true); err != nil {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Cmd")
+	res, err := inspectFieldJSON(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err, res)
 	}
@@ -4436,11 +4436,11 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 	var id2 string
 	var err error
 
-	if id1, err = buildImage(name, "FROM busybox\nCMD [\"echo hi\"]\n", true); err != nil {
+	if id1, err = buildImage(s, name, "FROM busybox\nCMD [\"echo hi\"]\n", true); err != nil {
 		c.Fatal(err)
 	}
 
-	if id2, err = buildImage(name, "FROM busybox\nCMD [\"echo\", \"hi\"]\n", true); err != nil {
+	if id2, err = buildImage(s, name, "FROM busybox\nCMD [\"echo\", \"hi\"]\n", true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -4449,11 +4449,11 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 	}
 
 	// Now do the same with ENTRYPOINT
-	if id1, err = buildImage(name, "FROM busybox\nENTRYPOINT [\"echo hi\"]\n", true); err != nil {
+	if id1, err = buildImage(s, name, "FROM busybox\nENTRYPOINT [\"echo hi\"]\n", true); err != nil {
 		c.Fatal(err)
 	}
 
-	if id2, err = buildImage(name, "FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n", true); err != nil {
+	if id2, err = buildImage(s, name, "FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n", true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -4466,11 +4466,11 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdjson"
-	if _, err := buildImage(name, "FROM busybox\nCMD [\"echo\", \"cmd\"]", true); err != nil {
+	if _, err := buildImage(s, name, "FROM busybox\nCMD [\"echo\", \"cmd\"]", true); err != nil {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Cmd")
+	res, err := inspectFieldJSON(s, name, "Config.Cmd")
 	if err != nil {
 		c.Fatal(err, res)
 	}
@@ -4487,7 +4487,7 @@ func (s *DockerSuite) TestBuildErrorInvalidInstruction(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildignoreinvalidinstruction"
 
-	out, _, err := buildImageWithOut(name, "FROM busybox\nfoo bar", true)
+	out, _, err := buildImageWithOut(s, name, "FROM busybox\nfoo bar", true)
 	if err == nil {
 		c.Fatalf("Should have failed: %s", out)
 	}
@@ -4497,7 +4497,7 @@ func (s *DockerSuite) TestBuildErrorInvalidInstruction(c *check.C) {
 func (s *DockerSuite) TestBuildEntrypointInheritance(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
-	if _, err := buildImage("parent", `
+	if _, err := buildImage(s, "parent", `
     FROM busybox
     ENTRYPOINT exit 130
     `, true); err != nil {
@@ -4508,7 +4508,7 @@ func (s *DockerSuite) TestBuildEntrypointInheritance(c *check.C) {
 		c.Fatalf("expected exit code 130 but received %d", status)
 	}
 
-	if _, err := buildImage("child", `
+	if _, err := buildImage(s, "child", `
     FROM parent
     ENTRYPOINT exit 5
     `, true); err != nil {
@@ -4529,15 +4529,15 @@ func (s *DockerSuite) TestBuildEntrypointInheritanceInspect(c *check.C) {
 		expected = `["/bin/sh","-c","echo quux"]`
 	)
 
-	if _, err := buildImage(name, "FROM busybox\nENTRYPOINT /foo/bar", true); err != nil {
+	if _, err := buildImage(s, name, "FROM busybox\nENTRYPOINT /foo/bar", true); err != nil {
 		c.Fatal(err)
 	}
 
-	if _, err := buildImage(name2, fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name), true); err != nil {
+	if _, err := buildImage(s, name2, fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name), true); err != nil {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name2, "Config.Entrypoint")
+	res, err := inspectFieldJSON(s, name2, "Config.Entrypoint")
 	if err != nil {
 		c.Fatal(err, res)
 	}
@@ -4559,7 +4559,7 @@ func (s *DockerSuite) TestBuildEntrypointInheritanceInspect(c *check.C) {
 func (s *DockerSuite) TestBuildRunShEntrypoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildentrypoint"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
                                 ENTRYPOINT /bin/echo`,
 		true)
@@ -4574,7 +4574,7 @@ func (s *DockerSuite) TestBuildExoticShellInterpolation(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildexoticshellinterpolation"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
 		FROM busybox
 
 		ENV SOME_VAR a.b.c
@@ -4608,7 +4608,7 @@ func (s *DockerSuite) TestBuildVerifySingleQuoteFails(c *check.C) {
 	// it should barf on it.
 	name := "testbuildsinglequotefails"
 
-	if _, err := buildImage(name,
+	if _, err := buildImage(s, name,
 		`FROM busybox
 		CMD [ '/bin/sh', '-c', 'echo hi' ]`,
 		true); err != nil {
@@ -4625,7 +4625,7 @@ func (s *DockerSuite) TestBuildVerboseOut(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildverboseout"
 
-	_, out, err := buildImageWithOut(name,
+	_, out, err := buildImageWithOut(s, name,
 		`FROM busybox
 RUN echo 123`,
 		false)
@@ -4642,12 +4642,12 @@ RUN echo 123`,
 func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildwithtabs"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		"FROM busybox\nRUN echo\tone\t\ttwo", true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "ContainerConfig.Cmd")
+	res, err := inspectFieldJSON(s, name, "ContainerConfig.Cmd")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4662,7 +4662,7 @@ func (s *DockerSuite) TestBuildLabels(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildlabel"
 	expected := `{"License":"GPL","Vendor":"Acme"}`
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		LABEL Vendor=Acme
                 LABEL License GPL`,
@@ -4670,7 +4670,7 @@ func (s *DockerSuite) TestBuildLabels(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Labels")
+	res, err := inspectFieldJSON(s, name, "Config.Labels")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -4683,28 +4683,28 @@ func (s *DockerSuite) TestBuildLabelsCache(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildlabelcache"
 
-	id1, err := buildImage(name,
+	id1, err := buildImage(s, name,
 		`FROM busybox
 		LABEL Vendor=Acme`, false)
 	if err != nil {
 		c.Fatalf("Build 1 should have worked: %v", err)
 	}
 
-	id2, err := buildImage(name,
+	id2, err := buildImage(s, name,
 		`FROM busybox
 		LABEL Vendor=Acme`, true)
 	if err != nil || id1 != id2 {
 		c.Fatalf("Build 2 should have worked & used cache(%s,%s): %v", id1, id2, err)
 	}
 
-	id2, err = buildImage(name,
+	id2, err = buildImage(s, name,
 		`FROM busybox
 		LABEL Vendor=Acme1`, true)
 	if err != nil || id1 == id2 {
 		c.Fatalf("Build 3 should have worked & NOT used cache(%s,%s): %v", id1, id2, err)
 	}
 
-	id2, err = buildImage(name,
+	id2, err = buildImage(s, name,
 		`FROM busybox
 		LABEL Vendor Acme`, true) // Note: " " and "=" should be same
 	if err != nil || id1 != id2 {
@@ -4712,14 +4712,14 @@ func (s *DockerSuite) TestBuildLabelsCache(c *check.C) {
 	}
 
 	// Now make sure the cache isn't used by mistake
-	id1, err = buildImage(name,
+	id1, err = buildImage(s, name,
 		`FROM busybox
        LABEL f1=b1 f2=b2`, false)
 	if err != nil {
 		c.Fatalf("Build 5 should have worked: %q", err)
 	}
 
-	id2, err = buildImage(name,
+	id2, err = buildImage(s, name,
 		`FROM busybox
        LABEL f1="b1 f2=b2"`, true)
 	if err != nil || id1 == id2 {
@@ -4733,7 +4733,7 @@ func (s *DockerSuite) TestBuildStderr(c *check.C) {
 	// This test just makes sure that no non-error output goes
 	// to stderr
 	name := "testbuildstderr"
-	_, _, stderr, err := buildImageWithStdoutStderr(name,
+	_, _, stderr, err := buildImageWithStdoutStderr(s, name,
 		"FROM busybox\nRUN echo one", true)
 	if err != nil {
 		c.Fatal(err)
@@ -4777,7 +4777,7 @@ RUN [ $(ls -l /test | awk '{print $3":"$4}') = 'root:root' ]
 		c.Fatal(err)
 	}
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -4827,7 +4827,7 @@ func (s *DockerSuite) TestBuildSymlinkBreakout(c *check.C) {
 	})
 	w.Close()
 	f.Close()
-	if _, err := buildImageFromContext(name, fakeContextFromDir(ctx), false); err != nil {
+	if _, err := buildImageFromContext(s, name, fakeContextFromDir(ctx), false); err != nil {
 		c.Fatal(err)
 	}
 	if _, err := os.Lstat(filepath.Join(tmpdir, "inject")); err == nil {
@@ -4859,7 +4859,7 @@ RUN [ ! -e /injected ]`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
 
@@ -4884,7 +4884,7 @@ CMD cat /foo/file`,
 	}
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, false); err != nil {
+	if _, err := buildImageFromContext(s, name, ctx, false); err != nil {
 		c.Fatal(err)
 	}
 
@@ -5053,7 +5053,7 @@ RUN echo from Dockerfile`,
 func (s *DockerSuite) TestBuildFromURLWithF(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
-	server, err := fakeStorage(map[string]string{"baz": `FROM busybox
+	server, err := fakeStorage(s, map[string]string{"baz": `FROM busybox
 RUN echo from baz
 COPY * /tmp/
 RUN find /tmp/`})
@@ -5129,11 +5129,11 @@ func (s *DockerSuite) TestBuildFromOfficialNames(c *check.C) {
 	}
 	for idx, fromName := range fromNames {
 		imgName := fmt.Sprintf("%s%d", name, idx)
-		_, err := buildImage(imgName, "FROM "+fromName, true)
+		_, err := buildImage(s, imgName, "FROM "+fromName, true)
 		if err != nil {
 			c.Errorf("Build failed using FROM %s: %s", fromName, err)
 		}
-		deleteImages(imgName)
+		deleteImages(s, imgName)
 	}
 }
 
@@ -5184,7 +5184,7 @@ func (s *DockerSuite) TestBuildDockerfileOutsideContext(c *check.C) {
 		if !strings.Contains(out, "must be within the build context") && !strings.Contains(out, "Cannot locate Dockerfile") {
 			c.Fatalf("Unexpected error with %s. Out: %s", dockerfilePath, out)
 		}
-		deleteImages(name)
+		deleteImages(s, name)
 	}
 
 	os.Chdir(tmpdir)
@@ -5216,12 +5216,12 @@ func (s *DockerSuite) TestBuildSpaces(c *check.C) {
 	}
 	defer ctx.Close()
 
-	if _, err1 = buildImageFromContext(name, ctx, false); err1 == nil {
+	if _, err1 = buildImageFromContext(s, name, ctx, false); err1 == nil {
 		c.Fatal("Build 1 was supposed to fail, but didn't")
 	}
 
 	ctx.Add("Dockerfile", "FROM busybox\nCOPY    ")
-	if _, err2 = buildImageFromContext(name, ctx, false); err2 == nil {
+	if _, err2 = buildImageFromContext(s, name, ctx, false); err2 == nil {
 		c.Fatal("Build 2 was supposed to fail, but didn't")
 	}
 
@@ -5239,7 +5239,7 @@ func (s *DockerSuite) TestBuildSpaces(c *check.C) {
 	}
 
 	ctx.Add("Dockerfile", "FROM busybox\n   COPY")
-	if _, err2 = buildImageFromContext(name, ctx, false); err2 == nil {
+	if _, err2 = buildImageFromContext(s, name, ctx, false); err2 == nil {
 		c.Fatal("Build 3 was supposed to fail, but didn't")
 	}
 
@@ -5253,7 +5253,7 @@ func (s *DockerSuite) TestBuildSpaces(c *check.C) {
 	}
 
 	ctx.Add("Dockerfile", "FROM busybox\n   COPY    ")
-	if _, err2 = buildImageFromContext(name, ctx, false); err2 == nil {
+	if _, err2 = buildImageFromContext(s, name, ctx, false); err2 == nil {
 		c.Fatal("Build 4 was supposed to fail, but didn't")
 	}
 
@@ -5277,7 +5277,7 @@ func (s *DockerSuite) TestBuildSpacesWithQuotes(c *check.C) {
 RUN echo "  \
   foo  "`
 
-	_, out, err := buildImageWithOut(name, dockerfile, false)
+	_, out, err := buildImageWithOut(s, name, dockerfile, false)
 	if err != nil {
 		c.Fatal("Build failed:", err)
 	}
@@ -5338,7 +5338,7 @@ func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
 		}
 		defer ctx.Close()
 		var out string
-		if out, err = buildImageFromContext("args", ctx, true); err == nil {
+		if out, err = buildImageFromContext(s, "args", ctx, true); err == nil {
 			c.Fatalf("%s was supposed to fail. Out:%s", cmd, out)
 		}
 		if !strings.Contains(err.Error(), cmd+" requires") {
@@ -5350,7 +5350,7 @@ func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
 
 func (s *DockerSuite) TestBuildEmptyScratch(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	_, out, err := buildImageWithOut("sc", "FROM scratch", true)
+	_, out, err := buildImageWithOut(s, "sc", "FROM scratch", true)
 	if err == nil {
 		c.Fatalf("Build was supposed to fail")
 	}
@@ -5371,7 +5371,7 @@ func (s *DockerSuite) TestBuildDotDotFile(c *check.C) {
 	}
 	defer ctx.Close()
 
-	if _, err = buildImageFromContext("sc", ctx, false); err != nil {
+	if _, err = buildImageFromContext(s, "sc", ctx, false); err != nil {
 		c.Fatalf("Build was supposed to work: %s", err)
 	}
 }
@@ -5430,7 +5430,7 @@ func (s *DockerSuite) TestBuildEmptyStringVolume(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildemptystringvolume"
 
-	_, err := buildImage(name, `
+	_, err := buildImage(s, name, `
   FROM busybox
   ENV foo=""
   VOLUME $foo
@@ -5480,7 +5480,7 @@ func (s *DockerSuite) TestBuildNoDupOutput(c *check.C) {
 	// Step X  line
 	name := "testbuildnodupoutput"
 
-	_, out, err := buildImageWithOut(name, `
+	_, out, err := buildImageWithOut(s, name, `
   FROM busybox
   RUN env`, false)
 	if err != nil {
@@ -5499,7 +5499,7 @@ func (s *DockerSuite) TestBuildStartsFromOne(c *check.C) {
 	// Explicit check to ensure that build starts from step 1 rather than 0
 	name := "testbuildstartsfromone"
 
-	_, out, err := buildImageWithOut(name, `
+	_, out, err := buildImageWithOut(s, name, `
   FROM busybox`, false)
 	if err != nil {
 		c.Fatalf("Build should have worked: %q", err)
@@ -5515,7 +5515,7 @@ func (s *DockerSuite) TestBuildBadCmdFlag(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildbadcmdflag"
 
-	_, out, err := buildImageWithOut(name, `
+	_, out, err := buildImageWithOut(s, name, `
   FROM busybox
   MAINTAINER --boo joe@example.com`, false)
 	if err == nil {
@@ -5533,7 +5533,7 @@ func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
 	// Test to make sure the bad command is quoted with just "s and
 	// not as a Go []string
 	name := "testbuildbadrunerrmsg"
-	_, out, err := buildImageWithOut(name, `
+	_, out, err := buildImageWithOut(s, name, `
   FROM busybox
   RUN badEXE a1 \& a2	a3`, false) // tab between a2 and a3
 	if err == nil {
@@ -5555,7 +5555,7 @@ func (s *DockerTrustSuite) TestTrustedBuild(c *check.C) {
 
 	name := "testtrustedbuild"
 
-	buildCmd := buildImageCmd(name, dockerFile, true)
+	buildCmd := buildImageCmd(s, name, dockerFile, true)
 	s.trustedCmd(buildCmd)
 	out, _, err := runCommandWithOutput(buildCmd)
 	if err != nil {
@@ -5567,14 +5567,10 @@ func (s *DockerTrustSuite) TestTrustedBuild(c *check.C) {
 	}
 
 	// We should also have a tag reference for the image.
-	if out, exitCode := dockerCmd(c, "inspect", repoName); exitCode != 0 {
-		c.Fatalf("unexpected exit code inspecting image %q: %d: %s", repoName, exitCode, out)
-	}
+	s.Cmd(c, "inspect", repoName)
 
 	// We should now be able to remove the tag reference.
-	if out, exitCode := dockerCmd(c, "rmi", repoName); exitCode != 0 {
-		c.Fatalf("unexpected exit code inspecting image %q: %d: %s", repoName, exitCode, out)
-	}
+	s.Cmd(c, "rmi", repoName)
 }
 
 func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
@@ -5586,7 +5582,7 @@ func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
 
 	name := "testtrustedbuilduntrustedtag"
 
-	buildCmd := buildImageCmd(name, dockerFile, true)
+	buildCmd := buildImageCmd(s, name, dockerFile, true)
 	s.trustedCmd(buildCmd)
 	out, _, err := runCommandWithOutput(buildCmd)
 	if err == nil {
@@ -5632,9 +5628,7 @@ func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
 
 	// Executing the build with the symlink as the specified context should
 	// *not* fail.
-	if out, exitStatus := dockerCmd(c, "build", contextSymlinkName); exitStatus != 0 {
-		c.Fatalf("build failed with exit status %d: %s", exitStatus, out)
-	}
+	s.Cmd(c, "build", contextSymlinkName)
 }
 
 // Issue #15634: COPY fails when path starts with "null"
@@ -5657,18 +5651,18 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 	defer ctx.Close()
 	c.Assert(err, check.IsNil)
 
-	_, err = buildImageFromContext(name, ctx, true)
+	_, err = buildImageFromContext(s, name, ctx, true)
 	c.Assert(err, check.IsNil)
 }
 
 func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
 	name := "test_build_stop_signal"
-	_, err := buildImage(name,
+	_, err := buildImage(s, name,
 		`FROM busybox
 		 STOPSIGNAL SIGKILL`,
 		true)
 	c.Assert(err, check.IsNil)
-	res, err := inspectFieldJSON(name, "Config.StopSignal")
+	res, err := inspectFieldJSON(s, name, "Config.StopSignal")
 	c.Assert(err, check.IsNil)
 
 	if res != `"SIGKILL"` {

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -38,7 +38,7 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 		Ulimits    []*ulimit.Ulimit
 	}
 
-	cfg, err := inspectFieldJSON(cID, "HostConfig")
+	cfg, err := inspectFieldJSON(s, cID, "HostConfig")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	// Make sure constraints aren't saved to image
 	dockerCmd(c, "run", "--name=test", name)
 
-	cfg, err = inspectFieldJSON("test", "HostConfig")
+	cfg, err = inspectFieldJSON(s, "test", "HostConfig")
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -39,7 +39,7 @@ func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
 //test commit a paused container should not unpause it after commit
 func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	defer unpauseAllContainers()
+	defer unpauseAllContainers(s)
 	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -48,7 +48,7 @@ func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 
 	out, _ = dockerCmd(c, "commit", cleanedContainerID)
 
-	out, err := inspectField(cleanedContainerID, "State.Paused")
+	out, err := inspectField(s, cleanedContainerID, "State.Paused")
 	c.Assert(err, check.IsNil)
 	if !strings.Contains(out, "true") {
 		c.Fatalf("commit should not unpause a paused container")
@@ -161,7 +161,7 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 	}
 
 	for conf, value := range expected {
-		res, err := inspectField(imageID, conf)
+		res, err := inspectField(s, imageID, conf)
 		c.Assert(err, check.IsNil)
 		if res != value {
 			c.Errorf("%s('%s'), expected %s", conf, res, value)
@@ -189,11 +189,11 @@ func (s *DockerSuite) TestCommitMergeConfigRun(c *check.C) {
 		Cmd []string
 	}
 	config1 := cfg{}
-	if err := inspectFieldAndMarshall(id, "Config", &config1); err != nil {
+	if err := inspectFieldAndMarshall(s, id, "Config", &config1); err != nil {
 		c.Fatal(err)
 	}
 	config2 := cfg{}
-	if err := inspectFieldAndMarshall(name, "Config", &config2); err != nil {
+	if err := inspectFieldAndMarshall(s, name, "Config", &config2); err != nil {
 		c.Fatal(err)
 	}
 

--- a/integration-cli/docker_cli_cp_from_container_test.go
+++ b/integration-cli/docker_cli_cp_from_container_test.go
@@ -25,7 +25,7 @@ import (
 func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-err-src-not-exists")
 	defer os.RemoveAll(tmpDir)
@@ -45,7 +45,7 @@ func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
 func (s *DockerSuite) TestCpFromErrSrcNotDir(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-err-src-not-dir")
 	defer os.RemoveAll(tmpDir)
@@ -65,7 +65,7 @@ func (s *DockerSuite) TestCpFromErrSrcNotDir(c *check.C) {
 func (s *DockerSuite) TestCpFromErrDstParentNotExists(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-err-dst-parent-not-exists")
 	defer os.RemoveAll(tmpDir)
@@ -102,7 +102,7 @@ func (s *DockerSuite) TestCpFromErrDstParentNotExists(c *check.C) {
 func (s *DockerSuite) TestCpFromErrDstNotDir(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-err-dst-not-dir")
 	defer os.RemoveAll(tmpDir)
@@ -139,7 +139,7 @@ func (s *DockerSuite) TestCpFromErrDstNotDir(c *check.C) {
 func (s *DockerSuite) TestCpFromSymlinkDestination(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-err-dst-not-dir")
 	defer os.RemoveAll(tmpDir)
@@ -267,7 +267,7 @@ func (s *DockerSuite) TestCpFromCaseA(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-a")
 	defer os.RemoveAll(tmpDir)
@@ -290,7 +290,7 @@ func (s *DockerSuite) TestCpFromCaseA(c *check.C) {
 func (s *DockerSuite) TestCpFromCaseB(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-b")
 	defer os.RemoveAll(tmpDir)
@@ -315,7 +315,7 @@ func (s *DockerSuite) TestCpFromCaseC(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-c")
 	defer os.RemoveAll(tmpDir)
@@ -345,7 +345,7 @@ func (s *DockerSuite) TestCpFromCaseC(c *check.C) {
 func (s *DockerSuite) TestCpFromCaseD(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-d")
 	defer os.RemoveAll(tmpDir)
@@ -397,7 +397,7 @@ func (s *DockerSuite) TestCpFromCaseD(c *check.C) {
 func (s *DockerSuite) TestCpFromCaseE(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-e")
 	defer os.RemoveAll(tmpDir)
@@ -438,7 +438,7 @@ func (s *DockerSuite) TestCpFromCaseF(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-f")
 	defer os.RemoveAll(tmpDir)
@@ -466,7 +466,7 @@ func (s *DockerSuite) TestCpFromCaseG(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-g")
 	defer os.RemoveAll(tmpDir)
@@ -514,7 +514,7 @@ func (s *DockerSuite) TestCpFromCaseG(c *check.C) {
 func (s *DockerSuite) TestCpFromCaseH(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-h")
 	defer os.RemoveAll(tmpDir)
@@ -556,7 +556,7 @@ func (s *DockerSuite) TestCpFromCaseI(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-i")
 	defer os.RemoveAll(tmpDir)
@@ -585,7 +585,7 @@ func (s *DockerSuite) TestCpFromCaseJ(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-from-case-j")
 	defer os.RemoveAll(tmpDir)

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -24,7 +24,7 @@ import (
 func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-err-src-not-exists")
 	defer os.RemoveAll(tmpDir)
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
 func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-err-src-not-dir")
 	defer os.RemoveAll(tmpDir)
@@ -72,7 +72,7 @@ func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
 func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-err-dst-parent-not-exists")
 	defer os.RemoveAll(tmpDir)
@@ -110,7 +110,7 @@ func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
 func (s *DockerSuite) TestCpToErrDstNotDir(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-err-dst-not-dir")
 	defer os.RemoveAll(tmpDir)
@@ -164,7 +164,7 @@ func (s *DockerSuite) TestCpToSymlinkDestination(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		volumes: defaultVolumes(testVol), // Our bind mount is at /vol2
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	// First, copy a local file to a symlink to a file in the container. This
 	// should overwrite the symlink target contents with the source contents.
@@ -287,7 +287,7 @@ func (s *DockerSuite) TestCpToCaseA(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		workDir: "/root", command: makeCatFileCommand("itWorks.txt"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-a")
 	defer os.RemoveAll(tmpDir)
@@ -314,7 +314,7 @@ func (s *DockerSuite) TestCpToCaseB(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("testDir/file1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-b")
 	defer os.RemoveAll(tmpDir)
@@ -342,7 +342,7 @@ func (s *DockerSuite) TestCpToCaseC(c *check.C) {
 		addContent: true, workDir: "/root",
 		command: makeCatFileCommand("file2"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-c")
 	defer os.RemoveAll(tmpDir)
@@ -376,7 +376,7 @@ func (s *DockerSuite) TestCpToCaseD(c *check.C) {
 		addContent: true,
 		command:    makeCatFileCommand("/dir1/file1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-d")
 	defer os.RemoveAll(tmpDir)
@@ -407,7 +407,7 @@ func (s *DockerSuite) TestCpToCaseD(c *check.C) {
 		addContent: true,
 		command:    makeCatFileCommand("/dir1/file1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	dstDir = containerCpPathTrailingSep(cID, "dir1")
 
@@ -435,7 +435,7 @@ func (s *DockerSuite) TestCpToCaseE(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-e")
 	defer os.RemoveAll(tmpDir)
@@ -460,7 +460,7 @@ func (s *DockerSuite) TestCpToCaseE(c *check.C) {
 	cID = makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	dstDir = containerCpPathTrailingSep(cID, "testDir")
 
@@ -482,7 +482,7 @@ func (s *DockerSuite) TestCpToCaseF(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-f")
 	defer os.RemoveAll(tmpDir)
@@ -511,7 +511,7 @@ func (s *DockerSuite) TestCpToCaseG(c *check.C) {
 		addContent: true, workDir: "/root",
 		command: makeCatFileCommand("dir2/dir1/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-g")
 	defer os.RemoveAll(tmpDir)
@@ -542,7 +542,7 @@ func (s *DockerSuite) TestCpToCaseG(c *check.C) {
 		addContent: true,
 		command:    makeCatFileCommand("/dir2/dir1/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	dstDir = containerCpPathTrailingSep(cID, "/dir2")
 
@@ -570,7 +570,7 @@ func (s *DockerSuite) TestCpToCaseH(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-h")
 	defer os.RemoveAll(tmpDir)
@@ -595,7 +595,7 @@ func (s *DockerSuite) TestCpToCaseH(c *check.C) {
 	cID = makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	dstDir = containerCpPathTrailingSep(cID, "testDir")
 
@@ -617,7 +617,7 @@ func (s *DockerSuite) TestCpToCaseI(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-i")
 	defer os.RemoveAll(tmpDir)
@@ -647,7 +647,7 @@ func (s *DockerSuite) TestCpToCaseJ(c *check.C) {
 		addContent: true, workDir: "/root",
 		command: makeCatFileCommand("/dir2/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	tmpDir := getTestDir(c, "test-cp-to-case-j")
 	defer os.RemoveAll(tmpDir)
@@ -677,7 +677,7 @@ func (s *DockerSuite) TestCpToCaseJ(c *check.C) {
 	cID = makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/dir2/file1-1"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	dstDir = containerCpPathTrailingSep(cID, "/dir2")
 
@@ -709,7 +709,7 @@ func (s *DockerSuite) TestCpToErrReadOnlyRootfs(c *check.C) {
 		readOnly: true, workDir: "/root",
 		command: makeCatFileCommand("shouldNotExist"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	srcPath := cpPath(tmpDir, "file1")
 	dstPath := containerCpPath(cID, "/root/shouldNotExist")
@@ -742,7 +742,7 @@ func (s *DockerSuite) TestCpToErrReadOnlyVolume(c *check.C) {
 		volumes: defaultVolumes(tmpDir), workDir: "/root",
 		command: makeCatFileCommand("/vol_ro/shouldNotExist"),
 	})
-	defer deleteContainer(cID)
+	defer deleteContainer(s, cID)
 
 	srcPath := cpPath(tmpDir, "file1")
 	dstPath := containerCpPath(cID, "/vol_ro/shouldNotExist")

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -14,7 +14,7 @@ import (
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testbuildhistory"
-	_, err := buildImage(name, `FROM busybox
+	_, err := buildImage(s, name, `FROM busybox
 RUN echo "A"
 RUN echo "B"
 RUN echo "C"

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -21,12 +21,12 @@ func (s *DockerSuite) TestImagesEnsureImageIsListed(c *check.C) {
 
 func (s *DockerSuite) TestImagesEnsureImageWithTagIsListed(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	_, err := buildImage("imagewithtag:v1",
+	_, err := buildImage(s, "imagewithtag:v1",
 		`FROM scratch
 		MAINTAINER dockerio1`, true)
 	c.Assert(err, check.IsNil)
 
-	_, err = buildImage("imagewithtag:v2",
+	_, err = buildImage(s, "imagewithtag:v2",
 		`FROM scratch
 		MAINTAINER dockerio1`, true)
 	c.Assert(err, check.IsNil)
@@ -55,21 +55,21 @@ func (s *DockerSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *check.C) {
 
 func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	id1, err := buildImage("order:test_a",
+	id1, err := buildImage(s, "order:test_a",
 		`FROM scratch
 		MAINTAINER dockerio1`, true)
 	if err != nil {
 		c.Fatal(err)
 	}
 	time.Sleep(1 * time.Second)
-	id2, err := buildImage("order:test_c",
+	id2, err := buildImage(s, "order:test_c",
 		`FROM scratch
 		MAINTAINER dockerio2`, true)
 	if err != nil {
 		c.Fatal(err)
 	}
 	time.Sleep(1 * time.Second)
-	id3, err := buildImage("order:test_b",
+	id3, err := buildImage(s, "order:test_b",
 		`FROM scratch
 		MAINTAINER dockerio3`, true)
 	if err != nil {
@@ -101,21 +101,21 @@ func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
 	imageName1 := "images_filter_test1"
 	imageName2 := "images_filter_test2"
 	imageName3 := "images_filter_test3"
-	image1ID, err := buildImage(imageName1,
+	image1ID, err := buildImage(s, imageName1,
 		`FROM scratch
 		 LABEL match me`, true)
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	image2ID, err := buildImage(imageName2,
+	image2ID, err := buildImage(s, imageName2,
 		`FROM scratch
 		 LABEL match="me too"`, true)
 	if err != nil {
 		c.Fatal(err)
 	}
 
-	image3ID, err := buildImage(imageName3,
+	image3ID, err := buildImage(s, imageName3,
 		`FROM scratch
 		 LABEL nomatch me`, true)
 	if err != nil {
@@ -138,7 +138,7 @@ func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageName := "images_filter_test"
-	buildImage(imageName,
+	buildImage(s, imageName,
 		`FROM scratch
 		 RUN touch /test/foo
 		 RUN touch /test/bar

--- a/integration-cli/docker_cli_inspect_experimental_test.go
+++ b/integration-cli/docker_cli_inspect_experimental_test.go
@@ -11,7 +11,7 @@ func (s *DockerSuite) TestInspectNamedMountPoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "data:/data", "busybox", "cat")
 
-	vol, err := inspectFieldJSON("test", "Mounts")
+	vol, err := inspectFieldJSON(s, "test", "Mounts")
 	c.Assert(err, check.IsNil)
 
 	var mp []types.MountPoint

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -17,7 +17,7 @@ func (s *DockerSuite) TestInspectImage(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	imageTestID := "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
-	id, err := inspectField(imageTest, "Id")
+	id, err := inspectField(s, imageTest, "Id")
 	c.Assert(err, check.IsNil)
 
 	if id != imageTestID {
@@ -34,7 +34,7 @@ func (s *DockerSuite) TestInspectInt64(c *check.C) {
 	}
 	out = strings.TrimSpace(out)
 
-	inspectOut, err := inspectField(out, "HostConfig.Memory")
+	inspectOut, err := inspectField(s, out, "HostConfig.Memory")
 	c.Assert(err, check.IsNil)
 
 	if inspectOut != "314572800" {
@@ -56,28 +56,28 @@ func (s *DockerSuite) TestInspectStatus(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	out = strings.TrimSpace(out)
 
-	inspectOut, err := inspectField(out, "State.Status")
+	inspectOut, err := inspectField(s, out, "State.Status")
 	c.Assert(err, check.IsNil)
 	if inspectOut != "running" {
 		c.Fatalf("inspect got wrong status, got: %q, expected: running", inspectOut)
 	}
 
 	dockerCmd(c, "pause", out)
-	inspectOut, err = inspectField(out, "State.Status")
+	inspectOut, err = inspectField(s, out, "State.Status")
 	c.Assert(err, check.IsNil)
 	if inspectOut != "paused" {
 		c.Fatalf("inspect got wrong status, got: %q, expected: paused", inspectOut)
 	}
 
 	dockerCmd(c, "unpause", out)
-	inspectOut, err = inspectField(out, "State.Status")
+	inspectOut, err = inspectField(s, out, "State.Status")
 	c.Assert(err, check.IsNil)
 	if inspectOut != "running" {
 		c.Fatalf("inspect got wrong status, got: %q, expected: running", inspectOut)
 	}
 
 	dockerCmd(c, "stop", out)
-	inspectOut, err = inspectField(out, "State.Status")
+	inspectOut, err = inspectField(s, out, "State.Status")
 	c.Assert(err, check.IsNil)
 	if inspectOut != "exited" {
 		c.Fatalf("inspect got wrong status, got: %q, expected: exited", inspectOut)
@@ -152,7 +152,7 @@ func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *check.C) {
 func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
-	out, err := inspectField(imageTest, "Size")
+	out, err := inspectField(s, imageTest, "Size")
 	c.Assert(err, check.IsNil)
 
 	size, err := strconv.Atoi(out)
@@ -182,7 +182,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 
 	id := strings.TrimSpace(out)
 
-	out, err = inspectField(id, "State.ExitCode")
+	out, err = inspectField(s, id, "State.ExitCode")
 	c.Assert(err, check.IsNil)
 
 	exitCode, err := strconv.Atoi(out)
@@ -201,7 +201,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
-	name, err := inspectField(imageTest, "GraphDriver.Name")
+	name, err := inspectField(s, imageTest, "GraphDriver.Name")
 	c.Assert(err, check.IsNil)
 
 	if name != "devicemapper" && name != "overlay" && name != "vfs" && name != "zfs" && name != "btrfs" && name != "aufs" {
@@ -212,7 +212,7 @@ func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 		return
 	}
 
-	deviceID, err := inspectField(imageTest, "GraphDriver.Data.DeviceId")
+	deviceID, err := inspectField(s, imageTest, "GraphDriver.Data.DeviceId")
 	c.Assert(err, check.IsNil)
 
 	_, err = strconv.Atoi(deviceID)
@@ -220,7 +220,7 @@ func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 		c.Fatalf("failed to inspect DeviceId of the image: %s, %v", deviceID, err)
 	}
 
-	deviceSize, err := inspectField(imageTest, "GraphDriver.Data.DeviceSize")
+	deviceSize, err := inspectField(s, imageTest, "GraphDriver.Data.DeviceSize")
 	c.Assert(err, check.IsNil)
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
@@ -234,7 +234,7 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	out = strings.TrimSpace(out)
 
-	name, err := inspectField(out, "GraphDriver.Name")
+	name, err := inspectField(s, out, "GraphDriver.Name")
 	c.Assert(err, check.IsNil)
 
 	if name != "devicemapper" && name != "overlay" && name != "vfs" && name != "zfs" && name != "btrfs" && name != "aufs" {
@@ -245,7 +245,7 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 		return
 	}
 
-	deviceID, err := inspectField(out, "GraphDriver.Data.DeviceId")
+	deviceID, err := inspectField(s, out, "GraphDriver.Data.DeviceId")
 	c.Assert(err, check.IsNil)
 
 	_, err = strconv.Atoi(deviceID)
@@ -253,7 +253,7 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 		c.Fatalf("failed to inspect DeviceId of the image: %s, %v", deviceID, err)
 	}
 
-	deviceSize, err := inspectField(out, "GraphDriver.Data.DeviceSize")
+	deviceSize, err := inspectField(s, out, "GraphDriver.Data.DeviceSize")
 	c.Assert(err, check.IsNil)
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
@@ -266,7 +266,7 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "/data:/data:ro,z", "busybox", "cat")
 
-	vol, err := inspectFieldJSON("test", "Mounts")
+	vol, err := inspectFieldJSON(s, "test", "Mounts")
 	c.Assert(err, check.IsNil)
 
 	var mp []types.MountPoint
@@ -309,11 +309,11 @@ func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	id := strings.TrimSpace(out)
-	startedAt, err := inspectField(id, "State.StartedAt")
+	startedAt, err := inspectField(s, id, "State.StartedAt")
 	c.Assert(err, check.IsNil)
-	finishedAt, err := inspectField(id, "State.FinishedAt")
+	finishedAt, err := inspectField(s, id, "State.FinishedAt")
 	c.Assert(err, check.IsNil)
-	created, err := inspectField(id, "Created")
+	created, err := inspectField(s, id, "Created")
 	c.Assert(err, check.IsNil)
 
 	_, err = time.Parse(time.RFC3339Nano, startedAt)
@@ -323,7 +323,7 @@ func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
 	_, err = time.Parse(time.RFC3339Nano, created)
 	c.Assert(err, check.IsNil)
 
-	created, err = inspectField("busybox", "Created")
+	created, err = inspectField(s, "busybox", "Created")
 	c.Assert(err, check.IsNil)
 
 	_, err = time.Parse(time.RFC3339Nano, created)
@@ -336,7 +336,7 @@ func (s *DockerSuite) TestInspectLogConfigNoType(c *check.C) {
 	dockerCmd(c, "create", "--name=test", "--log-opt", "max-file=42", "busybox")
 	var logConfig runconfig.LogConfig
 
-	out, err := inspectFieldJSON("test", "HostConfig.LogConfig")
+	out, err := inspectFieldJSON(s, "test", "HostConfig.LogConfig")
 	c.Assert(err, check.IsNil)
 
 	err = json.NewDecoder(strings.NewReader(out)).Decode(&logConfig)

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -12,7 +12,7 @@ func (s *DockerSuite) TestKillContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
-	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	c.Assert(waitRun(s, cleanedContainerID), check.IsNil)
 
 	dockerCmd(c, "kill", cleanedContainerID)
 
@@ -37,7 +37,7 @@ func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
-	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	c.Assert(waitRun(s, cleanedContainerID), check.IsNil)
 
 	dockerCmd(c, "kill", cleanedContainerID)
 
@@ -52,11 +52,11 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
-	c.Assert(waitRun(cid), check.IsNil)
+	c.Assert(waitRun(s, cid), check.IsNil)
 
 	dockerCmd(c, "kill", "-s", "SIGWINCH", cid)
 
-	running, _ := inspectField(cid, "State.Running")
+	running, _ := inspectField(s, cid, "State.Running")
 	if running != "true" {
 		c.Fatal("Container should be in running state after SIGWINCH")
 	}
@@ -66,7 +66,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
-	c.Assert(waitRun(cid), check.IsNil)
+	c.Assert(waitRun(s, cid), check.IsNil)
 
 	out, _, err := dockerCmdWithError("kill", "-s", "0", cid)
 	c.Assert(err, check.NotNil)
@@ -74,14 +74,14 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 		c.Fatal("Kill with an invalid signal didn't error out correctly")
 	}
 
-	running, _ := inspectField(cid, "State.Running")
+	running, _ := inspectField(s, cid, "State.Running")
 	if running != "true" {
 		c.Fatal("Container should be in running state after an invalid signal")
 	}
 
 	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
 	cid = strings.TrimSpace(out)
-	c.Assert(waitRun(cid), check.IsNil)
+	c.Assert(waitRun(s, cid), check.IsNil)
 
 	out, _, err = dockerCmdWithError("kill", "-s", "SIG42", cid)
 	c.Assert(err, check.NotNil)
@@ -89,7 +89,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 		c.Fatal("Kill with an invalid signal error out correctly")
 	}
 
-	running, _ = inspectField(cid, "State.Running")
+	running, _ = inspectField(s, cid, "State.Running")
 	if running != "true" {
 		c.Fatal("Container should be in running state after an invalid signal")
 	}

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestLinksInspectLinksStarted(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "top")
-	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
+	links, err := inspectFieldJSON(s, "testinspectlink", "HostConfig.Links")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func (s *DockerSuite) TestLinksInspectLinksStopped(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
-	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
+	links, err := inspectFieldJSON(s, "testinspectlink", "HostConfig.Links")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -140,14 +140,14 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 	out, _ = dockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top")
 	idTwo := strings.TrimSpace(out)
 
-	c.Assert(waitRun(idTwo), check.IsNil)
+	c.Assert(waitRun(s, idTwo), check.IsNil)
 
-	contentOne, err := readContainerFileWithExec(idOne, "/etc/hosts")
+	contentOne, err := readContainerFileWithExec(s, idOne, "/etc/hosts")
 	if err != nil {
 		c.Fatal(err, string(contentOne))
 	}
 
-	contentTwo, err := readContainerFileWithExec(idTwo, "/etc/hosts")
+	contentTwo, err := readContainerFileWithExec(s, idTwo, "/etc/hosts")
 	if err != nil {
 		c.Fatal(err, string(contentTwo))
 	}
@@ -165,11 +165,11 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
 	id := strings.TrimSpace(string(out))
 
-	realIP, err := inspectField("one", "NetworkSettings.IPAddress")
+	realIP, err := inspectField(s, "one", "NetworkSettings.IPAddress")
 	if err != nil {
 		c.Fatal(err)
 	}
-	content, err := readContainerFileWithExec(id, "/etc/hosts")
+	content, err := readContainerFileWithExec(s, id, "/etc/hosts")
 	if err != nil {
 		c.Fatal(err, string(content))
 	}
@@ -188,11 +188,11 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 		c.Fatalf("For 'onetwo' alias expected IP: %s, got: %s", realIP, ip)
 	}
 	dockerCmd(c, "restart", "one")
-	realIP, err = inspectField("one", "NetworkSettings.IPAddress")
+	realIP, err = inspectField(s, "one", "NetworkSettings.IPAddress")
 	if err != nil {
 		c.Fatal(err)
 	}
-	content, err = readContainerFileWithExec(id, "/etc/hosts")
+	content, err = readContainerFileWithExec(s, id, "/etc/hosts")
 	if err != nil {
 		c.Fatal(err, string(content))
 	}
@@ -220,14 +220,14 @@ func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
 
 	cid := strings.TrimSpace(out)
-	c.Assert(waitRun(cid), check.IsNil)
+	c.Assert(waitRun(s, cid), check.IsNil)
 
 	out, _ = dockerCmd(c, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top")
 
 	cid2 := strings.TrimSpace(out)
-	c.Assert(waitRun(cid2), check.IsNil)
+	c.Assert(waitRun(s, cid2), check.IsNil)
 
-	links, err := inspectFieldJSON(cid2, "HostConfig.Links")
+	links, err := inspectFieldJSON(s, cid2, "HostConfig.Links")
 	c.Assert(err, check.IsNil)
 	c.Assert(links, check.Equals, "[\"/shortlinkdef:/link2/shortlinkdef\"]")
 }

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -285,7 +285,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 2; done")
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	type info struct {
 		NGoroutines int
@@ -337,7 +337,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesNoOutput(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 2; done")
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	type info struct {
 		NGoroutines int

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -9,13 +9,13 @@ import (
 
 func (s *DockerSuite) TestPause(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	defer unpauseAllContainers()
+	defer unpauseAllContainers(s)
 
 	name := "testeventpause"
 	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 
 	dockerCmd(c, "pause", name)
-	pausedContainers, err := getSliceOfPausedContainers()
+	pausedContainers, err := getSliceOfPausedContainers(s)
 	if err != nil {
 		c.Fatalf("error thrown while checking if containers were paused: %v", err)
 	}
@@ -45,7 +45,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 
 func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	defer unpauseAllContainers()
+	defer unpauseAllContainers(s)
 
 	containers := []string{
 		"testpausewithmorecontainers1",
@@ -55,7 +55,7 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 		dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 	}
 	dockerCmd(c, append([]string{"pause"}, containers...)...)
-	pausedContainers, err := getSliceOfPausedContainers()
+	pausedContainers, err := getSliceOfPausedContainers(s)
 	if err != nil {
 		c.Fatalf("error thrown while checking if containers were paused: %v", err)
 	}

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -33,13 +33,13 @@ func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
 	fourthID := strings.TrimSpace(out)
 
 	// make sure the second is running
-	c.Assert(waitRun(secondID), check.IsNil)
+	c.Assert(waitRun(s, secondID), check.IsNil)
 
 	// make sure third one is not running
 	dockerCmd(c, "wait", thirdID)
 
 	// make sure the forth is running
-	c.Assert(waitRun(fourthID), check.IsNil)
+	c.Assert(waitRun(s, fourthID), check.IsNil)
 
 	// all
 	out, _ = dockerCmd(c, "ps", "-a")
@@ -173,7 +173,7 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 
 	name := "test_size"
 	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo 1 > test")
-	id, err := getIDByName(name)
+	id, err := getIDByName(s, name)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -295,19 +295,19 @@ func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// Build images
 	imageName1 := "images_ps_filter_test1"
-	imageID1, err := buildImage(imageName1,
+	imageID1, err := buildImage(s, imageName1,
 		`FROM busybox
 		 LABEL match me 1`, true)
 	c.Assert(err, check.IsNil)
 
 	imageName1Tagged := "images_ps_filter_test1:tag"
-	imageID1Tagged, err := buildImage(imageName1Tagged,
+	imageID1Tagged, err := buildImage(s, imageName1Tagged,
 		`FROM busybox
 		 LABEL match me 1 tagged`, true)
 	c.Assert(err, check.IsNil)
 
 	imageName2 := "images_ps_filter_test2"
-	imageID2, err := buildImage(imageName2,
+	imageID2, err := buildImage(s, imageName2,
 		fmt.Sprintf(`FROM %s
 		 LABEL match me 2`, imageName1), true)
 	c.Assert(err, check.IsNil)
@@ -439,13 +439,13 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "top", "busybox", "top")
 
 	dockerCmd(c, "run", "--name", "zero1", "busybox", "true")
-	firstZero, err := getIDByName("zero1")
+	firstZero, err := getIDByName(s, "zero1")
 	if err != nil {
 		c.Fatal(err)
 	}
 
 	dockerCmd(c, "run", "--name", "zero2", "busybox", "true")
-	secondZero, err := getIDByName("zero2")
+	secondZero, err := getIDByName(s, "zero2")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -454,7 +454,7 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
 		c.Fatal("Should fail.", out, err)
 	}
 
-	firstNonZero, err := getIDByName("nonzero1")
+	firstNonZero, err := getIDByName(s, "nonzero1")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
 	if out, _, err := dockerCmdWithError("run", "--name", "nonzero2", "busybox", "false"); err == nil {
 		c.Fatal("Should fail.", out, err)
 	}
-	secondNonZero, err := getIDByName("nonzero2")
+	secondNonZero, err := getIDByName(s, "nonzero2")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -706,7 +706,7 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
 	out, _, err := runCommandWithOutput(runCmd)
 	c.Assert(err, check.IsNil)
 
-	originalImageID, err := getIDByName(originalImageName)
+	originalImageID, err := getIDByName(s, originalImageName)
 	c.Assert(err, check.IsNil)
 
 	runCmd = exec.Command(dockerBinary, "run", "-d", originalImageName, "top")

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -16,7 +16,7 @@ import (
 func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out := s.Cmd(c, "pull", "hello-world")
-	defer deleteImages("hello-world")
+	defer deleteImages(s, "hello-world")
 
 	c.Assert(out, checker.Contains, "Using default tag: latest", check.Commentf("expected the 'latest' tag to be automatically assumed"))
 	c.Assert(out, checker.Contains, "Pulling from library/hello-world", check.Commentf("expected the 'library/' prefix to be automatically assumed"))
@@ -65,7 +65,7 @@ func (s *DockerHubPullSuite) TestPullNonExistingImage(c *check.C) {
 func (s *DockerHubPullSuite) TestPullFromCentralRegistryImplicitRefParts(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	s.Cmd(c, "pull", "hello-world")
-	defer deleteImages("hello-world")
+	defer deleteImages(s, "hello-world")
 
 	for _, i := range []string{
 		"hello-world",

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -14,11 +14,11 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	name, err := inspectField(cleanedContainerID, "Name")
+	name, err := inspectField(s, cleanedContainerID, "Name")
 	newName := "new_name" + stringid.GenerateNonCryptoID()
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err = inspectField(cleanedContainerID, "Name")
+	name, err = inspectField(s, cleanedContainerID, "Name")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err := inspectField(cleanedContainerID, "Name")
+	name, err := inspectField(s, cleanedContainerID, "Name")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 	newName := "new_name" + stringid.GenerateNonCryptoID()
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err := inspectField(newName, "Name")
+	name, err := inspectField(s, newName, "Name")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 		c.Fatal("Failed to rename container ")
 	}
 
-	name, err = inspectField("first_name", "Name")
+	name, err = inspectField(s, "first_name", "Name")
 	if err == nil && !strings.Contains(err.Error(), "No such image or container: first_name") {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -32,7 +32,7 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	c.Assert(waitRun(s, cleanedContainerID), check.IsNil)
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 	if out != "foobar\n" {
@@ -43,7 +43,7 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 
-	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	c.Assert(waitRun(s, cleanedContainerID), check.IsNil)
 
 	if out != "foobar\nfoobar\n" {
 		c.Errorf("container should've printed 'foobar' twice")
@@ -62,7 +62,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 		c.Errorf("expect 1 volume received %s", out)
 	}
 
-	source, err := inspectMountSourceField(cleanedContainerID, "/test")
+	source, err := inspectMountSourceField(s, cleanedContainerID, "/test")
 	c.Assert(err, check.IsNil)
 
 	dockerCmd(c, "restart", cleanedContainerID)
@@ -72,7 +72,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 		c.Errorf("expect 1 volume after restart received %s", out)
 	}
 
-	sourceAfterRestart, err := inspectMountSourceField(cleanedContainerID, "/test")
+	sourceAfterRestart, err := inspectMountSourceField(s, cleanedContainerID, "/test")
 	c.Assert(err, check.IsNil)
 
 	if source != sourceAfterRestart {
@@ -85,7 +85,7 @@ func (s *DockerSuite) TestRestartPolicyNO(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=no", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
-	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
+	name, err := inspectField(s, id, "HostConfig.RestartPolicy.Name")
 	c.Assert(err, check.IsNil)
 	if name != "no" {
 		c.Fatalf("Container restart policy name is %s, expected %s", name, "no")
@@ -97,13 +97,13 @@ func (s *DockerSuite) TestRestartPolicyAlways(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=always", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
-	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
+	name, err := inspectField(s, id, "HostConfig.RestartPolicy.Name")
 	c.Assert(err, check.IsNil)
 	if name != "always" {
 		c.Fatalf("Container restart policy name is %s, expected %s", name, "always")
 	}
 
-	MaximumRetryCount, err := inspectField(id, "HostConfig.RestartPolicy.MaximumRetryCount")
+	MaximumRetryCount, err := inspectField(s, id, "HostConfig.RestartPolicy.MaximumRetryCount")
 	c.Assert(err, check.IsNil)
 
 	// MaximumRetryCount=0 if the restart policy is always
@@ -117,7 +117,7 @@ func (s *DockerSuite) TestRestartPolicyOnFailure(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:1", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
-	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
+	name, err := inspectField(s, id, "HostConfig.RestartPolicy.Name")
 	c.Assert(err, check.IsNil)
 	if name != "on-failure" {
 		c.Fatalf("Container restart policy name is %s, expected %s", name, "on-failure")
@@ -132,15 +132,15 @@ func (s *DockerSuite) TestContainerRestartwithGoodContainer(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "true")
 
 	id := strings.TrimSpace(string(out))
-	if err := waitInspect(id, "{{ .State.Restarting }} {{ .State.Running }}", "false false", 5); err != nil {
+	if err := waitInspect(s, id, "{{ .State.Restarting }} {{ .State.Running }}", "false false", 5); err != nil {
 		c.Fatal(err)
 	}
-	count, err := inspectField(id, "RestartCount")
+	count, err := inspectField(s, id, "RestartCount")
 	c.Assert(err, check.IsNil)
 	if count != "0" {
 		c.Fatalf("Container was restarted %s times, expected %d", count, 0)
 	}
-	MaximumRetryCount, err := inspectField(id, "HostConfig.RestartPolicy.MaximumRetryCount")
+	MaximumRetryCount, err := inspectField(s, id, "HostConfig.RestartPolicy.MaximumRetryCount")
 	c.Assert(err, check.IsNil)
 	if MaximumRetryCount != "3" {
 		c.Fatalf("Container Maximum Retry Count is %s, expected %s", MaximumRetryCount, "3")

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -54,7 +54,7 @@ func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	MAINTAINER Integration Tests`
 
 	// build first dockerfile
-	img1, err := buildImage(img, dockerfile1, true)
+	img1, err := buildImage(s, img, dockerfile1, true)
 	if err != nil {
 		c.Fatalf("Could not build image %s: %v", img, err)
 	}
@@ -64,7 +64,7 @@ func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	}
 
 	// rebuild dockerfile with a small addition at the end
-	if _, err := buildImage(img, dockerfile2, true); err != nil {
+	if _, err := buildImage(s, img, dockerfile2, true); err != nil {
 		c.Fatalf("Could not rebuild image %s: %v", img, err)
 	}
 	// try to remove the image, should error out.

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -96,7 +96,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 		c.Fatalf("tag busybox to create 2 more images with same imageID; docker images shows: %q\n", imagesAfter)
 	}
 
-	imgID, err := inspectField("busybox-one:tag1", "Id")
+	imgID, err := inspectField(s, "busybox-one:tag1", "Id")
 	c.Assert(err, check.IsNil)
 
 	// run a container with the image
@@ -147,7 +147,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 			c.Fatalf("tag busybox to create 4 more images with same imageID; docker images shows: %q\n", imagesAfter)
 		}
 	}
-	imgID, err := inspectField("busybox-test", "Id")
+	imgID, err := inspectField(s, "busybox-test", "Id")
 	c.Assert(err, check.IsNil)
 
 	// first checkout without force it fails
@@ -169,7 +169,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerfile := "FROM busybox\nRUN echo test 14116\n"
-	imgID, err := buildImage("test-14116", dockerfile, false)
+	imgID, err := buildImage(s, "test-14116", dockerfile, false)
 	c.Assert(err, check.IsNil)
 
 	newTag := "newtag"
@@ -283,7 +283,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	imageIds := make([]string, 2)
 	for i, name := range imageNames {
 		dockerfile := fmt.Sprintf("FROM busybox\nMAINTAINER %s\nRUN echo %s\n", name, name)
-		id, err := buildImage(name, dockerfile, false)
+		id, err := buildImage(s, name, dockerfile, false)
 		c.Assert(err, check.IsNil)
 		imageIds[i] = id
 	}
@@ -314,7 +314,7 @@ RUN echo 0 #layer0
 RUN echo 1 #layer1
 RUN echo 2 #layer2
 `
-	_, err := buildImage(image, dockerfile, false)
+	_, err := buildImage(s, image, dockerfile, false)
 	c.Assert(err, check.IsNil)
 
 	out, _ := dockerCmd(c, "history", "-q", image)

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -116,7 +116,7 @@ func (s *DockerSuite) TestRunAttachDetach(c *check.C) {
 	if err := cmd.Start(); err != nil {
 		c.Fatal(err)
 	}
-	c.Assert(waitRun(name), check.IsNil)
+	c.Assert(waitRun(s, name), check.IsNil)
 
 	if _, err := cpty.Write([]byte("hello\n")); err != nil {
 		c.Fatal(err)
@@ -145,7 +145,7 @@ func (s *DockerSuite) TestRunAttachDetach(c *check.C) {
 		ch <- struct{}{}
 	}()
 
-	running, err := inspectField(name, "State.Running")
+	running, err := inspectField(s, name, "State.Running")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func (s *DockerSuite) TestRunEchoStdoutWithCPUQuota(c *check.C) {
 		c.Errorf("container should've printed 'test'")
 	}
 
-	out, err = inspectField("test", "HostConfig.CpuQuota")
+	out, err = inspectField(s, "test", "HostConfig.CpuQuota")
 	c.Assert(err, check.IsNil)
 
 	if out != "8000" {
@@ -192,7 +192,7 @@ func (s *DockerSuite) TestRunWithCpuPeriod(c *check.C) {
 		c.Fatalf("failed to run container: %v", err)
 	}
 
-	out, err := inspectField("test", "HostConfig.CpuPeriod")
+	out, err := inspectField(s, "test", "HostConfig.CpuPeriod")
 	c.Assert(err, check.IsNil)
 	if out != "50000" {
 		c.Fatalf("setting the CPU CFS period failed")
@@ -204,7 +204,7 @@ func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
 
 	dockerCmd(c, "run", "--kernel-memory", "50M", "--name", "test", "busybox", "true")
 
-	out, err := inspectField("test", "HostConfig.KernelMemory")
+	out, err := inspectField(s, "test", "HostConfig.KernelMemory")
 	c.Assert(err, check.IsNil)
 	if out != "52428800" {
 		c.Fatalf("setting the kernel memory limit failed")
@@ -320,7 +320,7 @@ func (s *DockerSuite) TestStopContainerSignal(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--stop-signal", "SIGUSR1", "-d", "busybox", "/bin/sh", "-c", `trap 'echo "exit trapped"; exit 0' USR1; while true; do sleep 1; done`)
 	containerID := strings.TrimSpace(out)
 
-	if err := waitRun(containerID); err != nil {
+	if err := waitRun(s, containerID); err != nil {
 		c.Fatal(err)
 	}
 

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -31,7 +31,7 @@ func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
 	if err != nil {
 		c.Fatalf("failed to save repo: %v %v", out, err)
 	}
-	deleteImages(repoName)
+	deleteImages(s, repoName)
 
 	loadCmd := exec.Command(dockerBinary, "load")
 	loadCmd.Stdin = strings.NewReader(repoTarball)
@@ -65,7 +65,7 @@ func (s *DockerSuite) TestSaveXzGzAndLoadRepoStdout(c *check.C) {
 		c.Fatalf("failed to save repo: %v %v", out, err)
 	}
 
-	deleteImages(repoName)
+	deleteImages(s, repoName)
 
 	loadCmd := exec.Command(dockerBinary, "load")
 	loadCmd.Stdin = strings.NewReader(out)
@@ -146,7 +146,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 
 	repoName := "foobar-save-load-test"
 
-	deleteImages(repoName)
+	deleteImages(s, repoName)
 	dockerCmd(c, "commit", name, repoName)
 
 	before, _ := dockerCmd(c, "inspect", repoName)
@@ -205,7 +205,7 @@ func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
 	idFoo := makeImage("busybox:latest", tagFoo)
 	idBar := makeImage("busybox:latest", tagBar)
 
-	deleteImages(repoName)
+	deleteImages(s, repoName)
 
 	// create the archive
 	out, _, err := runCommandPipelineWithOutput(
@@ -244,7 +244,7 @@ func (s *DockerSuite) TestSaveDirectoryPermissions(c *check.C) {
 	os.Mkdir(extractionDirectory, 0777)
 
 	defer os.RemoveAll(tmpDir)
-	_, err = buildImage(name,
+	_, err = buildImage(s, name,
 		`FROM busybox
 	RUN adduser -D user && mkdir -p /opt/a/b && chown -R user:user /opt/a
 	RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`,

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 	tmpFile, err = os.Open(tmpFile.Name())
 	c.Assert(err, check.IsNil)
 
-	deleteImages(repoName)
+	deleteImages(s, repoName)
 
 	loadCmd := exec.Command(dockerBinary, "load")
 	loadCmd.Stdin = tmpFile
@@ -51,7 +51,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 		c.Fatalf("inspect is not the same after a save / load")
 	}
 
-	deleteImages(repoName)
+	deleteImages(s, repoName)
 
 	pty, tty, err := pty.Open()
 	if err != nil {

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// when container runs successfully, we should not have state.Error
 	dockerCmd(c, "run", "-d", "-p", "9999:9999", "--name", "test", "busybox", "top")
-	stateErr, err := inspectField("test", "State.Error")
+	stateErr, err := inspectField(s, "test", "State.Error")
 	c.Assert(err, check.IsNil)
 	if stateErr != "" {
 		c.Fatalf("Expected to not have state error but got state.Error(%q)", stateErr)
@@ -86,7 +86,7 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 		c.Fatalf("Expected error but got none, output %q", out)
 	}
 
-	stateErr, err = inspectField("test2", "State.Error")
+	stateErr, err = inspectField(s, "test2", "State.Error")
 	c.Assert(err, check.IsNil)
 	expected := "port is already allocated"
 	if stateErr == "" || !strings.Contains(stateErr, expected) {
@@ -96,7 +96,7 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 	// Expect the conflict to be resolved when we stop the initial container
 	dockerCmd(c, "stop", "test")
 	dockerCmd(c, "start", "test2")
-	stateErr, err = inspectField("test2", "State.Error")
+	stateErr, err = inspectField(s, "test2", "State.Error")
 	c.Assert(err, check.IsNil)
 	if stateErr != "" {
 		c.Fatalf("Expected to not have state error but got state.Error(%q)", stateErr)
@@ -105,7 +105,7 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 
 func (s *DockerSuite) TestStartPausedContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	defer unpauseAllContainers()
+	defer unpauseAllContainers(s)
 
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
 
@@ -128,7 +128,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
 	// stop 'parent' container
 	dockerCmd(c, "stop", "parent")
 
-	out, err := inspectField("parent", "State.Running")
+	out, err := inspectField(s, "parent", "State.Running")
 	c.Assert(err, check.IsNil)
 	if out != "false" {
 		c.Fatal("Container should be stopped")
@@ -142,7 +142,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
 	}
 
 	for container, expected := range map[string]string{"parent": "true", "child_first": "false", "child_second": "true"} {
-		out, err := inspectField(container, "State.Running")
+		out, err := inspectField(s, container, "State.Running")
 		c.Assert(err, check.IsNil)
 		if out != expected {
 			c.Fatal("Container running state wrong")
@@ -173,7 +173,7 @@ func (s *DockerSuite) TestStartAttachMultipleContainers(c *check.C) {
 
 	// confirm the state of all the containers be stopped
 	for container, expected := range map[string]string{"test1": "false", "test2": "false", "test3": "false"} {
-		out, err := inspectField(container, "State.Running")
+		out, err := inspectField(s, container, "State.Running")
 		if err != nil {
 			c.Fatal(out, err)
 		}

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -19,7 +19,7 @@ import (
 
 func init() {
 	check.Suite(&DockerExternalVolumeSuite{
-		ds: &DockerSuite{},
+		DockerSuite: &DockerSuite{},
 	})
 }
 
@@ -33,8 +33,9 @@ type eventCounter struct {
 }
 
 type DockerExternalVolumeSuite struct {
+	*DockerSuite
+
 	server *httptest.Server
-	ds     *DockerSuite
 	d      *Daemon
 	ec     *eventCounter
 }
@@ -46,7 +47,7 @@ func (s *DockerExternalVolumeSuite) SetUpTest(c *check.C) {
 
 func (s *DockerExternalVolumeSuite) TearDownTest(c *check.C) {
 	s.d.Stop()
-	s.ds.TearDownTest(c)
+	s.DockerSuite.TearDownTest(c)
 }
 
 func (s *DockerExternalVolumeSuite) SetUpSuite(c *check.C) {
@@ -355,7 +356,7 @@ func (s *DockerExternalVolumeSuite) TestStartExternalVolumeDriverBindExternalVol
 		Name   string
 		Driver string
 	}
-	out, err := inspectFieldJSON("testing", "Mounts")
+	out, err := inspectFieldJSON(s, "testing", "Mounts")
 	c.Assert(err, check.IsNil)
 	c.Assert(json.NewDecoder(strings.NewReader(out)).Decode(&mounts), check.IsNil)
 	c.Assert(len(mounts), check.Equals, 1, check.Commentf(out))

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -12,7 +12,7 @@ func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
-	c.Assert(waitRun(id), check.IsNil)
+	c.Assert(waitRun(s, id), check.IsNil)
 
 	statsCmd := exec.Command(dockerBinary, "stats", "--no-stream", id)
 	chErr := make(chan error)

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -10,7 +10,7 @@ import (
 // tagging a named image in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+	if err := pullImageIfNotExist(s, "busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
@@ -20,7 +20,7 @@ func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
 // tagging an image by ID in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByID(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	imageID, err := inspectField("busybox", "Id")
+	imageID, err := inspectField(s, "busybox", "Id")
 	c.Assert(err, check.IsNil)
 	dockerCmd(c, "tag", imageID, "testfoobarbaz")
 }
@@ -55,7 +55,7 @@ func (s *DockerSuite) TestTagInvalidPrefixedRepo(c *check.C) {
 // ensure we allow the use of valid tags
 func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+	if err := pullImageIfNotExist(s, "busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
@@ -67,14 +67,14 @@ func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 			c.Errorf("tag busybox %v should have worked: %s", repo, err)
 			continue
 		}
-		deleteImages(repo)
+		deleteImages(s, repo)
 	}
 }
 
 // tag an image with an existed tag name without -f option should fail
 func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+	if err := pullImageIfNotExist(s, "busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
@@ -88,7 +88,7 @@ func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 // tag an image with an existed tag name with -f option should work
 func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+	if err := pullImageIfNotExist(s, "busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
@@ -98,7 +98,7 @@ func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
 
 func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+	if err := pullImageIfNotExist(s, "busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 	// test repository name begin with '-'
@@ -143,7 +143,7 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 			c.Errorf("listing images failed with errors: %v, %s", err, out)
 		} else if strings.Contains(out, name) {
 			c.Errorf("images should not have listed '%s'", name)
-			deleteImages(name + ":latest")
+			deleteImages(s, name+":latest")
 		}
 	}
 
@@ -153,6 +153,6 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 			c.Errorf("tag %v fooo/bar should have worked: %s", name, err)
 			continue
 		}
-		deleteImages("fooo/bar:latest")
+		deleteImages(s, "fooo/bar:latest")
 	}
 }

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -15,7 +15,7 @@ func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "true")
 	containerID := strings.TrimSpace(out)
 
-	if err := waitInspect(containerID, "{{.State.Running}}", "false", 1); err != nil {
+	if err := waitInspect(s, containerID, "{{.State.Running}}", "false", 1); err != nil {
 		c.Fatal("Container should have stopped by now")
 	}
 
@@ -32,7 +32,7 @@ func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 0.01; done")
 	containerID := strings.TrimSpace(out)
 
-	c.Assert(waitRun(containerID), check.IsNil)
+	c.Assert(waitRun(s, containerID), check.IsNil)
 
 	chWait := make(chan string)
 	go func() {
@@ -60,7 +60,7 @@ func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "exit 99")
 	containerID := strings.TrimSpace(out)
 
-	if err := waitInspect(containerID, "{{.State.Running}}", "false", 1); err != nil {
+	if err := waitInspect(s, containerID, "{{.State.Running}}", "false", 1); err != nil {
 		c.Fatal("Container should have stopped by now")
 	}
 
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestWaitBlockedExitRandom(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 99' TERM; while true; do sleep 0.01; done")
 	containerID := strings.TrimSpace(out)
-	c.Assert(waitRun(containerID), check.IsNil)
+	c.Assert(waitRun(s, containerID), check.IsNil)
 
 	chWait := make(chan error)
 	waitCmd := exec.Command(dockerBinary, "wait", containerID)

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"os/exec"
 	"runtime"
-	"strings"
 
 	"github.com/go-check/check"
 )
@@ -20,72 +18,23 @@ func init() {
 // images that are baked into our 'global' test environment daemon (e.g.,
 // busybox, httpserver, ...).
 //
-// We use it for push/pull tests where we want to start fresh, and measure the
-// relative impact of each individual operation. As part of this suite, all
-// images are removed after each test.
+// We use it for pull tests where we want to start fresh. As part of this
+// suite, all images are removed after each test.
 type DockerHubPullSuite struct {
-	d  *Daemon
-	ds *DockerSuite
+	DockerIsolatedDaemonSuite
 }
 
 // newDockerHubPullSuite returns a new instance of a DockerHubPullSuite.
 func newDockerHubPullSuite() *DockerHubPullSuite {
 	return &DockerHubPullSuite{
-		ds: &DockerSuite{},
-	}
-}
-
-// SetUpSuite starts the suite daemon.
-func (s *DockerHubPullSuite) SetUpSuite(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	s.d = NewDaemon(c)
-	if err := s.d.Start(); err != nil {
-		c.Fatalf("starting push/pull test daemon: %v", err)
-	}
-}
-
-// TearDownSuite stops the suite daemon.
-func (s *DockerHubPullSuite) TearDownSuite(c *check.C) {
-	if s.d != nil {
-		if err := s.d.Stop(); err != nil {
-			c.Fatalf("stopping push/pull test daemon: %v", err)
-		}
+		DockerIsolatedDaemonSuite: DockerIsolatedDaemonSuite{
+			ds: &DockerSuite{},
+		},
 	}
 }
 
 // SetUpTest declares that all tests of this suite require network.
 func (s *DockerHubPullSuite) SetUpTest(c *check.C) {
 	testRequires(c, Network)
-}
-
-// TearDownTest removes all images from the suite daemon.
-func (s *DockerHubPullSuite) TearDownTest(c *check.C) {
-	out := s.Cmd(c, "images", "-aq")
-	images := strings.Split(out, "\n")
-	images = append([]string{"-f"}, images...)
-	s.d.Cmd("rmi", images...)
-	s.ds.TearDownTest(c)
-}
-
-// Cmd executes a command against the suite daemon and returns the combined
-// output. The function fails the test when the command returns an error.
-func (s *DockerHubPullSuite) Cmd(c *check.C, name string, arg ...string) string {
-	out, err := s.CmdWithError(name, arg...)
-	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(arg, " "), out, err))
-	return out
-}
-
-// CmdWithError executes a command against the suite daemon and returns the
-// combined output as well as any error.
-func (s *DockerHubPullSuite) CmdWithError(name string, arg ...string) (string, error) {
-	c := s.MakeCmd(name, arg...)
-	b, err := c.CombinedOutput()
-	return string(b), err
-}
-
-// MakeCmd returns a exec.Cmd command to run against the suite daemon.
-func (s *DockerHubPullSuite) MakeCmd(name string, arg ...string) *exec.Cmd {
-	args := []string{"--host", s.d.sock(), name}
-	args = append(args, arg...)
-	return exec.Command(dockerBinary, args...)
+	s.DockerIsolatedDaemonSuite.SetUpTest(c)
 }

--- a/integration-cli/docker_isolated_daemon_suite.go
+++ b/integration-cli/docker_isolated_daemon_suite.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+// DockerIsolatedDaemonSuite provides a isolated daemon that doesn't have all the
+// images that are baked into our 'global' test environment daemon (e.g.,
+// busybox, httpserver, ...).
+//
+// We use it as a basis for other testsuites to run for push/pull tests where we want to
+// start fresh, and measure the relative impact of each individual operation. As part of
+// this suite, all images are removed after each test.
+type DockerIsolatedDaemonSuite struct {
+	d  *Daemon
+	ds *DockerSuite
+}
+
+// SetUpSuite starts the suite daemon.
+func (s *DockerIsolatedDaemonSuite) SetUpSuite(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	s.d = NewDaemon(c)
+	if err := s.d.Start(); err != nil {
+		c.Fatalf("starting push/pull test daemon: %v", err)
+	}
+}
+
+// TearDownSuite stops the suite daemon.
+func (s *DockerIsolatedDaemonSuite) TearDownSuite(c *check.C) {
+	if s.d != nil {
+		if err := s.d.Stop(); err != nil {
+			c.Fatalf("stopping push/pull test daemon: %v", err)
+		}
+	}
+}
+
+// SetUpTest is an empty function provided for consistency with TearDownTest.
+func (s *DockerIsolatedDaemonSuite) SetUpTest(c *check.C) {
+}
+
+// TearDownTest removes all images from the suite daemon.
+func (s *DockerIsolatedDaemonSuite) TearDownTest(c *check.C) {
+	out := s.Cmd(c, "images", "-aq")
+	images := strings.Split(out, "\n")
+	images = append([]string{"-f"}, images...)
+	s.d.Cmd("rmi", images...)
+	s.ds.TearDownTest(c)
+}
+
+// Cmd executes a command against the suite daemon and returns the combined
+// output. The function fails the test when the command returns an error.
+func (s *DockerIsolatedDaemonSuite) Cmd(c *check.C, name string, arg ...string) string {
+	out, err := s.CmdWithError(name, arg...)
+	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(arg, " "), out, err))
+	return out
+}
+
+// CmdWithError executes a command against the suite daemon and returns the
+// combined output as well as any error.
+func (s *DockerIsolatedDaemonSuite) CmdWithError(name string, arg ...string) (string, error) {
+	c := s.MakeCmd(append([]string{name}, arg...)...)
+	b, err := c.CombinedOutput()
+	return string(b), err
+}
+
+// MakeCmd returns a exec.Cmd command to run against the suite daemon.
+func (s *DockerIsolatedDaemonSuite) MakeCmd(arg ...string) *exec.Cmd {
+	args := []string{"--host", s.d.sock()}
+	args = append(args, arg...)
+	return exec.Command(dockerBinary, args...)
+}

--- a/integration-cli/docker_registry_suite_test.go
+++ b/integration-cli/docker_registry_suite_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"runtime"
+
+	"github.com/go-check/check"
+)
+
+func init() {
+	// FIXME. Temporarily turning this off for Windows as GH16039 was breaking
+	// Windows to Linux CI @icecrime
+	if runtime.GOOS != "windows" {
+		check.Suite(newDockerRegistrySuite())
+	}
+}
+
+// DockerRegistrySuite provides a isolated daemon that doesn't have all the
+// images that are baked into our 'global' test environment daemon, except
+// a busybox image for testing. It also provides a local registry to test
+// against.
+//
+// We use it for push/pull tests against a local registry where we want to
+// start fresh. As part of this suite, all images are removed after each test
+// and busybox is restored).
+type DockerRegistrySuite struct {
+	DockerIsolatedDaemonSuite
+	reg *testRegistryV2
+}
+
+// newDockerRegistrySuite returns a new instance of a DockerRegistrySuite.
+func newDockerRegistrySuite() *DockerRegistrySuite {
+	return &DockerRegistrySuite{
+		DockerIsolatedDaemonSuite: DockerIsolatedDaemonSuite{
+			ds: &DockerSuite{},
+		},
+	}
+}
+
+// SetUpTest declares that all tests of this suite require network, and
+// sets up a local registry.
+func (s *DockerRegistrySuite) SetUpTest(c *check.C) {
+	testRequires(c, Network)
+	s.reg = setupRegistry(c)
+	s.DockerIsolatedDaemonSuite.SetUpTest(c)
+	err := s.d.loadBusybox()
+	c.Assert(err, check.IsNil)
+}
+
+// TearDownTest shuts down the local registry.
+func (s *DockerRegistrySuite) TearDownTest(c *check.C) {
+	if s.reg != nil {
+		s.reg.Close()
+	}
+	s.DockerIsolatedDaemonSuite.TearDownTest(c)
+}

--- a/integration-cli/docker_trust_suite_test.go
+++ b/integration-cli/docker_trust_suite_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"runtime"
+
+	"github.com/go-check/check"
+)
+
+func init() {
+	// FIXME. Temporarily turning this off for Windows as GH16039 was breaking
+	// Windows to Linux CI @icecrime
+	if runtime.GOOS != "windows" {
+		check.Suite(newDockerTrustSuite())
+	}
+}
+
+// DockerTrustSuite is used for testing content trust with pushes and pulls.
+// It combines a isolated daemon with a fresh busybox image, a local registry,
+// and a notary server.
+type DockerTrustSuite struct {
+	DockerIsolatedDaemonSuite
+	reg *testRegistryV2
+	not *testNotary
+}
+
+// newDockerTrustSuite returns a new instance of a DockerTrustSuite.
+func newDockerTrustSuite() *DockerTrustSuite {
+	return &DockerTrustSuite{
+		DockerIsolatedDaemonSuite: DockerIsolatedDaemonSuite{
+			ds: &DockerSuite{},
+		},
+	}
+}
+
+// SetUpTest declares that all tests of this suite require network, and
+// sets up a local registry and notary server.
+func (s *DockerTrustSuite) SetUpTest(c *check.C) {
+	testRequires(c, Network)
+	s.reg = setupRegistry(c)
+	s.not = setupNotary(c)
+	s.DockerIsolatedDaemonSuite.SetUpTest(c)
+	err := s.d.loadBusybox()
+	c.Assert(err, check.IsNil)
+}
+
+// TearDownTest shuts down the local registry.
+func (s *DockerTrustSuite) TearDownTest(c *check.C) {
+	if s.reg != nil {
+		s.reg.Close()
+	}
+	s.not.Close()
+	s.DockerIsolatedDaemonSuite.TearDownTest(c)
+}

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -142,9 +142,9 @@ func trustCmdEnv(cmd *exec.Cmd, server, offlinePwd, taggingPwd string) {
 func (s *DockerTrustSuite) setupTrustedImage(c *check.C, name string) string {
 	repoName := fmt.Sprintf("%v/dockercli/%s:latest", privateRegistryURL, name)
 	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
+	s.Cmd(c, "tag", "busybox", repoName)
 
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
+	pushCmd := s.MakeCmd("push", repoName)
 	s.trustedCmd(pushCmd)
 	out, _, err := runCommandWithOutput(pushCmd)
 	if err != nil {
@@ -154,9 +154,7 @@ func (s *DockerTrustSuite) setupTrustedImage(c *check.C, name string) string {
 		c.Fatalf("Missing expected output on trusted push:\n%s", out)
 	}
 
-	if out, status := dockerCmd(c, "rmi", repoName); status != 0 {
-		c.Fatalf("Error removing image %q\n%s", repoName, out)
-	}
+	s.Cmd(c, "rmi", repoName)
 
 	return repoName
 }


### PR DESCRIPTION
busybox is loaded from the main daemon after every test, but no other images
are present in this daemon.

This will prevent push/pull tests from being polluted by changes made by
other tests (i.e. busybox being repulled).

Create a DockerIsolatedDaemonSuite struct which is used to implement
DockerRegistrySuite and DockerHubPullSuite.

Change many functions in docker_utils.go to take a CmdMaker interface,
so they can be used with a separate daemon. Update existing tests
accordingly (this accounts for the bulk of the commit).

Adjust tests in DockerRegistrySuite and DockerTrustSuite to all s.Cmd
instead of dockerCmd, and so on.

@icecrime @vdemeester PTAL
