### PR TITLE
skip devmapper unit tests if no udev sync;

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/devicemapper"
 )
 
 var (
@@ -79,6 +80,9 @@ func newDriver(t *testing.T, name string) *Driver {
 		t.Logf("graphdriver: %v\n", err)
 		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || err == graphdriver.ErrIncompatibleFS {
 			t.Skipf("Driver %s not supported", name)
+		}
+		if supported := devicemapper.UdevSetSyncSupport(true); !supported && name == "devicemapper" {
+			t.Skipf("Driver %s requires udev sync support", name)
 		}
 		t.Fatal(err)
 	}


### PR DESCRIPTION
pinng @vbatts @tiborvass this is so that i can switch the main jenkins nodes to use aufs, we still run devmapper tests on devmapper machines :)

stop gap so we can see if other bug is overlay related :/ 
