### PR TITLE
Skip racey TestDockerCmdInDirWithTimeout

### DIFF
--- a/pkg/integration/dockerCmd_utils_test.go
+++ b/pkg/integration/dockerCmd_utils_test.go
@@ -269,6 +269,7 @@ func (s *DockerCmdSuite) TestDockerCmdInDir(c *check.C) {
 // DockerCmdInDirWithTimeout tests
 
 func (s *DockerCmdSuite) TestDockerCmdInDirWithTimeout(c *check.C) {
+	c.Skip("racey test")
 	tempFolder, err := ioutil.TempDir("", "test-docker-cmd-in-dir")
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
This is also failing often:

https://jenkins.dockerproject.org/job/Docker-PRs/15789/console
https://jenkins.dockerproject.org/job/Docker-PRs/15790/console

ping @cpuguy83 

Signed-off-by: Antonio Murdaca runcom@linux.com
