### PR TITLE
Deprecate 'docker run -c' option in zsh completion

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -394,7 +394,7 @@ __docker_subcommand() {
 
     opts_help=("(: -)--help[Print usage]")
     opts_cpumemlimit=(
-        "($help -c --cpu-shares)"{-c,--cpu-shares=-}"[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)"
+        "($help)--cpu-shares=-[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)"
         "($help)--cgroup-parent=-[Parent cgroup for the container]:cgroup: "
         "($help)--cpu-period=-[Limit the CPU CFS (Completely Fair Scheduler) period]:CPU period: "
         "($help)--cpu-quota=-[Limit the CPU CFS (Completely Fair Scheduler) quota]:CPU quota: "


### PR DESCRIPTION
Ref. #16271

ping @albers for bash

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
