### PR TITLE
Fix docker search problem

### DIFF
--- a/api/client/search.go
+++ b/api/client/search.go
@@ -41,12 +41,13 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 
 	// Resolve the Repository name from fqn to hostname + name
 	taglessRemote, _ := parsers.ParseRepositoryTag(name)
-	repoInfo, err := registry.ParseRepositoryInfo(taglessRemote)
+
+	indexInfo, err := registry.ParseIndexInfo(taglessRemote)
 	if err != nil {
 		return err
 	}
 
-	rdr, _, err := cli.clientRequestAttemptLogin("GET", "/images/search?"+v.Encode(), nil, nil, repoInfo.Index, "search")
+	rdr, _, err := cli.clientRequestAttemptLogin("GET", "/images/search?"+v.Encode(), nil, nil, indexInfo, "search")
 	if err != nil {
 		return err
 	}

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -89,3 +89,11 @@ func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 		c.Fatalf("failed to search with stars&automated&no-trunc options on the central registry: %s", out)
 	}
 }
+
+// search for repos which start with "ubuntu-" on the central registry
+func (s *DockerSuite) TestSearchOnCentralRegistryWithDash(c *check.C) {
+	testRequires(c, Network, DaemonIsLinux)
+
+	out, exitCode := dockerCmd(c, "search", "ubuntu-")
+	c.Assert(exitCode, check.Equals, 0, check.Commentf("failed to search on the central registry: %s", out))
+}

--- a/registry/config.go
+++ b/registry/config.go
@@ -295,14 +295,17 @@ func splitReposName(reposName string) (string, string) {
 }
 
 // NewRepositoryInfo validates and breaks down a repository name into a RepositoryInfo
-func (config *ServiceConfig) NewRepositoryInfo(reposName string) (*RepositoryInfo, error) {
+func (config *ServiceConfig) NewRepositoryInfo(reposName string, bySearch bool) (*RepositoryInfo, error) {
 	if err := validateNoSchema(reposName); err != nil {
 		return nil, err
 	}
 
 	indexName, remoteName := splitReposName(reposName)
-	if err := validateRemoteName(remoteName); err != nil {
-		return nil, err
+
+	if !bySearch {
+		if err := validateRemoteName(remoteName); err != nil {
+			return nil, err
+		}
 	}
 
 	repoInfo := &RepositoryInfo{
@@ -354,7 +357,18 @@ func (repoInfo *RepositoryInfo) GetSearchTerm() string {
 // ParseRepositoryInfo performs the breakdown of a repository name into a RepositoryInfo, but
 // lacks registry configuration.
 func ParseRepositoryInfo(reposName string) (*RepositoryInfo, error) {
-	return emptyServiceConfig.NewRepositoryInfo(reposName)
+	return emptyServiceConfig.NewRepositoryInfo(reposName, false)
+}
+
+// ParseIndexInfo will use repository name to get back an indexInfo.
+func ParseIndexInfo(reposName string) (*IndexInfo, error) {
+	indexName, _ := splitReposName(reposName)
+
+	indexInfo, err := emptyServiceConfig.NewIndexInfo(indexName)
+	if err != nil {
+		return nil, err
+	}
+	return indexInfo, nil
 }
 
 // NormalizeLocalName transforms a repository name into a normalize LocalName

--- a/registry/service.go
+++ b/registry/service.go
@@ -51,7 +51,8 @@ func (s *Service) Auth(authConfig *cliconfig.AuthConfig) (string, error) {
 // Search queries the public registry for images matching the specified
 // search terms, and returns the results.
 func (s *Service) Search(term string, authConfig *cliconfig.AuthConfig, headers map[string][]string) (*SearchResults, error) {
-	repoInfo, err := s.ResolveRepository(term)
+
+	repoInfo, err := s.ResolveRepositoryBySearch(term)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +72,13 @@ func (s *Service) Search(term string, authConfig *cliconfig.AuthConfig, headers 
 // ResolveRepository splits a repository name into its components
 // and configuration of the associated registry.
 func (s *Service) ResolveRepository(name string) (*RepositoryInfo, error) {
-	return s.Config.NewRepositoryInfo(name)
+	return s.Config.NewRepositoryInfo(name, false)
+}
+
+// ResolveRepositoryBySearch splits a repository name into its components
+// and configuration of the associated registry.
+func (s *Service) ResolveRepositoryBySearch(name string) (*RepositoryInfo, error) {
+	return s.Config.NewRepositoryInfo(name, true)
 }
 
 // ResolveIndex takes indexName and returns index info


### PR DESCRIPTION
Fixes: https://github.com/docker/docker/issues/16155

Search terms shouldn't be restricted to only full valid repository
names. It should be perfectly valid to search using a part of a name,
even if it ends with a period, dash or underscore.

Signed-off-by: Hu Keping hukeping@huawei.com
