### PR TITLE
Format the output of docker history

### DIFF
--- a/api/client/history.go
+++ b/api/client/history.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -57,9 +58,9 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			}
 
 			if *noTrunc {
-				fmt.Fprintf(w, "%s\t", entry.CreatedBy)
+				fmt.Fprintf(w, "%s\t", strings.Replace(entry.CreatedBy, "\t", " ", -1))
 			} else {
-				fmt.Fprintf(w, "%s\t", stringutils.Truncate(entry.CreatedBy, 45))
+				fmt.Fprintf(w, "%s\t", stringutils.Truncate(strings.Replace(entry.CreatedBy, "\t", " ", -1), 45))
 			}
 
 			if *human {


### PR DESCRIPTION
Once there have '\t' in the "CREATED BY" section, it will possibly
cause a messy output of docker history.

Signed-off-by: Hu Keping hukeping@huawei.com
