### PR TITLE
Windows: [TP4] Fix daemon AV on docker network ls

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -67,6 +67,9 @@ func (daemon *Daemon) GetNetwork(idName string, by int) (libnetwork.Network, err
 // GetNetworksByID returns a list of networks whose ID partially matches zero or more networks
 func (daemon *Daemon) GetNetworksByID(partialID string) []libnetwork.Network {
 	c := daemon.netController
+	if c == nil {
+		return nil
+	}
 	list := []libnetwork.Network{}
 	l := func(nw libnetwork.Network) bool {
 		if strings.HasPrefix(nw.ID(), partialID) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@mavenugo. `docker network ls` will cause the daemon to AV in GetNetworksByID by dereferencing through a nil pointer without this fix.

Before
`
time="2015-10-14T11:39:26.396368600-07:00" level=info msg="GET /v1.22/networks"
2015/10/14 11:39:26 http: panic serving 127.0.0.1:51377: runtime error: invalid memory address or nil pointer dereference
goroutine 16 [running]:
net/http.func·011()
        C:/Go/src/net/http/server.go:1130 +0xc2
github.com/docker/docker/daemon.(*Daemon).GetNetworksByID(0xc08206b400, 0x0, 0x0, 0x0, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/daemon/network.go:77 +0x17e
github.com/docker/docker/api/server/router/network.(*networkRouter).getNetworksList(0xc08259f2e0, 0x2171f28, 0xc08280d470, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340, 0xc08280d020, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/api/server/router/network/network_routes.go:52 +0x76b
github.com/docker/docker/api/server/router/network.*networkRouter.(github.com/docker/docker/api/server/router/network.getNetworksList)·fm(0x2171f28, 0xc08280d470, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340, 0xc08280d020, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/api/server/router/network/network.go:32 +0x82
github.com/docker/docker/api/server.func·004(0x2171f28, 0xc08280d470, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340, 0xc08280d020, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/api/server/middleware.go:87 +0x7ce
github.com/docker/docker/api/server.func·003(0x20d2b68, 0xc082002fd8, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340, 0xc08280d020, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/api/server/middleware.go:66 +0x115
github.com/docker/docker/api/server.func·002(0x20d2b68, 0xc082002fd8, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340, 0xc08280d020, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/api/server/middleware.go:49 +0x483
github.com/docker/docker/api/server.func·001(0x20d2b68, 0xc082002fd8, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340, 0xc08280d020, 0x0, 0x0)
        e:/go/src/github.com/docker/docker/api/server/middleware.go:27 +0x1e3
github.com/docker/docker/api/server.func·007(0x2171ec8, 0xc0827ec8c0, 0xc0827b2340)
        e:/go/src/github.com/docker/docker/api/server/server.go:156 +0x26c
net/http.HandlerFunc.ServeHTTP(0xc0827b8080, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340)
        C:/Go/src/net/http/server.go:1265 +0x48
github.com/gorilla/mux.(*Router).ServeHTTP(0xc082519f90, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340)
        e:/go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x29e
net/http.serverHandler.ServeHTTP(0xc08204eae0, 0x2171ec8, 0xc0827ec8c0, 0xc0827b2340)
        C:/Go/src/net/http/server.go:1703 +0x1a1
net/http.(*conn).serve(0xc0827ec820)
        C:/Go/src/net/http/server.go:1204 +0xb5e
created by net/http.(*Server).Serve
        C:/Go/src/net/http/server.go:1751 +0x365`

`E:\go\src\github.com\docker\docker\integration-cli>docker network ls
An error occurred trying to connect: Get http://localhost:2375/v1.22/networks: EOF`

After
`time="2015-10-14T11:44:22.006103700-07:00" level=debug msg="Calling GET /v1.22/networks"
time="2015-10-14T11:44:22.009104400-07:00" level=info msg="GET /v1.22/networks"`

`E:\go\src\github.com\docker\docker\integration-cli>docker network ls
NETWORK ID          NAME                DRIVER`
