### PR TITLE
Checksum the volume name when the data mount point is created in the local driver

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"crypto/md5"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -138,8 +139,9 @@ func TestLoadWithVolume(t *testing.T) {
 	}
 
 	hostVolumeID := stringid.GenerateNonCryptoID()
+	volumeMD5 := fmt.Sprintf("%x", md5.Sum([]byte(hostVolumeID)))
 	vfsPath := filepath.Join(tmp, "vfs", "dir", hostVolumeID)
-	volumePath := filepath.Join(tmp, "volumes", hostVolumeID)
+	volumePath := filepath.Join(tmp, "volumes", volumeMD5)
 
 	if err := os.MkdirAll(vfsPath, 0755); err != nil {
 		t.Fatal(err)
@@ -322,7 +324,8 @@ func TestLoadWithVolume17RC(t *testing.T) {
 	}
 
 	hostVolumeID := "6a3c03fc4a4e588561a543cc3bdd50089e27bd11bbb0e551e19bf735e2514101"
-	volumePath := filepath.Join(tmp, "volumes", hostVolumeID)
+	volumeMD5 := fmt.Sprintf("%x", md5.Sum([]byte(hostVolumeID)))
+	volumePath := filepath.Join(tmp, "volumes", volumeMD5)
 
 	if err := os.MkdirAll(volumePath, 0755); err != nil {
 		t.Fatal(err)
@@ -423,7 +426,8 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 
 	hostVolumeID := stringid.GenerateNonCryptoID()
 	vfsPath := filepath.Join(tmp, "vfs", "dir", hostVolumeID)
-	volumePath := filepath.Join(tmp, "volumes", hostVolumeID)
+	volumeMD5 := fmt.Sprintf("%x", md5.Sum([]byte(hostVolumeID)))
+	volumePath := filepath.Join(tmp, "volumes", volumeMD5)
 
 	if err := os.MkdirAll(vfsPath, 0755); err != nil {
 		t.Fatal(err)

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -76,6 +76,6 @@ func TestInitializeWithVolumes(t *testing.T) {
 	}
 
 	if v.Path() != vol.Path() {
-		t.Fatal("expected to re-initialize root with existing volumes")
+		t.Fatalf("expected to re-initialize root with existing volumes, expected %s, got %s", vol.Path(), v.Path())
 	}
 }


### PR DESCRIPTION
To avoid issues with unexpected volume names, we checksum the user input.
It keeps backwards compatibility by letting paths created before docker 1.9 to
remain as they are.

Closes #16132
Closes #16140

/cc @tiborvass, @thaJeztah

Signed-off-by: David Calavera david.calavera@gmail.com
