### PR TITLE
Windows: Fix annoying bad log

### DIFF
--- a/daemon/execdriver/windows/namedpipes.go
+++ b/daemon/execdriver/windows/namedpipes.go
@@ -3,6 +3,7 @@
 package windows
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/Sirupsen/logrus"
@@ -22,7 +23,11 @@ func startStdinCopy(dst io.WriteCloser, src io.Reader) {
 	go func() {
 		defer dst.Close()
 		bytes, err := io.Copy(dst, src)
-		logrus.Debugf("Copied %d bytes from stdin err=%s", bytes, err)
+		log := fmt.Sprintf("Copied %d bytes from stdin.", bytes)
+		if err != nil {
+			log = log + " err=" + err.Error()
+		}
+		logrus.Debugf(log)
 	}()
 }
 
@@ -35,7 +40,11 @@ func startStdouterrCopy(dst io.Writer, src io.ReadCloser, name string) {
 	go func() {
 		defer src.Close()
 		bytes, err := io.Copy(dst, src)
-		logrus.Debugf("Copied %d bytes from %s err=%s", bytes, name, err)
+		log := fmt.Sprintf("Copied %d bytes from %s.", bytes, name)
+		if err != nil {
+			log = log + " err=" + err.Error()
+		}
+		logrus.Debugf(log)
 	}()
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This bad logging has been annoying me for months. 
Before example: 
`time="2015-10-13T14:41:14.764156600-07:00" level=debug msg="Copied 7179 bytes from stdout err=%!s(<nil>)"`

After example:
`
time="2015-10-13T15:00:14.777766600-07:00" level=debug msg="Copied 349 bytes from stdout."
time="2015-10-13T15:00:18.173653000-07:00" level=debug msg="Copied 5 bytes from stdin. err=io: read/write on closed pipe"
`
