### PR TITLE
Refactor volume store's error usage

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	derr "github.com/docker/docker/errors"
-	"github.com/docker/docker/volume/store"
+	volumestore "github.com/docker/docker/volume/store"
 )
 
 // ContainerRmConfig is a holder for passing in runtime config.
@@ -153,7 +153,7 @@ func (daemon *Daemon) VolumeRm(name string) error {
 		return err
 	}
 	if err := daemon.volumes.Remove(v); err != nil {
-		if err == store.ErrVolumeInUse {
+		if volumestore.IsInUse(err) {
 			return derr.ErrorCodeRmVolumeInUse.WithArgs(err)
 		}
 		return derr.ErrorCodeRmVolume.WithArgs(name, err)

--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	derr "github.com/docker/docker/errors"
-	"github.com/docker/docker/volume/store"
+	volumestore "github.com/docker/docker/volume/store"
 )
 
 func (daemon *Daemon) prepareMountPoints(container *Container) error {
@@ -34,7 +34,7 @@ func (daemon *Daemon) removeMountPoints(container *Container, rm bool) error {
 			// not an error, but an implementation detail.
 			// This prevents docker from logging "ERROR: Volume in use"
 			// where there is another container using the volume.
-			if err != nil && err != store.ErrVolumeInUse {
+			if err != nil && !volumestore.IsInUse(err) {
 				rmErrors = append(rmErrors, err.Error())
 			}
 		}

--- a/volume/store/errors.go
+++ b/volume/store/errors.go
@@ -1,0 +1,58 @@
+package store
+
+import "errors"
+
+var (
+	// errVolumeInUse is a typed error returned when trying to remove a volume that is currently in use by a container
+	errVolumeInUse = errors.New("volume is in use")
+	// errNoSuchVolume is a typed error returned if the requested volume doesn't exist in the volume store
+	errNoSuchVolume = errors.New("no such volume")
+	// errInvalidName is a typed error returned when creating a volume with a name that is not valid on the platform
+	errInvalidName = errors.New("volume name is not valid on this platform")
+)
+
+// OpErr is the error type returned by functions in the store package. It describes
+// the operation, volume name, and error.
+type OpErr struct {
+	// Err is the error that occurred during the operation.
+	Err error
+	// Op is the operation which caused the error, such as "create", or "list".
+	Op string
+	// Name is the name of the resource being requested for this op, typically the volume name or the driver name.
+	Name string
+}
+
+// Error satifies the built-in error interface type.
+func (e *OpErr) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	s := e.Op
+	if e.Name != "" {
+		s = s + " " + e.Name
+	}
+
+	s = s + ": " + e.Err.Error()
+	return s
+}
+
+// IsInUse returns a boolean indicating whether the error indicates that a
+// volume is in use
+func IsInUse(err error) bool {
+	return isErr(err, errVolumeInUse)
+}
+
+// IsNotExist returns a boolean indicating whether the error indicates that the volume does not exist
+func IsNotExist(err error) bool {
+	return isErr(err, errNoSuchVolume)
+}
+
+func isErr(err error, expected error) bool {
+	switch pe := err.(type) {
+	case nil:
+		return false
+	case *OpErr:
+		err = pe.Err
+	}
+	return err == expected
+}


### PR DESCRIPTION
Uses an errors API similar the `net` package.

This is extracted from what was discussed for #16534.
Stops using string comparisons for daemon side error checking from the volume store.
Also will make #16232 simpler to implement.
