### PR TITLE
Windows: Enable kill (part one)

### DIFF
--- a/pkg/signal/signal_unsupported.go
+++ b/pkg/signal/signal_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd
+// +build !linux,!darwin,!freebsd,!windows
 
 package signal
 

--- a/pkg/signal/signal_windows.go
+++ b/pkg/signal/signal_windows.go
@@ -14,3 +14,14 @@ const (
 	// DefaultStopSignal is the syscall signal used to stop a container in windows systems.
 	DefaultStopSignal = "15"
 )
+
+// SignalMap is a map of "supported" signals. As per the comment in GOLang's
+// ztypes_windows.go: "More invented values for signals". Windows doesn't
+// really support signals in any way, shape or form that Unix does.
+//
+// We have these so that docker kill can be used to gracefully (TERM) and
+// forcibly (KILL) terminate a container on Windows.
+var SignalMap = map[string]syscall.Signal{
+	"KILL": syscall.SIGKILL,
+	"TERM": syscall.SIGTERM,
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This is the first part (trying to keep to small PRs) of enabling docker kill on Windows. This part simply enables the use of SIGKILL and SIGTERM as constructs in the signal map. They don't actually relate to signals in the Unix sense, since Windows does not support signals. 

This PR will actually start docker kill working against a Windows daemon, as opposed to erroring out immediately, just it will always go through an attempt at graceful shutdown, not the forced shutdown. That'll be fixed in part two...
