### PR TITLE
[Fix 16326] Bash completion syntax error on OSX

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -182,12 +182,12 @@ __docker_pos_first_nonflag() {
 # globs like '--log-level|-l'
 # Only positions between the command and the current word are considered.
 __docker_value_of_option() {
-	local option_glob=$1
+	local option_extglob=$(__docker_to_extglob "$1")
 
 	local counter=$((command_pos + 1))
 	while [ $counter -lt $cword ]; do
 		case ${words[$counter]} in
-			@($option_glob) )
+			$option_extglob )
 				echo ${words[$counter + 1]}
 				break
 				;;


### PR DESCRIPTION
ref: #16326
On systems where the extglob shell option is not set by default, bash completion would issue an error when sourcing the Docker completion file, see #16326.
The code dealing with this condition (in `_docker` function) was insufficient.

I verified the script in the `albers/bash-completion-mac` image with and without the extglob option set.
