### PR TITLE
PROPOSAL: allow user to pass all env variables to container

### DIFF
--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -2,6 +2,7 @@ package runconfig
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -75,6 +76,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flContainerIDFile   = cmd.String([]string{"#cidfile", "-cidfile"}, "", "Write the container ID to the file")
 		flEntrypoint        = cmd.String([]string{"#entrypoint", "-entrypoint"}, "", "Overwrite the default ENTRYPOINT of the image")
 		flHostname          = cmd.String([]string{"h", "-hostname"}, "", "Container host name")
+		flHostenvs          = cmd.Bool([]string{"H", "-hostenvs"}, false, "Pass through host ENVIRONMENT variables")
 		flMemoryString      = cmd.String([]string{"m", "-memory"}, "", "Memory limit")
 		flMemoryReservation = cmd.String([]string{"-memory-reservation"}, "", "Memory soft limit")
 		flMemorySwap        = cmd.String([]string{"-memory-swap"}, "", "Total memory (memory + swap), '-1' to disable swap")
@@ -282,6 +284,11 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	envVariables, err := readKVStrings(flEnvFile.GetAll(), flEnv.GetAll())
 	if err != nil {
 		return nil, nil, cmd, err
+	}
+
+	// add in host environments if asked for
+	if *flHostenvs {
+		envVariables = append(envVariables, os.Environ()...)
 	}
 
 	// collect all the labels for the container


### PR DESCRIPTION
Often I want to treat a process in a container exactly as if it was outside of the container.   I do this by creating a bash alias or function to hide the `docker run -ti --rm blah` portion of it.   Sometimes these commands want environment variables ( and quite a few ) and it gets cumbersome to have to add them all into the bash function or try to pass them through at the command line.

This addresses that by adding a -H or --hostenvs option to pass all environment variables from the current shell through to the docker container.

I'm not sure if this is going to be controversial, so I want to post the change for discussion before I add tests/docs etc for it.   However it does work as is.

example usage:

```
$ POOP=NOPE docker run -ti --rm -H -e NOPE=POOP busybox env | grep POOP
NOPE=POOP
POOP=NOPE
$
```

Signed-off-by: Paul Czarkowski username.taken@gmail.com
