### PR TITLE
Keep daemon quiet when using docker info

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -61,7 +61,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		initPath = daemon.systemInitPath()
 	}
 
-	sysInfo := sysinfo.New(false)
+	sysInfo := sysinfo.New(true)
 
 	v := &types.Info{
 		ID:                 daemon.ID,


### PR DESCRIPTION
If I have some unsupported sysinfo, it's warning on daemon
side every time I use `docker info`, it seems unnecessay and
annoying to me, let's keep it quiet.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
