### PR TITLE
Increase ping timeout for registries

### DIFF
--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -37,7 +37,7 @@ func (p *v2Puller) Pull(tag string) (fallback bool, err error) {
 	// TODO(tiborvass): was ReceiveTimeout
 	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
-		logrus.Debugf("Error getting v2 registry: %v", err)
+		logrus.Warnf("Error getting v2 registry: %v", err)
 		return true, err
 	}
 

--- a/graph/registry.go
+++ b/graph/registry.go
@@ -57,7 +57,7 @@ func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEnd
 	authTransport := transport.NewTransport(base, modifiers...)
 	pingClient := &http.Client{
 		Transport: authTransport,
-		Timeout:   5 * time.Second,
+		Timeout:   15 * time.Second,
 	}
 	endpointStr := endpoint.URL + "/v2/"
 	req, err := http.NewRequest("GET", endpointStr, nil)


### PR DESCRIPTION
Ensure v2 registries are given more than 5 seconds to return a ping and avoid an unnecessary fallback to v1.

Some v1 only registries may experience the additional 10 second delay if the `/v2` endpoint is not returning a result.
