### PR TITLE
add insecure registry

### DIFF
--- a/api/client/registry.go
+++ b/api/client/registry.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+
+	Cli "github.com/docker/docker/cli"
+	"github.com/docker/docker/opts"
+	flag "github.com/docker/docker/pkg/mflag"
+)
+
+// CmdRegistryAdd is the add registry in the runtime
+//
+// Usage: docker registry add [OPTIONS] [REGISTRIES]
+func (cli *DockerCli) CmdRegistryAdd(args ...string) (err error) {
+	cmd := Cli.Subcmd("registry add", nil, "Add registries.", true)
+	cmd.Require(flag.Exact, 0)
+	flInsecureRegistries := opts.NewListOpts(nil)
+	cmd.Var(&flInsecureRegistries, []string{"-insecure-registry"}, "Enable insecure registry communication")
+
+	cmd.ParseFlags(args, true)
+
+	v := url.Values{}
+	for _, registry := range flInsecureRegistries.GetAll() {
+		v.Add("registry", registry)
+	}
+
+	if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/registry/add?%s", v.Encode()), nil, nil)); err != nil {
+		fmt.Fprintf(cli.err, "%s\n", err)
+		return fmt.Errorf("Error: failed to add insecure registry.")
+	}
+
+	return nil
+}

--- a/api/server/router/local/info.go
+++ b/api/server/router/local/info.go
@@ -138,3 +138,17 @@ func (s *router) getEvents(ctx context.Context, w http.ResponseWriter, r *http.R
 		}
 	}
 }
+
+func (s *router) postAddInsecureRegistry(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	insecureRegistries := r.Form["registry"]
+
+	if err := s.daemon.AddInsecureRegistry(insecureRegistries); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/server/router/local/local.go
+++ b/api/server/router/local/local.go
@@ -142,6 +142,7 @@ func (r *router) initRoutes() {
 		NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
 		NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
 		NewPostRoute("/volumes", r.postVolumesCreate),
+		NewPostRoute("/registry/add", r.postAddInsecureRegistry),
 		// PUT
 		NewPutRoute("/containers/{name:.*}/archive", r.putContainersArchive),
 		// DELETE

--- a/daemon/registry.go
+++ b/daemon/registry.go
@@ -1,0 +1,7 @@
+package daemon
+
+// AddInsecureRegistry add insecure registry in the runtime
+func (daemon *Daemon) AddInsecureRegistry(insecureRegistries []string) error {
+
+	return daemon.RegistryService.AddInsecureRegistryService(insecureRegistries)
+}

--- a/registry/service.go
+++ b/registry/service.go
@@ -160,3 +160,8 @@ func (s *Service) lookupEndpoints(repoName string) (endpoints []APIEndpoint, err
 
 	return endpoints, nil
 }
+
+// AddInsecureRegistryService add insecure regsitry
+func (s *Service) AddInsecureRegistryService(insecureRegistries []string) error {
+	return s.Config.AddInsecureRegistryConfig(insecureRegistries)
+}


### PR DESCRIPTION
Signed-off-by: Kun Zhang zkazure@gmail.com
#16578

Add a command to manage registry configuration without restart daemon.
Here I just implement add insecure registry. 
Example:  docker registry add --insecure-registry 172.10.0.3:5000
I can implement remove  insecure registry and also mirror registry management if this design is ok
