### PR TITLE
Vendor in stretchr/testify to fix GCCGO issue with function name parsing (GCCGO CI)

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -17,7 +17,7 @@ clone git github.com/mattn/go-sqlite3 v1.1.0
 clone git github.com/microsoft/hcsshim 7f646aa6b26bcf90caee91e93cde4a80d0d8a83e
 clone git github.com/mistifyio/go-zfs v2.1.1
 clone git github.com/stretchr/objx cbeaeb16a013161a98496fad62933b1d21786672
-clone git github.com/stretchr/testify 7c2b1e5640dcf2631213ca962d892bffa1e08860
+clone git github.com/stretchr/testify 2b15294402a895a4224659d181866f545991021e
 clone git github.com/tchap/go-patricia v2.1.0
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 

--- a/vendor/src/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/src/github.com/stretchr/testify/assert/assertions.go
@@ -287,24 +287,10 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-
-	success := true
-
-	if object == nil {
-		success = false
-	} else {
-		value := reflect.ValueOf(object)
-		kind := value.Kind()
-		if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
-			success = false
-		}
+	if !isNil(object) {
+		return true
 	}
-
-	if !success {
-		Fail(t, "Expected value not to be nil.", msgAndArgs...)
-	}
-
-	return success
+	return Fail(t, "Expected value not to be nil.", msgAndArgs...)
 }
 
 // isNil checks if a specified object is nil or not, without Failing.


### PR DESCRIPTION
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
