### PR TITLE
Windows [TP4]: Adds support for Hyper-V Containers

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -269,7 +269,7 @@ func (container *Container) Start() (err error) {
 		}
 	}()
 
-	if err := container.Mount(); err != nil {
+	if err := container.conditionalMountOnStart(); err != nil {
 		return err
 	}
 
@@ -341,9 +341,7 @@ func (container *Container) cleanup() {
 		logrus.Errorf("%s: Failed to umount ipc filesystems: %v", container.ID, err)
 	}
 
-	if err := container.Unmount(); err != nil {
-		logrus.Errorf("%s: Failed to umount filesystem: %v", container.ID, err)
-	}
+	container.conditionalUnmountOnCleanup()
 
 	for _, eConfig := range container.execCommands.s {
 		container.daemon.unregisterExecCommand(eConfig)

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1433,3 +1433,20 @@ func (container *Container) ipcMounts() []execdriver.Mount {
 func detachMounted(path string) error {
 	return syscall.Unmount(path, syscall.MNT_DETACH)
 }
+
+// conditionalMountOnStart is a platform specific helper function during the
+// container start to call mount.
+func (container *Container) conditionalMountOnStart() error {
+	if err := container.Mount(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// conditionalUnmountOnCleanup is a platform specific helper function called
+// during the cleanup of a container to unmount.
+func (container *Container) conditionalUnmountOnCleanup() {
+	if err := container.Unmount(); err != nil {
+		logrus.Errorf("%v: Failed to umount filesystem: %v", container.ID, err)
+	}
+}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -210,4 +210,5 @@ type Command struct {
 	LayerPaths         []string          `json:"layer_paths"` // Windows needs to know the layer paths and folder for a command
 	LayerFolder        string            `json:"layer_folder"`
 	Hostname           string            `json:"hostname"` // Windows sets the hostname in the execdriver
+	Isolated           bool              `json:"isolated"` // Windows: Isolated is a Hyper-V container rather than Windows Server Container
 }

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -77,6 +77,8 @@ type containerInit struct {
 	ProcessorWeight         int64       // CPU Shares 1..9 on Windows; or 0 is platform default.
 	HostName                string      // Hostname
 	MappedDirectories       []mappedDir // List of mapped directories (volumes/mounts)
+	SandboxPath             string      // Location of unmounted sandbox (used for Hyper-V containers, not Windows Server containers)
+	HvPartition             bool        // True if it a Hyper-V Container
 }
 
 // defaultOwner is a tag passed to HCS to allow it to differentiate between
@@ -108,6 +110,14 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 		LayerFolderPath:         c.LayerFolder,
 		ProcessorWeight:         c.Resources.CPUShares,
 		HostName:                c.Hostname,
+		HvPartition:             c.Isolated,
+	}
+
+	if c.Isolated {
+		cu.SandboxPath = filepath.Dir(c.LayerFolder)
+	} else {
+		cu.VolumePath = c.Rootfs
+		cu.LayerFolderPath = c.LayerFolder
 	}
 
 	for _, layerPath := range c.LayerPaths {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -75,6 +75,10 @@ func DecodeContainerConfig(src io.Reader) (*Config, *HostConfig, error) {
 		return nil, nil, err
 	}
 
+	// Validate the isolation level
+	if err := ValidateIsolationLevel(hc); err != nil {
+		return nil, nil, err
+	}
 	return w.Config, hc, nil
 }
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -19,6 +19,16 @@ type KeyValuePair struct {
 // NetworkMode represents the container network stack.
 type NetworkMode string
 
+// IsolationLevel represents the isolation level of a container. The supported
+// values are platform specific
+type IsolationLevel string
+
+// IsDefault indicates the default isolation level of a container. On Linux this
+// is LXC. On Windows, this is a Windows Server Container.
+func (i IsolationLevel) IsDefault() bool {
+	return strings.ToLower(string(i)) == "default" || string(i) == ""
+}
+
 // IpcMode represents the container ipc stack.
 type IpcMode string
 
@@ -254,6 +264,7 @@ type HostConfig struct {
 	CgroupParent      string                // Parent cgroup.
 	ConsoleSize       [2]int                // Initial console size on Windows
 	VolumeDriver      string                // Name of the volume driver used to mount volumes
+	Isolation         IsolationLevel        // Isolation level of the container (eg default, hyperv)
 }
 
 // DecodeHostConfig creates a HostConfig based on the specified Reader.

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+// IsValid indicates is an isolation level is valid
+func (i IsolationLevel) IsValid() bool {
+	return i.IsDefault()
+}
+
 // IsPrivate indicates whether container uses it's private network stack.
 func (n NetworkMode) IsPrivate() bool {
 	return !(n.IsHost() || n.IsContainer())

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -1,8 +1,21 @@
 package runconfig
 
+import "strings"
+
 // IsDefault indicates whether container uses the default network stack.
 func (n NetworkMode) IsDefault() bool {
 	return n == "default"
+}
+
+// IsHyperV indicates the use of Hyper-V Containers for isolation (as opposed
+// to Windows Server Containers
+func (i IsolationLevel) IsHyperV() bool {
+	return strings.ToLower(string(i)) == "hyperv"
+}
+
+// IsValid indicates is an isolation level is valid
+func (i IsolationLevel) IsValid() bool {
+	return i.IsDefault() || i.IsHyperV()
 }
 
 // DefaultDaemonNetworkMode returns the default network stack the daemon should

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -55,22 +55,21 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 
 		flUlimits = opts.NewUlimitOpt(nil)
 
-		flPublish     = opts.NewListOpts(nil)
-		flExpose      = opts.NewListOpts(nil)
-		flDNS         = opts.NewListOpts(opts.ValidateIPAddress)
-		flDNSSearch   = opts.NewListOpts(opts.ValidateDNSSearch)
-		flDNSOptions  = opts.NewListOpts(nil)
-		flExtraHosts  = opts.NewListOpts(opts.ValidateExtraHost)
-		flVolumesFrom = opts.NewListOpts(nil)
-		flLxcOpts     = opts.NewListOpts(nil)
-		flEnvFile     = opts.NewListOpts(nil)
-		flCapAdd      = opts.NewListOpts(nil)
-		flCapDrop     = opts.NewListOpts(nil)
-		flGroupAdd    = opts.NewListOpts(nil)
-		flSecurityOpt = opts.NewListOpts(nil)
-		flLabelsFile  = opts.NewListOpts(nil)
-		flLoggingOpts = opts.NewListOpts(nil)
-
+		flPublish           = opts.NewListOpts(nil)
+		flExpose            = opts.NewListOpts(nil)
+		flDNS               = opts.NewListOpts(opts.ValidateIPAddress)
+		flDNSSearch         = opts.NewListOpts(opts.ValidateDNSSearch)
+		flDNSOptions        = opts.NewListOpts(nil)
+		flExtraHosts        = opts.NewListOpts(opts.ValidateExtraHost)
+		flVolumesFrom       = opts.NewListOpts(nil)
+		flLxcOpts           = opts.NewListOpts(nil)
+		flEnvFile           = opts.NewListOpts(nil)
+		flCapAdd            = opts.NewListOpts(nil)
+		flCapDrop           = opts.NewListOpts(nil)
+		flGroupAdd          = opts.NewListOpts(nil)
+		flSecurityOpt       = opts.NewListOpts(nil)
+		flLabelsFile        = opts.NewListOpts(nil)
+		flLoggingOpts       = opts.NewListOpts(nil)
 		flNetwork           = cmd.Bool([]string{"#n", "#-networking"}, true, "Enable networking for this container")
 		flPrivileged        = cmd.Bool([]string{"#privileged", "-privileged"}, false, "Give extended privileges to this container")
 		flPidMode           = cmd.String([]string{"-pid"}, "", "PID namespace to use")
@@ -104,6 +103,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flCgroupParent      = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 		flVolumeDriver      = cmd.String([]string{"-volume-driver"}, "", "Optional volume driver for the container")
 		flStopSignal        = cmd.String([]string{"-stop-signal"}, signal.DefaultStopSignal, fmt.Sprintf("Signal to stop a container, %v by default", signal.DefaultStopSignal))
+		flIsolation         = cmd.String([]string{"-isolation"}, "default", "Container isolation level")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR")
@@ -377,6 +377,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		LogConfig:         LogConfig{Type: *flLoggingDriver, Config: loggingOpts},
 		CgroupParent:      *flCgroupParent,
 		VolumeDriver:      *flVolumeDriver,
+		Isolation:         IsolationLevel(*flIsolation),
 	}
 
 	// When allocating stdin in attached mode, close stdin at client disconnect

--- a/runconfig/parse_unix.go
+++ b/runconfig/parse_unix.go
@@ -4,6 +4,7 @@ package runconfig
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -55,6 +56,20 @@ func ValidateNetMode(c *Config, hc *HostConfig) error {
 
 	if hc.NetworkMode.IsContainer() && len(c.ExposedPorts) > 0 {
 		return ErrConflictNetworkExposePorts
+	}
+	return nil
+}
+
+// ValidateIsolationLevel performs platform specific validation of the
+// isolation level in the hostconfig structure. Linux only supports "default"
+// which is LXC container isolation
+func ValidateIsolationLevel(hc *HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if !hc.Isolation.IsValid() {
+		return fmt.Errorf("invalid --isolation: %q - %s only supports 'default'", hc.Isolation, runtime.GOOS)
 	}
 	return nil
 }

--- a/runconfig/parse_windows.go
+++ b/runconfig/parse_windows.go
@@ -20,3 +20,18 @@ func ValidateNetMode(c *Config, hc *HostConfig) error {
 	}
 	return nil
 }
+
+// ValidateIsolationLevel performs platform specific validation of the
+// isolation level in the hostconfig structure. Windows supports 'default' (or
+// blank), and 'hyperv'. These refer to Windows Server Containers and
+// Hyper-V Containers respectively.
+func ValidateIsolationLevel(hc *HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if !hc.Isolation.IsValid() {
+		return fmt.Errorf("invalid --isolation: %q. Windows supports 'default' (Windows Server Container) or 'hyperv' (Hyper-V Container)", hc.Isolation)
+	}
+	return nil
+}


### PR DESCRIPTION
@jstarks This adds the --isolated flag to allow a container to be run as a Hyper-V Container rather than a Windows Server Container.
