### PR TITLE
Introduce support for `--env` option in `docker exec`

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"io"
 	"io/ioutil"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -166,6 +167,9 @@ func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, erro
 	}
 
 	processConfig := &execdriver.ProcessConfig{
+		Cmd: exec.Cmd{
+			Env: config.Env,
+		},
 		Tty:        config.Tty,
 		Entrypoint: entrypoint,
 		Arguments:  args,

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -26,9 +26,10 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		return -1, fmt.Errorf("No active container exists with ID %s", c.ID)
 	}
 
+	env := append(c.ProcessConfig.Env, processConfig.Cmd.Env...)
 	p := &libcontainer.Process{
 		Args: append([]string{processConfig.Entrypoint}, processConfig.Arguments...),
-		Env:  c.ProcessConfig.Env,
+		Env:  env,
 		Cwd:  c.WorkingDir,
 		User: processConfig.User,
 	}

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -619,7 +619,7 @@ func (s *DockerSuite) TestExecStartFails(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 	c.Assert(waitRun(name), check.IsNil)
 
-	out, _, err := dockerCmdWithError("exec", name, "no-such-cmd")
+	out, _, err := dockerCmdWithError("exec", "-t", name, "no-such-cmd")
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "executable file not found")
 }


### PR DESCRIPTION
When using `docker exec` to run a process inside an existing container, the environment is inherited from the container initial configuration. 
This proposal add support for additional environment variables when such a process is attached to the container.

Signed-off-by: Nicolas De Loof nicolas.deloof@gmail.com
