### PR TITLE
bash completion can be configured to complete network IDs

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -17,6 +17,13 @@
 #
 # Configuration:
 #
+# For several commands, the amount of completions can be configured by
+# setting environment variables.
+#
+# DOCKER_COMPLETION_SHOW_NETWORK_IDS
+#   "false" - Show names only (default)
+#   "true"  - Show names and ids
+#
 # You can tailor completion for the "events", "history", "inspect", "run",
 # "rmi" and "save" commands by settings the following environment
 # variables:
@@ -139,7 +146,12 @@ __docker_containers_and_images() {
 }
 
 __docker_networks() {
-	COMPREPLY=( $(compgen -W "$(__docker_q network ls | awk 'NR>1 {print $2}')" -- "$cur") )
+	# By default, only network names are completed.
+	# Set DOCKER_COMPLETION_SHOW_NETWORK_IDS=true to also complete network IDs.
+	local fields='$2'
+	[ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS}" = true ] && fields='$1,$2'
+	local networks=$(__docker_q network ls --no-trunc | awk "NR>1 {print $fields}")
+	COMPREPLY=( $(compgen -W "$networks" -- "$cur") )
 }
 
 __docker_volumes() {


### PR DESCRIPTION
The addition of network IDs was requested by @mrjana in https://github.com/docker/docker/pull/16922#discussion_r41795952. This implementation lets you choose whether you want to have network IDs completed or not.

The concept of configurable bash completion was introduced by @pugnascotia in #15332.
With DOCKER_COMPLETION_SHOW_IMAGE_IDS for several commands you can control whether completion includes all image IDs, intermediate IDs only or no IDs at all.

This PR introduces another environment variable that allows you to configure if you want to have IDs included in your network completions. The default is to not include them. This is consistent with the default settings from #15332.

ping @jfrazelle, @tianon for review
