### PR TITLE
Windows: Native ANSI console support

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -3,13 +3,13 @@ package daemon
 import (
 	"fmt"
 	"os"
-	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 	// register the windows graph driver
 	_ "github.com/docker/docker/daemon/graphdriver/windows"
 	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/libnetwork"
 )
@@ -62,21 +62,15 @@ func checkConfigOptions(config *Config) error {
 
 // checkSystem validates platform-specific requirements
 func checkSystem() error {
-	var dwVersion uint32
-
-	// TODO Windows. May need at some point to ensure have elevation and
-	// possibly LocalSystem.
-
 	// Validate the OS version. Note that docker.exe must be manifested for this
 	// call to return the correct version.
-	dwVersion, err := syscall.GetVersion()
+	osv, err := system.GetOSVersion()
 	if err != nil {
-		return fmt.Errorf("Failed to call GetVersion()")
+		return err
 	}
-	if int(dwVersion&0xFF) < 10 {
+	if osv.MajorVersion < 10 {
 		return fmt.Errorf("This version of Windows does not support the docker daemon")
 	}
-
 	return nil
 }
 

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -1,5 +1,34 @@
 package system
 
+import (
+	"fmt"
+	"syscall"
+)
+
+// OSVersion is a wrapper for Windows version information
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
+type OSVersion struct {
+	Version      uint32
+	MajorVersion uint8
+	MinorVersion uint8
+	Build        uint16
+}
+
+// GetOSVersion gets the operating system version on Windows. Note that
+// docker.exe must be manifested to get the correct version information.
+func GetOSVersion() (OSVersion, error) {
+	var err error
+	osv := OSVersion{}
+	osv.Version, err = syscall.GetVersion()
+	if err != nil {
+		return osv, fmt.Errorf("Failed to call GetVersion()")
+	}
+	osv.MajorVersion = uint8(osv.Version & 0xFF)
+	osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
+	osv.Build = uint16(osv.Version >> 16)
+	return osv, nil
+}
+
 // Unmount is a platform-specific helper function to call
 // the unmount syscall. Not supported on Windows
 func Unmount(dest string) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR enables native ANSI console support (as opposed to the golang written ANSI emulator) if the client OS is a recent version of Windows 10/Windows Server 2016. For TP4, we are leaving the default to the golang emulator - users have to set environment variable USE_NATIVE_CONSOLE=1 as it is not good quite enough for prime time use. 

This PR also tidies up the GetVersion() call as it is now called from multiple places.
