### PR TITLE
Do not update etc/hosts file for every container

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -477,8 +477,9 @@ func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint *stringutils.StrSlic
 
 func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID string) (*Container, error) {
 	var (
-		id  string
-		err error
+		id             string
+		err            error
+		noExplicitName = name == ""
 	)
 	id, name, err = daemon.generateIDAndName(name)
 	if err != nil {
@@ -495,7 +496,7 @@ func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID 
 	base.Config = config
 	base.hostConfig = &runconfig.HostConfig{}
 	base.ImageID = imgID
-	base.NetworkSettings = &network.Settings{}
+	base.NetworkSettings = &network.Settings{IsAnonymousEndpoint: noExplicitName}
 	base.Name = name
 	base.Driver = daemon.driver.String()
 	base.ExecDriver = daemon.execDriver.Name()

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -43,4 +43,5 @@ type Settings struct {
 	SandboxKey             string
 	SecondaryIPAddresses   []Address
 	SecondaryIPv6Addresses []Address
+	IsAnonymousEndpoint    bool
 }


### PR DESCRIPTION
For non default network:
- Only containers with a user chosen name will be published in the etc/hosts file of the other containers.
  This behavior is achieved connecting auto-generated name containers to a network via anonymous endpoints. Anonymous endpoints are not published in the network. User named containers are instead connected to the network via regular endpoints, which get published across the network.
- This change does not affect linked containers. Publishing of linked containers will work as today.

Also block linking to containers which are not connected to the default network
