### PR TITLE
remove testify asserts from pkg/discovery

### DIFF
--- a/pkg/discovery/file/file_test.go
+++ b/pkg/discovery/file/file_test.go
@@ -6,41 +6,49 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/discovery"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/go-check/check"
 )
 
-func TestInitialize(t *testing.T) {
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type DiscoverySuite struct{}
+
+var _ = check.Suite(&DiscoverySuite{})
+
+func (s *DiscoverySuite) TestInitialize(c *check.C) {
 	d := &Discovery{}
 	d.Initialize("/path/to/file", 1000, 0)
-	assert.Equal(t, d.path, "/path/to/file")
+	c.Assert(d.path, check.Equals, "/path/to/file")
 }
 
-func TestNew(t *testing.T) {
+func (s *DiscoverySuite) TestNew(c *check.C) {
 	d, err := discovery.New("file:///path/to/file", 0, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, d.(*Discovery).path, "/path/to/file")
+	c.Assert(err, check.IsNil)
+	c.Assert(d.(*Discovery).path, check.Equals, "/path/to/file")
 }
 
-func TestContent(t *testing.T) {
+func (s *DiscoverySuite) TestContent(c *check.C) {
 	data := `
 1.1.1.[1:2]:1111
 2.2.2.[2:4]:2222
 `
 	ips := parseFileContent([]byte(data))
-	assert.Len(t, ips, 5)
-	assert.Equal(t, ips[0], "1.1.1.1:1111")
-	assert.Equal(t, ips[1], "1.1.1.2:1111")
-	assert.Equal(t, ips[2], "2.2.2.2:2222")
-	assert.Equal(t, ips[3], "2.2.2.3:2222")
-	assert.Equal(t, ips[4], "2.2.2.4:2222")
+	c.Assert(ips, check.HasLen, 5)
+	c.Assert(ips[0], check.Equals, "1.1.1.1:1111")
+	c.Assert(ips[1], check.Equals, "1.1.1.2:1111")
+	c.Assert(ips[2], check.Equals, "2.2.2.2:2222")
+	c.Assert(ips[3], check.Equals, "2.2.2.3:2222")
+	c.Assert(ips[4], check.Equals, "2.2.2.4:2222")
 }
 
-func TestRegister(t *testing.T) {
+func (s *DiscoverySuite) TestRegister(c *check.C) {
 	discovery := &Discovery{path: "/path/to/file"}
-	assert.Error(t, discovery.Register("0.0.0.0"))
+	c.Assert(discovery.Register("0.0.0.0"), check.NotNil)
 }
 
-func TestParsingContentsWithComments(t *testing.T) {
+func (s *DiscoverySuite) TestParsingContentsWithComments(c *check.C) {
 	data := `
 ### test ###
 1.1.1.1:1111 # inline comment
@@ -50,12 +58,12 @@ func TestParsingContentsWithComments(t *testing.T) {
 ### test ###
 `
 	ips := parseFileContent([]byte(data))
-	assert.Len(t, ips, 2)
-	assert.Equal(t, "1.1.1.1:1111", ips[0])
-	assert.Equal(t, "3.3.3.3:3333", ips[1])
+	c.Assert(ips, check.HasLen, 2)
+	c.Assert("1.1.1.1:1111", check.Equals, ips[0])
+	c.Assert("3.3.3.3:3333", check.Equals, ips[1])
 }
 
-func TestWatch(t *testing.T) {
+func (s *DiscoverySuite) TestWatch(c *check.C) {
 	data := `
 1.1.1.1:1111
 2.2.2.2:2222
@@ -67,9 +75,9 @@ func TestWatch(t *testing.T) {
 
 	// Create a temporary file and remove it.
 	tmp, err := ioutil.TempFile(os.TempDir(), "discovery-file-test")
-	assert.NoError(t, err)
-	assert.NoError(t, tmp.Close())
-	assert.NoError(t, os.Remove(tmp.Name()))
+	c.Assert(err, check.IsNil)
+	c.Assert(tmp.Close(), check.IsNil)
+	c.Assert(os.Remove(tmp.Name()), check.IsNil)
 
 	// Set up file discovery.
 	d := &Discovery{}
@@ -78,7 +86,7 @@ func TestWatch(t *testing.T) {
 	ch, errCh := d.Watch(stopCh)
 
 	// Make sure it fires errors since the file doesn't exist.
-	assert.Error(t, <-errCh)
+	c.Assert(<-errCh, check.NotNil)
 	// We have to drain the error channel otherwise Watch will get stuck.
 	go func() {
 		for range errCh {
@@ -86,21 +94,21 @@ func TestWatch(t *testing.T) {
 	}()
 
 	// Write the file and make sure we get the expected value back.
-	assert.NoError(t, ioutil.WriteFile(tmp.Name(), []byte(data), 0600))
-	assert.Equal(t, expected, <-ch)
+	c.Assert(ioutil.WriteFile(tmp.Name(), []byte(data), 0600), check.IsNil)
+	c.Assert(<-ch, check.DeepEquals, expected)
 
 	// Add a new entry and look it up.
 	expected = append(expected, &discovery.Entry{Host: "3.3.3.3", Port: "3333"})
 	f, err := os.OpenFile(tmp.Name(), os.O_APPEND|os.O_WRONLY, 0600)
-	assert.NoError(t, err)
-	assert.NotNil(t, f)
+	c.Assert(err, check.IsNil)
+	c.Assert(f, check.NotNil)
 	_, err = f.WriteString("\n3.3.3.3:3333\n")
-	assert.NoError(t, err)
+	c.Assert(err, check.IsNil)
 	f.Close()
-	assert.Equal(t, expected, <-ch)
+	c.Assert(<-ch, check.DeepEquals, expected)
 
 	// Stop and make sure it closes all channels.
 	close(stopCh)
-	assert.Nil(t, <-ch)
-	assert.Nil(t, <-errCh)
+	c.Assert(<-ch, check.IsNil)
+	c.Assert(<-errCh, check.IsNil)
 }

--- a/pkg/discovery/generator_test.go
+++ b/pkg/discovery/generator_test.go
@@ -1,55 +1,53 @@
 package discovery
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/go-check/check"
 )
 
-func TestGeneratorNotGenerate(t *testing.T) {
+func (s *DiscoverySuite) TestGeneratorNotGenerate(c *check.C) {
 	ips := Generate("127.0.0.1")
-	assert.Equal(t, len(ips), 1)
-	assert.Equal(t, ips[0], "127.0.0.1")
+	c.Assert(len(ips), check.Equals, 1)
+	c.Assert(ips[0], check.Equals, "127.0.0.1")
 }
 
-func TestGeneratorWithPortNotGenerate(t *testing.T) {
+func (s *DiscoverySuite) TestGeneratorWithPortNotGenerate(c *check.C) {
 	ips := Generate("127.0.0.1:8080")
-	assert.Equal(t, len(ips), 1)
-	assert.Equal(t, ips[0], "127.0.0.1:8080")
+	c.Assert(len(ips), check.Equals, 1)
+	c.Assert(ips[0], check.Equals, "127.0.0.1:8080")
 }
 
-func TestGeneratorMatchFailedNotGenerate(t *testing.T) {
+func (s *DiscoverySuite) TestGeneratorMatchFailedNotGenerate(c *check.C) {
 	ips := Generate("127.0.0.[1]")
-	assert.Equal(t, len(ips), 1)
-	assert.Equal(t, ips[0], "127.0.0.[1]")
+	c.Assert(len(ips), check.Equals, 1)
+	c.Assert(ips[0], check.Equals, "127.0.0.[1]")
 }
 
-func TestGeneratorWithPort(t *testing.T) {
+func (s *DiscoverySuite) TestGeneratorWithPort(c *check.C) {
 	ips := Generate("127.0.0.[1:11]:2375")
-	assert.Equal(t, len(ips), 11)
-	assert.Equal(t, ips[0], "127.0.0.1:2375")
-	assert.Equal(t, ips[1], "127.0.0.2:2375")
-	assert.Equal(t, ips[2], "127.0.0.3:2375")
-	assert.Equal(t, ips[3], "127.0.0.4:2375")
-	assert.Equal(t, ips[4], "127.0.0.5:2375")
-	assert.Equal(t, ips[5], "127.0.0.6:2375")
-	assert.Equal(t, ips[6], "127.0.0.7:2375")
-	assert.Equal(t, ips[7], "127.0.0.8:2375")
-	assert.Equal(t, ips[8], "127.0.0.9:2375")
-	assert.Equal(t, ips[9], "127.0.0.10:2375")
-	assert.Equal(t, ips[10], "127.0.0.11:2375")
+	c.Assert(len(ips), check.Equals, 11)
+	c.Assert(ips[0], check.Equals, "127.0.0.1:2375")
+	c.Assert(ips[1], check.Equals, "127.0.0.2:2375")
+	c.Assert(ips[2], check.Equals, "127.0.0.3:2375")
+	c.Assert(ips[3], check.Equals, "127.0.0.4:2375")
+	c.Assert(ips[4], check.Equals, "127.0.0.5:2375")
+	c.Assert(ips[5], check.Equals, "127.0.0.6:2375")
+	c.Assert(ips[6], check.Equals, "127.0.0.7:2375")
+	c.Assert(ips[7], check.Equals, "127.0.0.8:2375")
+	c.Assert(ips[8], check.Equals, "127.0.0.9:2375")
+	c.Assert(ips[9], check.Equals, "127.0.0.10:2375")
+	c.Assert(ips[10], check.Equals, "127.0.0.11:2375")
 }
 
-func TestGenerateWithMalformedInputAtRangeStart(t *testing.T) {
+func (s *DiscoverySuite) TestGenerateWithMalformedInputAtRangeStart(c *check.C) {
 	malformedInput := "127.0.0.[x:11]:2375"
 	ips := Generate(malformedInput)
-	assert.Equal(t, len(ips), 1)
-	assert.Equal(t, ips[0], malformedInput)
+	c.Assert(len(ips), check.Equals, 1)
+	c.Assert(ips[0], check.Equals, malformedInput)
 }
 
-func TestGenerateWithMalformedInputAtRangeEnd(t *testing.T) {
+func (s *DiscoverySuite) TestGenerateWithMalformedInputAtRangeEnd(c *check.C) {
 	malformedInput := "127.0.0.[1:x]:2375"
 	ips := Generate(malformedInput)
-	assert.Equal(t, len(ips), 1)
-	assert.Equal(t, ips[0], malformedInput)
+	c.Assert(len(ips), check.Equals, 1)
+	c.Assert(ips[0], check.Equals, malformedInput)
 }

--- a/pkg/discovery/nodes/nodes_test.go
+++ b/pkg/discovery/nodes/nodes_test.go
@@ -4,29 +4,37 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/discovery"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/go-check/check"
 )
 
-func TestInitialize(t *testing.T) {
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type DiscoverySuite struct{}
+
+var _ = check.Suite(&DiscoverySuite{})
+
+func (s *DiscoverySuite) TestInitialize(c *check.C) {
 	d := &Discovery{}
 	d.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0, 0)
-	assert.Equal(t, len(d.entries), 2)
-	assert.Equal(t, d.entries[0].String(), "1.1.1.1:1111")
-	assert.Equal(t, d.entries[1].String(), "2.2.2.2:2222")
+	c.Assert(len(d.entries), check.Equals, 2)
+	c.Assert(d.entries[0].String(), check.Equals, "1.1.1.1:1111")
+	c.Assert(d.entries[1].String(), check.Equals, "2.2.2.2:2222")
 }
 
-func TestInitializeWithPattern(t *testing.T) {
+func (s *DiscoverySuite) TestInitializeWithPattern(c *check.C) {
 	d := &Discovery{}
 	d.Initialize("1.1.1.[1:2]:1111,2.2.2.[2:4]:2222", 0, 0)
-	assert.Equal(t, len(d.entries), 5)
-	assert.Equal(t, d.entries[0].String(), "1.1.1.1:1111")
-	assert.Equal(t, d.entries[1].String(), "1.1.1.2:1111")
-	assert.Equal(t, d.entries[2].String(), "2.2.2.2:2222")
-	assert.Equal(t, d.entries[3].String(), "2.2.2.3:2222")
-	assert.Equal(t, d.entries[4].String(), "2.2.2.4:2222")
+	c.Assert(len(d.entries), check.Equals, 5)
+	c.Assert(d.entries[0].String(), check.Equals, "1.1.1.1:1111")
+	c.Assert(d.entries[1].String(), check.Equals, "1.1.1.2:1111")
+	c.Assert(d.entries[2].String(), check.Equals, "2.2.2.2:2222")
+	c.Assert(d.entries[3].String(), check.Equals, "2.2.2.3:2222")
+	c.Assert(d.entries[4].String(), check.Equals, "2.2.2.4:2222")
 }
 
-func TestWatch(t *testing.T) {
+func (s *DiscoverySuite) TestWatch(c *check.C) {
 	d := &Discovery{}
 	d.Initialize("1.1.1.1:1111,2.2.2.2:2222", 0, 0)
 	expected := discovery.Entries{
@@ -34,10 +42,10 @@ func TestWatch(t *testing.T) {
 		&discovery.Entry{Host: "2.2.2.2", Port: "2222"},
 	}
 	ch, _ := d.Watch(nil)
-	assert.True(t, expected.Equals(<-ch))
+	c.Assert(expected.Equals(<-ch), check.Equals, true)
 }
 
-func TestRegister(t *testing.T) {
+func (s *DiscoverySuite) TestRegister(c *check.C) {
 	d := &Discovery{}
-	assert.Error(t, d.Register("0.0.0.0"))
+	c.Assert(d.Register("0.0.0.0"), check.NotNil)
 }


### PR DESCRIPTION
for  #16633
Opening PR to get clarity on the mocking situation.

What's left:

```
λ ag testify pkg/
pkg/discovery/kv/kv_test.go
12: "github.com/stretchr/testify/mock"
```

Test's running:

```
+ go test -test.timeout=60m github.com/docker/docker/pkg/discovery
OK: 12 passed
PASS
coverage: 83.8% of statements

+ go test -test.timeout=60m github.com/docker/docker/pkg/discovery/file
OK: 6 passed
PASS
coverage: 93.0% of statements

+ go test -test.timeout=60m github.com/docker/docker/pkg/discovery/kv
OK: 2 passed
PASS
coverage: 89.1% of statements

+ go test -test.timeout=60m github.com/docker/docker/pkg/discovery/nodes
OK: 4 passed
PASS
coverage: 93.8% of statements
```
