### PR TITLE
Update test-and-docs with TESTDIRS

### DIFF
--- a/docs/project/test-and-docs.md
+++ b/docs/project/test-and-docs.md
@@ -185,6 +185,29 @@ Most test targets require that you build these precursor targets first:
 
 ## Running individual or multiple named tests 
 
+### Unit tests 
+
+We use golang standard [testing](https://golang.org/pkg/testing/)
+package or [gocheck](https://labix.org/gocheck) for our unit tests. 
+
+You can use the `TESTDIRS` environment variable to run unit tests for
+a single package.
+
+    $ TESTDIRS='opts' make test-unit
+
+You can also use the `TESTFLAGS` environment variable to run a single test. The
+flag's value is passed as arguments to the `go test` command. For example, from
+your local host you can run the `TestBuild` test with this command:
+
+    $ TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit
+
+On unit tests, it's better to use `TESTFLAGS` in combination with
+`TESTDIRS` to make it quicker to run a specific test.
+
+    $ TESTDIRS='opts' TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit
+
+### Integration tests 
+
 We use [gocheck](https://labix.org/gocheck) for our integration-cli tests. 
 You can use the `TESTFLAGS` environment variable to run a single test. The
 flag's value is passed as arguments to the `go test` command. For example, from

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -56,7 +56,7 @@ go_run_test_dir() {
 	TESTS_FAILED=()
 	while read dir; do
 		echo
-		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
+		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}/${dir#./}"
 		precompiled="$ABS_DEST/precompiled/$dir.test$(binary_extension)"
 		if ! ( cd "$dir" && test_env "$precompiled" $TESTFLAGS ); then
 			TESTS_FAILED+=("$dir")


### PR DESCRIPTION
Add a paragraph on `TESTDIRS` and the combination with `TEST_FLAGS` in `test_and_docs.md`, as I didn't find anywhere that this is mentionned 🐡.

Also fix the rendering of `make test-unit` when `TESTDIRS` is used.

``` bash
# before
$ TESTDIRS=opts TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit
# […]
+ go test -test.run ^TestValidateIPAddress$ -test.timeout=60m github.com/docker/dockeropts
PASS
coverage: 2.4% of statements
# after
$ TESTDIRS=opts TESTFLAGS='-test.run ^TestValidateIPAddress$' make test-unit
# […]
+ go test -test.run ^TestValidateIPAddress$ -test.timeout=60m github.com/docker/docker/opts
PASS
coverage: 2.4% of statements
```
- docs : @thaJeztah @moxiegirl 
- scripts : @jfrazelle @tianon 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
