### PR TITLE
Fix few comments in validate scripts

### DIFF
--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -8,7 +8,6 @@ unset IFS
 
 errors=()
 for f in "${files[@]}"; do
-	# we use "git show" here to validate that what's committed passes go vet
 	failedLint=$(golint "$f")
 	if [ "$failedLint" ]; then
 		errors+=( "$failedLint" )

--- a/hack/make/validate-test
+++ b/hack/make/validate-test
@@ -15,7 +15,7 @@ for f in "${files[@]}"; do
 		continue
 	fi
 
-	# we use "git show" here to validate that what's committed is formatted
+	# we use "git show" here to validate that what's committed doesn't contain golang built-in testing
 	if git show "$VALIDATE_HEAD:$f" | grep -q testing.T; then
 		badFiles+=( "$f" )
 	fi

--- a/hack/make/validate-toml
+++ b/hack/make/validate-toml
@@ -8,7 +8,7 @@ unset IFS
 
 badFiles=()
 for f in "${files[@]}"; do
-	# we use "git show" here to validate that what's committed is formatted
+	# we use "git show" here to validate that what's committed has valid toml syntax
 	if ! git show "$VALIDATE_HEAD:$f" | tomlv /proc/self/fd/0 ; then
 		badFiles+=( "$f" )
 	fi

--- a/hack/make/validate-vet
+++ b/hack/make/validate-vet
@@ -8,7 +8,6 @@ unset IFS
 
 errors=()
 for f in "${files[@]}"; do
-	# we use "git show" here to validate that what's committed passes go vet
 	failedVet=$(go vet "$f")
 	if [ "$failedVet" ]; then
 		errors+=( "$failedVet" )


### PR DESCRIPTION
As the name of the branch says, it's a bit _ocd_ and silly, but this fixes some comments in the `./hack/make/validate-*` scripts 🐙.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
