### PR TITLE
daemon: faster cache miss detection

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1044,6 +1044,14 @@ func (daemon *Daemon) containerGraph() *graphdb.Database {
 // created. nil is returned if a child cannot be found. An error is
 // returned if the parent image cannot be found.
 func (daemon *Daemon) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {
+	// for now just exit if imgID has no children.
+	// maybe parentRefs in graph could be used to store
+	// the Image obj children for faster lookup below but this can
+	// be quite memory hungry.
+	if !daemon.Graph().HasChildren(imgID) {
+		return nil, nil
+	}
+
 	// Retrieve all images
 	images := daemon.Graph().Map()
 

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -192,7 +192,7 @@ func (d Docker) Copy(c *daemon.Container, destPath string, src builder.FileInfo,
 // GetCachedImage returns a reference to a cached image whose parent equals `parent`
 // and runconfig equals `cfg`. A cache miss is expected to return an empty ID and a nil error.
 func (d Docker) GetCachedImage(imgID string, cfg *runconfig.Config) (string, error) {
-	cache, err := d.Daemon.ImageGetCached(string(imgID), cfg)
+	cache, err := d.Daemon.ImageGetCached(imgID, cfg)
 	if cache == nil || err != nil {
 		return "", err
 	}

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -279,7 +279,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(img *image.Image) *imageDelet
 	}
 
 	// Check if the image has any descendent images.
-	if daemon.Graph().HasChildren(img) {
+	if daemon.Graph().HasChildren(img.ID) {
 		return &imageDeleteConflict{
 			hard:    true,
 			imgID:   img.ID,
@@ -337,5 +337,5 @@ func (daemon *Daemon) checkImageDeleteSoftConflict(img *image.Image) *imageDelet
 // that there are no repository references to the given image and it has no
 // child images.
 func (daemon *Daemon) imageIsDangling(img *image.Image) bool {
-	return !(daemon.Repositories().HasReferences(img) || daemon.Graph().HasChildren(img))
+	return !(daemon.Repositories().HasReferences(img) || daemon.Graph().HasChildren(img.ID))
 }


### PR DESCRIPTION
Lookup the graph parent reference to detect a cache miss before looping
the whole graph image index to build a parent-children tree.

see https://github.com/docker/docker/pull/16818#issuecomment-146269683

/cc @LK4D4 @cpuguy83 @icecrime

Signed-off-by: Antonio Murdaca amurdaca@redhat.com
