### PR TITLE
integration-cli: skip TestRunDeviceDirectory with testRequires

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -87,9 +87,7 @@ func (s *DockerSuite) TestRunWithVolumesIsRecursive(c *check.C) {
 
 func (s *DockerSuite) TestRunDeviceDirectory(c *check.C) {
 	testRequires(c, NativeExecDriver)
-	if _, err := os.Stat("/dev/snd"); err != nil {
-		c.Skip("Host does not have /dev/snd")
-	}
+	testRequires(c, SameHostDaemon)
 
 	out, _ := dockerCmd(c, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
 	if actual := strings.Trim(out, "\r\n"); !strings.Contains(out, "timer") {


### PR DESCRIPTION
skipping test by requiring same daemon host (unix) instead of stat'ing

Signed-off-by: Antonio Murdaca runcom@linux.com
