### PR TITLE
Format output of docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -53,13 +53,13 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	if info.Debug {
 		fmt.Fprintf(cli.out, "Debug mode (server): %v\n", info.Debug)
-		fmt.Fprintf(cli.out, "File Descriptors: %d\n", info.NFd)
-		fmt.Fprintf(cli.out, "Goroutines: %d\n", info.NGoroutines)
-		fmt.Fprintf(cli.out, "System Time: %s\n", info.SystemTime)
-		fmt.Fprintf(cli.out, "EventsListeners: %d\n", info.NEventsListener)
-		fmt.Fprintf(cli.out, "Init SHA1: %s\n", info.InitSha1)
-		fmt.Fprintf(cli.out, "Init Path: %s\n", info.InitPath)
-		fmt.Fprintf(cli.out, "Docker Root Dir: %s\n", info.DockerRootDir)
+		fmt.Fprintf(cli.out, " File Descriptors: %d\n", info.NFd)
+		fmt.Fprintf(cli.out, " Goroutines: %d\n", info.NGoroutines)
+		fmt.Fprintf(cli.out, " System Time: %s\n", info.SystemTime)
+		fmt.Fprintf(cli.out, " EventsListeners: %d\n", info.NEventsListener)
+		fmt.Fprintf(cli.out, " Init SHA1: %s\n", info.InitSha1)
+		fmt.Fprintf(cli.out, " Init Path: %s\n", info.InitPath)
+		fmt.Fprintf(cli.out, " Docker Root Dir: %s\n", info.DockerRootDir)
 	}
 
 	ioutils.FprintfIfNotEmpty(cli.out, "Http Proxy: %s\n", info.HTTPProxy)
@@ -73,7 +73,8 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 			fmt.Fprintf(cli.out, "Registry: %v\n", info.IndexServerAddress)
 		}
 	}
-	// Only output these warnings if the server supports these features
+
+	// Only output these warnings if the server does not support these features
 	if h, err := httputils.ParseServerHeader(serverResp.header.Get("Server")); err == nil {
 		if h.OS != "windows" {
 			if !info.MemoryLimit {
@@ -101,9 +102,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		}
 	}
 
-	if info.ExperimentalBuild {
-		fmt.Fprintf(cli.out, "Experimental: true\n")
-	}
+	ioutils.FprintfIfTrue(cli.out, "Experimental: %v\n", info.ExperimentalBuild)
 
 	return nil
 }

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -26,25 +26,26 @@ For example:
      Root Dir: /var/lib/docker/aufs
      Backing Filesystem: extfs
      Dirs: 545
+     Dirperm1 Supported: true
     Execution Driver: native-0.2
     Logging Driver: json-file
-    Kernel Version: 3.13.0-24-generic
-    Operating System: Ubuntu 14.04 LTS
-    CPUs: 1
-    Name: prod-server-42
-    ID: 7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS
-    Total Memory: 2 GiB
-    Debug mode (server): false
-    Debug mode (client): true
-    File Descriptors: 10
-    Goroutines: 9
-    System Time: Tue Mar 10 18:38:57 UTC 2015
-    EventsListeners: 0
-    Init Path: /usr/bin/docker
-    Docker Root Dir: /var/lib/docker
-    Http Proxy: http://test:test@localhost:8080
-    Https Proxy: https://test:test@localhost:8080
-    No Proxy: 9.81.1.160
+    Kernel Version: 3.19.0-22-generic
+    Operating System: Ubuntu 15.04
+    CPUs: 24
+    Total Memory: 62.86 GiB
+    Name: docker
+    ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    Debug mode (server): true
+     File Descriptors: 59
+     Goroutines: 159
+     System Time: 2015-09-23T14:04:20.699842089+08:00
+     EventsListeners: 0
+     Init SHA1:
+     Init Path: /usr/bin/docker
+     Docker Root Dir: /var/lib/docker
+     Http Proxy: http://test:test@localhost:8080
+     Https Proxy: https://test:test@localhost:8080
+    WARNING: No swap limit support
     Username: svendowideit
     Registry: [https://index.docker.io/v1/]
     Labels:

--- a/docs/userguide/labels-custom-metadata.md
+++ b/docs/userguide/labels-custom-metadata.md
@@ -185,29 +185,36 @@ on how to query labels set on a container.
 
 These labels appear as part of the `docker info` output for the daemon:
 
-    docker -D info
+    $ docker -D info
     Containers: 12
     Images: 672
+    Engine Version: 1.9.0
     Storage Driver: aufs
      Root Dir: /var/lib/docker/aufs
      Backing Filesystem: extfs
      Dirs: 697
+     Dirperm1 Supported: true
     Execution Driver: native-0.2
     Logging Driver: json-file
-    Kernel Version: 3.13.0-32-generic
-    Operating System: Ubuntu 14.04.1 LTS
-    CPUs: 1
-    Total Memory: 994.1 MiB
-    Name: docker.example.com
-    ID: RC3P:JTCT:32YS:XYSB:YUBG:VFED:AAJZ:W3YW:76XO:D7NN:TEVU:UCRW
-    Debug mode (server): false
-    Debug mode (client): true
-    File Descriptors: 11
-    Goroutines: 14
-    EventsListeners: 0
-    Init Path: /usr/bin/docker
-    Docker Root Dir: /var/lib/docker
+    Kernel Version: 3.19.0-22-generic
+    Operating System: Ubuntu 15.04
+    CPUs: 24
+    Total Memory: 62.86 GiB
+    Name: docker
+    ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    Debug mode (server): true
+     File Descriptors: 59
+     Goroutines: 159
+     System Time: 2015-09-23T14:04:20.699842089+08:00
+     EventsListeners: 0
+     Init SHA1:
+     Init Path: /usr/bin/docker
+     Docker Root Dir: /var/lib/docker
+     Http Proxy: http://test:test@localhost:8080
+     Https Proxy: https://test:test@localhost:8080
     WARNING: No swap limit support
+    Username: svendowideit
+    Registry: [https://index.docker.io/v1/]
     Labels:
      com.example.environment=production
      com.example.storage=ssd

--- a/pkg/ioutils/fmt.go
+++ b/pkg/ioutils/fmt.go
@@ -12,3 +12,11 @@ func FprintfIfNotEmpty(w io.Writer, format, value string) (int, error) {
 	}
 	return 0, nil
 }
+
+// FprintfIfTrue prints the boolean value if it's true
+func FprintfIfTrue(w io.Writer, format string, ok bool) (int, error) {
+	if ok {
+		return fmt.Fprintf(w, format, ok)
+	}
+	return 0, nil
+}


### PR DESCRIPTION
Two main things:
- Format those info which will only be displayed when daemon is in debug mode.
- Add a function `FprintfIfTrue` which is like `FprintfIfNotEmpty` to simplify the logic 

Signed-off-by: Hu Keping hukeping@huawei.com
