### PR TITLE
Systemd init script should support DOCKER_OPTS

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,8 +6,9 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
 MountFlags=slave
+EnvironmentFile=-/etc/default/docker
+ExecStart=/usr/bin/docker daemon $DOCKER_OPTS -H fd://
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity


### PR DESCRIPTION
See #9889 (specifically, [here](#9889 %28comment%29). The systemd daemon should support `DOCKER_OPTS` the same as upstart and sysv do.

This commit is copied from
https://github.com/docker/docker/commit/0e7fb272d6ce8e26984dd1b3501b6fb6a57ba9ff
The commit itself is not present anymore (maybe it's orphaned?).

Signed-off-by: Matthias Brandt matthias.brandt@inoio.de
