### PR TITLE
Remove unused param on ParseHost

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -105,20 +105,15 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, clientFlags *cli.ClientF
 
 		switch len(hosts) {
 		case 0:
-			defaultHost := os.Getenv("DOCKER_HOST")
-			hosts = []string{defaultHost}
+			hosts = []string{os.Getenv("DOCKER_HOST")}
 		case 1:
 			// only accept one host to talk to
 		default:
 			return errors.New("Please specify only one -H")
 		}
 
-		defaultHost := opts.DefaultTCPHost
-		if clientFlags.Common.TLSOptions != nil {
-			defaultHost = opts.DefaultTLSHost
-		}
 		var e error
-		if hosts[0], e = opts.ParseHost(defaultHost, hosts[0]); e != nil {
+		if hosts[0], e = opts.ParseHost(hosts[0]); e != nil {
 			return e
 		}
 

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -210,7 +210,6 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 	}
 	serverConfig = setPlatformServerConfig(serverConfig, cli.Config)
 
-	defaultHost := opts.DefaultHost
 	if commonFlags.TLSOptions != nil {
 		if !commonFlags.TLSOptions.InsecureSkipVerify {
 			// server requires and verifies client's certificate
@@ -221,12 +220,11 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 			logrus.Fatal(err)
 		}
 		serverConfig.TLSConfig = tlsConfig
-		defaultHost = opts.DefaultTLSHost
 	}
 
 	for i := 0; i < len(commonFlags.Hosts); i++ {
 		var err error
-		if commonFlags.Hosts[i], err = opts.ParseHost(defaultHost, commonFlags.Hosts[i]); err != nil {
+		if commonFlags.Hosts[i], err = opts.ParseHost(commonFlags.Hosts[i]); err != nil {
 			logrus.Fatalf("error parsing -H %s : %v", commonFlags.Hosts[i], err)
 		}
 	}

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -352,7 +352,7 @@ func ValidateHost(val string) (string, error) {
 }
 
 // ParseHost and set defaults for a Daemon host string
-func ParseHost(defaultHTTPHost, val string) (string, error) {
+func ParseHost(val string) (string, error) {
 	host, err := parsers.ParseDockerDaemonHost(DefaultTCPHost, DefaultUnixSocket, val)
 	if err != nil {
 		return val, err

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -458,12 +458,12 @@ func TestParseHost(t *testing.T) {
 	}
 
 	for value, errorMessage := range invalid {
-		if _, err := ParseHost(defaultHTTPHost, value); err == nil || err.Error() != errorMessage {
+		if _, err := ParseHost(value); err == nil || err.Error() != errorMessage {
 			t.Fatalf("Expected an error for %v with [%v], got [%v]", value, errorMessage, err)
 		}
 	}
 	for value, expected := range valid {
-		if actual, err := ParseHost(defaultHTTPHost, value); err != nil || actual != expected {
+		if actual, err := ParseHost(value); err != nil || actual != expected {
 			t.Fatalf("Expected for %v [%v], got [%v, %v]", value, expected, actual, err)
 		}
 	}


### PR DESCRIPTION
The first param on opts.ParseHost() wasn't being used for anything.

Once we get rid of that param we can then also clean-up some code
that calls ParseHost() because the param that was passed in wasn't
being used for anything else.

Signed-off-by: Doug Davis dug@us.ibm.com
