### PR TITLE
Fix help test comment to align with the code

### DIFF
--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 			}
 		}
 
-		// Make sure each cmd's help text fits within 80 chars and that
+		// Make sure each cmd's help text fits within 90 chars and that
 		// on non-windows system we use ~ when possible (to shorten things).
 		// Pull the list of commands from the "Commands:" section of docker help
 		helpCmd = exec.Command(dockerBinary, "help")


### PR DESCRIPTION
I disagree with #14546 that pushed the help text past 80 chars.
Aside from it now making the help text look ugly on 80 char displays,
which I use, one thing I like about the previous limitation is that it
forced us to keep our options down to more reasonable phrases/words.
For example, I think
`--disable-content-trust=true`
could have been:
`--disable-trust=true`
or even:
`--disable-ctrust=true`

I'd like it if we could reconsider the name of this option.

But regardless, let's at least make the comments match what the code does.

ping @dmcgowan 

Signed-off-by: Doug Davis dug@us.ibm.com
