### PR TITLE
Update distribution package for name regexp change

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -36,7 +36,7 @@ clone git github.com/hashicorp/consul v0.5.2
 clone git github.com/boltdb/bolt v1.0
 
 # get graph and distribution packages
-clone git github.com/docker/distribution ec87e9b6971d831f0eff752ddb54fb64693e51cd # docker/1.8 branch
+clone git github.com/docker/distribution 20c4b7a1805a52753dfd593ee1cc35558722a0ce # docker/1.9 branch
 clone git github.com/vbatts/tar-split v0.9.10
 
 clone git github.com/docker/notary ac05822d7d71ef077df3fc24f506672282a1feea

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -767,6 +767,9 @@ func TestValidRemoteName(t *testing.T) {
 		// Allow embedded hyphens.
 		"docker-rules/docker",
 
+		// Allow multiple hyphens as well.
+		"docker---rules/docker",
+
 		//Username doc and image name docker being tested.
 		"doc/docker",
 
@@ -800,8 +803,11 @@ func TestValidRemoteName(t *testing.T) {
 
 		"_docker/_docker",
 
-		// Disallow consecutive hyphens.
-		"dock--er/docker",
+		// Disallow consecutive underscores and periods.
+		"dock__er/docker",
+		"dock..er/docker",
+		"dock_.er/docker",
+		"dock-.er/docker",
 
 		// No repository.
 		"docker/",

--- a/vendor/src/github.com/docker/distribution/registry/api/v2/names.go
+++ b/vendor/src/github.com/docker/distribution/registry/api/v2/names.go
@@ -15,10 +15,23 @@ const (
 	RepositoryNameTotalLengthMax = 255
 )
 
+// domainLabelRegexp represents the following RFC-2396 BNF construct:
+//   domainlabel   = alphanum | alphanum *( alphanum | "-" ) alphanum
+var domainLabelRegexp = regexp.MustCompile(`[a-z0-9](?:-*[a-z0-9])*`)
+
 // RepositoryNameComponentRegexp restricts registry path component names to
-// start with at least one letter or number, with following parts able to
-// be separated by one period, dash or underscore.
-var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
+// the allow valid hostnames according to: https://www.ietf.org/rfc/rfc2396.txt
+// with the following differences:
+//  1) It DOES NOT allow for fully-qualified domain names, which include a
+//    trailing '.', e.g. "google.com."
+//  2) It DOES NOT restrict 'top-level' domain labels to start with just alpha
+//    characters.
+//  3) It DOES allow for underscores to appear in the same situations as dots.
+//
+// RFC-2396 uses the BNF construct:
+//   hostname      = *( domainlabel "." ) toplabel [ "." ]
+var RepositoryNameComponentRegexp = regexp.MustCompile(
+	domainLabelRegexp.String() + `(?:[._]` + domainLabelRegexp.String() + `)*`)
 
 // RepositoryNameComponentAnchoredRegexp is the version of
 // RepositoryNameComponentRegexp which must completely match the content


### PR DESCRIPTION
Pick up name regexp change in distribution to allow matching of hostnames as a valid component of a repository. This should only expand the set of valid names and provide no further restrictions.

ping @mattmoor
