### PR TITLE
Handle registries that don't provides API version.

### DIFF
--- a/graph/registry.go
+++ b/graph/registry.go
@@ -71,6 +71,11 @@ func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEnd
 	defer resp.Body.Close()
 
 	versions := auth.APIVersions(resp, endpoint.VersionHeader)
+	if len(versions) == 0 {
+		// The remote server didn't give us a version header. Let's set it to something to avoid nil pointer
+		// errors later
+		versions = append(versions, auth.APIVersion{Type: "unknown", Version: "-1"})
+	}
 	if endpoint.VersionHeader != "" && len(endpoint.Versions) > 0 {
 		var foundVersion bool
 		for _, version := range endpoint.Versions {


### PR DESCRIPTION
This commit works around an issue wherein docker pull from a webserver serving flat files would cause docker daemon
to traceback with nil pointer errors. This commit sets the version of the remote registry to "unknown" when the
registry did not provide the API version header.

Thanks to Vincent Batts (vbatts) for the fix in his comment on #15173.

Fixes #15173

Signed-off-by: Randy Barlow rbarlow@redhat.com
