### PR TITLE
nsexec: Align clone child stack ptr to 16

### DIFF
--- a/vendor/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -23,7 +23,7 @@ struct clone_arg {
 	 * Reserve some space for clone() to locate arguments
 	 * and retcode in this place
 	 */
-	char stack[4096] __attribute__ ((aligned(8)));
+	char stack[4096] __attribute__ ((aligned(16)));
 	char stack_ptr[0];
 	jmp_buf *env;
 };


### PR DESCRIPTION
This is required when running Docker on ARM64 platforms so that clone syscall doesn't fail. Check [1].

[1] http://lxr.free-electrons.com/source/arch/arm64/kernel/process.c#L264

Signed-off-by: Bogdan Purcareata bogdan.purcareata@freescale.com
