### PR TITLE
Fix TestDockerCmd*Timeout racey tests

### DIFF
--- a/pkg/integration/dockerCmd_utils_test.go
+++ b/pkg/integration/dockerCmd_utils_test.go
@@ -160,7 +160,6 @@ func (s *DockerCmdSuite) TestDockerCmdSuccess(c *check.C) {
 // DockerCmdWithTimeout tests
 
 func (s *DockerCmdSuite) TestDockerCmdWithTimeout(c *check.C) {
-	c.Skip("racey test")
 	cmds := []struct {
 		binary           string
 		args             []string
@@ -269,7 +268,6 @@ func (s *DockerCmdSuite) TestDockerCmdInDir(c *check.C) {
 // DockerCmdInDirWithTimeout tests
 
 func (s *DockerCmdSuite) TestDockerCmdInDirWithTimeout(c *check.C) {
-	c.Skip("racey test")
 	tempFolder, err := ioutil.TempDir("", "test-docker-cmd-in-dir")
 	c.Assert(err, check.IsNil)
 
@@ -391,7 +389,8 @@ func TestHelperProcess(t *testing.T) {
 		case "a command that times out":
 			time.Sleep(10 * time.Millisecond)
 			fmt.Fprintf(os.Stdout, "too long, should be killed")
-			os.Exit(0)
+			// A random exit code (that should never happened in tests)
+			os.Exit(7)
 		case "run -ti ubuntu echo hello":
 			fmt.Fprintf(os.Stdout, "hello")
 		default:

--- a/pkg/integration/utils.go
+++ b/pkg/integration/utils.go
@@ -105,8 +105,16 @@ func RunCommandWithOutputForDuration(cmd *exec.Cmd, duration time.Duration) (out
 	cmd.Stderr = &outputBuffer
 
 	done := make(chan error)
+
+	// Start the command in the main thread..
+	err = cmd.Start()
+	if err != nil {
+		err = fmt.Errorf("Fail to start command %v : %v", cmd, err)
+	}
+
 	go func() {
-		exitErr := cmd.Run()
+		// And wait for it to exit in the goroutine :)
+		exitErr := cmd.Wait()
 		exitCode = ProcessExitCode(exitErr)
 		done <- exitErr
 	}()


### PR DESCRIPTION
A <del>very</del> less Naǐve way to fix these racey tests 🐻, but it seems to do the work :sweat_smile:.

I'm gonna re-run janky & friends a bunch times on it to make sure it's not failing..

Fixes #16360 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
