### PR TITLE
Fix discovery package README with the right --cluster* flags

### DIFF
--- a/pkg/discovery/README.md
+++ b/pkg/discovery/README.md
@@ -13,29 +13,29 @@ Docker comes with multiple Discovery backends.
 ### Using etcd
 
 Point your Docker Engine instances to a common etcd instance. You can specify
-the address Docker uses to advertise the node using the `--discovery-address`
+the address Docker uses to advertise the node using the `--cluster-advertise`
 flag.
 
 ```bash
-$ docker daemon -H=<node_ip:2376> --discovery-address=<node_ip:2376> --discovery-backend etcd://<etcd_ip>/<path>
+$ docker daemon -H=<node_ip:2376> --cluster-advertise=<node_ip:2376> --cluster-store etcd://<etcd_ip1>,<etcd_ip2>/<path>
 ```
 
 ### Using consul
 
 Point your Docker Engine instances to a common Consul instance. You can specify
-the address Docker uses to advertise the node using the `--discovery-address`
+the address Docker uses to advertise the node using the `--cluster-advertise`
 flag.
 
 ```bash
-$ docker daemon -H=<node_ip:2376> --discovery-address=<node_ip:2376> --discovery-backend consul://<consul_ip>/<path>
+$ docker daemon -H=<node_ip:2376> --cluster-advertise=<node_ip:2376> --cluster-store consul://<consul_ip>/<path>
 ```
 
 ### Using zookeeper
 
 Point your Docker Engine instances to a common Zookeeper instance. You can specify
-the address Docker uses to advertise the node using the `--discovery-address`
+the address Docker uses to advertise the node using the `--cluster-advertise`
 flag.
 
 ```bash
-$ docker daemon -H=<node_ip:2376> --discovery-address=<node_ip:2376> --discovery-backend zk://<zk_addr1>,<zk_addr2>>/<path>
+$ docker daemon -H=<node_ip:2376> --cluster-advertise=<node_ip:2376> --cluster-store zk://<zk_addr1>,<zk_addr2>/<path>
 ```


### PR DESCRIPTION
`docs-review` was skipped for #16229 but the README was not updated to include the new flag names.

/cc @icecrime

Signed-off-by: Alexandre Beslic abronan@docker.com
