### PR TITLE
Add documentation files

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -165,6 +165,7 @@ install -p -m 644 contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/shar
 
 # list files owned by the package here
 %files
+%doc AUTHORS CHANGELOG.md CONTRIBUTING.md LICENSE MAINTAINERS NOTICE README.md
 /%{_bindir}/docker
 /%{_libexecdir}/docker/dockerinit
 /%{_sysconfdir}/udev/rules.d/80-docker.rules


### PR DESCRIPTION
This very small patch ensures that the documentation files in the root of the source repository are copied into the appropriate `/usr/share/doc/` directory by the binary RPM. This ensures the `LICENSE` file is available for every install as well.

Signed-off-by: Avi Miller avi.miller@oracle.com
