### PR TITLE
Fix regression in /v.../containers/json for empty array

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -84,7 +84,7 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 
 // reduceContainer parses the user filtering and generates the list of containers to return based on a reducer.
 func (daemon *Daemon) reduceContainers(config *ContainersConfig, reducer containerReducer) ([]*types.Container, error) {
-	var containers []*types.Container
+	containers := []*types.Container{}
 
 	ctx, err := daemon.foldFilter(config)
 	if err != nil {

--- a/daemon/list_test.go
+++ b/daemon/list_test.go
@@ -1,0 +1,54 @@
+package daemon
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/docker/docker/pkg/graphdb"
+)
+
+func TestContainersReturnsEmptyArray(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "docker-daemon-list-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	graph, err := graphdb.NewSqliteConn(path.Join(tmp, "daemon_test.db"))
+	if err != nil {
+		t.Fatalf("Failed to create daemon test sqlite database.")
+	}
+
+	store := &contStore{s: map[string]*Container{}}
+
+	daemon := &Daemon{
+		repository:       tmp,
+		root:             tmp,
+		containerGraphDB: graph,
+		containers:       store,
+	}
+
+	containerConfig := &ContainersConfig{
+		All:     true,
+		Since:   "",
+		Before:  "",
+		Limit:   -1,
+		Size:    false,
+		Filters: "",
+	}
+
+	containers, err := daemon.Containers(containerConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if containers == nil {
+		t.Errorf("Expected empty array of containers, got nil")
+	}
+
+	if len(containers) != 0 {
+		t.Errorf("Expected empty array of containers, length was %d", len(containers))
+	}
+}


### PR DESCRIPTION
Reported as https://github.com/docker/compose/issues/2009

I believe 06699f73fb6d779894a875f9177afc5a1f3bc5b3 broke the API return value for `/v.../containers/json` when the response is empty. It should be an empty json array, currently it returns `null`.

+area/api
+kind/bug
