### PR TITLE
allow filtering containers by any status

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -149,9 +149,8 @@ func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error)
 			if !isValidStateString(value) {
 				return nil, errors.New("Unrecognised filter value for status")
 			}
-			if value == "exited" || value == "created" {
-				config.All = true
-			}
+
+			config.All = true
 		}
 	}
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -114,7 +114,7 @@ Query Parameters:
         sizes
 -   **filters** - a JSON encoded value of the filters (a `map[string][]string`) to process on the containers list. Available filters:
   -   `exited=<int>`; -- containers with exit code of  `<int>` ;
-  -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`)
+  -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`|`dead`)
   -   `label=key` or `label="key=value"` of a container label
 
 Status Codes:


### PR DESCRIPTION
It's safe to assume that if a client specified status filters, they'd want to filter the full list every time. No need to single out `exited` and `created` statuses.

Fixes #17058
