### PR TITLE
Fix exp tests cast protodriver to naivediffdriver

### DIFF
--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -97,7 +97,7 @@ func (s *DockerExternalGraphdriverSuite) SetUpSuite(c *check.C) {
 	if err != nil {
 		c.Fatalf("error initializing graph driver: %v", err)
 	}
-	driver := graphdriver.NaiveDiffDriver(vfsProto)
+	driver := graphdriver.NewNaiveDiffDriver(vfsProto)
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
 		s.ec.activations++


### PR DESCRIPTION
A recent change made `graphdriver.NaiveDiffDriver` from a function to a
struct. New function is `graphdriver.NewNaiveDiffDriver.

The graphdriver plugin PR was created (and tests run) before this change
was introduced causing the failure to not be seen until after merge.
