### PR TITLE
Fixing bootup inconsistencies due to invalid cluster-store config

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork fc6cbea49cd8197c0a8d22b9e8f24f37d9e7b1b8
+clone git github.com/docker/libnetwork 0d7a57ddb94a92a57755eec5dc54f905287c7e65
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4


### PR DESCRIPTION
In scenarios where the cluster-store configuration is invalid or the store is down during daemon bootup, the Get APIs in libnetwork were aggressively failing resulting in failing even the local networks and endpoints. There is no reason to be aggressive when the cluster-store is unreachable especially on the Get All Apis. Hence it also helps in solving a bunch of inconsistency issues for the docker0 bridge as well as tracked in https://github.com/docker/libnetwork/issues/651 also solves a part of https://github.com/docker/docker/issues/17007 .
