### PR TITLE
Add daemon-side signature verification on pull

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -3,33 +3,24 @@ package client
 import (
 	"bufio"
 	"encoding/hex"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/registry/client/auth"
-	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/ansiescape"
 	"github.com/docker/docker/pkg/ioutils"
 	flag "github.com/docker/docker/pkg/mflag"
-	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/docker/registry"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/pkg/passphrase"
-	"github.com/docker/notary/trustmanager"
 	"github.com/endophage/gotuf/data"
 )
 
@@ -56,131 +47,10 @@ func isTrusted() bool {
 
 var targetRegexp = regexp.MustCompile(`([\S]+): digest: ([\S]+) size: ([\d]+)`)
 
-type target struct {
-	reference registry.Reference
-	digest    digest.Digest
-	size      int64
-}
-
-func (cli *DockerCli) trustDirectory() string {
-	return filepath.Join(cliconfig.ConfigDir(), "trust")
-}
-
-// certificateDirectory returns the directory containing
-// TLS certificates for the given server. An error is
-// returned if there was an error parsing the server string.
-func (cli *DockerCli) certificateDirectory(server string) (string, error) {
-	u, err := url.Parse(server)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(cliconfig.ConfigDir(), "tls", u.Host), nil
-}
-
-func trustServer(index *registry.IndexInfo) (string, error) {
-	if s := os.Getenv("DOCKER_CONTENT_TRUST_SERVER"); s != "" {
-		urlObj, err := url.Parse(s)
-		if err != nil || urlObj.Scheme != "https" {
-			return "", fmt.Errorf("valid https URL required for trust server, got %s", s)
-		}
-
-		return s, nil
-	}
-	if index.Official {
-		return registry.NotaryServer, nil
-	}
-	return "https://" + index.Name, nil
-}
-
-type simpleCredentialStore struct {
-	auth cliconfig.AuthConfig
-}
-
-func (scs simpleCredentialStore) Basic(u *url.URL) (string, string) {
-	return scs.auth.Username, scs.auth.Password
-}
-
 func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, authConfig cliconfig.AuthConfig) (*client.NotaryRepository, error) {
-	server, err := trustServer(repoInfo.Index)
-	if err != nil {
-		return nil, err
-	}
-
-	var cfg = tlsconfig.ClientDefault
-	cfg.InsecureSkipVerify = !repoInfo.Index.Secure
-
-	// Get certificate base directory
-	certDir, err := cli.certificateDirectory(server)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debugf("reading certificate directory: %s", certDir)
-
-	if err := registry.ReadCertsDirectory(&cfg, certDir); err != nil {
-		return nil, err
-	}
-
-	base := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).Dial,
-		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     &cfg,
-		DisableKeepAlives:   true,
-	}
-
-	// Skip configuration headers since request is not going to Docker daemon
-	modifiers := registry.DockerHeaders(http.Header{})
-	authTransport := transport.NewTransport(base, modifiers...)
-	pingClient := &http.Client{
-		Transport: authTransport,
-		Timeout:   5 * time.Second,
-	}
-	endpointStr := server + "/v2/"
-	req, err := http.NewRequest("GET", endpointStr, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	challengeManager := auth.NewSimpleChallengeManager()
-
-	resp, err := pingClient.Do(req)
-	if err != nil {
-		// Ignore error on ping to operate in offline mode
-		logrus.Debugf("Error pinging notary server %q: %s", endpointStr, err)
-	} else {
-		defer resp.Body.Close()
-
-		// Add response to the challenge manager to parse out
-		// authentication header and register authentication method
-		if err := challengeManager.AddResponse(resp); err != nil {
-			return nil, err
-		}
-	}
-
-	creds := simpleCredentialStore{auth: authConfig}
-	tokenHandler := auth.NewTokenHandler(authTransport, creds, repoInfo.CanonicalName, "push", "pull")
-	basicHandler := auth.NewBasicHandler(creds)
-	modifiers = append(modifiers, transport.RequestModifier(auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)))
-	tr := transport.NewTransport(base, modifiers...)
-
-	return client.NewNotaryRepository(cli.trustDirectory(), repoInfo.CanonicalName, server, tr, cli.getPassphraseRetriever())
-}
-
-func convertTarget(t client.Target) (target, error) {
-	h, ok := t.Hashes["sha256"]
-	if !ok {
-		return target{}, errors.New("no valid hash, expecting sha256")
-	}
-	return target{
-		reference: registry.ParseReference(t.Name),
-		digest:    digest.NewDigestFromHex("sha256", hex.EncodeToString(h)),
-		size:      t.Length,
-	}, nil
+	trustDirectory := filepath.Join(cliconfig.ConfigDir(), "trust")
+	certificateRootDirectory := filepath.Join(cliconfig.ConfigDir(), "tls")
+	return registry.GetNotaryRepository(repoInfo, trustDirectory, certificateRootDirectory, &authConfig, cli.getPassphraseRetriever())
 }
 
 func (cli *DockerCli) getPassphraseRetriever() passphrase.Retriever {
@@ -232,17 +102,12 @@ func (cli *DockerCli) trustedReference(repo string, ref registry.Reference) (reg
 		return nil, err
 	}
 
-	t, err := notaryRepo.GetTargetByName(ref.String())
+	r, err := registry.ResolveTagByNotary(notaryRepo, ref.String())
 	if err != nil {
 		return nil, err
 	}
-	r, err := convertTarget(*t)
-	if err != nil {
-		return nil, err
 
-	}
-
-	return registry.DigestReference(r.digest), nil
+	return registry.DigestReference(r.Digest), nil
 }
 
 func (cli *DockerCli) tagTrusted(repoInfo *registry.RepositoryInfo, trustedRef, ref registry.Reference) error {
@@ -260,27 +125,8 @@ func (cli *DockerCli) tagTrusted(repoInfo *registry.RepositoryInfo, trustedRef, 
 	return nil
 }
 
-func notaryError(err error) error {
-	switch err.(type) {
-	case *json.SyntaxError:
-		logrus.Debugf("Notary syntax error: %s", err)
-		return errors.New("no trust data available for remote repository")
-	case client.ErrExpired:
-		return fmt.Errorf("remote repository out-of-date: %v", err)
-	case trustmanager.ErrKeyNotFound:
-		return fmt.Errorf("signing keys not found: %v", err)
-	case *net.OpError:
-		return fmt.Errorf("error contacting notary server: %v", err)
-	}
-
-	return err
-}
-
 func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registry.Reference, authConfig cliconfig.AuthConfig) error {
-	var (
-		v    = url.Values{}
-		refs = []target{}
-	)
+	var v = url.Values{}
 
 	notaryRepo, err := cli.getNotaryRepository(repoInfo, authConfig)
 	if err != nil {
@@ -288,41 +134,19 @@ func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registr
 		return err
 	}
 
-	if ref.String() == "" {
-		// List all targets
-		targets, err := notaryRepo.ListTargets()
-		if err != nil {
-			return notaryError(err)
-		}
-		for _, tgt := range targets {
-			t, err := convertTarget(*tgt)
-			if err != nil {
-				fmt.Fprintf(cli.out, "Skipping target for %q\n", repoInfo.LocalName)
-				continue
-			}
-			refs = append(refs, t)
-		}
-	} else {
-		t, err := notaryRepo.GetTargetByName(ref.String())
-		if err != nil {
-			return notaryError(err)
-		}
-		r, err := convertTarget(*t)
-		if err != nil {
-			return err
-
-		}
-		refs = append(refs, r)
+	refs, err := registry.ResolveTagSetByNotary(notaryRepo, ref.String())
+	if err != nil {
+		return err
 	}
 
 	v.Set("fromImage", repoInfo.LocalName)
 	for i, r := range refs {
-		displayTag := r.reference.String()
+		displayTag := r.Reference.String()
 		if displayTag != "" {
 			displayTag = ":" + displayTag
 		}
-		fmt.Fprintf(cli.out, "Pull (%d of %d): %s%s@%s\n", i+1, len(refs), repoInfo.LocalName, displayTag, r.digest)
-		v.Set("tag", r.digest.String())
+		fmt.Fprintf(cli.out, "Pull (%d of %d): %s%s@%s\n", i+1, len(refs), repoInfo.LocalName, displayTag, r.Digest)
+		v.Set("tag", r.Digest.String())
 
 		_, _, err = cli.clientRequestAttemptLogin("POST", "/images/create?"+v.Encode(), nil, cli.out, repoInfo.Index, "pull")
 		if err != nil {
@@ -330,8 +154,8 @@ func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registr
 		}
 
 		// If reference is not trusted, tag by trusted reference
-		if !r.reference.HasDigest() {
-			if err := cli.tagTrusted(repoInfo, registry.DigestReference(r.digest), r.reference); err != nil {
+		if !r.Reference.HasDigest() {
+			if err := cli.tagTrusted(repoInfo, registry.DigestReference(r.Digest), r.Reference); err != nil {
 				return err
 
 			}
@@ -356,13 +180,13 @@ func selectKey(keys map[string]string) string {
 	return keyIDs[0]
 }
 
-func targetStream(in io.Writer) (io.WriteCloser, <-chan []target) {
+func targetStream(in io.Writer) (io.WriteCloser, <-chan []registry.ResolvedTag) {
 	r, w := io.Pipe()
 	out := io.MultiWriter(in, w)
-	targetChan := make(chan []target)
+	targetChan := make(chan []registry.ResolvedTag)
 
 	go func() {
-		targets := []target{}
+		targets := []registry.ResolvedTag{}
 		scanner := bufio.NewScanner(r)
 		scanner.Split(ansiescape.ScanANSILines)
 		for scanner.Scan() {
@@ -381,10 +205,10 @@ func targetStream(in io.Writer) (io.WriteCloser, <-chan []target) {
 					continue
 				}
 
-				targets = append(targets, target{
-					reference: registry.ParseReference(string(matches[1])),
-					digest:    dgst,
-					size:      s,
+				targets = append(targets, registry.ResolvedTag{
+					Reference: registry.ParseReference(string(matches[1])),
+					Digest:    dgst,
+					Size:      s,
 				})
 			}
 		}
@@ -431,16 +255,16 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string,
 	}
 
 	for _, target := range targets {
-		h, err := hex.DecodeString(target.digest.Hex())
+		h, err := hex.DecodeString(target.Digest.Hex())
 		if err != nil {
 			return err
 		}
 		t := &client.Target{
-			Name: target.reference.String(),
+			Name: target.Reference.String(),
 			Hashes: data.Hashes{
-				string(target.digest.Algorithm()): h,
+				string(target.Digest.Algorithm()): h,
 			},
-			Length: int64(target.size),
+			Length: int64(target.Size),
 		}
 		if err := repo.AddTarget(t); err != nil {
 			return err
@@ -449,7 +273,7 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string,
 
 	err = repo.Publish()
 	if _, ok := err.(*client.ErrRepoNotInitialized); !ok {
-		return notaryError(err)
+		return registry.WrapNotaryError(err)
 	}
 
 	ks := repo.KeyStoreManager
@@ -469,9 +293,9 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string,
 	}
 
 	if err := repo.Initialize(cryptoService); err != nil {
-		return notaryError(err)
+		return registry.WrapNotaryError(err)
 	}
 	fmt.Fprintf(cli.out, "Finished initializing %q\n", repoInfo.CanonicalName)
 
-	return notaryError(repo.Publish())
+	return registry.WrapNotaryError(repo.Publish())
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -33,6 +33,7 @@ type CommonConfig struct {
 	RemappedRoot   string
 	Root           string
 	TrustKeyPath   string
+	UntrustedPull  bool
 	DefaultNetwork string
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
@@ -71,6 +72,7 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.Var(opts.NewListOptsRef(&config.Labels, opts.ValidateLabel), []string{"-label"}, usageFn("Set key=value labels to the daemon"))
 	cmd.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", usageFn("Default driver for container logs"))
 	cmd.Var(opts.NewMapOpts(config.LogConfig.Config, nil), []string{"-log-opt"}, usageFn("Set log driver options"))
+	cmd.BoolVar(&config.UntrustedPull, []string{"-untrusted-pull"}, true, usageFn("Allow pulling untrusted images"))
 	cmd.StringVar(&config.ClusterAdvertise, []string{"-cluster-advertise"}, "", usageFn("Address of the daemon instance to advertise"))
 	cmd.StringVar(&config.ClusterStore, []string{"-cluster-store"}, "", usageFn("Set the cluster store"))
 	cmd.Var(opts.NewMapOpts(config.ClusterOpts, nil), []string{"-cluster-store-opt"}, usageFn("Set cluster store options"))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -741,10 +741,12 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	eventsService := events.New()
 	logrus.Debug("Creating repository list")
 	tagCfg := &graph.TagStoreConfig{
-		Graph:    g,
-		Key:      trustKey,
-		Registry: registryService,
-		Events:   eventsService,
+		Graph:         g,
+		Key:           trustKey,
+		Registry:      registryService,
+		Events:        eventsService,
+		TrustDir:      filepath.Join(config.Root, "trust"),
+		UntrustedPull: config.UntrustedPull,
 	}
 	repositories, err := graph.NewTagStore(filepath.Join(config.Root, "repositories-"+d.driver.String()), tagCfg)
 	if err != nil {

--- a/docs/security/trust/content_trust.md
+++ b/docs/security/trust/content_trust.md
@@ -295,6 +295,17 @@ $  docker push --disable-content-trust docker/trusttest:untrusted
 ...
 ```
 
+## Daemon-enforced trust
+
+When the docker daemon is started with `--untrusted-pull=false`, all it will
+only pull images with valid content signatures. This is similar to setting
+`DOCKER_CONTENT_TRUST` in the CLI, but it affects all clients, both CLI and
+users of the Remote API.
+
+**Note**: The signature enforcement only happens on `pull` operations; users
+with access to the daemon can locally build or manually tag images with any
+image tag.
+
 ## Related information
 
 * [Manage keys for content trust](trust_key_mng.md)

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -40,6 +40,8 @@ type TagStore struct {
 	pushingPool     map[string]*broadcaster.Buffered
 	registryService *registry.Service
 	eventsService   *events.Events
+	trustDir        string
+	untrustedPull   bool
 }
 
 // Repository maps tags to image IDs.
@@ -75,6 +77,10 @@ type TagStoreConfig struct {
 	Registry *registry.Service
 	// Events is the events service to use for logging.
 	Events *events.Events
+	// TrustDir is the directory used to store trusted notary certificates and cached metadata
+	TrustDir string
+	// UntrustedPull disables use of notary when pulling images
+	UntrustedPull bool
 }
 
 // NewTagStore creates a new TagStore at specified path, using the parameters
@@ -94,6 +100,8 @@ func NewTagStore(path string, cfg *TagStoreConfig) (*TagStore, error) {
 		pushingPool:     make(map[string]*broadcaster.Buffered),
 		registryService: cfg.Registry,
 		eventsService:   cfg.Events,
+		trustDir:        cfg.TrustDir,
+		untrustedPull:   cfg.UntrustedPull,
 	}
 	// Load the json file if it exists, otherwise create it.
 	if err := store.reload(); os.IsNotExist(err) {

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -105,3 +105,26 @@ func (s *DockerTrustSuite) TearDownTest(c *check.C) {
 	s.not.Close()
 	s.ds.TearDownTest(c)
 }
+
+func init() {
+	check.Suite(&DockerDaemonTrustSuite{
+		dts: &DockerTrustSuite{},
+	})
+}
+
+type DockerDaemonTrustSuite struct {
+	dts *DockerTrustSuite
+	d   *Daemon
+}
+
+func (s *DockerDaemonTrustSuite) SetUpTest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	s.dts.SetUpTest(c)
+	s.d = NewDaemon(c)
+}
+
+func (s *DockerDaemonTrustSuite) TearDownTest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	s.d.Stop()
+	s.dts.TearDownTest(c)
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -95,6 +95,12 @@ func NewDaemon(c *check.C) *Daemon {
 // Start will start the daemon and return once it is ready to receive requests.
 // You can specify additional daemon flags.
 func (d *Daemon) Start(arg ...string) error {
+	return d.StartWithEnv(nil, arg...)
+}
+
+// StartWithEnv will start the daemon with the specified environment and return
+// once it is ready to receive requests. You can specify additional daemon flags.
+func (d *Daemon) StartWithEnv(env []string, arg ...string) error {
 	dockerBinary, err := exec.LookPath(dockerBinary)
 	if err != nil {
 		d.c.Fatalf("[%s] could not find docker binary in $PATH: %v", d.id, err)
@@ -142,6 +148,9 @@ func (d *Daemon) Start(arg ...string) error {
 
 	d.cmd.Stdout = d.logFile
 	d.cmd.Stderr = d.logFile
+	if env != nil {
+		d.cmd.Env = env
+	}
 
 	if err := d.cmd.Start(); err != nil {
 		return fmt.Errorf("[%s] could not start daemon container: %v", d.id, err)
@@ -369,6 +378,13 @@ func (d *Daemon) CmdWithArgs(daemonArgs []string, name string, arg ...string) (s
 	c := exec.Command(dockerBinary, args...)
 	b, err := c.CombinedOutput()
 	return string(b), err
+}
+
+// CmdOrAssert will execute a docker CLI command against a daemon and assert that it succeeded
+func (d *Daemon) CmdOrAssert(name string, args ...string) string {
+	out, err := d.Cmd(name, args...)
+	d.c.Assert(err, check.IsNil, check.Commentf("%q %q failed with errors: %s, %v", name, strings.Join(args, " "), out, err))
+	return out
 }
 
 // LogfileName returns the path the the daemon's log file

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -175,3 +175,22 @@ func (s *DockerTrustSuite) setupTrustedImage(c *check.C, name string) string {
 
 	return repoName
 }
+
+func (s *DockerDaemonTrustSuite) startDaemonWithServer(server string, args ...string) error {
+	env := append(os.Environ(), fmt.Sprintf("DOCKER_CONTENT_TRUST_SERVER=%s", server))
+	allArgs := append([]string{"--untrusted-pull=false"}, args...)
+	return s.d.StartWithEnv(env, allArgs...)
+}
+
+func (s *DockerDaemonTrustSuite) restartDaemonWithServer(server string, args ...string) error {
+	s.d.Stop()
+	return s.startDaemonWithServer(server, args...)
+}
+
+func (s *DockerDaemonTrustSuite) startDaemon(args ...string) error {
+	return s.startDaemonWithServer(notaryURL, args...)
+}
+
+func (s *DockerDaemonTrustSuite) restartDaemon(args ...string) error {
+	return s.restartDaemonWithServer(notaryURL, args...)
+}

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -52,6 +52,7 @@ docker-daemon - Enable daemon mode
 [**--tlskey**[=*~/.docker/key.pem*]]
 [**--tlsverify**[=*false*]]
 [**--userland-proxy**[=*true*]]
+[**--untrusted-pull**[=*true*]]
 
 # DESCRIPTION
 **docker** has two distinct functions. It is used for starting the Docker
@@ -217,6 +218,9 @@ unix://[/path/to/socket] to use.
 
 **--userland-proxy**=*true*|*false*
     Rely on a userland proxy implementation for inter-container and outside-to-container loopback communications. Default is true.
+
+**--untrusted-pull**=*true*|*false*
+  Pull images from remote repositories without using the notary to verify their authenticity. Default is true. If set to false, uses the notary set by the DOCKER_CONTENT_TRUST_SERVER environment variable, or if not specified, assumes that each registry has a collocated notary.
 
 # STORAGE DRIVER OPTIONS
 

--- a/registry/notary.go
+++ b/registry/notary.go
@@ -1,0 +1,201 @@
+package registry
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/pkg/tlsconfig"
+	"github.com/docker/notary/client"
+	"github.com/docker/notary/pkg/passphrase"
+	"github.com/docker/notary/trustmanager"
+)
+
+// WrapNotaryError returns an error object with a description customized for Docker's use of the notary
+// instead of a generic text.
+func WrapNotaryError(err error) error {
+	switch err.(type) {
+	case *json.SyntaxError:
+		logrus.Debugf("Notary syntax error: %s", err)
+		return errors.New("no trust data available for remote repository")
+	case client.ErrExpired:
+		return fmt.Errorf("remote repository out-of-date: %v", err)
+	case trustmanager.ErrKeyNotFound:
+		return fmt.Errorf("signing keys not found: %v", err)
+	case *net.OpError:
+		return fmt.Errorf("error contacting notary server: %v", err)
+	}
+
+	return err
+}
+
+func trustServer(index *IndexInfo) (string, error) {
+	if s := os.Getenv("DOCKER_CONTENT_TRUST_SERVER"); s != "" {
+		urlObj, err := url.Parse(s)
+		if err != nil || urlObj.Scheme != "https" {
+			return "", fmt.Errorf("valid https URL required for trust server, got %s", s)
+		}
+
+		return s, nil
+	}
+	if index.Official {
+		return NotaryServer, nil
+	}
+	return "https://" + index.Name, nil
+}
+
+type simpleCredentialStore struct {
+	auth *cliconfig.AuthConfig
+}
+
+func (scs simpleCredentialStore) Basic(u *url.URL) (string, string) {
+	return scs.auth.Username, scs.auth.Password
+}
+
+// GetNotaryRepository returns a fully configured notary client object for a specific repository
+// and environment-dependent paths, authentication and passphrase configuration.
+func GetNotaryRepository(repoInfo *RepositoryInfo, trustDir, certificateRootDir string,
+	authConfig *cliconfig.AuthConfig, retriever passphrase.Retriever) (*client.NotaryRepository, error) {
+	server, err := trustServer(repoInfo.Index)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg = tlsconfig.ClientDefault
+	cfg.InsecureSkipVerify = !repoInfo.Index.Secure
+
+	// Get certificate base directory
+	u, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	certDir := filepath.Join(certificateRootDir, u.Host)
+	logrus.Debugf("reading certificate directory: %s", certDir)
+
+	if err := ReadCertsDirectory(&cfg, certDir); err != nil {
+		return nil, err
+	}
+
+	base := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     &cfg,
+		DisableKeepAlives:   true,
+	}
+
+	// Skip configuration headers since request is not going to Docker daemon
+	modifiers := DockerHeaders(http.Header{})
+	authTransport := transport.NewTransport(base, modifiers...)
+	pingClient := &http.Client{
+		Transport: authTransport,
+		Timeout:   5 * time.Second,
+	}
+	endpointStr := server + "/v2/"
+	req, err := http.NewRequest("GET", endpointStr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	challengeManager := auth.NewSimpleChallengeManager()
+
+	resp, err := pingClient.Do(req)
+	if err != nil {
+		// Ignore error on ping to operate in offline mode
+		logrus.Debugf("Error pinging notary server %q: %s", endpointStr, err)
+	} else {
+		defer resp.Body.Close()
+
+		// Add response to the challenge manager to parse out
+		// authentication header and register authentication method
+		if err := challengeManager.AddResponse(resp); err != nil {
+			return nil, err
+		}
+	}
+
+	creds := simpleCredentialStore{auth: authConfig}
+	tokenHandler := auth.NewTokenHandler(authTransport, creds, repoInfo.CanonicalName, "push", "pull")
+	basicHandler := auth.NewBasicHandler(creds)
+	modifiers = append(modifiers, transport.RequestModifier(auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)))
+	tr := transport.NewTransport(base, modifiers...)
+
+	return client.NewNotaryRepository(trustDir, repoInfo.CanonicalName, server, tr, retriever)
+}
+
+// ResolvedTag associates a Reference (normally with !HasDigest()) with a digest and size, either as an item to be signed
+// or as a verified association.
+type ResolvedTag struct {
+	Reference Reference
+	Digest    digest.Digest
+	Size      int64
+}
+
+func convertTarget(t client.Target) (ResolvedTag, error) {
+	h, ok := t.Hashes["sha256"]
+	if !ok {
+		return ResolvedTag{}, errors.New("no valid hash, expecting sha256")
+	}
+	return ResolvedTag{
+		Reference: ParseReference(t.Name),
+		Digest:    digest.NewDigestFromHex("sha256", hex.EncodeToString(h)),
+		Size:      t.Length,
+	}, nil
+}
+
+// ResolveTagByNotary resolves a tag to a verified digest and size
+func ResolveTagByNotary(notaryRepo *client.NotaryRepository, tag string) (ResolvedTag, error) {
+	t, err := notaryRepo.GetTargetByName(tag)
+	if err != nil {
+		return ResolvedTag{}, WrapNotaryError(err)
+	}
+	return convertTarget(*t)
+}
+
+// ResolveTagSetByNotary resolves a tag to a verified digest and size resolves a tag or "" (meaning all tags
+// in the repository) into a list of tags with the signed digest and size. The treatment of an empty tag
+// is intended to mirror behavior of (docker pull) when not given a tag.
+func ResolveTagSetByNotary(notaryRepo *client.NotaryRepository, tag string) ([]ResolvedTag, error) {
+	refs := []ResolvedTag{}
+	if tag == "" {
+		// List all targets
+		targets, err := notaryRepo.ListTargets()
+		if err != nil {
+			return nil, WrapNotaryError(err)
+		}
+		for _, tgt := range targets {
+			t, err := convertTarget(*tgt)
+			if err != nil {
+				logrus.Debugf("Skipping target for %v\n", *tgt)
+				continue
+			}
+			refs = append(refs, t)
+		}
+	} else {
+		t, err := notaryRepo.GetTargetByName(tag)
+		if err != nil {
+			return nil, WrapNotaryError(err)
+		}
+		r, err := convertTarget(*t)
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, r)
+	}
+	return refs, nil
+}

--- a/registry/notary_test.go
+++ b/registry/notary_test.go
@@ -1,10 +1,8 @@
-package client
+package registry
 
 import (
 	"os"
 	"testing"
-
-	"github.com/docker/docker/registry"
 )
 
 func unsetENV() {
@@ -14,7 +12,7 @@ func unsetENV() {
 
 func TestENVTrustServer(t *testing.T) {
 	defer unsetENV()
-	indexInfo := &registry.IndexInfo{Name: "testserver"}
+	indexInfo := &IndexInfo{Name: "testserver"}
 	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "https://notary-test.com:5000"); err != nil {
 		t.Fatal("Failed to set ENV variable")
 	}
@@ -27,7 +25,7 @@ func TestENVTrustServer(t *testing.T) {
 
 func TestHTTPENVTrustServer(t *testing.T) {
 	defer unsetENV()
-	indexInfo := &registry.IndexInfo{Name: "testserver"}
+	indexInfo := &IndexInfo{Name: "testserver"}
 	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "http://notary-test.com:5000"); err != nil {
 		t.Fatal("Failed to set ENV variable")
 	}
@@ -38,15 +36,15 @@ func TestHTTPENVTrustServer(t *testing.T) {
 }
 
 func TestOfficialTrustServer(t *testing.T) {
-	indexInfo := &registry.IndexInfo{Name: "testserver", Official: true}
+	indexInfo := &IndexInfo{Name: "testserver", Official: true}
 	output, err := trustServer(indexInfo)
-	if err != nil || output != registry.NotaryServer {
-		t.Fatalf("Expected server to be %s, got %s", registry.NotaryServer, output)
+	if err != nil || output != NotaryServer {
+		t.Fatalf("Expected server to be %s, got %s", NotaryServer, output)
 	}
 }
 
 func TestNonOfficialTrustServer(t *testing.T) {
-	indexInfo := &registry.IndexInfo{Name: "testserver", Official: false}
+	indexInfo := &IndexInfo{Name: "testserver", Official: false}
 	output, err := trustServer(indexInfo)
 	expectedStr := "https://" + indexInfo.Name
 	if err != nil || output != expectedStr {


### PR DESCRIPTION
The current use of notary integrated in the docker(1) CLI is ineffective
in automated setups where Docker is driven using the Remote API. This
patch adds the necessary minimum, signature verification when directed
through the API to pull remote images.

This does not add support for creating signatures on push; the need to
manage signing keys and perhaps passphrases makes this difficult to
retrofit into the Remote API, and it makes sense that every user on a
multi-user system should manage their own signing keys.

To enable daemon-side verification, run the daemon with
--untrusted-pull=false. The double negative is slightly awkward at the
moment, but if we are going to enable content trust by default
eventually, I think it makes sense to start with an option name which
will best suit us in the future.

Like the CLI notary integration, this does not currently address trust
bootstrapping, and uses trust-on-first use; and like the CLI notary
integration, the system administrator can explicitly bootstrap trust by
copying the relevant certificates etc. into the daemon's trust
directory (/var/lib/docker/trust by default).

Note that this does not ensure that all tags seen by the daemon are
signed! Users with access to the daemon can still use (docker build) and
manually tag images even into repositories with configured and
bootstrapped trust, without having access to any signing keys.
Considering the difficulty with daemon-side signatures on push, this
seems necessary.

In particular, (docker pull) from a CLI with trust configured will
ask the daemon to pull by digest, and then manually tag the image, so
the daemon does not do a second (redundant/enforcing) signature
verification.

Fixes: #16654

I am not sure where to put the code shared between the CLI and the daemon; it requires other Docker subpackages so it seems not to fit into `pkg/`, and it can’t go into `utils` because that would create a circular dependency between `registry` and `utils`. So I went with `registry/notary.go`, because it is at least conceptually related to the registry, and has several dependencies on the `registry` package.
