### PR TITLE
Use libcontainer hook for network namespace info passing to libnetwork's sandbox

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -811,7 +811,7 @@ func (container *Container) exec(ExecConfig *ExecConfig) error {
 	container.Lock()
 	defer container.Unlock()
 
-	callback := func(processConfig *execdriver.ProcessConfig, pid int) {
+	callback := func(processConfig *execdriver.ProcessConfig, pid int) error {
 		if processConfig.Tty {
 			// The callback is called after the process Start()
 			// so we are in the parent process. In TTY mode, stdin/out/err is the PtySlave
@@ -821,6 +821,7 @@ func (container *Container) exec(ExecConfig *ExecConfig) error {
 			}
 		}
 		close(ExecConfig.waitStart)
+		return nil
 	}
 
 	// We use a callback here instead of a goroutine and an chan for
@@ -837,7 +838,7 @@ func (container *Container) exec(ExecConfig *ExecConfig) error {
 	return nil
 }
 
-func (container *Container) monitorExec(ExecConfig *ExecConfig, callback execdriver.StartCallback) error {
+func (container *Container) monitorExec(ExecConfig *ExecConfig, callback execdriver.DriverCallback) error {
 	var (
 		err      error
 		exitCode int

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -174,8 +174,9 @@ func getDevicesFromPath(deviceMapping runconfig.DeviceMapping) (devs []*configs.
 func populateCommand(c *Container, env []string) error {
 	var en *execdriver.Network
 	if !c.Config.NetworkDisabled {
-		en = &execdriver.Network{
-			NamespacePath: c.NetworkSettings.SandboxKey,
+		en = &execdriver.Network{}
+		if !c.daemon.execDriver.SupportsHooks() || c.hostConfig.NetworkMode.IsHost() {
+			en.NamespacePath = c.NetworkSettings.SandboxKey
 		}
 
 		parts := strings.SplitN(string(c.hostConfig.NetworkMode), ":", 2)
@@ -405,6 +406,10 @@ func (container *Container) buildSandboxOptions() ([]libnetwork.SandboxOption, e
 		sboxOptions = append(sboxOptions, libnetwork.OptionUseDefaultSandbox())
 		sboxOptions = append(sboxOptions, libnetwork.OptionOriginHostsPath("/etc/hosts"))
 		sboxOptions = append(sboxOptions, libnetwork.OptionOriginResolvConfPath("/etc/resolv.conf"))
+	} else if container.daemon.execDriver.SupportsHooks() {
+		// OptionUseExternalKey is mandatory for userns support.
+		// But optional for non-userns support
+		sboxOptions = append(sboxOptions, libnetwork.OptionUseExternalKey())
 	}
 
 	container.HostsPath, err = container.getRootResourcePath("hosts")
@@ -945,6 +950,20 @@ func (container *Container) initializeNetworking() error {
 	}
 
 	return container.buildHostnameFile()
+}
+
+// called from the libcontainer pre-start hook to set the network
+// namespace configuration linkage to the libnetwork "sandbox" entity
+func (container *Container) setNetworkNamespaceKey(pid int) error {
+	path := fmt.Sprintf("/proc/%d/ns/net", pid)
+	var sandbox libnetwork.Sandbox
+	search := libnetwork.SandboxContainerWalker(&sandbox, container.ID)
+	container.daemon.netController.WalkSandboxes(search)
+	if sandbox == nil {
+		return fmt.Errorf("no sandbox present for %s", container.ID)
+	}
+
+	return sandbox.SetKey(path)
 }
 
 func (container *Container) getIpcContainer() (*Container, error) {

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -138,6 +138,11 @@ func (container *Container) getSize() (int64, int64) {
 	return 0, 0
 }
 
+// setNetworkNamespaceKey is a no-op on Windows.
+func (container *Container) setNetworkNamespaceKey(pid int) error {
+	return nil
+}
+
 // allocateNetwork is a no-op on Windows.
 func (container *Container) allocateNetwork() error {
 	return nil

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -267,8 +267,11 @@ func (d *Daemon) ContainerExecStart(execName string, stdin io.ReadCloser, stdout
 }
 
 // Exec calls the underlying exec driver to run
-func (d *Daemon) Exec(c *Container, ExecConfig *ExecConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
-	exitStatus, err := d.execDriver.Exec(c.command, ExecConfig.ProcessConfig, pipes, startCallback)
+func (d *Daemon) Exec(c *Container, ExecConfig *ExecConfig, pipes *execdriver.Pipes, startCallback execdriver.DriverCallback) (int, error) {
+	hooks := execdriver.Hooks{
+		Start: startCallback,
+	}
+	exitStatus, err := d.execDriver.Exec(c.command, ExecConfig.ProcessConfig, pipes, hooks)
 
 	// On err, make sure we don't leave ExitCode at zero
 	if err != nil && exitStatus == 0 {

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -125,7 +125,7 @@ func killNetNsProc(proc *os.Process) {
 
 // Run implements the exec driver Driver interface,
 // it calls 'exec.Cmd' to launch lxc commands to run a container.
-func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (execdriver.ExitStatus, error) {
+func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
 	var (
 		term     execdriver.Terminal
 		err      error
@@ -324,9 +324,9 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 
 	c.ContainerPid = pid
 
-	if startCallback != nil {
+	if hooks.Start != nil {
 		logrus.Debugf("Invoking startCallback")
-		startCallback(&c.ProcessConfig, pid)
+		hooks.Start(&c.ProcessConfig, pid)
 	}
 
 	oomKill := false
@@ -870,7 +870,7 @@ func (t *TtyConsole) Close() error {
 
 // Exec implements the exec driver Driver interface,
 // it is not implemented by lxc.
-func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
 	return -1, ErrExec
 }
 
@@ -882,4 +882,10 @@ func (d *Driver) Stats(id string) (*execdriver.ResourceStats, error) {
 		return nil, fmt.Errorf("%s is not a key in active containers", id)
 	}
 	return execdriver.Stats(d.containerDir(id), d.activeContainers[id].container.Cgroups.Memory, d.machineMemory)
+}
+
+// SupportsHooks implements the execdriver Driver interface.
+// The LXC execdriver does not support the hook mechanism, which is currently unique to runC/libcontainer.
+func (d *Driver) SupportsHooks() bool {
+	return false
 }

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -19,7 +19,7 @@ import (
 
 // Exec implements the exec driver Driver interface,
 // it calls libcontainer APIs to execute a container.
-func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
 	active := d.activeContainers[c.ID]
 	if active == nil {
 		return -1, fmt.Errorf("No active container exists with ID %s", c.ID)
@@ -45,14 +45,14 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		return -1, err
 	}
 
-	if startCallback != nil {
+	if hooks.Start != nil {
 		pid, err := p.Pid()
 		if err != nil {
 			p.Signal(os.Kill)
 			p.Wait()
 			return -1, err
 		}
-		startCallback(&c.ProcessConfig, pid)
+		hooks.Start(&c.ProcessConfig, pid)
 	}
 
 	ps, err := p.Wait()

--- a/daemon/execdriver/windows/exec.go
+++ b/daemon/execdriver/windows/exec.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Exec implements the exec driver Driver interface.
-func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
 
 	var (
 		term     execdriver.Terminal
@@ -69,8 +69,8 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 	processConfig.Terminal = term
 
 	// Invoke the start callback
-	if startCallback != nil {
-		startCallback(&c.ProcessConfig, int(pid))
+	if hooks.Start != nil {
+		hooks.Start(&c.ProcessConfig, int(pid))
 	}
 
 	if exitCode, err = hcsshim.WaitForProcessInComputeSystem(c.ID, pid); err != nil {

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -77,7 +77,7 @@ type containerInit struct {
 const defaultOwner = "docker"
 
 // Run implements the exec driver Driver interface
-func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (execdriver.ExitStatus, error) {
+func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
 
 	var (
 		term execdriver.Terminal
@@ -290,9 +290,8 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	}
 	d.Unlock()
 
-	// Invoke the start callback
-	if startCallback != nil {
-		startCallback(&c.ProcessConfig, int(pid))
+	if hooks.Start != nil {
+		hooks.Start(&c.ProcessConfig, int(pid))
 	}
 
 	var exitCode int32
@@ -304,4 +303,10 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 
 	logrus.Debugf("Exiting Run() exitCode %d id=%s", exitCode, c.ID)
 	return execdriver.ExitStatus{ExitCode: int(exitCode)}, nil
+}
+
+// SupportsHooks implements the execdriver Driver interface.
+// The windows driver does not support the hook mechanism
+func (d *Driver) SupportsHooks() bool {
+	return false
 }

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -250,7 +250,7 @@ func (m *containerMonitor) shouldRestart(exitCode int) bool {
 
 // callback ensures that the container's state is properly updated after we
 // received ack from the execution drivers
-func (m *containerMonitor) callback(processConfig *execdriver.ProcessConfig, pid int) {
+func (m *containerMonitor) callback(processConfig *execdriver.ProcessConfig, pid int) error {
 	if processConfig.Tty {
 		// The callback is called after the process Start()
 		// so we are in the parent process. In TTY mode, stdin/out/err is the PtySlave
@@ -273,6 +273,7 @@ func (m *containerMonitor) callback(processConfig *execdriver.ProcessConfig, pid
 	if err := m.container.toDiskLocking(); err != nil {
 		logrus.Errorf("Error saving container to disk: %v", err)
 	}
+	return nil
 }
 
 // resetContainer resets the container's IO and ensures that the command is able to be executed again


### PR DESCRIPTION
Use the new hook functionality from runC/libcontainer to perform the setting of the network namespace path into libnetwork's sandbox entity.  This is the final required step to solve the conflict between user namespaces and the (original) libnetwork network namespace setup flow.  See #15187 for more details.

Thanks @mavenugo for the original design.
