### PR TITLE
volume-create returns error if volume exist

### DIFF
--- a/volume/store/store_test.go
+++ b/volume/store/store_test.go
@@ -37,6 +37,7 @@ func TestGet(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	volumedrivers.Register(vt.FakeDriver{}, "fake")
+	volumedrivers.Register(vt.FakeDriver{}, "feka")
 	s := New()
 	v, err := s.Create("fake1", "fake", nil)
 	if err != nil {
@@ -56,6 +57,11 @@ func TestCreate(t *testing.T) {
 	_, err = s.Create("fakeError", "fake", map[string]string{"error": "create error"})
 	if err == nil || err.Error() != "create error" {
 		t.Fatalf("Expected create error, got %v", err)
+	}
+
+	_, err = s.Create("fake1", "feka", nil)
+	if err == nil || err.Error() != "volume fake1 already exist in driver fake" {
+		t.Fatalf("Expected volume exist error, got nil")
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Deng Guangxing dengguangxing@huawei.com

```
#docker volume
DRIVER              VOLUME NAME
local                    test
# docker volume create --name test --driver anotherdriver
test
```

Creating a volume with existing name(in different driver) would return successfully. This pr will return an error instead

``````
# docker volume create --name test--driver anotherdriver
Error response from daemon: volume test already exist in driver local
```.
``````
