### PR TITLE
Update integration test `integration-cli/docker_cli_rmi_test.go` with Assert

### DIFF
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
 
@@ -13,27 +14,21 @@ func (s *DockerSuite) TestRmiWithContainerFails(c *check.C) {
 	errSubstr := "is using it"
 
 	// create a container
-	out, _, err := dockerCmdWithError("run", "-d", "busybox", "true")
-	if err != nil {
-		c.Fatalf("failed to create a container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
 	// try to delete the image
-	out, _, err = dockerCmdWithError("rmi", "busybox")
-	if err == nil {
-		c.Fatalf("Container %q is using image, should not be able to rmi: %q", cleanedContainerID, out)
-	}
-	if !strings.Contains(out, errSubstr) {
-		c.Fatalf("Container %q is using image, error message should contain %q: %v", cleanedContainerID, errSubstr, out)
-	}
+	out, _, err := dockerCmdWithError("rmi", "busybox")
+	// Container is using image, should not be able to rmi
+	c.Assert(err, checker.NotNil)
+	// Container is using image, error message should contain errSubstr
+	c.Assert(out, checker.Contains, errSubstr, check.Commentf("Container: %q", cleanedContainerID))
 
 	// make sure it didn't delete the busybox name
 	images, _ := dockerCmd(c, "images")
-	if !strings.Contains(images, "busybox") {
-		c.Fatalf("The name 'busybox' should not have been removed from images: %q", images)
-	}
+	// The name 'busybox' should not have been removed from images
+	c.Assert(images, checker.Contains, "busybox")
 }
 
 func (s *DockerSuite) TestRmiTag(c *check.C) {
@@ -44,97 +39,71 @@ func (s *DockerSuite) TestRmiTag(c *check.C) {
 	dockerCmd(c, "tag", "busybox", "utest:5000/docker:tag3")
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
-		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+3 {
-			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
-		}
+		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+3, check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 	}
 	dockerCmd(c, "rmi", "utest/docker:tag2")
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
-		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+2 {
-			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
-		}
-
+		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+2, check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 	}
 	dockerCmd(c, "rmi", "utest:5000/docker:tag3")
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
-		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+1 {
-			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
-		}
+		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+1, check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 
 	}
 	dockerCmd(c, "rmi", "utest:tag1")
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
-		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+0 {
-			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
-		}
+		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n"), check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 
 	}
 }
 
 func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	out, _, err := dockerCmdWithError("run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-one'")
-	if err != nil {
-		c.Fatalf("failed to create a container:%s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-one'")
 
 	containerID := strings.TrimSpace(out)
-	out, _, err = dockerCmdWithError("commit", containerID, "busybox-one")
-	if err != nil {
-		c.Fatalf("failed to commit a new busybox-one:%s, %v", out, err)
-	}
+	dockerCmd(c, "commit", containerID, "busybox-one")
 
 	imagesBefore, _ := dockerCmd(c, "images", "-a")
 	dockerCmd(c, "tag", "busybox-one", "busybox-one:tag1")
 	dockerCmd(c, "tag", "busybox-one", "busybox-one:tag2")
 
 	imagesAfter, _ := dockerCmd(c, "images", "-a")
-	if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+2 {
-		c.Fatalf("tag busybox to create 2 more images with same imageID; docker images shows: %q\n", imagesAfter)
-	}
+	// tag busybox to create 2 more images with same imageID
+	c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+2, check.Commentf("docker images shows: %q\n", imagesAfter))
 
 	imgID, err := inspectField("busybox-one:tag1", "Id")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	// run a container with the image
