### PR TITLE
More AppArmor extensions

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -33,14 +33,19 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   @{DOCKER_GRAPH_PATH}/linkgraph.db k,
   @{DOCKER_GRAPH_PATH}/network/files/boltdb.db k,
   @{DOCKER_GRAPH_PATH}/network/files/local-kv.db k,
+  @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/linkgraph.db k,
 
   # For non-root client use:
   /dev/urandom r,
+  /dev/null rw,
+  /dev/pts/[0-9]* rw,
   /run/docker.sock rw,
   /proc/** r,
+  /proc/[0-9]*/attr/exec w,
   /sys/kernel/mm/hugepages/ r,
   /etc/localtime r,
   /etc/ld.so.cache r,
+  /etc/passwd r,
 
 {{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
   ptrace peer=@{profile_name},

--- a/daemon/execdriver/native/apparmor.go
+++ b/daemon/execdriver/native/apparmor.go
@@ -55,6 +55,12 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/cg[^r]*/** wklx,
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+  # suppress ptrace denails when using 'docker ps'
+  ptrace (trace,read) peer=docker-default,
 }
 `
 


### PR DESCRIPTION
Here are a couple more AppArmor policy extensions for the docker daemon and the containers when for example running the with user namespaces enabled and when running 'docker exec' or 'docker restart'.
