### PR TITLE
Add docker run/create support multiple volume driver

### DIFF
--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -92,7 +92,7 @@ func parseBindMount(spec, volumeDriver string) (*mountPoint, error) {
 	}
 
 	if len(source) == 0 {
-		bind.Driver = volumeDriver
+		name, bind.Driver = getVolumeDriverFromName(name, volumeDriver)
 		if len(bind.Driver) == 0 {
 			bind.Driver = volume.DefaultDriverName
 		}
@@ -103,6 +103,16 @@ func parseBindMount(spec, volumeDriver string) (*mountPoint, error) {
 	bind.Name = name
 	bind.Destination = filepath.Clean(bind.Destination)
 	return bind, nil
+}
+
+func getVolumeDriverFromName(name, volumeDriver string) (string, string) {
+	arr := strings.Split(name, "@")
+	switch len(arr) {
+	case 2:
+		return arr[0], arr[1]
+	default:
+		return arr[0], volumeDriver
+	}
 }
 
 // sortMounts sorts an array of mounts in lexicographic order. This ensure that

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -192,6 +192,9 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 			if arr[1] == "/" {
 				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: destination can't be '/'")
 			}
+			if strings.Count(arr[0], "@") > 1 {
+				return nil, nil, cmd, fmt.Errorf("Invalid format: '%s', valid format should be 'volumename' or 'volumename@volumedriver'", arr[0])
+			}
 			// after creating the bind mount we want to delete it from the flVolumes values because
 			// we do not want bind mounts being committed to image configs
 			binds = append(binds, bind)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

This is a original design of support multiple volume driver on docker run/create cli and waiting for some feedback from the community.
The `driver` should be a part of volume identifier, I think the user should aware what driver the volume used, since different driver have different feature and store the data in different place. In this way user can use multiple volume driver in a single `docker run/create` cli and 
different volume driver can have the same volume name.
Use the sytax `name@driver:/dest` as the volume identifier as @srust 's proposal.
Here is the example.

<pre><code>[lei@fedora ~]$ docker run -v test@convoy:/data -v test:/test busybox
[lei@fedora ~]$ docker volume ls
DRIVER              VOLUME NAME
convoy              test
local               test
</code></pre>

If no driver specified in the volume identifier, use default driver which is specified by `--volume-driver`, if no, use default `local`
the `docker volume` cli should use `name@driver`, if no driver specified, use default `local`

<pre><code>[lei@fedora ~]$ docker volume inspect test
[
    {
        "Name": "test",
        "Driver": "local",
        "Mountpoint": "/var/lib/docker/volumes/test/_data"
    }
]
[lei@fedora ~]$ docker volume inspect test@convoy
[
    {
        "Name": "test",
        "Driver": "convoy",
        "Mountpoint": "/var/lib/convoy/devicemapper/mounts/0f1c1fc2-21e3-4f83-99b1-9c23b9be649b"
    }
]
</code></pre>


For more information see #15997 
