### PR TITLE
Add missing Content-Type check to API Start Exec.

### DIFF
--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -24,7 +24,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		return Cli.StatusError{StatusCode: 1}
 	}
 
-	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, map[string][]string{"Content-Type": []string{"application/json"}})
+	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, map[string][]string{"Content-Type": {"application/json"}})
 	if err != nil {
 		return err
 	}

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -24,7 +24,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		return Cli.StatusError{StatusCode: 1}
 	}
 
-	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, map[string][]string{"Content-Type": "application/json"})
+	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, map[string][]string{"Content-Type": []string{"application/json"}})
 	if err != nil {
 		return err
 	}

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -24,7 +24,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		return Cli.StatusError{StatusCode: 1}
 	}
 
-	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, nil)
+	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, map[string][]string{"Content-Type": "application/json"})
 	if err != nil {
 		return err
 	}

--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -63,6 +63,9 @@ func (s *Server) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 	if err := parseForm(r); err != nil {
 		return err
 	}
+	if err := checkForJSON(r); err != nil {
+		return err
+	}
 	var (
 		execName                  = vars["name"]
 		stdin, inStream           io.ReadCloser


### PR DESCRIPTION
The request content-type for [Exec Start](https://docs.docker.com/reference/api/docker_remote_api_v1.20/#exec-start) needs to be "application/json" and while the Docker API does check content-type for  [Exec Create](https://docs.docker.com/reference/api/docker_remote_api_v1.20/#exec-create) it was not checked for Exec Start. Using invalid content-type would lead to 500 error without explanation. The proposed change adds this missing check and explanation if invalid content-type is used.
