### PR TITLE
Add CMD and EXPOSE instruction example

### DIFF
--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -61,3 +61,22 @@ created.  Supported `Dockerfile` instructions:
     f5283438590d
     $ docker inspect -f "{{ .Config.Env }}" f5283438590d
     [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true]
+
+## Commit a container with new `CMD` and `EXPOSE` instructions 
+
+    $ docker ps
+    ID                  IMAGE               COMMAND             CREATED             STATUS              PORTS
+    c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
+    197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
+
+    $ docker commit --change='CMD ["apachectl", "-DFOREGROUND"]' -c "EXPOSE 80" c3f279d17e0a  SvenDowideit/testimage:version4
+    f5283438590d
+    
+    $ docker run -d SvenDowideit/testimage:version4
+    89373736e2e7f00bc149bd783073ac43d0507da250e999f3f1036e0db60817c0
+
+    $ docker ps
+    ID                  IMAGE               COMMAND                 CREATED             STATUS              PORTS
+    89373736e2e7        testimage:version4  "apachectl -DFOREGROU"  3 seconds ago       Up 2 seconds        80/tcp
+    c3f279d17e0a        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours
+    197387f1b436        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours


### PR DESCRIPTION
After I had some issues using `commit`, I decided to add it to the docs. I believe this should also be merged with the branch `docs`.
