### PR TITLE
deb: add fish completions

### DIFF
--- a/hack/make/.build-deb/docker-engine.install
+++ b/hack/make/.build-deb/docker-engine.install
@@ -3,6 +3,7 @@
 #contrib/syntax/vim/syntax/* /usr/share/vim/vimfiles/syntax/
 contrib/*-integration usr/share/docker-engine/contrib/
 contrib/check-config.sh usr/share/docker-engine/contrib/
+contrib/completion/fish/docker.fish usr/share/fish/vendor_completions.d/
 contrib/completion/zsh/_docker usr/share/zsh/vendor-completions/
 contrib/init/systemd/docker.service lib/systemd/system/
 contrib/init/systemd/docker.socket lib/systemd/system/


### PR DESCRIPTION
This adds the Fish completions to the .deb package.

Relates to https://github.com/docker/docker/issues/16668
