### PR TITLE
Vendoring libnetwork & libkv with fixes

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -26,7 +26,7 @@ clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4
 clone git github.com/hashicorp/serf 7151adcef72687bf95f451a2e0ba15cb19412bf2
-clone git github.com/docker/libkv 749af6c5b3fb755bec1738cc5e0d3a6f1574d730
+clone git github.com/docker/libkv c2aac5dbbaa5c872211edea7c0f32b3bd67e7410
 clone git github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 clone git github.com/vishvananda/netlink 4b5dce31de6d42af5bb9811c6d265472199e0fec
 clone git github.com/BurntSushi/toml f706d00e3de6abe700c994cdd545a1a4915af060

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork f3c8ebf46b890d4612c5d98e792280d13abdb761
+clone git github.com/docker/libnetwork bf041154d27ed34ed39722328c8f1b0144a56fe2
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -794,6 +794,26 @@ func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidr(c *check.C) {
 	}
 }
 
+func (s *DockerDaemonSuite) TestDaemonBridgeFixedCidrFixedCIDREqualBridgeNetwork(c *check.C) {
+	d := s.d
+
+	bridgeName := "external-bridge"
+	bridgeIP := "172.27.42.1/16"
+
+	out, err := createInterface(c, "bridge", bridgeName, bridgeIP)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	defer deleteInterface(c, bridgeName)
+
+	err = d.StartWithBusybox("--bridge", bridgeName, "--fixed-cidr", bridgeIP)
+	c.Assert(err, check.IsNil)
+	defer s.d.Restart()
+
+	out, err = d.Cmd("run", "-d", "busybox", "top")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	cid1 := strings.TrimSpace(out)
+	defer d.Cmd("stop", cid1)
+}
+
 func (s *DockerDaemonSuite) TestDaemonDefaultGatewayIPv4Implicit(c *check.C) {
 	defaultNetworkBridge := "docker0"
 	deleteInterface(c, defaultNetworkBridge)

--- a/vendor/src/github.com/docker/libkv/store/boltdb/boltdb.go
+++ b/vendor/src/github.com/docker/libkv/store/boltdb/boltdb.go
@@ -330,6 +330,9 @@ func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 		}
 
 		val = bucket.Get([]byte(key))
+		if val == nil {
+			return store.ErrKeyNotFound
+		}
 		dbIndex := binary.LittleEndian.Uint64(val[:libkvmetadatalen])
 		if dbIndex != previous.LastIndex {
 			return store.ErrKeyModified

--- a/vendor/src/github.com/docker/libkv/store/consul/consul.go
+++ b/vendor/src/github.com/docker/libkv/store/consul/consul.go
@@ -467,6 +467,13 @@ func (s *Consul) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 	}
 
 	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex}
