### PR TITLE
continue daemon refactor of Repositories()

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -425,7 +425,7 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 
 	if repoName != "" {
-		if err := s.daemon.Repositories().Tag(repoName, tag, string(imgID), true); err != nil {
+		if err := s.daemon.TagImage(repoName, tag, string(imgID), true); err != nil {
 			return errf(err)
 		}
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1011,11 +1011,6 @@ func (daemon *Daemon) Graph() *graph.Graph {
 	return daemon.graph
 }
 
-// Repositories returns all repositories.
-func (daemon *Daemon) Repositories() *graph.TagStore {
-	return daemon.repositories
-}
-
 // TagImage creates a tag in the repository reponame, pointing to the image named
 // imageName. If force is true, an existing tag with the same name may be
 // overwritten.
@@ -1077,6 +1072,13 @@ func (daemon *Daemon) ListImages(filterArgs, filter string, all bool) ([]*types.
 // name by walking the image lineage.
 func (daemon *Daemon) ImageHistory(name string) ([]*types.ImageHistory, error) {
 	return daemon.repositories.History(name)
+}
+
+// GetImage returns pointer to an Image struct corresponding to the given
+// name. The name can include an optional tag; otherwise the default tag will
+// be used.
+func (daemon *Daemon) GetImage(name string) (*image.Image, error) {
+	return daemon.repositories.LookupImage(name)
 }
 
 func (daemon *Daemon) config() *Config {

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -39,7 +39,7 @@ var _ builder.Docker = Docker{}
 
 // LookupImage looks up a Docker image referenced by `name`.
 func (d Docker) LookupImage(name string) (*image.Image, error) {
-	return d.Daemon.Repositories().LookupImage(name)
+	return d.Daemon.GetImage(name)
 }
 
 // Pull tells Docker to pull image referenced by `name`.
@@ -69,11 +69,11 @@ func (d Docker) Pull(name string) (*image.Image, error) {
 		OutStream:  ioutils.NopWriteCloser(d.OutOld),
 	}
 
-	if err := d.Daemon.Repositories().Pull(remote, tag, imagePullConfig); err != nil {
+	if err := d.Daemon.PullImage(remote, tag, imagePullConfig); err != nil {
 		return nil, err
 	}
 
-	return d.Daemon.Repositories().LookupImage(name)
+	return d.Daemon.GetImage(name)
 }
 
 // Container looks up a Docker container referenced by `id`.

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -163,7 +163,7 @@ func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error)
 		// The idea is to walk the graph down the most "efficient" way.
 		for _, ancestor := range ancestors {
 			// First, get the imageId of the ancestor filter (yay)
-			image, err := daemon.Repositories().LookupImage(ancestor)
+			image, err := daemon.repositories.LookupImage(ancestor)
 			if err != nil {
 				logrus.Warnf("Error while looking up for image %v", ancestor)
 				continue
@@ -297,7 +297,7 @@ func (daemon *Daemon) transformContainer(container *Container, ctx *listContext)
 		newC.Names = []string{}
 	}
 
-	img, err := daemon.Repositories().LookupImage(container.Config.Image)
+	img, err := daemon.repositories.LookupImage(container.Config.Image)
 	if err != nil {
 		// If the image can no longer be found by its original reference,
 		// it makes sense to show the ID instead of a stale reference.


### PR DESCRIPTION
continuation of work done in #16638. That contains only enough of the refactor to sever the API references to graph/. This is the natural continuation of that.
- The Repositories() method simply returns a member of the daemon, so access inside the daemon class can be done by using it directly rather than indirectly. 
- External users of LookupImage get a new function called GetImage to call (named so because 16638 creates a LookupImage that calls tagStore.Lookup() where this one calls tagStore.LookupImage() )
