### PR TITLE
Added possibility to use TLS with systemd socket activation

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -49,7 +49,7 @@ clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
 clone git github.com/opencontainers/runc 6c198ae2d065c37f44316e0de3df7f3b88950923 # libcontainer
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
-clone git github.com/coreos/go-systemd v3
+clone git github.com/coreos/go-systemd db045881d426f46e064766fa9f546c3006d0973e
 clone git github.com/godbus/dbus v2
 clone git github.com/syndtr/gocapability 66ef2aa7a23ba682594e2b6f74cf40c0692b49fb
 clone git github.com/golang/protobuf 655cdfa588ea

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -49,7 +49,7 @@ clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
 clone git github.com/opencontainers/runc 6c198ae2d065c37f44316e0de3df7f3b88950923 # libcontainer
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
-clone git github.com/coreos/go-systemd db045881d426f46e064766fa9f546c3006d0973e
+clone git github.com/coreos/go-systemd v4
 clone git github.com/godbus/dbus v2
 clone git github.com/syndtr/gocapability 66ef2aa7a23ba682594e2b6f74cf40c0692b49fb
 clone git github.com/golang/protobuf 655cdfa588ea

--- a/vendor/src/github.com/coreos/go-systemd/activation/listeners.go
+++ b/vendor/src/github.com/coreos/go-systemd/activation/listeners.go
@@ -15,6 +15,7 @@
 package activation
 
 import (
+	"crypto/tls"
 	"net"
 )
 
@@ -34,4 +35,28 @@ func Listeners(unsetEnv bool) ([]net.Listener, error) {
 		}
 	}
 	return listeners, nil
+}
+
+// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
+// passed to this process.
+// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
+func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners(unsetEnv)
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		tlsConfig.NextProtos = []string{"http/1.1"}
+
+		for i, l := range listeners {
+			// Activate TLS only for TCP sockets
+			if l.Addr().Network() == "tcp" {
+				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
 }


### PR DESCRIPTION
Before docker daemon used insecure connection with systemd socket activation even if you specify `--tlsverify` flag. Now it is fixed.
