### PR TITLE
Modifying trusted/untrusted pull behavior for create/run/build

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -16,6 +16,15 @@ import (
 	networktypes "github.com/docker/engine-api/types/network"
 )
 
+type createConfig struct {
+	config           *container.Config              // Config of the contaiiner
+	hostConfig       *container.HostConfig          // HostConfig of the container
+	networkingConfig *networktypes.NetworkingConfig // NetworkingConfig of the container
+	cidfile          string                         // File the where the ContainerID is written
+	name             string                         // The name assign to the container
+	pull             bool                           // Always to pull a newer version of the image
+}
+
 func (cli *DockerCli) pullImage(image string) error {
 	return cli.pullImageCustomOut(image, cli.out)
 }
@@ -80,7 +89,14 @@ func newCIDFile(path string) (*cidFile, error) {
 	return &cidFile{path: path, file: f}, nil
 }
 
-func (cli *DockerCli) createContainer(config *container.Config, hostConfig *container.HostConfig, networkingConfig *networktypes.NetworkingConfig, cidfile, name string) (*types.ContainerCreateResponse, error) {
+func (cli *DockerCli) createContainer(createConfig *createConfig) (*types.ContainerCreateResponse, error) {
+	config := createConfig.config
+	hostConfig := createConfig.hostConfig
+	networkingConfig := createConfig.networkingConfig
+	cidfile := createConfig.cidfile
+	name := createConfig.name
+	pull := createConfig.pull
+
 	var containerIDFile *cidFile
 	if cidfile != "" {
 		var err error
@@ -98,6 +114,12 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 
 	var trustedRef reference.Canonical
 
+	if pull {
+		if err := cli.pullImageCustomOut(config.Image, cli.err); err != nil {
+			return nil, err
+		}
+	}
+
 	if ref, ok := ref.(reference.NamedTagged); ok && isTrusted() {
 		var err error
 		trustedRef, err = cli.trustedReference(ref)
@@ -106,7 +128,6 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 		}
 		config.Image = trustedRef.String()
 	}
-
 	//create the container
 	response, err := cli.client.ContainerCreate(config, hostConfig, networkingConfig, name)
 
@@ -151,6 +172,7 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 // Usage: docker create [OPTIONS] IMAGE [COMMAND] [ARG...]
 func (cli *DockerCli) CmdCreate(args ...string) error {
 	cmd := Cli.Subcmd("create", []string{"IMAGE [COMMAND] [ARG...]"}, Cli.DockerCommands["create"].Description, true)
+	flPull := cmd.Bool([]string{"-pull"}, false, "Always attempt to pull a newer version of the image")
 	addTrustedFlags(cmd, true)
 
 	// These are flags not stored in Config/HostConfig
@@ -168,7 +190,15 @@ func (cli *DockerCli) CmdCreate(args ...string) error {
 		cmd.Usage()
 		return nil
 	}
-	response, err := cli.createContainer(config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, *flName)
+	createConfig := &createConfig{
+		config:           config,
+		hostConfig:       hostConfig,
+		networkingConfig: networkingConfig,
+		cidfile:          hostConfig.ContainerIDFile,
+		name:             *flName,
+		pull:             *flPull,
+	}
+	response, err := cli.createContainer(createConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/image"
 	networktypes "github.com/docker/engine-api/types/network"
 )
 
@@ -22,7 +23,8 @@ type createConfig struct {
 	networkingConfig *networktypes.NetworkingConfig // NetworkingConfig of the container
 	cidfile          string                         // File the where the ContainerID is written
 	name             string                         // The name assign to the container
-	pull             bool                           // Always to pull a newer version of the image
+	pull             image.PullBehavior             // How to deal with image pulls
+	translator       reference.TranslatorFunc       // Callback for trusted reference conversion
 }
 
 func (cli *DockerCli) pullImage(image string) error {
@@ -91,16 +93,11 @@ func newCIDFile(path string) (*cidFile, error) {
 
 func (cli *DockerCli) createContainer(createConfig *createConfig) (*types.ContainerCreateResponse, error) {
 	config := createConfig.config
-	hostConfig := createConfig.hostConfig
-	networkingConfig := createConfig.networkingConfig
-	cidfile := createConfig.cidfile
-	name := createConfig.name
-	pull := createConfig.pull
-
 	var containerIDFile *cidFile
-	if cidfile != "" {
+
+	if createConfig.cidfile != "" {
 		var err error
-		if containerIDFile, err = newCIDFile(cidfile); err != nil {
+		if containerIDFile, err = newCIDFile(createConfig.cidfile); err != nil {
 			return nil, err
 		}
 		defer containerIDFile.Close()
@@ -112,47 +109,60 @@ func (cli *DockerCli) createContainer(createConfig *createConfig) (*types.Contai
 	}
 	ref = reference.WithDefaultTag(ref)
 
-	var trustedRef reference.Canonical
-
-	if pull {
+	var (
+		namedTaggedRef reference.NamedTagged
+		trustedRef     reference.Canonical
+	)
+	if createConfig.translator != nil {
+		// Updating config.Image to the trusted (notary) reference
+		// should be sufficient to deal with --pull=true on the first create attempt.
+		// Note: This update is only attempted in the case of a NamedTagged reference.
+		var ok bool
+		if namedTaggedRef, ok = ref.(reference.NamedTagged); ok {
+			trustedRef, err = createConfig.translator(namedTaggedRef)
+			if err != nil {
+				return nil, err
+			}
+			config.Image = trustedRef.String()
+		}
+	}
+	if createConfig.pull == image.PullAlways {
 		if err := cli.pullImageCustomOut(config.Image, cli.err); err != nil {
 			return nil, err
 		}
 	}
 
-	if ref, ok := ref.(reference.NamedTagged); ok && isTrusted() {
-		var err error
-		trustedRef, err = cli.trustedReference(ref)
-		if err != nil {
+	//create the container
+	response, err := cli.client.ContainerCreate(config, createConfig.hostConfig, createConfig.networkingConfig, createConfig.name)
+
+	if err != nil {
+		// deal with image not found case, return error for anything else.
+		if !client.IsErrImageNotFound(err) {
 			return nil, err
 		}
-		config.Image = trustedRef.String()
-	}
-	//create the container
-	response, err := cli.client.ContainerCreate(config, hostConfig, networkingConfig, name)
 
-	//if image not found try to pull it
-	if err != nil {
-		if client.IsErrImageNotFound(err) {
-			fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", ref.String())
+		fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", ref.String())
 
-			// we don't want to write to stdout anything apart from container.ID
-			if err = cli.pullImageCustomOut(config.Image, cli.err); err != nil {
+		if createConfig.pull != image.PullMissing {
+			return nil, err
+		}
+
+		// we don't want to write to stdout anything apart from container.ID
+		if err = cli.pullImageCustomOut(config.Image, cli.err); err != nil {
+			return nil, err
+		}
+		if trustedRef != nil {
+			// We successfully pulled an updated trusted image for the given named reference.
+			// Tag it with the trusted canonical reference.
+			if err := cli.tagTrusted(trustedRef, namedTaggedRef); err != nil {
 				return nil, err
 			}
-			if ref, ok := ref.(reference.NamedTagged); ok && trustedRef != nil {
-				if err := cli.tagTrusted(trustedRef, ref); err != nil {
-					return nil, err
-				}
-			}
-			// Retry
-			var retryErr error
-			response, retryErr = cli.client.ContainerCreate(config, hostConfig, networkingConfig, name)
-			if retryErr != nil {
-				return nil, retryErr
-			}
-		} else {
-			return nil, err
+		}
+		// Retry
+		var retryErr error
+		response, retryErr = cli.client.ContainerCreate(config, createConfig.hostConfig, createConfig.networkingConfig, createConfig.name)
+		if retryErr != nil {
+			return nil, retryErr
 		}
 	}
 
@@ -172,7 +182,7 @@ func (cli *DockerCli) createContainer(createConfig *createConfig) (*types.Contai
 // Usage: docker create [OPTIONS] IMAGE [COMMAND] [ARG...]
 func (cli *DockerCli) CmdCreate(args ...string) error {
 	cmd := Cli.Subcmd("create", []string{"IMAGE [COMMAND] [ARG...]"}, Cli.DockerCommands["create"].Description, true)
-	flPull := cmd.Bool([]string{"-pull"}, false, "Always attempt to pull a newer version of the image")
+	flPull := addPullFlag(cmd)
 	addTrustedFlags(cmd, true)
 
 	// These are flags not stored in Config/HostConfig
@@ -190,13 +200,16 @@ func (cli *DockerCli) CmdCreate(args ...string) error {
 		cmd.Usage()
 		return nil
 	}
+
+	pullBehavior, translator := cli.trustedPullBehavior(flPull.Val())
 	createConfig := &createConfig{
 		config:           config,
 		hostConfig:       hostConfig,
 		networkingConfig: networkingConfig,
 		cidfile:          hostConfig.ContainerIDFile,
 		name:             *flName,
-		pull:             *flPull,
+		pull:             pullBehavior,
+		translator:       translator,
 	}
 	response, err := cli.createContainer(createConfig)
 	if err != nil {

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -75,6 +75,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		flSigProxy   = cmd.Bool([]string{"-sig-proxy"}, true, "Proxy received signals to the process")
 		flName       = cmd.String([]string{"-name"}, "", "Assign a name to the container")
 		flDetachKeys = cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
+		flPull       = cmd.Bool([]string{"-pull"}, false, "Always attempt to pull a newer version of the image")
 		flAttach     *opts.ListOpts
 
 		ErrConflictAttachDetach               = fmt.Errorf("Conflicting options: -a and -d")
@@ -146,7 +147,15 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = cli.getTtySize()
 	}
 
-	createResponse, err := cli.createContainer(config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, *flName)
+	createConfig := &createConfig{
+		config:           config,
+		hostConfig:       hostConfig,
+		networkingConfig: networkingConfig,
+		cidfile:          hostConfig.ContainerIDFile,
+		name:             *flName,
+		pull:             *flPull,
+	}
+	createResponse, err := cli.createContainer(createConfig)
 	if err != nil {
 		cmd.ReportError(err.Error(), true)
 		return runStartContainerErr(err)

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -75,7 +75,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		flSigProxy   = cmd.Bool([]string{"-sig-proxy"}, true, "Proxy received signals to the process")
 		flName       = cmd.String([]string{"-name"}, "", "Assign a name to the container")
 		flDetachKeys = cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
-		flPull       = cmd.Bool([]string{"-pull"}, false, "Always attempt to pull a newer version of the image")
+		flPull       = addPullFlag(cmd)
 		flAttach     *opts.ListOpts
 
 		ErrConflictAttachDetach               = fmt.Errorf("Conflicting options: -a and -d")
@@ -147,13 +147,15 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = cli.getTtySize()
 	}
 
+	pullBehavior, translator := cli.trustedPullBehavior(flPull.Val())
 	createConfig := &createConfig{
 		config:           config,
 		hostConfig:       hostConfig,
 		networkingConfig: networkingConfig,
 		cidfile:          hostConfig.ContainerIDFile,
 		name:             *flName,
-		pull:             *flPull,
+		pull:             pullBehavior,
+		translator:       translator,
 	}
 	createResponse, err := cli.createContainer(createConfig)
 	if err != nil {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1612,6 +1612,7 @@ _docker_run() {
 		--oom-kill-disable
 		--privileged
 		--publish-all -P
+		--pull
 		--read-only
 		--tty -t
 	"

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -128,6 +128,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /networks/{network-id}` Now returns IPAM config options for custom IPAM plugins if any
   are available.
 * `GET /networks/<network-id>` now returns subnets info for user-defined networks.
+* `POST /build` now takes a string `pull` parameter instead of a boolean.  Can be one of 'never', 'missing', or 'always'.
 
 ### v1.21 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1591,7 +1591,10 @@ Query Parameters:
 		called `Dockerfile`.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
--   **pull** - Attempt to pull the image even if an older image exists locally.
+-   **pull** - String value containing the pull behavior to use for parent image.  The default value is `missing`. Can be set to one of:
+        + `never` pull parent image.  Will produce error if no local image exists.
+        + `missing` image will be pulled.  Local image will be used if it exists.
+        + `always` pull parent image, even if there is already a matching local image.
 -   **rm** - Remove intermediate containers after a successful build (default behavior).
 -   **forcerm** - Always remove intermediate containers (includes `rm`).
 -   **memory** - Set memory limit for build.

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -29,7 +29,7 @@ parent = "smn_cli"
       -m, --memory=""                 Memory limit for all build containers
       --memory-swap=""                A positive integer equal to memory plus swap. Specify -1 to enable unlimited swap.
       --no-cache                      Do not use cache when building the image
-      --pull                          Always attempt to pull a newer version of the image
+      --pull=<content-trust>          Always attempt to pull a newer version of the image
       -q, --quiet                     Suppress the build output and print image ID on success
       --rm=true                       Remove intermediate containers after a successful build
       --shm-size=[]                   Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.  Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -75,7 +75,7 @@ Creates a new container.
       -p, --publish=[]              Publish a container's port(s) to the host
       --pid=""                      PID namespace to use
       --privileged                  Give extended privileges to this container
-      --pull=false                  Always attempt to pull a newer version of the image
+      --pull=<content-trust>        Always attempt to pull a newer version of the image
       --read-only                   Mount the container's root filesystem as read only
       --restart="no"                Restart policy (no, on-failure[:max-retry], always, unless-stopped)
       --security-opt=[]             Security options

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -75,6 +75,7 @@ Creates a new container.
       -p, --publish=[]              Publish a container's port(s) to the host
       --pid=""                      PID namespace to use
       --privileged                  Give extended privileges to this container
+      --pull=false                  Always attempt to pull a newer version of the image
       --read-only                   Mount the container's root filesystem as read only
       --restart="no"                Restart policy (no, on-failure[:max-retry], always, unless-stopped)
       --security-opt=[]             Security options

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -75,6 +75,7 @@ parent = "smn_cli"
       -p, --publish=[]              Publish a container's port(s) to the host
       --pid=""                      PID namespace to use
       --privileged                  Give extended privileges to this container
+      --pull=false                  Always attempt to pull a newer version of the image
       --read-only                   Mount the container's root filesystem as read only
       --restart="no"                Restart policy (no, on-failure[:max-retry], always, unless-stopped)
       --rm                          Automatically remove the container when it exits

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -75,7 +75,7 @@ parent = "smn_cli"
       -p, --publish=[]              Publish a container's port(s) to the host
       --pid=""                      PID namespace to use
       --privileged                  Give extended privileges to this container
-      --pull=false                  Always attempt to pull a newer version of the image
+      --pull=<content-trust>        Always attempt to pull a newer version of the image
       --read-only                   Mount the container's root filesystem as read only
       --restart="no"                Restart policy (no, on-failure[:max-retry], always, unless-stopped)
       --rm                          Automatically remove the container when it exits

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -287,7 +287,7 @@ func (s *DockerTrustSuite) TestTrustedCreate(c *check.C) {
 	s.trustedCmd(createCmd)
 	out, _, err := runCommandWithOutput(createCmd)
 	c.Assert(err, check.IsNil)
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf("Missing expected output on trusted push:\n%s", out))
+	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf("Missing expected output on trusted create:\n%s", out))
 
 	dockerCmd(c, "rmi", repoName)
 
@@ -377,7 +377,7 @@ func (s *DockerTrustSuite) TestTrustedCreateFromBadTrustServer(c *check.C) {
 	s.trustedCmd(createCmd)
 	out, _, err = runCommandWithOutput(createCmd)
 	c.Assert(err, check.IsNil)
-	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf("Missing expected output on trusted push:\n%s", out))
+	c.Assert(string(out), checker.Contains, "Tagging", check.Commentf("Missing expected output on trusted create:\n%s", out))
 
 	dockerCmd(c, "rmi", repoName)
 
@@ -422,4 +422,65 @@ func (s *DockerSuite) TestCreateWithWorkdir(c *check.C) {
 	dir := "/home/foo/bar"
 	dockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
 	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), "/tmp")
+}
+
+func (s *DockerSuite) TestCreateWithPull(c *check.C) {
+	testRequires(c, Network)
+
+	// pull image when missing (default)
+	dockerCmd(c, "rmi", "busybox")
+	out, _, err := dockerCmdWithError("create", "busybox", "true")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "Pulling from ", check.Commentf("expected pull fallback"))
+
+	// no pull image if already exists
+	out, _, err = dockerCmdWithError("create", "busybox", "true")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "Pulling from ", check.Commentf("unexpected pull fallback"))
+
+	// create with --pull still pulls the image
+	// even if the image exists on local
+	out, _, err = dockerCmdWithError("create", "--pull", "busybox", "true")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	if !(strings.Contains(out, "Downloaded newer image for busybox:latest") || strings.Contains(out, "Image is up to date for busybox:latest")) {
+		c.Fatalf("expected to download latest image from docker hub")
+	}
+}
+
+func (s *DockerTrustSuite) TestTrustedCreateWithPull(c *check.C) {
+	repoName := s.setupTrustedImage(c, "trusted-create-with-pull")
+
+	// pull image when missing (default)
+	createCmd := exec.Command(dockerBinary, "create", repoName)
+	s.trustedCmd(createCmd)
+	out, _, err := runCommandWithOutput(createCmd)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "Pulling from ", check.Commentf("expected pull fallback"))
+
+	// no pull image if already exists
+	// create with --pull (default, for trust) verifies the image is up to date
+	// no pull should be performed in this case (just verification)
+	createCmd = exec.Command(dockerBinary, "--debug", "-l", "debug", "create", "--pull", repoName)
+	s.trustedCmd(createCmd)
+	out, _, err = runCommandWithOutput(createCmd)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "successfully verified targets", check.Commentf("expected trust verification"))
+	c.Assert(out, checker.Not(checker.Contains), "Pulling from ", check.Commentf("unexpected pull fallback"))
+
+	// create with --pull=false will neither pull nor verify the image
+	createCmd = exec.Command(dockerBinary, "--debug", "-l", "debug", "create", "--pull=false", repoName)
+	s.trustedCmd(createCmd)
+	out, _, err = runCommandWithOutput(createCmd)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "successfully verified targets", check.Commentf("unexpected trust verification"))
+	c.Assert(out, checker.Not(checker.Contains), "Pulling from ", check.Commentf("unexpected pull"))
+
+	// create with --pull=false will neither pull nor verify the image
+	// gives an error if there is no local image
+	dockerCmd(c, "rmi", repoName)
+	createCmd = exec.Command(dockerBinary, "--debug", "-l", "debug", "create", "--pull=false", repoName)
+	s.trustedCmd(createCmd)
+	out, _, err = runCommandWithOutput(createCmd)
+	c.Assert(err, check.NotNil, check.Commentf("expected error on trusted --pull=false:\n%s", out))
+	c.Assert(out, checker.Contains, "Unable to find image", check.Commentf("out: %s", out))
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4176,3 +4176,16 @@ func (s *DockerSuite) TestRunNamedVolumesFromNotRemoved(c *check.C) {
 	out, _ := dockerCmd(c, "volume", "ls", "-q")
 	c.Assert(strings.TrimSpace(out), checker.Equals, "test")
 }
+
+func (s *DockerSuite) TestRunWithPull(c *check.C) {
+	testRequires(c, Network)
+	// pull a image from hub to local
+	dockerCmd(c, "pull", "hello-world")
+	// run with --pull still try to pull the image from hub
+	// even if the image exists on local
+	out, _, err := dockerCmdWithError("run", "--pull", "hello-world")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	if !(strings.Contains(out, "Downloaded newer image for hello-world:latest") || strings.Contains(out, "Image is up to date for hello-world:latest")) {
+		c.Fatalf("expected to download latest image from docker hub")
+	}
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3158,7 +3158,7 @@ func (s *DockerTrustSuite) TestTrustedRun(c *check.C) {
 	}
 
 	if !strings.Contains(string(out), "Tagging") {
-		c.Fatalf("Missing expected output on trusted push:\n%s", out)
+		c.Fatalf("Missing expected output on trusted run:\n%s", out)
 	}
 
 	dockerCmd(c, "rmi", repoName)
@@ -3269,7 +3269,7 @@ func (s *DockerTrustSuite) TestTrustedRunFromBadTrustServer(c *check.C) {
 	}
 
 	if !strings.Contains(string(out), "Tagging") {
-		c.Fatalf("Missing expected output on trusted push:\n%s", out)
+		c.Fatalf("Missing expected output on trusted run:\n%s", out)
 	}
 
 	dockerCmd(c, "rmi", repoName)
@@ -3305,7 +3305,7 @@ func (s *DockerTrustSuite) TestTrustedRunFromBadTrustServer(c *check.C) {
 	}
 
 	if !strings.Contains(string(out), "valid signatures did not meet threshold") {
-		c.Fatalf("Missing expected output on trusted push:\n%s", out)
+		c.Fatalf("Missing expected output on trusted run:\n%s", out)
 	}
 }
 
@@ -4179,13 +4179,62 @@ func (s *DockerSuite) TestRunNamedVolumesFromNotRemoved(c *check.C) {
 
 func (s *DockerSuite) TestRunWithPull(c *check.C) {
 	testRequires(c, Network)
-	// pull a image from hub to local
-	dockerCmd(c, "pull", "hello-world")
-	// run with --pull still try to pull the image from hub
-	// even if the image exists on local
-	out, _, err := dockerCmdWithError("run", "--pull", "hello-world")
+
+	// pull image when missing (default)
+	dockerCmd(c, "rmi", "busybox")
+	out, _, err := dockerCmdWithError("run", "busybox", "true")
 	c.Assert(err, check.IsNil, check.Commentf(out))
-	if !(strings.Contains(out, "Downloaded newer image for hello-world:latest") || strings.Contains(out, "Image is up to date for hello-world:latest")) {
+	c.Assert(out, checker.Contains, "Pulling from ", check.Commentf("expected pull fallback"))
+
+	// no pull image if already exists
+	out, _, err = dockerCmdWithError("run", "busybox", "true")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "Pulling from ", check.Commentf("unexpected pull fallback"))
+
+	// run with --pull still pulls the image
+	// even if the image exists on local
+	out, _, err = dockerCmdWithError("run", "--pull", "busybox", "true")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	if !(strings.Contains(out, "Downloaded newer image for busybox:latest") || strings.Contains(out, "Image is up to date for busybox:latest")) {
 		c.Fatalf("expected to download latest image from docker hub")
 	}
+}
+
+func (s *DockerTrustSuite) TestTrustedRunWithPull(c *check.C) {
+	repoName := s.setupTrustedImage(c, "trusted-run-with-pull")
+
+	// pull image when missing (default)
+	runCmd := exec.Command(dockerBinary, "run", repoName)
+	s.trustedCmd(runCmd)
+	out, _, err := runCommandWithOutput(runCmd)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "Pulling from ", check.Commentf("expected pull fallback"))
+
+	// no pull image if already exists
+	// run with --pull (default, for trust) verifies the image is up to date
+	// no pull should be performed in this case (just verification)
+	runCmd = exec.Command(dockerBinary, "--debug", "-l", "debug", "run", "--pull", repoName)
+	s.trustedCmd(runCmd)
+	out, _, err = runCommandWithOutput(runCmd)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "successfully verified targets", check.Commentf("expected trust verification"))
+	c.Assert(out, checker.Not(checker.Contains), "Pulling from ", check.Commentf("unexpected pull fallback"))
+
+	// run with --pull=false will neither pull nor verify the image
+	runCmd = exec.Command(dockerBinary, "--debug", "-l", "debug", "run", "--pull=false", repoName)
+	s.trustedCmd(runCmd)
+	out, _, err = runCommandWithOutput(runCmd)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "successfully verified targets", check.Commentf("unexpected trust verification"))
+	c.Assert(out, checker.Not(checker.Contains), "Pulling from ", check.Commentf("unexpected pull"))
+
+	// run with --pull=false will neither pull nor verify the image
+	// gives an error if there is no local image
+	dockerCmd(c, "rmi", repoName)
+	runCmd = exec.Command(dockerBinary, "--debug", "-l", "debug", "run", "--pull=false", repoName)
+	s.trustedCmd(runCmd)
+	out, _, err = runCommandWithOutput(runCmd)
+	c.Assert(err, check.NotNil, check.Commentf("expected error on trusted --pull=false:\n%s", out))
+	c.Assert(out, checker.Contains, "Unable to find image", check.Commentf("out: %s", out))
+
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1241,7 +1241,7 @@ func getContainerState(c *check.C, id string) (int, bool, error) {
 }
 
 func buildImageCmd(name, dockerfile string, useCache bool, buildFlags ...string) *exec.Cmd {
-	args := []string{"-D", "build", "-t", name}
+	args := []string{"-D", "-l", "debug", "build", "-t", name}
 	if !useCache {
 		args = append(args, "--no-cache")
 	}
@@ -1626,7 +1626,7 @@ func buildImageWithOutInDamon(socket string, name, dockerfile string, useCache b
 }
 
 func buildImageCmdArgs(args []string, name, dockerfile string, useCache bool) *exec.Cmd {
-	args = append(args, []string{"-D", "build", "-t", name}...)
+	args = append(args, []string{"-D", "-l", "debug", "build", "-t", name}...)
 	if !useCache {
 		args = append(args, "--no-cache")
 	}

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -9,12 +9,13 @@ docker-build - Build a new image from the source code at PATH
 [**--build-arg**[=*[]*]]
 [**--cpu-shares**[=*0*]]
 [**--cgroup-parent**[=*CGROUP-PARENT*]]
+[**--disable-content-trust**[=*true*]]
 [**--help**]
 [**-f**|**--file**[=*PATH/Dockerfile*]]
 [**--force-rm**]
 [**--isolation**[=*default*]]
 [**--no-cache**]
-[**--pull**]
+[**--pull**[=*<content-trust>*]]]
 [**-q**|**--quiet**]
 [**--rm**[=*true*]]
 [**-t**|**--tag**[=*[]*]]
@@ -78,7 +79,7 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
   Print usage statement
 
 **--pull**=*true*|*false*
-   Always attempt to pull a newer version of the image. The default is *false*.
+   Always attempt to pull a newer version of the FROM image. The default is set to whether or not content-trust is enabled.  See --disable-content-trust.
 
 **-q**, **--quiet**=*true*|*false*
    Suppress the build output and print image ID on success. The default is *false*.
@@ -188,6 +189,10 @@ two memory nodes.
 
   If the path is not absolute, the path is considered relative to the `cgroups` path of the init process.
 Cgroups are created if they do not already exist.
+
+**--disable-content-trust**=*true*|*false*
+  Skip image verification. The default is the inverse of the DOCKER_CONTENT_TRUST environment value, if set, otherwise the default is *true*.
+
 
 **--ulimit**=[]
   Ulimit options

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -24,6 +24,7 @@ docker-create - Create a new container
 [**--device-read-iops**[=*[]*]]
 [**--device-write-bps**[=*[]*]]
 [**--device-write-iops**[=*[]*]]
+[**--disable-content-trust**[=*true*]]
 [**--dns**[=*[]*]]
 [**--dns-search**[=*[]*]]
 [**--dns-opt**[=*[]*]]
@@ -59,7 +60,7 @@ docker-create - Create a new container
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
 [**--privileged**]
-[**--pull**[=*false*]]
+[**--pull**[=*<content-trust>*]]]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
 [**--security-opt**[=*[]*]]
@@ -144,6 +145,9 @@ two memory nodes.
 
 **--device-write-iops**=[]
     Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)
+
+**--disable-content-trust**=*true*|*false*
+   Skip image verification. The default is the inverse of the DOCKER_CONTENT_TRUST environment value, if set, otherwise the default is *true*.
 
 **--dns**=[]
    Set custom DNS servers
@@ -295,7 +299,7 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
    Give extended privileges to this container. The default is *false*.
 
 **--pull**=*true*|*false*
-   Always attempt to pull a newer version of the image.
+   Always attempt to pull a newer version of the image. The default is set to whether or not content-trust is enabled.  See --disable-content-trust.
 
 **--read-only**=*true*|*false*
    Mount the container's root filesystem as read only.

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -59,6 +59,7 @@ docker-create - Create a new container
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
 [**--privileged**]
+[**--pull**[=*false*]]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
 [**--security-opt**[=*[]*]]
@@ -292,6 +293,9 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
 **--privileged**=*true*|*false*
    Give extended privileges to this container. The default is *false*.
+
+**--pull**=*true*|*false*
+   Always attempt to pull a newer version of the image.
 
 **--read-only**=*true*|*false*
    Mount the container's root filesystem as read only.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -26,6 +26,7 @@ docker-run - Run a command in a new container
 [**--device-read-iops**[=*[]*]]
 [**--device-write-bps**[=*[]*]]
 [**--device-write-iops**[=*[]*]]
+[**--disable-content-trust**[=*true*]]
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
 [**--dns-search**[=*[]*]]
@@ -61,7 +62,7 @@ docker-run - Run a command in a new container
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
 [**--privileged**]
-[**--pull**[=*false*]]
+[**--pull**[=*<content-trust>*]]]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
 [**--rm**]
@@ -217,6 +218,9 @@ See **config-json(5)** for documentation on using a configuration file.
 
 **--device-write-iops**=[]
    Limit write rate a a device (e.g. --device-write-iops=/dev/sda:1000)
+
+**--disable-content-trust**=*true*|*false*
+   Skip image verification. The default is the inverse of the DOCKER_CONTENT_TRUST environment value, if set, otherwise the default is *true*.
 
 **--dns-search**=[]
    Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
@@ -440,7 +444,7 @@ allow the container nearly all the same access to the host as processes running
 outside of a container on the host.
 
 **--pull**=*true*|*false*
-   Always attempt to pull a newer version of the image.
+   Always attempt to pull a newer version of the image. The default is set to whether or not content-trust is enabled.  See --disable-content-trust.
 
 **--read-only**=*true*|*false*
    Mount the container's root filesystem as read only.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -61,6 +61,7 @@ docker-run - Run a command in a new container
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
 [**--privileged**]
+[**--pull**[=*false*]]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
 [**--rm**]
@@ -437,6 +438,9 @@ access any devices. A “privileged” container is given access to all devices.
 to all devices on the host as well as set some configuration in AppArmor to
 allow the container nearly all the same access to the host as processes running
 outside of a container on the host.
+
+**--pull**=*true*|*false*
+   Always attempt to pull a newer version of the image.
 
 **--read-only**=*true*|*false*
    Mount the container's root filesystem as read only.

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -20,6 +20,9 @@ const (
 	DefaultRepoPrefix = "library/"
 )
 
+// TranslatorFunc defines a callback function for resolving named tags into canonical tags.
+type TranslatorFunc func(NamedTagged) (Canonical, error)
+
 // Named is an object with a full name
 type Named interface {
 	// Name returns normalized repository name, like "ubuntu".

--- a/vendor/src/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_build.go
@@ -68,14 +68,11 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 		query.Set("forcerm", "1")
 	}
 
-	if options.PullParent {
-		query.Set("pull", "1")
-	}
-
 	if !container.IsolationLevel.IsDefault(options.IsolationLevel) {
 		query.Set("isolation", string(options.IsolationLevel))
 	}
 
+	query.Set("pull", options.PullParent.String())
 	query.Set("cpusetcpus", options.CPUSetCPUs)
 	query.Set("cpusetmems", options.CPUSetMems)
 	query.Set("cpushares", strconv.FormatInt(options.CPUShares, 10))

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/image"
 	"github.com/docker/go-units"
 )
 
@@ -126,7 +127,7 @@ type ImageBuildOptions struct {
 	NoCache        bool
 	Remove         bool
 	ForceRemove    bool
-	PullParent     bool
+	PullParent     image.PullBehavior
 	IsolationLevel container.IsolationLevel
 	CPUSetCPUs     string
 	CPUSetMems     string

--- a/vendor/src/github.com/docker/engine-api/types/image/pull_behavior.go
+++ b/vendor/src/github.com/docker/engine-api/types/image/pull_behavior.go
@@ -1,0 +1,41 @@
+package image
+
+import (
+	"fmt"
+)
+
+// PullBehavior can be one of: never, always, or missing
+type PullBehavior int
+
+// PullBehavior can be one of: never, always, or missing
+const (
+	PullNever PullBehavior = iota
+	PullAlways
+	PullMissing
+)
+
+// ParsePullBehavior validates and converts a string into a PullBehavior
+func ParsePullBehavior(pullVal string) (PullBehavior, error) {
+	switch pullVal {
+	case "never":
+		return PullNever, nil
+	case "always":
+		return PullAlways, nil
+	case "missing", "":
+		return PullMissing, nil
+	}
+	return PullNever, fmt.Errorf("Invalid pull behavior '%s'", pullVal)
+}
+
+// String returns a string representation of a PullBehavior
+func (p PullBehavior) String() string {
+	switch p {
+	case PullNever:
+		return "never"
+	case PullAlways:
+		return "always"
+	case PullMissing:
+		return "missing"
+	}
+	return ""
+}


### PR DESCRIPTION
Currently, when content trust is enabled, a docker run/create will always check the image against the trust server.  This is problematic for a couple of reasons:
- This causes an implicit 'pull' to occur on the next docker run if a new image has been published since the last run.  This may or may not be desirable.  However, it is different behavior and may cause unexpected issues in production deployments.
- Local docker images that aren't intended to be published cannot be run without disabling trust.  For example, even building docker itself creates/utilizes a 'docker-dev:<branch>' build image.  Without disabling docker trust, docker cannot build itself in this scenario.

This PR modifies pull behavior and trusted reference translation.  The commands 'build', 'run', and 'create' take both content-trust and the --pull flag into account to produce a 'pull behavior' and 'reference translator'.  The pull behavior can be one of 'never', 'missing', or 'always'.  The reference translator callback is used for content trust verification.

[trustedPullBehavior()](https://github.com/docker/docker/pull/16609/files#diff-e78c64facaeb78db4e77642d321b7252R72) deals with this logic, which is summarized as:

**Pull Behavior**

| --pull | Is Trusted | Not Trusted |
| --- | --- | --- |
| **true** | _PullMissing_ | _PullAlways_ |
| **false** | _PullNever_ | _PullMissing_ |

**Reference Translator**

| --pull | Is Trusted | Not Trusted |
| --- | --- | --- |
| **true** | _trustedReference_ | _nil_ |
| **false** | _nil_ | _nil_ |

Splitting these out simplifies the logic in [createContainer()](https://github.com/docker/docker/pull/16609/files#diff-3d537578e5c3f29c85ab371eb727e7c8R91), [rewriteDockerfileFrom()](https://github.com/docker/docker/pull/16609/files#diff-3a1632a75e011091e0bae6f8c8435fd2R565) and [dispatchers.from()](https://github.com/docker/docker/pull/16609/files#diff-77aa50fa42bcdf6c3bedc962a396b6eaR213), which consume these values.  However, it does mean passing a PullBehavior setting from the client to the daemon during a build command, which required changing the remote API for /build.

closes https://github.com/docker/docker/issues/13331
