### PR TITLE
When a push or pull is in progress, wait for completion instead of failing a new push

### DIFF
--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -73,17 +73,21 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 
 	}
 
-	broadcaster, found := p.poolAdd("pull", taggedName)
+	broadcaster, found := p.acquirePull(taggedName, p.repoInfo.CanonicalName,
+		func() {
+			p.config.OutStream.Write(p.sf.FormatStatus("", "Repository %s is presently being pushed. Waiting.", p.repoInfo.CanonicalName))
+		})
 	broadcaster.Add(p.config.OutStream)
 	if found {
-		// Another pull of the same repository is already taking place; just wait for it to finish
+		// Another push or pull of the same repository is already taking place; just wait
+		// for it to finish
 		return broadcaster.Wait()
 	}
 
 	// This must use a closure so it captures the value of err when the
 	// function returns, not when the 'defer' is evaluated.
 	defer func() {
-		p.poolRemoveWithError("pull", taggedName, err)
+		p.releasePullWithError(taggedName, p.repoInfo.CanonicalName, err)
 	}()
 
 	var layersDownloaded bool
@@ -202,7 +206,7 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 		p.graph.Release(p.sessionID, layerIDs...)
 
 		for _, d := range downloads {
-			p.poolRemoveWithError("pull", d.poolKey, err)
+			p.releasePullWithError(d.poolKey, p.repoInfo.CanonicalName, err)
 			if d.tmpFile != nil {
 				d.tmpFile.Close()
 				if err := os.RemoveAll(d.tmpFile.Name()); err != nil {
@@ -247,7 +251,10 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 
 		downloads = append(downloads, d)
 
-		broadcaster, found := p.poolAdd("pull", d.poolKey)
+		broadcaster, found := p.acquirePull(d.poolKey, p.repoInfo.CanonicalName,
+			func() {
+				out.Write(p.sf.FormatStatus(stringid.TruncateID(img.ID), "Waiting for push to complete before pulling"))
+			})
 		broadcaster.Add(out)
 		d.broadcaster = broadcaster
 		if found {

--- a/graph/push_v1.go
+++ b/graph/push_v1.go
@@ -211,7 +211,7 @@ func (p *v1Pusher) pushImageToEndpoint(endpoint string, imageIDs []string, tags 
 }
 
 // pushRepository pushes layers that do not already exist on the registry.
-func (p *v1Pusher) pushRepository(tag string) error {
+func (p *v1Pusher) pushRepository(tag string) (err error) {
 	logrus.Debugf("Local repo: %s", p.localRepo)
 	p.out = ioutils.NewWriteFlusher(p.config.OutStream)
 	imgList, tags, err := p.getImageList(tag)
@@ -226,10 +226,12 @@ func (p *v1Pusher) pushRepository(tag string) error {
 		logrus.Debugf("Pushing ID: %s with Tag: %s", data.ID, data.Tag)
 	}
 
-	if _, found := p.poolAdd("push", p.repoInfo.LocalName); found {
-		return fmt.Errorf("push or pull %s is already in progress", p.repoInfo.LocalName)
-	}
-	defer p.poolRemove("push", p.repoInfo.LocalName)
+	p.acquirePush(p.repoInfo.CanonicalName,
+		func() {
+			p.out.Write(p.sf.FormatStatus("", "Repository %s is presently being pulled or pushed. Waiting.", p.repoInfo.CanonicalName))
+		})
+
+	defer p.releasePush(p.repoInfo.CanonicalName)
 
 	// Register all the images in a repository with the registry
 	// If an image is not in this list it will not be associated with the repository


### PR DESCRIPTION
Previously, trying to push the same tag when a push for that tag was
already in progress would fail. This was disruptive to some CI
workflows.

This change instead makes the new push wait for any in-progress push or
pull operation on the same repo to finish. A message is printed to
explain to the user why the push doesn't start immediately. Output from
the already-running push or pull isn't shown, because that might appear
to be output from the newly-requested push.

Note that this gating is done at the repo level rather than the tag
level. Tags of the same repo are likely to share layers, so it's best to
let the first push finish, and then the second push won't have to push
layers that were already pushed.

This PR supersedes #16246. I opened a new PR becuase the intended behavior changed, after discussion in #16246.
