### PR TITLE
Do not remove volumes on `docker run --rm`

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -192,7 +192,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 
 	defer func() {
 		if *flAutoRemove {
-			if _, _, err = readBody(cli.call("DELETE", "/containers/"+createResponse.ID+"?v=1", nil, nil)); err != nil {
+			if _, _, err = readBody(cli.call("DELETE", "/containers/"+createResponse.ID, nil, nil)); err != nil {
 				fmt.Fprintf(cli.err, "Error deleting container: %s\n", err)
 			}
 		}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3438,3 +3438,9 @@ func (s *DockerSuite) TestRunWrongCpusetMemsFlagValue(c *check.C) {
 	expected := "Error response from daemon: Invalid value 1-42-- for cpuset mems.\n"
 	c.Assert(out, check.Equals, expected, check.Commentf("Expected output to contain %q, got %q", expected, out))
 }
+
+// Make sure that when `--rm` is used, the volume is not removed
+func (s *DockerSuite) TestRunRmKeepVolume(c *check.C) {
+	dockerCmd(c, "run", "--rm", "-v", "test:/foo", "busybox", "/bin/sh", "-c", "echo hello world")
+	dockerCmd(c, "volume", "inspect", "test")
+}

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -168,7 +168,7 @@ func (s *DockerExternalVolumeSuite) TestStartExternalNamedVolumeDriver(c *check.
 
 	c.Assert(s.ec.activations, check.Equals, 1)
 	c.Assert(s.ec.creations, check.Equals, 1)
-	c.Assert(s.ec.removals, check.Equals, 1)
+	c.Assert(s.ec.removals, check.Equals, 0)
 	c.Assert(s.ec.mounts, check.Equals, 1)
 	c.Assert(s.ec.unmounts, check.Equals, 1)
 }
@@ -189,7 +189,7 @@ func (s *DockerExternalVolumeSuite) TestStartExternalVolumeUnnamedDriver(c *chec
 
 	c.Assert(s.ec.activations, check.Equals, 1)
 	c.Assert(s.ec.creations, check.Equals, 1)
-	c.Assert(s.ec.removals, check.Equals, 1)
+	c.Assert(s.ec.removals, check.Equals, 0)
 	c.Assert(s.ec.mounts, check.Equals, 1)
 	c.Assert(s.ec.unmounts, check.Equals, 1)
 }
@@ -265,7 +265,7 @@ func (s *DockerExternalVolumeSuite) TestStartExternalNamedVolumeDriverCheckBindL
 
 	c.Assert(s.ec.activations, check.Equals, 1)
 	c.Assert(s.ec.creations, check.Equals, 1)
-	c.Assert(s.ec.removals, check.Equals, 1)
+	c.Assert(s.ec.removals, check.Equals, 0)
 	c.Assert(s.ec.mounts, check.Equals, 1)
 	c.Assert(s.ec.unmounts, check.Equals, 1)
 }
@@ -342,7 +342,7 @@ func (s *DockerExternalVolumeSuite) TestStartExternalVolumeDriverRetryNotImmedia
 
 	c.Assert(s.ec.activations, check.Equals, 1)
 	c.Assert(s.ec.creations, check.Equals, 1)
-	c.Assert(s.ec.removals, check.Equals, 1)
+	c.Assert(s.ec.removals, check.Equals, 0)
 	c.Assert(s.ec.mounts, check.Equals, 1)
 	c.Assert(s.ec.unmounts, check.Equals, 1)
 }


### PR DESCRIPTION
In the past it was nice to have `docker run --rm` clean up any volumes
the container was using since these volumes were not really easily
referenceable again.
Now with named volumes, removing these volumes may potentially remove
important data.

In addition, since we now have a volume management API, cleaning up a
container's volumes in this case is no longer needed.
