### PR TITLE
Windows: Fix ADD from URL in dockerfile

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -36,6 +36,10 @@ func checkKernel() error {
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
 func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, adjustCPUShares bool) {
+	if hostConfig == nil {
+		return
+	}
+
 	if hostConfig.CPUShares < 0 {
 		logrus.Warnf("Changing requested CPUShares of %d to minimum allowed of %d", hostConfig.CPUShares, windowsMinCPUShares)
 		hostConfig.CPUShares = windowsMinCPUShares


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Needed an is-nil check in adaptContainerSettings, otherwise docker build with an ADD from URL will cause a daemon panic referencing through a nil pointer.

(Oh for Windows to Windows CI to be running to catch this....)
