### PR TITLE
Add support for setting sysctls

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1392,6 +1392,7 @@ _docker_run() {
 		--restart
 		--security-opt
 		--stop-signal
+		--sysctl
 		--ulimit
 		--user -u
 		--uts

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -450,6 +450,7 @@ __docker_subcommand() {
         "($help)--read-only[Mount the container's root filesystem as read only]"
         "($help)--restart=[Restart policy]:restart policy:(no on-failure always unless-stopped)"
         "($help)*--security-opt=[Security options]:security option: "
+        "($help)*--sysctl=-[sysctl options]:sysctl: "
         "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]"
         "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users"
         "($help)*-v[Bind mount a volume]:volume: "

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -334,6 +334,7 @@ func (daemon *Daemon) populateCommand(c *Container, env []string) error {
 			ProcessLabel:  c.getProcessLabel(),
 			Rootfs:        c.rootfsPath(),
 			Resources:     resources,
+			Sysctls:       c.hostConfig.Sysctls,
 			WorkingDir:    c.Config.WorkingDir,
 		},
 		AllowedDevices:     allowedDevices,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -177,7 +177,7 @@ func TestLoadWithVolume(t *testing.T) {
 	hostConfig := `{"Binds":[],"ContainerIDFile":"","LxcConf":[],"Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
 "Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
-"SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
+"SecurityOpt":null,"ReadonlyRootfs":false,"Sysctls":null,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func TestLoadWithBindMount(t *testing.T) {
 	hostConfig := `{"Binds":["/vol1:/vol1"],"ContainerIDFile":"","LxcConf":[],"Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
 "Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
-"SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
+"SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"Sysctls":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func TestLoadWithVolume17RC(t *testing.T) {
 	hostConfig := `{"Binds":[],"ContainerIDFile":"","LxcConf":[],"Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
 "Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
-"SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
+"SecurityOpt":null,"ReadonlyRootfs":false,"Sysctls":null,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +461,7 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 	hostConfig := `{"Binds":[],"ContainerIDFile":"","LxcConf":[],"Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
 "Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
-"SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
+"SecurityOpt":null,"ReadonlyRootfs":false,"Sysctls":null,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -145,15 +145,16 @@ type ProcessConfig struct {
 // CommonCommand is the common platform agnostic part of the Command structure
 // which wraps an os/exec.Cmd to add more metadata
 type CommonCommand struct {
-	ContainerPid  int           `json:"container_pid"` // the pid for the process inside a container
-	ID            string        `json:"id"`
-	InitPath      string        `json:"initpath"`    // dockerinit
-	MountLabel    string        `json:"mount_label"` // TODO Windows. More involved, but can be factored out
-	Mounts        []Mount       `json:"mounts"`
-	Network       *Network      `json:"network"`
-	ProcessConfig ProcessConfig `json:"process_config"` // Describes the init process of the container.
-	ProcessLabel  string        `json:"process_label"`  // TODO Windows. More involved, but can be factored out
-	Resources     *Resources    `json:"resources"`
-	Rootfs        string        `json:"rootfs"` // root fs of the container
-	WorkingDir    string        `json:"working_dir"`
+	ContainerPid  int               `json:"container_pid"` // the pid for the process inside a container
+	ID            string            `json:"id"`
+	InitPath      string            `json:"initpath"`    // dockerinit
+	MountLabel    string            `json:"mount_label"` // TODO Windows. More involved, but can be factored out
+	Mounts        []Mount           `json:"mounts"`
+	Network       *Network          `json:"network"`
+	ProcessConfig ProcessConfig     `json:"process_config"` // Describes the init process of the container.
+	ProcessLabel  string            `json:"process_label"`  // TODO Windows. More involved, but can be factored out
+	Resources     *Resources        `json:"resources"`
+	Rootfs        string            `json:"rootfs"` // root fs of the container
+	Sysctls       map[string]string `json:"sysctls"`
+	WorkingDir    string            `json:"working_dir"`
 }

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -74,6 +74,7 @@ func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) 
 		}
 	}
 	container.AdditionalGroups = c.GroupAdd
+	container.Sysctl = c.Sysctls
 
 	if c.AppArmorProfile != "" {
 		container.AppArmorProfile = c.AppArmorProfile

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -99,6 +99,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.21](docker_remote_api_v1.21.md) documentation
 
+* `POST /containers/create` and `POST /containers/(id)/start` allow you to configure kernel parameters (sysctls) for use in the container.
 * `GET /volumes` lists volumes from all volume drivers.
 * `POST /volumes/create` to create a volume.
 * `GET /volumes/(name)` get low-level information about a volume.

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -200,6 +200,7 @@ Create a container
              "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
              "NetworkMode": "bridge",
              "Devices": [],
+             "Sysctls": { "net.ipv4.ip_forward": "1" },
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
              "SecurityOpt": [""],
@@ -304,6 +305,10 @@ Json Parameters:
     -   **Devices** - A list of devices to add to the container specified as a JSON object in the
       form
           `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
+    -   **Sysctls** - A list of kernel parameters (sysctls) to set in the container, specified as
+          `{ <name>: <Value> }`, for example:
+	  `{ "net.ipv4.ip_forward": "1" }`
+
     -   **Ulimits** - A list of ulimits to set in the container, specified as
           `{ "Name": <name>, "Soft": <soft limit>, "Hard": <hard limit> }`, for example:
           `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard": 2048 }`
@@ -424,6 +429,9 @@ Return low-level information on the container `id`
 				"Type": "json-file"
 			},
 			"SecurityOpt": null,
+			"Sysctls": {
+			        "net.ipv4.ip_forward": "1"
+			},
 			"VolumesFrom": null,
 			"Ulimits": [{}],
 			"VolumeDriver": ""

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -65,6 +65,7 @@ Creates a new container.
       --restart="no"                Restart policy (no, on-failure[:max-retry], always, unless-stopped)
       --security-opt=[]             Security options
       --stop-signal="SIGTERM"       Signal to stop a container
+      --sysctl[=*[]*]]              Configure namespaced kernel parameters at runtime
       -t, --tty=false               Allocate a pseudo-TTY
       -u, --user=""                 Username or UID
       --ulimit=[]                   Ulimit options

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -71,6 +71,7 @@ parent = "smn_cli"
       --security-opt=[]             Security Options
       --sig-proxy=true              Proxy received signals to the process
       --stop-signal="SIGTERM"       Signal to stop a container
+      --sysctl[=*[]*]]              Configure namespaced kernel parameters at runtime
       -t, --tty=false               Allocate a pseudo-TTY
       -u, --user=""                 Username or UID (format: <name|uid>[:<group|gid>])
       --ulimit=[]                   Ulimit options