-	out, _, err = dockerCmdWithError("run", "-d", "busybox-one", "top")
-	if err != nil {
-		c.Fatalf("failed to create a container:%s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "run", "-d", "busybox-one", "top")
 
 	containerID = strings.TrimSpace(out)
 
 	// first checkout without force it fails
 	out, _, err = dockerCmdWithError("rmi", imgID)
 	expected := fmt.Sprintf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", imgID[:12], containerID[:12])
-	if err == nil || !strings.Contains(out, expected) {
-		c.Fatalf("rmi tagged in multiple repos should have failed without force: %s, %v, expected: %s", out, err, expected)
-	}
+	// rmi tagged in multiple repos should have failed without force
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, expected)
 
 	dockerCmd(c, "stop", containerID)
 	dockerCmd(c, "rmi", "-f", imgID)
 
 	imagesAfter, _ = dockerCmd(c, "images", "-a")
-	if strings.Contains(imagesAfter, imgID[:12]) {
-		c.Fatalf("rmi -f %s failed, image still exists: %q\n\n", imgID, imagesAfter)
-	}
+	// rmi -f failed, image still exists
+	c.Assert(imagesAfter, checker.Not(checker.Contains), imgID[:12], check.Commentf("ImageID:%q; ImagesAfter: %q", imgID, imagesAfter))
 }
 
 func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	out, _, err := dockerCmdWithError("run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'")
-	if err != nil {
-		c.Fatalf("failed to create a container:%s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'")
 
 	containerID := strings.TrimSpace(out)
-	out, _, err = dockerCmdWithError("commit", containerID, "busybox-test")
-	if err != nil {
-		c.Fatalf("failed to commit a new busybox-test:%s, %v", out, err)
-	}
+	dockerCmd(c, "commit", containerID, "busybox-test")
 
 	imagesBefore, _ := dockerCmd(c, "images", "-a")
 	dockerCmd(c, "tag", "busybox-test", "utest:tag1")
@@ -143,25 +112,23 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 	dockerCmd(c, "tag", "busybox-test", "utest:5000/docker:tag4")
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
-		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+4 {
-			c.Fatalf("tag busybox to create 4 more images with same imageID; docker images shows: %q\n", imagesAfter)
-		}
+		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+4, check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 	}
 	imgID, err := inspectField("busybox-test", "Id")
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	// first checkout without force it fails
 	out, _, err = dockerCmdWithError("rmi", imgID)
-	if err == nil || !strings.Contains(out, "(must be forced) - image is referenced in one or more repositories") {
-		c.Fatalf("rmi tagged in multiple repos should have failed without force:%s, %v", out, err)
-	}
+	// rmi tagged in multiple repos should have failed without force
+	c.Assert(err, checker.NotNil)
+	// rmi tagged in multiple repos should have failed without force
+	c.Assert(out, checker.Contains, "(must be forced) - image is referenced in one or more repositories", check.Commentf("out: %s; err: %v;", out, err))
 
 	dockerCmd(c, "rmi", "-f", imgID)
 	{
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
-		if strings.Contains(imagesAfter, imgID[:12]) {
-			c.Fatalf("rmi -f %s failed, image still exists: %q\n\n", imgID, imagesAfter)
-		}
+		// rmi failed, image still exists
+		c.Assert(imagesAfter, checker.Not(checker.Contains), imgID[:12])
 	}
 }
 
@@ -170,17 +137,16 @@ func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c 
 	testRequires(c, DaemonIsLinux)
 	dockerfile := "FROM busybox\nRUN echo test 14116\n"
 	imgID, err := buildImage("test-14116", dockerfile, false)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	newTag := "newtag"
 	dockerCmd(c, "tag", imgID, newTag)
 	dockerCmd(c, "run", "-d", imgID, "top")
 
 	out, _, err := dockerCmdWithError("rmi", "-f", imgID)
