### PR TITLE
Generate a full RPM changelog from the existing CHANGELOG.md file

### DIFF
--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -46,6 +46,20 @@ set -e
 	./man/md2man-all.sh -q || true
 	# TODO decide if it's worth getting go-md2man in _each_ builder environment to avoid this
 
+	# Convert the CHANGELOG.md file into RPM changelog format
+	VERSION_REGEX="^\W\W (.*) \((.*)\)$"
+	ENTRY_REGEX="^[-+*] (.*)$"
+	while read -r line || [[ -n "$line" ]]; do
+		if [ -z "$line" ]; then continue; fi
+		if [[ "$line" =~ $VERSION_REGEX ]]; then
+			echo >> contrib/builder/rpm/changelog
+			echo "* `date -d ${BASH_REMATCH[2]} '+%a %b %d %Y'` ${rpmPackager} - ${BASH_REMATCH[1]}" >> contrib/builder/rpm/changelog
+		fi
+		if [[ "$line" =~ $ENTRY_REGEX ]]; then
+			echo "- ${BASH_REMATCH[1]//\`}" >> contrib/builder/rpm/changelog
+		fi
+	done < CHANGELOG.md
+
 	# TODO add a configurable knob for _which_ rpms to build so we don't have to modify the file or build all of them every time we need to test
 	for dir in contrib/builder/rpm/*/; do
 		version="$(basename "$dir")"
@@ -71,7 +85,7 @@ set -e
 			RUN ln -sfv /usr/src/${rpmName}/hack/make/.build-rpm SPECS
 			WORKDIR /root/rpmbuild/SPECS
 			RUN tar -cz -C /usr/src -f /root/rpmbuild/SOURCES/${rpmName}.tar.gz ${rpmName}
-			RUN { echo '* $rpmDate $rpmPackager $rpmVersion-$rpmRelease'; echo '* Version: $VERSION'; } >> ${rpmName}.spec && tail >&2 ${rpmName}.spec
+			RUN { cat /usr/src/${rpmName}/contrib/builder/rpm/changelog; } >> ${rpmName}.spec && tail >&2 ${rpmName}.spec
 			RUN rpmbuild -ba --define '_release $rpmRelease' --define '_version $rpmVersion' --define '_origversion $VERSION' ${rpmName}.spec
 		EOF
 		# selinux policy referencing systemd things won't work on non-systemd versions


### PR DESCRIPTION
This resolves #16535 by converting the existing CHANGELOG.md file into RPM changelog format and appending it to each .spec file.

Signed-off-by: Avi Miller avi.miller@oracle.com
