### PR TITLE
zsh: enable option stacking

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -38,6 +38,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+# Short-option stacking can be enabled with:
+#  zstyle ':completion:*:*:docker:*' option-stacking yes
+#  zstyle ':completion:*:*:docker-*:*' option-stacking yes
+__docker_arguments() {
+    if zstyle -t ":completion:${curcontext}:" option-stacking; then
+        print -- -s
+    fi
+}
+
 __docker_get_containers() {
     [[ $PREFIX = -* ]] && return 1
     integer ret=1
@@ -244,13 +253,13 @@ __docker_network_subcommand() {
 
     case "$words[1]" in
         (connect|disconnect)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)1:network:__docker_networks" \
                 "($help -)2:containers:__docker_runningcontainers" && ret=0
             ;;
         (create)
-            _arguments -A '-*' \
+            _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
                 "($help -d --driver)"{-d=,--driver=}"[Driver to manage the Network]:driver:(null host bridge overlay)" \
                 "($help)--ipam-driver=[IP Address Management Driver]:driver:(default)" \
@@ -262,18 +271,18 @@ __docker_network_subcommand() {
                 "($help -)1:Network Name: " && ret=0
             ;;
         (inspect|rm)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)*:network:__docker_networks" && ret=0
             ;;
         (ls)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--no-trunc[Do not truncate the output]" \
                 "($help -q --quiet)"{-q,--quiet}"[Only display numeric IDs]" && ret=0
             ;;
         (help)
-            _arguments ":subcommand:__docker_network_commands" && ret=0
+            _arguments $(__docker_arguments) ":subcommand:__docker_network_commands" && ret=0
             ;;
     esac
 
@@ -332,31 +341,31 @@ __docker_volume_subcommand() {
 
     case "$words[1]" in
         (create)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -d --driver)"{-d=,--driver=}"[Specify volume driver name]:Driver name: " \
                 "($help)--name=[Specify volume name]" \
                 "($help)*"{-o=,--opt=}"[Set driver specific options]:Driver option: " && ret=0
             ;;
         (inspect)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --format)"{-f=,--format=}"[Format the output using the given go template]:template: " \
                 "($help -)1:volume:__docker_volumes" && ret=0
             ;;
         (ls)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)*"{-f=,--filter=}"[Provide filter values (i.e. 'dangling=true')]:filter: " \
                 "($help -q --quiet)"{-q,--quiet}"[Only display volume names]" && ret=0
             ;;
         (rm)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -):volume:__docker_volumes" && ret=0
             ;;
         (help)
-            _arguments ":subcommand:__docker_volume_commands" && ret=0
+            _arguments $(__docker_arguments) ":subcommand:__docker_volume_commands" && ret=0
             ;;
     esac
 
