### PR TITLE
Make sure the container will always be unpaused on test exit

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -51,6 +51,7 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectStatus(c *check.C) {
+	defer unpauseAllContainers()
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	out = strings.TrimSpace(out)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Though there is a `unpause` command below `pause` command, there is risk
the test will exit before `unpause`. So just to make sure the paused container
will unpause 100%, add a `defer unpauseAllContainers()` at the beginning of the test.
