### PR TITLE
Fix 'rename' error msg and error checking

### DIFF
--- a/api/client/rename.go
+++ b/api/client/rename.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -16,8 +17,12 @@ func (cli *DockerCli) CmdRename(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	oldName := cmd.Arg(0)
-	newName := cmd.Arg(1)
+	oldName := strings.TrimSpace(cmd.Arg(0))
+	newName := strings.TrimSpace(cmd.Arg(1))
+
+	if oldName == "" || newName == "" {
+		return fmt.Errorf("Error: Neither old nor new names may be empty")
+	}
 
 	if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/rename?name=%s", oldName, newName), nil, nil)); err != nil {
 		fmt.Fprintf(cli.err, "%s\n", err)

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -9,7 +9,7 @@ import (
 // reserved.
 func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	if oldName == "" || newName == "" {
-		return fmt.Errorf("usage: docker rename OLD_NAME NEW_NAME")
+		return fmt.Errorf("Neither old nor new names may be empty")
 	}
 
 	container, err := daemon.Get(oldName)

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -74,6 +74,14 @@ func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
 		c.Fatalf("Renaming container to invalid name should have failed: %s\n%v", out, err)
 	}
 
+	if out, _, err := dockerCmdWithError("rename", "myname", ""); err == nil || !strings.Contains(out, "may be empty") {
+		c.Fatalf("Renaming container to empty name should have failed: %s\n%v", out, err)
+	}
+
+	if out, _, err := dockerCmdWithError("rename", "", "newname"); err == nil || !strings.Contains(out, "may be empty") {
+		c.Fatalf("Renaming container to empty name should have failed: %s\n%v", out, err)
+	}
+
 	if out, _, err := dockerCmdWithError("ps", "-a"); err != nil || !strings.Contains(out, "myname") {
 		c.Fatalf("Output of docker ps should have included 'myname': %s\n%v", out, err)
 	}


### PR DESCRIPTION
`docker rename foo ''` would result in:

```
usage: docker rename OLD_NAME NEW_NAME
```

which is the old engine's way of return errors - yes that's in the
daemon code.  So I fixed that error msg to just be normal.

While doing that I noticed that using an empty string for the
source container name failed but didn't print any error message at all.
This is because we would generate a URL like: ../containers//rename/..
which would cause a 301 redirect to ../containers/rename/..
however the CLI code doesn't actually deal with 301's - it just ignores
them and returns back to the CLI code/caller.

Rather than changing the CLI to deal with 3xx error codes, which would
probably be a good thing to do in a follow-on PR, for this immediate
issue I just added a cli-side check for empty strings for both old and
new names. This way we catch it even before we hit the daemon.

API callers will get a 404, assuming they follow the 301, for the
case of the src being empty, and the new error msg when the destination
is empty - so we should be good now.

Add tests for both cases too.

Signed-off-by: Doug Davis dug@us.ibm.com
