### PR TITLE
Fail the container start if the network has been removed

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -894,11 +894,7 @@ func (container *Container) allocateNetwork() error {
 
 	for _, n := range settings {
 		if err := container.connectToNetwork(n, updateSettings); err != nil {
-			if updateSettings {
-				return err
-			}
-			// dont fail a container restart case if the user removed the network
-			logrus.Warnf("Could not connect container %s : %v", container.ID, err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
There is no legitimate case to let the container to start even when the network it was originally connected to was removed. Hence failing the container start instead of just a warning log.

fixes #17160

Signed-off-by: Madhu Venugopal madhu@docker.com
