### PR TITLE
Allow docker stats without arguments

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -24,7 +24,6 @@ type ContainerStatsConfig struct {
 // ContainerStats writes information about the container to the stream
 // given in the config object.
 func (daemon *Daemon) ContainerStats(prefixOrName string, config *ContainerStatsConfig) error {
-
 	container, err := daemon.Get(prefixOrName)
 	if err != nil {
 		return err

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -10,24 +10,31 @@ parent = "smn_cli"
 
 # stats
 
-    Usage: docker stats [OPTIONS] CONTAINER [CONTAINER...]
+    Usage: docker stats [OPTIONS] [CONTAINER...]
 
     Display a live stream of one or more containers' resource usage statistics
 
+      -a, --all=false    Show all containers (default shows just running)
       --help=false       Print usage
       --no-stream=false  Disable streaming stats and only pull the first result
 
-Running `docker stats` on multiple containers
+The `docker stats` command returns a live data stream for running containers. To limit data to one or more specific containers, specify a list of container names or ids separated by a space. You can specify a stopped container but stopped containers do not return any data.
 
-    $ docker stats redis1 redis2
+If you want more detailed information about a container's resource usage, use the `/containers/(id)/stats` API endpoint. 
+
+## Examples
+
+Running `docker stats` on all running containers
+
+    $ docker stats
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
     redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
     redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    nginx1              0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
 
+Running `docker stats` on multiple containers by name and id.
 
-The `docker stats` command will only return a live stream of data for running
-containers. Stopped containers will not return any data.
-
-> **Note:**
-> If you want more detailed information about a container's resource
-> usage, use the API endpoint.
+    $ docker stats fervent_panini 5acfcb1b4fd1
+    CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
+    5acfcb1b4fd1        0.00%               115.2 MB/1.045 GB   11.03%              1.422 kB/648 B
+    fervent_panini      0.02%               11.08 MB/1.045 GB   1.06%               648 B/648 B

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -206,6 +206,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 				"login":   "",
 				"logout":  "",
 				"network": "",
+				"stats":   "",
 			}
 
 			if _, ok := noShortUsage[cmd]; !ok {

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -47,4 +49,81 @@ func (s *DockerSuite) TestStatsContainerNotFound(c *check.C) {
 	out, _, err = dockerCmdWithError("stats", "--no-stream", "notfound")
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, "no such id: notfound", check.Commentf("Expected to fail on not found container stats with --no-stream, got %q instead", out))
+}
+
+func (s *DockerSuite) TestStatsAllRunningNoStream(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	id1 := strings.TrimSpace(out)[:12]
+	c.Assert(waitRun(id1), check.IsNil)
+	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	id2 := strings.TrimSpace(out)[:12]
+	c.Assert(waitRun(id2), check.IsNil)
+	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	id3 := strings.TrimSpace(out)[:12]
+	c.Assert(waitRun(id3), check.IsNil)
+	dockerCmd(c, "stop", id3)
+
+	out, _ = dockerCmd(c, "stats", "--no-stream")
+	if !strings.Contains(out, id1) || !strings.Contains(out, id2) {
+		c.Fatalf("Expected stats output to contain both %s and %s, got %s", id1, id2, out)
+	}
+	if strings.Contains(out, id3) {
+		c.Fatalf("Did not expect %s in stats, got %s", id3, out)
+	}
+}
+
+func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	id1 := strings.TrimSpace(out)[:12]
+	c.Assert(waitRun(id1), check.IsNil)
+	dockerCmd(c, "stop", id1)
+	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	id2 := strings.TrimSpace(out)[:12]
+	c.Assert(waitRun(id2), check.IsNil)
+
+	out, _ = dockerCmd(c, "stats", "--all", "--no-stream")
+	if !strings.Contains(out, id1) || !strings.Contains(out, id2) {
+		c.Fatalf("Expected stats output to contain both %s and %s, got %s", id1, id2, out)
+	}
+}
+
+func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	id := make(chan string)
+	addedChan := make(chan struct{})
+
+	dockerCmd(c, "run", "-d", "busybox", "top")
+	statsCmd := exec.Command(dockerBinary, "stats")
+	stdout, err := statsCmd.StdoutPipe()
+	c.Assert(err, check.IsNil)
+	c.Assert(statsCmd.Start(), check.IsNil)
+	defer statsCmd.Process.Kill()
+
+	go func() {
+		containerID := <-id
+		matchID := regexp.MustCompile(containerID)
+
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			switch {
+			case matchID.MatchString(scanner.Text()):
+				close(addedChan)
+			}
+		}
+	}()
+
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	id <- strings.TrimSpace(out)[:12]
+
+	select {
+	case <-time.After(5 * time.Second):
+		c.Fatal("failed to observe new container created added to stats")
+	case <-addedChan:
+		// ignore, done
+	}
 }

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -6,15 +6,19 @@ docker-stats - Display a live stream of one or more containers' resource usage s
 
 # SYNOPSIS
 **docker stats**
+[**-a**|**--all**[=*false*]]
 [**--help**]
 [**--no-stream**[=*false*]]
-CONTAINER [CONTAINER...]
+[CONTAINER...]
 
 # DESCRIPTION
 
 Display a live stream of one or more containers' resource usage statistics
 
 # OPTIONS
+**-a**, **--all**=*true*|*false*
+   Show all containers. Only running containers are shown by default. The default is *false*.
+
 **--help**
   Print usage statement
 
@@ -23,9 +27,17 @@ Display a live stream of one or more containers' resource usage statistics
 
 # EXAMPLES
 
-Run **docker stats** with multiple containers.
+Running `docker stats` on all running containers
 
-    $ docker stats redis1 redis2
+    $ docker stats
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
     redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
     redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    nginx1              0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+
+Running `docker stats` on multiple containers by name and id.
+
+    $ docker stats fervent_panini 5acfcb1b4fd1
+    CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
+    5acfcb1b4fd1        0.00%               115.2 MB/1.045 GB   11.03%              1.422 kB/648 B
+    fervent_panini      0.02%               11.08 MB/1.045 GB   1.06%               648 B/648 B


### PR DESCRIPTION
This patch adds the ability to run `docker stats` w/o arguments and get
statistics for all running containers by default. Also add a new
`--all` flag to list statistics for all containers (like `docker ps`).
New running containers are added to the list as they show up also.
Add integration tests for this new behavior.
Docs updated accordingly. Fix missing stuff in man/commandline
reference for `docker stats`.

Close #10772

Signed-off-by: Antonio Murdaca amurdaca@redhat.com
