### PR TITLE
Revert AppArmor skip tests

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2772,8 +2772,6 @@ func (s *DockerSuite) TestMountIntoSys(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
-	c.Skip("unstable test: is apparmor in a container reliable?")
-
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, Apparmor, NativeExecDriver, DaemonIsLinux)
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3141,8 +3141,6 @@ func (s *DockerSuite) TestAppArmorTraceSelf(c *check.C) {
 }
 
 func (s *DockerSuite) TestAppArmorDeniesChmodProc(c *check.C) {
-	c.Skip("Test is failing, and what it tests is unclear")
-
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, SameHostDaemon, NativeExecDriver, Apparmor, DaemonIsLinux)
 	_, exitCode, _ := dockerCmdWithError("run", "busybox", "chmod", "744", "/proc/cpuinfo")


### PR DESCRIPTION
These tests are to guarantee protection from malicious containers, enforced by AppArmor. These tests should be working and should not be skipped.

I have run these tests on Ubuntu, running them several times, and have not experienced any failures.
