### PR TITLE
Don't let `Names` be null on GET /containers/JSON

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -177,7 +177,7 @@ func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error)
 		}
 	}
 
-	names := map[string][]string{}
+	names := make(map[string][]string)
 	daemon.containerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
 		names[e.ID()] = append(names[e.ID()], p)
 		return nil
@@ -291,6 +291,10 @@ func (daemon *Daemon) transformContainer(container *Container, ctx *listContext)
 		ID:      container.ID,
 		Names:   ctx.names[container.ID],
 		ImageID: container.ImageID,
+	}
+	if newC.Names == nil {
+		// Dead containers will often have no name, so make sure the response isn't  null
+		newC.Names = []string{}
 	}
 
 	img, err := daemon.Repositories().LookupImage(container.Config.Image)


### PR DESCRIPTION
Fixes an issue where a `Dead` container has no names so the API returns
`null` instead of an empty array.

Fixes #16706
