### PR TITLE
TestRunUnknownCommand 30s, not 30ns

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2140,7 +2140,7 @@ func (s *DockerSuite) TestRunUnknownCommand(c *check.C) {
 	// the command which will fail.
 	if daemonPlatform == "windows" {
 		// Wait for it to exit.
-		waitExited(cID, 30)
+		waitExited(cID, 30*time.Second)
 		c.Assert(err, check.IsNil)
 	} else {
 		c.Assert(err, check.NotNil)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Not a surprise the test was extremely flaky running locally against a Windows daemon. The max wait timeout for the Windows container to exit (far longer than it ever should) was set to 30 NANOseconds, not 30 seconds.
