### PR TITLE
#16560 Add timeout to `sudo service docker stop` on sysvinit

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -117,7 +117,7 @@ case "$1" in
 		check_init
 		fail_unless_root
 		log_begin_msg "Stopping $DOCKER_DESC: $BASE"
-		start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE"
+		start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE" --retry 10
 		log_end_msg $?
 		;;
 


### PR DESCRIPTION
Add 10 seconds timeout when running `sudo service docker stop`. This is
especially needed when running `sudo service docker restart`. Otherwise,
`restart` results in exitstatus 1, because `start` has nothing to do.
