### PR TITLE
Docker pull "dry run" mode

### DIFF
--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -17,6 +17,7 @@ import (
 func (cli *DockerCli) CmdPull(args ...string) error {
 	cmd := Cli.Subcmd("pull", []string{"NAME[:TAG|@DIGEST]"}, "Pull an image or a repository from a registry", true)
 	allTags := cmd.Bool([]string{"a", "-all-tags"}, false, "Download all tagged images in the repository")
+	dryRun := cmd.Bool([]string{"d", "-dry-run"}, false, "Dry run mode - only displays the download size")
 	addTrustedFlags(cmd, true)
 	cmd.Require(flag.Exact, 1)
 
@@ -47,6 +48,10 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 
 	v := url.Values{}
 	v.Set("fromImage", ref.ImageName(taglessRemote))
+
+	if *dryRun {
+		v.Set("dryRun", "true")
+	}
 
 	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/create?"+v.Encode(), nil, cli.out, repoInfo.Index, "pull")
 	return err

--- a/api/server/image.go
+++ b/api/server/image.go
@@ -76,6 +76,7 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 		repo    = r.Form.Get("repo")
 		tag     = r.Form.Get("tag")
 		message = r.Form.Get("message")
+		dryRun  = r.Form.Get("dryRun")
 	)
 	authEncoded := r.Header.Get("X-Registry-Auth")
 	authConfig := &cliconfig.AuthConfig{}
@@ -112,7 +113,7 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			OutStream:   output,
 		}
 
-		err = s.daemon.Repositories().Pull(image, tag, imagePullConfig)
+		err = s.daemon.Repositories().Pull(image, tag, imagePullConfig, dryRun != "")
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/docker/pkg/progressreader"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/stringutils"
+	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/tarsum"
 	"github.com/docker/docker/pkg/urlutil"
