### PR TITLE
Fix daemon logs so that "API listen on" is INFO not ERROR

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -79,7 +79,7 @@ func (s *Server) ServeAPI() error {
 		srv.srv.Handler = s.CreateMux()
 		go func(srv *HTTPServer) {
 			var err error
-			logrus.Errorf("API listen on %s", srv.l.Addr())
+			logrus.Infof("API listen on %s", srv.l.Addr())
 			if err = srv.Serve(); err != nil && strings.Contains(err.Error(), "use of closed network connection") {
 				err = nil
 			}


### PR DESCRIPTION
W/o this PR the logs would show:

```
ERRO[0000] API listen on [::]:2375
ERRO[0000] API listen on /var/run/docker.sock
```

which is misleading since these aren't "errors" they're just informational.

Signed-off-by: Doug Davis dug@us.ibm.com
