### PR TITLE
Test that the graphdriver actually works on init

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -675,6 +675,15 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	if err != nil {
 		return nil, fmt.Errorf("error initializing graphdriver: %v", err)
 	}
+	// make sure the graphdriver actually works as configured
+	// often if there is an unknown backingfs or dangling mounts from an improperly shutdown daemon there can be issues
+	logrus.Debugf("testing graph driver initialization")
+	if err := testGraphDriver(driver); err != nil {
+		driver.Cleanup()
+		logrus.Debugf("Graph Driver Status: %v", driver.Status())
+		return nil, fmt.Errorf("error testing graphdriver: %v", err)
+	}
+
 	logrus.Debugf("Using graph driver %s", driver)
 
 	d := &Daemon{}
@@ -1356,4 +1365,29 @@ func convertLnNetworkStats(name string, stats *lntypes.InterfaceStatistics) *lib
 	n.TxErrors = stats.TxErrors
 	n.TxDropped = stats.TxDropped
 	return n
+}
+
+// testGraphDriver will create 2 new empty graph layers (parent/child), mount them, then remove
+// if there is an error in any step of the way an error will be returned
+func testGraphDriver(driver graphdriver.Driver) error {
+	parentID := stringid.GenerateNonCryptoID()
+	if err := driver.Create(parentID, ""); err != nil {
+		return err
+	}
+	defer driver.Remove(parentID)
+
+	testID := stringid.GenerateNonCryptoID()
+	if err := driver.Create(testID, parentID); err != nil {
+		return err
+	}
+	defer driver.Remove(testID)
+
+	if _, err := driver.Get(testID, ""); err != nil {
+		return err
+	}
+
+	if err := driver.Put(testID); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Lots of people have issues because they use docker, for instance, on xfs+overlay, which is currently unsupported but is being fixed in the kernel.
Other people are on FS's that we weren't able to detect but didn't fail
out on, sometimes this works sometimes it doesn't.

Other times there are some dangling mounts left from an unclean shutdown
which cause errors when starting a container.

This patch checks that the graphdriver is actually able to create and
use a graphdriver layer and causes the daemon init to fail if not.
Otherwise the daemon will start up, but container creation/starting will
fail.
