### PR TITLE
docker/logs: Fix race in --follow option

### DIFF
--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -40,9 +40,10 @@ type Logger interface {
 
 // ReadConfig is the configuration passed into ReadLogs.
 type ReadConfig struct {
-	Since  time.Time
-	Tail   int
-	Follow bool
+	Since            time.Time
+	Tail             int
+	Follow           bool
+	ContainerStopped chan bool
 }
 
 // LogReader is the interface for reading log messages for loggers that support reading.

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -60,12 +60,37 @@ func (daemon *Daemon) ContainerLogs(container *Container, config *ContainerLogsC
 
 	logrus.Debug("logs: begin stream")
 	readConfig := logger.ReadConfig{
-		Since:  config.Since,
-		Tail:   tailLines,
-		Follow: follow,
+		Since:            config.Since,
+		Tail:             tailLines,
+		Follow:           follow,
+		ContainerStopped: make(chan bool, 2),
 	}
-	logs := logReader.ReadLogs(readConfig)
 
+	done := false
+
+	/*
+	 * In case of follow notify logger code when container stops
+	 */
+	if follow {
+		go func() {
+			for {
+				container.WaitStop(time.Second)
+				if !container.IsRunning() {
+					readConfig.ContainerStopped <- true
+					return
+				}
+				if done {
+					return
+				}
+			}
+		}()
+	}
+
+	defer func() {
+		done = true
+	}()
+
+	logs := logReader.ReadLogs(readConfig)
 	for {
 		select {
 		case err := <-logs.Err:


### PR DESCRIPTION
The "TestLogsFollowSlowStdoutConsumer" test sometimes hangs on s390x.
Also on x86 systems we could reproduce the hang by changing the test
variables as follows:

```
- out, _ := dockerCmd(c, "run",...`usleep 200000;yes X | head -c 200000`)
+ out, _ := dockerCmd(c, "run",...`usleep 10000;yes X | head -c 10000`)
```

We analyzed the problem and found a race in "docker logs -f".
The following sequence leads to the hang situation:

```
[1] Container is started: <container ID> =
    docker run -d busybox /bin/sh -c "usleep 200000;yes X | head -c 200000"

[2] Docker logs -f is started: docker logs -f <container ID>

    daemon/logs.go:

    ContainerLogs()
     follow := config.Follow && container.IsRunning()
     readConfig.Follow = follow  [3] follow is true

     [4] Container exits here -> no more inode actity on json log file

     logReader.ReadLogs(readConfig)

    daemon/logger/jsonfilelog/jsonfilelog.go:

    ReadLogs(config)
     go readLogs(config)

      tailFile() -> read current log
        if (!config.Follow) <--- follow is true
          return
        else
          followLogs()
            fileWatcher.Add(f.Name()) [5] fsnotify watcher for json file
            for {
               msg, err := decodeLogLine(dec, l)
                 -> msg = nil, err = EOF

               if err != nil {
                 select {

                 [6] We block here because fsnotify will not report
                     any events

                 }
```

To fix the problem add a new channel "containerStopped" to "ReadConfig"
and start a go routine that informs the follow logs code via the channel
when the container is stopped. In "followLogs()" add the new channel to
the select statement where the hang situation occurs. Now the select
statement is unblocked via the "containerStopped" channel if the container
is stopped.

Closes #16462
Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
