### PR TITLE
Extract api types to version packages.

### DIFF
--- a/api/types/stats.go
+++ b/api/types/stats.go
@@ -96,14 +96,6 @@ type Stats struct {
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
 }
 
-// StatsJSONPre121 is a backcompatibility struct along with ContainerConfig
-type StatsJSONPre121 struct {
-	Stats
-
-	// Network is for fallback stats where API Version < 1.21
-	Network NetworkStats `json:"network,omitempty"`
-}
-
 // StatsJSON is newly used Networks
 type StatsJSON struct {
 	Stats

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -277,41 +277,6 @@ type ContainerJSON struct {
 	Config *runconfig.Config
 }
 
-// ContainerJSON120 is a backcompatibility struct along with ContainerConfig120.
-type ContainerJSON120 struct {
-	*ContainerJSONBase
-	Mounts []MountPoint
-	Config *ContainerConfig120
-}
-
-// ContainerJSONPre120 is a backcompatibility struct along with ContainerConfigPre120.
-// Note this is not used by the Windows daemon.
-type ContainerJSONPre120 struct {
-	*ContainerJSONBase
-	Volumes   map[string]string
-	VolumesRW map[string]bool
-	Config    *ContainerConfigPre120
-}
-
-// ContainerConfigPre120 is a backcompatibility struct used in ContainerJSONPre120
-type ContainerConfigPre120 struct {
-	*runconfig.Config
-
-	// backward compatibility, they now live in HostConfig
-	VolumeDriver string
-	Memory       int64
-	MemorySwap   int64
-	CPUShares    int64  `json:"CpuShares"`
-	CPUSet       string `json:"CpuSet"`
-}
-
-// ContainerConfig120 is a backcompatibility struct used in ContainerJSON120
-type ContainerConfig120 struct {
-	*runconfig.Config
-	// backward compatibility, it lives now in HostConfig
-	VolumeDriver string
-}
-
 // MountPoint represents a mount point configuration inside the container.
 type MountPoint struct {
 	Name        string `json:",omitempty"`

--- a/api/types/versions/README.md
+++ b/api/types/versions/README.md
@@ -1,0 +1,14 @@
+## Legacy API type versions
+
+This package includes types for legacy API versions. The stable version of the API types live in `api/types/*.go`.
+
+Consider moving a type here when you need to keep backwards compatibility in the API. This legacy types are organized by the latest API version they appear in. For instance, types in the `v1p19` package are valid for API versions below or equal `1.19`. Types in the `v1p20` package are valid for the API version `1.20`, since the versions below that will use the legacy types in `v1p19`.
+
+### Package name conventions
+
+The package name convention is to use `v` as a prefix for the version number and `p`(patch) as a separator. We use this nomenclature due to a few restrictions in the Go package name convention:
+
+1. We cannot use `.` because it's interpreted by the language, think of `v1.20.CallFunction`.
+2. We cannot use `_` because golint complains abount it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
+
+For instance, if you want to modify a type that was available in the version `1.21` of the API but it will have different fields in the version `1.22`, you want to create a new package under `api/types/versions/v1p21`.

--- a/api/types/versions/v1p19/types.go
+++ b/api/types/versions/v1p19/types.go
@@ -1,0 +1,28 @@
+// Package v1p19 provides specific API types for the API version 1, patch 19.
+package v1p19
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/runconfig"
+)
+
+// ContainerJSON is a backcompatibility struct for APIs prior to 1.20.
+// Note this is not used by the Windows daemon.
+type ContainerJSON struct {
+	*types.ContainerJSONBase
+	Volumes   map[string]string
+	VolumesRW map[string]bool
+	Config    *ContainerConfig
+}
+
+// ContainerConfig is a backcompatibility struct for APIs prior to 1.20.
+type ContainerConfig struct {
+	*runconfig.Config
+
+	// backward compatibility, they now live in HostConfig
+	VolumeDriver string
+	Memory       int64
+	MemorySwap   int64
+	CPUShares    int64  `json:"CpuShares"`
+	CPUSet       string `json:"CpuSet"`
+}

--- a/api/types/versions/v1p20/types.go
+++ b/api/types/versions/v1p20/types.go
@@ -1,0 +1,27 @@
+// Package v1p20 provides specific API types for the API version 1, patch 20.
+package v1p20
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/runconfig"
+)
+
+// ContainerJSON is a backcompatibility struct for the API 1.20
+type ContainerJSON struct {
+	*types.ContainerJSONBase
+	Mounts []types.MountPoint
+	Config *ContainerConfig
+}
+
+// ContainerConfig is a backcompatibility struct used in ContainerJSON for the API 1.20
+type ContainerConfig struct {
+	*runconfig.Config
+	// backward compatibility, it lives now in HostConfig
+	VolumeDriver string
+}
+
+// StatsJSON is a backcompatibility struct used in Stats for API prior to 1.21
+type StatsJSON struct {
+	types.Stats
+	Network types.NetworkStats `json:"network,omitempty"`
+}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions/v1p20"
 )
 
 // ContainerInspect returns low-level information about a
