### PR TITLE
Redirect containers' stdout/stderr to /dev/null if log-driver is none

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -180,7 +181,11 @@ func (cli *DockerCli) hijackWithContentType(method, path, contentType string, se
 	defer clientconn.Close()
 
 	// Server hijacks the connection, error 'connection closed' expected
-	clientconn.Do(req)
+	res, _ := clientconn.Do(req)
+	if res.StatusCode != 101 && res.StatusCode != 200 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return fmt.Errorf("Error response from daemon: %s", string(body))
+	}
 
 	rwc, br := clientconn.Hijack()
 	defer rwc.Close()

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -62,6 +62,7 @@ type monitorBackend interface {
 type attachBackend interface {
 	ContainerAttachWithLogs(name string, c *daemon.ContainerAttachWithLogsConfig) error
 	ContainerWsAttachWithLogs(name string, c *daemon.ContainerWsAttachWithLogsConfig) error
+	CheckContainerAttachable(containerName string) error
 }
 
 // Backend is all the methods that need to be implemented to provide container specific functionality.

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -400,12 +400,8 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 	}
 	containerName := vars["name"]
 
-	if !s.backend.Exists(containerName) {
-		return derr.ErrorCodeNoSuchContainer.WithArgs(containerName)
-	}
-
-	if s.backend.IsPaused(containerName) {
-		return derr.ErrorCodePausedContainer.WithArgs(containerName)
+	if err := s.backend.CheckContainerAttachable(containerName); err != nil {
+		return err
 	}
 
 	inStream, outStream, err := httputils.HijackConnection(w)

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -543,3 +543,7 @@ func (container *Container) stopSignal() int {
 	}
 	return int(stopSignal)
 }
+
+func (container *Container) unAttachable(defaultConfig runconfig.LogConfig) bool {
+	return !container.Config.AttachStdout && !container.Config.AttachStderr && container.getLogConfig(defaultConfig).Type == "none"
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -209,6 +209,8 @@ func (daemon *Daemon) load(id string) (*Container, error) {
 		return container, fmt.Errorf("Container %s is stored at %s", container.ID, id)
 	}
 
+	daemon.checkStreamConfig(container)
+
 	return container, nil
 }
 
@@ -222,13 +224,6 @@ func (daemon *Daemon) Register(container *Container) error {
 	}
 	if err := daemon.ensureName(container); err != nil {
 		return err
-	}
-
-	// Attach to stdout and stderr
-	if container.Config.OpenStdin {
-		container.NewInputPipes()
-	} else {
-		container.NewNopInputPipe()
 	}
 	daemon.containers.Add(container.ID, container)
 
@@ -1377,7 +1372,10 @@ func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.
 	}
 
 	container.hostConfig = hostConfig
-	container.toDisk()
+	daemon.checkStreamConfig(container)
+	if err := container.toDisk(); err != nil {
+		return fmt.Errorf("Error saving hostConfig to disk: %v", err)
+	}
 	return nil
 }
 
@@ -1527,4 +1525,17 @@ func convertLnNetworkStats(name string, stats *lntypes.InterfaceStatistics) *lib
 	n.TxErrors = stats.TxErrors
 	n.TxDropped = stats.TxDropped
 	return n
+}
+
+func (daemon *Daemon) checkStreamConfig(container *Container) {
+	// Redirect containers' stdout/stderr to /dev/nil if running in detach mode with log-driver=none
+	if container.unAttachable(daemon.defaultLogConfig) {
+		container.StreamConfig.ResetStdoutStderr()
+	}
+	// Attach to stdin
+	if container.Config.OpenStdin {
+		container.NewInputPipes()
+	} else {
+		container.NewNopInputPipe()
+	}
 }

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -158,7 +158,15 @@ func (m *containerMonitor) Start() error {
 			return err
 		}
 
-		pipes := execdriver.NewPipes(m.container.Stdin(), m.container.Stdout(), m.container.Stderr(), m.container.Config.OpenStdin)
+		var stdout, stderr io.Writer
+		if m.container.Stdout() != nil {
+			// if m.container.stdout is nil, we have to avoid assigning it to stdout, see https://golang.org/doc/faq#nil_error
+			stdout = m.container.Stdout()
+		}
+		if m.container.Stderr() != nil {
+			stderr = m.container.Stderr()
+		}
+		pipes := execdriver.NewPipes(m.container.Stdin(), stdout, stderr, m.container.Config.OpenStdin)
 
 		m.logEvent("start")
 

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -939,4 +939,13 @@ var (
 		Description:    "There was an error while trying to start a container",
 		HTTPStatusCode: http.StatusInternalServerError,
 	})
+
+	// ErrorCodeAttach is generated when we try to attach to an exec
+	// but failed.
+	ErrorCodeAttach = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "ATTACH",
+		Message:        "attach container %s failed with error: %s",
+		Description:    "There was an error while trying to attach container",
+		HTTPStatusCode: http.StatusInternalServerError,
+	})
 )

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -160,3 +160,13 @@ func (s *DockerSuite) TestAttachPausedContainer(c *check.C) {
 	c.Assert(err, checker.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "You cannot attach to a paused container, unpause it first")
 }
+
+func (s *DockerSuite) TestAttachToUnAttachableContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	out, _ := dockerCmd(c, "run", "-d", "--log-driver", "none", "busybox", "/bin/sh", "-c", `while true; do echo 2; sleep 1; done`)
+	id := strings.TrimSpace(out)
+
+	out, _, err := dockerCmdWithError("attach", id)
+	c.Assert(err, checker.NotNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "can't attach to a detached container whose log driver is none")
+}

--- a/runconfig/streams.go
+++ b/runconfig/streams.go
@@ -71,6 +71,14 @@ func (streamConfig *StreamConfig) StderrPipe() io.ReadCloser {
 	return bytesPipe
 }
 
+// ResetStdoutStderr sets stdout and stderr to nil
+func (streamConfig *StreamConfig) ResetStdoutStderr() {
+	streamConfig.stdout.Clean()
+	streamConfig.stdout = nil
+	streamConfig.stderr.Clean()
+	streamConfig.stderr = nil
+}
+
 // NewInputPipes creates new pipes for both standard inputs, Stdin and StdinPipe.
 func (streamConfig *StreamConfig) NewInputPipes() {
 	streamConfig.stdin, streamConfig.stdinPipe = io.Pipe()
@@ -91,12 +99,16 @@ func (streamConfig *StreamConfig) CloseStreams() error {
 		}
 	}
 
-	if err := streamConfig.stdout.Clean(); err != nil {
-		errors = append(errors, fmt.Sprintf("error close stdout: %s", err))
+	if streamConfig.stdout != nil {
+		if err := streamConfig.stdout.Clean(); err != nil {
+			errors = append(errors, fmt.Sprintf("error close stdout: %s", err))
+		}
 	}
 
-	if err := streamConfig.stderr.Clean(); err != nil {
-		errors = append(errors, fmt.Sprintf("error close stderr: %s", err))
+	if streamConfig.stderr != nil {
+		if err := streamConfig.stderr.Clean(); err != nil {
+			errors = append(errors, fmt.Sprintf("error close stderr: %s", err))
+		}
 	}
 
 	if len(errors) > 0 {


### PR DESCRIPTION
Currently, containers' stdout/stderr redirects to a pipe if log-driver
is none and no one will read from the it. Kernel will waste unnecessary
buffers to keep the data writen to the pipe. This is obviously wasteful

Signed-off-by: Chun Chen ramichen@tencent.com
