### PR TITLE
Separate graph identifier from graph driver

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -84,6 +84,7 @@ type CommonContainer struct {
 	command                *execdriver.Command
 	monitor                *containerMonitor
 	execCommands           *execStore
+	cacheID                string
 	daemon                 *Daemon
 	// logDriver for closing
 	logDriver logger.Logger

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -465,12 +465,20 @@ func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint *stringutils.StrSlic
 
 func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID string) (*Container, error) {
 	var (
-		id  string
-		err error
+		id      string
+		cacheID string
+		err     error
 	)
 	id, name, err = daemon.generateIDAndName(name)
 	if err != nil {
 		return nil, err
+	}
+
+	if imgID != "" {
+		cacheID, err = daemon.graph.GetCacheID(imgID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	daemon.generateHostname(id, config)
@@ -483,6 +491,7 @@ func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID 
 	base.Config = config
 	base.hostConfig = &runconfig.HostConfig{}
 	base.ImageID = imgID
+	base.cacheID = cacheID
 	base.NetworkSettings = &network.Settings{}
 	base.Name = name
 	base.Driver = daemon.driver.String()
@@ -914,7 +923,7 @@ func (daemon *Daemon) createRootfs(container *Container) error {
 		return err
 	}
 	initID := fmt.Sprintf("%s-init", container.ID)
-	if err := daemon.driver.Create(initID, container.ImageID); err != nil {
+	if err := daemon.driver.Create(initID, container.cacheID); err != nil {
 		return err
 	}
 	initPath, err := daemon.driver.Get(initID, "")

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -89,6 +89,7 @@ const (
 	jsonFileName      = "json"
 	layersizeFileName = "layersize"
 	digestFileName    = "checksum"
+	cacheIDFileName   = "cache-id"
 	tarDataFileName   = "tar-data.json.gz"
 )
 
@@ -97,6 +98,10 @@ var (
 	// but the layer has no digest value or content to compute the
 	// the digest.
 	ErrDigestNotSet = errors.New("digest is not set for layer")
+
+	// ErrCacheNotSet is used when there is no cached identifier
+	// with the graph driver set for the layer.
+	ErrCacheNotSet = errors.New("cache id is not set for layer")
 )
 
 // NewGraph instantiates a new graph at the given root path in the filesystem.
@@ -142,7 +147,20 @@ func (graph *Graph) restore() error {
 	var ids = []string{}
 	for _, v := range dir {
 		id := v.Name()
-		if graph.driver.Exists(id) {
+
+		cacheID, err := graph.GetCacheID(id)
+		if err != nil {
+			if err == ErrCacheNotSet && graph.driver.Exists(cacheID) {
+				logrus.Debugf("Layer file not set, creating for %s", id)
+				cacheID = id
+				if err := graph.SetCacheID(id, cacheID); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+		if graph.driver.Exists(cacheID) {
 			ids = append(ids, id)
 		}
 	}
@@ -184,7 +202,11 @@ func (graph *Graph) Get(name string) (*image.Image, error) {
 	}
 
 	if img.Size < 0 {
-		size, err := graph.driver.DiffSize(img.ID, img.Parent)
+		cacheID, parentID, err := graph.GetCacheIDs(img.ID, img.Parent)
+		if err != nil {
+			return nil, err
+		}
+		size, err := graph.driver.DiffSize(cacheID, parentID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to calculate size of image id %q: %s", img.ID, err)
 		}
@@ -235,10 +257,13 @@ func (graph *Graph) Register(img *image.Image, layerData io.Reader) (err error) 
 	graph.imageMutex.Lock(img.ID)
 	defer graph.imageMutex.Unlock(img.ID)
 
+	cacheID, err := graph.getCacheID(img.ID)
 	// Skip register if image is already registered
-	if graph.Exists(img.ID) {
+	if err == nil && graph.Exists(cacheID) {
 		return nil
 	}
+
+	cacheID = stringid.GenerateRandomID()
 
 	// The returned `error` must be named in this function's signature so that
 	// `err` is not shadowed in this deferred cleanup.
@@ -246,7 +271,7 @@ func (graph *Graph) Register(img *image.Image, layerData io.Reader) (err error) 
 		// If any error occurs, remove the new dir from the driver.
 		// Don't check for errors since the dir might not have been created.
 		if err != nil {
-			graph.driver.Remove(img.ID)
+			graph.driver.Remove(cacheID)
 		}
 	}()
 
@@ -261,7 +286,7 @@ func (graph *Graph) Register(img *image.Image, layerData io.Reader) (err error) 
 	// (the graph is the source of truth).
 	// Ignore errors, since we don't know if the driver correctly returns ErrNotExist.
 	// (FIXME: make that mandatory for drivers).
-	graph.driver.Remove(img.ID)
+	graph.driver.Remove(cacheID)
 
 	tmp, err := graph.mktemp("")
 	defer os.RemoveAll(tmp)
@@ -269,8 +294,12 @@ func (graph *Graph) Register(img *image.Image, layerData io.Reader) (err error) 
 		return fmt.Errorf("mktemp failed: %s", err)
 	}
 
+	if err := graph.saveCacheID(tmp, cacheID); err != nil {
+		return err
+	}
+
 	// Create root filesystem in the driver
-	if err := createRootFilesystemInDriver(graph, img); err != nil {
+	if err := createRootFilesystemInDriver(graph, img, tmp); err != nil {
 		return err
 	}
 
@@ -286,9 +315,13 @@ func (graph *Graph) Register(img *image.Image, layerData io.Reader) (err error) 
 	return nil
 }
 
-func createRootFilesystemInDriver(graph *Graph, img *image.Image) error {
-	if err := graph.driver.Create(img.ID, img.Parent); err != nil {
-		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", graph.driver, img.ID, err)
+func createRootFilesystemInDriver(graph *Graph, img *image.Image, root string) error {
+	cacheID, parentID, err := graph.getCacheIDs(root, img.Parent)
+	if err != nil {
+		return err
+	}
+	if err := graph.driver.Create(cacheID, parentID); err != nil {
+		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", graph.driver, cacheID, err)
 	}
 	return nil
 }
@@ -357,8 +390,12 @@ func (graph *Graph) Delete(name string) error {
 		// On err make tmp point to old dir for cleanup
 		tmp = graph.imageRoot(id)
 	}
+	cacheID, err := graph.getCacheID(tmp)
+	if err != nil {
+		return err
+	}
 	// Remove rootfs data from the driver
-	graph.driver.Remove(id)
+	graph.driver.Remove(cacheID)
 	// Remove the trashed image directory
 	return os.RemoveAll(tmp)
 }
@@ -439,8 +476,12 @@ func (graph *Graph) Heads() map[string]*image.Image {
 func (graph *Graph) TarLayer(img *image.Image) (arch io.ReadCloser, err error) {
 	rdr, err := graph.assembleTarLayer(img)
 	if err != nil {
+		cacheID, parentID, err := graph.GetCacheIDs(img.ID, img.Parent)
+		if err != nil {
+			return nil, err
+		}
 		logrus.Debugf("[graph] TarLayer with traditional differ: %s", img.ID)
-		return graph.driver.Diff(img.ID, img.Parent)
+		return graph.driver.Diff(cacheID, parentID)
 	}
 	return rdr, nil
 }
@@ -528,6 +569,68 @@ func (graph *Graph) GetDigest(id string) (digest.Digest, error) {
 	return digest.ParseDigest(string(cs))
 }
 
+// SetCacheID sets the layer id for the provided graph id
+func (graph *Graph) SetCacheID(id string, cacheID string) error {
+	graph.imageMutex.Lock(id)
+	defer graph.imageMutex.Unlock(id)
+
+	return graph.saveCacheID(graph.imageRoot(id), cacheID)
+}
+
+// saveCacheID sets the layer id for the provided graph id
+func (graph *Graph) saveCacheID(root, cacheID string) error {
+	if err := ioutil.WriteFile(filepath.Join(root, cacheIDFileName), []byte(cacheID), 0600); err != nil {
+		return fmt.Errorf("Error storing layer in %s/%s: %s", root, cacheIDFileName, err)
+	}
+	return nil
+}
+
+// GetCacheID gets the layer id for the provided graph id
+func (graph *Graph) GetCacheID(id string) (string, error) {
+	graph.imageMutex.Lock(id)
+	defer graph.imageMutex.Unlock(id)
+
+	return graph.getCacheID(graph.imageRoot(id))
+}
+
+// getCacheID gets the layer id for the provided graph id
+func (graph *Graph) getCacheID(root string) (string, error) {
+	li, err := ioutil.ReadFile(filepath.Join(root, cacheIDFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrCacheNotSet
+		}
+		return "", err
+	}
+	return string(li), nil
+}
+
+// GetCacheIDs gets both the image and parent cache ids
+func (graph *Graph) GetCacheIDs(id, parent string) (string, string, error) {
+	graph.imageMutex.Lock(id)
+	defer graph.imageMutex.Unlock(id)
+
+	return graph.getCacheIDs(graph.imageRoot(id), parent)
+}
+
+// getCacheIDs gets both the image and parent cache ids
+// with the image passing in the root.
+func (graph *Graph) getCacheIDs(root, parent string) (string, string, error) {
+	cacheID, err := graph.getCacheID(root)
+	if err != nil {
+		return "", "", err
+	}
+	parentID := ""
+	if parent != "" {
+		parentID, err = graph.GetCacheID(parent)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return cacheID, parentID, nil
+
+}
+
 // RawJSON returns the JSON representation for an image as a byte array.
 func (graph *Graph) RawJSON(id string) ([]byte, error) {
 	root := graph.imageRoot(id)
@@ -601,7 +704,8 @@ func (graph *Graph) disassembleAndApplyTarLayer(img *image.Image, layerData io.R
 		ar = archive.Reader(rdr)
 	}
 
-	if img.Size, err = graph.driver.ApplyDiff(img.ID, img.Parent, ar); err != nil {
+	layerID, parentID, err := graph.getCacheIDs(root, img.Parent)
+	if img.Size, err = graph.driver.ApplyDiff(layerID, parentID, ar); err != nil {
 		return err
 	}
 
@@ -633,13 +737,19 @@ func (graph *Graph) assembleTarLayer(img *image.Image) (io.ReadCloser, error) {
 		}
 		defer mfz.Close()
 
-		// get our relative path to the container
-		fsLayer, err := graph.driver.Get(img.ID, "")
+		cacheID, err := graph.GetCacheID(img.ID)
 		if err != nil {
 			pW.CloseWithError(err)
 			return
 		}
-		defer graph.driver.Put(img.ID)
+
+		// get our relative path to the container
+		fsLayer, err := graph.driver.Get(cacheID, "")
+		if err != nil {
+			pW.CloseWithError(err)
+			return
+		}
+		defer graph.driver.Put(cacheID)
 
 		metaUnpacker := storage.NewJSONUnpacker(mfz)
 		fileGetter := storage.NewPathFileGetter(fsLayer)

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -42,7 +42,12 @@ func TestMount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := driver.Get(image.ID, ""); err != nil {
+	cacheID, err := graph.GetCacheID(image.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := driver.Get(cacheID, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/graph/service.go
+++ b/graph/service.go
@@ -67,7 +67,11 @@ func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {
 
 	imageInspect.GraphDriver.Name = s.graph.driver.String()
 
-	graphDriverData, err := s.graph.driver.GetMetadata(image.ID)
+	cacheID, err := s.graph.GetCacheID(image.ID)
+	if err != nil {
+		return nil, err
+	}
+	graphDriverData, err := s.graph.driver.GetMetadata(cacheID)
 	if err != nil {
 		return nil, err
 	}

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -20,7 +20,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 	repoName := "foobar-save-load-test"
 	out, _ := dockerCmd(c, "commit", name, repoName)
 
-	before, _ := dockerCmd(c, "inspect", repoName)
+	before, _ := dockerCmd(c, "inspect", "-f", `{{.Id}}`, repoName)
 
 	tmpFile, err := ioutil.TempFile("", "foobar-save-load-test.tar")
 	c.Assert(err, check.IsNil)
@@ -45,7 +45,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 		c.Fatalf("failed to load repo: %s, %v", out, err)
 	}
 
-	after, _ := dockerCmd(c, "inspect", repoName)
+	after, _ := dockerCmd(c, "inspect", "-f", `{{.Id}}`, repoName)
 
 	if before != after {
 		c.Fatalf("inspect is not the same after a save / load")


### PR DESCRIPTION
The graph holds identifiers used to reference images.
Each of these images contains chain of layers which are each referenced by the graph with content cached on disk by the graph driver.
Using a separate ID for the graph driver allows the IDs of the images referenced by the graph to change without modifying the on disk content.
The graph driver IDs should be considered private and never exported regardless of the identifier used by the graph.

Note:
This patch keeps the 1-1 relationship between graph directories and what is stored in the graph driver. Collisions are no more likely than a collision with any other identifier, and their relationship could only be broken through manual intervention.
