### PR TITLE
Add docker info show base filesystem size of container/image when use devicemapper

### DIFF
--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -49,6 +49,7 @@ will display something like:
 	Storage Driver: devicemapper
 	 Pool Name: docker-253:1-17538953-pool
 	 Pool Blocksize: 65.54 kB
+	 Base Device Size: 107.4 GB
 	 Data file: /dev/loop4
 	 Metadata file: /dev/loop4
 	 Data Space Used: 2.536 GB
@@ -69,6 +70,7 @@ Each item in the indented section under `Storage Driver: devicemapper` are
 status information about the driver.
  *  `Pool Name` name of the devicemapper pool for this driver.
  *  `Pool Blocksize` tells the blocksize the thin pool was initialized with. This only changes on creation.
+ *  `Base Device Size` tells the maximum size of a container and image
  *  `Data file` blockdevice file used for the devicemapper data
  *  `Metadata file` blockdevice file used for the devicemapper metadata
  *  `Data Space Used` tells how much of `Data file` is currently used

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -140,6 +140,8 @@ type Status struct {
 	Data DiskUsage
 	// Metadata is the disk used for meta data.
 	Metadata DiskUsage
+	// BaseDeviceSize is base size of container and image
+	BaseDeviceSize uint64
 	// SectorSize size of the vector.
 	SectorSize uint64
 	// UdevSyncSupported is true if sync is supported.
@@ -821,6 +823,14 @@ func getDeviceUUID(device string) (string, error) {
 	uuid = strings.TrimSpace(uuid)
 	logrus.Debugf("UUID for device: %s is:%s", device, uuid)
 	return uuid, nil
+}
+
+func (devices *DeviceSet) getBaseDeviceSize() uint64 {
+	info, _ := devices.lookupDevice("")
+	if info == nil {
+		return 0
+	}
+	return info.Size
 }
 
 func (devices *DeviceSet) verifyBaseDeviceUUID(baseInfo *devInfo) error {
@@ -2154,6 +2164,7 @@ func (devices *DeviceSet) Status() *Status {
 	status.DeferredRemoveEnabled = devices.deferredRemove
 	status.DeferredDeleteEnabled = devices.deferredDelete
 	status.DeferredDeletedDeviceCount = devices.nrDeletedDevices
+	status.BaseDeviceSize = devices.getBaseDeviceSize()
 
 	totalSizeInSectors, _, dataUsed, dataTotal, metadataUsed, metadataTotal, err := devices.poolStatus()
 	if err == nil {

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -73,6 +73,7 @@ func (d *Driver) Status() [][2]string {
 	status := [][2]string{
 		{"Pool Name", s.PoolName},
 		{"Pool Blocksize", fmt.Sprintf("%s", units.HumanSize(float64(s.SectorSize)))},
+		{"Base Device Size", fmt.Sprintf("%s", units.HumanSize(float64(s.BaseDeviceSize)))},
 		{"Backing Filesystem", backingFs},
 		{"Data file", s.DataFile},
 		{"Metadata file", s.MetadataFile},


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
The base fs size is an important parameter of devicemapper graph driver.
It is the maximum size of the container, user should have a way 
to get this size.
