### PR TITLE
[Fix 17029] docker cp completion not correct

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -561,9 +561,18 @@ _docker_cp() {
 						return
 						;;
 					*)
+						# combined container and filename completion
+						_filedir
+						local files=( ${COMPREPLY[@]} )
+
 						__docker_containers_all
 						COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
-						__docker_nospace
+						local containers=( ${COMPREPLY[@]} )
+
+						COMPREPLY=( $( compgen -W "${files[*]} ${containers[*]}" -- "$cur" ) )
+						if [[ "$COMPREPLY" == *: ]]; then
+							__docker_nospace
+						fi
 						return
 						;;
 				esac
@@ -571,7 +580,13 @@ _docker_cp() {
 			(( counter++ ))
 
 			if [ $cword -eq $counter ]; then
-				_filedir -d
+				if [ -e "$prev" ]; then
+					__docker_containers_all
+					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
+					__docker_nospace
+				else
+					_filedir
+				fi
 				return
 			fi
 			;;


### PR DESCRIPTION
Ref #17029.

Since 1.8, `docker cp` allows copying files to and from a container. Bash completion only supports copying files out of a container.

This PR changes bash completion to support both ways.

The first argument now completes to a combined list of files and containers.
This is a bit confusing if you complete an empty string, but once you typed a few characters, it becomes pretty obvious.

The second argument is completed to containers if the first argument is an existing local file. If not, it is completed to local files.

ping @jfrazelle @tianon for review
cc @sdurrheimer maybe you can use this too.