@@ -30,7 +31,7 @@ func (daemon *Daemon) ContainerInspect(name string) (*types.ContainerJSON, error
 }
 
 // ContainerInspect120 serializes the master version of a container into a json type.
-func (daemon *Daemon) ContainerInspect120(name string) (*types.ContainerJSON120, error) {
+func (daemon *Daemon) ContainerInspect120(name string) (*v1p20.ContainerJSON, error) {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return nil, err
@@ -45,12 +46,12 @@ func (daemon *Daemon) ContainerInspect120(name string) (*types.ContainerJSON120,
 	}
 
 	mountPoints := addMountPoints(container)
-	config := &types.ContainerConfig120{
+	config := &v1p20.ContainerConfig{
 		container.Config,
 		container.hostConfig.VolumeDriver,
 	}
 
-	return &types.ContainerJSON120{base, mountPoints, config}, nil
+	return &v1p20.ContainerJSON{base, mountPoints, config}, nil
 }
 
 func (daemon *Daemon) getInspectData(container *Container) (*types.ContainerJSONBase, error) {

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -2,7 +2,10 @@
 
 package daemon
 
-import "github.com/docker/docker/api/types"
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions/v1p19"
+)
 
 // This sets platform-specific fields
 func setPlatformSpecificContainerFields(container *Container, contJSONBase *types.ContainerJSONBase) *types.ContainerJSONBase {
@@ -15,7 +18,7 @@ func setPlatformSpecificContainerFields(container *Container, contJSONBase *type
 }
 
 // ContainerInspectPre120 gets containers for pre 1.20 APIs.
-func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSONPre120, error) {
+func (daemon *Daemon) ContainerInspectPre120(name string) (*v1p19.ContainerJSON, error) {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return nil, err
@@ -36,7 +39,7 @@ func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSONP
 		volumesRW[m.Destination] = m.RW
 	}
 
-	config := &types.ContainerConfigPre120{
+	config := &v1p19.ContainerConfig{
 		container.Config,
 		container.hostConfig.VolumeDriver,
 		container.hostConfig.Memory,
@@ -45,7 +48,7 @@ func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSONP
 		container.hostConfig.CpusetCpus,
 	}
 
-	return &types.ContainerJSONPre120{base, volumes, volumesRW, config}, nil
+	return &v1p19.ContainerJSON{base, volumes, volumesRW, config}, nil
 }
 
 func addMountPoints(container *Container) []types.MountPoint {

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/libnetwork/osl"
@@ -96,7 +97,7 @@ func (daemon *Daemon) ContainerStats(prefixOrName string, config *ContainerStats
 					txErrors += v.TxErrors
 					txDropped += v.TxDropped
 				}
-				statsJSONPre121 := &types.StatsJSONPre121{
+				statsJSONPre121 := &v1p20.StatsJSON{
 					Stats: statsJSON.Stats,
 					Network: types.NetworkStats{
 						RxBytes:   rxBytes,


### PR DESCRIPTION
This is a less polemic(I hope) version of #16200.

I'm slightly tired of seen those types with `PreXXX` suffix all around the api.
I think these types would be much better in independent packages. This would also be a
better convention to follow when we need to version another type.

/cc @MHBauer because there are some changes in the api.
/cc @HuKeping and @cpuguy83 that commented in the previous PR.

Signed-off-by: David Calavera david.calavera@gmail.com
