### PR TITLE
Skipping two tests when running with GCCGO (CI)

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -58,6 +58,7 @@ func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	testRequires(c, oomControl)
+	testRequires(c, NotGCCGO)
 
 	errChan := make(chan error)
 	go func() {
@@ -106,6 +107,7 @@ func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	testRequires(c, oomControl)
+	testRequires(c, NotGCCGO)
 
 	errChan := make(chan error)
 	go func() {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3138,7 +3138,7 @@ func (s *DockerSuite) TestAppArmorDeniesPtrace(c *check.C) {
 
 	// Run through 'sh' so we are NOT pid 1. Pid 1 may be able to trace
 	// itself, but pid>1 should not be able to trace pid1.
-	_, exitCode, _ := dockerCmdWithError("run", "busybox", "sh", "-c", "readlink /proc/1/ns/net")
+	_, exitCode, _ := dockerCmdWithError("run", "busybox", "sh", "-c", "sh -c readlink /proc/1/ns/net")
 	if exitCode == 0 {
 		c.Fatal("ptrace was not successfully restricted by AppArmor")
 	}

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -141,10 +141,10 @@ var (
 	NotGCCGO = testRequirement{
 		func() bool {
 			out, err := exec.Command("go", "version").Output()
-			if err != nil && strings.Contains(string(out), "gccgo") {
-				return true
+			if err == nil && strings.Contains(string(out), "gccgo") {
+				return false
 			}
-			return false
+			return true
 		},
 		"Test requires native Golang compiler instead of GCCGO",
 	}


### PR DESCRIPTION
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com

One of the TestEventsOOMDisableTrue and TestEventsOOMDisableFalse are hanging intermittently causing most of the x86 CI builds to fail. We are investigating the test failures but in the interim I would like to Skip these tests using existing flag. Also the PR is fixing a bug when Skipping a test while GCCGO compiler is detected. 
