### PR TITLE
Zombie package

### DIFF
--- a/pkg/zombie/zombie.go
+++ b/pkg/zombie/zombie.go
@@ -1,0 +1,110 @@
+package zombie
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+)
+
+// MonitoredPids will keep track of all the processIDs that need to be killed.
+var MonitoredPids map[int]string
+
+// Executor will execute arbitrary commands.
+func Executor(exe string) (err error) {
+
+	// simple command start. it's a string, so it should execute simply.
+	cmd := exec.Command("sh", "-c", exe)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		log.Println(err)
+	}
+
+	// and now we wait.
+	err = cmd.Wait()
+
+	//if there is one.
+	return err
+}
+
+// SignalHandler will wait for a keyboard or system signal before trying to kill
+//
+func SignalHandler(signal chan os.Signal, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
+
+	for sig := range signal {
+		switch sig {
+		case syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL:
+			// exits with no error code.
+			return
+
+		case syscall.SIGCHLD:
+			//this is the call that will exit the children processes.
+
+			//information on a child process.
+			var (
+				status syscall.WaitStatus
+				usage  syscall.Rusage
+			)
+
+			// this calls the child process of the processID via a WNOHANG
+			// but does nothing until we determine the state and act accordingly
+			processID, err := syscall.Wait4(-1, &status, syscall.WNOHANG, &usage)
+			if err != nil {
+				log.Println(err)
+			}
+
+			if _, ok := MonitoredPids[processID]; ok {
+				// assuming the process is ok, delete the processID from the
+				// monitored processes.
+				delete(MonitoredPids, processID)
+
+				// loop through the monitoredPids to make sure all the processes
+				// are dead and return.
+				if len(MonitoredPids) == 0 {
+					return
+				}
+
+			}
+		}
+	}
+}
+
+// Exit provices the arrayed structure for the childReaper exit.
+type Exit struct {
+	Process int
+	Status  int
+}
+
+// ChildReaper is designed to be called at the end execution, when all children
+// processes need to be cleaned. This prevents zombie processes from being
+// left behind when a container exits.
+func ChildReaper() (exits []Exit, err error) {
+	//start the loop to reap any abandonded children.
+	for {
+		var (
+			status syscall.WaitStatus
+			usage  syscall.Rusage
+		)
+
+		// make the `wait4` call and check for errors. if the error equals
+		// ECHILD (no child process), return empty exit status.
+		processID, err := syscall.Wait4(-1, &status, syscall.WNOHANG, &usage)
+		if err != nil {
+			if err == syscall.ECHILD {
+				return exits, nil
+			}
+		}
+
+		// shows which processes have exited and with what status.
+		exits = append(exits, Exit{
+			processID, status.ExitStatus(),
+		})
+	}
+}

--- a/pkg/zombie/zombie_test.go
+++ b/pkg/zombie/zombie_test.go
@@ -1,0 +1,89 @@
+package zombie
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+func TestExecutor(t *testing.T) {
+	// shell loop to test multiple step applications.
+	testString := "for i in {1..5}; do echo $i; done"
+	err := Executor(testString)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// sleep test to test arbitrary waiting.
+	testSleep := "sleep 1"
+	err = Executor(testSleep)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestChildReaper tests `cat /dev/random` to demonstrate a long running command
+// that will never exit. It creates the processs, then detaches the process as a
+// child process. This demonstrates a process that creates a detached child,
+// then calls `ChildReaper()` to clean it up.
+func TestChildReaper(t *testing.T) {
+	cmdToRun := "/bin/cat"
+	args := []string{"/dev/random"}
+	procAttr := new(os.ProcAttr)
+	procAttr.Files = []*os.File{os.Stdin, os.Stdout, os.Stderr}
+
+	fork, err := os.StartProcess(cmdToRun, args, procAttr)
+	if err != nil {
+		t.Error(err)
+	}
+	log.Println("started fork:", fork.Pid)
+
+	err = fork.Release()
+	if err != nil {
+		t.Error(err)
+	}
+	log.Println("releasing fork:", fork.Pid)
+
+	exit, err := ChildReaper()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// 	// In the test results, you will see:
+	// 	// started fork: processID
+	// 	// releasing fork: -1
+	// 	// [{0 0} {0 0} ... {processID, ExitStatus}
+	// 	//log.Println(exit)
+	for pid, status := range exit {
+		if exit[pid].Status != 0 {
+			t.Error(pid, "HAS BAD EXIT STATUS:", status)
+		}
+	}
+	log.Println("all exits are good!")
+}
+
+func TestSignalhandler(t *testing.T) {
+	testString := "sleep 1"
+	MonitoredPids = make(map[int]string)
+
+	signals := make(chan os.Signal, 1024)
+	signal.Notify(signals, syscall.SIGCHLD, syscall.SIGTERM, syscall.SIGINT)
+
+	waitGroup := sync.WaitGroup{}
+
+	waitGroup.Add(1)
+	go SignalHandler(signals, &waitGroup)
+
+	for i := 0; i < 3; i++ {
+		if err := Executor(testString); err != nil {
+			t.Error(err)
+		}
+	}
+
+	log.Println("sending SIGCHLD.")
+	syscall.Kill(syscall.Getpid(), syscall.SIGCHLD)
+	log.Println("processes have exited.")
+}


### PR DESCRIPTION
This PR is to address issue #11529. I'm not sure if it is core functionality that should be addressed within the daemon or as a package, so it's under `pkg/` for right now, as that seemed like an okay place to put it. I'm a new contributor, so I'm not sure how this should be implemented just yet.

It adds three functions:
Executor: arbitrary shell executor.
SignalHandler: this will handle all incoming signals and clean up things accordingly.
ChildReaper: will clean up every single process that is a child process.

Some things to note.
- It passes the unit tests when executed manually, however it has issues with the `hack/make.sh test-unit` functionality. I think this is due to the fact I have to send signals in order to test it's functionality, which interrupts the script. I didn't put a whole lot of effort into figuring out a workaround outside of just commenting them out. However, it's at the end of the package list, so in theory it shouldn't interfere with the results.
- `ChildReaper`, if utilised, will loop through every process that is running. It provides a custom `Exit` structure with the PID and its exit status, so if something isn't exited cleanly, it can be processed downstream.
- The `MonitoredPids` code is only a framework, based off the discussion in the issue. I'm not actively monitoring processes, but if there were processes to be monitored, the framework is there from the beginning.

I figured this is just a starting point to get the issue rolling to get this functionality implemented. I was going to write my own `init` when I stumbled across the issue, so I'm hoping by working with the Docker team, the issue can be resolved as part of the core functionality.

@tiborvass 
