### PR TITLE
Allocate resources for server API before daemon creation

### DIFF
--- a/api/server/server_unix.go
+++ b/api/server/server_unix.go
@@ -14,8 +14,9 @@ import (
 	systemdActivation "github.com/coreos/go-systemd/activation"
 )
 
-// newServer sets up the required serverClosers and does protocol specific checking.
-func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
+// newServer sets up the required HTTPServers and does protocol specific checking.
+// newServer does not set any muxers, you should set it later to Handler field
+func (s *Server) newServer(proto, addr string) ([]*HTTPServer, error) {
 	var (
 		err error
 		ls  []net.Listener
@@ -45,12 +46,11 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 	default:
 		return nil, fmt.Errorf("Invalid protocol format: %q", proto)
 	}
-	var res []serverCloser
+	var res []*HTTPServer
 	for _, l := range ls {
 		res = append(res, &HTTPServer{
 			&http.Server{
-				Addr:    addr,
-				Handler: s.CreateMux(),
+				Addr: addr,
 			},
 			l,
 		})

--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewServer sets up the required Server and does protocol specific checking.
-func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
+func (s *Server) newServer(proto, addr string) ([]*HTTPServer, error) {
 	var (
 		ls []net.Listener
 	)
@@ -25,12 +25,11 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 		return nil, errors.New("Invalid protocol format. Windows only supports tcp.")
 	}
 
-	var res []serverCloser
+	var res []*HTTPServer
 	for _, l := range ls {
 		res = append(res, &HTTPServer{
 			&http.Server{
-				Addr:    addr,
-				Handler: s.CreateMux(),
+				Addr: addr,
 			},
 			l,
 		})

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1462,7 +1462,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
 
 	socket := filepath.Join(s.d.folder, "docker.sock")
 
-	out, err := s.d.Cmd("run", "-d", "-v", socket+":/sock", "busybox")
+	out, err := s.d.Cmd("run", "-d", "--restart=always", "-v", socket+":/sock", "busybox")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 	c.Assert(s.d.Restart(), check.IsNil)
 }


### PR DESCRIPTION
It prevents occupying of those resources (ports, unix-sockets) by
containers.
Also fixed false-positive test for that case.

Fix #15912
