### PR TITLE
Provide an option to specify per container root mount propagation flag

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1309,6 +1309,7 @@ _docker_run() {
 		--volumes-from
 		--volume -v
 		--workdir -w
+		--root-mount-propagation
 	"
 
 	local all_options="$options_with_args

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -154,6 +154,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s v -l volume 
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l volumes-from -d 'Mount volumes from the specified container(s)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s w -l workdir -d 'Working directory inside the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -a '(__fish_print_docker_images)' -d "Image"
+complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l root-mount-propagation -d 'Root mount propagation mode'
 
 # diff
 complete -c docker -f -n '__fish_docker_no_subcommand' -a diff -d "Inspect changes on a container's filesystem"
@@ -346,6 +347,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s v -l volume -d 
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l volumes-from -d 'Mount volumes from the specified container(s)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s w -l workdir -d 'Working directory inside the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -a '(__fish_print_docker_images)' -d "Image"
+complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l root-mount-propagation -d 'Root mount propagation mode'
 
 # save
 complete -c docker -f -n '__fish_docker_no_subcommand' -a save -d 'Save an image to a tar archive'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -442,6 +442,7 @@ __docker_subcommand() {
         "($help)*-v[Bind mount a volume]:volume: "
         "($help)*--volumes-from=-[Mount volumes from the specified container]:volume: "
         "($help -w --workdir)"{-w,--workdir=-}"[Working directory inside the container]:directory:_directories"
+        "($help)*--root-mount-propagation=-[Root mount propagation mode]:mode: "
     )
 
     case "$words[1]" in

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -21,6 +21,7 @@ import (
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/directory"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/system"
@@ -312,6 +313,8 @@ func populateCommand(c *Container, env []string) error {
 	}
 	uidMap, gidMap := c.daemon.GetUIDGIDMaps()
 
+	rootPropagation, _ := mount.ParseOptions(c.hostConfig.RootMountPropagation)
+
 	c.command = &execdriver.Command{
 		ID:                 c.ID,
 		Rootfs:             c.rootfsPath(),
@@ -337,6 +340,7 @@ func populateCommand(c *Container, env []string) error {
 		LxcConfig:          lxcConfig,
 		AppArmorProfile:    c.AppArmorProfile,
 		CgroupParent:       c.hostConfig.CgroupParent,
+		RootPropagation:    rootPropagation,
 	}
 
 	return nil

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -230,4 +230,5 @@ type Command struct {
 	LayerPaths         []string          `json:"layer_paths"` // Windows needs to know the layer paths and folder for a command
 	LayerFolder        string            `json:"layer_folder"`
 	Hostname           string            `json:"hostname"` // Windows sets the hostname in the execdriver
+	RootPropagation    int               `json:"mount_propagation"`
 }

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -38,7 +38,10 @@ func InitContainer(c *Command) *configs.Config {
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs
-	container.RootPropagation = mount.RPRIVATE
+	container.RootPropagation = c.RootPropagation
+	if c.RootPropagation == 0 {
+		container.RootPropagation = mount.RPRIVATE
+	}
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -204,7 +204,8 @@ Create a container
              "LogConfig": { "Type": "json-file", "Config": {} },
              "SecurityOpt": [""],
              "CgroupParent": "",
-	      "VolumeDriver": ""
+	      "VolumeDriver": "",
+              "RootMountPropagation": ""
           }
       }
 
@@ -313,6 +314,7 @@ Json Parameters:
           `json-file` logging driver.
     -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
     -   **VolumeDriver** - Driver that this container users to mount volumes.
+    -   **RootMountPropagation** - Root mount propagation mode.
 
 Query Parameters:
 
@@ -425,6 +427,7 @@ Return low-level information on the container `id`
 			"VolumesFrom": null,
 			"Ulimits": [{}],
 			"VolumeDriver": ""
+			"RootMountPropagation": ""
 		},
 		"HostnamePath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname",
 		"HostsPath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts",

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -72,6 +72,7 @@ Creates a new container.
       -v, --volume=[]               Bind mount a volume
       --volumes-from=[]             Mount volumes from the specified container(s)
       -w, --workdir=""              Working directory inside the container
+      --root-mount-propagation=""   Root mount propagation mode
 
 The `docker create` command creates a writeable container layer over the
 specified image and prepares it for running the specified command.  The

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -73,6 +73,7 @@ parent = "smn_cli"
       -v, --volume=[]               Bind mount a volume
       --volumes-from=[]             Mount volumes from the specified container(s)
       -w, --workdir=""              Working directory inside the container
+      --root-mount-propagation=""   Root mount propagation mode
 
 The `docker run` command first `creates` a writeable container layer over the
 specified image, and then `starts` it using the specified command. That is,

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -61,6 +61,7 @@ docker-create - Create a new container
 [**-v**|**--volume**[=*[]*]]
 [**--volumes-from**[=*[]*]]
 [**-w**|**--workdir**[=*WORKDIR*]]
+[**--root-mount-propagation**[=*[]*]]
 IMAGE [COMMAND] [ARG...]
 
 # DESCRIPTION
@@ -280,6 +281,11 @@ This value should always larger than **-m**, so you should always use this with 
 
 **-w**, **--workdir**=""
    Working directory inside the container
+
+**--root-mount-propagation**=[]
+   Specify mount propagation flag for / (root). Valid values are [r]private,
+   [r]slave, [r]shared. These can be helpful in implementing shared/slave
+   volumes inside containers.
 
 # HISTORY
 August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -64,6 +64,7 @@ docker-run - Run a command in a new container
 [**--uts**[=*[]*]]
 [**--volumes-from**[=*[]*]]
 [**-w**|**--workdir**[=*WORKDIR*]]
+[**--root-mount-propagation**[=*[]*]]
 IMAGE [COMMAND] [ARG...]
 
 # DESCRIPTION
@@ -507,6 +508,11 @@ the `foo` specification, Docker creates a named volume.
 running binaries within a container is the root directory (/). The developer can
 set a different default with the Dockerfile WORKDIR instruction. The operator
 can override the working directory by using the **-w** option.
+
+**--root-mount-propagation**=[]
+   Specify mount propagation flag for / (root). Valid values are [r]private,
+   [r]slave, [r]shared. These can be helpful in implementing shared/slave
+   volumes inside containers.
 
 # EXAMPLES
 

--- a/pkg/mount/flags.go
+++ b/pkg/mount/flags.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 )
 
