### PR TITLE
Correct mismatched function names (UID() and Gid())

### DIFF
--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -28,7 +28,7 @@ func copyOwnership(source, destination string) error {
 		return err
 	}
 
-	if err := os.Chown(destination, int(stat.UID()), int(stat.Gid())); err != nil {
+	if err := os.Chown(destination, int(stat.UID()), int(stat.GID())); err != nil {
 		return err
 	}
 

--- a/integration-cli/docker_cli_experimental_test.go
+++ b/integration-cli/docker_cli_experimental_test.go
@@ -80,5 +80,5 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
 		c.Fatal(err)
 	}
 	c.Assert(stat.UID(), check.Equals, uint32(uid), check.Commentf("Touched file not owned by remapped root UID"))
-	c.Assert(stat.Gid(), check.Equals, uint32(gid), check.Commentf("Touched file not owned by remapped root GID"))
+	c.Assert(stat.GID(), check.Equals, uint32(gid), check.Commentf("Touched file not owned by remapped root GID"))
 }

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -12,7 +12,7 @@ func statDifferent(oldStat *system.StatT, newStat *system.StatT) bool {
 	// Don't look at size for dirs, its not a good measure of change
 	if oldStat.Mode() != newStat.Mode() ||
 		oldStat.UID() != newStat.UID() ||
-		oldStat.Gid() != newStat.Gid() ||
+		oldStat.GID() != newStat.GID() ||
 		oldStat.Rdev() != newStat.Rdev() ||
 		// Don't look at size for dirs, its not a good measure of change
 		(oldStat.Mode()&syscall.S_IFDIR != syscall.S_IFDIR &&

--- a/pkg/system/stat.go
+++ b/pkg/system/stat.go
@@ -27,8 +27,8 @@ func (s StatT) UID() uint32 {
 	return s.uid
 }
 
-// Gid returns file's group id of owner.
-func (s StatT) Gid() uint32 {
+// GID returns file's group id of owner.
+func (s StatT) GID() uint32 {
 	return s.gid
 }
 

--- a/pkg/system/stat_unix_test.go
+++ b/pkg/system/stat_unix_test.go
@@ -27,7 +27,7 @@ func TestFromStatT(t *testing.T) {
 	if stat.Uid != s.UID() {
 		t.Fatal("got invalid uid")
 	}
-	if stat.Gid != s.Gid() {
+	if stat.Gid != s.GID() {
 		t.Fatal("got invalid gid")
 	}
 	if stat.Rdev != s.Rdev() {


### PR DESCRIPTION
All the go-lint work forced any existing "Uid" -> "UID", but seems to
not have the same rules for Gid, so stat package has calls UID() and
Gid().

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
