### PR TITLE
Make connection failure error message more clear

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	errConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
+	errConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host and is the current user in the docker group?")
 )
 
 type serverResponse struct {


### PR DESCRIPTION
The current connection failure error message can be a bit cryptic for new users, since while it mentions the docker daemon needs to be running it doesn't mention that the current user also needs to be in the docker user group:

```
calid@arch ~
[✔]▶ docker run ubuntu:14.04 /bin/echo 'Hello world'
Cannot connect to the Docker daemon. Is the docker daemon running on this host?

calid@arch ~
[✘]▶ id
uid=1000(calid) gid=1000(calid) groups=1000(calid),1001(sudo)

calid@arch ~
[✘]▶ sudo usermod -aG docker calid

calid@arch ~
[✔]▶ newgrp docker

calid@arch ~
[✔]▶ id
uid=1000(calid) gid=996(docker) groups=996(docker),1000(calid),1001(sudo)

calid@arch ~
[✔]▶ docker run ubuntu:14.04 /bin/echo 'Hello world'
Unable to find image 'ubuntu:14.04' locally
14.04: Pulling from library/ubuntu
...
```

This is a small patch that simply adds the docker group reminder to the connection error message.
