### PR TITLE
Remove 'docker network ls -n -l --latest' options from in zsh completion

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -263,8 +263,6 @@ __docker_network_subcommand() {
         (ls)
             _arguments \
                 $opts_help \
-                "($help -l --latest)"{-l,--latest}"[Show the latest network created]" \
-                "($help)-n=-[Show n last created networks]:Number of networks: " \
                 "($help)--no-trunc[Do not truncate the output]" \
                 "($help -q --quiet)"{-q,--quiet}"[Only display numeric IDs]" && ret=0
             ;;


### PR DESCRIPTION
Fixes #16909

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
