### PR TITLE
Don't put dockerfiles in one continuous code block

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1166,6 +1166,9 @@ or a signal name in the format SIGNAME, for instance SIGKILL.
 
 ## Dockerfile examples
 
+Below you can see some examples of Dockerfile syntax. If you're interested in
+something more realistic, take a look at the list of [Dockerization examples](/examples/).
+
 ```
 # Nginx
 #

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1166,45 +1166,50 @@ or a signal name in the format SIGNAME, for instance SIGKILL.
 
 ## Dockerfile examples
 
-    # Nginx
-    #
-    # VERSION               0.0.1
+```
+# Nginx
+#
+# VERSION               0.0.1
 
-    FROM      ubuntu
-    MAINTAINER Victor Vieux <victor@docker.com>
+FROM      ubuntu
+MAINTAINER Victor Vieux <victor@docker.com>
 
-    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products" Version="1.0"
-    RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
+LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products" Version="1.0"
+RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
+```
 
-    # Firefox over VNC
-    #
-    # VERSION               0.3
+```
+# Firefox over VNC
+#
+# VERSION               0.3
 
-    FROM ubuntu
+FROM ubuntu
 
-    # Install vnc, xvfb in order to create a 'fake' display and firefox
-    RUN apt-get update && apt-get install -y x11vnc xvfb firefox
-    RUN mkdir ~/.vnc
-    # Setup a password
-    RUN x11vnc -storepasswd 1234 ~/.vnc/passwd
-    # Autostart firefox (might not be the best way, but it does the trick)
-    RUN bash -c 'echo "firefox" >> /.bashrc'
+# Install vnc, xvfb in order to create a 'fake' display and firefox
+RUN apt-get update && apt-get install -y x11vnc xvfb firefox
+RUN mkdir ~/.vnc
+# Setup a password
+RUN x11vnc -storepasswd 1234 ~/.vnc/passwd
+# Autostart firefox (might not be the best way, but it does the trick)
+RUN bash -c 'echo "firefox" >> /.bashrc'
 
-    EXPOSE 5900
-    CMD    ["x11vnc", "-forever", "-usepw", "-create"]
+EXPOSE 5900
+CMD    ["x11vnc", "-forever", "-usepw", "-create"]
+```
 
-    # Multiple images example
-    #
-    # VERSION               0.1
+```
+# Multiple images example
+#
+# VERSION               0.1
 
-    FROM ubuntu
-    RUN echo foo > bar
-    # Will output something like ===> 907ad6c2736f
+FROM ubuntu
+RUN echo foo > bar
+# Will output something like ===> 907ad6c2736f
 
-    FROM ubuntu
-    RUN echo moo > oink
-    # Will output something like ===> 695d7793cbe4
+FROM ubuntu
+RUN echo moo > oink
+# Will output something like ===> 695d7793cbe4
 
-    # You᾿ll now have two images, 907ad6c2736f with /bar, and 695d7793cbe4 with
-    # /oink.
-
+# You᾿ll now have two images, 907ad6c2736f with /bar, and 695d7793cbe4 with
+# /oink.
+```


### PR DESCRIPTION
Fixes the confusion at the bottom of https://docs.docker.com/reference/builder/#dockerfile-examples with multiple dockerfiles merged into one.
