### PR TITLE
bash completion for `docker network inspect` supports multiple networks

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1101,11 +1101,7 @@ _docker_network_inspect() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_networks
-			fi
-			;;
+			__docker_networks
 	esac
 }
 


### PR DESCRIPTION
ref. #17218, #17023
ping @jfrazelle, @tianon for review
ping @sdurrheimer does #17218 affect zsh completion as well?
