### PR TITLE
updating notary and gotuf with latest bugfixes

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -41,8 +41,8 @@ clone git github.com/boltdb/bolt v1.0
 clone git github.com/docker/distribution 20c4b7a1805a52753dfd593ee1cc35558722a0ce # docker/1.9 branch
 clone git github.com/vbatts/tar-split v0.9.10
 
-clone git github.com/docker/notary ac05822d7d71ef077df3fc24f506672282a1feea
-clone git github.com/endophage/gotuf 9bcdad0308e34a49f38448b8ad436ad8860825ce
+clone git github.com/docker/notary 089d8450d8928aa1c58fd03f09cabbde9bcb4590
+clone git github.com/endophage/gotuf 876c31a61bc4aa0dae09bb8ef3946dc26dd04924
 clone git github.com/jfrazelle/go 6e461eb70cb4187b41a84e9a567d7137bdbe0f16
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 

--- a/vendor/src/github.com/docker/notary/client/changelist/change.go
+++ b/vendor/src/github.com/docker/notary/client/changelist/change.go
@@ -1,5 +1,9 @@
 package changelist
 
+import (
+	"github.com/endophage/gotuf/data"
+)
+
 // Scopes for TufChanges are simply the TUF roles.
 // Unfortunately because of targets delegations, we can only
 // cover the base roles.
@@ -10,6 +14,17 @@ const (
 	ScopeTimestamp = "timestamp"
 )
 
+// Types for TufChanges are namespaced by the Role they
+// are relevant for. The Root and Targets roles are the
+// only ones for which user action can cause a change, as
+// all changes in Snapshot and Timestamp are programatically
+// generated base on Root and Targets changes.
+const (
+	TypeRootRole          = "role"
+	TypeTargetsTarget     = "target"
+	TypeTargetsDelegation = "delegation"
+)
+
 // TufChange represents a change to a TUF repo
 type TufChange struct {
 	// Abbreviated because Go doesn't permit a field and method of the same name
@@ -18,6 +33,13 @@ type TufChange struct {
 	ChangeType string `json:"type"`
 	ChangePath string `json:"path"`
 	Data       []byte `json:"data"`
+}
+
+// TufRootData represents a modification of the keys associated
+// with a role that appears in the root.json
+type TufRootData struct {
+	Keys     []data.TUFKey `json:"keys"`
+	RoleName string        `json:"role"`
 }
 
 // NewTufChange initializes a tufChange object

--- a/vendor/src/github.com/endophage/gotuf/client/errors.go
+++ b/vendor/src/github.com/endophage/gotuf/client/errors.go
@@ -10,6 +10,14 @@ var (
 	ErrInsufficientKeys = errors.New("tuf: insufficient keys to meet threshold")
 )
 
+type ErrChecksumMismatch struct {
+	role string
+}
+
+func (e ErrChecksumMismatch) Error() string {
+	return fmt.Sprintf("tuf: checksum for %s did not match", e.role)
+}
+
 type ErrMissingRemoteMetadata struct {
 	Name string
 }

--- a/vendor/src/github.com/endophage/gotuf/data/keys.go
+++ b/vendor/src/github.com/endophage/gotuf/data/keys.go
@@ -71,7 +71,7 @@ func (k TUFKey) Public() []byte {
 	return k.Value.Public
 }
 
-func (k *TUFKey) Private() []byte {
+func (k TUFKey) Private() []byte {
 	return k.Value.Private
 }
 

--- a/vendor/src/github.com/endophage/gotuf/data/roles.go
+++ b/vendor/src/github.com/endophage/gotuf/data/roles.go
@@ -24,7 +24,7 @@ var ValidRoles = map[string]string{
 
 func SetValidRoles(rs map[string]string) {
 	// iterate ValidRoles
-	for k, _ := range ValidRoles {
+	for k := range ValidRoles {
 		if v, ok := rs[k]; ok {
 			ValidRoles[k] = v
 		}
@@ -88,6 +88,7 @@ type Role struct {
 	Name             string   `json:"name"`
 	Paths            []string `json:"paths,omitempty"`
 	PathHashPrefixes []string `json:"path_hash_prefixes,omitempty"`
+	Email            string   `json:"email,omitempty"`
 }
 
 func NewRole(name string, threshold int, keyIDs, paths, pathHashPrefixes []string) (*Role, error) {

--- a/vendor/src/github.com/endophage/gotuf/store/httpstore.go
+++ b/vendor/src/github.com/endophage/gotuf/store/httpstore.go
@@ -90,6 +90,7 @@ func (s HTTPStore) GetMeta(name string, size int64) ([]byte, error) {
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrMetaNotFound{}
 	} else if resp.StatusCode != http.StatusOK {
+		logrus.Debugf("received HTTP status %d when requesting %s.", resp.StatusCode, name)
 		return nil, ErrServerUnavailable{code: resp.StatusCode}
 	}
 	if resp.ContentLength > size {


### PR DESCRIPTION
Includes some bugfixes, and the ability to rotate the targets and snapshot keys. The actual rotation is done by the notary cli, but this patch enables docker to publish the update when pushing.
