### PR TITLE
Fix #16356 (--net=none jenkins build)

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1618,7 +1618,7 @@ func (s *DockerDaemonSuite) TestDaemonCorruptedSyslogAddress(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *check.C) {
-	c.Assert(s.d.Start("--log-driver=json-file", "--log-opt=max-size=1k"), check.IsNil)
+	c.Assert(s.d.StartWithBusybox("--log-driver=json-file", "--log-opt=max-size=1k"), check.IsNil)
 	out, err := s.d.Cmd("run", "-d", "--name=logtest", "busybox", "top")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s, err: %v", out, err))
 	out, err = s.d.Cmd("inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", "logtest")


### PR DESCRIPTION
Fixes TestDaemonWideLogConfig test by making sure to have busybox image available

Signed-off-by: Sergey Evstifeev sergey.evstifeev@gmail.com
