### PR TITLE
Replaced slash with hiphen in syslog log format

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -81,7 +81,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		proto,
 		address,
 		facility,
-		path.Base(os.Args[0])+"/"+tag,
+		path.Base(os.Args[0])+"-"+tag,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Slash is not a valid character inside tag (RFC3164) and skipped by rsyslog when reading `%appName%`
