### PR TITLE
cliconfig: Do not rely on platform dependent code

### DIFF
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/homedir"
-	"github.com/docker/docker/pkg/system"
 )
 
 const (
@@ -228,7 +227,7 @@ func (configFile *ConfigFile) Save() error {
 		return fmt.Errorf("Can't save config with empty filename")
 	}
 
-	if err := system.MkdirAll(filepath.Dir(configFile.filename), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configFile.filename), 0700); err != nil {
 		return err
 	}
 	f, err := os.OpenFile(configFile.filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)


### PR DESCRIPTION
The     `github.com/docker/docker/pkg/system` import was only being used to call to os.MkdirAll so it seems unnecessary to pull in all of system/\* when this is all that is necessary. 

Additionally, this was causing problems with attempting to vendor cliconfig using Godeps, as it would only vendor the necessary files based on the platform it's running on, this was seen when vendoring the package on a Mac, and then attempting to build on a Linux box due to `github.com/docker/docker/pkg/units/` not being properly included vendored.
