### PR TITLE
Windows: Flags to cmd are now sent as two separate arguments

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -315,7 +315,7 @@ func run(ctx context.Context, b *builder, args []string, attributes map[string]b
 		if runtime.GOOS != "windows" {
 			args = append([]string{"/bin/sh", "-c"}, args...)
 		} else {
-			args = append([]string{"cmd", "/S /C"}, args...)
+			args = append([]string{"cmd", "/S", "/C"}, args...)
 		}
 	}
 
@@ -439,7 +439,7 @@ func cmd(ctx context.Context, b *builder, args []string, attributes map[string]b
 		if runtime.GOOS != "windows" {
 			cmdSlice = append([]string{"/bin/sh", "-c"}, cmdSlice...)
 		} else {
-			cmdSlice = append([]string{"cmd", "/S /C"}, cmdSlice...)
+			cmdSlice = append([]string{"cmd", "/S", "/C"}, cmdSlice...)
 		}
 	}
 
@@ -483,7 +483,7 @@ func entrypoint(ctx context.Context, b *builder, args []string, attributes map[s
 		if runtime.GOOS != "windows" {
 			b.Config.Entrypoint = stringutils.NewStrSlice("/bin/sh", "-c", parsed[0])
 		} else {
-			b.Config.Entrypoint = stringutils.NewStrSlice("cmd", "/S /C", parsed[0])
+			b.Config.Entrypoint = stringutils.NewStrSlice("cmd", "/S", "/C", parsed[0])
 		}
 	}
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -89,7 +89,7 @@ func (b *builder) commit(ctx context.Context, id string, autoCmd *stringutils.St
 		if runtime.GOOS != "windows" {
 			b.Config.Cmd = stringutils.NewStrSlice("/bin/sh", "-c", "#(nop) "+comment)
 		} else {
-			b.Config.Cmd = stringutils.NewStrSlice("cmd", "/S /C", "REM (nop) "+comment)
+			b.Config.Cmd = stringutils.NewStrSlice("cmd", "/S", "/C", "REM (nop) "+comment)
 		}
 		defer func(cmd *stringutils.StrSlice) { b.Config.Cmd = cmd }(cmd)
 
@@ -220,7 +220,7 @@ func (b *builder) runContextCommand(ctx context.Context, args []string, allowRem
 	if runtime.GOOS != "windows" {
 		b.Config.Cmd = stringutils.NewStrSlice("/bin/sh", "-c", fmt.Sprintf("#(nop) %s %s in %s", cmdName, srcHash, dest))
 	} else {
-		b.Config.Cmd = stringutils.NewStrSlice("cmd", "/S /C", fmt.Sprintf("REM (nop) %s %s in %s", cmdName, srcHash, dest))
+		b.Config.Cmd = stringutils.NewStrSlice("cmd", "/S", "/C", fmt.Sprintf("REM (nop) %s %s in %s", cmdName, srcHash, dest))
 	}
 	defer func(cmd *stringutils.StrSlice) { b.Config.Cmd = cmd }(cmd)
 


### PR DESCRIPTION
Docker build on master on Windows is currently broken due to PR #16538, this fixes the regression.

Signed-off-by: Darren Stahl darst@microsoft.com
