### PR TITLE
api: client: logs: error out if logging driver isn't supported

### DIFF
--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -34,6 +35,11 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	var c types.ContainerJSON
 	if err := json.NewDecoder(serverResp.body).Decode(&c); err != nil {
 		return err
+	}
+
+	logType := c.HostConfig.LogConfig.Type
+	if logType != "json-file" && logType != "journald" {
+		return fmt.Errorf("\"logs\" command is not supported for %s logging driver", logType)
 	}
 
 	v := url.Values{}


### PR DESCRIPTION
If the configured logging driver isn't supported by docker logs cmd
error out before doing the api request. This is the output w/o this
patch:

``` sh
# syslog & co
Error running logs job: configured logging reader does not support reading

# none driver
Error running logs job: Failed to get logging factory: logger: no log driver named 'none' is registered
```

After (slightly modified from the previous one):

```
"logs" command is not supported for %log_driver% logging driver
```

I believe this was introduced by https://github.com/nalind/docker/commit/e611a189cb3147cd79ccabfe8ba61ae3e3e28459#diff-2c425d9181734045f201994a41678275L40

Signed-off-by: Antonio Murdaca runcom@linux.com
