### PR TITLE
Fix --ipc=host dependency on /dev/mqueue existing

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -288,7 +288,7 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
-	if !container.hostConfig.IpcMode.IsContainer() {
+	if !container.hostConfig.IpcMode.IsContainer() && !container.hostConfig.IpcMode.IsHost() {
 		if err := container.setupIpcDirs(); err != nil {
 			return err
 		}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -288,7 +288,7 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
-	if !container.hostConfig.IpcMode.IsContainer() && !container.hostConfig.IpcMode.IsHost() {
+	if !container.hostConfig.IpcMode.IsContainer() {
 		if err := container.setupIpcDirs(); err != nil {
 			return err
 		}

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -214,6 +214,12 @@ func populateCommand(c *Container, env []string) error {
 		ipc.ContainerID = ic.ID
 		c.ShmPath = ic.ShmPath
 		c.MqueuePath = ic.MqueuePath
+	} else {
+		ipc.HostIpc = c.hostConfig.IpcMode.IsHost()
+		if ipc.HostIpc {
+			c.ShmPath = "/dev/shm"
+			c.MqueuePath = "/dev/mqueue"
+		}
 	}
 
 	pid := &execdriver.Pid{}
@@ -1402,7 +1408,7 @@ func (container *Container) setupIpcDirs() error {
 }
 
 func (container *Container) unmountIpcMounts() error {
-	if container.hostConfig.IpcMode.IsContainer() {
+	if container.hostConfig.IpcMode.IsContainer() || container.hostConfig.IpcMode.IsHost() {
 		return nil
 	}
 

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -214,12 +214,6 @@ func populateCommand(c *Container, env []string) error {
 		ipc.ContainerID = ic.ID
 		c.ShmPath = ic.ShmPath
 		c.MqueuePath = ic.MqueuePath
-	} else {
-		ipc.HostIpc = c.hostConfig.IpcMode.IsHost()
-		if ipc.HostIpc {
-			c.ShmPath = "/dev/shm"
-			c.MqueuePath = "/dev/mqueue"
-		}
 	}
 
 	pid := &execdriver.Pid{}
@@ -1408,7 +1402,7 @@ func (container *Container) setupIpcDirs() error {
 }
 
 func (container *Container) unmountIpcMounts() error {
-	if container.hostConfig.IpcMode.IsContainer() || container.hostConfig.IpcMode.IsHost() {
+	if container.hostConfig.IpcMode.IsContainer() {
 		return nil
 	}
 

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -217,6 +217,12 @@ func populateCommand(c *Container, env []string) error {
 	} else {
 		ipc.HostIpc = c.hostConfig.IpcMode.IsHost()
 		if ipc.HostIpc {
+			if _, err := os.Stat("/dev/shm"); err != nil {
+				return fmt.Errorf("/dev/shm is not mounted, but must be for --host=ipc")
+			}
+			if _, err := os.Stat("/dev/mqueue"); err != nil {
+				return fmt.Errorf("/dev/mqueue is not mounted, but must be for --host=ipc")
+			}
 			c.ShmPath = "/dev/shm"
 			c.MqueuePath = "/dev/mqueue"
 		}


### PR DESCRIPTION
Since #15862, containers fail to start when started with `--ipc=host` if `/dev/mqueue` is not present. This change causes docker to create container-local mounts for `--ipc=host` containers as well as in the default case.

Three other options (which I consider undesirable for various reasons):
1. Warn the user more explicitly if `/dev/shm` or `/dev/mqueue` is not mounted, with instructions on mounting it;
2. Mount `/dev/shm` and/or `/dev/mqueue` for the user, if necessary; or
3. Check for presence of `/dev/{shm,mqueue}` when `--ipc=host` is specified, preferring to use the global mounts, but falling back to creating container-root mounts if they are not found.

Option 3 sounds fine from a behaviour perspective, but it adds nontrivial complexity.

cc @calavera @mrunalp
