### PR TITLE
refactor stats to not use internal data structures

### DIFF
--- a/api/server/container.go
+++ b/api/server/container.go
@@ -59,16 +59,6 @@ func (s *Server) getContainersStats(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	stream := boolValueOrDefault(r, "stream", true)
-
-	// If the container is not running and requires no stream, return an empty stats.
-	container, err := s.daemon.Get(vars["name"])
-	if err != nil {
-		return err
-	}
-	if !container.IsRunning() && !stream {
-		return writeJSON(w, http.StatusOK, &types.Stats{})
-	}
-
 	var out io.Writer
 	if !stream {
 		w.Header().Set("Content-Type", "application/json")
@@ -90,7 +80,7 @@ func (s *Server) getContainersStats(ctx context.Context, w http.ResponseWriter, 
 		Version:   version,
 	}
 
-	return s.daemon.ContainerStats(container, config)
+	return s.daemon.ContainerStats(vars["name"], config)
 }
 
 func (s *Server) getContainersLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -22,7 +22,18 @@ type ContainerStatsConfig struct {
 
 // ContainerStats writes information about the container to the stream
 // given in the config object.
-func (daemon *Daemon) ContainerStats(container *Container, config *ContainerStatsConfig) error {
+func (daemon *Daemon) ContainerStats(prefixOrName string, config *ContainerStatsConfig) error {
+
+	container, err := daemon.Get(prefixOrName)
+	if err != nil {
+		return err
+	}
+
+	// If the container is not running and requires no stream, return an empty stats.
+	if !container.IsRunning() && !config.Stream {
+		return json.NewEncoder(config.OutStream).Encode(&types.Stats{})
+	}
+
 	updates, err := daemon.subscribeToContainerStats(container)
 	if err != nil {
 		return err


### PR DESCRIPTION
In preparation for future work to pull the APIs into a separate deliverable, we need to not make references back into the daemon or other core engine code. The stats command referenced the daemon-struct for a container. This work attempts to move the code that does that into the daemon itself.

Also tried to improve the test case for stats by checking that the container we're asking for actually shows up in the output.

cc @icecrime @calavera 
