### PR TITLE
use of checkers on `integration-cli/docker_cli_links_test.go` and `integration-cli/docker_cli_links_unix_test.go`

### DIFF
--- a/integration-cli/docker_cli_links_unix_test.go
+++ b/integration-cli/docker_cli_links_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
 
@@ -20,8 +21,6 @@ func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
 		c.Skip("/etc/hosts does not exist, skip this test")
 	}
 
-	if out != string(hosts) {
-		c.Errorf("container: %s\n\nhost:%s", out, hosts)
-	}
+	c.Assert(out, checker.Equals, string(hosts), check.Commentf("container: %s\n\nhost:%s", out, hosts))
 
 }


### PR DESCRIPTION
Part of #16756

Use c.Assert instead of condition judgement

Signed-off-by: Zhang Wei zhangwei555@huawei.com