@@ -450,14 +459,14 @@ __docker_subcommand() {
 
     case "$words[1]" in
         (attach)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--no-stdin[Do not attach stdin]" \
                 "($help)--sig-proxy[Proxy all received signals to the process (non-TTY mode only)]" \
                 "($help -):containers:__docker_runningcontainers" && ret=0
             ;;
         (build)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 $opts_cpumemlimit \
                 "($help)*--build-arg[Set build-time variables]:<varname>=<value>: " \
@@ -471,7 +480,7 @@ __docker_subcommand() {
                 "($help -):path or URL:_directories" && ret=0
             ;;
         (commit)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --author)"{-a=,--author=}"[Author]:author: " \
                 "($help)*"{-c=,--change=}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
@@ -481,7 +490,7 @@ __docker_subcommand() {
                 "($help -): :__docker_repositories_with_tags" && ret=0
             ;;
         (cp)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)1:container:->container" \
                 "($help -)2:hostpath:_files" && ret=0
@@ -496,7 +505,7 @@ __docker_subcommand() {
             esac
             ;;
         (create)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 $opts_cpumemlimit \
                 $opts_create \
@@ -516,7 +525,7 @@ __docker_subcommand() {
 
             ;;
         (daemon)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--api-cors-header=[Set CORS headers in the remote API]:CORS headers: " \
                 "($help -b --bridge)"{-b=,--bridge=}"[Attach containers to a network bridge]:bridge:_net_interfaces" \
@@ -584,12 +593,12 @@ __docker_subcommand() {
             esac
             ;;
         (diff)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (events)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)*"{-f=,--filter=}"[Filter values]:filter: " \
                 "($help)--since=[Events created since this timestamp]:timestamp: " \
@@ -597,7 +606,7 @@ __docker_subcommand() {
             ;;
         (exec)
             local state
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -d --detach)"{-d,--detach}"[Detached mode: leave the container running in the background]" \
                 "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]" \
@@ -616,13 +625,13 @@ __docker_subcommand() {
             esac
             ;;
         (export)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -o --output)"{-o=,--output=}"[Write to a file, instead of stdout]:output file:_files" \
                 "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (history)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -H --human)"{-H,--human}"[Print sizes and dates in human readable format]" \
                 "($help)--no-trunc[Do not truncate output]" \
@@ -630,7 +639,7 @@ __docker_subcommand() {
                 "($help -)*: :__docker_images" && ret=0
             ;;
         (images)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Show all images]" \
                 "($help)--digest[Show digests]" \
@@ -640,7 +649,7 @@ __docker_subcommand() {
                 "($help -): :__docker_repositories" && ret=0
             ;;
         (import)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)*"{-c=,--change=}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
                 "($help -m --message)"{-m=,--message=}"[Set commit message for imported image]:message: " \
@@ -648,12 +657,12 @@ __docker_subcommand() {
                 "($help -): :__docker_repositories_with_tags" && ret=0
             ;;
         (info|version)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help && ret=0
             ;;
         (inspect)
             local state
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --format)"{-f=,--format=}"[Format the output using the given go template]:template: " \
                 "($help -s --size)"{-s,--size}"[Display total file sizes if the type is container]" \
@@ -673,18 +682,18 @@ __docker_subcommand() {
             esac
             ;;
         (kill)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -s --signal)"{-s=,--signal=}"[Signal to send]:signal:_signals" \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (load)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -i --input)"{-i=,--input=}"[Read from tar archive file]:archive file:_files -g "*.((tar|TAR)(.gz|.GZ|.Z|.bz2|.lzma|.xz|)|(tbz|tgz|txz))(-.)"" && ret=0
             ;;
         (login)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -e --email)"{-e=,--email=}"[Email]:email: " \
                 "($help -p --password)"{-p=,--password=}"[Password]:password: " \
@@ -692,12 +701,12 @@ __docker_subcommand() {
                 "($help -)1:server: " && ret=0
             ;;
         (logout)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)1:server: " && ret=0
             ;;
         (logs)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --follow)"{-f,--follow}"[Follow log output]" \
                 "($help -s --since)"{-s=,--since=}"[Show logs since this timestamp]:timestamp: " \
@@ -707,7 +716,7 @@ __docker_subcommand() {
             ;;
         (network)
             local curcontext="$curcontext" state
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -): :->command" \
                 "($help -)*:: :->option-or-argument" && ret=0
@@ -723,18 +732,18 @@ __docker_subcommand() {
             esac
             ;;
         (pause|unpause)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (port)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)1:containers:__docker_runningcontainers" \
                 "($help -)2:port:_ports" && ret=0
             ;;
         (ps)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Show all containers]" \
                 "($help)--before=[Show only container created before...]:containers:__docker_containers" \
@@ -748,30 +757,30 @@ __docker_subcommand() {
                 "($help)--since=[Show only containers created since...]:containers:__docker_containers" && ret=0
             ;;
         (pull)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all-tags)"{-a,--all-tags}"[Download all tagged images]" \
                 "($help -):name:__docker_search" && ret=0
             ;;
         (push)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -): :__docker_images" && ret=0
             ;;
         (rename)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -):old name:__docker_containers" \
                 "($help -):new name: " && ret=0
             ;;
         (restart|stop)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -t --time)"{-t=,--time=}"[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)" \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (rm)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --force)"{-f,--force}"[Force removal]" \
                 "($help -l --link)"{-l,--link}"[Remove the specified link and not the underlying container]" \
