### PR TITLE
docker looks for certificates in a wrong place, and do not uses certificates on pull/push

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/distribution/registry/api/v2"
@@ -131,6 +134,23 @@ func NewServiceConfig(options *Options) *ServiceConfig {
 	return config
 }
 
+// certificatesPresent returns false if certificates are not found in CertsDir.
+// True will be returned if directory contains any *.crt file
+func certificatesPresent(indexName string) bool {
+	certPath := filepath.Join(CertsDir, cleanPath(indexName))
+	files, err := ioutil.ReadDir(certPath)
+	if err != nil && !os.IsNotExist(err) {
+		return false
+	}
+
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".crt") {
+			return true
+		}
+	}
+	return false
+}
+
 // isSecureIndex returns false if the provided indexName is part of the list of insecure registries
 // Insecure registries accept HTTP and/or accept HTTPS with certificates from unknown CAs.
 //
@@ -147,6 +167,11 @@ func (config *ServiceConfig) isSecureIndex(indexName string) bool {
 	// is called from anything besides NewIndexInfo, in order to honor per-index configurations.
 	if index, ok := config.IndexConfigs[indexName]; ok {
 		return index.Secure
+	}
+
+	// Check for certificates, if they are installed, connection should be secure
+	if certificatesPresent(indexName) {
+		return true
 	}
 
 	host, _, err := net.SplitHostPort(indexName)
@@ -207,7 +232,16 @@ func ValidateIndexName(val string) (string, error) {
 	if strings.HasPrefix(val, "-") || strings.HasSuffix(val, "-") {
 		return "", fmt.Errorf("Invalid index name (%s). Cannot begin or end with a hyphen.", val)
 	}
-	// *TODO: Check if valid hostname[:port]/ip[:port]?
+
+	parsedURL, err := url.Parse(val)
+	if err != nil {
+		return "", fmt.Errorf("Invalid index url (%s): %v\n", val, err)
+	}
+
+	if parsedURL.Host != "" {
+		val = parsedURL.Host
+	}
+
 	return val, nil
 }
 
@@ -248,6 +282,12 @@ func ValidateRepositoryName(reposName string) error {
 // NewIndexInfo returns IndexInfo configuration from indexName
 func (config *ServiceConfig) NewIndexInfo(indexName string) (*IndexInfo, error) {
 	var err error
+	secureIndex := false
+
+	if strings.HasPrefix(indexName, "https://") {
+		secureIndex = true
+	}
+
 	indexName, err = ValidateIndexName(indexName)
 	if err != nil {
 		return nil, err
@@ -263,8 +303,13 @@ func (config *ServiceConfig) NewIndexInfo(indexName string) (*IndexInfo, error) 
 		Name:     indexName,
 		Mirrors:  make([]string, 0),
 		Official: false,
+		Secure:   secureIndex,
 	}
-	index.Secure = config.isSecureIndex(indexName)
+
+	if !secureIndex {
+		index.Secure = config.isSecureIndex(indexName)
+	}
+
 	return index, nil
 }
 


### PR DESCRIPTION
I was trying to login to my private registry using self-signed user certificates, but always received error:

``` bash
~$ docker login -u test -p test -e test@test.com https://localhost:5000
Error response from daemon: invalid registry endpoint https://localhost:5000/v0/: unable to ping registry endpoint https://localhost:5000/v0/
v2 ping attempt failed with error: Get https://localhost:5000/v2/: dial tcp 127.0.0.1:5000: connection refused
 v1 ping attempt failed with error: Get https://localhost:5000/v1/_ping: dial tcp 127.0.0.1:5000: connection refused. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry localhost:5000` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/localhost:5000/ca.crt
```

in this time, docker daemon was trying to search certificates in `/etc/docker/certs.d/https:/localhost:5000` directory, i think this wrong path, and in docs has no information about "http:" prefix in certificates path

``` bash
DEBU[0071] hostDir: /etc/docker/certs.d/https:/localhost:5000 
DEBU[0071] crt: /etc/docker/certs.d/https:/localhost:5000/ca.crt 
DEBU[0071] cert: /etc/docker/certs.d/https:/localhost:5000/client.cert 
DEBU[0071] key: /etc/docker/certs.d/https:/localhost:5000/client.key 
```

This fix allows me to login correctly without setting https prefix in index name, and allow to pull/push images.

Signed-off-by: Vladimir Bulyga xx@ccxx.cc
