### PR TITLE
Remove unncessary GOARCH and GOOS from .ensure-httpserver

### DIFF
--- a/hack/make/.ensure-httpserver
+++ b/hack/make/.ensure-httpserver
@@ -4,11 +4,16 @@ set -e
 # Build a Go static web server on top of busybox image
 # and compile it for target daemon
 
+MACHINE=`uname -m`
+if [ $MACHINE != "ppc64le" ]; then
+    MACHINE="amd64"
+fi
+
 dir="$DEST/httpserver"
 mkdir -p "$dir"
 (
 	cd "$dir"
-	GOOS=linux GOARCH=amd64 go build -o httpserver github.com/docker/docker/contrib/httpserver
+	GOOS="linux" GOARCH=$MACHINE go build -o httpserver github.com/docker/docker/contrib/httpserver
 	cp ../../../../contrib/httpserver/Dockerfile .
 	docker build -qt httpserver . > /dev/null
 )


### PR DESCRIPTION
Those keep the integration tests from running on non-amd64
hosts with golang.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
