### PR TITLE
Don’t overwrite layer checksum on push

### DIFF
--- a/graph/push_v2.go
+++ b/graph/push_v2.go
@@ -169,15 +169,17 @@ func (p *v2Pusher) pushV2Tag(tag string) error {
 		// if digest was empty or not saved, or if blob does not exist on the remote repository,
 		// then fetch it.
 		if !exists {
-			if pushDigest, err := p.pushV2Image(p.repo.Blobs(context.Background()), layer); err != nil {
+			var pushDigest digest.Digest
+			if pushDigest, err = p.pushV2Image(p.repo.Blobs(context.Background()), layer); err != nil {
 				return err
-			} else if pushDigest != dgst {
+			}
+			if dgst == "" {
 				// Cache new checksum
 				if err := p.graph.SetLayerDigest(layer.ID, pushDigest); err != nil {
 					return err
 				}
-				dgst = pushDigest
 			}
+			dgst = pushDigest
 		}
 
 		// read v1Compatibility config, generate new if needed


### PR DESCRIPTION
After v1.8.3 layer checksum is used for image ID
validation. Rewriting the checksums on push would
mean that next pulls will get different image IDs if
compression returns a different blobsum
and pulls may fail if its detected that same
manifest digest can now point to new image ID.

Fixes #17178

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com

cc @aaronlehmann 
