### PR TITLE
make sure the value of the dangling filter is correct

### DIFF
--- a/graph/list.go
+++ b/graph/list.go
@@ -51,8 +51,10 @@ func (s *TagStore) Images(filterArgs, filter string, all bool) ([]*types.Image, 
 
 	if i, ok := imageFilters["dangling"]; ok {
 		for _, value := range i {
-			if strings.ToLower(value) == "true" {
+			if v := strings.ToLower(value); v == "true" {
 				filtTagged = false
+			} else if v != "false" {
+				return nil, fmt.Errorf("Invalid filter 'dangling=%s'", v)
 			}
 		}
 	}

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/go-check/check"
 )
@@ -196,4 +197,10 @@ func (s *DockerSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *check.C) {
 	if e, a := 1, strings.Count(out, imageID); e != a {
 		c.Fatalf("expected 1 dangling image, got %d: %s", a, out)
 	}
+}
+
+func (s *DockerSuite) TestImagesWithIncorrectFilter(c *check.C) {
+	out, _, err := dockerCmdWithError("images", "-f", "dangling=invalid")
+	c.Assert(err, check.NotNil)
+	c.Assert(out, checker.Contains, "Invalid filter")
 }


### PR DESCRIPTION
I mistakenly ran `docker rmi $(docker images -q -f dangling=ture)` and then all the images (except for those were in use) were gone :broken_heart: :broken_heart: :broken_heart: :crying_cat_face:  (note it's `ture`, not `true`)
I think it would be better to error out when the user provided incorrect filter parameters.
