### PR TITLE
Windows: Turn off TestBuildStopSignal

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5662,6 +5662,7 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test_build_stop_signal"
 	_, err := buildImage(name,
 		`FROM busybox


### PR DESCRIPTION
@calavera Missed this one before. Making this test Linux specific. Addressing the rest of the tests to run on Windows is being done incrementally such as in #16312. This specific test will be addressed by introducing an alternate negative test as Windows does not support StopSignal.
