### PR TITLE
Fix docker daemon exit immediately after starting without -H option closes #16927

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -224,6 +224,9 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 		defaultHost = opts.DefaultTLSHost
 	}
 
+	if len(commonFlags.Hosts) == 0 {
+		commonFlags.Hosts = make([]string, 1)
+	}
 	for i := 0; i < len(commonFlags.Hosts); i++ {
 		var err error
 		if commonFlags.Hosts[i], err = opts.ParseHost(defaultHost, commonFlags.Hosts[i]); err != nil {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1715,3 +1715,11 @@ func (s *DockerDaemonSuite) TestDaemonCorruptedFluentdAddress(c *check.C) {
 		c.Fatalf("Expected %q message; but doesn't exist in log: %q, err: %v", expected, out, err)
 	}
 }
+
+func (s *DockerDaemonSuite) TestDaemonStartWithoutHost(c *check.C) {
+	s.d.useDefaultHost = true
+	defer func() {
+		s.d.useDefaultHost = false
+	}()
+	c.Assert(s.d.Start(), check.IsNil)
+}


### PR DESCRIPTION
Fixes #16927 

if without -H `len(commonFlags.Hosts)` is `0` so the block

<pre><code>for i := 0; i < len(commonFlags.Hosts); i++ {
        var err error
        if commonFlags.Hosts[i], err = opts.ParseHost(defaultHost, commonFlags.Hosts[i]); err != nil {
            logrus.Fatalf("error parsing -H %s : %v", commonFlags.Hosts[i], err)
        }
    }</code></pre>

will skip and lead server is 0, so the daemon exit immediately
Signed-off-by: Lei Jitang leijtiang@huawei.com
