### PR TITLE
use gocheck asserts instead of fatal

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -9,20 +9,25 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/runconfig"
 	"github.com/go-check/check"
 )
+
+func checkValidGraphDriver(c *check.C, name string) {
+	if name != "devicemapper" && name != "overlay" && name != "vfs" && name != "zfs" && name != "btrfs" && name != "aufs" {
+		c.Fatalf("%v is not a valid graph driver name", name)
+	}
+}
 
 func (s *DockerSuite) TestInspectImage(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	imageTestID := "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
 	id, err := inspectField(imageTest, "Id")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
-	if id != imageTestID {
-		c.Fatalf("Expected id: %s for image: %s but received id: %s", imageTestID, imageTest, id)
-	}
+	c.Assert(id, checker.Equals, imageTestID)
 }
 
 func (s *DockerSuite) TestInspectInt64(c *check.C) {
@@ -31,10 +36,7 @@ func (s *DockerSuite) TestInspectInt64(c *check.C) {
 	dockerCmd(c, "run", "-d", "-m=300M", "--name", "inspectTest", "busybox", "true")
 	inspectOut, err := inspectField("inspectTest", "HostConfig.Memory")
 	c.Assert(err, check.IsNil)
-
-	if inspectOut != "314572800" {
-		c.Fatalf("inspect got wrong value, got: %q, expected: 314572800", inspectOut)
-	}
+	c.Assert(inspectOut, checker.Equals, "314572800")
 }
 
 func (s *DockerSuite) TestInspectDefault(c *check.C) {
@@ -53,31 +55,24 @@ func (s *DockerSuite) TestInspectStatus(c *check.C) {
 	out = strings.TrimSpace(out)
 
 	inspectOut, err := inspectField(out, "State.Status")
-	c.Assert(err, check.IsNil)
-	if inspectOut != "running" {
-		c.Fatalf("inspect got wrong status, got: %q, expected: running", inspectOut)
-	}
+	c.Assert(err, checker.IsNil)
+	c.Assert(inspectOut, checker.Equals, "running")
 
 	dockerCmd(c, "pause", out)
 	inspectOut, err = inspectField(out, "State.Status")
-	c.Assert(err, check.IsNil)
-	if inspectOut != "paused" {
-		c.Fatalf("inspect got wrong status, got: %q, expected: paused", inspectOut)
-	}
+	c.Assert(err, checker.IsNil)
+	c.Assert(inspectOut, checker.Equals, "paused")
 
 	dockerCmd(c, "unpause", out)
 	inspectOut, err = inspectField(out, "State.Status")
-	c.Assert(err, check.IsNil)
-	if inspectOut != "running" {
-		c.Fatalf("inspect got wrong status, got: %q, expected: running", inspectOut)
-	}
+	c.Assert(err, checker.IsNil)
+	c.Assert(inspectOut, checker.Equals, "running")
 
 	dockerCmd(c, "stop", out)
 	inspectOut, err = inspectField(out, "State.Status")
-	c.Assert(err, check.IsNil)
-	if inspectOut != "exited" {
-		c.Fatalf("inspect got wrong status, got: %q, expected: exited", inspectOut)
-	}
+	c.Assert(err, checker.IsNil)
+	c.Assert(inspectOut, checker.Equals, "exited")
+
 }
 
 func (s *DockerSuite) TestInspectTypeFlagContainer(c *check.C) {
@@ -88,14 +83,8 @@ func (s *DockerSuite) TestInspectTypeFlagContainer(c *check.C) {
 	dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "top")
 
 	formatStr := fmt.Sprintf("--format='{{.State.Running}}'")
-	out, exitCode, err := dockerCmdWithError("inspect", "--type=container", formatStr, "busybox")
-	if exitCode != 0 || err != nil {
-		c.Fatalf("failed to inspect container: %s, %v", out, err)
-	}
-
-	if out != "true\n" {
-		c.Fatal("not a container JSON")
-	}
+	out, _ := dockerCmd(c, "inspect", "--type=container", formatStr, "busybox")
+	c.Assert(out, checker.Equals, "true\n") // not a container JSON
 }
 
 func (s *DockerSuite) TestInspectTypeFlagWithNoContainer(c *check.C) {
@@ -106,10 +95,9 @@ func (s *DockerSuite) TestInspectTypeFlagWithNoContainer(c *check.C) {
 
 	dockerCmd(c, "run", "-d", "busybox", "true")
 
-	_, exitCode, err := dockerCmdWithError("inspect", "--type=container", "busybox")
-	if exitCode == 0 || err == nil {
-		c.Fatalf("docker inspect should have failed, as there is no container named busybox")
-	}
+	_, _, err := dockerCmdWithError("inspect", "--type=container", "busybox")
+	// docker inspect should fail, as there is no container named busybox
+	c.Assert(err, checker.NotNil)
 }
 
 func (s *DockerSuite) TestInspectTypeFlagWithImage(c *check.C) {
@@ -120,14 +108,8 @@ func (s *DockerSuite) TestInspectTypeFlagWithImage(c *check.C) {
 
 	dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "true")
 
-	out, exitCode, err := dockerCmdWithError("inspect", "--type=image", "busybox")
-	if exitCode != 0 || err != nil {
-		c.Fatalf("failed to inspect image: %s, %v", out, err)
-	}
-
-	if strings.Contains(out, "State") {
-		c.Fatal("not an image JSON")
-	}
+	out, _ := dockerCmd(c, "inspect", "--type=image", "busybox")
+	c.Assert(out, checker.Not(checker.Contains), "State") // not an image JSON
 }
 
 func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *check.C) {
@@ -138,33 +120,26 @@ func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *check.C) {
 	dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "true")
 
 	out, exitCode, err := dockerCmdWithError("inspect", "--type=foobar", "busybox")
-	if exitCode != 0 || err != nil {
-		if !strings.Contains(out, "not a valid value for --type") {
-			c.Fatalf("failed to inspect image: %s, %v", out, err)
-		}
-	}
+	c.Assert(err, checker.NotNil, check.Commentf("%s", exitCode))
+	c.Assert(exitCode, checker.Equals, 1, check.Commentf("%s", err))
+	c.Assert(out, checker.Contains, "not a valid value for --type")
 }
 
 func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	out, err := inspectField(imageTest, "Size")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	size, err := strconv.Atoi(out)
-	if err != nil {
-		c.Fatalf("failed to inspect size of the image: %s, %v", out, err)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect size of the image: %s, %v", out, err))
 
 	//now see if the size turns out to be the same
 	formatStr := fmt.Sprintf("--format='{{eq .Size %d}}'", size)
-	out, exitCode, err := dockerCmdWithError("inspect", formatStr, imageTest)
-	if exitCode != 0 || err != nil {
-		c.Fatalf("failed to inspect image: %s, %v", out, err)
-	}
-	if result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n")); err != nil || !result {
-		c.Fatalf("Expected size: %d for image: %s but received size: %s", size, imageTest, strings.TrimSuffix(out, "\n"))
-	}
+	out, _ = dockerCmd(c, "inspect", formatStr, imageTest)
+	result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n"))
+	c.Assert(err, checker.IsNil)
+	c.Assert(result, checker.Equals, true)
 }
 
 func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
