### PR TITLE
Adding note about apparmor install on Ubuntu

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -172,11 +172,13 @@ To upgrade your kernel and install the additional packages, do the following:
 
 5. After your system reboots, go ahead and install Docker.
 
-
+If you are installing on Ubuntu 14.04 or 12.04, `apparmor` is required.  You can install it using: `apt-get install apparmor`
 
 ## Install
 
-Make sure you have installed the prerequisites for your Ubuntu version. Then,
+Make sure you have installed the prerequisites for your Ubuntu version.
+
+Then,
 install Docker using the following:
 
 1. Log into your Ubuntu installation as a user with `sudo` privileges.


### PR DESCRIPTION
This note regarding apparmor installation, allows users who are running Docker on Ubuntu to verify that apparmor  is installed.  There are also instructions on how to install apparmor, if it isn't present on the machine

Reference: Issue##9745

Signed-off-by: Zuhayr Elahi elahi.zuhayr@gmail.com
