### PR TITLE
Windows: [TP4] Pass container name to HCS

### DIFF
--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -125,6 +125,7 @@ func populateCommand(c *Container, env []string) error {
 	// TODO Windows: Factor out remainder of unused fields.
 	c.command = &execdriver.Command{
 		ID:             c.ID,
+		Name:           strings.Replace(c.Name, "/", "", -1), // Strips prefix
 		Rootfs:         c.rootfsPath(),
 		ReadonlyRootfs: c.hostConfig.ReadonlyRootfs,
 		InitPath:       "/.dockerinit",

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -200,6 +200,7 @@ type ProcessConfig struct {
 // and CgroupParent.
 type Command struct {
 	ID                 string            `json:"id"`
+	Name               string            `json:"name"`   // name of the container eg stupified_hodgkin
 	Rootfs             string            `json:"rootfs"` // root fs of the container
 	ReadonlyRootfs     bool              `json:"readonly_rootfs"`
 	InitPath           string            `json:"initpath"` // dockerinit

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -95,7 +95,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 
 	cu := &containerInit{
 		SystemType:              "Container",
-		Name:                    c.ID,
+		Name:                    c.Name,
 		Owner:                   defaultOwner,
 		IsDummy:                 dummyMode,
 		VolumePath:              c.Rootfs,


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

The PowerShell direct folks have requested that the friendly name of the container be passed into HCS so that when entering a powershell session into a container, the user prompt contains the friendly name (adjective_noun construct) rather than the container ID.