-	if err == nil || !strings.Contains(out, "(cannot be forced) - image is being used by running container") {
-		c.Log(out)
-		c.Fatalf("rmi -f should not delete image with running containers")
-	}
+	// rmi -f should not delete image with running containers
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "(cannot be forced) - image is being used by running container")
 }
 
 func (s *DockerSuite) TestRmiTagWithExistingContainers(c *check.C) {
@@ -188,19 +154,12 @@ func (s *DockerSuite) TestRmiTagWithExistingContainers(c *check.C) {
 	container := "test-delete-tag"
 	newtag := "busybox:newtag"
 	bb := "busybox:latest"
-	if out, _, err := dockerCmdWithError("tag", bb, newtag); err != nil {
-		c.Fatalf("Could not tag busybox: %v: %s", err, out)
-	}
-	if out, _, err := dockerCmdWithError("run", "--name", container, bb, "/bin/true"); err != nil {
-		c.Fatalf("Could not run busybox: %v: %s", err, out)
-	}
-	out, _, err := dockerCmdWithError("rmi", newtag)
-	if err != nil {
-		c.Fatalf("Could not remove tag %s: %v: %s", newtag, err, out)
-	}
-	if d := strings.Count(out, "Untagged: "); d != 1 {
-		c.Fatalf("Expected 1 untagged entry got %d: %q", d, out)
-	}
+	dockerCmd(c, "tag", bb, newtag)
+
+	dockerCmd(c, "run", "--name", container, bb, "/bin/true")
+
+	out, _ := dockerCmd(c, "rmi", newtag)
+	c.Assert(strings.Count(out, "Untagged: "), checker.Equals, 1)
 }
 
 func (s *DockerSuite) TestRmiForceWithExistingContainers(c *check.C) {
@@ -211,17 +170,12 @@ func (s *DockerSuite) TestRmiForceWithExistingContainers(c *check.C) {
 	cmd.Stdin = strings.NewReader(`FROM busybox
 MAINTAINER foo`)
 
-	if out, _, err := runCommandWithOutput(cmd); err != nil {
-		c.Fatalf("Could not build %s: %s, %v", image, out, err)
-	}
+	out, _, err := runCommandWithOutput(cmd)
+	c.Assert(err, checker.IsNil, check.Commentf("Could not build %s: %s", image, out))
 
-	if out, _, err := dockerCmdWithError("run", "--name", "test-force-rmi", image, "/bin/true"); err != nil {
-		c.Fatalf("Could not run container: %s, %v", out, err)
-	}
+	dockerCmd(c, "run", "--name", "test-force-rmi", image, "/bin/true")
 
-	if out, _, err := dockerCmdWithError("rmi", "-f", image); err != nil {
-		c.Fatalf("Could not remove image %s:  %s, %v", image, out, err)
-	}
+	dockerCmd(c, "rmi", "-f", image)
 }
 
 func (s *DockerSuite) TestRmiWithMultipleRepositories(c *check.C) {
@@ -229,51 +183,32 @@ func (s *DockerSuite) TestRmiWithMultipleRepositories(c *check.C) {
 	newRepo := "127.0.0.1:5000/busybox"
 	oldRepo := "busybox"
 	newTag := "busybox:test"
-	out, _, err := dockerCmdWithError("tag", oldRepo, newRepo)
-	if err != nil {
-		c.Fatalf("Could not tag busybox: %v: %s", err, out)
-	}
+	dockerCmd(c, "tag", oldRepo, newRepo)
 
-	out, _, err = dockerCmdWithError("run", "--name", "test", oldRepo, "touch", "/home/abcd")
-	if err != nil {
-		c.Fatalf("failed to run container: %v, output: %s", err, out)
-	}
+	dockerCmd(c, "run", "--name", "test", oldRepo, "touch", "/home/abcd")
 
-	out, _, err = dockerCmdWithError("commit", "test", newTag)
-	if err != nil {
-		c.Fatalf("failed to commit container: %v, output: %s", err, out)
-	}
+	dockerCmd(c, "commit", "test", newTag)
 
-	out, _, err = dockerCmdWithError("rmi", newTag)
-	if err != nil {
-		c.Fatalf("failed to remove image: %v, output: %s", err, out)
-	}
-	if !strings.Contains(out, "Untagged: "+newTag) {
-		c.Fatalf("Could not remove image %s: %s, %v", newTag, out, err)
-	}
+	out, _ := dockerCmd(c, "rmi", newTag)
+	c.Assert(out, checker.Contains, "Untagged: "+newTag)
 }
 
 func (s *DockerSuite) TestRmiBlank(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// try to delete a blank image name
 	out, _, err := dockerCmdWithError("rmi", "")
-	if err == nil {
-		c.Fatal("Should have failed to delete '' image")
-	}
-	if strings.Contains(out, "no such id") {
-		c.Fatalf("Wrong error message generated: %s", out)
-	}
-	if !strings.Contains(out, "image name cannot be blank") {
-		c.Fatalf("Expected error message not generated: %s", out)
-	}
+	// Should have failed to delete '' image
+	c.Assert(err, checker.NotNil)
+	// Wrong error message generated
+	c.Assert(out, checker.Not(checker.Contains), "no such id", check.Commentf("out: %s", out))
+	// Expected error message not generated
+	c.Assert(out, checker.Contains, "image name cannot be blank", check.Commentf("out: %s", out))
 
 	out, _, err = dockerCmdWithError("rmi", " ")
-	if err == nil {
-		c.Fatal("Should have failed to delete '' image")
-	}
-	if !strings.Contains(out, "no such id") {
-		c.Fatalf("Expected error message not generated: %s", out)
-	}
+	// Should have failed to delete '' image
+	c.Assert(err, checker.NotNil)
+	// Expected error message not generated
+	c.Assert(out, checker.Contains, "no such id", check.Commentf("out: %s", out))
 }
 
 func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
@@ -284,7 +219,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	for i, name := range imageNames {
 		dockerfile := fmt.Sprintf("FROM busybox\nMAINTAINER %s\nRUN echo %s\n", name, name)
 		id, err := buildImage(name, dockerfile, false)
-		c.Assert(err, check.IsNil)
+		c.Assert(err, checker.IsNil)
 		imageIds[i] = id
 	}
 
@@ -297,10 +232,9 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 
 	// Try to remove the image of the running container and see if it fails as expected.
 	out, _, err := dockerCmdWithError("rmi", "-f", imageIds[0])
-	if err == nil || !strings.Contains(out, "image is being used by running container") {
-		c.Log(out)
-		c.Fatal("The image of the running container should not be removed.")
-	}
+	// The image of the running container should not be removed.
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "image is being used by running container", check.Commentf("out: %s", out))
 }
 
 // #13422
@@ -315,7 +249,7 @@ RUN echo 1 #layer1
 RUN echo 2 #layer2
 `
 	_, err := buildImage(image, dockerfile, false)
-	c.Assert(err, check.IsNil)
+	c.Assert(err, checker.IsNil)
 
 	out, _ := dockerCmd(c, "history", "-q", image)
 	ids := strings.Split(out, "\n")
@@ -329,10 +263,8 @@ RUN echo 2 #layer2
 
 	// See if the "tmp2" can be untagged.
 	out, _ = dockerCmd(c, "rmi", newTag)
-	if d := strings.Count(out, "Untagged: "); d != 1 {
-		c.Log(out)
-		c.Fatalf("Expected 1 untagged entry got %d: %q", d, out)
-	}
+	// Expected 1 untagged entry
+	c.Assert(strings.Count(out, "Untagged: "), checker.Equals, 1, check.Commentf("out: %s", out))
 
 	// Now let's add the tag again and create a container based on it.
 	dockerCmd(c, "tag", idToTag, newTag)
@@ -342,15 +274,13 @@ RUN echo 2 #layer2
 	// At this point we have 2 containers, one based on layer2 and another based on layer0.
 	// Try to untag "tmp2" without the -f flag.
 	out, _, err = dockerCmdWithError("rmi", newTag)
-	if err == nil || !strings.Contains(out, cid[:12]) || !strings.Contains(out, "(must force)") {
-		c.Log(out)
-		c.Fatalf("%q should not be untagged without the -f flag", newTag)
-	}
+	// should not be untagged without the -f flag
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, cid[:12])
+	c.Assert(out, checker.Contains, "(must force)")
 
 	// Add the -f flag and test again.
 	out, _ = dockerCmd(c, "rmi", "-f", newTag)
-	if !strings.Contains(out, fmt.Sprintf("Untagged: %s:latest", newTag)) {
-		c.Log(out)
-		c.Fatalf("%q should be allowed to untag with the -f flag", newTag)
-	}
+	// should be allowed to untag with the -f flag
+	c.Assert(out, checker.Contains, fmt.Sprintf("Untagged: %s:latest", newTag))
 }


### PR DESCRIPTION
Part of #16756

Update integration-cli/docker_cli_rmi_test.go:
Use Assert instead of condition judgement in test.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
