### PR TITLE
Remove deprecated --restart flag on daemon

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -14,7 +14,6 @@ const (
 // CommonConfig defines the configuration of a docker daemon which are
 // common across platforms.
 type CommonConfig struct {
-	AutoRestart    bool
 	Bridge         bridgeConfig // Bridge holds bridge network specific configuration.
 	Context        map[string][]string
 	DisableBridge  bool
@@ -59,7 +58,6 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, defaultPidFile, usageFn("Path to use for daemon PID file"))
 	cmd.StringVar(&config.Root, []string{"g", "-graph"}, defaultGraph, usageFn("Root of the Docker runtime"))
 	cmd.StringVar(&config.ExecRoot, []string{"-exec-root"}, "/var/run/docker", usageFn("Root of the Docker execdriver"))
-	cmd.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, usageFn("--restart on the daemon has been deprecated in favor of --restart policies on docker run"))
 	cmd.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", usageFn("Storage driver to use"))
 	cmd.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, defaultExec, usageFn("Exec driver to use"))
 	cmd.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, usageFn("Set the containers network MTU"))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -335,7 +335,7 @@ func (daemon *Daemon) restore() error {
 
 			// check the restart policy on the containers and restart any container with
 			// the restart policy of "always"
-			if daemon.configStore.AutoRestart && container.shouldRestart() {
+			if container.shouldRestart() {
 				logrus.Debugf("Starting container %s", container.ID)
 
 				if err := container.Start(); err != nil {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -422,15 +422,14 @@ func (s *DockerSuite) TestDaemonStartWithDaemonCommand(c *check.C) {
 
 	var flags = []map[kind][]string{
 		{common: {"-l", "info"}, daemon: {"--selinux-enabled"}},
-		{common: {"-D"}, daemon: {"--selinux-enabled", "-r"}},
-		{common: {"-D"}, daemon: {"--restart"}},
+		{common: {"-D"}, daemon: {"--selinux-enabled"}},
 		{common: {"--debug"}, daemon: {"--log-driver=json-file", "--log-opt=max-size=1k"}},
 	}
 
 	var invalidGlobalFlags = [][]string{
 		//Invalid because you cannot pass daemon flags as global flags.
 		{"--selinux-enabled", "-l", "info"},
-		{"-D", "-r"},
+		{"-D"},
 		{"--config", "/tmp"},
 	}
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
`--restart` on the daemon has been deprecated in favor of --restart policies on docker run
