### PR TITLE
Skip TestExecStartFails on windows

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -613,8 +613,9 @@ func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
 }
 
 // #15750
+// TODO Fix this test on windows #16738
 func (s *DockerSuite) TestExecStartFails(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	name := "exec-15750"
 	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 	c.Assert(waitRun(name), check.IsNil)


### PR DESCRIPTION
While #16738 and #16598 are fixed 👻, skip this test on windows :sweat: :cold_sweat:.

We should not get used to merge PRs with red builds (or at some point we might miss some errors). I don't really like doing a _skip this test_, so feel free to close it if you don't agree on that :stuck_out_tongue_closed_eyes:.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
