### PR TITLE
Windows: [TP4] Fix AV due to userns

### DIFF
--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -25,6 +25,13 @@ func UnpackLayer(dest string, layer Reader, options *TarOptions) (size int64, er
 	defer pools.BufioReader32KPool.Put(trBuf)
 
 	var dirs []*tar.Header
+
+	if options == nil {
+		options = &TarOptions{}
+	}
+	if options.ExcludePatterns == nil {
+		options.ExcludePatterns = []string{}
+	}
 	remappedRootUID, remappedRootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @estesp. After the introduction of user namespaces, the archive package has regressed on Windows causing an AV in the daemon in the case of a Dockerfile containing `ADD file.txt /`. 

This should be in 1.9 as it has regressed functionality on docker master currently (ie build does not work). 
