### PR TITLE
Add api to manage docker daemon labels

### DIFF
--- a/api/client/label.go
+++ b/api/client/label.go
@@ -1,0 +1,115 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	Cli "github.com/docker/docker/cli"
+	flag "github.com/docker/docker/pkg/mflag"
+)
+
+// CmdLabel is the parent subcommand for all label commands
+//
+// Usage: docker label <COMMAND> <OPTS>
+func (cli *DockerCli) CmdLabel(args ...string) error {
+	description := "Manage Docker daemon labels\n\nCommands:\n"
+	commands := [][]string{
+		{"list", "Show the docker daemon labels."},
+		{"add", "add new labels to docker daemon."},
+		{"remove", "remove any exist labels from docker daemon."},
+	}
+
+	for _, cmd := range commands {
+		description += fmt.Sprintf("  %-25.25s%s\n", cmd[0], cmd[1])
+	}
+
+	description += "\nRun 'docker label COMMAND --help' for more information on a command"
+	cmd := Cli.Subcmd("label", []string{"[COMMAND]"}, description, true)
+	cmd.Require(flag.Exact, 0)
+	cmd.ParseFlags(args, true)
+
+	return cli.CmdLabelList(args...)
+}
+
+// CmdLabelList outputs a list of Docker daemon labels.
+//
+// Usage: docker label list [OPTIONS]
+func (cli *DockerCli) CmdLabelList(args ...string) error {
+	cmd := Cli.Subcmd("label list", nil, "List daemon labels", true)
+
+	cmd.Require(flag.Exact, 0)
+	cmd.ParseFlags(args, true)
+
+	resp, err := cli.call("GET", "/labels", nil, nil)
+	if err != nil {
+		return err
+	}
+
+	var labels []string
+	if err := json.NewDecoder(resp.body).Decode(&labels); err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
+	fmt.Fprintf(w, "Labels:")
+	fmt.Fprintf(w, "\n")
+
+	for _, label := range labels {
+		fmt.Fprintf(w, "%s\n", label)
+	}
+	w.Flush()
+	return nil
+}
+
+// CmdLabelAdd adds a new label to a daemon label.
+//
+// Usage: docker label add LABEL[LABEL...]
+func (cli *DockerCli) CmdLabelAdd(args ...string) error {
+	cmd := Cli.Subcmd("label add", nil, "Add a label", true)
+
+	cmd.Require(flag.Min, 1)
+	cmd.ParseFlags(args, true)
+
+	var status = 0
+	for _, name := range cmd.Args() {
+		_, err := cli.call("POST", "/labels/"+name, nil, nil)
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			status = 1
+			continue
+		}
+		fmt.Fprintf(cli.out, "%s\n", name)
+	}
+
+	if status != 0 {
+		return Cli.StatusError{StatusCode: status}
+	}
+	return nil
+
+}
+
+// CmdLabelRemove removes one or more labels.
+//
+// Usage: docker label remove LABEL[LABEL...]
+func (cli *DockerCli) CmdLabelRemove(args ...string) error {
+	cmd := Cli.Subcmd("label remove", []string{"LABEL [LABEL...]"}, "Remove a label", true)
+	cmd.Require(flag.Min, 1)
+	cmd.ParseFlags(args, true)
+
+	var status = 0
+	for _, name := range cmd.Args() {
+		_, err := cli.call("DELETE", "/labels/"+name, nil, nil)
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			status = 1
+			continue
+		}
+		fmt.Fprintf(cli.out, "%s\n", name)
+	}
+
+	if status != 0 {
+		return Cli.StatusError{StatusCode: status}
+	}
+	return nil
+}

