### PR TITLE
Return empty Config fields, now omitempty, for API < 1.21

### DIFF
--- a/api/types/versions/v1p19/types.go
+++ b/api/types/versions/v1p19/types.go
@@ -3,6 +3,7 @@ package v1p19
 
 import (
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -18,6 +19,10 @@ type ContainerJSON struct {
 // ContainerConfig is a backcompatibility struct for APIs prior to 1.20.
 type ContainerConfig struct {
 	*runconfig.Config
+
+	MacAddress      string
+	NetworkDisabled bool
+	ExposedPorts    map[nat.Port]struct{}
 
 	// backward compatibility, they now live in HostConfig
 	VolumeDriver string

--- a/api/types/versions/v1p20/types.go
+++ b/api/types/versions/v1p20/types.go
@@ -3,6 +3,7 @@ package v1p20
 
 import (
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -16,6 +17,10 @@ type ContainerJSON struct {
 // ContainerConfig is a backcompatibility struct used in ContainerJSON for the API 1.20
 type ContainerConfig struct {
 	*runconfig.Config
+
+	MacAddress      string
+	NetworkDisabled bool
+	ExposedPorts    map[nat.Port]struct{}
 
 	// backward compatibility, they now live in HostConfig
 	VolumeDriver string

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -48,6 +48,9 @@ func (daemon *Daemon) ContainerInspect120(name string) (*v1p20.ContainerJSON, er
 	mountPoints := addMountPoints(container)
 	config := &v1p20.ContainerConfig{
 		container.Config,
+		container.Config.MacAddress,
+		container.Config.NetworkDisabled,
+		container.Config.ExposedPorts,
 		container.hostConfig.VolumeDriver,
 	}
 

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -41,6 +41,9 @@ func (daemon *Daemon) ContainerInspectPre120(name string) (*v1p19.ContainerJSON,
 
 	config := &v1p19.ContainerConfig{
 		container.Config,
+		container.Config.MacAddress,
+		container.Config.NetworkDisabled,
+		container.Config.ExposedPorts,
 		container.hostConfig.VolumeDriver,
 		container.hostConfig.Memory,
 		container.hostConfig.MemorySwap,


### PR DESCRIPTION
- Fix #17131
- Fix #17139
- Fix #17173

Signed-off-by: Antonio Murdaca runcom@redhat.com
