### PR TITLE
Windows: [TP4] Add CPU Weight

### DIFF
--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -72,8 +72,10 @@ func populateCommand(c *Container, env []string) error {
 	// TODO Windows. This can probably be factored out.
 	pid.HostPid = c.hostConfig.PidMode.IsHost()
 
-	// TODO Windows. Resource controls to be implemented later.
-	resources := &execdriver.Resources{}
+	// TODO Windows. More resource controls to be implemented later.
+	resources := &execdriver.Resources{
+		CPUShares: c.hostConfig.CPUShares,
+	}
 
 	// TODO Windows. Further refactoring required (privileged/user)
 	processConfig := execdriver.ProcessConfig{

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -186,7 +186,7 @@ type ProcessConfig struct {
 	ConsoleSize [2]int   `json:"-"` // h,w of initial console size
 }
 
-// Command wrapps an os/exec.Cmd to add more metadata
+// Command wraps an os/exec.Cmd to add more metadata
 //
 // TODO Windows: Factor out unused fields such as LxcConfig, AppArmorProfile,
 // and CgroupParent.

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -69,6 +69,7 @@ type containerInit struct {
 	IgnoreFlushesDuringBoot bool     // Optimisation hint for container startup in Windows
 	LayerFolderPath         string   // Where the layer folders are located
 	Layers                  []layer  // List of storage layers
+	ProcessorWeight         int64    // CPU Shares 1..9 on Windows; or 0 is platform default.
 }
 
 // defaultOwner is a tag passed to HCS to allow it to differentiate between
@@ -98,6 +99,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 		VolumePath:              c.Rootfs,
 		IgnoreFlushesDuringBoot: c.FirstStart,
 		LayerFolderPath:         c.LayerFolder,
+		ProcessorWeight:         c.Resources.CPUShares,
 	}
 
 	for i := 0; i < len(c.LayerPaths); i++ {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This adds the ability for docker run --cpu-shares=n to set the relative weight for containers similar to Linux. The Windows platform (only) supports 1..9 as opposed to 2..262144 that Linux does. 
