### PR TITLE
Turn off discovery when icc == false

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -777,7 +777,7 @@ func (container *Container) updateNetwork() error {
 	return nil
 }
 
-func (container *Container) buildCreateEndpointOptions() ([]libnetwork.EndpointOption, error) {
+func (container *Container) buildCreateEndpointOptions(n libnetwork.Network) ([]libnetwork.EndpointOption, error) {
 	var (
 		portSpecs     = make(nat.PortSet)
 		bindings      = make(nat.PortMap)
@@ -853,6 +853,10 @@ func (container *Container) buildCreateEndpointOptions() ([]libnetwork.EndpointO
 		}
 
 		createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
+	}
+
+	if n.Name() == "bridge" && !container.daemon.config().Bridge.InterContainerCommunication {
+		createOptions = append(createOptions, libnetwork.CreateOptionAnonymous())
 	}
 
 	return createOptions, nil
@@ -944,7 +948,7 @@ func (container *Container) connectToNetwork(idOrName string, updateSettings boo
 		return err
 	}
 
-	createOptions, err := container.buildCreateEndpointOptions()
+	createOptions, err := container.buildCreateEndpointOptions(n)
 	if err != nil {
 		return err
 	}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 0d7a57ddb94a92a57755eec5dc54f905287c7e65
+clone git github.com/docker/libnetwork f3c8ebf46b890d4612c5d98e792280d13abdb761
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -384,3 +384,80 @@ func (s *DockerNetworkSuite) TestDockerNetworkDriverOptions(c *check.C) {
 	dockerCmd(c, "network", "rm", "testopt")
 
 }
+
+func (s *DockerDaemonSuite) TestDockerNetworkDiscoveryICCFalse(c *check.C) {
+	// When icc == false, containers' etc/hosts should not be populated with containers' names
+	hostsFile := "/etc/hosts"
+	bridgeName := "external-bridge"
+	bridgeIP := "192.169.255.254/24"
+	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	defer deleteInterface(c, bridgeName)
+
+	err = s.d.StartWithBusybox("--bridge", bridgeName, "--icc=false")
+	c.Assert(err, check.IsNil)
+	defer s.d.Restart()
+
+	// run two containers and store first container's etc/hosts content
+	out, err = s.d.Cmd("run", "-d", "busybox", "top")
+	c.Assert(err, check.IsNil)
+	cid1 := strings.TrimSpace(out)
+	defer s.d.Cmd("stop", cid1)
+
+	hosts, err := s.d.Cmd("exec", cid1, "cat", hostsFile)
+	c.Assert(err, checker.IsNil)
+
+	out, err = s.d.Cmd("run", "-d", "busybox", "top")
+	c.Assert(err, check.IsNil)
+	cid2 := strings.TrimSpace(out)
+
+	// verify first container's etc/hosts file has not changed after spawning second container
+	hostsPost, err := s.d.Cmd("exec", cid1, "cat", hostsFile)
+	c.Assert(err, checker.IsNil)
+	c.Assert(string(hosts), checker.Equals, string(hostsPost),
+		check.Commentf("Unexpected %s change on second container creation", hostsFile))
+
+	// stop container 2 and verify first container's etc/hosts has not changed
+	_, err = s.d.Cmd("stop", cid2)
+	c.Assert(err, check.IsNil)
+
+	hostsPost, err = s.d.Cmd("exec", cid1, "cat", hostsFile)
+	c.Assert(err, checker.IsNil)
+	c.Assert(string(hosts), checker.Equals, string(hostsPost),
+		check.Commentf("Unexpected %s change on second container creation", hostsFile))
+
+	// but discovery is on when connecting to non default bridge network
+	network := "anotherbridge"
+	out, err = s.d.Cmd("network", "create", network)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	defer s.d.Cmd("network", "rm", network)
+
+	out, err = s.d.Cmd("network", "connect", network, cid1)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+
+	hostsPost, err = s.d.Cmd("exec", cid1, "cat", hostsFile)
+	c.Assert(err, checker.IsNil)
+	c.Assert(string(hosts), checker.Equals, string(hostsPost),
+		check.Commentf("Unexpected %s change on second network connection", hostsFile))
+
+	cName := "container3"
+	out, err = s.d.Cmd("run", "-d", "--net", network, "--name", cName, "busybox", "top")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	cid3 := strings.TrimSpace(out)
+	defer s.d.Cmd("stop", cid3)
+
+	// container1 etc/hosts file should contain an entry for the third container
+	hostsPost, err = s.d.Cmd("exec", cid1, "cat", hostsFile)
+	c.Assert(err, checker.IsNil)
+	c.Assert(string(hostsPost), checker.Contains, cName,
+		check.Commentf("Container 1  %s file does not contain entries for named container %q: %s", hostsFile, cName, string(hostsPost)))
+
+	// on container3 disconnect, first container's etc/hosts should go back to original form
+	out, err = s.d.Cmd("network", "disconnect", network, cid3)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+
+	hostsPost, err = s.d.Cmd("exec", cid1, "cat", hostsFile)
+	c.Assert(err, checker.IsNil)
+	c.Assert(string(hosts), checker.Equals, string(hostsPost),
+		check.Commentf("Unexpected %s content after disconnecting from second network", hostsFile))
+}

--- a/vendor/src/github.com/docker/libnetwork/network.go
+++ b/vendor/src/github.com/docker/libnetwork/network.go
@@ -753,6 +753,10 @@ func (n *network) EndpointByID(id string) (Endpoint, error) {
 }
 
 func (n *network) updateSvcRecord(ep *endpoint, localEps []*endpoint, isAdd bool) {
+	if ep.isAnonymous() {
+		return
+	}
+
 	c := n.getController()
 	sr, ok := c.svcDb[n.ID()]
 	if !ok {


### PR DESCRIPTION
- This patch is to fix an issue which unveiled during design review of #17230: libnetwork built-in host discovery should not kick in when daemon icc flag is false
