### PR TITLE
Wire up libnetwork with TLS discovery options

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -341,6 +341,9 @@ func (daemon *Daemon) networkOptions(dconfig *Config) ([]nwconfig.Option, error)
 		options = append(options, nwconfig.OptionKVProvider(kv[0]))
 		options = append(options, nwconfig.OptionKVProviderURL(strings.Join(kv[1:], "://")))
 	}
+	if len(dconfig.ClusterOpts) > 0 {
+		options = append(options, nwconfig.OptionKVOpts(dconfig.ClusterOpts))
+	}
 
 	if daemon.discoveryWatcher != nil {
 		options = append(options, nwconfig.OptionDiscoveryWatcher(daemon.discoveryWatcher))


### PR DESCRIPTION
This change exposes the TLS configuration settings to libnetwork so it can
communicate with a key/value store that has been set up with mutual TLS.

TLS options were introduced with https://github.com/docker/docker/pull/16644
Libnetwork support was introduced with https://github.com/docker/libnetwork/pull/602

Signed-off-by: Daniel Hiltgen daniel.hiltgen@docker.com
