### PR TITLE
Cleanup: remove unnecessary return at the end of block in volume.go

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -210,7 +210,6 @@ func (s *volumeStore) Increment(v volume.Volume) {
 		return
 	}
 	vc.count++
-	return
 }
 
 // Decrement decrements the usage count of the passed in volume by 1
@@ -224,7 +223,6 @@ func (s *volumeStore) Decrement(v volume.Volume) {
 		return
 	}
 	vc.count--
-	return
 }
 
 // Count returns the usage count of the passed in volume


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Remove the unnecessary return at the end of block
