### PR TITLE
remove incorrect "readonly" example

### DIFF
--- a/docs/userguide/dockervolumes.md
+++ b/docs/userguide/dockervolumes.md
@@ -59,11 +59,6 @@ This will create a new volume inside a container at `/webapp`.
 > You can also use the `VOLUME` instruction in a `Dockerfile` to add one or
 > more new volumes to any container created from that image.
 
-Docker volumes default to mount in read-write mode, but you can also set it to be mounted read-only.
-
-    $ docker run -d -P --name web -v /opt/webapp:ro training/webapp python app.py
-
-
 ### Locating a volume
 
 You can locate the volume on the host by utilizing the 'docker inspect' command.


### PR DESCRIPTION
The :ro option can only be used for named and bind-mounted
volumes, not on "regular" (unnamed) volumes as explained in
https://github.com/docker/docker/pull/16013#issuecomment-146647216

The example in the documentation actually resulted in a
bind-mounted volume, mounted at "ro" inside the container.

This removes the incorrect example from the documentation.