@@ -42,7 +43,7 @@ import (
 )
 
 func (b *builder) readContext(context io.Reader) (err error) {
-	tmpdirPath, err := ioutil.TempDir("", "docker-build")
+	tmpdirPath, err := getTempDir("", "docker-build")
 	if err != nil {
 		return
 	}
@@ -305,7 +306,7 @@ func calcCopyInfo(b *builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 		}
 
 		// Create a tmp dir
-		tmpDirName, err := ioutil.TempDir(b.contextPath, "docker-remote")
+		tmpDirName, err := getTempDir(b.contextPath, "docker-remote")
 		if err != nil {
 			return err
 		}
@@ -684,14 +685,14 @@ func (b *builder) run(c *daemon.Container) error {
 
 func (b *builder) checkPathForAddition(orig string) error {
 	origPath := filepath.Join(b.contextPath, orig)
-	origPath, err := filepath.EvalSymlinks(origPath)
+	origPath, err := symlink.EvalSymlinks(origPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("%s: no such file or directory", orig)
 		}
 		return err
 	}
-	contextPath, err := filepath.EvalSymlinks(b.contextPath)
+	contextPath, err := symlink.EvalSymlinks(b.contextPath)
 	if err != nil {
 		return err
 	}

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -30,7 +30,7 @@ type Puller interface {
 	// Pull returns an error if any, as well as a boolean that determines whether to retry Pull on the next configured endpoint.
 	//
 	// TODO(tiborvass): have Pull() take a reference to repository + tag, so that the puller itself is repository-agnostic.
-	Pull(tag string) (fallback bool, err error)
+	Pull(tag string, dryRun bool) (fallback bool, err error)
 }
 
 // NewPuller returns a Puller interface that will pull from either a v1 or v2
@@ -62,7 +62,7 @@ func NewPuller(s *TagStore, endpoint registry.APIEndpoint, repoInfo *registry.Re
 
 // Pull initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConfig) error {
+func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConfig, dryRun bool) error {
 	var sf = streamformatter.NewJSONStreamFormatter()
 
 	// Resolve the Repository name from fqn to RepositoryInfo
@@ -112,7 +112,7 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 			lastErr = err
 			continue
 		}
-		if fallback, err := puller.Pull(tag); err != nil {
+		if fallback, err := puller.Pull(tag, dryRun); err != nil {
 			if fallback {
 				if _, ok := err.(registry.ErrNoSupport); !ok {
 					// Because we found an error that's not ErrNoSupport, discard all subsequent ErrNoSupport errors.
@@ -145,8 +145,10 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 // status message indicates that a newer image was downloaded. Otherwise, it
 // indicates that the image is up to date. requestedTag is the tag the message
 // will refer to.
-func writeStatus(requestedTag string, out io.Writer, sf *streamformatter.StreamFormatter, layersDownloaded bool) {
-	if layersDownloaded {
+func writeStatus(requestedTag string, out io.Writer, sf *streamformatter.StreamFormatter, layersDownloaded bool, dryRun bool) {
+	if dryRun {
+		out.Write(sf.FormatStatus("", "Status: Dry Run completed for %s", requestedTag))
+	} else if layersDownloaded {
 		out.Write(sf.FormatStatus("", "Status: Downloaded newer image for %s", requestedTag))
 	} else {
 		out.Write(sf.FormatStatus("", "Status: Image is up to date for %s", requestedTag))

--- a/graph/pull_v1.go
+++ b/graph/pull_v1.go
@@ -28,10 +28,15 @@ type v1Puller struct {
 	session  *registry.Session
 }
 
-func (p *v1Puller) Pull(tag string) (fallback bool, err error) {
+func (p *v1Puller) Pull(tag string, dryRun bool) (fallback bool, err error) {
 	if utils.DigestReference(tag) {
 		// Allowing fallback, because HTTPS v1 is before HTTP v2
 		return true, registry.ErrNoSupport{errors.New("Cannot pull by digest with v1 registry")}
+	}
+
+	if dryRun {
+		// Only in v2 for now
+		return true, registry.ErrNoSupport{errors.New("Dry Run not supported with v1 registry")}
 	}
 
 	tlsConfig, err := p.registryService.TLSConfig(p.repoInfo.Index.Name)
@@ -56,14 +61,14 @@ func (p *v1Puller) Pull(tag string) (fallback bool, err error) {
 		logrus.Debugf("Fallback from error: %s", err)
 		return true, err
 	}
-	if err := p.pullRepository(tag); err != nil {
+	if err := p.pullRepository(tag, dryRun); err != nil {
 		// TODO(dmcgowan): Check if should fallback
 		return false, err
 	}
 	return false, nil
 }
 
-func (p *v1Puller) pullRepository(askedTag string) error {
+func (p *v1Puller) pullRepository(askedTag string, dryRun bool) error {
 	out := p.config.OutStream
 	out.Write(p.sf.FormatStatus("", "Pulling repository %s", p.repoInfo.CanonicalName))
 
@@ -220,7 +225,7 @@ func (p *v1Puller) pullRepository(askedTag string) error {
 	if len(askedTag) > 0 {
 		requestedTag = utils.ImageReference(p.repoInfo.LocalName, askedTag)
 	}
-	writeStatus(requestedTag, out, p.sf, layersDownloaded)
+	writeStatus(requestedTag, out, p.sf, layersDownloaded, dryRun)
 	return nil
 }
 

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -250,7 +250,7 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 		}
 
 		totalSize += desc.Size
-		nbLayers ++
+		nbLayers++
 		if dryRun {
 			logrus.Debugf("%v layer size is %v bytes", stringid.TruncateID(img.ID), desc.Size)
 			continue

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -31,7 +31,7 @@ type v2Puller struct {
 	sessionID string
 }
 
-func (p *v2Puller) Pull(tag string) (fallback bool, err error) {
+func (p *v2Puller) Pull(tag string, dryRun bool) (fallback bool, err error) {
 	// TODO(tiborvass): was ReceiveTimeout
 	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
@@ -41,7 +41,7 @@ func (p *v2Puller) Pull(tag string) (fallback bool, err error) {
 
 	p.sessionID = stringid.GenerateRandomID()
 
-	if err := p.pullV2Repository(tag); err != nil {
+	if err := p.pullV2Repository(tag, dryRun); err != nil {
 		if registry.ContinueOnError(err) {
 			logrus.Debugf("Error trying v2 registry: %v", err)
 			return true, err
@@ -51,7 +51,7 @@ func (p *v2Puller) Pull(tag string) (fallback bool, err error) {
 	return false, nil
 }
 
-func (p *v2Puller) pullV2Repository(tag string) (err error) {
+func (p *v2Puller) pullV2Repository(tag string, dryRun bool) (err error) {
 	var tags []string
 	taggedName := p.repoInfo.LocalName
 	if len(tag) > 0 {
@@ -76,6 +76,9 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 	broadcaster.Add(p.config.OutStream)
 	if found {
 		// Another pull of the same repository is already taking place; just wait for it to finish
+		if dryRun {
+			fmt.Printf("!!! Another pull of the same image is already running, dry-run is not possible unless you restart the Docker daemon !!!\n")
+		}
 		return broadcaster.Wait()
 	}
 
@@ -89,14 +92,15 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 	for _, tag := range tags {
 		// pulledNew is true if either new layers were downloaded OR if existing images were newly tagged
 		// TODO(tiborvass): should we change the name of `layersDownload`? What about message in WriteStatus?
-		pulledNew, err := p.pullV2Tag(broadcaster, tag, taggedName)
+		pulledNew, err := p.pullV2Tag(broadcaster, tag, taggedName, dryRun)
+
 		if err != nil {
 			return err
 		}
 		layersDownloaded = layersDownloaded || pulledNew
 	}
 
-	writeStatus(taggedName, broadcaster, p.sf, layersDownloaded)
+	writeStatus(taggedName, broadcaster, p.sf, layersDownloaded, dryRun)
 
 	return nil
 }
@@ -172,7 +176,7 @@ func (p *v2Puller) download(di *downloadInfo) {
 	di.err <- nil
 }
 
-func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bool, err error) {
+func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool) (verified bool, err error) {
 	logrus.Debugf("Pulling tag from V2 registry: %q", tag)
 
 	manSvc, err := p.repo.Manifests(context.Background())
@@ -211,12 +215,22 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 		}
 	}()
 
+	var totalSize int64
+	totalSize = 0
+	nbLayers := 0
+
+	if dryRun {
+		fmt.Printf("**** Dry Run - nothing will be downloaded ****\n")
+	}
+
 	for i := len(manifest.FSLayers) - 1; i >= 0; i-- {
+
 		img, err := image.NewImgJSON([]byte(manifest.History[i].V1Compatibility))
 		if err != nil {
 			logrus.Debugf("error getting image v1 json: %v", err)
 			return false, err
 		}
+
 		p.graph.Retain(p.sessionID, img.ID)
 		layerIDs = append(layerIDs, img.ID)
 
@@ -226,12 +240,28 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 			out.Write(p.sf.FormatProgress(stringid.TruncateID(img.ID), "Already exists", nil))
 			continue
 		}
+
+		digest := manifest.FSLayers[i].BlobSum
+		blobs := p.repo.Blobs(context.Background())
+		desc, err := blobs.Stat(context.Background(), digest)
+		if err != nil {
+			logrus.Debugf("Error statting layer: %v", err)
+			return false, err
+		}
+
+		totalSize += desc.Size
+		nbLayers += 1
+		if dryRun {
+			logrus.Debugf("%v layer size is %v bytes", stringid.TruncateID(img.ID), desc.Size)
+			continue
+		}
+
 		out.Write(p.sf.FormatProgress(stringid.TruncateID(img.ID), "Pulling fs layer", nil))
 
 		d := &downloadInfo{
 			img:     img,
 			poolKey: "layer:" + img.ID,
-			digest:  manifest.FSLayers[i].BlobSum,
+			digest:  digest,
 			// TODO: seems like this chan buffer solved hanging problem in go1.5,
 			// this can indicate some deeper problem that somehow we never take
 			// error from channel in loop below
@@ -254,6 +284,10 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 		} else {
 			go p.download(d)
 		}
+	}
+	if dryRun {
+		out.Write(p.sf.FormatStatus(tag, "Dry Run: %v bytes to be downloaded, in %v layers", totalSize, nbLayers))
+		return true, nil
 	}
 
 	var tagUpdated bool

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -250,7 +250,7 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 		}
 
 		totalSize += desc.Size
-		nbLayers += 1
+		nbLayers ++
 		if dryRun {
 			logrus.Debugf("%v layer size is %v bytes", stringid.TruncateID(img.ID), desc.Size)
 			continue

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -137,11 +137,11 @@ func (p *v2Puller) download(di *downloadInfo) {
 
 	if di.size == 0 {
 		size, err := p.extractSize(di)
-		di.size = size
 		if err != nil {
 			di.err <- err
 			return
 		}
+		di.size = size
 	}
 
 	layerDownload, err := blobs.Open(context.Background(), di.digest)
@@ -225,8 +225,7 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 		}
 	}()
 
-	var layerSizes map[string]int64
-	layerSizes = make(map[string]int64)
+	layerSizes := make(map[string]int64)
 
 	if dryRun {
 		out.Write(p.sf.FormatStatus(tag, "**** Dry Run - nothing will be downloaded ****"))
@@ -255,7 +254,6 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 			img:     img,
 			poolKey: "layer:" + img.ID,
 			digest:  digest,
-			size:    0,
 			// TODO: seems like this chan buffer solved hanging problem in go1.5,
 			// this can indicate some deeper problem that somehow we never take
 			// error from channel in loop below
@@ -267,9 +265,8 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 			if err != nil {
 				return false, err
 			}
-			d.size = size
 			logrus.Debugf("Layer %s size: %v", digest.String(), size)
-			layerSizes[digest.String()] = d.size
+			layerSizes[digest.String()] = size
 			continue
 		}
 
@@ -294,7 +291,6 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 	}
 	if dryRun {
 		var totalSize int64
-		totalSize = 0
 		for _, v := range layerSizes {
 			totalSize += v
 		}

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -77,7 +77,7 @@ func (p *v2Puller) pullV2Repository(tag string, dryRun bool) (err error) {
 	if found {
 		// Another pull of the same repository is already taking place; just wait for it to finish
 		if dryRun {
-			fmt.Printf("!!! Another pull of the same image is already running, dry-run is not possible unless you restart the Docker daemon !!!\n")
+			broadcaster.Write(p.sf.FormatStatus(tag, "!!! Another pull of the same image is already running, dry-run is not possible unless you restart the Docker daemon !!!"))
 		}
 		return broadcaster.Wait()
 	}
@@ -220,7 +220,7 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string, dryRun bool)
 	nbLayers := 0
 
 	if dryRun {
-		fmt.Printf("**** Dry Run - nothing will be downloaded ****\n")
+		out.Write(p.sf.FormatStatus(tag, "**** Dry Run - nothing will be downloaded ****"))
 	}
 
 	for i := len(manifest.FSLayers) - 1; i >= 0; i-- {


### PR DESCRIPTION
This is our contribution to Docker Global Hack Day 3.
It adds the ability to "dry run" a "docker pull" command, obtaining only the total size of image layers that have to be downloaded.
A new `-d` flag activates this mode:

```
docker pull -d jenkins
Using default tag: latest
INFO[0005] POST /v1.21/images/create?dryRun=true&fromImage=jenkins%3Alatest 
INFO[0008] Image manifest for jenkins:latest has been verified 
**** Dry Run - nothing will be downloaded ****
latest: Pulling from library/jenkins
latest: Dry Run: 376344319 bytes to be downloaded, in 33 layers
Status: Dry Run completed for jenkins:latest
```

At the end of the Hackaton, we found this related Feature request: https://github.com/docker/docker/issues/1512. Although it's labelled "docker pull info", a comment by @unclejack states that a flag approach would be preferred.
So it seems we're in the right direction with this.
## 

Some limitations:
- Currently only works with v2 registry. 
- Does not work if a background pull is already running on the same image (but displays a nice warning ;-) )
- Please review the REST API and CLI parts to be sure we did not break anything.