--- a/api/server/label.go
+++ b/api/server/label.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/docker/docker/context"
+	"github.com/docker/docker/opts"
+)
+
+func (s *Server) getLabelList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	labels, err := s.daemon.Labels()
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusOK, labels)
+}
+
+func (s *Server) postLabelsAdd(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	req, err := opts.ValidateLabel(vars["name"])
+	if err != nil {
+		return err
+	}
+	labels, err := s.daemon.LabelAdd(req)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusCreated, labels)
+}
+
+func (s *Server) deleteLabels(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	if err := s.daemon.LabelRm(vars["name"]); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -345,6 +345,7 @@ func createRouter(s *Server) *mux.Router {
 			"/containers/{name:.*}/archive":   s.getContainersArchive,
 			"/volumes":                        s.getVolumesList,
 			"/volumes/{name:.*}":              s.getVolumeByName,
+			"/labels":                         s.getLabelList,
 		},
 		"POST": {
 			"/auth":                         s.postAuth,
@@ -370,6 +371,7 @@ func createRouter(s *Server) *mux.Router {
 			"/exec/{name:.*}/resize":        s.postContainerExecResize,
 			"/containers/{name:.*}/rename":  s.postContainerRename,
 			"/volumes":                      s.postVolumesCreate,
+			"/labels/{name:.*}":             s.postLabelsAdd,
 		},
 		"PUT": {
 			"/containers/{name:.*}/archive": s.putContainersArchive,
@@ -378,6 +380,7 @@ func createRouter(s *Server) *mux.Router {
 			"/containers/{name:.*}": s.deleteContainers,
 			"/images/{name:.*}":     s.deleteImages,
 			"/volumes/{name:.*}":    s.deleteVolumes,
+			"/labels/{name:.*}":     s.deleteLabels,
 		},
 		"OPTIONS": {
 			"": s.optionsHandler,

--- a/daemon/label.go
+++ b/daemon/label.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Labels lists known daemon labels and returned.
+// This is called directly from the remote API
+func (daemon *Daemon) Labels() ([]string, error) {
+	return daemon.config().Labels, nil
+}
+
+// LabelAdd add a label
+// This is called directly from the remote API
+func (daemon *Daemon) LabelAdd(name string) ([]string, error) {
+	labels := daemon.configStore.Labels
+	daemon.configStore.Labels = append(labels, name)
+	return daemon.configStore.Labels, nil
+}
+
+// LabelRm removes the labels with the given name.
+// If the label don't in daemon labels, it is not removed
+// This is called directly from the remote API
+func (daemon *Daemon) LabelRm(name string) error {
+	labels := &daemon.configStore.Labels
+	if err := remove(labels, name); err != nil {
+		return fmt.Errorf("Error while removing labels %s: %v", name, err)
+	}
+	return nil
+}
+
+func remove(labels *[]string, label string) error {
+	for i, elem := range *labels {
+		if elem == label {
+			*labels = append((*labels)[:i], (*labels)[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("no such label")
+}

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -36,6 +36,7 @@ var dockerCommands = []command{
 	{"info", "Display system-wide information"},
 	{"inspect", "Return low-level information on a container or image"},
 	{"kill", "Kill a running container"},
+	{"label", "Manage Docker daemon label"},
 	{"load", "Load an image from a tar archive or STDIN"},
 	{"login", "Register or log in to a Docker registry"},
 	{"logout", "Log out from a Docker registry"},

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -260,7 +260,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 
 		// Number of commands for standard release and experimental release
 		standard := 40
-		experimental := 1
+		experimental := 2
 		expected := standard + experimental
 		if isLocalDaemon {
 			expected++ // for the daemon command


### PR DESCRIPTION
Managing docker daemon labels is good for doing some specific scheduling with Swarm.

I am interesting in posting a PR to add api to manage docker daemon labels with @feiyang21687 help.

Docker was able to modify daemon label with `docker label` command, like this:

![2015-09-25 8 41 41](https://cloud.githubusercontent.com/assets/3353639/10101077/e9c57450-63c8-11e5-982c-640fbe824ade.png)

Signed-off-by: hacpai balckwing@gmail.com
