### PR TITLE
bash completion for new `docker network create` options

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1054,6 +1054,13 @@ _docker_network_connect() {
 
 _docker_network_create() {
 	case "$prev" in
+		--aux-address|--gateway|--ip-range|--opt|-o|--subnet)
+			return
+			;;
+		--ipam-driver)
+			COMPREPLY=( $( compgen -W "default" -- "$cur" ) )
+			return
+			;;
 		--driver|-d)
 			# no need to suggest drivers that allow one instance only
 			# (host, null)
@@ -1064,7 +1071,7 @@ _docker_network_create() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--driver -d --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--aux-address --driver -d --gateway --help --ip-range --ipam-driver --opt -o --subnet" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This adds new options to bash completion for `docker network create`:
`--aux-address`, `--gateway`, `--ip-range`, `--ipam-driver`, `--opt -o`, `--subnet`.

Ref: #16910, #17046.
