### PR TITLE
install.sh: Support Linux Mint Debian Edition

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -152,6 +152,10 @@ do_install() {
 	if [ -z "$lsb_dist" ] && [ -r /etc/lsb-release ]; then
 		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
 	fi
+	if [ "$lsb_dist" = 'LinuxMint' ]; then
+		# We need more information.
+		lsb_dist=''
+	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/debian_version ]; then
 		lsb_dist='debian'
 	fi


### PR DESCRIPTION
For all editions of Linux Mint, `lsb_release -si` returns `LinuxMint`.

Signed-off-by: Jean-Christophe Beaupré jcbrinfo@users.noreply.github.com