@@ -172,57 +147,47 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat")
 	runCmd.Stdin = strings.NewReader("blahblah")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("failed to run container: %v, output: %q", err, out)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to run container: %v, output: %q", err, out))
 
 	id := strings.TrimSpace(out)
 
 	out, err = inspectField(id, "State.ExitCode")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	exitCode, err := strconv.Atoi(out)
-	if err != nil {
-		c.Fatalf("failed to inspect exitcode of the container: %s, %v", out, err)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect exitcode of the container: %s, %v", out, err))
 
 	//now get the exit code to verify
 	formatStr := fmt.Sprintf("--format='{{eq .State.ExitCode %d}}'", exitCode)
 	out, _ = dockerCmd(c, "inspect", formatStr, id)
-	if result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n")); err != nil || !result {
-		c.Fatalf("Expected exitcode: %d for container: %s", exitCode, id)
-	}
+	result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n"))
+	c.Assert(err, checker.IsNil)
+	c.Assert(result, checker.Equals, true)
 }
 
 func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	name, err := inspectField(imageTest, "GraphDriver.Name")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
-	if name != "devicemapper" && name != "overlay" && name != "vfs" && name != "zfs" && name != "btrfs" && name != "aufs" {
-		c.Fatalf("%v is not a valid graph driver name", name)
-	}
+	checkValidGraphDriver(c, name)
 
 	if name != "devicemapper" {
-		return
+		c.Skip("requires devicemapper graphdriver")
 	}
 
 	deviceID, err := inspectField(imageTest, "GraphDriver.Data.DeviceId")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	_, err = strconv.Atoi(deviceID)
-	if err != nil {
-		c.Fatalf("failed to inspect DeviceId of the image: %s, %v", deviceID, err)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))
 
 	deviceSize, err := inspectField(imageTest, "GraphDriver.Data.DeviceSize")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
