### PR TITLE
Remove unused parmeter of createRootFilesystemInDriver in graph/graph.go

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -327,7 +327,7 @@ func (graph *Graph) register(im image.Descriptor, layerData io.Reader) (err erro
 	parent := im.Parent()
 
 	// Create root filesystem in the driver
-	if err := createRootFilesystemInDriver(graph, imgID, parent, layerData); err != nil {
+	if err := createRootFilesystemInDriver(graph, imgID, parent); err != nil {
 		return err
 	}
 
@@ -353,7 +353,7 @@ func (graph *Graph) register(im image.Descriptor, layerData io.Reader) (err erro
 	return nil
 }
 
-func createRootFilesystemInDriver(graph *Graph, id, parent string, layerData io.Reader) error {
+func createRootFilesystemInDriver(graph *Graph, id, parent string) error {
 	if err := graph.driver.Create(id, parent); err != nil {
 		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", graph.driver, id, err)
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Parameter `layerData io.Reader` is never used in func `createRootFilesystemInDriver`
