### PR TITLE
refactor use of container struct from daemon

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -126,11 +126,7 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 		return err
 	}
 
-	container, err := n.daemon.Get(connect.Container)
-	if err != nil {
-		return fmt.Errorf("invalid container %s : %v", container, err)
-	}
-	return container.ConnectToNetwork(nw.Name())
+	return n.daemon.ConnectContainerToNetwork(connect.Container, nw.Name())
 }
 
 func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -152,11 +148,7 @@ func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.Respon
 		return err
 	}
 
-	container, err := n.daemon.Get(disconnect.Container)
-	if err != nil {
-		return fmt.Errorf("invalid container %s : %v", container, err)
-	}
-	return container.DisconnectFromNetwork(nw)
+	return n.daemon.DisconnectContainerFromNetwork(disconnect.Container, nw)
 }
 
 func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -120,3 +120,24 @@ func getIpamConfig(data []network.IPAMConfig) ([]*libnetwork.IpamConf, []*libnet
 	}
 	return ipamV4Cfg, ipamV6Cfg, nil
 }
+
+// ConnectContainerToNetwork connects the given container to the given
+// network. If either cannot be found, an err is returned. If the
+// network cannot be set up, an err is returned.
+func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName string) error {
+	container, err := daemon.Get(containerName)
+	if err != nil {
+		return err
+	}
+	return container.ConnectToNetwork(networkName)
+}
+
+// DisconnectContainerFromNetwork disconnects the given container from
+// the given network. If either cannot be found, an err is returned.
+func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, network libnetwork.Network) error {
+	container, err := daemon.Get(containerName)
+	if err != nil {
+		return err
+	}
+	return container.DisconnectFromNetwork(network)
+}

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/go-check/check"
 )
@@ -133,6 +134,11 @@ func (s *DockerNetworkSuite) TestDockerNetworkCreateDelete(c *check.C) {
 
 	dockerCmd(c, "network", "rm", "test")
 	assertNwNotAvailable(c, "test")
+}
+
+func (s *DockerSuite) TestDockerNetworkDeleteNotExists(c *check.C) {
+	out, _, err := dockerCmdWithError("network", "rm", "test")
+	c.Assert(err, checker.NotNil, check.Commentf("%v", out))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnect(c *check.C) {


### PR DESCRIPTION
- do existence check instead of get container
- new connect method on daemon.

like #16966

@calavera @duglin @icecrime 

The existence check on the outside could be considered redundant.
