### PR TITLE
Windows: Fix error in daemon log on info

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,17 +140,6 @@ func CopyFile(src, dst string) (int64, error) {
 	}
 	defer df.Close()
 	return io.Copy(df, sf)
-}
-
-// GetTotalUsedFds Returns the number of used File Descriptors by
-// reading it via /proc filesystem.
-func GetTotalUsedFds() int {
-	if fds, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
-		logrus.Errorf("Error opening /proc/%d/fd: %s", os.Getpid(), err)
-	} else {
-		return len(fds)
-	}
-	return -1
 }
 
 // ReadSymlinkedDirectory returns the target directory of a symlink.

--- a/pkg/fileutils/fileutils_unix.go
+++ b/pkg/fileutils/fileutils_unix.go
@@ -1,0 +1,22 @@
+// +build linux freebsd
+
+package fileutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// GetTotalUsedFds Returns the number of used File Descriptors by
+// reading it via /proc filesystem.
+func GetTotalUsedFds() int {
+	if fds, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
+		logrus.Errorf("Error opening /proc/%d/fd: %s", os.Getpid(), err)
+	} else {
+		return len(fds)
+	}
+	return -1
+}

--- a/pkg/fileutils/fileutils_windows.go
+++ b/pkg/fileutils/fileutils_windows.go
@@ -1,0 +1,7 @@
+package fileutils
+
+// GetTotalUsedFds Returns the number of used File Descriptors. Not supported
+// on Windows.
+func GetTotalUsedFds() int {
+	return -1
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This has been annoying me for ages! Finally fixed it. When you run docker info against a Windows daemon, the daemon log will error log it could access /proc/fd, which is hardly surprising as there is no concept of that on Windows. Made it a no-op in a platform file on Windows.
