### PR TITLE
bash completion: support for more devicemapper options

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -667,6 +667,8 @@ _docker_daemon() {
 				dm.mountopt
 				dm.override_udev_sync_check
 				dm.thinpooldev
+				dm.use_deferred_deletion
+				dm.use_deferred_removal
 			"
 			local zfs_options="zfs.fsname"
 
@@ -704,16 +706,12 @@ _docker_daemon() {
 
 	case "${words[$cword-2]}$prev=" in
 		# completions for --storage-opt
-		*dm.blkdiscard=*)
+		*dm.@(blkdiscard|override_udev_sync_check|use_deferred_@(removal|deletion))=*)
 			COMPREPLY=( $( compgen -W "false true" -- "${cur#=}" ) )
 			return
 			;;
 		*dm.fs=*)
 			COMPREPLY=( $( compgen -W "ext4 xfs" -- "${cur#=}" ) )
-			return
-			;;
-		*dm.override_udev_sync_check=*)
-			COMPREPLY=( $( compgen -W "false true" -- "${cur#=}" ) )
 			return
 			;;
 		*dm.thinpooldev=*)


### PR DESCRIPTION
This adds completion for the deamon devicemapper storage options
- `dm.use_deferred_deletion`
- `dm.use_deferred_removal`

Ref: #16381
