### PR TITLE
errors: daemon: fix wrong http status codes

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 	}
 
 	if container.IsRunning() {
-		return derr.ErrorCodeAlreadyStarted
+		return derr.ErrorCodeAlreadyStarted.WithArgs(name)
 	}
 
 	// Windows does not have the backwards compatibility issue here.

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -16,7 +16,7 @@ func (daemon *Daemon) ContainerStop(name string, seconds int) error {
 		return err
 	}
 	if !container.IsRunning() {
-		return derr.ErrorCodeStopped
+		return derr.ErrorCodeStopped.WithArgs(name)
 	}
 	if err := container.Stop(seconds); err != nil {
 		return derr.ErrorCodeCantStop.WithArgs(name, err)

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -458,9 +458,9 @@ var (
 	// that is already stopped.
 	ErrorCodeStopped = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "STOPPED",
-		Message:        "Container already stopped",
+		Message:        "Conflict: container %s already stopped",
 		Description:    "An attempt was made to stop a container, but the container is already stopped",
-		HTTPStatusCode: http.StatusNotModified,
+		HTTPStatusCode: http.StatusConflict,
 	})
 
 	// ErrorCodeCantStop is generated when we try to stop a container
@@ -527,9 +527,9 @@ var (
 	// that is already running.
 	ErrorCodeAlreadyStarted = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "ALREADYSTARTED",
-		Message:        "Container already started",
+		Message:        "Conflict: container %s already started",
 		Description:    "An attempt to start a container was made, but the container is already started",
-		HTTPStatusCode: http.StatusNotModified,
+		HTTPStatusCode: http.StatusConflict,
 	})
 
 	// ErrorCodeHostConfigStart is generated when a HostConfig is passed
@@ -617,7 +617,7 @@ var (
 	// but it is being used.
 	ErrorCodeImgDelUsed = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "IMGDELUSED",
-		Message:        "conflict: unable to remove repository reference %q (must force) - container %s is using its referenced image %s",
+		Message:        "Conflict: unable to remove repository reference %q (must force) - container %s is using its referenced image %s",
 		Description:    "An attempt was made to delete an image but it is currently being used",
 		HTTPStatusCode: http.StatusConflict,
 	})
@@ -715,7 +715,7 @@ var (
 	// default name of a container.
 	ErrorCodeDefaultName = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "DEFAULTNAME",
-		Message:        "Conflict, cannot remove the default name of the container",
+		Message:        "Conflict: cannot remove the default name of the container",
 		Description:    "An attempt to delete the default name of a container was made, but that is not allowed",
 		HTTPStatusCode: http.StatusConflict,
 	})
@@ -742,7 +742,7 @@ var (
 	// but its still running.
 	ErrorCodeRmRunning = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "RMRUNNING",
-		Message:        "Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f",
+		Message:        "Conflict: You cannot remove a running container. Stop the container before attempting removal or use -f",
 		Description:    "An attempt was made to delete a container but the container is still running, try to either stop it first or use '-f'",
 		HTTPStatusCode: http.StatusConflict,
 	})

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -182,3 +182,17 @@ func (s *DockerSuite) TestStartAttachMultipleContainers(c *check.C) {
 		}
 	}
 }
+
+func (s *DockerSuite) TestStartContainerAlreadyStarted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	name := "already-started"
+	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
+	c.Assert(waitRun(name), check.IsNil)
+	out, _, err := dockerCmdWithError("start", name)
+	c.Assert(err, check.NotNil)
+	expected := fmt.Sprintf("Conflict: container %s already started", name)
+	if !strings.Contains(out, expected) {
+		c.Fatalf("Expected %s, got %s", expected, out)
+	}
+}

--- a/integration-cli/docker_cli_stop_test.go
+++ b/integration-cli/docker_cli_stop_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestStopContainerAlreadyStopped(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	name := "already-stopped"
+	dockerCmd(c, "run", "-d", "--name", name, "busybox", "true")
+	// just making sure `true` finished
+	time.Sleep(3 * time.Second)
+	out, _, err := dockerCmdWithError("stop", name)
+	c.Assert(err, check.NotNil)
+	expected := fmt.Sprintf("Conflict: container %s already stopped", name)
+	if !strings.Contains(out, expected) {
+		c.Fatalf("Expected %s, got %s", expected, out)
+	}
+}


### PR DESCRIPTION
`ErrorCodeAlreadyStarted` and `ErrorCodeStopped` were wrongly defining
a status code of `304` to be returned by the api.
This has a side-effect in the cli where `304` isn't treated as an
error. As a result, calling `docker start` with an already running
container or `docker stop` with an already stopped container resulted
in no error shown in the cli. Directly calling the remote api resulted
in just logging an error with a statusCode of `304` (no sense).
This patch fixes this wrong behavior by changing the status codes to `409`.
Also add integration tests for both cli and api.

Signed-off-by: Antonio Murdaca amurdaca@redhat.com
