### PR TITLE
Patch for Plugin drivers in docker info 

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -44,6 +44,19 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	}
 	ioutils.FprintfIfNotEmpty(cli.out, "Execution Driver: %s\n", info.ExecutionDriver)
 	ioutils.FprintfIfNotEmpty(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
+
+	fmt.Fprintf(cli.out, "Plugins: \n")
+	fmt.Fprintf(cli.out, " Volume:")
+	for _, driver := range info.Plugins.Volume {
+		fmt.Fprintf(cli.out, " %s", driver)
+	}
+	fmt.Fprintf(cli.out, "\n")
+	fmt.Fprintf(cli.out, " Network:")
+	for _, driver := range info.Plugins.Network {
+		fmt.Fprintf(cli.out, " %s", driver)
+	}
+	fmt.Fprintf(cli.out, "\n")
+
 	ioutils.FprintfIfNotEmpty(cli.out, "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
 	fmt.Fprintf(cli.out, "CPUs: %d\n", info.NCPU)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -188,6 +188,7 @@ type Info struct {
 	Images             int
 	Driver             string
 	DriverStatus       [][2]string
+	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
@@ -223,6 +224,15 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
+}
+
+// PluginsInfo is temp struct holds Plugins name
+// registered with docker daemon. It used by Info struct
+type PluginsInfo struct {
+	// List of Volume plugins registered
+	Volume []string
+	// List of Network plugins registered
+	Network []string
 }
 
 // ExecStartCheck is a temp struct used by execStart

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
+	"github.com/docker/docker/volume/drivers"
 )
 
 // SystemInfo returns information about the host server the daemon is running on.
@@ -62,6 +63,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		Images:             len(daemon.Graph().Map()),
 		Driver:             daemon.GraphDriver().String(),
 		DriverStatus:       daemon.GraphDriver().Status(),
+		Plugins:            daemon.showPluginsInfo(),
 		IPv4Forwarding:     !sysInfo.IPv4ForwardingDisabled,
 		BridgeNfIptables:   !sysInfo.BridgeNfCallIptablesDisabled,
 		BridgeNfIP6tables:  !sysInfo.BridgeNfCallIP6tablesDisabled,
@@ -110,4 +112,17 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	}
 
 	return v, nil
+}
+
+func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
+	var pluginsInfo types.PluginsInfo
+
+	pluginsInfo.Volume = volumedrivers.GetDriverList()
+
+	networkDriverList := daemon.GetNetworkDriverList()
+	for nd := range networkDriverList {
+		pluginsInfo.Network = append(pluginsInfo.Network, nd)
+	}
+
+	return pluginsInfo
 }

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -146,3 +146,19 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 	}
 	return container.DisconnectFromNetwork(network)
 }
+
+// GetNetworkDriverList returns the list of plugins drivers
+// registered for network.
+func (daemon *Daemon) GetNetworkDriverList() map[string]bool {
+	pluginList := make(map[string]bool)
+
+	c := daemon.netController
+	networks := c.Networks()
+
+	for _, network := range networks {
+		driver := network.Type()
+		pluginList[driver] = true
+	}
+
+	return pluginList
+}

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1891,6 +1891,16 @@ Display system-wide information
         "DockerRootDir": "/var/lib/docker",
         "Driver": "btrfs",
         "DriverStatus": [[""]],
+	"Plugins": {
+		"Volume": [
+			"local"
+		],
+		"Network": [
+			"null",
+			"host",
+			"bridge"
+		]
+	},
         "ExecutionDriver": "native-0.1",
         "ExperimentalBuild": false,
         "HttpProxy": "http://test:test@localhost:8080",

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -25,6 +25,8 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Total Memory:",
 		"Kernel Version:",
 		"Storage Driver:",
+		"Volume:",
+		"Network:",
 	}
 
 	if utils.ExperimentalBuild() {

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -39,6 +39,9 @@ Here is a sample output:
      Dirs: 80
     Execution Driver: native-0.2
     Logging Driver: json-file
+    Plugins:
+     Volume: local
+     Network: bridge null host
     Kernel Version: 3.13.0-24-generic
     Operating System: Ubuntu 14.04 LTS
     CPUs: 1

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -106,3 +106,13 @@ func GetDriver(name string) (volume.Driver, error) {
 	}
 	return Lookup(name)
 }
+
+// GetDriverList returns list of volume drivers registered.
+// If no driver is registered, empty string list will be returned.
+func GetDriverList() []string {
+	var driverList []string
+	for driverName := range drivers.extensions {
+		driverList = append(driverList, driverName)
+	}
+	return driverList
+}


### PR DESCRIPTION
Supported added for retrieving Plugin list for Network and Volume.
Also, plugin information in docker info output. https://github.com/docker/docker/issues/16205

Signed-off-by: Kunal Kushwaha kushwaha_kunal_v7@lab.ntt.co.jp
