### PR TITLE
Move responsibility of ls/inspect to volume driver

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -65,6 +65,9 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
+		for _, warn := range volumes.Warnings {
+			fmt.Fprintln(cli.err, warn)
+		}
 		fmt.Fprintf(w, "DRIVER \tVOLUME NAME")
 		fmt.Fprintf(w, "\n")
 	}
@@ -102,7 +105,7 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 	return cli.inspectElements(*tmplStr, cmd.Args(), inspectSearcher)
 }
 
-// CmdVolumeCreate creates a new container from a given image.
+// CmdVolumeCreate creates a new volume.
 //
 // Usage: docker volume create [OPTIONS]
 func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
@@ -131,7 +134,7 @@ func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
 	return nil
 }
 
-// CmdVolumeRm removes one or more containers.
+// CmdVolumeRm removes one or more volumes.
 //
 // Usage: docker volume rm VOLUME [VOLUME...]
 func (cli *DockerCli) CmdVolumeRm(args ...string) error {
@@ -140,6 +143,7 @@ func (cli *DockerCli) CmdVolumeRm(args ...string) error {
 	cmd.ParseFlags(args, true)
 
 	var status = 0
+
 	for _, name := range cmd.Args() {
 		if err := cli.client.VolumeRemove(name); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)

--- a/api/server/router/volume/backend.go
+++ b/api/server/router/volume/backend.go
@@ -8,7 +8,7 @@ import (
 // Backend is the methods that need to be implemented to provide
 // volume specific functionality
 type Backend interface {
-	Volumes(filter string) ([]*types.Volume, error)
+	Volumes(filter string) ([]*types.Volume, []string, error)
 	VolumeInspect(name string) (*types.Volume, error)
 	VolumeCreate(name, driverName string,
 		opts map[string]string) (*types.Volume, error)

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -14,11 +14,11 @@ func (v *volumeRouter) getVolumesList(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	volumes, err := v.backend.Volumes(r.Form.Get("filters"))
+	volumes, warnings, err := v.backend.Volumes(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
-	return httputils.WriteJSON(w, http.StatusOK, &types.VolumesListResponse{Volumes: volumes})
+	return httputils.WriteJSON(w, http.StatusOK, &types.VolumesListResponse{Volumes: volumes, Warnings: warnings})
 }
 
 func (v *volumeRouter) getVolumeByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -366,7 +366,8 @@ type Volume struct {
 // VolumesListResponse contains the response for the remote API:
 // GET "/volumes"
 type VolumesListResponse struct {
-	Volumes []*Volume // Volumes is the list of volumes being returned
+	Volumes  []*Volume // Volumes is the list of volumes being returned
+	Warnings []string  // Warnings is a list of warnings that occurred when getting the list from the volume drivers
 }
 
 // VolumeCreateRequest contains the response for the remote API:

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -51,7 +51,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 			}
 		}
 
-		v, err := daemon.createVolume(name, volumeDriver, nil)
+		v, err := daemon.volumes.CreateWithRef(name, volumeDriver, container.ID, nil)
 		if err != nil {
 			return err
 		}

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -42,7 +42,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 
 		// Create the volume in the volume driver. If it doesn't exist,
 		// a new one will be created.
-		v, err := daemon.createVolume(mp.Name, volumeDriver, nil)
+		v, err := daemon.volumes.CreateWithRef(mp.Name, volumeDriver, container.ID, nil)
 		if err != nil {
 			return err
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1470,10 +1470,7 @@ func configureVolumes(config *Config, rootUID, rootGID int) (*store.VolumeStore,
 	}
 
 	volumedrivers.Register(volumesDriver, volumesDriver.Name())
-	s := store.New()
-	s.AddAll(volumesDriver.List())
-
-	return s, nil
+	return store.New(), nil
 }
 
 // AuthenticateToRegistry checks the validity of credentials in authConfig

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -151,6 +151,7 @@ func (daemon *Daemon) VolumeRm(name string) error {
 	if err != nil {
 		return err
 	}
+
 	if err := daemon.volumes.Remove(v); err != nil {
 		if volumestore.IsInUse(err) {
 			return derr.ErrorCodeRmVolumeInUse.WithArgs(err)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -32,16 +32,6 @@ func volumeToAPIType(v volume.Volume) *types.Volume {
 	}
 }
 
-// createVolume creates a volume.
-func (daemon *Daemon) createVolume(name, driverName string, opts map[string]string) (volume.Volume, error) {
-	v, err := daemon.volumes.Create(name, driverName, opts)
-	if err != nil {
-		return nil, err
-	}
-	daemon.volumes.Increment(v)
-	return v, nil
-}
-
 // Len returns the number of mounts. Used in sorting.
 func (m mounts) Len() int {
 	return len(m)
@@ -103,7 +93,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}
 
 			if len(cp.Source) == 0 {
-				v, err := daemon.createVolume(cp.Name, cp.Driver, nil)
+				v, err := daemon.volumes.GetWithRef(cp.Name, cp.Driver, container.ID)
 				if err != nil {
 					return err
 				}
@@ -128,7 +118,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 
 		if len(bind.Name) > 0 && len(bind.Driver) > 0 {
 			// create the volume
-			v, err := daemon.createVolume(bind.Name, bind.Driver, nil)
+			v, err := daemon.volumes.CreateWithRef(bind.Name, bind.Driver, container.ID, nil)
 			if err != nil {
 				return err
 			}
@@ -153,7 +143,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 	for _, m := range mountPoints {
 		if m.BackwardsCompatible() {
 			if mp, exists := container.MountPoints[m.Destination]; exists && mp.Volume != nil {
-				daemon.volumes.Decrement(mp.Volume)
+				daemon.volumes.Dereference(mp.Volume, container.ID)
 			}
 		}
 	}

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -908,7 +908,7 @@ var (
 	// trying to create a volume that has existed using different driver.
 	ErrorVolumeNameTaken = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "VOLUME_NAME_TAKEN",
-		Message:        "A volume named %q already exists with the %q driver. Choose a different volume name.",
+		Message:        "A volume named %s already exists. Choose a different volume name.",
 		Description:    "An attempt to create a volume using a driver but the volume already exists with a different driver",
 		HTTPStatusCode: http.StatusInternalServerError,
 	})

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1733,8 +1733,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartRmVolumeInUse(c *check.C) {
 	c.Assert(s.d.Restart(), check.IsNil)
 
 	out, err = s.d.Cmd("volume", "rm", "test")
-	c.Assert(err, check.Not(check.IsNil), check.Commentf("should not be able to remove in use volume after daemon restart"))
-	c.Assert(strings.Contains(out, "in use"), check.Equals, true)
+	c.Assert(err, check.NotNil, check.Commentf("should not be able to remove in use volume after daemon restart"))
+	c.Assert(out, checker.Contains, "in use")
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *check.C) {

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -4,9 +4,7 @@ import (
 	"os/exec"
 	"strings"
 
-	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/integration/checker"
-	"github.com/docker/docker/volume"
 	"github.com/go-check/check"
 )
 
@@ -25,8 +23,7 @@ func (s *DockerSuite) TestVolumeCliCreateOptionConflict(c *check.C) {
 	dockerCmd(c, "volume", "create", "--name=test")
 	out, _, err := dockerCmdWithError("volume", "create", "--name", "test", "--driver", "nosuchdriver")
 	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use with another driver"))
-	stderr := derr.ErrorVolumeNameTaken.WithArgs("test", volume.DefaultDriverName).Error()
-	c.Assert(strings.Contains(out, strings.TrimPrefix(stderr, "volume name taken: ")), check.Equals, true)
+	c.Assert(out, checker.Contains, "A volume named test already exists")
 
 	out, _ = dockerCmd(c, "volume", "inspect", "--format='{{ .Driver }}'", "test")
 	_, _, err = dockerCmdWithError("volume", "create", "--name", "test", "--driver", strings.TrimSpace(out))

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -108,6 +108,15 @@ func (p *Plugin) activateWithLock() error {
 	return nil
 }
 
+func (p *Plugin) implements(kind string) bool {
+	for _, driver := range p.Manifest.Implements {
+		if driver == kind {
+			return true
+		}
+	}
+	return false
+}
+
 func load(name string) (*Plugin, error) {
 	return loadWithRetry(name, true)
 }
@@ -166,11 +175,9 @@ func Get(name, imp string) (*Plugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, driver := range pl.Manifest.Implements {
-		logrus.Debugf("%s implements: %s", name, driver)
-		if driver == imp {
-			return pl, nil
-		}
+	if pl.implements(imp) {
+		logrus.Debugf("%s implements: %s", name, imp)
+		return pl, nil
 	}
 	return nil, ErrNotImplements
 }
@@ -178,4 +185,38 @@ func Get(name, imp string) (*Plugin, error) {
 // Handle adds the specified function to the extpointHandlers.
 func Handle(iface string, fn func(string, *Client)) {
 	extpointHandlers[iface] = fn
+}
+
+// GetAll returns all the plugins for the specified implementation
+func GetAll(imp string) ([]*Plugin, error) {
+	pluginNames, err := Scan()
+	if err != nil {
+		return nil, err
+	}
+
+	type plLoad struct {
+		pl  *Plugin
+		err error
+	}
+
+	chPl := make(chan plLoad, len(pluginNames))
+	for _, name := range pluginNames {
+		go func(name string) {
+			pl, err := loadWithRetry(name, false)
+			chPl <- plLoad{pl, err}
+		}(name)
+	}
+
+	var out []*Plugin
+	for i := 0; i < len(pluginNames); i++ {
+		pl := <-chPl
+		if pl.err != nil {
+			logrus.Error(err)
+			continue
+		}
+		if pl.pl.implements(imp) {
+			out = append(out, pl.pl)
+		}
+	}
+	return out, nil
 }

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -26,6 +26,38 @@ func (a *volumeDriverAdapter) Remove(v volume.Volume) error {
 	return a.proxy.Remove(v.Name())
 }
 
+func (a *volumeDriverAdapter) List() ([]volume.Volume, error) {
+	ls, err := a.proxy.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []volume.Volume
+	for _, vp := range ls {
+		out = append(out, &volumeAdapter{
+			proxy:      a.proxy,
+			name:       vp.Name,
+			driverName: a.name,
+			eMount:     vp.Mountpoint,
+		})
+	}
+	return out, nil
+}
+
+func (a *volumeDriverAdapter) Get(name string) (volume.Volume, error) {
+	v, err := a.proxy.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &volumeAdapter{
+		proxy:      a.proxy,
+		name:       v.Name,
+		driverName: a.Name(),
+		eMount:     v.Mountpoint,
+	}, nil
+}
+
 type volumeAdapter struct {
 	proxy      *volumeDriverProxy
 	name       string

--- a/volume/drivers/extpoint_test.go
+++ b/volume/drivers/extpoint_test.go
@@ -11,7 +11,8 @@ func TestGetDriver(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}
-	Register(volumetestutils.FakeDriver{}, "fake")
+
+	Register(volumetestutils.NewFakeDriver("fake"), "fake")
 	d, err := GetDriver("fake")
 	if err != nil {
 		t.Fatal(err)

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -149,3 +149,59 @@ func (pp *volumeDriverProxy) Unmount(name string) (err error) {
 
 	return
 }
+
+type volumeDriverProxyListRequest struct {
+}
+
+type volumeDriverProxyListResponse struct {
+	Volumes list
+	Err     string
+}
+
+func (pp *volumeDriverProxy) List() (volumes list, err error) {
+	var (
+		req volumeDriverProxyListRequest
+		ret volumeDriverProxyListResponse
+	)
+
+	if err = pp.Call("VolumeDriver.List", req, &ret); err != nil {
+		return
+	}
+
+	volumes = ret.Volumes
+
+	if ret.Err != "" {
+		err = errors.New(ret.Err)
+	}
+
+	return
+}
+
+type volumeDriverProxyGetRequest struct {
+	Name string
+}
+
+type volumeDriverProxyGetResponse struct {
+	Volume *proxyVolume
+	Err    string
+}
+
+func (pp *volumeDriverProxy) Get(name string) (volume *proxyVolume, err error) {
+	var (
+		req volumeDriverProxyGetRequest
+		ret volumeDriverProxyGetResponse
+	)
+
+	req.Name = name
+	if err = pp.Call("VolumeDriver.Get", req, &ret); err != nil {
+		return
+	}
+
+	volume = ret.Volume
+
+	if ret.Err != "" {
+		err = errors.New(ret.Err)
+	}
+
+	return
+}

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -42,6 +42,16 @@ func TestVolumeRequestError(t *testing.T) {
 		fmt.Fprintln(w, `{"Err": "Unknown volume"}`)
 	})
 
+	mux.HandleFunc("/VolumeDriver.List", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		fmt.Fprintln(w, `{"Err": "Cannot list volumes"}`)
+	})
+
+	mux.HandleFunc("/VolumeDriver.Get", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		fmt.Fprintln(w, `{"Err": "Cannot get volume"}`)
+	})
+
 	u, _ := url.Parse(server.URL)
 	client, err := plugins.NewClient("tcp://"+u.Host, tlsconfig.Options{InsecureSkipVerify: true})
 	if err != nil {
@@ -91,6 +101,22 @@ func TestVolumeRequestError(t *testing.T) {
 	}
 
 	if !strings.Contains(err.Error(), "Unknown volume") {
+		t.Fatalf("Unexpected error: %v\n", err)
+	}
+
+	_, err = driver.List()
+	if err == nil {
+		t.Fatal("Expected error, was nil")
+	}
+	if !strings.Contains(err.Error(), "Cannot list volumes") {
+		t.Fatalf("Unexpected error: %v\n", err)
+	}
+
+	_, err = driver.Get("volume")
+	if err == nil {
+		t.Fatal("Expected error, was nil")
+	}
+	if !strings.Contains(err.Error(), "Cannot get volume") {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 }

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -82,12 +82,12 @@ type Root struct {
 }
 
 // List lists all the volumes
-func (r *Root) List() []volume.Volume {
+func (r *Root) List() ([]volume.Volume, error) {
 	var ls []volume.Volume
 	for _, v := range r.volumes {
 		ls = append(ls, v)
 	}
-	return ls
+	return ls, nil
 }
 
 // DataPath returns the constructed path of this volume.

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -43,7 +43,7 @@ func TestRemove(t *testing.T) {
 		t.Fatal("volume dir not removed")
 	}
 
-	if len(r.List()) != 0 {
+	if l, _ := r.List(); len(l) != 0 {
 		t.Fatal("expected there to be no volumes")
 	}
 }

--- a/volume/store/errors.go
+++ b/volume/store/errors.go
@@ -1,6 +1,9 @@
 package store
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 var (
 	// errVolumeInUse is a typed error returned when trying to remove a volume that is currently in use by a container
@@ -9,6 +12,8 @@ var (
 	errNoSuchVolume = errors.New("no such volume")
 	// errInvalidName is a typed error returned when creating a volume with a name that is not valid on the platform
 	errInvalidName = errors.New("volume name is not valid on this platform")
+	// errNameConflict is a typed error returned on create when a volume exists with the given name, but for a different driver
+	errNameConflict = errors.New("conflict: volume name must be unique")
 )
 
 // OpErr is the error type returned by functions in the store package. It describes
@@ -20,6 +25,8 @@ type OpErr struct {
 	Op string
 	// Name is the name of the resource being requested for this op, typically the volume name or the driver name.
 	Name string
+	// Refs is the list of references associated with the resource.
+	Refs []string
 }
 
 // Error satisfies the built-in error interface type.
@@ -33,6 +40,9 @@ func (e *OpErr) Error() string {
 	}
 
 	s = s + ": " + e.Err.Error()
+	if len(e.Refs) > 0 {
+		s = s + " - " + "[" + strings.Join(e.Refs, ", ") + "]"
+	}
 	return s
 }
 
@@ -45,6 +55,12 @@ func IsInUse(err error) bool {
 // IsNotExist returns a boolean indicating whether the error indicates that the volume does not exist
 func IsNotExist(err error) bool {
 	return isErr(err, errNoSuchVolume)
+}
+
+// IsNameConflict returns a boolean indicating whether the error indicates that a
+// volume name is already taken
+func IsNameConflict(err error) bool {
+	return isErr(err, errNameConflict)
 }
 
 func isErr(err error, expected error) bool {

--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -13,66 +13,153 @@ import (
 // reference counting of volumes in the system.
 func New() *VolumeStore {
 	return &VolumeStore{
-		vols:  make(map[string]*volumeCounter),
 		locks: &locker.Locker{},
+		names: make(map[string]string),
+		refs:  make(map[string][]string),
 	}
 }
 
-func (s *VolumeStore) get(name string) (*volumeCounter, bool) {
+func (s *VolumeStore) getNamed(name string) (string, bool) {
 	s.globalLock.Lock()
-	vc, exists := s.vols[name]
+	driverName, exists := s.names[name]
 	s.globalLock.Unlock()
-	return vc, exists
+	return driverName, exists
 }
 
-func (s *VolumeStore) set(name string, vc *volumeCounter) {
+func (s *VolumeStore) setNamed(name, driver, ref string) {
 	s.globalLock.Lock()
-	s.vols[name] = vc
+	s.names[name] = driver
+	if len(ref) > 0 {
+		s.refs[name] = append(s.refs[name], ref)
+	}
 	s.globalLock.Unlock()
 }
 
-func (s *VolumeStore) remove(name string) {
+func (s *VolumeStore) purge(name string) {
 	s.globalLock.Lock()
-	delete(s.vols, name)
+	delete(s.names, name)
+	delete(s.refs, name)
 	s.globalLock.Unlock()
 }
 
 // VolumeStore is a struct that stores the list of volumes available and keeps track of their usage counts
 type VolumeStore struct {
-	vols       map[string]*volumeCounter
 	locks      *locker.Locker
 	globalLock sync.Mutex
+	// names stores the volume name -> driver name relationship.
+	// This is used for making lookups faster so we don't have to probe all drivers
+	names map[string]string
+	// refs stores the volume name and the list of things referencing it
+	refs map[string][]string
 }
 
-// volumeCounter keeps track of references to a volume
-type volumeCounter struct {
-	volume.Volume
-	count uint
-}
-
-// AddAll adds a list of volumes to the store
-func (s *VolumeStore) AddAll(vols []volume.Volume) {
-	for _, v := range vols {
-		s.vols[normaliseVolumeName(v.Name())] = &volumeCounter{v, 0}
+// List proxies to all registered volume drivers to get the full list of volumes
+// If a driver returns a volume that has name which conflicts with a another volume from a different driver,
+// the first volume is chosen and the conflicting volume is dropped.
+func (s *VolumeStore) List() ([]volume.Volume, []string, error) {
+	vols, warnings, err := s.list()
+	if err != nil {
+		return nil, nil, &OpErr{Err: err, Op: "list"}
 	}
+	var out []volume.Volume
+
+	for _, v := range vols {
+		name := normaliseVolumeName(v.Name())
+
+		s.locks.Lock(name)
+		driverName, exists := s.getNamed(name)
+		if !exists {
+			s.setNamed(name, v.DriverName(), "")
+		}
+		if exists && driverName != v.DriverName() {
+			logrus.Warnf("Volume name %s already exists for driver %s, not including volume returned by %s", v.Name(), driverName, v.DriverName())
+			s.locks.Unlock(v.Name())
+			continue
+		}
+
+		out = append(out, v)
+		s.locks.Unlock(v.Name())
+	}
+	return out, warnings, nil
 }
 
-// Create tries to find an existing volume with the given name or create a new one from the passed in driver
+// list goes through each volume driver and asks for its list of volumes.
+func (s *VolumeStore) list() ([]volume.Volume, []string, error) {
+	drivers, err := volumedrivers.GetAllDrivers()
+	if err != nil {
+		return nil, nil, err
+	}
+	var (
+		ls       []volume.Volume
+		warnings []string
+	)
+
+	type vols struct {
+		vols []volume.Volume
+		err  error
+	}
+	chVols := make(chan vols, len(drivers))
+
+	for _, vd := range drivers {
+		go func(d volume.Driver) {
+			vs, err := d.List()
+			if err != nil {
+				chVols <- vols{err: &OpErr{Err: err, Name: d.Name(), Op: "list"}}
+				return
+			}
+			chVols <- vols{vols: vs}
+		}(vd)
+	}
+
+	for i := 0; i < len(drivers); i++ {
+		vs := <-chVols
+
+		if vs.err != nil {
+			warnings = append(warnings, vs.err.Error())
+			logrus.Warn(vs.err)
+			continue
+		}
+		ls = append(ls, vs.vols...)
+	}
+	return ls, warnings, nil
+}
+
+// CreateWithRef creates a volume with the given name and driver and stores the ref
+// This is just like Create() except we store the reference while holding the lock.
+// This ensures there's no race between creating a volume and then storing a reference.
+func (s *VolumeStore) CreateWithRef(name, driverName, ref string, opts map[string]string) (volume.Volume, error) {
+	name = normaliseVolumeName(name)
+	s.locks.Lock(name)
+	defer s.locks.Unlock(name)
+
+	v, err := s.create(name, driverName, opts)
+	if err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "create"}
+	}
+
+	s.setNamed(name, v.DriverName(), ref)
+	return v, nil
+}
+
+// Create creates a volume with the given name and driver.
 func (s *VolumeStore) Create(name, driverName string, opts map[string]string) (volume.Volume, error) {
 	name = normaliseVolumeName(name)
 	s.locks.Lock(name)
 	defer s.locks.Unlock(name)
 
-	if vc, exists := s.get(name); exists {
-		v := vc.Volume
-		return v, nil
-	}
-
-	vd, err := volumedrivers.GetDriver(driverName)
+	v, err := s.create(name, driverName, opts)
 	if err != nil {
-		return nil, &OpErr{Err: err, Name: driverName, Op: "create"}
+		return nil, &OpErr{Err: err, Name: name, Op: "create"}
 	}
+	s.setNamed(name, v.DriverName(), "")
+	return v, nil
+}
 
+// create asks the given driver to create a volume with the name/opts.
+// If a volume with the name is already known, it will ask the stored driver for the volume.
+// If the passed in driver name does not match the driver name which is stored for the given volume name, an error is returned.
+// It is expected that callers of this function hold any neccessary locks.
+func (s *VolumeStore) create(name, driverName string, opts map[string]string) (volume.Volume, error) {
 	// Validate the name in a platform-specific manner
 	valid, err := volume.IsVolumeNameValid(name)
 	if err != nil {
@@ -82,12 +169,45 @@ func (s *VolumeStore) Create(name, driverName string, opts map[string]string) (v
 		return nil, &OpErr{Err: errInvalidName, Name: name, Op: "create"}
 	}
 
-	v, err := vd.Create(name, opts)
+	vdName, exists := s.getNamed(name)
+	if exists {
+		if vdName != driverName && driverName != "" && driverName != volume.DefaultDriverName {
+			return nil, errNameConflict
+		}
+		driverName = vdName
+	}
+
+	logrus.Debugf("Registering new volume reference: driver %s, name %s", driverName, name)
+	vd, err := volumedrivers.GetDriver(driverName)
 	if err != nil {
 		return nil, &OpErr{Op: "create", Name: name, Err: err}
 	}
 
-	s.set(name, &volumeCounter{v, 0})
+	if v, err := vd.Get(name); err == nil {
+		return v, nil
+	}
+	return vd.Create(name, opts)
+}
+
+// GetWithRef gets a volume with the given name from the passed in driver and stores the ref
+// This is just like Get(), but we store the reference while holding the lock.
+// This makes sure there are no races between checking for the existance of a volume and adding a reference for it
+func (s *VolumeStore) GetWithRef(name, driverName, ref string) (volume.Volume, error) {
+	name = normaliseVolumeName(name)
+	s.locks.Lock(name)
+	defer s.locks.Unlock(name)
+
+	vd, err := volumedrivers.GetDriver(driverName)
+	if err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "get"}
+	}
+
+	v, err := vd.Get(name)
+	if err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "get"}
+	}
+
+	s.setNamed(name, v.DriverName(), ref)
 	return v, nil
 }
 
@@ -97,120 +217,116 @@ func (s *VolumeStore) Get(name string) (volume.Volume, error) {
 	s.locks.Lock(name)
 	defer s.locks.Unlock(name)
 
-	vc, exists := s.get(name)
-	if !exists {
-		return nil, &OpErr{Err: errNoSuchVolume, Name: name, Op: "get"}
+	v, err := s.getVolume(name)
+	if err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "get"}
 	}
-	return vc.Volume, nil
+	return v, nil
 }
 
-// Remove removes the requested volume. A volume is not removed if the usage count is > 0
+// get requests the volume, if the driver info is stored it just access that driver,
+// if the driver is unknown it probes all drivers until it finds the first volume with that name.
+// it is expected that callers of this function hold any neccessary locks
+func (s *VolumeStore) getVolume(name string) (volume.Volume, error) {
+	logrus.Debugf("Getting volume reference for name: %s", name)
+	if vdName, exists := s.names[name]; exists {
+		vd, err := volumedrivers.GetDriver(vdName)
+		if err != nil {
+			return nil, err
+		}
+		return vd.Get(name)
+	}
+
+	logrus.Debugf("Probing all drivers for volume with name: %s", name)
+	drivers, err := volumedrivers.GetAllDrivers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, d := range drivers {
+		v, err := d.Get(name)
+		if err != nil {
+			continue
+		}
+		return v, nil
+	}
+	return nil, errNoSuchVolume
+}
+
+// Remove removes the requested volume. A volume is not removed if it has any refs
 func (s *VolumeStore) Remove(v volume.Volume) error {
 	name := normaliseVolumeName(v.Name())
 	s.locks.Lock(name)
 	defer s.locks.Unlock(name)
 
-	logrus.Debugf("Removing volume reference: driver %s, name %s", v.DriverName(), name)
-	vc, exists := s.get(name)
-	if !exists {
-		return &OpErr{Err: errNoSuchVolume, Name: name, Op: "remove"}
+	if refs, exists := s.refs[name]; exists && len(refs) > 0 {
+		return &OpErr{Err: errVolumeInUse, Name: v.Name(), Op: "remove", Refs: refs}
 	}
 
-	if vc.count > 0 {
-		return &OpErr{Err: errVolumeInUse, Name: name, Op: "remove"}
-	}
-
-	vd, err := volumedrivers.GetDriver(vc.DriverName())
+	vd, err := volumedrivers.GetDriver(v.DriverName())
 	if err != nil {
-		return &OpErr{Err: err, Name: vc.DriverName(), Op: "remove"}
+		return &OpErr{Err: err, Name: vd.Name(), Op: "remove"}
 	}
-	if err := vd.Remove(vc.Volume); err != nil {
+
+	logrus.Debugf("Removing volume reference: driver %s, name %s", v.DriverName(), name)
+	if err := vd.Remove(v); err != nil {
 		return &OpErr{Err: err, Name: name, Op: "remove"}
 	}
 
-	s.remove(name)
+	s.purge(name)
 	return nil
 }
 
-// Increment increments the usage count of the passed in volume by 1
-func (s *VolumeStore) Increment(v volume.Volume) {
-	name := normaliseVolumeName(v.Name())
-	s.locks.Lock(name)
-	defer s.locks.Unlock(name)
+// Dereference removes the specified reference to the volume
+func (s *VolumeStore) Dereference(v volume.Volume, ref string) {
+	s.locks.Lock(v.Name())
+	defer s.locks.Unlock(v.Name())
 
-	logrus.Debugf("Incrementing volume reference: driver %s, name %s", v.DriverName(), v.Name())
-	vc, exists := s.get(name)
-	if !exists {
-		s.set(name, &volumeCounter{v, 1})
-		return
-	}
-	vc.count++
-}
-
-// Decrement decrements the usage count of the passed in volume by 1
-func (s *VolumeStore) Decrement(v volume.Volume) {
-	name := normaliseVolumeName(v.Name())
-	s.locks.Lock(name)
-	defer s.locks.Unlock(name)
-	logrus.Debugf("Decrementing volume reference: driver %s, name %s", v.DriverName(), v.Name())
-
-	vc, exists := s.get(name)
-	if !exists {
-		return
-	}
-	if vc.count == 0 {
-		return
-	}
-	vc.count--
-}
-
-// Count returns the usage count of the passed in volume
-func (s *VolumeStore) Count(v volume.Volume) uint {
-	name := normaliseVolumeName(v.Name())
-	s.locks.Lock(name)
-	defer s.locks.Unlock(name)
-
-	vc, exists := s.get(name)
-	if !exists {
-		return 0
-	}
-	return vc.count
-}
-
-// List returns all the available volumes
-func (s *VolumeStore) List() []volume.Volume {
 	s.globalLock.Lock()
-	defer s.globalLock.Unlock()
-	var ls []volume.Volume
-	for _, vc := range s.vols {
-		ls = append(ls, vc.Volume)
+	refs, exists := s.refs[v.Name()]
+	if !exists {
+		return
 	}
-	return ls
+
+	for i, r := range refs {
+		if r == ref {
+			s.refs[v.Name()] = append(s.refs[v.Name()][:i], s.refs[v.Name()][i+1:]...)
+		}
+	}
+	s.globalLock.Unlock()
 }
 
 // FilterByDriver returns the available volumes filtered by driver name
-func (s *VolumeStore) FilterByDriver(name string) []volume.Volume {
-	return s.filter(byDriver(name))
+func (s *VolumeStore) FilterByDriver(name string) ([]volume.Volume, error) {
+	vd, err := volumedrivers.GetDriver(name)
+	if err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "list"}
+	}
+	ls, err := vd.List()
+	if err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "list"}
+	}
+	return ls, nil
+}
+
+// FilterByUsed returns the available volumes filtered by if they are not in use
+func (s *VolumeStore) FilterByUsed(vols []volume.Volume) []volume.Volume {
+	return s.filter(vols, func(v volume.Volume) bool {
+		s.locks.Lock(v.Name())
+		defer s.locks.Unlock(v.Name())
+		return len(s.refs[v.Name()]) == 0
+	})
 }
 
 // filterFunc defines a function to allow filter volumes in the store
 type filterFunc func(vol volume.Volume) bool
 
-// byDriver generates a filterFunc to filter volumes by their driver name
-func byDriver(name string) filterFunc {
-	return func(vol volume.Volume) bool {
-		return vol.DriverName() == name
-	}
-}
-
 // filter returns the available volumes filtered by a filterFunc function
-func (s *VolumeStore) filter(f filterFunc) []volume.Volume {
-	s.globalLock.Lock()
-	defer s.globalLock.Unlock()
+func (s *VolumeStore) filter(vols []volume.Volume, f filterFunc) []volume.Volume {
 	var ls []volume.Volume
-	for _, vc := range s.vols {
-		if f(vc.Volume) {
-			ls = append(ls, vc.Volume)
+	for _, v := range vols {
+		if f(v) {
+			ls = append(ls, v)
 		}
 	}
 	return ls

--- a/volume/store/store_test.go
+++ b/volume/store/store_test.go
@@ -2,42 +2,16 @@ package store
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
-	"github.com/docker/docker/volume"
 	"github.com/docker/docker/volume/drivers"
 	vt "github.com/docker/docker/volume/testutils"
 )
 
-func TestList(t *testing.T) {
-	volumedrivers.Register(vt.FakeDriver{}, "fake")
-	s := New()
-	s.AddAll([]volume.Volume{vt.NewFakeVolume("fake1"), vt.NewFakeVolume("fake2")})
-	l := s.List()
-	if len(l) != 2 {
-		t.Fatalf("Expected 2 volumes in the store, got %v: %v", len(l), l)
-	}
-}
-
-func TestGet(t *testing.T) {
-	volumedrivers.Register(vt.FakeDriver{}, "fake")
-	s := New()
-	s.AddAll([]volume.Volume{vt.NewFakeVolume("fake1"), vt.NewFakeVolume("fake2")})
-	v, err := s.Get("fake1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if v.Name() != "fake1" {
-		t.Fatalf("Expected fake1 volume, got %v", v)
-	}
-
-	if _, err := s.Get("fake4"); !IsNotExist(err) {
-		t.Fatalf("Expected IsNotExist error, got %v", err)
-	}
-}
-
 func TestCreate(t *testing.T) {
-	volumedrivers.Register(vt.FakeDriver{}, "fake")
+	volumedrivers.Register(vt.NewFakeDriver("fake"), "fake")
+	defer volumedrivers.Unregister("fake")
 	s := New()
 	v, err := s.Create("fake1", "fake", nil)
 	if err != nil {
@@ -46,7 +20,7 @@ func TestCreate(t *testing.T) {
 	if v.Name() != "fake1" {
 		t.Fatalf("Expected fake1 volume, got %v", v)
 	}
-	if l := s.List(); len(l) != 1 {
+	if l, _, _ := s.List(); len(l) != 1 {
 		t.Fatalf("Expected 1 volume in the store, got %v: %v", len(l), l)
 	}
 
@@ -62,93 +36,90 @@ func TestCreate(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	volumedrivers.Register(vt.FakeDriver{}, "fake")
+	volumedrivers.Register(vt.NewFakeDriver("fake"), "fake")
+	volumedrivers.Register(vt.NewFakeDriver("noop"), "noop")
+	defer volumedrivers.Unregister("fake")
+	defer volumedrivers.Unregister("noop")
 	s := New()
-	if err := s.Remove(vt.NoopVolume{}); !IsNotExist(err) {
-		t.Fatalf("Expected IsNotExist error, got %v", err)
+
+	// doing string compare here since this error comes directly from the driver
+	expected := "no such volume"
+	if err := s.Remove(vt.NoopVolume{}); err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("Expected error %q, got %v", expected, err)
 	}
-	v, err := s.Create("fake1", "fake", nil)
+
+	v, err := s.CreateWithRef("fake1", "fake", "fake", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.Increment(v)
+
 	if err := s.Remove(v); !IsInUse(err) {
-		t.Fatalf("Expected IsInUse error, got %v", err)
+		t.Fatalf("Expected ErrVolumeInUse error, got %v", err)
 	}
-	s.Decrement(v)
+	s.Dereference(v, "fake")
 	if err := s.Remove(v); err != nil {
 		t.Fatal(err)
 	}
-	if l := s.List(); len(l) != 0 {
+	if l, _, _ := s.List(); len(l) != 0 {
 		t.Fatalf("Expected 0 volumes in the store, got %v, %v", len(l), l)
 	}
 }
 
-func TestIncrement(t *testing.T) {
+func TestList(t *testing.T) {
+	volumedrivers.Register(vt.NewFakeDriver("fake"), "fake")
+	volumedrivers.Register(vt.NewFakeDriver("fake2"), "fake2")
+	defer volumedrivers.Unregister("fake")
+	defer volumedrivers.Unregister("fake2")
+
 	s := New()
-	v := vt.NewFakeVolume("fake1")
-	s.Increment(v)
-	if l := s.List(); len(l) != 1 {
-		t.Fatalf("Expected 1 volume, got %v, %v", len(l), l)
+	if _, err := s.Create("test", "fake", nil); err != nil {
+		t.Fatal(err)
 	}
-	if c := s.Count(v); c != 1 {
-		t.Fatalf("Expected 1 counter, got %v", c)
+	if _, err := s.Create("test2", "fake2", nil); err != nil {
+		t.Fatal(err)
 	}
 
-	s.Increment(v)
-	if l := s.List(); len(l) != 1 {
-		t.Fatalf("Expected 1 volume, got %v, %v", len(l), l)
+	ls, _, err := s.List()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if c := s.Count(v); c != 2 {
-		t.Fatalf("Expected 2 counter, got %v", c)
-	}
-
-	v2 := vt.NewFakeVolume("fake2")
-	s.Increment(v2)
-	if l := s.List(); len(l) != 2 {
-		t.Fatalf("Expected 2 volume, got %v, %v", len(l), l)
-	}
-}
-
-func TestDecrement(t *testing.T) {
-	s := New()
-	v := vt.NoopVolume{}
-	s.Decrement(v)
-	if c := s.Count(v); c != 0 {
-		t.Fatalf("Expected 0 volumes, got %v", c)
+	if len(ls) != 2 {
+		t.Fatalf("expected 2 volumes, got: %d", len(ls))
 	}
 
-	s.Increment(v)
-	s.Increment(v)
-	s.Decrement(v)
-	if c := s.Count(v); c != 1 {
-		t.Fatalf("Expected 1 volume, got %v", c)
+	// and again with a new store
+	s = New()
+	ls, _, err = s.List()
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	s.Decrement(v)
-	if c := s.Count(v); c != 0 {
-		t.Fatalf("Expected 0 volumes, got %v", c)
-	}
-
-	// Test counter cannot be negative.
-	s.Decrement(v)
-	if c := s.Count(v); c != 0 {
-		t.Fatalf("Expected 0 volumes, got %v", c)
+	if len(ls) != 2 {
+		t.Fatalf("expected 2 volumes, got: %d", len(ls))
 	}
 }
 
 func TestFilterByDriver(t *testing.T) {
+	volumedrivers.Register(vt.NewFakeDriver("fake"), "fake")
+	volumedrivers.Register(vt.NewFakeDriver("noop"), "noop")
+	defer volumedrivers.Unregister("fake")
+	defer volumedrivers.Unregister("noop")
 	s := New()
 
-	s.Increment(vt.NewFakeVolume("fake1"))
-	s.Increment(vt.NewFakeVolume("fake2"))
-	s.Increment(vt.NoopVolume{})
+	if _, err := s.Create("fake1", "fake", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Create("fake2", "fake", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Create("fake3", "noop", nil); err != nil {
+		t.Fatal(err)
+	}
 
-	if l := s.FilterByDriver("fake"); len(l) != 2 {
+	if l, _ := s.FilterByDriver("fake"); len(l) != 2 {
 		t.Fatalf("Expected 2 volumes, got %v, %v", len(l), l)
 	}
 
-	if l := s.FilterByDriver("noop"); len(l) != 1 {
+	if l, _ := s.FilterByDriver("noop"); len(l) != 1 {
 		t.Fatalf("Expected 1 volume, got %v, %v", len(l), l)
 	}
 }

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -21,7 +21,11 @@ type Driver interface {
 	// Create makes a new volume with the given id.
 	Create(name string, opts map[string]string) (Volume, error)
 	// Remove deletes the volume.
-	Remove(Volume) error
+	Remove(vol Volume) (err error)
+	// List lists all the volumes the driver has
+	List() ([]Volume, error)
+	// Get retreives the volume with the requested name
+	Get(name string) (Volume, error)
 }
 
 // Volume is a place to store data. It is backed by a specific driver, and can be mounted.


### PR DESCRIPTION
Makes `docker volume ls` and `docker volume inspect` ask the volume
drivers rather than only using what is cached locally.

Previously in order to use a volume from an external driver, one would
either have to use `docker volume create` or have a container that is
already using that volume for it to be visible to the other volume
API's.

For keeping uniqueness of volume names in the daemon, names are bound to
a driver on a first come first serve basis. If two drivers have a volume
with the same name, the first one is chosen, and a warning is logged
about the second one.

Adds 2 new methods to the plugin API, `List` and `Get`.
If a plugin does not implement these endpoints, a user will not be able
to find the specified volumes as well requests go through the drivers.

Fixes #15997
Closes #16513
Closes #16473

ping @calavera @srust @thaJeztah @lukemarsden
