### PR TITLE
Bump libcontainer

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -150,7 +150,7 @@ type Resources struct {
 	CpusetMems        string           `json:"cpuset_mems"`
 	CPUPeriod         int64            `json:"cpu_period"`
 	CPUQuota          int64            `json:"cpu_quota"`
-	BlkioWeight       int64            `json:"blkio_weight"`
+	BlkioWeight       uint16           `json:"blkio_weight"`
 	Rlimits           []*ulimit.Rlimit `json:"rlimits"`
 	OomKillDisable    bool             `json:"oom_kill_disable"`
 	MemorySwappiness  int64            `json:"memory_swappiness"`

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/daemon/execdriver/native/template"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -37,7 +38,7 @@ func InitContainer(c *Command) *configs.Config {
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs
-	container.Privatefs = true
+	container.RootPropagation = mount.RPRIVATE
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -44,8 +44,8 @@ clone git github.com/endophage/gotuf 9bcdad0308e34a49f38448b8ad436ad8860825ce
 clone git github.com/jfrazelle/go 6e461eb70cb4187b41a84e9a567d7137bdbe0f16
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
-clone git github.com/opencontainers/runc fba07bce72e72ce5b2dd618e4f67dd86ccb49c82 # libcontainer
-# libcontainer deps (see src/github.com/docker/libcontainer/update-vendor.sh)
+clone git github.com/opencontainers/runc 902c012e85cdae6bb68d8c7a0df69a42f818ce96 # libcontainer
+# libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v3
 clone git github.com/godbus/dbus v2
 clone git github.com/syndtr/gocapability 66ef2aa7a23ba682594e2b6f74cf40c0692b49fb

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -200,6 +200,24 @@ func (i *uint64Value) Get() interface{} { return uint64(*i) }
 
 func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
 
+// -- uint16 Value
+type uint16Value uint16
+
+func newUint16Value(val uint16, p *uint16) *uint16Value {
+	*p = val
+	return (*uint16Value)(p)
+}
+
+func (i *uint16Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 16)
+	*i = uint16Value(v)
+	return err
+}
+
+func (i *uint16Value) Get() interface{} { return uint16(*i) }
+
+func (i *uint16Value) String() string { return fmt.Sprintf("%v", *i) }
+
 // -- string Value
 type stringValue string
 
