### PR TITLE
remove the unused DefaultNetwork member from daemon.Config

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -14,25 +14,24 @@ const (
 // CommonConfig defines the configuration of a docker daemon which are
 // common across platforms.
 type CommonConfig struct {
-	AutoRestart    bool
-	Bridge         bridgeConfig // Bridge holds bridge network specific configuration.
-	Context        map[string][]string
-	DisableBridge  bool
-	DNS            []string
-	DNSOptions     []string
-	DNSSearch      []string
-	ExecOptions    []string
-	ExecRoot       string
-	GraphDriver    string
-	GraphOptions   []string
-	Labels         []string
-	LogConfig      runconfig.LogConfig
-	Mtu            int
-	Pidfile        string
-	RemappedRoot   string
-	Root           string
-	TrustKeyPath   string
-	DefaultNetwork string
+	AutoRestart   bool
+	Bridge        bridgeConfig // Bridge holds bridge network specific configuration.
+	Context       map[string][]string
+	DisableBridge bool
+	DNS           []string
+	DNSOptions    []string
+	DNSSearch     []string
+	ExecOptions   []string
+	ExecRoot      string
+	GraphDriver   string
+	GraphOptions  []string
+	Labels        []string
+	LogConfig     runconfig.LogConfig
+	Mtu           int
+	Pidfile       string
+	RemappedRoot  string
+	Root          string
+	TrustKeyPath  string
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
 	// multihost networking (to store networks and endpoints information) and by the node discovery

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -554,7 +554,6 @@ func TestNetworkOptions(t *testing.T) {
 	daemon := &Daemon{}
 	dconfigCorrect := &Config{
 		CommonConfig: CommonConfig{
-			DefaultNetwork:   "netPlugin:mynet:dev",
 			ClusterStore:     "consul://localhost:8500",
 			ClusterAdvertise: "192.168.0.1:8000",
 		},

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -313,19 +313,10 @@ func (daemon *Daemon) networkOptions(dconfig *Config) ([]nwconfig.Option, error)
 
 	options = append(options, nwconfig.OptionDataDir(dconfig.Root))
 
-	if strings.TrimSpace(dconfig.DefaultNetwork) != "" {
-		dn := strings.Split(dconfig.DefaultNetwork, ":")
-		if len(dn) < 2 {
-			return nil, fmt.Errorf("default network daemon config must be of the form NETWORKDRIVER:NETWORKNAME")
-		}
-		options = append(options, nwconfig.OptionDefaultDriver(dn[0]))
-		options = append(options, nwconfig.OptionDefaultNetwork(strings.Join(dn[1:], ":")))
-	} else {
-		dd := runconfig.DefaultDaemonNetworkMode()
-		dn := runconfig.DefaultDaemonNetworkMode().NetworkName()
-		options = append(options, nwconfig.OptionDefaultDriver(string(dd)))
-		options = append(options, nwconfig.OptionDefaultNetwork(dn))
-	}
+	dd := runconfig.DefaultDaemonNetworkMode()
+	dn := runconfig.DefaultDaemonNetworkMode().NetworkName()
+	options = append(options, nwconfig.OptionDefaultDriver(string(dd)))
+	options = append(options, nwconfig.OptionDefaultNetwork(dn))
 
 	if strings.TrimSpace(dconfig.ClusterStore) != "" {
 		kv := strings.Split(dconfig.ClusterStore, "://")


### PR DESCRIPTION
The `DefaultNetwork` in the daemon config is not used.
The default network is hard coded at https://github.com/docker/docker/blob/master/runconfig/hostconfig_unix.go#L22 and then passed to libnetwork via the `OptionDefaultNetwork` config helper in the `libnetwork/config` package.

I think if we want to make the default network configurable in the future, we can add a new command to docker, say, `docker network config --default=bridge`.
For now I think the unused code can be safely removed.
