### PR TITLE
Make 'TestRandomUnixTmpDirPath' platform agnostic

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -191,7 +191,7 @@ func (s *DockerSuite) TestContainerApiStartVolumeBinds(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated)
 
-	bindPath := randomUnixTmpDirPath("test")
+	bindPath := randomTmpDirPath("test")
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":/tmp"},
 	}
@@ -222,8 +222,8 @@ func (s *DockerSuite) TestContainerApiStartDupVolumeBinds(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated)
 
-	bindPath1 := randomUnixTmpDirPath("test1")
-	bindPath2 := randomUnixTmpDirPath("test2")
+	bindPath1 := randomTmpDirPath("test1")
+	bindPath2 := randomTmpDirPath("test2")
 
 	config = map[string]interface{}{
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -322,8 +322,8 @@ func (s *DockerSuite) TestRunNoDupVolumes(c *check.C) {
 	// TODO Windows: This test cannot run on a Windows daemon as Windows does
 	// not support volumes
 	testRequires(c, DaemonIsLinux)
-	mountstr1 := randomUnixTmpDirPath("test1") + ":/someplace"
-	mountstr2 := randomUnixTmpDirPath("test2") + ":/someplace"
+	mountstr1 := randomTmpDirPath("test1") + ":/someplace"
+	mountstr2 := randomTmpDirPath("test2") + ":/someplace"
 
 	if out, _, err := dockerCmdWithError("run", "-v", mountstr1, "-v", mountstr2, "busybox", "true"); err == nil {
 		c.Fatal("Expected error about duplicate volume definitions")
@@ -2015,7 +2015,7 @@ func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
 		c.Fatalf("Data was copied on volumes-from but shouldn't be:\n%q", out)
 	}
 
-	tmpDir := randomUnixTmpDirPath("docker_test_bind_mount_copy_data")
+	tmpDir := randomTmpDirPath("docker_test_bind_mount_copy_data")
 	if out, _, err := dockerCmdWithError("run", "-v", tmpDir+":/foo", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
 		c.Fatalf("Data was copied on bind-mount but shouldn't be:\n%q", out)
 	}

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -61,8 +61,8 @@ func listTar(f io.Reader) ([]string, error) {
 	return integration.ListTar(f)
 }
 
-func randomUnixTmpDirPath(s string) string {
-	return integration.RandomUnixTmpDirPath(s)
+func randomTmpDirPath(s string) string {
+	return integration.RandomTmpDirPath(s)
 }
 
 func consumeWithSpeed(reader io.Reader, chunkSize int, interval time.Duration, stop chan bool) (n int, err error) {

--- a/pkg/integration/utils.go
+++ b/pkg/integration/utils.go
@@ -9,8 +9,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -244,10 +245,14 @@ func ListTar(f io.Reader) ([]string, error) {
 	}
 }
 
-// RandomUnixTmpDirPath provides a temporary unix path with rand string appended.
+// RandomTmpDirPath provides a temporary path with rand string appended.
 // does not create or checks if it exists.
-func RandomUnixTmpDirPath(s string) string {
-	return path.Join("/tmp", fmt.Sprintf("%s.%s", s, stringutils.GenerateRandomAlphaOnlyString(10)))
+func RandomTmpDirPath(s string) string {
+	tmp := "/tmp"
+	if runtime.GOOS == "windows" {
+		tmp = os.Getenv("TEMP")
+	}
+	return filepath.Join(tmp, fmt.Sprintf("%s.%s", s, stringutils.GenerateRandomAlphaOnlyString(10)))
 }
 
 // ConsumeWithSpeed reads chunkSize bytes from reader after every interval.

--- a/pkg/integration/utils_test.go
+++ b/pkg/integration/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -341,10 +342,13 @@ func TestListTar(t *testing.T) {
 	}
 }
 
-func TestRandomUnixTmpDirPath(t *testing.T) {
-	path := RandomUnixTmpDirPath("something")
+func TestRandomTmpDirPath(t *testing.T) {
+	path := RandomTmpDirPath("something")
 
 	prefix := "/tmp/something"
+	if runtime.GOOS == "windows" {
+		prefix = os.Getenv("TEMP") + `\something`
+	}
 	expectedSize := len(prefix) + 11
 
 	if !strings.HasPrefix(path, prefix) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Simple PR which makes the "TestRandomUnixTmpDirPath" function platform agnostic by removing the "Unix" bit from the name, updating all callers of it to use the new name, adding Windows support, and updating the unit test for it.
