### PR TITLE
Add cluster advertise address to host address as default

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -231,6 +231,19 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 			logrus.Fatalf("error parsing -H %s : %v", commonFlags.Hosts[i], err)
 		}
 	}
+	if len(cli.ClusterAdvertise) != 0 {
+		var exists bool
+		for _, addr := range commonFlags.Hosts {
+			if addr == "tcp://"+cli.ClusterAdvertise {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			return fmt.Errorf("--cluser-advertise '%s' should be give to -H", cli.ClusterAdvertise)
+		}
+	}
+
 	for _, protoAddr := range commonFlags.Hosts {
 		protoAddrParts := strings.SplitN(protoAddr, "://", 2)
 		if len(protoAddrParts) != 2 {

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -43,9 +43,11 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 func (s *DockerSuite) TestInfoDiscoveryBackend(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
+	testDaemonHTTPAddr := "localhost:2375"
 	d := NewDaemon(c)
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
-	if err := d.Start(fmt.Sprintf("--cluster-store=%s", discoveryBackend), "--cluster-advertise=foo"); err != nil {
+	if err := d.Start(fmt.Sprintf("--cluster-store=%s", discoveryBackend), fmt.Sprintf("--cluster-advertise=%s", testDaemonHTTPAddr),
+		fmt.Sprintf("-H=tcp://%s", testDaemonHTTPAddr)); err != nil {
 		c.Fatal(err)
 	}
 	defer d.Stop()


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
#16229  has add builtin nodes discovery,

since docker daemon could listen multiple address, we should make sure
the advertise address is listened by docker daemon.

ping @icecrime 
