### PR TITLE
Fix GET /containers/json emtpy response regression

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -84,7 +84,7 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 
 // reduceContainer parses the user filtering and generates the list of containers to return based on a reducer.
 func (daemon *Daemon) reduceContainers(config *ContainersConfig, reducer containerReducer) ([]*types.Container, error) {
-	var containers []*types.Container
+	containers := []*types.Container{}
 
 	ctx, err := daemon.foldFilter(config)
 	if err != nil {

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1514,3 +1514,14 @@ func (s *DockerSuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs(
 		c.Fatalf("expected ErrContainerRootfsReadonly error, but got %d: %s", statusCode, string(body))
 	}
 }
+
+func (s *DockerSuite) TestContainersApiGetContainersJSONEmpty(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	if string(body) != "[]\n" {
+		c.Fatalf("Expected empty response to be `[]`, got %q", string(body))
+	}
+}


### PR DESCRIPTION
GET /containers/json route used to reply with and empty array `[]` when no
containers where available. Daemon containers list refactor introduced
this bug by declaring an empty slice istead of initializing it as well
and it was now replying with `null`.

Signed-off-by: Antonio Murdaca runcom@linux.com
