### PR TITLE
Windows: Fixed escaping of command line arguments

### DIFF
--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/execdriver"
@@ -258,7 +259,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 	createProcessParms.CommandLine = c.ProcessConfig.Entrypoint
 	for _, arg := range c.ProcessConfig.Arguments {
 		logrus.Debugln("appending ", arg)
-		createProcessParms.CommandLine += " " + arg
+		createProcessParms.CommandLine += " " + syscall.EscapeArg(arg)
 	}
 	logrus.Debugf("CommandLine: %s", createProcessParms.CommandLine)
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -450,12 +450,9 @@ func (s *DockerSuite) TestRunExitCode(c *check.C) {
 		exit int
 		err  error
 	)
-	if daemonPlatform == "windows" {
-		// FIXME Windows: Work out the bug in busybox why exit doesn't set the exit code.
-		_, exit, err = dockerCmdWithError("run", WindowsBaseImage, "cmd", "/s", "/c", "exit 72")
-	} else {
-		_, exit, err = dockerCmdWithError("run", "busybox", "/bin/sh", "-c", "exit 72")
-	}
+
+	_, exit, err = dockerCmdWithError("run", "busybox", "/bin/sh", "-c", "exit 72")
+
 	if err == nil {
 		c.Fatal("should not have a non nil error")
 	}


### PR DESCRIPTION
Signed-off-by: Darren Stahl darst@microsoft.com

This fixes TestRunExitCode on Windows, and results in more closely matching the command line parsing on other platforms.