@@ -779,14 +788,14 @@ __docker_subcommand() {
                 "($help -)*:containers:__docker_stoppedcontainers" && ret=0
             ;;
         (rmi)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --force)"{-f,--force}"[Force removal]" \
                 "($help)--no-prune[Do not delete untagged parents]" \
                 "($help -)*: :__docker_images" && ret=0
             ;;
         (run)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 $opts_cpumemlimit \
                 $opts_create \
@@ -810,13 +819,13 @@ __docker_subcommand() {
 
             ;;
         (save)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -o --output)"{-o=,--output=}"[Write to file]:file:_files" \
                 "($help -)*: :__docker_images" && ret=0
             ;;
         (search)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--automated[Only show automated builds]" \
                 "($help)--no-trunc[Do not truncate output]" \
@@ -824,27 +833,27 @@ __docker_subcommand() {
                 "($help -):term: " && ret=0
             ;;
         (start)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --attach)"{-a,--attach}"[Attach container's stdout/stderr and forward all signals]" \
                 "($help -i --interactive)"{-i,--interactive}"[Attach container's stding]" \
                 "($help -)*:containers:__docker_stoppedcontainers" && ret=0
             ;;
         (stats)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--no-stream[Disable streaming stats and only pull the first result]" \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (tag)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --force)"{-f,--force}"[force]"\
                 "($help -):source:__docker_images"\
                 "($help -):destination:__docker_repositories_with_tags" && ret=0
             ;;
         (top)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)1:containers:__docker_runningcontainers" \
                 "($help -)*:: :->ps-arguments" && ret=0
@@ -857,7 +866,7 @@ __docker_subcommand() {
             ;;
         (volume)
             local curcontext="$curcontext" state
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -): :->command" \
                 "($help -)*:: :->option-or-argument" && ret=0
