### PR TITLE
refactor away direct references to daemon member

### DIFF
--- a/api/server/router/local/auth.go
+++ b/api/server/router/local/auth.go
@@ -17,7 +17,7 @@ func (s *router) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
-	status, err := s.daemon.RegistryService.Auth(config)
+	status, err := s.daemon.AuthenticateToRegistry(config)
 	if err != nil {
 		return err
 	}

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -504,7 +504,7 @@ func (s *router) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *
 			headers[k] = v
 		}
 	}
-	query, err := s.daemon.RegistryService.Search(r.Form.Get("term"), config, headers)
+	query, err := s.daemon.SearchRegistryForImages(r.Form.Get("term"), config, headers)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -21,15 +21,15 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/execdriver/execdrivers"
 	"github.com/docker/docker/daemon/graphdriver"
-	derr "github.com/docker/docker/errors"
-	// register vfs
-	_ "github.com/docker/docker/daemon/graphdriver/vfs"
+	_ "github.com/docker/docker/daemon/graphdriver/vfs" // register vfs
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/network"
+	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
@@ -1239,4 +1239,17 @@ func configureVolumes(config *Config) (*store.VolumeStore, error) {
 	s.AddAll(volumesDriver.List())
 
 	return s, nil
+}
+
+// AuthenticateToRegistry checks the validity of credentials in authConfig
+func (daemon *Daemon) AuthenticateToRegistry(authConfig *cliconfig.AuthConfig) (string, error) {
+	return daemon.RegistryService.Auth(authConfig)
+}
+
+// SearchRegistryForImages queries the registry for images matching
+// term. authConfig is used to login.
+func (daemon *Daemon) SearchRegistryForImages(term string,
+	authConfig *cliconfig.AuthConfig,
+	headers map[string][]string) (*registry.SearchResults, error) {
+	return daemon.RegistryService.Search(term, authConfig, headers)
 }


### PR DESCRIPTION
removing more references to daemon in api/
- add daemon methods Authenticate & SearchRegistryForImages
- use new methods instead of directly accessing RegistryService

Signed-off-by: Morgan Bauer mbauer@us.ibm.com

@icecrime @duglin @calavera 
