### PR TITLE
Fix VFS build tags

### DIFF
--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -1,4 +1,4 @@
-// +build linux windows
+// +build daemon
 
 package vfs
 

--- a/daemon/graphdriver/vfs/driver_unsupported.go
+++ b/daemon/graphdriver/vfs/driver_unsupported.go
@@ -1,3 +1,3 @@
-// +build !linux,!windows
+// +build !daemon
 
 package vfs


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ties the VFS build tags to the daemon tag. This avoids the excessively annoying error I've ignored for months when trying to go build from docker/docker/daemon "e:\go\src\github.com\docker\docker\daemon\graphdriver\vfs\driver.go:26: undefined: graphdriver.NewNaiveDiffDriver"
