### PR TITLE
devmapper: Drop devices lock before returning from function

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -599,6 +599,7 @@ func (devices *DeviceSet) cleanupDeletedDevices() error {
 
 	// If there are no deleted devices, there is nothing to do.
 	if devices.nrDeletedDevices == 0 {
+		devices.Unlock()
 		return nil
 	}
 

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -5,6 +5,7 @@ package devmapper
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/graphtest"
@@ -77,5 +78,33 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 	}
 	if err := driver.Cleanup(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// Make sure devices.Lock() has been release upon return from cleanupDeletedDevices() function
+func TestDevmapperLockReleasedDeviceDeletion(t *testing.T) {
+	driver := graphtest.GetDriver(t, "devicemapper").(*graphtest.Driver).Driver.(*graphdriver.NaiveDiffDriver).ProtoDriver.(*Driver)
+	defer graphtest.PutDriver(t)
+
+	// Call cleanupDeletedDevices() and after the call take and release
+	// DeviceSet Lock. If lock has not been released, this will hang.
+	driver.DeviceSet.cleanupDeletedDevices()
+
+	doneChan := make(chan bool)
+
+	go func() {
+		driver.DeviceSet.Lock()
+		defer driver.DeviceSet.Unlock()
+		doneChan <- true
+	}()
+
+	select {
+	case <-time.After(time.Second * 5):
+		// Timer expired. That means lock was not released upon
+		// function return and we are deadlocked. Release lock
+		// here so that cleanup could succeed and fail the test.
+		driver.DeviceSet.Unlock()
+		t.Fatalf("Could not acquire devices lock after call to cleanupDeletedDevices()")
+	case <-doneChan:
 	}
 }


### PR DESCRIPTION
cleanupDeleted() takes devices.Lock() but does not drop it if there are
no deleted devices. Hence docker deadlocks if one is using deferred
device deletion feature. (--storage-opt dm.use_deferred_deletion=true).

Fix it. Drop the lock before returning.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
