### PR TITLE
Bump Go to 1.4.3 for builder

### DIFF
--- a/contrib/builder/deb/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/debian-jessie/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:jessie
 
 RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/debian-stretch/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:stretch
 
 RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/debian-wheezy/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:wheezy-backports
 
 RUN apt-get update && apt-get install -y bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ubuntu-precise/Dockerfile
+++ b/contrib/builder/deb/ubuntu-precise/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:precise
 
 RUN apt-get update && apt-get install -y bash-completion  build-essential curl ca-certificates debhelper  git libapparmor-dev  libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ubuntu-vivid/Dockerfile
+++ b/contrib/builder/deb/ubuntu-vivid/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:vivid
 
 RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/deb/ubuntu-wily/Dockerfile
+++ b/contrib/builder/deb/ubuntu-wily/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:wily
 
 RUN apt-get update && apt-get install -y bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-systemd git libapparmor-dev libdevmapper-dev libsqlite3-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -8,7 +8,7 @@ RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/fedora-21/Dockerfile
+++ b/contrib/builder/rpm/fedora-21/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora:21
 RUN yum install -y @development-tools fedora-packager
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora:22
 RUN yum install -y @development-tools fedora-packager
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/opensuse-13.2/Dockerfile
@@ -7,7 +7,7 @@ FROM opensuse:13.2
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-6/Dockerfile
@@ -7,7 +7,7 @@ FROM oraclelinux:6
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -7,7 +7,7 @@ FROM oraclelinux:7
 RUN yum groupinstall -y "Development Tools"
 RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 


### PR DESCRIPTION
We already bumped this for Dockerfile, should keep build environment
consistent with that.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
