### PR TITLE
Increase test timeout to accommodate slow gccgo compiles

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -150,7 +150,7 @@ ORIG_BUILDFLAGS=( -a -tags "netgo static_build sqlite_omit_load_extension $DOCKE
 # see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.
-: ${TIMEOUT:=60m}
+: ${TIMEOUT:=120m}
 TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 LDFLAGS_STATIC_DOCKER="


### PR DESCRIPTION
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
