### PR TITLE
Update runc to fba07bce72e72ce5b2dd618e4f67dd86ccb49c82

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -45,7 +45,7 @@ clone git github.com/endophage/gotuf 9bcdad0308e34a49f38448b8ad436ad8860825ce
 clone git github.com/jfrazelle/go 6e461eb70cb4187b41a84e9a567d7137bdbe0f16
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
-clone git github.com/opencontainers/runc aac9179bbadbf958054ce97ab368ac178140e5da # libcontainer
+clone git github.com/opencontainers/runc fba07bce72e72ce5b2dd618e4f67dd86ccb49c82 # libcontainer
 # libcontainer deps (see src/github.com/docker/libcontainer/update-vendor.sh)
 clone git github.com/coreos/go-systemd v3
 clone git github.com/godbus/dbus v2

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/process_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/process_linux.go
@@ -58,7 +58,7 @@ func (p *setnsProcess) signal(sig os.Signal) error {
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}
-	return syscall.Kill(p.cmd.Process.Pid, s)
+	return syscall.Kill(p.pid(), s)
 }
 
 func (p *setnsProcess) start() (err error) {
@@ -67,7 +67,7 @@ func (p *setnsProcess) start() (err error) {
 		return newSystemError(err)
 	}
 	if len(p.cgroupPaths) > 0 {
-		if err := cgroups.EnterPid(p.cgroupPaths, p.cmd.Process.Pid); err != nil {
+		if err := cgroups.EnterPid(p.cgroupPaths, p.pid()); err != nil {
 			return newSystemError(err)
 		}
 	}
@@ -290,7 +290,7 @@ func (p *initProcess) signal(sig os.Signal) error {
 	if !ok {
 		return errors.New("os: unsupported signal type")
 	}
-	return syscall.Kill(p.cmd.Process.Pid, s)
+	return syscall.Kill(p.pid(), s)
 }
 
 func (p *initProcess) setExternalDescriptors(newFds []string) {


### PR DESCRIPTION
Fixing user namespaces (again) with a vendor update from runc
(specifically, the remount() only if special flags change)

Other changes are very minimal.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
