### PR TITLE
refactor attach to not use internal data structures

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -15,7 +15,12 @@ type ContainerAttachWithLogsConfig struct {
 }
 
 // ContainerAttachWithLogs attaches to logs according to the config passed in. See ContainerAttachWithLogsConfig.
-func (daemon *Daemon) ContainerAttachWithLogs(container *Container, c *ContainerAttachWithLogsConfig) error {
+func (daemon *Daemon) ContainerAttachWithLogs(prefixOrName string, c *ContainerAttachWithLogsConfig) error {
+	container, err := daemon.Get(prefixOrName)
+	if err != nil {
+		return err
+	}
+
 	var errStream io.Writer
 
 	if !container.Config.Tty {
@@ -50,6 +55,10 @@ type ContainerWsAttachWithLogsConfig struct {
 }
 
 // ContainerWsAttachWithLogs websocket connection
-func (daemon *Daemon) ContainerWsAttachWithLogs(container *Container, c *ContainerWsAttachWithLogsConfig) error {
+func (daemon *Daemon) ContainerWsAttachWithLogs(prefixOrName string, c *ContainerWsAttachWithLogsConfig) error {
+	container, err := daemon.Get(prefixOrName)
+	if err != nil {
+		return err
+	}
 	return container.attachWithLogs(c.InStream, c.OutStream, c.ErrStream, c.Logs, c.Stream)
 }


### PR DESCRIPTION
- refactor to make it easier to split the api in the future

I found a currently existing function that makes it much easier than I expected to make this change. There are other branches in my fork with similar work in different ways.

The tests seem pretty comprehensive.
