### PR TITLE
Do not parse config.Volumes for named volumes

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -5,7 +5,6 @@ package daemon
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/image"
@@ -18,17 +17,9 @@ import (
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
 func createContainerPlatformSpecificSettings(container *Container, config *runconfig.Config, hostConfig *runconfig.HostConfig, img *image.Image) error {
 	for spec := range config.Volumes {
-		var (
-			name, destination string
-			parts             = strings.Split(spec, ":")
-		)
-		switch len(parts) {
-		case 2:
-			name, destination = parts[0], filepath.Clean(parts[1])
-		default:
-			name = stringid.GenerateNonCryptoID()
-			destination = filepath.Clean(parts[0])
-		}
+		name := stringid.GenerateNonCryptoID()
+		destination := filepath.Clean(spec)
+
 		// Skip volumes for which we already have something mounted on that
 		// destination because of a --volume-from.
 		if container.isDestinationMounted(destination) {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5641,7 +5641,7 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 
 	ctx, err := fakeContext(`
 		FROM busybox
-		
+
 		ADD null /
 		COPY nullfile /
 		VOLUME nullvolume
@@ -6193,4 +6193,16 @@ func (s *DockerSuite) TestBuildBuildTimeArgDefintionWithNoEnvInjection(c *check.
 		}
 		c.Fatalf("unexpected number of occurrences of the arg in output: %q expected: 1", out)
 	}
+}
+
+func (s *DockerSuite) TestBuildNoNamedVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	dockerCmd(c, "run", "-v", "testname:/foo", "busybox", "sh", "-c", "touch /foo/oops")
+
+	dockerFile := `FROM busybox
+	VOLUME testname:/foo
+	RUN ls /foo/oops
+	`
+	_, err := buildImage("test", dockerFile, false)
+	c.Assert(err, check.NotNil, check.Commentf("image build should have failed"))
 }


### PR DESCRIPTION
Fixes an issue where `VOLUME some_name:/foo` would be parsed as a named
volume, allowing access from the builder to any volume on the host.

This makes sure that named volumes must always be passed in as a bind.
