### PR TITLE
Fix TestInspectInt64 for kernels without swap limit capability

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -27,13 +27,9 @@ func (s *DockerSuite) TestInspectImage(c *check.C) {
 
 func (s *DockerSuite) TestInspectInt64(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	out, _, err := dockerCmdWithError("run", "-d", "-m=300M", "busybox", "true")
-	if err != nil {
-		c.Fatalf("failed to run container: %v, output: %q", err, out)
-	}
-	out = strings.TrimSpace(out)
 
-	inspectOut, err := inspectField(out, "HostConfig.Memory")
+	dockerCmd(c, "run", "-d", "-m=300M", "--name", "inspectTest", "busybox", "true")
+	inspectOut, err := inspectField("inspectTest", "HostConfig.Memory")
 	c.Assert(err, check.IsNil)
 
 	if inspectOut != "314572800" {


### PR DESCRIPTION
Instead of returning only the container ID, starting a container may
also return a warning:

"WARNING: Your kernel does not support swap
limit capabilities, memory limited without
swap.\nff6ebd9f7a8d035d17bb9a61eb9d3f0a5d563160cc43471a9d7ac9f71945d061"

Update the test requirement and move to a _unix_test.go file.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
