### PR TITLE
Handle escaped characters sent by a HTTP client

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -112,11 +112,11 @@ func ParseTCPAddr(tryAddr string, defaultAddr string) (string, error) {
 func ParseRepositoryTag(repos string) (string, string) {
 	// Handle escaped characters sent by a HTTP client.
 	unescapedRepos, err := url.QueryUnescape(repos)
-	
+
 	if err != nil {
 		unescapedRepos = repos
 	}
-	
+
 	n := strings.Index(unescapedRepos, "@")
 	if n >= 0 {
 		parts := strings.Split(unescapedRepos, "@")

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -110,19 +110,26 @@ func ParseTCPAddr(tryAddr string, defaultAddr string) (string, error) {
 //     Ex: localhost.localdomain:5000/samalba/hipache:latest
 //     Digest ex: localhost:5000/foo/bar@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb
 func ParseRepositoryTag(repos string) (string, string) {
-	n := strings.Index(repos, "@")
+	// Handle escaped characters sent by a HTTP client.
+	unescapedRepos, err := url.QueryUnescape(repos)
+	
+	if err != nil {
+		unescapedRepos = repos
+	}
+	
+	n := strings.Index(unescapedRepos, "@")
 	if n >= 0 {
-		parts := strings.Split(repos, "@")
+		parts := strings.Split(unescapedRepos, "@")
 		return parts[0], parts[1]
 	}
-	n = strings.LastIndex(repos, ":")
+	n = strings.LastIndex(unescapedRepos, ":")
 	if n < 0 {
-		return repos, ""
+		return unescapedRepos, ""
 	}
-	if tag := repos[n+1:]; !strings.Contains(tag, "/") {
-		return repos[:n], tag
+	if tag := unescapedRepos[n+1:]; !strings.Contains(tag, "/") {
+		return unescapedRepos[:n], tag
 	}
-	return repos, ""
+	return unescapedRepos, ""
 }
 
 // PartParser parses and validates the specified string (data) using the specified template

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -144,6 +144,12 @@ func TestParseRepositoryTag(t *testing.T) {
 	if repo, tag := ParseRepositoryTag("url:5000/repo:tag"); repo != "url:5000/repo" || tag != "tag" {
 		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "tag", repo, tag)
 	}
+	if repo, tag := ParseRepositoryTag("url%3A5000%2Frepo"); repo != "url:5000/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s' (the scenario with URI encoded characters)", "url:5000/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("url%3A5000%2Frepo%3Atag"); repo != "url:5000/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s' (the scenario with URI encoded characters)", "url:5000/repo", "tag", repo, tag)
+	}
 	if repo, digest := ParseRepositoryTag("url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "url:5000/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
 		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "url:5000/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
 	}


### PR DESCRIPTION
When the request was sent from a HTTP client, the tag value may be escaped. This is to unescape the value first before parse the tag value.

**How to reproduce:**
1. Use docker-py's Client to build an image with a tag like "john/doe".
2. When you run `docker images -a`, you will notice that the new image does not have the tag "john/doe".
