### PR TITLE
Correct API docs for /images/create

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1465,12 +1465,15 @@ a base64-encoded AuthConfig object.
 
 Query Parameters:
 
--   **fromImage** – Name of the image to pull.
+-   **fromImage** – Name of the image to pull. The name may include a tag or
+        digest. This parameter may only be used when pulling an image.
 -   **fromSrc** – Source to import.  The value may be a URL from which the image
         can be retrieved or `-` to read the image from the request body.
--   **repo** – Repository name.
--   **tag** – Tag.
--   **registry** – The registry to pull from.
+        This parameter may only be used when importing an image.
+-   **repo** – Repository name given to an image when it is imported.
+        The repo may include a tag. This parameter may only be used when importing
+        an image.
+-   **tag** – Tag or digest.
 
     Request Headers:
 


### PR DESCRIPTION
The API docs for this endpoint are incomplete and from what I can tell just wrong in one case.
- I can't see any reference in the code to a `registry` param. Maybe it was removed at some point?
- this endpoint supports two operations (it should probably be split into two endpoints eventually), but each operation supports different sets of args. I tried to clarify which operation uses which args.
- tags and digest can be included either as part of `fromImage` or in `tag`

I think these fixes could probably be backported to the 1.20 api docs as well, but I wanted to get a review of the wording first, then I can copy it.

+kind/docs
