### PR TITLE
rename `POST /volumes` to `POST /volumes/create`

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -195,7 +195,7 @@ func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
 		volReq.Name = *flName
 	}
 
-	resp, err := cli.call("POST", "/volumes", volReq, nil)
+	resp, err := cli.call("POST", "/volumes/create", volReq, nil)
 	if err != nil {
 		return err
 	}

--- a/api/server/router/local/local.go
+++ b/api/server/router/local/local.go
@@ -141,7 +141,7 @@ func (r *router) initRoutes() {
 		NewPostRoute("/exec/{name:.*}/start", r.postContainerExecStart),
 		NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
 		NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
-		NewPostRoute("/volumes", r.postVolumesCreate),
+		NewPostRoute("/volumes/create", r.postVolumesCreate),
 		// PUT
 		NewPutRoute("/containers/{name:.*}/archive", r.putContainersArchive),
 		// DELETE

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -304,7 +304,7 @@ type VolumesListResponse struct {
 }
 
 // VolumeCreateRequest contains the response for the remote API:
-// POST "/volumes"
+// POST "/volumes/create"
 type VolumeCreateRequest struct {
 	Name       string            // Name is the requested name of the volume
 	Driver     string            // Driver is the name of the driver that should be used to create the volume

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -100,7 +100,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.21](docker_remote_api_v1.21.md) documentation
 
 * `GET /volumes` lists volumes from all volume drivers.
-* `POST /volumes` to create a volume.
+* `POST /volumes/create` to create a volume.
 * `GET /volumes/(name)` get low-level information about a volume.
 * `DELETE /volumes/(name)`remove a volume with the specified name.
 * `VolumeDriver` has been moved from config to hostConfig to make the configuration portable.

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -2428,13 +2428,13 @@ Status Codes:
 
 ### Create a volume
 
-`POST /volumes`
+`POST /volumes/create`
 
 Create a volume
 
 **Example request**:
 
-  POST /volumes HTTP/1.1
+  POST /volumes/create HTTP/1.1
   Content-Type: application/json
 
   {

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2425,13 +2425,13 @@ Status Codes:
 
 ### Create a volume
 
-`POST /volumes`
+`POST /volumes/create`
 
 Create a volume
 
 **Example request**:
 
-  POST /volumes HTTP/1.1
+  POST /volumes/create HTTP/1.1
   Content-Type: application/json
 
   {

--- a/integration-cli/docker_api_volumes_test.go
+++ b/integration-cli/docker_api_volumes_test.go
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestVolumesApiCreate(c *check.C) {
 	config := types.VolumeCreateRequest{
 		Name: "test",
 	}
-	status, b, err := sockRequest("POST", "/volumes", config)
+	status, b, err := sockRequest("POST", "/volumes/create", config)
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated, check.Commentf(string(b)))
 
@@ -68,7 +68,7 @@ func (s *DockerSuite) TestVolumesApiInspect(c *check.C) {
 	config := types.VolumeCreateRequest{
 		Name: "test",
 	}
-	status, b, err := sockRequest("POST", "/volumes", config)
+	status, b, err := sockRequest("POST", "/volumes/create", config)
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated, check.Commentf(string(b)))
 


### PR DESCRIPTION
rename `POST /volumes` to `POST /volumes/create` to be consistent with the other `POST /.../create` endpoints

Closes #17132

Signed-off-by: Tobias Gesellchen tobias@gesellix.de
