### PR TITLE
Do not initialize the networking routes when netController is not enabled.

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -170,6 +170,7 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 func (s *Server) InitRouters(d *daemon.Daemon) {
 	s.addRouter(local.NewRouter(d))
 	s.addRouter(network.NewRouter(d))
+
 	for _, srv := range s.servers {
 		srv.srv.Handler = s.CreateMux()
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -17,6 +17,12 @@ const (
 	NetworkByName
 )
 
+// NetworkControllerEnabled checks if the networking stack is enabled.
+// This feature depends on OS primitives and it's dissabled in systems like Windows.
+func (daemon *Daemon) NetworkControllerEnabled() bool {
+	return daemon.netController != nil
+}
+
 // FindNetwork function finds a network for a given string that can represent network name or id
 func (daemon *Daemon) FindNetwork(idName string) (libnetwork.Network, error) {
 	// Find by Name

--- a/errors/server.go
+++ b/errors/server.go
@@ -24,4 +24,13 @@ var (
 		Description:    "The client version is too old for the server",
 		HTTPStatusCode: http.StatusBadRequest,
 	})
+
+	// ErrorNetworkControllerNotEnabled is generated when the networking stack in not enabled
+	// for certain platforms, like windows.
+	ErrorNetworkControllerNotEnabled = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "NETWORK_CONTROLLER_NOT_ENABLED",
+		Message:        "the network controller is not enabled for this platform",
+		Description:    "Docker's networking stack is disabled for this platform",
+		HTTPStatusCode: http.StatusNotFound,
+	})
 )


### PR DESCRIPTION
This will prevent the api from trying to serve network requests in
systems where libnetwork is not enabled, returning 404 responses in any
case.

This is a better fix than #17036 for windows.

Closes #17036.

/cc @jhowardmsft, @mavenugo 

Signed-off-by: David Calavera david.calavera@gmail.com
