### PR TITLE
Add docker config api to config daemon without restarting docker

### DIFF
--- a/api/client/config.go
+++ b/api/client/config.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+
+	Cli "github.com/docker/docker/cli"
+)
+
+// CmdConfig config the docker daemon without restarting docker daemon.
+//
+// Usage: docker config
+func (cli *DockerCli) CmdConfig(args ...string) error {
+	cmd := Cli.Subcmd("config", []string{"KEY=VALUE"}, Cli.DockerCommands["config"].Description, true)
+
+	flAdd := cmd.Bool([]string{"a", "-add"}, false, "Add config")
+	flRemove := cmd.Bool([]string{"r", "-remove"}, false, "Remove  config")
+	flModify := cmd.Bool([]string{"m", "-modify"}, false, "Modify  config")
+
+	cmd.ParseFlags(args, true)
+	if *flAdd && *flRemove && *flModify {
+		return fmt.Errorf("Conflict: only a method is allowed")
+	}
+	if !*flAdd && !*flRemove && !*flModify {
+		return fmt.Errorf("You should specify a method")
+	}
+
+	var method string
+	if *flAdd {
+		method = "Add"
+	}
+	if *flRemove {
+		method = "Remove"
+	}
+	if *flModify {
+		method = "Modify"
+	}
+
+	v := url.Values{}
+	v.Set("method", method)
+	v.Set("config", cmd.Arg(0))
+
+	if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/config?%s", v.Encode()), nil, nil)); err != nil {
+		return fmt.Errorf("Error: failed to '%s' config '%s': %v.", method, cmd.Arg(0), err)
+	}
+	return nil
+}

--- a/api/server/router/local/info.go
+++ b/api/server/router/local/info.go
@@ -138,3 +138,17 @@ func (s *router) getEvents(ctx context.Context, w http.ResponseWriter, r *http.R
 		}
 	}
 }
+
+func (s *router) postConfigDaemon(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	method := r.Form.Get("method")
+	config := r.Form.Get("config")
+
+	if err := s.daemon.ModifyDaemonConfig(method, config); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/server/router/local/local.go
+++ b/api/server/router/local/local.go
@@ -142,6 +142,7 @@ func (r *router) initRoutes() {
 		NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
 		NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
 		NewPostRoute("/volumes", r.postVolumesCreate),
+		NewPostRoute("/config", r.postConfigDaemon),
 		// PUT
 		NewPutRoute("/containers/{name:.*}/archive", r.putContainersArchive),
 		// DELETE

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -50,6 +50,12 @@ type CommonConfig struct {
 	ClusterAdvertise string
 }
 
+// DaemonAllowedModifedArgs is the args that can be modified during daemon running
+var DaemonAllowedModifedArgs = map[string]bool{
+	"insecure-registry": true,
+	"label":             true,
+}
+
 // InstallCommonFlags adds command-line options to the top-level flag parser for
 // the current process.
 // Subsequent calls to `flag.Parse` will populate config with values parsed

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1279,3 +1279,32 @@ func (daemon *Daemon) SearchRegistryForImages(term string,
 	headers map[string][]string) (*registry.SearchResults, error) {
 	return daemon.RegistryService.Search(term, authConfig, headers)
 }
+
+// ModifyInsecureRegistry add insecure registry in the runtime
+func (daemon *Daemon) ModifyInsecureRegistry(method, value string) error {
+	return daemon.RegistryService.ModifyRegistryService(method, value)
+}
+
+// ModifyDaemonConfig add/remove/modify some daemon config
+func (daemon *Daemon) ModifyDaemonConfig(method, config string) error {
+	if method != "Add" && method != "Remove" && method != "Modify" {
+		return fmt.Errorf("Operation method `%s` not exists, see docker config --help", method)
+	}
+	slice := strings.SplitN(config, "=", 2)
+	if len(slice) < 2 {
+		return fmt.Errorf("Invalid format `%s`, valid format should be: key=value(=bar)", config)
+	}
+	key := slice[0]
+	value := slice[1]
+	_, ok := DaemonAllowedModifedArgs[key]
+	if !ok {
+		return fmt.Errorf("Config `%s` is not support modified during daemon running", key)
+	}
+	if key == "insecure-registry" {
+		return daemon.ModifyInsecureRegistry(method, value)
+	}
+	if key == "label" {
+		return daemon.ModifyLabel(method, value)
+	}
+	return nil
+}

--- a/daemon/lablel.go
+++ b/daemon/lablel.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ModifyLabel modify daemon label
+func (daemon *Daemon) ModifyLabel(method, value string) error {
+	if strings.Count(value, "=") != 1 {
+		return fmt.Errorf("Bad format label '%s'", value)
+	}
+	if method == "Add" {
+		labels := daemon.configStore.Labels
+		for _, label := range labels {
+			if label == value {
+				return nil
+			}
+		}
+		daemon.configStore.Labels = append(labels, value)
+	}
+	if method == "Remove" {
+		labels := daemon.configStore.Labels
+		for i, label := range labels {
+			if label == value {
+				daemon.configStore.Labels = append(labels[0:i], labels[i+1:]...)
+				return nil
+			}
+		}
+		return fmt.Errorf("Remove failed: lable '%s' is not exists", value)
+	}
+	if method == "Modify" {
+		key := strings.Split(value, "=")[0]
+		labels := daemon.configStore.Labels
+		for i, label := range labels {
+			if key == strings.Split(label, "=")[0] {
+				daemon.configStore.Labels[i] = value
+				return nil
+			}
+		}
+	}
+	return nil
+}

--- a/registry/service.go
+++ b/registry/service.go
@@ -160,3 +160,8 @@ func (s *Service) lookupEndpoints(repoName string) (endpoints []APIEndpoint, err
 
 	return endpoints, nil
 }
+
+// ModifyRegistryService modify the insecure regsitry
+func (s *Service) ModifyRegistryService(method, value string) error {
+	return s.Config.ModifyRegistryService(method, value)
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
Sometimes we need config the `label` or `insecure-registry` of the docker daemon,
but we have to restart the daemon to make the these config.
so add the `docker config` to config the daemon during running, currently 
it support config `label` and `insecure-registry`
Usage:

<pre><code>Usage:  docker config [OPTIONS] KEY=VALUE

  -a, --add=false       Add config
  -m, --modify=false    Modify  config
  -r, --remove=false    Remove  config
  --help=false          Print usage
</code></pre>

For example:

`docker config -a label=test=node1`
This is to add a label
`docker config -r label=test=node1`
This is to delete a label
`docker config -m label=test=node2`
This is to modify a label

`docker config -a insecure-registry=9.81.1.160:5000`
This is to add a insecure-registry
`docker config -r insecure-registry=9.81.1.160:5000`
This is to remove a insecure-registry

ping @duglin  @calavera  @LK4D4  @estesp  @icecrime @cpuguy83  @jfrazelle 

docs and tests will add if design ok
