### PR TITLE
Missing a single dash in error message

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -91,7 +91,7 @@ fi
 if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 	mount -t securityfs none /sys/kernel/security || {
 		echo >&2 'Could not mount /sys/kernel/security.'
-		echo >&2 'AppArmor detection and -privileged mode might break.'
+		echo >&2 'AppArmor detection and --privileged mode might break.'
 	}
 fi
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit SvenDowideit@home.org.au

for want of a dash:

```
$ docker run --rm -it docker:dind
mount: permission denied (are you root?)
Could not mount /sys/kernel/security.
AppArmor detection and -privileged mode might break.
mount: permission denied (are you root?)
```
