### PR TITLE
Make Close() on simpleReaderCloser actually close the reader

### DIFF
--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -129,13 +129,16 @@ func TestBufReaderCloseWithNonReaderCloser(t *testing.T) {
 }
 
 // implements io.ReadCloser
-type simpleReaderCloser struct{}
+type simpleReaderCloser struct {
+	err error
+}
 
 func (r *simpleReaderCloser) Read(p []byte) (n int, err error) {
-	return 0, nil
+	return 0, r.err
 }
 
 func (r *simpleReaderCloser) Close() error {
+	r.err = io.EOF
 	return nil
 }
 


### PR DESCRIPTION
see #16569 for some more info - but when Read() never returns EOF the for-loop in #16569 gets so tight that the thread causes a hang on gcc-go. But, irrespective of that issue, Read() should still return EOF after Close() is called.

Signed-off-by: Doug Davis dug@us.ibm.com