@@ -540,3 +541,16 @@ the three processes quota set for the `daemon` user.
 The `--stop-signal` flag sets the system call signal that will be sent to the container to exit.
 This signal can be a valid unsigned number that matches a position in the kernel's syscall table, for instance 9,
 or a signal name in the format SIGNAME, for instance SIGKILL.
+
+### Configure namespaced kernel parameters (sysctls) at runtime
+
+The `--sysctl` sets namespaced kernel parameters (sysctls) in the
+container. For example, to turn on IP forwarding in the containers
+network namespace, run this command:
+
+    $ docker run --sysctl net.ipv4.ip_forward=1 someimage
+
+
+> **Note**: Not all sysctls are namespaced. You should make sure that
+> modifying a sysctl inside of a container does not modify it on the host
+> system. As the kernel evolves more sysctls will become namespaced.

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -54,6 +54,7 @@ docker-create - Create a new container
 [**--restart**[=*RESTART*]]
 [**--security-opt**[=*[]*]]
 [**--stop-signal**[=*SIGNAL*]]
+[**--sysctl**[=*[]*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**--ulimit**[=*[]*]]
@@ -257,6 +258,9 @@ This value should always larger than **-m**, so you should always use this with 
 
 **--stop-signal**=SIGTERM
   Signal to stop a container. Default is SIGTERM.
+
+**--sysctl**=SYSCTL
+  Configure namespaced kernel parameters at runtime
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -55,8 +55,9 @@ docker-run - Run a command in a new container
 [**--restart**[=*RESTART*]]
 [**--rm**[=*false*]]
 [**--security-opt**[=*[]*]]
-[**--stop-signal**[=*SIGNAL*]]
 [**--sig-proxy**[=*true*]]
+[**--stop-signal**[=*SIGNAL*]]
+[**--sysctl**[=*[]*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -410,6 +411,9 @@ its root filesystem mounted as read only prohibiting any writes.
 **--stop-signal**=SIGTERM
   Signal to stop a container. Default is SIGTERM.
 
+**--sysctl**=SYSCTL
+  Configure namespaced kernel parameters at runtime
+
 **--sig-proxy**=*true*|*false*
    Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
 
@@ -758,6 +762,20 @@ command:
 Note:
 
 You would have to write policy defining a `svirt_apache_t` type.
+
+## Setting Namespaced Kernel Parameters (Sysctls)
+
+The `--sysctl` sets namespaced kernel parameters (sysctls) in the
+container. For example, to turn on IP forwarding in the containers
+network namespace, run this command:
+
+    $ docker run --sysctl net.ipv4.ip_forward=1 someimage
+
+Note:
+
+Not all sysctls are namespaced. You should make sure that
+modifying a sysctl inside of a container does not modify it on the host
+system. As the kernel evolves more sysctls will become namespaced.
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -358,3 +358,12 @@ func doesEnvExist(name string) bool {
 	}
 	return false
 }
+
+// ValidateSysctl validates an sysctl and returns it.
+func ValidateSysctl(val string) (string, error) {
+	arr := strings.Split(val, "=")
+	if len(arr) > 1 {
+		return val, nil
+	}
+	return val, fmt.Errorf("sysctl '%s' is not valid ", val)
+}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -259,6 +259,7 @@ type HostConfig struct {
 	RestartPolicy     RestartPolicy         // Restart policy to be used for the container
 	SecurityOpt       []string              // List of string values to customize labels for MLS systems, such as SELinux.
 	ReadonlyRootfs    bool                  // Is the container root filesystem in read-only	// Unix specific
+	Sysctls           map[string]string     // List of system controls to be set in the container
 	Ulimits           []*ulimit.Ulimit      // List of ulimits to be set in the container
 	LogConfig         LogConfig             // Configuration of the logs for this container
 	CgroupParent      string                // Parent cgroup.

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -53,6 +53,8 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flLabels  = opts.NewListOpts(opts.ValidateEnv)
 		flDevices = opts.NewListOpts(opts.ValidateDevice)
 
+		flSysctls = opts.NewMapOpts(nil, opts.ValidateSysctl)
+
 		flUlimits = opts.NewUlimitOpt(nil)
 
 		flPublish           = opts.NewListOpts(nil)
@@ -127,6 +129,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	cmd.Var(&flGroupAdd, []string{"-group-add"}, "Add additional groups to join")
 	cmd.Var(&flSecurityOpt, []string{"-security-opt"}, "Security Options")
 	cmd.Var(flUlimits, []string{"-ulimit"}, "Ulimit options")
+	cmd.Var(flSysctls, []string{"-sysctl"}, "Sysctl options")
 	cmd.Var(&flLoggingOpts, []string{"-log-opt"}, "Log driver options")
 
 	cmd.Require(flag.Min, 1)
@@ -376,6 +379,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		Ulimits:           flUlimits.GetList(),
 		LogConfig:         LogConfig{Type: *flLoggingDriver, Config: loggingOpts},
 		CgroupParent:      *flCgroupParent,
+		Sysctls:           flSysctls.GetAll(),
 		VolumeDriver:      *flVolumeDriver,
 		Isolation:         IsolationLevel(*flIsolation),
 	}


### PR DESCRIPTION
This patch will allow users to specify namespace specific "kernel parameters"
for running inside of a container.

Dan Walsh dwalsh@redhat.com

Signed-off-by: Dan Walsh dwalsh@redhat.com
