### PR TITLE
only display 'Engine Version' when it's not empty

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -35,7 +35,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	fmt.Fprintf(cli.out, "Containers: %d\n", info.Containers)
 	fmt.Fprintf(cli.out, "Images: %d\n", info.Images)
-	fmt.Fprintf(cli.out, "Engine Version: %s\n", info.ServerVersion)
+	ioutils.FprintfIfNotEmpty(cli.out, "Engine Version: %s\n", info.ServerVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Storage Driver: %s\n", info.Driver)
 	if info.DriverStatus != nil {
 		for _, pair := range info.DriverStatus {

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -35,7 +35,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	fmt.Fprintf(cli.out, "Containers: %d\n", info.Containers)
 	fmt.Fprintf(cli.out, "Images: %d\n", info.Images)
-	ioutils.FprintfIfNotEmpty(cli.out, "Engine Version: %s\n", info.ServerVersion)
+	ioutils.FprintfIfNotEmpty(cli.out, "Server Version: %s\n", info.ServerVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Storage Driver: %s\n", info.Driver)
 	if info.DriverStatus != nil {
 		for _, pair := range info.DriverStatus {

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -22,7 +22,7 @@ For example:
     $ docker -D info
     Containers: 14
     Images: 52
-    Engine Version: 1.9.0
+    Server Version: 1.9.0
     Storage Driver: aufs
      Root Dir: /var/lib/docker/aufs
      Backing Filesystem: extfs

--- a/docs/userguide/labels-custom-metadata.md
+++ b/docs/userguide/labels-custom-metadata.md
@@ -188,7 +188,7 @@ These labels appear as part of the `docker info` output for the daemon:
     $ docker -D info
     Containers: 12
     Images: 672
-    Engine Version: 1.9.0
+    Server Version: 1.9.0
     Storage Driver: aufs
      Root Dir: /var/lib/docker/aufs
      Backing Filesystem: extfs

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -33,7 +33,7 @@ Here is a sample output:
     # docker info
     Containers: 14
     Images: 52
-    Engine Version: 1.9.0
+    Server Version: 1.9.0
     Storage Driver: aufs
      Root Dir: /var/lib/docker/aufs
      Dirs: 80


### PR DESCRIPTION
Please keep in mid that the cli doesn't always talk to an engine, sometimes it's swarm :D
