### PR TITLE
Proposal: emit a "tag" event when building image with "-t" parameter

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -462,7 +462,6 @@ func (s *router) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 	if err := s.daemon.TagImage(repo, tag, name, force); err != nil {
 		return err
 	}
-	s.daemon.EventsService.Log("tag", utils.ImageReference(repo, tag), "")
 	w.WriteHeader(http.StatusCreated)
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -50,6 +50,7 @@ import (
 	"github.com/docker/docker/pkg/truncindex"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
+	"github.com/docker/docker/utils"
 	volumedrivers "github.com/docker/docker/volume/drivers"
 	"github.com/docker/docker/volume/local"
 	"github.com/docker/docker/volume/store"
@@ -1026,7 +1027,11 @@ func (daemon *Daemon) Graph() *graph.Graph {
 // imageName. If force is true, an existing tag with the same name may be
 // overwritten.
 func (daemon *Daemon) TagImage(repoName, tag, imageName string, force bool) error {
-	return daemon.repositories.Tag(repoName, tag, imageName, force)
+	if err := daemon.repositories.Tag(repoName, tag, imageName, force); err != nil {
+		return err
+	}
+	daemon.EventsService.Log("tag", utils.ImageReference(repoName, tag), "")
+	return nil
 }
 
 // PullImage initiates a pull operation. image is the repository name to pull, and

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -414,13 +414,13 @@ func (s *DockerSuite) TestEventsFilterLabels(c *check.C) {
 func (s *DockerSuite) TestEventsFilterImageLabels(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
-	name := "labelfilterimage"
+	name := "labelfiltertest"
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	_, err := buildImage(name, `
+	_, err := buildImage(name, fmt.Sprintf(`
 		FROM busybox:latest
-		LABEL io.docker.testing=image`, true)
+		LABEL %s`, label), true)
 	if err != nil {
 		c.Fatalf("Couldn't create image: %q", err)
 	}
@@ -437,7 +437,9 @@ func (s *DockerSuite) TestEventsFilterImageLabels(c *check.C) {
 		"--filter", fmt.Sprintf("label=%s", label))
 
 	events := strings.Split(strings.TrimSpace(out), "\n")
-	c.Assert(len(events), checker.Equals, 2, check.Commentf("Events == %s", events))
+
+	// 2 events from the "docker tag" command, another one is from "docker build"
+	c.Assert(len(events), checker.Equals, 3, check.Commentf("Events == %s", events))
 	for _, e := range events {
 		c.Assert(e, checker.Contains, "labelfiltertest")
 	}


### PR DESCRIPTION
Move the event logic to daemon. 
When a new image is built, the builder will call `daemon.TagImage()`, thus the "tag" event will be emitted.
This is useful for cluster systems such as swarm to sync the image state when new images are successfully built.

Signed-off-by: Shijiang Wei mountkin@gmail.com
