### PR TITLE
Bash completion for restart policy `unless-stopped`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1465,7 +1465,7 @@ _docker_run() {
 				on-failure:*)
 					;;
 				*)
-					COMPREPLY=( $( compgen -W "no on-failure on-failure: always" -- "$cur") )
+					COMPREPLY=( $( compgen -W "always no on-failure on-failure: unless-stopped" -- "$cur") )
 					;;
 			esac
 			return


### PR DESCRIPTION
This adds bash completion for `docker run --restart unless-stopped`.
ref: #15348
Thanks @sdurrheimer for the ping.
