### PR TITLE
fix content-type of response for `/commit`

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.12.md
+++ b/docs/reference/api/docker_remote_api_v1.12.md
@@ -1287,7 +1287,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.13.md
+++ b/docs/reference/api/docker_remote_api_v1.13.md
@@ -1276,7 +1276,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.14.md
+++ b/docs/reference/api/docker_remote_api_v1.14.md
@@ -1286,7 +1286,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.15.md
+++ b/docs/reference/api/docker_remote_api_v1.15.md
@@ -1437,7 +1437,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -1394,7 +1394,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -1557,7 +1557,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1677,7 +1677,7 @@ Create a new image from a container's changes
 **Example response**:
 
         HTTP/1.1 201 Created
-        Content-Type: application/vnd.docker.raw-stream
+        Content-Type: application/json
 
         {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1734,7 +1734,7 @@ Create a new image from a container's changes
 **Example response**:
 
     HTTP/1.1 201 Created
-    Content-Type: application/vnd.docker.raw-stream
+    Content-Type: application/json
 
     {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1876,7 +1876,7 @@ Create a new image from a container's changes
 **Example response**:
 
     HTTP/1.1 201 Created
-    Content-Type: application/vnd.docker.raw-stream
+    Content-Type: application/json
 
     {"Id": "596069db4bf5"}
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1968,7 +1968,7 @@ Create a new image from a container's changes
 **Example response**:
 
     HTTP/1.1 201 Created
-    Content-Type: application/vnd.docker.raw-stream
+    Content-Type: application/json
 
     {"Id": "596069db4bf5"}
 


### PR DESCRIPTION
this one changes the api docs for `/commit` to the actually used response content-type "application/json".

Signed-off-by: Tobias Gesellchen tobias@gesellix.de
