### PR TITLE
some bugfixes on getting tuf files

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -43,7 +43,7 @@ clone git github.com/docker/distribution 20c4b7a1805a52753dfd593ee1cc35558722a0c
 clone git github.com/vbatts/tar-split v0.9.10
 
 clone git github.com/docker/notary 089d8450d8928aa1c58fd03f09cabbde9bcb4590
-clone git github.com/endophage/gotuf 876c31a61bc4aa0dae09bb8ef3946dc26dd04924
+clone git github.com/endophage/gotuf 2df1c8e0a7b7e10ae2113bf37aaa1bf1c1de8cc5
 clone git github.com/jfrazelle/go 6e461eb70cb4187b41a84e9a567d7137bdbe0f16
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 

--- a/vendor/src/github.com/endophage/gotuf/client/errors.go
+++ b/vendor/src/github.com/endophage/gotuf/client/errors.go
@@ -18,6 +18,14 @@ func (e ErrChecksumMismatch) Error() string {
 	return fmt.Sprintf("tuf: checksum for %s did not match", e.role)
 }
 
+type ErrMissingMeta struct {
+	role string
+}
+
+func (e ErrMissingMeta) Error() string {
+	return fmt.Sprintf("tuf: sha256 checksum required for %s", e.role)
+}
+
 type ErrMissingRemoteMetadata struct {
 	Name string
 }

--- a/vendor/src/github.com/endophage/gotuf/store/httpstore.go
+++ b/vendor/src/github.com/endophage/gotuf/store/httpstore.go
@@ -99,10 +99,6 @@ func (s HTTPStore) GetMeta(name string, size int64) ([]byte, error) {
 	logrus.Debugf("%d when retrieving metadata for %s", resp.StatusCode, name)
 	b := io.LimitReader(resp.Body, size)
 	body, err := ioutil.ReadAll(b)
-	if resp.ContentLength > 0 && int64(len(body)) < resp.ContentLength {
-		return nil, ErrShortRead{}
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/endophage/gotuf/store/memorystore.go
+++ b/vendor/src/github.com/endophage/gotuf/store/memorystore.go
@@ -31,7 +31,15 @@ type memoryStore struct {
 }
 
 func (m *memoryStore) GetMeta(name string, size int64) ([]byte, error) {
-	return m.meta[name], nil
+	d, ok := m.meta[name]
+	if ok {
+		if int64(len(d)) < size {
+			return d, nil
+		}
+		return d[:size], nil
+	} else {
+		return nil, ErrMetaNotFound{}
+	}
 }
 
 func (m *memoryStore) SetMeta(name string, meta []byte) error {


### PR DESCRIPTION
This is backed by a lot of new unit tests in gotuf to confirm the functionality is secure and valid. Original PR to gotuf can be found here: https://github.com/endophage/gotuf/pull/49

Signed-off-by: David Lawrence david.lawrence@docker.com (github: endophage)
