### PR TITLE
Windows: Enable docker volume

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -47,6 +47,8 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/trust"
+	volumedrivers "github.com/docker/docker/volume/drivers"
+	"github.com/docker/docker/volume/local"
 	"github.com/docker/libnetwork"
 	"github.com/opencontainers/runc/libcontainer/netlink"
 )
@@ -1117,4 +1119,13 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 
 	// Now do platform-specific verification
 	return verifyPlatformContainerSettings(daemon, hostConfig, config)
+}
+
+func configureVolumes(config *Config) (*volumeStore, error) {
+	volumesDriver, err := local.New(config.Root)
+	if err != nil {
+		return nil, err
+	}
+	volumedrivers.Register(volumesDriver, volumesDriver.Name())
+	return newVolumeStore(volumesDriver.List()), nil
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -21,8 +21,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
-	volumedrivers "github.com/docker/docker/volume/drivers"
-	"github.com/docker/docker/volume/local"
 	"github.com/docker/libnetwork"
 	nwapi "github.com/docker/libnetwork/api"
 	nwconfig "github.com/docker/libnetwork/config"
@@ -253,15 +251,6 @@ func configureKernelSecuritySupport(config *Config, driverName string) error {
 // MigrateIfDownlevel is a wrapper for AUFS migration for downlevel
 func migrateIfDownlevel(driver graphdriver.Driver, root string) error {
 	return migrateIfAufs(driver, root)
-}
-
-func configureVolumes(config *Config) (*volumeStore, error) {
-	volumesDriver, err := local.New(config.Root)
-	if err != nil {
-		return nil, err
-	}
-	volumedrivers.Register(volumesDriver, volumesDriver.Name())
-	return newVolumeStore(volumesDriver.List()), nil
 }
 
 func configureSysInit(config *Config) (string, error) {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -75,11 +75,6 @@ func migrateIfDownlevel(driver graphdriver.Driver, root string) error {
 	return nil
 }
 
-func configureVolumes(config *Config) (*volumeStore, error) {
-	// Windows does not support volumes at this time
-	return &volumeStore{}, nil
-}
-
 func configureSysInit(config *Config) (string, error) {
 	// TODO Windows.
 	return os.Getenv("TEMP"), nil

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/docker/docker/volume"
@@ -23,11 +22,8 @@ const (
 	volumesPathName    = "volumes"
 )
 
-var (
-	// ErrNotFound is the typed error returned when the requested volume name can't be found
-	ErrNotFound = errors.New("volume not found")
-	oldVfsDir   = filepath.Join("vfs", "dir")
-)
+// ErrNotFound is the typed error returned when the requested volume name can't be found
+var ErrNotFound = errors.New("volume not found")
 
 // New instantiates a new Root instance with the provided scope. Scope
 // is the base path that the Root instance uses to store its
@@ -171,22 +167,6 @@ func (r *Root) Get(name string) (volume.Volume, error) {
 		return nil, ErrNotFound
 	}
 	return v, nil
-}
-
-// scopedPath verifies that the path where the volume is located
-// is under Docker's root and the valid local paths.
-func (r *Root) scopedPath(realPath string) bool {
-	// Volumes path for Docker version >= 1.7
-	if strings.HasPrefix(realPath, filepath.Join(r.scope, volumesPathName)) && realPath != filepath.Join(r.scope, volumesPathName) {
-		return true
-	}
-
-	// Volumes path for Docker version < 1.7
-	if strings.HasPrefix(realPath, filepath.Join(r.scope, oldVfsDir)) {
-		return true
-	}
-
-	return false
 }
 
 // localVolume implements the Volume interface from the volume package and

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -1,0 +1,29 @@
+// +build linux freebsd
+
+// Package local provides the default implementation for volumes. It
+// is used to mount data volume containers and directories local to
+// the host server.
+package local
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+var oldVfsDir = filepath.Join("vfs", "dir")
+
+// scopedPath verifies that the path where the volume is located
+// is under Docker's root and the valid local paths.
+func (r *Root) scopedPath(realPath string) bool {
+	// Volumes path for Docker version >= 1.7
+	if strings.HasPrefix(realPath, filepath.Join(r.scope, volumesPathName)) && realPath != filepath.Join(r.scope, volumesPathName) {
+		return true
+	}
+
+	// Volumes path for Docker version < 1.7
+	if strings.HasPrefix(realPath, filepath.Join(r.scope, oldVfsDir)) {
+		return true
+	}
+
+	return false
+}

--- a/volume/local/local_windows.go
+++ b/volume/local/local_windows.go
@@ -1,0 +1,18 @@
+// Package local provides the default implementation for volumes. It
+// is used to mount data volume containers and directories local to
+// the host server.
+package local
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// scopedPath verifies that the path where the volume is located
+// is under Docker's root and the valid local paths.
+func (r *Root) scopedPath(realPath string) bool {
+	if strings.HasPrefix(realPath, filepath.Join(r.scope, volumesPathName)) && realPath != filepath.Join(r.scope, volumesPathName) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@cpuguy83 @calavera This enables the docker volume command to work against a Windows daemon. It's the precursor to adding volume support in the Windows daemon (actively working on it). This change is self contained enough to stand alone.

![volume](https://cloud.githubusercontent.com/assets/10522484/9919321/e06ae844-5c80-11e5-8069-008bb20da01b.JPG)
