### PR TITLE
Make `docker volume` behave like `docker network`

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -33,11 +33,12 @@ func (cli *DockerCli) CmdVolume(args ...string) error {
 	}
 
 	description += "\nRun 'docker volume COMMAND --help' for more information on a command"
-	cmd := Cli.Subcmd("volume", []string{"[COMMAND]"}, description, true)
-	cmd.Require(flag.Exact, 0)
-	cmd.ParseFlags(args, true)
+	cmd := Cli.Subcmd("volume", []string{"[COMMAND]"}, description, false)
 
-	return cli.CmdVolumeLs(args...)
+	cmd.Require(flag.Exact, 0)
+	err := cmd.ParseFlags(args, true)
+	cmd.Usage()
+	return err
 }
 
 // CmdVolumeLs outputs a list of Docker volumes.

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -130,13 +130,18 @@ func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
 
 func (s *DockerSuite) TestVolumeCliNoArgs(c *check.C) {
 	out, _ := dockerCmd(c, "volume")
-	// no args should produce the `volume ls` output
-	c.Assert(strings.Contains(out, "DRIVER"), check.Equals, true)
+	// no args should produce the cmd usage output
+	usage := "Usage:	docker volume [OPTIONS] [COMMAND]"
+	c.Assert(out, checker.Contains, usage)
 
 	// invalid arg should error and show the command usage on stderr
 	_, stderr, _, err := runCommandWithStdoutStderr(exec.Command(dockerBinary, "volume", "somearg"))
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.NotNil, check.Commentf(stderr))
+	c.Assert(stderr, checker.Contains, usage)
 
-	expected := "Usage:	docker volume [OPTIONS] [COMMAND]"
-	c.Assert(strings.Contains(stderr, expected), check.Equals, true)
+	// invalid flag should error and show the flag error and cmd usage
+	_, stderr, _, err = runCommandWithStdoutStderr(exec.Command(dockerBinary, "volume", "--no-such-flag"))
+	c.Assert(err, check.NotNil, check.Commentf(stderr))
+	c.Assert(stderr, checker.Contains, usage)
+	c.Assert(stderr, checker.Contains, "flag provided but not defined: --no-such-flag")
 }


### PR DESCRIPTION
Before, typing `docker volume` with no args would forward to the handler
for `docker volume ls`, except the flags for the `ls` subcommand were
not supported.
Instead just print the cmd usage.

This makes the behavior of the `docker volume` subcommand behave exactly
like the `docker network` subcommand.

Closes #16210
fixes #16070
