### PR TITLE
Move setRunningLocking to test code

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -121,7 +121,7 @@ func wait(waitChan <-chan struct{}, timeout time.Duration) error {
 // waitRunning waits until state is running. If state is already
 // running it returns immediately. If you want wait forever you must
 // supply negative timeout. Returns pid, that was passed to
-// setRunningLocking.
+// setRunning.
 func (s *State) waitRunning(timeout time.Duration) (int, error) {
 	s.Lock()
 	if s.Running {
@@ -176,12 +176,6 @@ func (s *State) getExitCode() int {
 	res := s.ExitCode
 	s.Unlock()
 	return res
-}
-
-func (s *State) setRunningLocking(pid int) {
-	s.Lock()
-	s.setRunning(pid)
-	s.Unlock()
 }
 
 func (s *State) setRunning(pid int) {

--- a/daemon/state_test.go
+++ b/daemon/state_test.go
@@ -18,7 +18,9 @@ func TestStateRunStop(t *testing.T) {
 			atomic.StoreInt64(&pid, int64(runPid))
 			close(started)
 		}()
-		s.setRunningLocking(i + 100)
+		s.Lock()
+		s.setRunning(i + 100)
+		s.Unlock()
 
 		if !s.IsRunning() {
 			t.Fatal("State not running")
@@ -90,7 +92,9 @@ func TestStateTimeoutWait(t *testing.T) {
 		t.Log("Start callback fired")
 	}
 
-	s.setRunningLocking(42)
+	s.Lock()
+	s.setRunning(49)
+	s.Unlock()
 
 	stopped := make(chan struct{})
 	go func() {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

While I was debugging some tests, I noticed setRunningLocking() in state.go is only actually used by test code, thus obscuring the interface. Made it in-line in the test code itself. #purity 
