### PR TITLE
Start container regardless fluentd status.

### DIFF
--- a/docs/reference/logging/fluentd.md
+++ b/docs/reference/logging/fluentd.md
@@ -52,9 +52,6 @@ connects to this daemon through `localhost:24224` by default. Use the
 
     docker run --log-driver=fluentd --log-opt fluentd-address=myhost.local:24224
 
-If container cannot connect to the Fluentd daemon, the container stops
-immediately.
-
 ## Options
 
 Users can use the `--log-opt NAME=VALUE` flag to specify additional Fluentd logging driver options.


### PR DESCRIPTION
Fixes #15757. Even if fluentd is not available we should start container, because problems with logging might affect critical services.

Signed-off-by: Dmitry Vorobev dimahabr@gmail.com