-	if err != nil {
-		c.Fatalf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err))
 }
 
 func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
@@ -231,31 +196,25 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 	out = strings.TrimSpace(out)
 
 	name, err := inspectField(out, "GraphDriver.Name")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
-	if name != "devicemapper" && name != "overlay" && name != "vfs" && name != "zfs" && name != "btrfs" && name != "aufs" {
-		c.Fatalf("%v is not a valid graph driver name", name)
-	}
+	checkValidGraphDriver(c, name)
 
 	if name != "devicemapper" {
 		return
 	}
 
 	deviceID, err := inspectField(out, "GraphDriver.Data.DeviceId")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	_, err = strconv.Atoi(deviceID)
-	if err != nil {
-		c.Fatalf("failed to inspect DeviceId of the image: %s, %v", deviceID, err)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))
 
 	deviceSize, err := inspectField(out, "GraphDriver.Data.DeviceSize")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
-	if err != nil {
-		c.Fatalf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err)
-	}
+	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err))
 }
 
 func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
@@ -263,41 +222,23 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "/data:/data:ro,z", "busybox", "cat")
 
 	vol, err := inspectFieldJSON("test", "Mounts")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	var mp []types.MountPoint
 	err = unmarshalJSON([]byte(vol), &mp)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
-	if len(mp) != 1 {
-		c.Fatalf("Expected 1 mount point, was %v\n", len(mp))
-	}
+	// check that there is only one mountpoint
+	c.Assert(mp, check.HasLen, 1)
 
 	m := mp[0]
 
-	if m.Name != "" {
-		c.Fatal("Expected name to be empty")
-	}
-
-	if m.Driver != "" {
-		c.Fatal("Expected driver to be empty")
-	}
-
-	if m.Source != "/data" {
-		c.Fatalf("Expected source /data, was %s\n", m.Source)
-	}
-
-	if m.Destination != "/data" {
-		c.Fatalf("Expected destination /data, was %s\n", m.Destination)
-	}
-
-	if m.Mode != "ro,z" {
-		c.Fatalf("Expected mode `ro,z`, was %s\n", m.Mode)
-	}
-
-	if m.RW != false {
-		c.Fatalf("Expected rw to be false")
-	}
+	c.Assert(m.Name, checker.Equals, "")
+	c.Assert(m.Driver, checker.Equals, "")
+	c.Assert(m.Source, checker.Equals, "/data")
+	c.Assert(m.Destination, checker.Equals, "/data")
+	c.Assert(m.Mode, checker.Equals, "ro,z")
+	c.Assert(m.RW, checker.Equals, false)
 }
 
 // #14947
@@ -306,24 +247,24 @@ func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	id := strings.TrimSpace(out)
 	startedAt, err := inspectField(id, "State.StartedAt")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 	finishedAt, err := inspectField(id, "State.FinishedAt")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 	created, err := inspectField(id, "Created")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	_, err = time.Parse(time.RFC3339Nano, startedAt)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 	_, err = time.Parse(time.RFC3339Nano, finishedAt)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 	_, err = time.Parse(time.RFC3339Nano, created)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	created, err = inspectField("busybox", "Created")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	_, err = time.Parse(time.RFC3339Nano, created)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 }
 
 // #15633
@@ -333,13 +274,13 @@ func (s *DockerSuite) TestInspectLogConfigNoType(c *check.C) {
 	var logConfig runconfig.LogConfig
 
 	out, err := inspectFieldJSON("test", "HostConfig.LogConfig")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf("%v", out))
 
 	err = json.NewDecoder(strings.NewReader(out)).Decode(&logConfig)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf("%v", out))
 
-	c.Assert(logConfig.Type, check.Equals, "json-file")
-	c.Assert(logConfig.Config["max-file"], check.Equals, "42", check.Commentf("%v", logConfig))
+	c.Assert(logConfig.Type, checker.Equals, "json-file")
+	c.Assert(logConfig.Config["max-file"], checker.Equals, "42", check.Commentf("%v", logConfig))
 }
 
 func (s *DockerSuite) TestInspectNoSizeFlagContainer(c *check.C) {


### PR DESCRIPTION
some of these are finicky, and I'm not sure how good the tests are. I've marked a couple of places.

I feel not doing a dot import for gocheck is both annoying and cluttery. Is there an actual policy against doing dot imports in any case? Tests would seem like the one place it might be appropriate.

I rearranged some of the checks, but I don't think I materially changed the results of the tests.
