### PR TITLE
Do not run yaourt as root/sudo

### DIFF
--- a/docs/installation/archlinux.md
+++ b/docs/installation/archlinux.md
@@ -42,7 +42,7 @@ is all that is needed.
 
 For the AUR package execute:
 
-    $ sudo yaourt -S docker-git
+    $ yaourt -S docker-git
 
 The instructions here assume **yaourt** is installed. See [Arch User
 Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)


### PR DESCRIPTION
This is not recommended, in fact it will fail as its passed to `makepkg` which will no longer make packages even with `--asroot`.
