### PR TITLE
Simplify dir removal in overlay driver

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -306,11 +306,7 @@ func (d *Driver) dir(id string) string {
 
 // Remove cleans the directories that are created for this id.
 func (d *Driver) Remove(id string) error {
-	dir := d.dir(id)
-	if _, err := os.Stat(dir); err != nil {
-		return err
-	}
-	return os.RemoveAll(dir)
+	return os.RemoveAll(d.dir(id))
 }
 
 // Get creates and mounts the required file system for the given id and returns the mount path.


### PR DESCRIPTION
There is no need to call `os.Stat` on the driver filesystem path of a
container as `os.RemoveAll` already handles (properly) the case where
the path no longer exists.

Given the results of the `os.Stat` were not even being used,  there is no
value in erroring out because of the stat call failure, and worse, it
prevents daemon cleanup of containers in "Dead" state unless you re-create
directories that were already removed via a manual cleanup after a
failure.  This brings removal in overlay in line with aufs/devicemapper
drivers which don't error out if the filesystem path no longer exists.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
