### PR TITLE
Reset data of stats in docker cli when container stopped

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -99,6 +99,11 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 			s.CPUPercentage = 0
 			s.Memory = 0
 			s.MemoryPercentage = 0
+			s.MemoryLimit = 0
+			s.NetworkRx = 0
+			s.NetworkTx = 0
+			s.BlockRead = 0
+			s.BlockWrite = 0
 			s.mu.Unlock()
 		case err := <-u:
 			if err != nil {


### PR DESCRIPTION
When use `docker stats` to minitor a running container and then stop it,
there are some fields need to be reset to zero. Otherwise it will keep
displaying the data it received last time.

Signed-off-by: Hu Keping hukeping@huawei.com