@@ -755,6 +773,32 @@ func (fs *FlagSet) Uint64(names []string, value uint64, usage string) *uint64 {
 // The return value is the address of a uint64 variable that stores the value of the flag.
 func Uint64(names []string, value uint64, usage string) *uint64 {
 	return CommandLine.Uint64(names, value, usage)
+}
+
+// Uint16Var defines a uint16 flag with specified name, default value, and usage string.
+// The argument p points to a uint16 variable in which to store the value of the flag.
+func (fs *FlagSet) Uint16Var(p *uint16, names []string, value uint16, usage string) {
+	fs.Var(newUint16Value(value, p), names, usage)
+}
+
+// Uint16Var defines a uint16 flag with specified name, default value, and usage string.
+// The argument p points to a uint16 variable in which to store the value of the flag.
+func Uint16Var(p *uint16, names []string, value uint16, usage string) {
+	CommandLine.Var(newUint16Value(value, p), names, usage)
+}
+
+// Uint16 defines a uint16 flag with specified name, default value, and usage string.
+// The return value is the address of a uint16 variable that stores the value of the flag.
+func (fs *FlagSet) Uint16(names []string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	fs.Uint16Var(p, names, value, usage)
+	return p
+}
+
+// Uint16 defines a uint16 flag with specified name, default value, and usage string.
+// The return value is the address of a uint16 variable that stores the value of the flag.
+func Uint16(names []string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16(names, value, usage)
 }
 
 // StringVar defines a string flag with specified name, default value, and usage string.

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -226,7 +226,7 @@ type HostConfig struct {
 	CpusetCpus        string                // CpusetCpus 0-2, 0,1
 	CpusetMems        string                // CpusetMems 0-2, 0,1
 	CPUQuota          int64                 `json:"CpuQuota"` // CPU CFS (Completely Fair Scheduler) quota
-	BlkioWeight       int64                 // Block IO weight (relative weight vs. other containers)
+	BlkioWeight       uint16                // Block IO weight (relative weight vs. other containers)
 	OomKillDisable    bool                  // Whether to disable OOM Killer or not
 	MemorySwappiness  *int64                // Tuning container memory swappiness behaviour
 	Privileged        bool                  // Is the container in privileged mode

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -86,7 +86,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flCPUQuota          = cmd.Int64([]string{"-cpu-quota"}, 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 		flCpusetCpus        = cmd.String([]string{"#-cpuset", "-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flCpusetMems        = cmd.String([]string{"-cpuset-mems"}, "", "MEMs in which to allow execution (0-3, 0,1)")
-		flBlkioWeight       = cmd.Int64([]string{"-blkio-weight"}, 0, "Block IO (relative weight), between 10 and 1000")
+		flBlkioWeight       = cmd.Uint16([]string{"-blkio-weight"}, 0, "Block IO (relative weight), between 10 and 1000")
 		flSwappiness        = cmd.Int64([]string{"-memory-swappiness"}, -1, "Tuning container memory swappiness (0 to 100)")
 		flNetMode           = cmd.String([]string{"-net"}, "default", "Set the Network mode for the container")
 		flMacAddress        = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/blkio.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/blkio.go
@@ -32,33 +32,41 @@ func (s *BlkioGroup) Apply(d *data) error {
 
 func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.BlkioWeight != 0 {
-		if err := writeFile(path, "blkio.weight", strconv.FormatInt(cgroup.BlkioWeight, 10)); err != nil {
+		if err := writeFile(path, "blkio.weight", strconv.FormatUint(uint64(cgroup.BlkioWeight), 10)); err != nil {
 			return err
 		}
 	}
 
-	if cgroup.BlkioWeightDevice != "" {
-		if err := writeFile(path, "blkio.weight_device", cgroup.BlkioWeightDevice); err != nil {
+	if cgroup.BlkioLeafWeight != 0 {
+		if err := writeFile(path, "blkio.leaf_weight", strconv.FormatUint(uint64(cgroup.BlkioLeafWeight), 10)); err != nil {
 			return err
 		}
 	}
-	if cgroup.BlkioThrottleReadBpsDevice != "" {
-		if err := writeFile(path, "blkio.throttle.read_bps_device", cgroup.BlkioThrottleReadBpsDevice); err != nil {
+	for _, wd := range cgroup.BlkioWeightDevice {
+		if err := writeFile(path, "blkio.weight_device", wd.WeightString()); err != nil {
+			return err
+		}
+		if err := writeFile(path, "blkio.leaf_weight_device", wd.LeafWeightString()); err != nil {
 			return err
 		}
 	}
-	if cgroup.BlkioThrottleWriteBpsDevice != "" {
-		if err := writeFile(path, "blkio.throttle.write_bps_device", cgroup.BlkioThrottleWriteBpsDevice); err != nil {
+	for _, td := range cgroup.BlkioThrottleReadBpsDevice {
+		if err := writeFile(path, "blkio.throttle.read_bps_device", td.String()); err != nil {
 			return err
 		}
 	}
-	if cgroup.BlkioThrottleReadIOpsDevice != "" {
-		if err := writeFile(path, "blkio.throttle.read_iops_device", cgroup.BlkioThrottleReadIOpsDevice); err != nil {
+	for _, td := range cgroup.BlkioThrottleWriteBpsDevice {
+		if err := writeFile(path, "blkio.throttle.write_bps_device", td.String()); err != nil {
 			return err
 		}
 	}
-	if cgroup.BlkioThrottleWriteIOpsDevice != "" {
-		if err := writeFile(path, "blkio.throttle.write_iops_device", cgroup.BlkioThrottleWriteIOpsDevice); err != nil {
+	for _, td := range cgroup.BlkioThrottleReadIOPSDevice {
+		if err := writeFile(path, "blkio.throttle.read_iops_device", td.String()); err != nil {
+			return err
+		}
+	}
+	for _, td := range cgroup.BlkioThrottleWriteIOPSDevice {
+		if err := writeFile(path, "blkio.throttle.write_iops_device", td.String()); err != nil {
 			return err
 		}
 	}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/hugetlb.go
@@ -29,7 +29,7 @@ func (s *HugetlbGroup) Apply(d *data) error {
 
 func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {
 	for _, hugetlb := range cgroup.HugetlbLimit {
-		if err := writeFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.Itoa(hugetlb.Limit)); err != nil {
+		if err := writeFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.FormatUint(hugetlb.Limit, 10)); err != nil {
 			return err
 		}
 	}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/name.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/name.go
@@ -1,0 +1,25 @@
+package fs
+
+import (
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+type NameGroup struct {
+}
+
+func (s *NameGroup) Apply(d *data) error {
+	return nil
+}
+
+func (s *NameGroup) Set(path string, cgroup *configs.Cgroup) error {
+	return nil
+}
+
+func (s *NameGroup) Remove(d *data) error {
+	return nil
+}
+
+func (s *NameGroup) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/blkio_device.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/blkio_device.go
@@ -1,0 +1,61 @@
+package configs
+
+import "fmt"
+
+// blockIODevice holds major:minor format supported in blkio cgroup
+type blockIODevice struct {
+	// Major is the device's major number
+	Major int64 `json:"major"`
+	// Minor is the device's minor number
+	Minor int64 `json:"minor"`
+}
+
+// WeightDevice struct holds a `major:minor weight`|`major:minor leaf_weight` pair
+type WeightDevice struct {
+	blockIODevice
+	// Weight is the bandwidth rate for the device, range is from 10 to 1000
+	Weight uint16 `json:"weight"`
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only
+	LeafWeight uint16 `json:"leafWeight"`
+}
+
+// NewWeightDevice returns a configured WeightDevice pointer
+func NewWeightDevice(major, minor int64, weight, leafWeight uint16) *WeightDevice {
+	wd := &WeightDevice{}
+	wd.Major = major
+	wd.Minor = minor
+	wd.Weight = weight
+	wd.LeafWeight = leafWeight
+	return wd
+}
+
+// WeightString formats the struct to be writable to the cgroup specific file
+func (wd *WeightDevice) WeightString() string {
+	return fmt.Sprintf("%d:%d %d", wd.Major, wd.Minor, wd.Weight)
+}
+
+// LeafWeightString formats the struct to be writable to the cgroup specific file
+func (wd *WeightDevice) LeafWeightString() string {
+	return fmt.Sprintf("%d:%d %d", wd.Major, wd.Minor, wd.LeafWeight)
+}
+
+// ThrottleDevice struct holds a `major:minor rate_per_second` pair
+type ThrottleDevice struct {
+	blockIODevice
+	// Rate is the IO rate limit per cgroup per device
+	Rate uint64 `json:"rate"`
+}
+
+// NewThrottleDevice returns a configured ThrottleDevice pointer
+func NewThrottleDevice(major, minor int64, rate uint64) *ThrottleDevice {
+	td := &ThrottleDevice{}
+	td.Major = major
+	td.Minor = minor
+	td.Rate = rate
+	return td
+}
+
+// String formats the struct to be writable to the cgroup specific file
+func (td *ThrottleDevice) String() string {
+	return fmt.Sprintf("%d:%d %d", td.Major, td.Minor, td.Rate)
+}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/cgroup.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/cgroup.go
@@ -57,23 +57,26 @@ type Cgroup struct {
 	// MEM to use
 	CpusetMems string `json:"cpuset_mems"`
 
-	// IO read rate limit per cgroup per device, bytes per second.
-	BlkioThrottleReadBpsDevice string `json:"blkio_throttle_read_bps_device"`
-
-	// IO write rate limit per cgroup per divice, bytes per second.
-	BlkioThrottleWriteBpsDevice string `json:"blkio_throttle_write_bps_device"`
-
-	// IO read rate limit per cgroup per device, IO per second.
-	BlkioThrottleReadIOpsDevice string `json:"blkio_throttle_read_iops_device"`
-
-	// IO write rate limit per cgroup per device, IO per second.
-	BlkioThrottleWriteIOpsDevice string `json:"blkio_throttle_write_iops_device"`
-
 	// Specifies per cgroup weight, range is from 10 to 1000.
-	BlkioWeight int64 `json:"blkio_weight"`
+	BlkioWeight uint16 `json:"blkio_weight"`
+
+	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, cfq scheduler only
+	BlkioLeafWeight uint16 `json:"blkio_leaf_weight"`
 
 	// Weight per cgroup per device, can override BlkioWeight.
-	BlkioWeightDevice string `json:"blkio_weight_device"`
+	BlkioWeightDevice []*WeightDevice `json:"blkio_weight_device"`
+
+	// IO read rate limit per cgroup per device, bytes per second.
+	BlkioThrottleReadBpsDevice []*ThrottleDevice `json:"blkio_throttle_read_bps_device"`
+
+	// IO write rate limit per cgroup per divice, bytes per second.
+	BlkioThrottleWriteBpsDevice []*ThrottleDevice `json:"blkio_throttle_write_bps_device"`
+
+	// IO read rate limit per cgroup per device, IO per second.
+	BlkioThrottleReadIOPSDevice []*ThrottleDevice `json:"blkio_throttle_read_iops_device"`
+
+	// IO write rate limit per cgroup per device, IO per second.
+	BlkioThrottleWriteIOPSDevice []*ThrottleDevice `json:"blkio_throttle_write_iops_device"`
 
 	// set the freeze value for the process
 	Freezer FreezerState `json:"freezer"`

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -92,8 +92,8 @@ type Config struct {
 	// bind mounts are writtable.
 	Readonlyfs bool `json:"readonlyfs"`
 
-	// Privatefs will mount the container's rootfs as private where mount points from the parent will not propogate
-	Privatefs bool `json:"privatefs"`
+	// Specifies the mount propagation flags to be applied to /.
+	RootPropagation int `json:"rootPropagation"`
 
 	// Mounts specify additional source and destination paths that will be mounted inside the container's
 	// rootfs and mount namespace if specified

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config_unix.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config_unix.go
@@ -21,7 +21,7 @@ func (c Config) HostUID() (int, error) {
 	return 0, nil
 }
 
-// Gets the root uid for the process on host which could be non-zero
+// Gets the root gid for the process on host which could be non-zero
 // when user namespaces are enabled.
 func (c Config) HostGID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
@@ -30,11 +30,11 @@ func (c Config) HostGID() (int, error) {
 		}
 		id, found := c.hostIDFromMapping(0, c.GidMappings)
 		if !found {
-			return -1, fmt.Errorf("User namespaces enabled, but no root user mapping found.")
+			return -1, fmt.Errorf("User namespaces enabled, but no root group mapping found.")
 		}
 		return id, nil
 	}
-	// Return default root uid 0
+	// Return default root gid 0
 	return 0, nil
 }
 

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/hugepage_limit.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/hugepage_limit.go
@@ -5,5 +5,5 @@ type HugepageLimit struct {
 	Pagesize string `json:"page_size"`
 
 	// usage limit for hugepage.
-	Limit int `json:"limit"`
+	Limit uint64 `json:"limit"`
 }

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -23,7 +23,7 @@ struct clone_arg {
 	 * Reserve some space for clone() to locate arguments
 	 * and retcode in this place
 	 */
-	char stack[4096] __attribute__ ((aligned(8)));
+	char stack[4096] __attribute__ ((aligned(16)));
 	char stack_ptr[0];
 	jmp_buf *env;
 };


### PR DESCRIPTION
This patch bumps libcontainer/runc to `cc84f2cc9b4e66ab85ae83546d50a74ae87fe034` which unblocks #15879, #14466 and #13959 (blkio cgroup fixes)

ping @LK4D4 @mrunalp (this comes with the cgroups name=systemd patch also)
