### PR TITLE
Dockerfile: update busybox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN ln -sv $PWD/contrib/completion/bash/docker /etc/bash_completion.d/docker
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
-	busybox:latest@8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55 \
+	busybox:latest@0064fda8c45ded4e3a4ac6d46e1f0d565697195d905960caabfe0e454f2fdfde \
 	hello-world:frozen@91c95931e552b11604fea91c2f537284149ec32fff0f700a4769cfd31d7696ae \
 	jess/unshare@5c9f6ea50341a2a8eb6677527f2bdedbf331ae894a41714fda770fb130f3314d
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)


### PR DESCRIPTION
The busybox image used for testing is not very current. Notably, it uses an older image in which /run is symlinked to /tmp, rather than it being its own tmpfs. During container initialization, docker follows symbolic links to ensure no breakouts happen and updates the mount path accordingly.

This is an issue for the [Fedora/RHEL releases](https://github.com/projectatomic/docker), which carries a secrets patch. This patch mounts secrets onto `/run/secrets`. However, this causes issues during testing because some tests manipulate `/tmp`, e.g. `TestRunBindMounts`, which mounts `/tmp` as read-only.

More generally, this will be an issue for any test which tries to mount things on `/run` and doesn't expect that to affect `/tmp`. E.g.:

```
$ contrib/download-frozen-image.sh /tmp/busybox \
    busybox:latest@8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55
$ tar -cC '/tmp/busybox' . | docker load
$ mkdir myrundir mytmpdir
$ docker run -v myrundir:/run/myrundir -v mytmpdir:/tmp:ro -d busybox
Error response from daemon: Cannot start container <snip>: [8] System
error: mkdir /var/lib/docker/devicemapper/mnt/<snip>/rootfs/tmp/myrundir:
read-only file system
```

In newer busybox images, `/run` is no longer made a symlink to `/tmp` and thus the issue above does not occur. This patch updates the used busybox image to a more current one (the image id I picked was the latest tag on the hub at the time of writing).

Signed-off-by: Jonathan Lebon jlebon@redhat.com
