### PR TITLE
More Rules for AppArmor

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -14,6 +14,9 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   mount -> /proc/**,
   mount -> /sys/**,
   mount -> /run/docker/netns/**,
+  mount -> /.pivot_root[0-9]*/,
+
+  / r,
 
   umount,
   pivot_root,
@@ -29,6 +32,7 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   @{DOCKER_GRAPH_PATH}/** rwl,
   @{DOCKER_GRAPH_PATH}/linkgraph.db k,
   @{DOCKER_GRAPH_PATH}/network/files/boltdb.db k,
+  @{DOCKER_GRAPH_PATH}/network/files/local-kv.db k,
 
   # For non-root client use:
   /dev/urandom r,


### PR DESCRIPTION
This patch addresses the following AppArmor complains:

type=AVC msg=audit(1445537397.873:547): apparmor="ALLOWED" operation="mount"
  info="failed srcname match" error=-13 profile="/usr/bin/docker"
  name="/.pivot_root602836504/" pid=11512 comm="exe" flags="rw, rprivate"

type=AVC msg=audit(1445537265.325:502): apparmor="ALLOWED"
  operation="file_lock" profile="/usr/bin/docker"
  name="/var/lib/docker/network/files/local-kv.db" pid=9574 comm="docker"
  requested_mask="k" denied_mask="k" fsuid=0 ouid=0

on Linux 3.19.0-25 also the following complain appears:

type=AVC msg=audit(1445538195.510:1658): apparmor="ALLOWED" operation="open"
  profile="/usr/bin/docker" name="/" pid=9505 comm="docker"
  requested_mask="r" denied_mask="r" fsuid=0 ouid=0

Signed-off-by: Stefan Berger stefanb@linux.vnet.ibm.com
