### PR TITLE
Fixing hang in archive.CopyFileWithTar with invalid dst

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -910,7 +910,11 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 		}
 	}()
 
-	return archiver.Untar(r, filepath.Dir(dst), nil)
+	err = archiver.Untar(r, filepath.Dir(dst), nil)
+	if err != nil {
+		r.CloseWithError(err)
+	}
+	return err
 }
 
 // CopyFileWithTar emulates the behavior of the 'cp' command-line

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -3,9 +3,31 @@
 package archive
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestCopyFileWithInvalidDest(t *testing.T) {
+	folder, err := ioutil.TempDir("", "docker-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+	dest := "c:dest"
+	srcFolder := filepath.Join(folder, "src")
+	src := filepath.Join(folder, "src", "src")
+	err = os.MkdirAll(srcFolder, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(src, []byte("content"), 0777)
+	err = CopyWithTar(src, dest)
+	if err == nil {
+		t.Fatalf("archiver.CopyWithTar should throw an error on invalid dest.")
+	}
+}
 
 func TestCanonicalTarNameForPath(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
@jhowardmsft @jstarks @vbatts @tiborvass 

archive.CopyFileWithTar can hit a hang if the destination path is invalid (either an invalid path name or an inaccessible folder), because archive.Untar will return the error without closing the Reader pipe but after CopyFileWithTar has started the go func that is waiting on the pipe.  The fix here is to check the error of archive.Untar and if it failed, explicitly close the pipe to unblock the thread waiting on it.

This issue is hard to hit in Linux, since the unit tests run as root and there aren't any invalid directory names we could give, but in Windows simply including "ADD myfile.txt /invalid:directory/" in a Dockerfile would cause the build to hang and the handles to the files in the layer to be leaked when the daemon is killed.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