+
+	// Extra Get operation to check on the key
+	_, err := s.Get(key)
+	if err != nil && err == store.ErrKeyNotFound {
+		return false, err
+	}
+
 	if work, _, err := s.client.KV().DeleteCAS(p, nil); err != nil {
 		return false, err
 	} else if !work {

--- a/vendor/src/github.com/docker/libkv/store/etcd/etcd.go
+++ b/vendor/src/github.com/docker/libkv/store/etcd/etcd.go
@@ -368,6 +368,10 @@ func (s *Etcd) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
 	_, err := s.client.Delete(context.Background(), s.normalize(key), delOpts)
 	if err != nil {
 		if etcdError, ok := err.(etcd.Error); ok {
+			// Key Not Found
+			if etcdError.Code == etcd.ErrorCodeKeyNotFound {
+				return false, store.ErrKeyNotFound
+			}
 			// Compare failed
 			if etcdError.Code == etcd.ErrorCodeTestFailed {
 				return false, store.ErrKeyModified

--- a/vendor/src/github.com/docker/libkv/store/zookeeper/zookeeper.go
+++ b/vendor/src/github.com/docker/libkv/store/zookeeper/zookeeper.go
@@ -347,9 +347,15 @@ func (s *Zookeeper) AtomicDelete(key string, previous *store.KVPair) (bool, erro
 
 	err := s.client.Delete(s.normalize(key), int32(previous.LastIndex))
 	if err != nil {
+		// Key not found
+		if err == zk.ErrNoNode {
+			return false, store.ErrKeyNotFound
+		}
+		// Compare failed
 		if err == zk.ErrBadVersion {
 			return false, store.ErrKeyModified
 		}
+		// General store error
 		return false, err
 	}
 	return true, nil

--- a/vendor/src/github.com/docker/libnetwork/controller.go
+++ b/vendor/src/github.com/docker/libnetwork/controller.go
@@ -218,7 +218,14 @@ func (c *controller) initDiscovery(watcher discovery.Watcher) error {
 	}
 
 	c.discovery = hostdiscovery.NewHostDiscovery(watcher)
-	return c.discovery.Watch(c.hostJoinCallback, c.hostLeaveCallback)
+	return c.discovery.Watch(c.activeCallback, c.hostJoinCallback, c.hostLeaveCallback)
+}
+
+func (c *controller) activeCallback() {
+	ds := c.getStore(datastore.GlobalScope)
+	if ds != nil && !ds.Active() {
+		ds.RestartWatch()
+	}
 }
 
 func (c *controller) hostJoinCallback(nodes []net.IP) {

--- a/vendor/src/github.com/docker/libnetwork/hostdiscovery/hostdiscovery_api.go
+++ b/vendor/src/github.com/docker/libnetwork/hostdiscovery/hostdiscovery_api.go
@@ -5,13 +5,16 @@ import "net"
 // JoinCallback provides a callback event for new node joining the cluster
 type JoinCallback func(entries []net.IP)
 
+// ActiveCallback provides a callback event for active discovery event
+type ActiveCallback func()
+
 // LeaveCallback provides a callback event for node leaving the cluster
 type LeaveCallback func(entries []net.IP)
 
 // HostDiscovery primary interface
 type HostDiscovery interface {
 	//Watch Node join and leave cluster events
-	Watch(joinCallback JoinCallback, leaveCallback LeaveCallback) error
+	Watch(activeCallback ActiveCallback, joinCallback JoinCallback, leaveCallback LeaveCallback) error
 	// StopDiscovery stops the discovery perocess
 	StopDiscovery() error
 	// Fetch returns a list of host IPs that are currently discovered

--- a/vendor/src/github.com/docker/libnetwork/ipam/allocator.go
+++ b/vendor/src/github.com/docker/libnetwork/ipam/allocator.go
@@ -250,11 +250,6 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 	ones, bits := pool.Mask.Size()
 	numAddresses := uint64(1 << uint(bits-ones))
 
-	if ipVer == v4 {
-		// Do not let broadcast address be reserved
-		numAddresses--
-	}
-
 	// Allow /64 subnet
 	if ipVer == v6 && numAddresses == 0 {
 		numAddresses--
@@ -269,6 +264,11 @@ func (a *Allocator) insertBitMask(key SubnetKey, pool *net.IPNet) error {
 	// Do not let network identifier address be reserved
 	// Do the same for IPv6 so that bridge ip starts with XXXX...::1
 	h.Set(0)
+
+	// Do not let broadcast address be reserved
+	if ipVer == v4 {
+		h.Set(numAddresses - 1)
+	}
 
 	a.Lock()
 	a.addresses[key] = h

--- a/vendor/src/github.com/docker/libnetwork/ipams/remote/remote.go
+++ b/vendor/src/github.com/docker/libnetwork/ipams/remote/remote.go
@@ -78,7 +78,11 @@ func (a *allocator) ReleasePool(poolID string) error {
 
 // RequestAddress requests an address from the address pool
 func (a *allocator) RequestAddress(poolID string, address net.IP, options map[string]string) (*net.IPNet, map[string]string, error) {
-	var prefAddress string
+	var (
+		prefAddress string
+		retAddress  *net.IPNet
+		err         error
+	)
 	if address != nil {
 		prefAddress = address.String()
 	}
@@ -87,7 +91,9 @@ func (a *allocator) RequestAddress(poolID string, address net.IP, options map[st
 	if err := a.call("RequestAddress", req, res); err != nil {
 		return nil, nil, err
 	}
-	retAddress, err := types.ParseCIDR(res.Address)
+	if res.Address != "" {
+		retAddress, err = types.ParseCIDR(res.Address)
+	}
 	return retAddress, res.Data, err
 }
 

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -182,6 +182,10 @@ func (sb *sandbox) Delete() error {
 		}
 	}
 
+	// Container is going away. Path cache in etchosts is most
+	// likely not required any more. Drop it.
+	etchosts.Drop(sb.config.hostsPath)
+
 	if sb.osSbox != nil {
 		sb.osSbox.Destroy()
 	}

--- a/vendor/src/github.com/docker/libnetwork/store.go
+++ b/vendor/src/github.com/docker/libnetwork/store.go
@@ -308,6 +308,11 @@ func (c *controller) processEndpointCreate(nmap map[string]*netWatch, ep *endpoi
 
 		c.Lock()
 		nw.localEps[ep.ID()] = ep
+
+		// If we had learned that from the kv store remove it
+		// from remote ep list now that we know that this is
+		// indeed a local endpoint
+		delete(nw.remoteEps, ep.ID())
 		c.Unlock()
 		return
 	}


### PR DESCRIPTION
Addresses a few issues 
- Internal racy /etc/hosts updates within container during SD as reported in #17190
- Renable SD service record watch after cluster-store restarts
- Fix to allow remote IPAM driver to return no IP if the user prefers 
- Fix to allow --fixed-cidr and --bip to be in same range (fixes #17276)
- Vendored in libkv that resolves a AtomicDelete issue with a missing Key.
