### PR TITLE
Windows: Fix TestRunStdinBlockedAfterContainerExit

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3403,7 +3403,7 @@ func (s *DockerSuite) TestRunStdinBlockedAfterContainerExit(c *check.C) {
 	select {
 	case err := <-waitChan:
 		c.Assert(err, check.IsNil)
-	case <-time.After(3 * time.Second):
+	case <-time.After(30 * time.Second):
 		c.Fatal("timeout waiting for command to exit")
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@cpuguy83 This test was recently introduced in #16289. Unfortunately Windows containers (at least today) take more than 3 seconds to exit, so this test is consistently failing in local Windows daemon CI testing. Extending to 30 to be safe - in reality it will be around 4 to 5 seconds when the container host is running on a fast SSD.
