### PR TITLE
Deprecate --volume-driver

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -79,6 +79,10 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		return nil
 	}
 
+	if hostConfig.VolumeDriver != "" {
+		fmt.Fprint(cli.err, "--volume-driver is deprecated and may be removed in a future release. Please use `docker volume create` instead.\n")
+	}
+
 	if !*flDetach {
 		if err := cli.CheckTtyInput(config.AttachStdin, config.Tty); err != nil {
 			return err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1100,6 +1100,10 @@ func (daemon *Daemon) verifyContainerSettings(ctx context.Context, hostConfig *r
 		return nil, nil
 	}
 
+	if hostConfig.VolumeDriver != "" {
+		logrus.Warnf("volume driver as specified with `--volume-driver %q` is deprecated", hostConfig.VolumeDriver)
+	}
+
 	for port := range hostConfig.PortBindings {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {

--- a/docs/misc/deprecated.md
+++ b/docs/misc/deprecated.md
@@ -22,6 +22,9 @@ variants:
 
     docker run -c (--cpu-shares)
 
+`docker run --volume-driver` is now deprecated in favor of `docker volume
+create`.
+
 ### Driver Specific Log Tags
 **Deprecated In Release: v1.9**
 


### PR DESCRIPTION
/cc @cpuguy83 @calavera @srust 

This deprecates the `--volume-driver` flag and pre-emptively schedules it for removal in 1.11. Please let me know if any wording needs to be adjusted, as this is principally a docs patch.

Thanks!

-Erik

Fixes #16069
