### PR TITLE
Fix docker cli silently does nothing when provided a slash-prefixed container name

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
@@ -24,8 +25,8 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)
-
-	serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+	cleanName := strings.TrimPrefix(cmd.Arg(0), "/")
+	serverResp, err := cli.call("GET", "/containers/"+cleanName+"/json", nil, nil)
 	if err != nil {
 		return err
 	}
@@ -46,7 +47,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	}
 
 	if c.Config.Tty && cli.isTerminalOut {
-		if err := cli.monitorTtySize(cmd.Arg(0), false); err != nil {
+		if err := cli.monitorTtySize(cleanName, false); err != nil {
 			logrus.Debugf("Error monitoring TTY size: %s", err)
 		}
 	}
@@ -64,15 +65,15 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	v.Set("stderr", "1")
 
 	if *proxy && !c.Config.Tty {
-		sigc := cli.forwardAllSignals(cmd.Arg(0))
+		sigc := cli.forwardAllSignals(cleanName)
 		defer signal.StopCatch(sigc)
 	}
 
-	if err := cli.hijack("POST", "/containers/"+cmd.Arg(0)+"/attach?"+v.Encode(), c.Config.Tty, in, cli.out, cli.err, nil, nil); err != nil {
+	if err := cli.hijack("POST", "/containers/"+cleanName+"/attach?"+v.Encode(), c.Config.Tty, in, cli.out, cli.err, nil, nil); err != nil {
 		return err
 	}
 
-	_, status, err := getExitCode(cli, cmd.Arg(0))
+	_, status, err := getExitCode(cli, cleanName)
 	if err != nil {
 		return err
 	}

--- a/api/client/kill.go
+++ b/api/client/kill.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -19,7 +20,8 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/kill?signal=%s", name, *signal), nil, nil)); err != nil {
+		cleanName := strings.TrimPrefix(name, "/")
+		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/kill?signal=%s", cleanName, *signal), nil, nil)); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)
 		} else {

--- a/api/client/pause.go
+++ b/api/client/pause.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -18,7 +19,8 @@ func (cli *DockerCli) CmdPause(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/pause", name), nil, nil)); err != nil {
+		cleanName := strings.TrimPrefix(name, "/")
+		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/pause", cleanName), nil, nil)); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)
 		} else {

--- a/api/client/rename.go
+++ b/api/client/rename.go
@@ -18,13 +18,14 @@ func (cli *DockerCli) CmdRename(args ...string) error {
 	cmd.ParseFlags(args, true)
 
 	oldName := strings.TrimSpace(cmd.Arg(0))
+	cleanOldName := strings.TrimPrefix(oldName, "/")
 	newName := strings.TrimSpace(cmd.Arg(1))
 
 	if oldName == "" || newName == "" {
 		return fmt.Errorf("Error: Neither old nor new names may be empty")
 	}
 
-	if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/rename?name=%s", oldName, newName), nil, nil)); err != nil {
+	if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/rename?name=%s", cleanOldName, newName), nil, nil)); err != nil {
 		fmt.Fprintf(cli.err, "%s\n", err)
 		return fmt.Errorf("Error: failed to rename container named %s", oldName)
 	}

--- a/api/client/restart.go
+++ b/api/client/restart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -24,7 +25,8 @@ func (cli *DockerCli) CmdRestart(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/restart?"+v.Encode(), nil, nil))
+		cleanName := strings.TrimPrefix(name, "/")
+		_, _, err := readBody(cli.call("POST", "/containers/"+cleanName+"/restart?"+v.Encode(), nil, nil))
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
@@ -61,8 +62,8 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		if cmd.NArg() > 1 {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")
 		}
-
-		serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+		name := strings.TrimPrefix(cmd.Arg(0), "/")
+		serverResp, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
 		if err != nil {
 			return err
 		}
@@ -77,7 +78,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		tty = c.Config.Tty
 
 		if !tty {
-			sigc := cli.forwardAllSignals(cmd.Arg(0))
+			sigc := cli.forwardAllSignals(name)
 			defer signal.StopCatch(sigc)
 		}
 
@@ -104,7 +105,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			cli.in.Close()
 		}()
 		cErr = promise.Go(func() error {
-			return cli.hijack("POST", "/containers/"+cmd.Arg(0)+"/attach?"+v.Encode(), tty, in, cli.out, cli.err, hijacked, nil)
+			return cli.hijack("POST", "/containers/"+name+"/attach?"+v.Encode(), tty, in, cli.out, cli.err, hijacked, nil)
 		})
 
 		// Acknowledge the hijack before starting
@@ -125,7 +126,8 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	var encounteredError error
 	var errNames []string
 	for _, name := range cmd.Args() {
-		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/start", nil, nil))
+		cleanName := strings.TrimPrefix(name, "/")
+		_, _, err := readBody(cli.call("POST", "/containers/"+cleanName+"/start", nil, nil))
 		if err != nil {
 			if !*attach && !*openStdin {
 				// attach and openStdin is false means it could be starting multiple containers
@@ -150,15 +152,16 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	}
 
 	if *openStdin || *attach {
+		name := strings.TrimPrefix(cmd.Arg(0), "/")
 		if tty && cli.isTerminalOut {
-			if err := cli.monitorTtySize(cmd.Arg(0), false); err != nil {
+			if err := cli.monitorTtySize(name, false); err != nil {
 				fmt.Fprintf(cli.err, "Error monitoring TTY size: %s\n", err)
 			}
 		}
 		if attchErr := <-cErr; attchErr != nil {
 			return attchErr
 		}
-		_, status, err := getExitCode(cli, cmd.Arg(0))
+		_, status, err := getExitCode(cli, name)
 		if err != nil {
 			return err
 		}

--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -26,7 +27,8 @@ func (cli *DockerCli) CmdStop(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/stop?"+v.Encode(), nil, nil))
+		cleanName := strings.TrimPrefix(name, "/")
+		_, _, err := readBody(cli.call("POST", "/containers/"+cleanName+"/stop?"+v.Encode(), nil, nil))
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)

--- a/api/client/unpause.go
+++ b/api/client/unpause.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -18,7 +19,8 @@ func (cli *DockerCli) CmdUnpause(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/unpause", name), nil, nil)); err != nil {
+		cleanName := strings.TrimPrefix(name, "/")
+		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/unpause", cleanName), nil, nil)); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)
 		} else {

--- a/api/client/wait.go
+++ b/api/client/wait.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -20,7 +21,8 @@ func (cli *DockerCli) CmdWait(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		status, err := waitForExit(cli, name)
+		cleanName := strings.TrimPrefix(name, "/")
+		status, err := waitForExit(cli, cleanName)
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -1,6 +1,8 @@
 package runconfig
 
 import (
+	"strings"
+
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
@@ -36,7 +38,7 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	if err := cmd.ParseFlags(args, true); err != nil {
 		return nil, err
 	}
-	container = cmd.Arg(0)
+	container = strings.TrimPrefix(cmd.Arg(0), "/")
 	parsedArgs := cmd.Args()
 	execCmd = parsedArgs[1:]
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

closed #16563 

When provided a slash-prefixed container name, the docker cli silently does nothing and thing going worse for cli `docker attach` and `docker start -ai`, it will block.

<pre><code>[lei@fedora ~]$ docker start -ai /test

</code></pre>

and there is no any response whatever you type.
