### PR TITLE
allow to start daemon with additional args

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,8 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
+EnvironmentFile=-/etc/sysconfig/docker
+ExecStart=/usr/bin/docker daemon $other_args -H fd://
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
- e.g. a different root dir using `"-g /mnt/data/docker"`
- uses the same sysconfig file as the init.d script

Also see  [EnvironmentFiles and support for /etc/sysconfig files](https://fedoraproject.org/wiki/Packaging:Systemd#EnvironmentFiles_and_support_for_.2Fetc.2Fsysconfig_files).