@@ -873,12 +882,12 @@ __docker_subcommand() {
             esac
             ;;
         (wait)
-            _arguments \
+            _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (help)
-            _arguments ":subcommand:__docker_commands" && ret=0
+            _arguments $(__docker_arguments) ":subcommand:__docker_commands" && ret=0
             ;;
     esac
 
@@ -897,7 +906,7 @@ _docker() {
     integer ret=1
     typeset -A opt_args
 
-    _arguments -C \
+    _arguments $(__docker_arguments) -C \
         "(: -)"{-h,--help}"[Print usage]" \
         "($help)--config[Location of client config files]:path:_directories" \
         "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -252,7 +252,7 @@ __docker_network_subcommand() {
         (create)
             _arguments -A '-*' \
                 $opts_help \
-                "($help -d --driver)"{-d,--driver=}"[Driver to manage the Network]:driver:(null host bridge overlay)" \
+                "($help -d --driver)"{-d=,--driver=}"[Driver to manage the Network]:driver:(null host bridge overlay)" \
                 "($help)--ipam-driver=[IP Address Management Driver]:driver:(default)" \
                 "($help)*--subnet=[Subnet in CIDR format that represents a network segment]:IP/mask: " \
                 "($help)*--ip-range=[Allocate container ip from a sub-range]:IP/mask: " \
@@ -334,20 +334,20 @@ __docker_volume_subcommand() {
         (create)
             _arguments \
                 $opts_help \
-                "($help -d --driver)"{-d,--driver=}"[Specify volume driver name]:Driver name: " \
+                "($help -d --driver)"{-d=,--driver=}"[Specify volume driver name]:Driver name: " \
                 "($help)--name=[Specify volume name]" \
-                "($help)*"{-o,--opt=}"[Set driver specific options]:Driver option: " && ret=0
+                "($help)*"{-o=,--opt=}"[Set driver specific options]:Driver option: " && ret=0
             ;;
         (inspect)
             _arguments \
                 $opts_help \
-                "($help -f --format)"{-f,--format=}"[Format the output using the given go template]:template: " \
+                "($help -f --format)"{-f=,--format=}"[Format the output using the given go template]:template: " \
                 "($help -)1:volume:__docker_volumes" && ret=0
             ;;
         (ls)
             _arguments \
                 $opts_help \
-                "($help)*"{-f,--filter=}"[Provide filter values (i.e. 'dangling=true')]:filter: " \
+                "($help)*"{-f=,--filter=}"[Provide filter values (i.e. 'dangling=true')]:filter: " \
                 "($help -q --quiet)"{-q,--quiet}"[Only display volume names]" && ret=0
             ;;
         (rm)
@@ -401,12 +401,12 @@ __docker_subcommand() {
         "($help)--cpu-quota=[Limit the CPU CFS (Completely Fair Scheduler) quota]:CPU quota: "
         "($help)--cpuset-cpus=[CPUs in which to allow execution]:CPUs: "
         "($help)--cpuset-mems=[MEMs in which to allow execution]:MEMs: "
-        "($help -m --memory)"{-m,--memory=}"[Memory limit]:Memory limit: "
+        "($help -m --memory)"{-m=,--memory=}"[Memory limit]:Memory limit: "
         "($help)--memory-swap=[Total memory limit with swap]:Memory limit: "
         "($help)*--ulimit=[ulimit options]:ulimit: "
     )
     opts_create=(
-        "($help -a --attach)"{-a,--attach=}"[Attach to stdin, stdout or stderr]:device:(STDIN STDOUT STDERR)"
+        "($help -a --attach)"{-a=,--attach=}"[Attach to stdin, stdout or stderr]:device:(STDIN STDOUT STDERR)"
         "($help)*--add-host=[Add a custom host-to-IP mapping]:host\:ip mapping: "
         "($help)--blkio-weight=[Block IO (relative weight), between 10 and 1000]:Block IO weight:(10 100 500 1000)"
         "($help)*--cap-add=[Add Linux capabilities]:capability: "
@@ -416,17 +416,17 @@ __docker_subcommand() {
         "($help)*--dns=[Set custom DNS servers]:DNS server: "
         "($help)*--dns-opt=[Set custom DNS options]:DNS option: "
         "($help)*--dns-search=[Set custom DNS search domains]:DNS domains: "
-        "($help)*"{-e,--env=}"[Set environment variables]:environment variable: "
+        "($help)*"{-e=,--env=}"[Set environment variables]:environment variable: "
         "($help)--entrypoint=[Overwrite the default entrypoint of the image]:entry point: "
         "($help)*--env-file=[Read environment variables from a file]:environment file:_files"
         "($help)*--expose=[Expose a port from the container without publishing it]: "
         "($help)*--group-add=[Add additional groups to run as]:group:_groups"
-        "($help -h --hostname)"{-h,--hostname=}"[Container host name]:hostname:_hosts"
+        "($help -h --hostname)"{-h=,--hostname=}"[Container host name]:hostname:_hosts"
         "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]"
         "($help)--ipc=[IPC namespace to use]:IPC namespace: "
         "($help)--kernel-memory[Kernel memory limit in bytes.]:Memory limit: "
         "($help)*--link=[Add link to another container]:link:->link"
-        "($help)*"{-l,--label=}"[Set meta data on a container]:label: "
+        "($help)*"{-l=,--label=}"[Set meta data on a container]:label: "
         "($help)--log-driver=[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd awslogs splunk none)"
         "($help)*--log-opt=[Log driver specific options]:log driver options: "
         "($help)*--lxc-conf=[Add custom lxc options]:lxc options: "
@@ -435,17 +435,17 @@ __docker_subcommand() {
         "($help)--net=[Connect a container to a network]:network mode:(bridge none container host)"
         "($help)--oom-kill-disable[Disable OOM Killer]"
         "($help -P --publish-all)"{-P,--publish-all}"[Publish all exposed ports]"
-        "($help)*"{-p,--publish=}"[Expose a container's port to the host]:port:_ports"
+        "($help)*"{-p=,--publish=}"[Expose a container's port to the host]:port:_ports"
         "($help)--pid=[PID namespace to use]:PID: "
         "($help)--privileged[Give extended privileges to this container]"
         "($help)--read-only[Mount the container's root filesystem as read only]"
         "($help)--restart=[Restart policy]:restart policy:(no on-failure always unless-stopped)"
         "($help)*--security-opt=[Security options]:security option: "
         "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]"
-        "($help -u --user)"{-u,--user=}"[Username or UID]:user:_users"
+        "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users"
         "($help)*-v[Bind mount a volume]:volume: "
         "($help)*--volumes-from=[Mount volumes from the specified container]:volume: "
-        "($help -w --workdir)"{-w,--workdir=}"[Working directory inside the container]:directory:_directories"
+        "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories"
     )
 
     case "$words[1]" in
@@ -461,21 +461,21 @@ __docker_subcommand() {
                 $opts_help \
                 $opts_cpumemlimit \
                 "($help)*--build-arg[Set build-time variables]:<varname>=<value>: " \
-                "($help -f --file)"{-f,--file=}"[Name of the Dockerfile]:Dockerfile:_files" \
+                "($help -f --file)"{-f=,--file=}"[Name of the Dockerfile]:Dockerfile:_files" \
                 "($help)--force-rm[Always remove intermediate containers]" \
                 "($help)--no-cache[Do not use cache when building the image]" \
                 "($help)--pull[Attempt to pull a newer version of the image]" \
                 "($help -q --quiet)"{-q,--quiet}"[Suppress verbose build output]" \
                 "($help)--rm[Remove intermediate containers after a successful build]" \
-                "($help -t --tag)*"{-t,--tag=}"[Repository, name and tag for the image]: :__docker_repositories_with_tags" \
+                "($help -t --tag)*"{-t=,--tag=}"[Repository, name and tag for the image]: :__docker_repositories_with_tags" \
                 "($help -):path or URL:_directories" && ret=0
             ;;
         (commit)
             _arguments \
                 $opts_help \
-                "($help -a --author)"{-a,--author=}"[Author]:author: " \
-                "($help)*"{-c,--change=}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
-                "($help -m --message)"{-m,--message=}"[Commit message]:message: " \
+                "($help -a --author)"{-a=,--author=}"[Author]:author: " \
+                "($help)*"{-c=,--change=}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
+                "($help -m --message)"{-m=,--message=}"[Commit message]:message: " \
                 "($help -p --pause)"{-p,--pause}"[Pause container during commit]" \
                 "($help -):container:__docker_containers" \
                 "($help -): :__docker_repositories_with_tags" && ret=0
@@ -519,7 +519,7 @@ __docker_subcommand() {
             _arguments \
                 $opts_help \
                 "($help)--api-cors-header=[Set CORS headers in the remote API]:CORS headers: " \
-                "($help -b --bridge)"{-b,--bridge=}"[Attach containers to a network bridge]:bridge:_net_interfaces" \
+                "($help -b --bridge)"{-b=,--bridge=}"[Attach containers to a network bridge]:bridge:_net_interfaces" \
                 "($help)--bip=[Specify network bridge IP]" \
                 "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
                 "($help)--default-gateway[Container default gateway IPv4 address]:IPv4 address: " \
@@ -532,14 +532,14 @@ __docker_subcommand() {
                 "($help)*--dns-opt=[DNS options to use]:DNS option: " \
                 "($help)*--default-ulimit=[Set default ulimit settings for containers]:ulimit: " \
                 "($help)--disable-legacy-registry[Do not contact legacy registries]" \
-                "($help -e --exec-driver)"{-e,--exec-driver=}"[Exec driver to use]:driver:(native lxc windows)" \
+                "($help -e --exec-driver)"{-e=,--exec-driver=}"[Exec driver to use]:driver:(native lxc windows)" \
                 "($help)*--exec-opt=[Set exec driver options]:exec driver options: " \
                 "($help)--exec-root=[Root of the Docker execdriver]:path:_directories" \
                 "($help)--fixed-cidr=[IPv4 subnet for fixed IPs]:IPv4 subnet: " \
                 "($help)--fixed-cidr-v6=[IPv6 subnet for fixed IPs]:IPv6 subnet: " \
-                "($help -G --group)"{-G,--group=}"[Group for the unix socket]:group:_groups" \
-                "($help -g --graph)"{-g,--graph=}"[Root of the Docker runtime]:path:_directories" \
-                "($help -H --host)"{-H,--host=}"[tcp://host:port to bind/connect to]:host: " \
+                "($help -G --group)"{-G=,--group=}"[Group for the unix socket]:group:_groups" \
+                "($help -g --graph)"{-g=,--graph=}"[Root of the Docker runtime]:path:_directories" \
+                "($help -H --host)"{-H=,--host=}"[tcp://host:port to bind/connect to]:host: " \
                 "($help)--icc[Enable inter-container communication]" \
                 "($help)*--insecure-registry=[Enable insecure registry communication]:registry: " \
                 "($help)--ip=[Default IP when binding container ports]" \
@@ -547,14 +547,14 @@ __docker_subcommand() {
                 "($help)--ip-masq[Enable IP masquerading]" \
                 "($help)--iptables[Enable addition of iptables rules]" \
                 "($help)--ipv6[Enable IPv6 networking]" \
-                "($help -l --log-level)"{-l,--log-level=}"[Set the logging level]:level:(debug info warn error fatal)" \
+                "($help -l --log-level)"{-l=,--log-level=}"[Set the logging level]:level:(debug info warn error fatal)" \
                 "($help)*--label=[Set key=value labels to the daemon]:label: " \
                 "($help)--log-driver=[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd awslogs splunk none)" \
                 "($help)*--log-opt=[Log driver specific options]:log driver options: " \
                 "($help)--mtu=[Set the containers network MTU]:mtu:(0 576 1420 1500 9000)" \
-                "($help -p --pidfile)"{-p,--pidfile=}"[Path to use for daemon PID file]:PID file:_files" \
+                "($help -p --pidfile)"{-p=,--pidfile=}"[Path to use for daemon PID file]:PID file:_files" \
                 "($help)*--registry-mirror=[Preferred Docker registry mirror]:registry mirror: " \
-                "($help -s --storage-driver)"{-s,--storage-driver=}"[Storage driver to use]:driver:(aufs devicemapper btrfs zfs overlay)" \
+                "($help -s --storage-driver)"{-s=,--storage-driver=}"[Storage driver to use]:driver:(aufs devicemapper btrfs zfs overlay)" \
                 "($help)--selinux-enabled[Enable selinux support]" \
                 "($help)*--storage-opt=[Set storage driver options]:storage driver options: " \
                 "($help)--tls[Use TLS]" \
@@ -591,7 +591,7 @@ __docker_subcommand() {
         (events)
             _arguments \
                 $opts_help \
-                "($help)*"{-f,--filter=}"[Filter values]:filter: " \
+                "($help)*"{-f=,--filter=}"[Filter values]:filter: " \
                 "($help)--since=[Events created since this timestamp]:timestamp: " \
                 "($help)--until=[Events created until this timestamp]:timestamp: " && ret=0
             ;;
@@ -603,7 +603,7 @@ __docker_subcommand() {
                 "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]" \
                 "($help)--privileged[Give extended Linux capabilities to the command]" \
                 "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]" \
-                "($help -u --user)"{-u,--user=}"[Username or UID]:user:_users" \
+                "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users" \
                 "($help -):containers:__docker_runningcontainers" \
                 "($help -)*::command:->anycommand" && ret=0
 
@@ -618,7 +618,7 @@ __docker_subcommand() {
         (export)
             _arguments \
                 $opts_help \
-                "($help -o --output)"{-o,--output=}"[Write to a file, instead of stdout]:output file:_files" \
+                "($help -o --output)"{-o=,--output=}"[Write to a file, instead of stdout]:output file:_files" \
                 "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (history)
@@ -634,7 +634,7 @@ __docker_subcommand() {
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Show all images]" \
                 "($help)--digest[Show digests]" \
-                "($help)*"{-f,--filter=}"[Filter values]:filter: " \
+                "($help)*"{-f=,--filter=}"[Filter values]:filter: " \
                 "($help)--no-trunc[Do not truncate output]" \
                 "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
                 "($help -): :__docker_repositories" && ret=0
@@ -642,8 +642,8 @@ __docker_subcommand() {
         (import)
             _arguments \
                 $opts_help \
-                "($help)*"{-c,--change=}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
-                "($help -m --message)"{-m,--message=}"[Set commit message for imported image]:message: " \
+                "($help)*"{-c=,--change=}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
+                "($help -m --message)"{-m=,--message=}"[Set commit message for imported image]:message: " \
                 "($help -):URL:(- http:// file://)" \
                 "($help -): :__docker_repositories_with_tags" && ret=0
             ;;
@@ -655,7 +655,7 @@ __docker_subcommand() {
             local state
             _arguments \
                 $opts_help \
-                "($help -f --format)"{-f,--format=}"[Format the output using the given go template]:template: " \
+                "($help -f --format)"{-f=,--format=}"[Format the output using the given go template]:template: " \
                 "($help -s --size)"{-s,--size}"[Display total file sizes if the type is container]" \
                 "($help)--type=[Return JSON for specified type]:type:(image container)" \
                 "($help -)*: :->values" && ret=0
@@ -675,20 +675,20 @@ __docker_subcommand() {
         (kill)
             _arguments \
                 $opts_help \
-                "($help -s --signal)"{-s,--signal=}"[Signal to send]:signal:_signals" \
+                "($help -s --signal)"{-s=,--signal=}"[Signal to send]:signal:_signals" \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (load)
             _arguments \
                 $opts_help \
-                "($help -i --input)"{-i,--input=}"[Read from tar archive file]:archive file:_files -g "*.((tar|TAR)(.gz|.GZ|.Z|.bz2|.lzma|.xz|)|(tbz|tgz|txz))(-.)"" && ret=0
+                "($help -i --input)"{-i=,--input=}"[Read from tar archive file]:archive file:_files -g "*.((tar|TAR)(.gz|.GZ|.Z|.bz2|.lzma|.xz|)|(tbz|tgz|txz))(-.)"" && ret=0
             ;;
         (login)
             _arguments \
                 $opts_help \
-                "($help -e --email)"{-e,--email=}"[Email]:email: " \
-                "($help -p --password)"{-p,--password=}"[Password]:password: " \
-                "($help -u --user)"{-u,--user=}"[Username]:username: " \
+                "($help -e --email)"{-e=,--email=}"[Email]:email: " \
+                "($help -p --password)"{-p=,--password=}"[Password]:password: " \
+                "($help -u --user)"{-u=,--user=}"[Username]:username: " \
                 "($help -)1:server: " && ret=0
             ;;
         (logout)
@@ -700,7 +700,7 @@ __docker_subcommand() {
             _arguments \
                 $opts_help \
                 "($help -f --follow)"{-f,--follow}"[Follow log output]" \
-                "($help -s --since)"{-s,--since=}"[Show logs since this timestamp]:timestamp: " \
+                "($help -s --since)"{-s=,--since=}"[Show logs since this timestamp]:timestamp: " \
                 "($help -t --timestamps)"{-t,--timestamps}"[Show timestamps]" \
                 "($help)--tail=[Output the last K lines]:lines:(1 10 20 50 all)" \
                 "($help -)*:containers:__docker_containers" && ret=0
@@ -738,7 +738,7 @@ __docker_subcommand() {
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Show all containers]" \
                 "($help)--before=[Show only container created before...]:containers:__docker_containers" \
-                "($help)*"{-f,--filter=}"[Filter values]:filter: " \
+                "($help)*"{-f=,--filter=}"[Filter values]:filter: " \
                 "($help)--format[Pretty-print containers using a Go template]:format: " \
                 "($help -l --latest)"{-l,--latest}"[Show only the latest created container]" \
                 "($help)-n[Show n last created containers, include non-running one]:n:(1 5 10 25 50)" \
@@ -767,7 +767,7 @@ __docker_subcommand() {
         (restart|stop)
             _arguments \
                 $opts_help \
-                "($help -t --time)"{-t,--time=}"[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)" \
+                "($help -t --time)"{-t=,--time=}"[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)" \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (rm)
@@ -812,7 +812,7 @@ __docker_subcommand() {
         (save)
             _arguments \
                 $opts_help \
-                "($help -o --output)"{-o,--output=}"[Write to file]:file:_files" \
+                "($help -o --output)"{-o=,--output=}"[Write to file]:file:_files" \
                 "($help -)*: :__docker_images" && ret=0
             ;;
         (search)
@@ -820,7 +820,7 @@ __docker_subcommand() {
                 $opts_help \
                 "($help)--automated[Only show automated builds]" \
                 "($help)--no-trunc[Do not truncate output]" \
-                "($help -s --stars)"{-s,--stars=}"[Only display with at least X stars]:stars:(0 10 100 1000)" \
+                "($help -s --stars)"{-s=,--stars=}"[Only display with at least X stars]:stars:(0 10 100 1000)" \
                 "($help -):term: " && ret=0
             ;;
         (start)
@@ -901,8 +901,8 @@ _docker() {
         "(: -)"{-h,--help}"[Print usage]" \
         "($help)--config[Location of client config files]:path:_directories" \
         "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
-        "($help -H --host)"{-H,--host=}"[tcp://host:port to bind/connect to]:host: " \
-        "($help -l --log-level)"{-l,--log-level=}"[Set the logging level]:level:(debug info warn error fatal)" \
+        "($help -H --host)"{-H=,--host=}"[tcp://host:port to bind/connect to]:host: " \
+        "($help -l --log-level)"{-l=,--log-level=}[Set the logging level]:level:(debug info warn error fatal)" \
         "($help)--tls[Use TLS]" \
         "($help)--tlscacert=[Trust certs signed only by this CA]:PEM file:_files -g "*.(pem|crt)"" \
         "($help)--tlscert=[Path to TLS certificate file]:PEM file:_files -g "*.(pem|crt)"" \


### PR DESCRIPTION
The first commit is about enabling short options with arguments to specify their arguments with `=` instead of just space. This is also a prerequisite for the second commit.

The second commit is about stacking short options: `docker run -it ubuntu bash` now works correctly. There is a minor drawback is that Zsh will allow completion of arguments for short options without a space nor an equal: `docker run -uapp<tab>` will complete to `-uapprox`. Therefore, I keep this commit separate in case it needs to be discarded/reverted but I think that its usefulness outweights this flaw.

I have asked for guidance on Zsh mailing list but got no answer yet.

I am adding `-s` even when there is no short option or only one for consistency. When a short option is added to an existing command, the `-s` is already here.

cc @sdurrheimer 
