### PR TITLE
Clean up: show usage when global --help present

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -56,12 +56,6 @@ func handleGlobalDaemonFlag() {
 	}
 
 	if *flDaemon {
-		if *flHelp {
-			// We do not show the help output here, instead, we tell the user about the new daemon command,
-			// because the help output is so long they would not see the warning anyway.
-			fmt.Fprintln(os.Stderr, "Please use 'docker daemon --help' instead.")
-			os.Exit(0)
-		}
 		daemonCli.(*DaemonCli).CmdDaemon(flag.Args()...)
 		os.Exit(0)
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -50,16 +50,16 @@ func main() {
 		return
 	}
 
-	clientCli := client.NewDockerCli(stdin, stdout, stderr, clientFlags)
-	// TODO: remove once `-d` is retired
-	handleGlobalDaemonFlag()
-
 	if *flHelp {
 		// if global flag --help is present, regardless of what other options and commands there are,
 		// just print the usage.
 		flag.Usage()
 		return
 	}
+
+	// TODO: remove once `-d` is retired
+	handleGlobalDaemonFlag()
+	clientCli := client.NewDockerCli(stdin, stdout, stderr, clientFlags)
 
 	c := cli.New(clientCli, daemonCli)
 	if err := c.Run(flag.Args()...); err != nil {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
As the comment in https://github.com/docker/docker/blob/master/docker/docker.go#L58
says
 `// if global flag --help is present, regardless of what other options and commands there are,
        // just print the usage.`
but not if provide a daemon flag.
This PR do two things:
- handler global --help flag before `handleGlobalDaemonFlag()` and `clientCli := client.NewDockerCli(stdin, stdout, stderr, clientFlags)`
- `handleGlobalDaemonFlag()` before  `clientCli := client.NewDockerCli(stdin, stdout, stderr, clientFlags)`, before if provide daemon flag `-d --daemon` the `clientcli` is never used.

But, anyway, `handleGlobalDaemonFlag()` will deprecated in the future once `-d --daemon` is retired, so feel free to close if unnecessary.    :-)
