### PR TITLE
Add missing '[OPTIONS]' arg to documentation for 'docker version'.

### DIFF
--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -11,7 +11,7 @@ weight=1
 
 # version
 
-    Usage: docker version
+    Usage: docker version [OPTIONS]
 
     Show the Docker version information.
 


### PR DESCRIPTION
Signed-off-by: Charles Chan charleswhchan@users.noreply.github.com
