### PR TITLE
Fix docker rmi trying to remove a being used parent

### DIFF
--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -60,9 +60,9 @@ func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
 	// rebuild dockerfile with a small addition at the end
 	_, err = buildImage(img, dockerfile2, true)
 	c.Assert(err, check.IsNil, check.Commentf("Could not rebuild image %s", img))
-	// try to remove the image, should error out.
+	// try to remove the image, should not error out.
 	out, _, err := dockerCmdWithError("rmi", img)
-	c.Assert(err, check.NotNil, check.Commentf("Expected to error out removing the image, but succeeded: %s", out))
+	c.Assert(err, check.IsNil, check.Commentf("Expected to removing the image, but failed: %s", out))
 
 	// check if we deleted the first image
 	out, _ = dockerCmd(c, "images", "-q", "--no-trunc")

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -322,3 +322,18 @@ func (*DockerSuite) TestRmiParentImageFail(c *check.C) {
 		c.Fatalf("rmi should have failed because it's a parent image, got %s", out)
 	}
 }
+
+func (s *DockerSuite) TestRmiWithParentInUse(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	out, _ := dockerCmd(c, "create", "busybox")
+	cID := strings.TrimSpace(out)
+	out, _ = dockerCmd(c, "commit", cID)
+	imageID := strings.TrimSpace(out)
+
+	out, _ = dockerCmd(c, "create", imageID)
+	cID = strings.TrimSpace(out)
+	out, _ = dockerCmd(c, "commit", cID)
+	imageID = strings.TrimSpace(out)
+
+	dockerCmd(c, "rmi", imageID)
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

When a parent is being used and the parent has no tag, remove the child
will trying to remove the parent. Steps to reproduce:
1 `cID=$(docker create busybox)`
2 `imageID=$(docker commit $cID)`   Step 1 and Step 2 is to create a image without tag
3 `cID=$(docker create $imageID)`
4 `imageID=$(docker commit $cID)`
5 `docker rmi $imageID`

<pre><code>[lei@fedora docker]$ docker rmi $imageID
Error response from daemon: conflict: unable to delete cda6afba8342 (must be forced) - image is being used by stopped container f2346b156f56
Error: failed to remove images: [8b80e30d563130ffb4ec81ceb032e5b64db2a5676beb690e5eec2561baf79997]
[lei@fedora docker]$ echo $imageID
8b80e30d563130ffb4ec81ceb032e5b64db2a5676beb690e5eec2561baf79997</code></pre>

With this error message, most user will think that the image I want to remove are being used but actually not, it's its parent being used by container, but the layer user want to remove are removed actually, but the error message misleading.

If the parent image has a tag name this will not happent and just delete the layer silently.

<pre><code>[lei@fedora docker]$ cID=$(docker create busybox)
[lei@fedora docker]$ imageID=$(docker commit $cID)
[lei@fedora docker]$ docker rmi $imageID
Deleted: e3cfb3dd73d38a9d5f1ea1a4ba62c19dd2e58a321fe75857b169c9c85df4af97</code></pre>
