### PR TITLE
Add more cgroup config to docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -83,6 +83,21 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 			if !info.SwapLimit {
 				fmt.Fprintf(cli.err, "WARNING: No swap limit support\n")
 			}
+			if !info.OomKillDisable {
+				fmt.Fprintf(cli.err, "WARNING: No oom kill disable support\n")
+			}
+			if !info.CPUCfsQuota {
+				fmt.Fprintf(cli.err, "WARNING: No cpu cfs quota support\n")
+			}
+			if !info.CPUCfsPeriod {
+				fmt.Fprintf(cli.err, "WARNING: No cpu cfs period support\n")
+			}
+			if !info.CPUShares {
+				fmt.Fprintf(cli.err, "WARNING: No cpu shares support\n")
+			}
+			if !info.CPUSet {
+				fmt.Fprintf(cli.err, "WARNING: No cpuset support\n")
+			}
 			if !info.IPv4Forwarding {
 				fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled\n")
 			}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -190,6 +190,8 @@ type Info struct {
 	SwapLimit          bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
+	CPUShares          bool
+	CPUSet             bool
 	IPv4Forwarding     bool
 	BridgeNfIptables   bool
 	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -104,6 +104,8 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		v.OomKillDisable = sysInfo.OomKillDisable
 		v.CPUCfsPeriod = sysInfo.CPUCfsPeriod
 		v.CPUCfsQuota = sysInfo.CPUCfsQuota
+		v.CPUShares = sysInfo.CPUShares
+		v.CPUSet = sysInfo.Cpuset
 	}
 
 	if httpProxy := os.Getenv("http_proxy"); httpProxy != "" {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -89,7 +89,7 @@ list of DNS options to be used in the container.
 * `POST /build` now optionally takes a serialized map of build-time variables.
 * `GET /events` now includes a `timenano` field, in addition to the existing `time` field.
 * `GET /events` now supports filtering by image and container labels.
-* `GET /info` now lists engine version information.
+* `GET /info` now lists engine version information and return the information of `CPUShares` and `Cpuset`.
 * `GET /containers/json` will return `ImageID` of the image used by container.
 * `POST /exec/(name)/start` will now return an HTTP 409 when the container is either stopped or paused.
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
- Add `cpu cfs qutoa` `cpu cfs period` `oom kill disable` show on the client side.
- Add daemon return the information of `cpu shares` `cpuset` and show on the client side
