### PR TITLE
docs: Add Netshare volume plugin to extend/plugins

### DIFF
--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -56,6 +56,9 @@ The following plugins exist:
 * The [Keywhiz plugin](https://github.com/calavera/docker-volume-keywhiz) is
   a plugin that provides credentials and secret management using Keywhiz as
   a central repository.
+  
+* The [Netshare plugin](https://github.com/gondor/docker-volume-netshare) is a volume plugin
+  which provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
 
 * The [Pachyderm PFS plugin](https://github.com/pachyderm/pachyderm/tree/master/src/cmd/pfs-volume-driver)
   is a volume plugin written in Go that provides functionality to mount Pachyderm File System (PFS)
@@ -64,9 +67,6 @@ The following plugins exist:
 * The [REX-Ray plugin](https://github.com/emccode/rexraycli) is a volume plugin
   which is written in Go and provides advanced storage functionality for many
   platforms including EC2, OpenStack, XtremIO, and ScaleIO.
-
-* The [Netshare plugin](https://github.com/gondor/docker-volume-netshare) is a volume plugin
-  which provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
 
 ## Troubleshooting a plugin
 

--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -56,9 +56,9 @@ The following plugins exist:
 * The [Keywhiz plugin](https://github.com/calavera/docker-volume-keywhiz) is
   a plugin that provides credentials and secret management using Keywhiz as
   a central repository.
-  
+
 * The [Netshare plugin](https://github.com/gondor/docker-volume-netshare) is a volume plugin
-  which provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
+  that provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
 
 * The [Pachyderm PFS plugin](https://github.com/pachyderm/pachyderm/tree/master/src/cmd/pfs-volume-driver)
   is a volume plugin written in Go that provides functionality to mount Pachyderm File System (PFS)

--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -65,6 +65,9 @@ The following plugins exist:
   which is written in Go and provides advanced storage functionality for many
   platforms including EC2, OpenStack, XtremIO, and ScaleIO.
 
+* The [Netshare plugin](https://github.com/gondor/docker-volume-netshare) is a volume plugin
+  which provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
+
 ## Troubleshooting a plugin
 
 If you are having problems with Docker after loading a plugin, ask the authors


### PR DESCRIPTION
This change adds the Netshare plugin to the documentation for extending/plugins (https://docs.docker.com/extend/plugins/)

A little background - Netshare is a docker volume plugin written in Go which adds support for NFS, EFS and CIFS file systems which can be directly mounted into a docker container.  

Signed-off-by: Jeremy Unruh jeremybunruh@gmail.com
