### PR TITLE
use syncfs instead of sync

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -460,6 +460,18 @@ func GetBlockDeviceSize(file *os.File) (uint64, error) {
 	return uint64(size), nil
 }
 
+// syncfs syscall available in newer linux kernels (2.6.39)
+// syscall.SYS_SYNCFS = 306
+func syncfs(fd uintptr) (err error) {
+	_, _, e := syscall.Syscall(syscall.SYS_SYNCFS, fd, 0, 0)
+
+	if e != 0 {
+		err = syscall.Errno(e)
+	}
+
+	return
+}
+
 // BlockDeviceDiscard runs discard for the given path.
 // This is used as a workaround for the kernel not discarding block so
 // on the thin pool when we remove a thinp device, so we do it
@@ -482,7 +494,7 @@ func BlockDeviceDiscard(path string) error {
 
 	// Without this sometimes the remove of the device that happens after
 	// discard fails with EBUSY.
-	syscall.Sync()
+	syncfs(file.Fd())
 
 	return nil
 }


### PR DESCRIPTION
When discarding devmapper block device, do sync just on related device,
not on all devices. It could save some time on i/o busy hosts.

I ran into this issue, when running docker on host with multiple disks. Other disks were i/o busy, but docker disk was idle. I still had to wait until kernel commited buffers of all devices.
This patch helped in this scenario.

I am not quite sure, if it also solves the race condition, which is (according to comments in the code) the reason why sync is there in the first place.
