### PR TITLE
Document updates for cluster-store-opt

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -536,7 +536,7 @@ please check the [run](run.md) reference.
 
 `--cluster-advertise` specifies the 'host:port' combination that this particular
 daemon instance should use when advertising itself to the cluster. The daemon
-should be reachable by remote hosts on this 'host:port' combination.
+is reached by remote hosts on this 'host:port' combination.
 
 The daemon uses [libkv](https://github.com/docker/libkv/) to advertise
 the node within the cluster.  Some Key/Value backends support mutual
@@ -545,12 +545,32 @@ using the `--cluster-store-opt` flag, specifying the paths to PEM encoded
 files. For example:
 
 ```bash
+docker daemon \
     --cluster-advertise 192.168.1.2:2376 \
     --cluster-store etcd://192.168.1.2:2379 \
     --cluster-store-opt kv.cacertfile=/path/to/ca.pem \
     --cluster-store-opt kv.certfile=/path/to/cert.pem \
     --cluster-store-opt kv.keyfile=/path/to/key.pem
 ```
+
+The currently supported cluster store options are:
+
+*  `kv.cacertfile`
+
+    Specifies the path to a local file with PEM encoded CA certificates to trust
+
+*  `kv.certfile`
+
+    Specifies the path to a local file with a PEM encoded certificate.  This
+    certificate is used as the client cert for communication with the
+    Key/Value store.
+
+*  `kv.keyfile`
+
+    Specifies the path to a local file with a PEM encoded private key.  This
+    private key is used as the client key for communication with the
+    Key/Value store.
+
 
 ## Miscellaneous options
 

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -9,6 +9,9 @@ docker-daemon - Enable daemon mode
 [**--api-cors-header**=[=*API-CORS-HEADER*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
+[**--cluster-store**[=*[]*]]
+[**--cluster-advertise**[=*[]*]]
+[**--cluster-store-opt**[=*map[]*]]
 [**-D**|**--debug**[=*false*]]
 [**--default-gateway**[=*DEFAULT-GATEWAY*]]
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
@@ -73,6 +76,16 @@ format.
 
 **--bip**=""
   Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
+
+**--cluster-store**=""
+  URL of the distributed storage backend
+
+**--cluster-advertise**=""
+  Specifies the 'host:port' combination that this particular daemon instance should use when advertising
+  itself to the cluster. The daemon is reached by remote hosts on this 'host:port' combination.
+
+**--cluster-store-opt**=""
+  Specifies options for the Key/Value store.
 
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.
@@ -421,6 +434,31 @@ this topic, see
 [docker#4036](https://github.com/docker/docker/issues/4036).
 Otherwise, set this flag for migrating existing Docker daemons to a
 daemon with a supported environment.
+
+# CLUSTER STORE OPTIONS
+
+The daemon uses libkv to advertise
+the node within the cluster.  Some Key/Value backends support mutual
+TLS, and the client TLS settings used by the daemon can be configured
+using the **--cluster-store-opt** flag, specifying the paths to PEM encoded
+files.
+
+#### kv.cacertfile
+
+Specifies the path to a local file with PEM encoded CA certificates to trust
+
+#### kv.certfile
+
+Specifies the path to a local file with a PEM encoded certificate.  This
+certificate is used as the client cert for communication with the
+Key/Value store.
+
+#### kv.keyfile
+
+Specifies the path to a local file with a PEM encoded private key.  This
+private key is used as the client key for communication with the
+Key/Value store.
+
 
 # HISTORY
 Sept 2015, Originally compiled by Shishir Mahajan <shishir.mahajan@redhat.com>


### PR DESCRIPTION
This updates the docs for the daemon based on the new cluster-store-opt
for TLS support.

Signed-off-by: Daniel Hiltgen daniel.hiltgen@docker.com
