### PR TITLE
Do not try to guess "docker" in Debian SysV init script

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -19,7 +19,7 @@ set -e
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASE=$(basename $0)
+BASE=docker
 
 # modify these in /etc/default/$BASE (/etc/default/docker)
 DOCKER=/usr/bin/$BASE


### PR DESCRIPTION
On boot, the init script is invoked from `/etc/rcN.d/S20docker` (where N
is the runlevel). Consequently, the init script tried to find the
defaults at `/etc/defaults/S20docker` and the binary at
`/usr/bin/S20docker`. This causes the docker daemon to fail at boot with
the error

```
/usr/bin/S20docker not present or not executable
```

Starting it manually works because it invokes `/etc/init.d/docker` which
has the correct basename.

Fix this by hardcoding "docker" as the base name.
