### PR TITLE
Define a context per request.

### DIFF
--- a/api/server/image.go
+++ b/api/server/image.go
@@ -112,7 +112,7 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			OutStream:   output,
 		}
 
-		err = s.daemon.Repositories(ctx).Pull(ctx, image, tag, imagePullConfig)
+		err = s.daemon.Repositories().Pull(ctx, image, tag, imagePullConfig)
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)
@@ -129,7 +129,7 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			return err
 		}
 
-		err = s.daemon.Repositories(ctx).Import(ctx, src, repo, tag, message, r.Body, output, newConfig)
+		err = s.daemon.Repositories().Import(ctx, src, repo, tag, message, r.Body, output, newConfig)
 	}
 	if err != nil {
 		if !output.Flushed() {
@@ -184,7 +184,7 @@ func (s *Server) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if err := s.daemon.Repositories(ctx).Push(ctx, name, imagePushConfig); err != nil {
+	if err := s.daemon.Repositories().Push(ctx, name, imagePushConfig); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -212,7 +212,7 @@ func (s *Server) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 		names = r.Form["names"]
 	}
 
-	if err := s.daemon.Repositories(ctx).ImageExport(names, output); err != nil {
+	if err := s.daemon.Repositories().ImageExport(names, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -223,7 +223,7 @@ func (s *Server) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 }
 
 func (s *Server) postImagesLoad(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return s.daemon.Repositories(ctx).Load(r.Body, w)
+	return s.daemon.Repositories().Load(r.Body, w)
 }
 
 func (s *Server) deleteImages(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -256,7 +256,7 @@ func (s *Server) getImagesByName(ctx context.Context, w http.ResponseWriter, r *
 		return fmt.Errorf("Missing parameter")
 	}
 
-	imageInspect, err := s.daemon.Repositories(ctx).Lookup(vars["name"])
+	imageInspect, err := s.daemon.Repositories().Lookup(vars["name"])
 	if err != nil {
 		return err
 	}
@@ -364,7 +364,7 @@ func (s *Server) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *ht
 	}
 
 	// FIXME: The filter parameter could just be a match filter
-	images, err := s.daemon.Repositories(ctx).Images(r.Form.Get("filters"), r.Form.Get("filter"), boolValue(r, "all"))
+	images, err := s.daemon.Repositories().Images(r.Form.Get("filters"), r.Form.Get("filter"), boolValue(r, "all"))
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (s *Server) getImagesHistory(ctx context.Context, w http.ResponseWriter, r 
 	}
 
 	name := vars["name"]
-	history, err := s.daemon.Repositories(ctx).History(name)
+	history, err := s.daemon.Repositories().History(name)
 	if err != nil {
 		return err
 	}
@@ -398,7 +398,7 @@ func (s *Server) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 	tag := r.Form.Get("tag")
 	force := boolValue(r, "force")
 	name := vars["name"]
-	if err := s.daemon.Repositories(ctx).Tag(repo, tag, name, force); err != nil {
+	if err := s.daemon.Repositories().Tag(repo, tag, name, force); err != nil {
 		return err
 	}
 	s.daemon.EventsService.Log(ctx, "tag", utils.ImageReference(repo, tag), "")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -42,12 +42,12 @@ type Server struct {
 }
 
 // New returns a new instance of the server based on the specified configuration.
-func New(ctx context.Context, cfg *Config) *Server {
+func New(cfg *Config) *Server {
 	srv := &Server{
 		cfg:   cfg,
 		start: make(chan struct{}),
 	}
-	srv.router = createRouter(ctx, srv)
+	srv.router = createRouter(srv)
 	return srv
 }
 
@@ -291,7 +291,7 @@ func (s *Server) initTCPSocket(addr string) (l net.Listener, err error) {
 	return
 }
 
-func (s *Server) makeHTTPHandler(ctx context.Context, localMethod string, localRoute string, localHandler HTTPAPIFunc) http.HandlerFunc {
+func (s *Server) makeHTTPHandler(localMethod string, localRoute string, localHandler HTTPAPIFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// log the handler generation
 		logrus.Debugf("Calling %s %s", localMethod, localRoute)
@@ -303,6 +303,8 @@ func (s *Server) makeHTTPHandler(ctx context.Context, localMethod string, localR
 		// apply to all requests. Data that is specific to the
 		// immediate function being called should still be passed
 		// as 'args' on the function call.
+		ctx := context.Background()
+
 		reqID := stringid.TruncateID(stringid.GenerateNonCryptoID())
 		ctx = context.WithValue(ctx, context.RequestID, reqID)
 		handlerFunc := s.handleWithGlobalMiddlewares(localHandler)
@@ -316,7 +318,7 @@ func (s *Server) makeHTTPHandler(ctx context.Context, localMethod string, localR
 
 // createRouter initializes the main router the server uses.
 // we keep enableCors just for legacy usage, need to be removed in the future
-func createRouter(ctx context.Context, s *Server) *mux.Router {
+func createRouter(s *Server) *mux.Router {
 	r := mux.NewRouter()
 	if os.Getenv("DEBUG") != "" {
 		profilerSetup(r, "/debug/")
@@ -396,7 +398,7 @@ func createRouter(ctx context.Context, s *Server) *mux.Router {
 			localMethod := method
 
 			// build the handler function
-			f := s.makeHTTPHandler(ctx, localMethod, localRoute, localFct)
+			f := s.makeHTTPHandler(localMethod, localRoute, localFct)
 
 			// add the new route
 			if localRoute == "" {

--- a/api/server/server_experimental_unix.go
+++ b/api/server/server_experimental_unix.go
@@ -2,12 +2,8 @@
 
 package server
 
-import (
-	"github.com/docker/docker/context"
-)
-
-func (s *Server) registerSubRouter(ctx context.Context) {
-	httpHandler := s.daemon.NetworkAPIRouter(ctx)
+func (s *Server) registerSubRouter() {
+	httpHandler := s.daemon.NetworkAPIRouter()
 
 	subrouter := s.router.PathPrefix("/v{version:[0-9.]+}/networks").Subrouter()
 	subrouter.Methods("GET", "POST", "PUT", "DELETE").HandlerFunc(httpHandler)

--- a/api/server/server_stub.go
+++ b/api/server/server_stub.go
@@ -2,9 +2,5 @@
 
 package server
 
-import (
-	"github.com/docker/docker/context"
-)
-
-func (s *Server) registerSubRouter(ctx context.Context) {
+func (s *Server) registerSubRouter() {
 }

--- a/api/server/server_unix.go
+++ b/api/server/server_unix.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/sockets"
 	"github.com/docker/libnetwork/portallocator"
@@ -64,10 +63,10 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 // AcceptConnections allows clients to connect to the API server.
 // Referenced Daemon is notified about this server, and waits for the
 // daemon acknowledgement before the incoming connections are accepted.
-func (s *Server) AcceptConnections(ctx context.Context, d *daemon.Daemon) {
+func (s *Server) AcceptConnections(d *daemon.Daemon) {
 	// Tell the init daemon we are accepting requests
 	s.daemon = d
-	s.registerSubRouter(ctx)
+	s.registerSubRouter()
 	go systemdDaemon.SdNotify("READY=1")
 	// close the lock so the listeners start accepting connections
 	select {

--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 )
 
@@ -43,9 +42,9 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 }
 
 // AcceptConnections allows router to start listening for the incoming requests.
-func (s *Server) AcceptConnections(ctx context.Context, d *daemon.Daemon) {
+func (s *Server) AcceptConnections(d *daemon.Daemon) {
 	s.daemon = d
-	s.registerSubRouter(ctx)
+	s.registerSubRouter()
 	// close the lock so the listeners start accepting connections
 	select {
 	case <-s.start:

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -209,7 +209,7 @@ func from(ctx context.Context, b *builder, args []string, attributes map[string]
 		return nil
 	}
 
-	image, err := b.Daemon.Repositories(ctx).LookupImage(name)
+	image, err := b.Daemon.Repositories().LookupImage(name)
 	if b.Pull {
 		image, err = b.pullImage(ctx, name)
 		if err != nil {
@@ -217,7 +217,7 @@ func from(ctx context.Context, b *builder, args []string, attributes map[string]
 		}
 	}
 	if err != nil {
-		if b.Daemon.Graph(ctx).IsNotExist(err, name) {
+		if b.Daemon.Graph().IsNotExist(err, name) {
 			image, err = b.pullImage(ctx, name)
 		}
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -132,7 +132,7 @@ func (b *builder) commit(ctx context.Context, id string, autoCmd *stringutils.St
 	if err != nil {
 		return err
 	}
-	b.Daemon.Graph(ctx).Retain(b.id, image.ID)
+	b.Daemon.Graph().Retain(b.id, image.ID)
 	b.activeImages = append(b.activeImages, image.ID)
 	b.image = image.ID
 	return nil
@@ -511,11 +511,11 @@ func (b *builder) pullImage(ctx context.Context, name string) (*image.Image, err
 		OutStream:  ioutils.NopWriteCloser(b.OutOld),
 	}
 
-	if err := b.Daemon.Repositories(ctx).Pull(ctx, remote, tag, imagePullConfig); err != nil {
+	if err := b.Daemon.Repositories().Pull(ctx, remote, tag, imagePullConfig); err != nil {
 		return nil, err
 	}
 
-	image, err := b.Daemon.Repositories(ctx).LookupImage(name)
+	image, err := b.Daemon.Repositories().LookupImage(name)
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +595,7 @@ func (b *builder) probeCache(ctx context.Context) (bool, error) {
 	fmt.Fprintf(b.OutStream, " ---> Using cache\n")
 	logrus.Debugf("[BUILDER] Use cached version")
 	b.image = cache.ID
-	b.Daemon.Graph(ctx).Retain(b.id, cache.ID)
+	b.Daemon.Graph().Retain(b.id, cache.ID)
 	b.activeImages = append(b.activeImages, cache.ID)
 	return true, nil
 }

--- a/builder/job.go
+++ b/builder/job.go
@@ -230,7 +230,7 @@ func Build(ctx context.Context, d *daemon.Daemon, buildConfig *Config) error {
 	}
 
 	defer func() {
-		builder.Daemon.Graph(ctx).Release(builder.id, builder.activeImages...)
+		builder.Daemon.Graph().Release(builder.id, builder.activeImages...)
 	}()
 
 	id, err := builder.Run(ctx, context)
@@ -238,7 +238,7 @@ func Build(ctx context.Context, d *daemon.Daemon, buildConfig *Config) error {
 		return err
 	}
 	if repoName != "" {
-		return d.Repositories(ctx).Tag(repoName, tag, id, true)
+		return d.Repositories().Tag(repoName, tag, id, true)
 	}
 	return nil
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -30,7 +30,7 @@ func (daemon *Daemon) ContainerCreate(ctx context.Context, name string, config *
 
 	container, buildWarnings, err := daemon.Create(ctx, config, hostConfig, name)
 	if err != nil {
-		if daemon.Graph(ctx).IsNotExist(err, config.Image) {
+		if daemon.Graph().IsNotExist(err, config.Image) {
 			if strings.Contains(config.Image, "@") {
 				return nil, warnings, derr.ErrorCodeNoSuchImageHash.WithArgs(config.Image)
 			}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -252,7 +252,7 @@ func (daemon *Daemon) ensureName(container *Container) error {
 	return nil
 }
 
-func (daemon *Daemon) restore(ctx context.Context) error {
+func (daemon *Daemon) restore() error {
 	type cr struct {
 		container  *Container
 		registered bool
@@ -308,6 +308,7 @@ func (daemon *Daemon) restore(ctx context.Context) error {
 	}
 
 	group := sync.WaitGroup{}
+	ctx := context.Background()
 	for _, c := range containers {
 		group.Add(1)
 
@@ -572,7 +573,7 @@ func (daemon *Daemon) registerLink(parent, child *Container, alias string) error
 
 // NewDaemon sets up everything for the daemon to be able to service
 // requests from the webserver.
-func NewDaemon(ctx context.Context, config *Config, registryService *registry.Service) (daemon *Daemon, err error) {
+func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemon, err error) {
 	setDefaultMtu(config)
 
 	// Ensure we have compatible configuration options
@@ -640,7 +641,7 @@ func NewDaemon(ctx context.Context, config *Config, registryService *registry.Se
 	// Ensure the graph driver is shutdown at a later point
 	defer func() {
 		if err != nil {
-			if err := d.Shutdown(ctx); err != nil {
+			if err := d.Shutdown(context.Background()); err != nil {
 				logrus.Error(err)
 			}
 		}
@@ -774,7 +775,7 @@ func NewDaemon(ctx context.Context, config *Config, registryService *registry.Se
 
 	go d.execCommandGC()
 
-	if err := d.restore(ctx); err != nil {
+	if err := d.restore(); err != nil {
 		return nil, err
 	}
 
@@ -787,7 +788,7 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 	if daemon.containers != nil {
 		group := sync.WaitGroup{}
 		logrus.Debug("starting clean shutdown of all containers...")
-		for _, container := range daemon.List(ctx) {
+		for _, container := range daemon.List() {
 			c := container
 			if c.IsRunning() {
 				logrus.Debugf("stopping %s", c.ID)
@@ -962,12 +963,12 @@ func (daemon *Daemon) createRootfs(container *Container) error {
 // which need direct access to daemon.graph.
 // Once the tests switch to using engine and jobs, this method
 // can go away.
-func (daemon *Daemon) Graph(ctx context.Context) *graph.Graph {
+func (daemon *Daemon) Graph() *graph.Graph {
 	return daemon.graph
 }
 
 // Repositories returns all repositories.
-func (daemon *Daemon) Repositories(ctx context.Context) *graph.TagStore {
+func (daemon *Daemon) Repositories() *graph.TagStore {
 	return daemon.repositories
 }
 
@@ -981,13 +982,13 @@ func (daemon *Daemon) systemInitPath() string {
 
 // GraphDriver returns the currently used driver for processing
 // container layers.
-func (daemon *Daemon) GraphDriver(ctx context.Context) graphdriver.Driver {
+func (daemon *Daemon) GraphDriver() graphdriver.Driver {
 	return daemon.driver
 }
 
 // ExecutionDriver returns the currently used driver for creating and
 // starting execs in a container.
-func (daemon *Daemon) ExecutionDriver(ctx context.Context) execdriver.Driver {
+func (daemon *Daemon) ExecutionDriver() execdriver.Driver {
 	return daemon.execDriver
 }
 
@@ -1001,7 +1002,7 @@ func (daemon *Daemon) containerGraph() *graphdb.Database {
 // returned if the parent image cannot be found.
 func (daemon *Daemon) ImageGetCached(ctx context.Context, imgID string, config *runconfig.Config) (*image.Image, error) {
 	// Retrieve all images
-	images := daemon.Graph(ctx).Map()
+	images := daemon.Graph().Map()
 
 	// Store the tree in a map of map (map[parentId][childId])
 	imageMap := make(map[string]map[string]struct{})

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -122,8 +122,8 @@ func verifyPlatformContainerSettings(ctx context.Context, daemon *Daemon, hostCo
 	warnings := []string{}
 	sysInfo := sysinfo.New(true)
 
-	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver(ctx).Name(), "lxc") {
-		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver(ctx).Name())
+	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver().Name(), "lxc") {
+		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver().Name())
 	}
 
 	// memory subsystem checks and adjustments
@@ -496,7 +496,7 @@ func setupInitLayer(initLayer string) error {
 
 // NetworkAPIRouter implements a feature for server-experimental,
 // directly calling into libnetwork.
-func (daemon *Daemon) NetworkAPIRouter(ctx context.Context) func(w http.ResponseWriter, req *http.Request) {
+func (daemon *Daemon) NetworkAPIRouter() func(w http.ResponseWriter, req *http.Request) {
 	return nwapi.NewHTTPHandler(daemon.netController)
 }
 

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -54,7 +54,7 @@ import (
 func (daemon *Daemon) ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDelete, error) {
 	records := []types.ImageDelete{}
 
-	img, err := daemon.Repositories(ctx).LookupImage(imageRef)
+	img, err := daemon.Repositories().LookupImage(imageRef)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (daemon *Daemon) ImageDelete(ctx context.Context, imageRef string, force, p
 		// true, there are multiple repository references to this
 		// image, or there are no containers using the given reference.
 		if !(force || daemon.imageHasMultipleRepositoryReferences(ctx, img.ID)) {
-			if container := daemon.getContainerUsingImage(ctx, img.ID); container != nil {
+			if container := daemon.getContainerUsingImage(img.ID); container != nil {
 				// If we removed the repository reference then
 				// this image would remain "dangling" and since
 				// we really want to avoid that the client must
@@ -91,7 +91,7 @@ func (daemon *Daemon) ImageDelete(ctx context.Context, imageRef string, force, p
 		// repository reference to the image then we will want to
 		// remove that reference.
 		// FIXME: Is this the behavior we want?
-		repoRefs := daemon.Repositories(ctx).ByID()[img.ID]
+		repoRefs := daemon.Repositories().ByID()[img.ID]
 		if len(repoRefs) == 1 {
 			parsedRef, err := daemon.removeImageRef(ctx, repoRefs[0])
 			if err != nil {
@@ -117,13 +117,13 @@ func isImageIDPrefix(imageID, possiblePrefix string) bool {
 // imageHasMultipleRepositoryReferences returns whether there are multiple
 // repository references to the given imageID.
 func (daemon *Daemon) imageHasMultipleRepositoryReferences(ctx context.Context, imageID string) bool {
-	return len(daemon.Repositories(ctx).ByID()[imageID]) > 1
+	return len(daemon.Repositories().ByID()[imageID]) > 1
 }
 
 // getContainerUsingImage returns a container that was created using the given
 // imageID. Returns nil if there is no such container.
-func (daemon *Daemon) getContainerUsingImage(ctx context.Context, imageID string) *Container {
-	for _, container := range daemon.List(ctx) {
+func (daemon *Daemon) getContainerUsingImage(imageID string) *Container {
+	for _, container := range daemon.List() {
 		if container.ImageID == imageID {
 			return container
 		}
@@ -146,7 +146,7 @@ func (daemon *Daemon) removeImageRef(ctx context.Context, repositoryRef string) 
 	// Ignore the boolean value returned, as far as we're concerned, this
 	// is an idempotent operation and it's okay if the reference didn't
 	// exist in the first place.
-	_, err := daemon.Repositories(ctx).Delete(repository, ref)
+	_, err := daemon.Repositories().Delete(repository, ref)
 
 	return utils.ImageReference(repository, ref), err
 }
@@ -157,7 +157,7 @@ func (daemon *Daemon) removeImageRef(ctx context.Context, repositoryRef string) 
 // daemon's event service. An "Untagged" types.ImageDelete is added to the
 // given list of records.
 func (daemon *Daemon) removeAllReferencesToImageID(ctx context.Context, imgID string, records *[]types.ImageDelete) error {
-	imageRefs := daemon.Repositories(ctx).ByID()[imgID]
+	imageRefs := daemon.Repositories().ByID()[imgID]
 
 	for _, imageRef := range imageRefs {
 		parsedRef, err := daemon.removeImageRef(ctx, imageRef)
@@ -224,7 +224,7 @@ func (daemon *Daemon) imageDeleteHelper(ctx context.Context, img *image.Image, r
 		return err
 	}
 
-	if err := daemon.Graph(ctx).Delete(img.ID); err != nil {
+	if err := daemon.Graph().Delete(img.ID); err != nil {
 		return err
 	}
 
@@ -238,7 +238,7 @@ func (daemon *Daemon) imageDeleteHelper(ctx context.Context, img *image.Image, r
 	// We need to prune the parent image. This means delete it if there are
 	// no tags/digests referencing it and there are no containers using it (
 	// either running or stopped).
-	parentImg, err := daemon.Graph(ctx).Get(img.Parent)
+	parentImg, err := daemon.Graph().Get(img.Parent)
 	if err != nil {
 		return derr.ErrorCodeImgNoParent.WithArgs(err)
 	}
@@ -271,7 +271,7 @@ func (daemon *Daemon) checkImageDeleteConflict(ctx context.Context, img *image.I
 
 func (daemon *Daemon) checkImageDeleteHardConflict(ctx context.Context, img *image.Image) *imageDeleteConflict {
 	// Check if the image ID is being used by a pull or build.
-	if daemon.Graph(ctx).IsHeld(img.ID) {
+	if daemon.Graph().IsHeld(img.ID) {
 		return &imageDeleteConflict{
 			hard:    true,
 			imgID:   img.ID,
@@ -280,7 +280,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(ctx context.Context, img *ima
 	}
 
 	// Check if the image has any descendent images.
-	if daemon.Graph(ctx).HasChildren(img) {
+	if daemon.Graph().HasChildren(img) {
 		return &imageDeleteConflict{
 			hard:    true,
 			imgID:   img.ID,
@@ -289,7 +289,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(ctx context.Context, img *ima
 	}
 
 	// Check if any running container is using the image.
-	for _, container := range daemon.List(ctx) {
+	for _, container := range daemon.List() {
 		if !container.IsRunning() {
 			// Skip this until we check for soft conflicts later.
 			continue
@@ -309,7 +309,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(ctx context.Context, img *ima
 
 func (daemon *Daemon) checkImageDeleteSoftConflict(ctx context.Context, img *image.Image) *imageDeleteConflict {
 	// Check if any repository tags/digest reference this image.
-	if daemon.Repositories(ctx).HasReferences(img) {
+	if daemon.Repositories().HasReferences(img) {
 		return &imageDeleteConflict{
 			imgID:   img.ID,
 			message: "image is referenced in one or more repositories",
@@ -317,7 +317,7 @@ func (daemon *Daemon) checkImageDeleteSoftConflict(ctx context.Context, img *ima
 	}
 
 	// Check if any stopped containers reference this image.
-	for _, container := range daemon.List(ctx) {
+	for _, container := range daemon.List() {
 		if container.IsRunning() {
 			// Skip this as it was checked above in hard conflict conditions.
 			continue
@@ -338,5 +338,5 @@ func (daemon *Daemon) checkImageDeleteSoftConflict(ctx context.Context, img *ima
 // that there are no repository references to the given image and it has no
 // child images.
 func (daemon *Daemon) imageIsDangling(ctx context.Context, img *image.Image) bool {
-	return !(daemon.Repositories(ctx).HasReferences(img) || daemon.Graph(ctx).HasChildren(img))
+	return !(daemon.Repositories().HasReferences(img) || daemon.Graph().HasChildren(img))
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -20,7 +20,7 @@ import (
 
 // SystemInfo returns information about the host server the daemon is running on.
 func (daemon *Daemon) SystemInfo(ctx context.Context) (*types.Info, error) {
-	images := daemon.Graph(ctx).Map()
+	images := daemon.Graph().Map()
 	var imgcount int
 	if images == nil {
 		imgcount = 0
@@ -66,10 +66,10 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*types.Info, error) {
 
 	v := &types.Info{
 		ID:                 daemon.ID,
-		Containers:         len(daemon.List(ctx)),
+		Containers:         len(daemon.List()),
 		Images:             imgcount,
-		Driver:             daemon.GraphDriver(ctx).String(),
-		DriverStatus:       daemon.GraphDriver(ctx).Status(),
+		Driver:             daemon.GraphDriver().String(),
+		DriverStatus:       daemon.GraphDriver().Status(),
 		IPv4Forwarding:     !sysInfo.IPv4ForwardingDisabled,
 		BridgeNfIptables:   !sysInfo.BridgeNfCallIptablesDisabled,
 		BridgeNfIP6tables:  !sysInfo.BridgeNfCallIP6tablesDisabled,
@@ -77,7 +77,7 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*types.Info, error) {
 		NFd:                fileutils.GetTotalUsedFds(),
 		NGoroutines:        runtime.NumGoroutine(),
 		SystemTime:         time.Now().Format(time.RFC3339Nano),
-		ExecutionDriver:    daemon.ExecutionDriver(ctx).Name(),
+		ExecutionDriver:    daemon.ExecutionDriver().Name(),
 		LoggingDriver:      daemon.defaultLogConfig.Type,
 		NEventsListener:    daemon.EventsService.SubscribersCount(),
 		KernelVersion:      kernelVersion,

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -36,7 +36,7 @@ const (
 var errStopIteration = errors.New("container list iteration stopped")
 
 // List returns an array of all containers registered in the daemon.
-func (daemon *Daemon) List(ctx context.Context) []*Container {
+func (daemon *Daemon) List() []*Container {
 	return daemon.containers.List()
 }
 
@@ -93,7 +93,7 @@ func (daemon *Daemon) reduceContainers(ctx context.Context, config *ContainersCo
 		return nil, err
 	}
 
-	for _, container := range daemon.List(ctx) {
+	for _, container := range daemon.List() {
 		t, err := daemon.reducePsContainer(ctx, container, fctx, reducer)
 		if err != nil {
 			if err != errStopIteration {
@@ -160,11 +160,11 @@ func (daemon *Daemon) foldFilter(ctx context.Context, config *ContainersConfig) 
 	var ancestorFilter bool
 	if ancestors, ok := psFilters["ancestor"]; ok {
 		ancestorFilter = true
-		byParents := daemon.Graph(ctx).ByParent()
+		byParents := daemon.Graph().ByParent()
 		// The idea is to walk the graph down the most "efficient" way.
 		for _, ancestor := range ancestors {
 			// First, get the imageId of the ancestor filter (yay)
-			image, err := daemon.Repositories(ctx).LookupImage(ancestor)
+			image, err := daemon.Repositories().LookupImage(ancestor)
 			if err != nil {
 				logrus.Warnf("Error while looking up for image %v", ancestor)
 				continue
@@ -293,7 +293,7 @@ func (daemon *Daemon) transformContainer(ctx context.Context, container *Contain
 		Names: lctx.names[container.ID],
 	}
 
-	img, err := daemon.Repositories(ctx).LookupImage(container.Config.Image)
+	img, err := daemon.Repositories().LookupImage(container.Config.Image)
 	if err != nil {
 		// If the image can no longer be found by its original reference,
 		// it makes sense to show the ID instead of a stale reference.

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -31,7 +31,7 @@ func (daemon *Daemon) ContainerTop(ctx context.Context, name string, psArgs stri
 		return nil, derr.ErrorCodeNotRunning.WithArgs(name)
 	}
 
-	pids, err := daemon.ExecutionDriver(ctx).GetPidsForContainer(container.ID)
+	pids, err := daemon.ExecutionDriver().GetPidsForContainer(container.ID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Avoid creating a global context object that will be used while the daemon is running.

Not only this object won't ever be garbage collected, but it won't ever be used for anything else than creating other contexts in each request. I think it's a bad practive to have something like this sprawling aroud the code.

This change removes that global object and initializes a context in the cases we don't have already one, like shutting down the server.
This also removes a bunch of context arguments from functions that did nothing with it.

/cc @duglin

Signed-off-by: David Calavera david.calavera@gmail.com
