### PR TITLE
Add dockerhooks program to run hooks under runc

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	Cli "github.com/docker/docker/cli"
+	"github.com/docker/docker/daemon/execdriver/dockerhooks"
 	"github.com/docker/docker/pkg/ioutils"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/units"
@@ -57,6 +58,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
 	ioutils.FprintfIfNotEmpty(cli.out, "OSType: %s\n", info.OSType)
 	ioutils.FprintfIfNotEmpty(cli.out, "Architecture: %s\n", info.Architecture)
+	fmt.Fprintf(cli.out, "Number of Docker Hooks: %d\n", dockerhooks.TotalHooks())
 	fmt.Fprintf(cli.out, "CPUs: %d\n", info.NCPU)
 	fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(info.MemTotal)))
 	ioutils.FprintfIfNotEmpty(cli.out, "Name: %s\n", info.Name)

--- a/daemon/execdriver/dockerhooks/dockerhooks_linux.go
+++ b/daemon/execdriver/dockerhooks/dockerhooks_linux.go
@@ -1,0 +1,90 @@
+// +build linux
+
+package dockerhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/docker/docker/utils"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+// Prestart function will be called after container process is created but
+// before it is started
+func Prestart(state configs.HookState, configPath string) error {
+	hooks, hookDirPath, err := getHooks()
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	for _, item := range hooks {
+		if item.Mode().IsRegular() {
+			if err := runHook(path.Join(hookDirPath, item.Name()), "prestart", configPath, b); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Poststop function will be called after container process has stopped but
+// before it is removed
+func Poststop(state configs.HookState, configPath string) error {
+	hooks, hookDirPath, err := getHooks()
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	for i := len(hooks) - 1; i >= 0; i-- {
+		fn := hooks[i].Name()
+		for _, item := range hooks {
+			if item.Mode().IsRegular() && fn == item.Name() {
+				if err := runHook(path.Join(hookDirPath, item.Name()), "poststop", configPath, b); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// TotalHooks returns the number of hooks to be used
+func TotalHooks() int {
+	hooks, _, _ := getHooks()
+	return len(hooks)
+}
+
+func getHooks() ([]os.FileInfo, string, error) {
+
+	hookDirPath := path.Join(path.Dir(utils.DockerInitPath("")), "hooks.d")
+	// find any hooks executables
+	if _, err := os.Stat(hookDirPath); os.IsNotExist(err) {
+		return nil, "", nil
+	}
+
+	hooks, err := ioutil.ReadDir(hookDirPath)
+	return hooks, hookDirPath, err
+}
+
+func runHook(hookFilePath string, hookType string, configPath string, stdinBytes []byte) error {
+	cmd := exec.Cmd{
+		Path: hookFilePath,
+		Args: []string{hookFilePath, hookType, configPath},
+		Env: []string{
+			"container=docker",
+		},
+		Stdin: bytes.NewReader(stdinBytes),
+	}
+	return cmd.Run()
+}

--- a/daemon/execdriver/dockerhooks/dockerhooks_unsupported.go
+++ b/daemon/execdriver/dockerhooks/dockerhooks_unsupported.go
@@ -1,0 +1,24 @@
+// +build !linux
+
+package dockerhooks
+
+import (
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+// Prestart function will be called after container process is created but
+// before it is started
+func Prestart(state configs.HookState, configPath string) error {
+	return nil
+}
+
+// Poststop function will be called after container process has stopped but
+// before it is removed
+func Poststop(state configs.HookState, configPath string) error {
+	return nil
+}
+
+// TotalHooks returns the number of hooks to be used
+func TotalHooks() int {
+	return 0
+}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -126,16 +126,17 @@ type CommonProcessConfig struct {
 // CommonCommand is the common platform agnostic part of the Command structure
 // which wraps an os/exec.Cmd to add more metadata
 type CommonCommand struct {
-	ContainerPid  int           `json:"container_pid"` // the pid for the process inside a container
-	ID            string        `json:"id"`
-	InitPath      string        `json:"initpath"`    // dockerinit
-	MountLabel    string        `json:"mount_label"` // TODO Windows. More involved, but can be factored out
-	Mounts        []Mount       `json:"mounts"`
-	Network       *Network      `json:"network"`
-	ProcessConfig ProcessConfig `json:"process_config"` // Describes the init process of the container.
-	ProcessLabel  string        `json:"process_label"`  // TODO Windows. More involved, but can be factored out
-	Resources     *Resources    `json:"resources"`
-	Rootfs        string        `json:"rootfs"` // root fs of the container
-	WorkingDir    string        `json:"working_dir"`
-	TmpDir        string        `json:"tmpdir"` // Directory used to store docker tmpdirs.
+	ContainerPid      int           `json:"container_pid"` // the pid for the process inside a container
+	ID                string        `json:"id"`
+	InitPath          string        `json:"initpath"`    // dockerinit
+	MountLabel        string        `json:"mount_label"` // TODO Windows. More involved, but can be factored out
+	Mounts            []Mount       `json:"mounts"`
+	Network           *Network      `json:"network"`
+	ProcessConfig     ProcessConfig `json:"process_config"` // Describes the init process of the container.
+	ProcessLabel      string        `json:"process_label"`  // TODO Windows. More involved, but can be factored out
+	Resources         *Resources    `json:"resources"`
+	Rootfs            string        `json:"rootfs"` // root fs of the container
+	WorkingDir        string        `json:"working_dir"`
+	TmpDir            string        `json:"tmpdir"` // Directory used to store docker tmpdirs.
+	ContainerJSONPath string        `json:"-"`
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -126,6 +126,12 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 	mounts = append(mounts, container.TmpfsMounts()...)
 
 	container.Command.Mounts = mounts
+	jsonPath, err := container.ConfigPath()
+	if err != nil {
+		return err
+	}
+	container.Command.ContainerJSONPath = jsonPath
+
 	if err := daemon.waitForStart(container); err != nil {
 		return err
 	}

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -37,6 +37,7 @@ For example:
     OSType: linux
     Architecture: x86_64
     Operating System: Ubuntu 15.04
+    Number of Hooks: 2
     CPUs: 24
     Total Memory: 62.86 GiB
     Name: docker

--- a/docs/userguide/labels-custom-metadata.md
+++ b/docs/userguide/labels-custom-metadata.md
@@ -198,6 +198,7 @@ These labels appear as part of the `docker info` output for the daemon:
     Logging Driver: json-file
     Kernel Version: 3.19.0-22-generic
     Operating System: Ubuntu 15.04
+    Number of Hooks: 2
     CPUs: 24
     Total Memory: 62.86 GiB
     Name: docker

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -46,6 +46,7 @@ Here is a sample output:
     Operating System: Ubuntu 14.04 LTS
     OSType: linux
     Architecture: x86_64
+    Number of Hooks: 2
     CPUs: 1
     Total Memory: 2 GiB
 


### PR DESCRIPTION
With the addition of runc/hooks support we want to add a feature
to allow third parties to run helper programs before a docker container
gets started and just after the container finishes.

For example we want to add a RegisterMachine hook.

For systems that support systemd/RegisterMachine, this hook would register
a machine to the machinectl.  machinectl could then list docker containers
along with other virtulization environments like kvm, and systemd-nspawn
containers. Overtime we would want to implement other machinectl features
to get docker containers better integrated into the system and machinectl.

Another example of a dockerhook might be for people wanting to do better logging
of starting and stopping of containers.  For example have a log agent that
records when a container starts and stops and then sends a message to a
monitoring station.

Dockerhooks reads an environment variable DOCKER_HOOKS_PATH for a directory
to search for hooks, if the directory does not exist dockerhooks just exits.

docker daemon uses the search mechanism for dockerinit to look for dockerhooks
it also sets the DOCKER_HOOKS_PATH based off the directory containers dockerhooks.

and will execute them via runc/libcontainer using PreStart and PostStop.

Signed-off-by: Sally O'Malley somalley@redhat.com

Signed-off-by: Dan Walsh dwalsh@redhat.com
