### PR TITLE
Windows: Daemon broken on master

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/docker/docker/pkg/system"
 )
 
 // IDMap contains a single entry for user namespace range remapping. An array
@@ -47,23 +45,6 @@ func MkdirAllAs(path string, mode os.FileMode, ownerUID, ownerGID int) error {
 // If the directory already exists, this function still changes ownership
 func MkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int) error {
 	return mkdirAs(path, mode, ownerUID, ownerGID, false)
-}
-
-func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll bool) error {
-	if mkAll {
-		if err := system.MkdirAll(path, mode); err != nil && !os.IsExist(err) {
-			return err
-		}
-	} else {
-		if err := os.Mkdir(path, mode); err != nil && !os.IsExist(err) {
-			return err
-		}
-	}
-	// even if it existed, we will chown to change ownership as requested
-	if err := os.Chown(path, ownerUID, ownerGID); err != nil {
-		return err
-	}
-	return nil
 }
 
 // GetRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.

--- a/pkg/idtools/usergroupadd_linux.go
+++ b/pkg/idtools/usergroupadd_linux.go
@@ -2,10 +2,13 @@ package idtools
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/docker/docker/pkg/system"
 )
 
 // add a user and/or group to Linux /etc/passwd, /etc/group using standard
@@ -152,4 +155,21 @@ func findUnused(file string, id int) (int, error) {
 			return -1, fmt.Errorf("Maximum id in %q reached with finding unused numeric ID", file)
 		}
 	}
+}
+
+func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll bool) error {
+	if mkAll {
+		if err := system.MkdirAll(path, mode); err != nil && !os.IsExist(err) {
+			return err
+		}
+	} else {
+		if err := os.Mkdir(path, mode); err != nil && !os.IsExist(err) {
+			return err
+		}
+	}
+	// even if it existed, we will chown to change ownership as requested
+	if err := os.Chown(path, ownerUID, ownerGID); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/idtools/usergroupadd_unsupported.go
+++ b/pkg/idtools/usergroupadd_unsupported.go
@@ -2,11 +2,25 @@
 
 package idtools
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/pkg/system"
+)
 
 // AddNamespaceRangesUser takes a name and finds an unused uid, gid pair
 // and calls the appropriate helper function to add the group and then
 // the user to the group in /etc/group and /etc/passwd respectively.
 func AddNamespaceRangesUser(name string) (int, int, error) {
 	return -1, -1, fmt.Errorf("No support for adding users or groups on this OS")
+}
+
+// Platforms such as Windows do not support the UID/GID concept. So make this
+// just a wrapper around system.MkdirAll.
+func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll bool) error {
+	if err := system.MkdirAll(path, mode); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

A recent change to use pkg\idtools causes a chown to be on the startup path of the daemon. Chown is not supported on Windows, hence the daemon would not start.
