### PR TITLE
Skip /dev setup in container when it is bind mounted in

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -260,6 +260,7 @@ func (d *Driver) setupMounts(container *configs.Config, c *execdriver.Command) e
 	for _, m := range container.Mounts {
 		if _, ok := userMounts[m.Destination]; !ok {
 			if mountDev && strings.HasPrefix(m.Destination, "/dev/") {
+				container.Devices = nil
 				continue
 			}
 			defaultMounts = append(defaultMounts, m)


### PR DESCRIPTION
We need to set the device array to nil to skip /dev setup in runc/libcontainer.
See https://github.com/opencontainers/runc/commit/c9d58506297ed6c86c9d8a91d861e4de3772e699

Signed-off-by: Mrunal Patel mrunalp@gmail.com
