### PR TITLE
Windows: --hostname support

### DIFF
--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -130,6 +130,7 @@ func populateCommand(ctx context.Context, c *Container, env []string) error {
 		FirstStart:     !c.HasBeenStartedBefore,
 		LayerFolder:    layerFolder,
 		LayerPaths:     layerPaths,
+		Hostname:       c.Config.Hostname,
 	}
 
 	return nil

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -220,4 +220,5 @@ type Command struct {
 	FirstStart         bool              `json:"first_start"`
 	LayerPaths         []string          `json:"layer_paths"` // Windows needs to know the layer paths and folder for a command
 	LayerFolder        string            `json:"layer_folder"`
+	Hostname           string            `json:"hostname"` // Windows sets the hostname in the execdriver
 }

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -72,6 +72,7 @@ type containerInit struct {
 	LayerFolderPath         string   // Where the layer folders are located
 	Layers                  []layer  // List of storage layers
 	ProcessorWeight         int64    // CPU Shares 1..9 on Windows; or 0 is platform default.
+	HostName                string   // Hostname
 }
 
 // defaultOwner is a tag passed to HCS to allow it to differentiate between
@@ -102,6 +103,7 @@ func (d *Driver) Run(ctx context.Context, c *execdriver.Command, pipes *execdriv
 		IgnoreFlushesDuringBoot: c.FirstStart,
 		LayerFolderPath:         c.LayerFolder,
 		ProcessorWeight:         c.Resources.CPUShares,
+		HostName:                c.Hostname,
 	}
 
 	for i := 0; i < len(c.LayerPaths); i++ {


### PR DESCRIPTION
This passes through the container hostname to HCS, which in Windows Server 2016 TP4 will set the container's hostname in the registry before starting it. This will be silently ignored by TP3.
