### PR TITLE
Add localhost.localdomain to /etc/hosts

### DIFF
--- a/vendor/src/github.com/docker/libnetwork/etchosts/etchosts.go
+++ b/vendor/src/github.com/docker/libnetwork/etchosts/etchosts.go
@@ -24,7 +24,7 @@ func (r Record) WriteTo(w io.Writer) (int64, error) {
 // Default hosts config records slice
 var defaultContent = []Record{
 	{Hosts: "localhost localhost.localdomain", IP: "127.0.0.1"},
-	{Hosts: "localhost ip6-localhost ip6-loopback", IP: "::1"},
+	{Hosts: "localhost localhost.localdomain ip6-localhost ip6-loopback", IP: "::1"},
 	{Hosts: "ip6-localnet", IP: "fe00::0"},
 	{Hosts: "ip6-mcastprefix", IP: "ff00::0"},
 	{Hosts: "ip6-allnodes", IP: "ff02::1"},

--- a/vendor/src/github.com/docker/libnetwork/etchosts/etchosts.go
+++ b/vendor/src/github.com/docker/libnetwork/etchosts/etchosts.go
@@ -23,7 +23,7 @@ func (r Record) WriteTo(w io.Writer) (int64, error) {
 
 // Default hosts config records slice
 var defaultContent = []Record{
-	{Hosts: "localhost", IP: "127.0.0.1"},
+	{Hosts: "localhost localhost.localdomain", IP: "127.0.0.1"},
 	{Hosts: "localhost ip6-localhost ip6-loopback", IP: "::1"},
 	{Hosts: "ip6-localnet", IP: "fe00::0"},
 	{Hosts: "ip6-mcastprefix", IP: "ff00::0"},


### PR DESCRIPTION
Add `localhost.localdomain` to `/etc/hosts` so the content better resembles a RHEL, Fedora server. Ubuntu, Debian or other distributions with a cleaner `/etc/hosts` should not be affected since  `127.0.0.1`  resolvs to `localhost` and `localhost.localdomain` is treated like an alias.

Closes #16912 
