### PR TITLE
bash completion: use generic `tag` log driver option

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -275,10 +275,10 @@ __docker_log_drivers() {
 
 __docker_log_driver_options() {
 	# see docs/reference/logging/index.md
-	local fluentd_options="fluentd-address fluentd-tag"
-	local gelf_options="gelf-address gelf-tag"
+	local fluentd_options="fluentd-address tag"
+	local gelf_options="gelf-address tag"
 	local json_file_options="max-file max-size"
-	local syslog_options="syslog-address syslog-facility syslog-tag"
+	local syslog_options="syslog-address syslog-facility tag"
 	local awslogs_options="awslogs-region awslogs-group awslogs-stream"
 
 	case $(__docker_value_of_option --log-driver) in


### PR DESCRIPTION
This implements bash completion for #15384.

In contrast to the `docker` command, completion no longer supports `{fluentd,gelf,syslog}-tag`.
The rationale behind this is that users should no longer be encouraged to use deprecated features.
Note that you still can use these options by typing them manually.