-// Parse fstab type mount options into mount() flags
+// ParseOptions parses fstab type mount options into mount() flags
 // and device specific data
-func parseOptions(options string) (int, string) {
+func ParseOptions(options string) (int, string) {
 	var (
 		flag int
 		data []string

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -31,7 +31,7 @@ func Mounted(mountpoint string) (bool, error) {
 // specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
 // flags.go for supported option flags.
 func Mount(device, target, mType, options string) error {
-	flag, _ := parseOptions(options)
+	flag, _ := ParseOptions(options)
 	if flag&REMOUNT != REMOUNT {
 		if mounted, err := Mounted(target); err != nil || mounted {
 			return err
@@ -45,7 +45,7 @@ func Mount(device, target, mType, options string) error {
 // specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
 // flags.go for supported option flags.
 func ForceMount(device, target, mType, options string) error {
-	flag, data := parseOptions(options)
+	flag, data := ParseOptions(options)
 	if err := mount(device, target, mType, uintptr(flag), data); err != nil {
 		return err
 	}

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -9,7 +9,7 @@ import (
 func TestMountOptionsParsing(t *testing.T) {
 	options := "noatime,ro,size=10k"
 
-	flag, data := parseOptions(options)
+	flag, data := ParseOptions(options)
 
 	if data != "size=10k" {
 		t.Fatalf("Expected size=10 got %s", data)

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -59,5 +59,11 @@ func DecodeContainerConfig(src io.Reader) (*Config, *HostConfig, error) {
 		return nil, nil, err
 	}
 
+	if hc != nil {
+		if err := validateRootPropagation(hc.RootMountPropagation); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	return w.Config, hc, nil
 }

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -214,46 +214,47 @@ func NewLxcConfig(values []KeyValuePair) *LxcConfig {
 // Here, "non-portable" means "dependent of the host we are running on".
 // Portable information *should* appear in Config.
 type HostConfig struct {
-	Binds             []string              // List of volume bindings for this container
-	ContainerIDFile   string                // File (path) where the containerId is written
-	LxcConf           *LxcConfig            // Additional lxc configuration
-	Memory            int64                 // Memory limit (in bytes)
-	MemoryReservation int64                 // Memory soft limit (in bytes)
-	MemorySwap        int64                 // Total memory usage (memory + swap); set `-1` to disable swap
-	KernelMemory      int64                 // Kernel memory limit (in bytes)
-	CPUShares         int64                 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
-	CPUPeriod         int64                 `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
-	CpusetCpus        string                // CpusetCpus 0-2, 0,1
-	CpusetMems        string                // CpusetMems 0-2, 0,1
-	CPUQuota          int64                 `json:"CpuQuota"` // CPU CFS (Completely Fair Scheduler) quota
-	BlkioWeight       uint16                // Block IO weight (relative weight vs. other containers)
-	OomKillDisable    bool                  // Whether to disable OOM Killer or not
-	MemorySwappiness  *int64                // Tuning container memory swappiness behaviour
-	Privileged        bool                  // Is the container in privileged mode
-	PortBindings      nat.PortMap           // Port mapping between the exposed port (container) and the host
-	Links             []string              // List of links (in the name:alias form)
-	PublishAllPorts   bool                  // Should docker publish all exposed port for the container
-	DNS               []string              `json:"Dns"`        // List of DNS server to lookup
-	DNSOptions        []string              `json:"DnsOptions"` // List of DNSOption to look for
-	DNSSearch         []string              `json:"DnsSearch"`  // List of DNSSearch to look for
-	ExtraHosts        []string              // List of extra hosts
-	VolumesFrom       []string              // List of volumes to take from other container
-	Devices           []DeviceMapping       // List of devices to map inside the container
-	NetworkMode       NetworkMode           // Network namespace to use for the container
-	IpcMode           IpcMode               // IPC namespace to use for the container
-	PidMode           PidMode               // PID namespace to use for the container
-	UTSMode           UTSMode               // UTS namespace to use for the container
-	CapAdd            *stringutils.StrSlice // List of kernel capabilities to add to the container
-	CapDrop           *stringutils.StrSlice // List of kernel capabilities to remove from the container
-	GroupAdd          []string              // List of additional groups that the container process will run as
-	RestartPolicy     RestartPolicy         // Restart policy to be used for the container
-	SecurityOpt       []string              // List of string values to customize labels for MLS systems, such as SELinux.
-	ReadonlyRootfs    bool                  // Is the container root filesystem in read-only
-	Ulimits           []*ulimit.Ulimit      // List of ulimits to be set in the container
-	LogConfig         LogConfig             // Configuration of the logs for this container
-	CgroupParent      string                // Parent cgroup.
-	ConsoleSize       [2]int                // Initial console size on Windows
-	VolumeDriver      string                // Name of the volume driver used to mount volumes
+	Binds                []string              // List of volume bindings for this container
+	ContainerIDFile      string                // File (path) where the containerId is written
+	LxcConf              *LxcConfig            // Additional lxc configuration
+	Memory               int64                 // Memory limit (in bytes)
+	MemoryReservation    int64                 // Memory soft limit (in bytes)
+	MemorySwap           int64                 // Total memory usage (memory + swap); set `-1` to disable swap
+	KernelMemory         int64                 // Kernel memory limit (in bytes)
+	CPUShares            int64                 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
+	CPUPeriod            int64                 `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
+	CpusetCpus           string                // CpusetCpus 0-2, 0,1
+	CpusetMems           string                // CpusetMems 0-2, 0,1
+	CPUQuota             int64                 `json:"CpuQuota"` // CPU CFS (Completely Fair Scheduler) quota
+	BlkioWeight          uint16                // Block IO weight (relative weight vs. other containers)
+	OomKillDisable       bool                  // Whether to disable OOM Killer or not
+	MemorySwappiness     *int64                // Tuning container memory swappiness behaviour
+	Privileged           bool                  // Is the container in privileged mode
+	PortBindings         nat.PortMap           // Port mapping between the exposed port (container) and the host
+	Links                []string              // List of links (in the name:alias form)
+	PublishAllPorts      bool                  // Should docker publish all exposed port for the container
+	DNS                  []string              `json:"Dns"`        // List of DNS server to lookup
+	DNSOptions           []string              `json:"DnsOptions"` // List of DNSOption to look for
+	DNSSearch            []string              `json:"DnsSearch"`  // List of DNSSearch to look for
+	ExtraHosts           []string              // List of extra hosts
+	VolumesFrom          []string              // List of volumes to take from other container
+	Devices              []DeviceMapping       // List of devices to map inside the container
+	NetworkMode          NetworkMode           // Network namespace to use for the container
+	IpcMode              IpcMode               // IPC namespace to use for the container
+	PidMode              PidMode               // PID namespace to use for the container
+	UTSMode              UTSMode               // UTS namespace to use for the container
+	CapAdd               *stringutils.StrSlice // List of kernel capabilities to add to the container
+	CapDrop              *stringutils.StrSlice // List of kernel capabilities to remove from the container
+	GroupAdd             []string              // List of additional groups that the container process will run as
+	RestartPolicy        RestartPolicy         // Restart policy to be used for the container
+	SecurityOpt          []string              // List of string values to customize labels for MLS systems, such as SELinux.
+	ReadonlyRootfs       bool                  // Is the container root filesystem in read-only
+	Ulimits              []*ulimit.Ulimit      // List of ulimits to be set in the container
+	LogConfig            LogConfig             // Configuration of the logs for this container
+	CgroupParent         string                // Parent cgroup.
+	ConsoleSize          [2]int                // Initial console size on Windows
+	VolumeDriver         string                // Name of the volume driver used to mount volumes
+	RootMountPropagation string                // Root mount propagation. [r]private, [r]slave, [r]shared
 }
 
 // DecodeHostConfig creates a HostConfig based on the specified Reader.

--- a/runconfig/parse_propagation_linux.go
+++ b/runconfig/parse_propagation_linux.go
@@ -1,0 +1,24 @@
+// +build linux
+
+package runconfig
+
+import (
+	"fmt"
+)
+
+// Ensure a valid string for mount propagation has been passed in.
+func validateRootPropagation(rootPropagation string) error {
+	if rootPropagation == "" {
+		return nil
+	}
+
+	validFlags := []string{"private", "rprivate", "slave", "rslave", "shared", "rshared"}
+
+	for _, flag := range validFlags {
+		if rootPropagation == flag {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Invalid value '%s' used for root mount propagation. Supported values are [r]private, [r]slave and [r]shared", rootPropagation)
+}

--- a/runconfig/parse_propagation_unsupported.go
+++ b/runconfig/parse_propagation_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux
+
+package runconfig
+
+import (
+	"fmt"
+)
+
+// Ensure a valid string for mount propagation has been passed in.
+func validateRootPropagation(rootPropagation string) error {
+	if rootPropagation == "" {
+		return nil
+	}
+
+	return fmt.Errorf("Specifying root mount propagation is not supported")
+}


### PR DESCRIPTION
Recently runc patches got merged where one can specify per container / (root) propagation flags. Backport these patches in docker and add an option --root-propagation to allow per container root
propagation flags. Valid values are [r]private, [r]shared, [r]slave. These are useful when one wants certain volumes to be slave/shared inside containers.
