### PR TITLE
Dockerfile: bump Go to 1.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN cd /usr/src/lxc \
 	&& ldconfig
 
 # Install Go
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
 	&& mkdir -p /go/bin
 ENV PATH /go/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
This PR bumps Go to the just released Go 1.4.3.

Go 1.4.3 milestone: https://github.com/golang/go/issues?q=is%3Aissue+milestone%3AGo1.4.3+is%3Aclosed

Description:

```
go1.4.3 (released 2015/09/22) includes security fixes to the net/http package and bug fixes to the
runtime package. See the Go 1.4.3 milestone on our issue tracker for details. 
```
