### PR TITLE
daemon/events: let Log be [slightly] blocking

### DIFF
--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -45,19 +45,17 @@ func (e *Events) Evict(l chan interface{}) {
 // Log broadcasts event to listeners. Each listener has 100 millisecond for
 // receiving event or it will be skipped.
 func (e *Events) Log(action, id, from string) {
-	go func() {
-		e.mu.Lock()
-		jm := &jsonmessage.JSONMessage{Status: action, ID: id, From: from, Time: time.Now().UTC().Unix()}
-		if len(e.events) == cap(e.events) {
-			// discard oldest event
-			copy(e.events, e.events[1:])
-			e.events[len(e.events)-1] = jm
-		} else {
-			e.events = append(e.events, jm)
-		}
-		e.mu.Unlock()
-		e.pub.Publish(jm)
-	}()
+	jm := &jsonmessage.JSONMessage{Status: action, ID: id, From: from, Time: time.Now().UTC().Unix()}
+	e.mu.Lock()
+	if len(e.events) == cap(e.events) {
+		// discard oldest event
+		copy(e.events, e.events[1:])
+		e.events[len(e.events)-1] = jm
+	} else {
+		e.events = append(e.events, jm)
+	}
+	e.mu.Unlock()
+	e.pub.Publish(jm)
 }
 
 // SubscribersCount returns number of event listeners


### PR DESCRIPTION
With go1.5's concurrency, the use of a goroutine in Log'ing events was
causing the resulting events to not be in order.

ping @LK4D4 

Signed-off-by: Vincent Batts vbatts@redhat.com
