### PR TITLE
Add IPAM Config Options to match libnetwork

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -40,12 +40,14 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 	flIpamIPRange := opts.NewListOpts(nil)
 	flIpamGateway := opts.NewListOpts(nil)
 	flIpamAux := opts.NewMapOpts(nil, nil)
+	flIpamOpt := opts.NewMapOpts(nil, nil)
 
 	cmd.Var(&flIpamSubnet, []string{"-subnet"}, "subnet in CIDR format that represents a network segment")
 	cmd.Var(&flIpamIPRange, []string{"-ip-range"}, "allocate container ip from a sub-range")
 	cmd.Var(&flIpamGateway, []string{"-gateway"}, "ipv4 or ipv6 Gateway for the master subnet")
 	cmd.Var(flIpamAux, []string{"-aux-address"}, "auxiliary ipv4 or ipv6 addresses used by Network driver")
 	cmd.Var(flOpts, []string{"o", "-opt"}, "set driver specific options")
+	cmd.Var(flIpamOpt, []string{"-ipam-opt"}, "set IPAM driver specific options")
 
 	flInternal := cmd.Bool([]string{"-internal"}, false, "restricts external access to the network")
 
@@ -71,7 +73,7 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 	nc := types.NetworkCreate{
 		Name:           cmd.Arg(0),
 		Driver:         driver,
-		IPAM:           network.IPAM{Driver: *flIpamDriver, Config: ipamCfg},
+		IPAM:           network.IPAM{Driver: *flIpamDriver, Config: ipamCfg, Options: flIpamOpt.GetAll()},
 		Options:        flOpts.GetAll(),
 		CheckDuplicate: true,
 		Internal:       *flInternal,

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -182,9 +182,11 @@ func buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {
 }
 
 func buildIpamResources(r *types.NetworkResource, nw libnetwork.Network) {
-	id, _, ipv4conf, ipv6conf := nw.Info().IpamConfig()
+	id, opts, ipv4conf, ipv6conf := nw.Info().IpamConfig()
 
 	r.IPAM.Driver = id
+
+	r.IPAM.Options = opts
 
 	r.IPAM.Config = []network.IPAMConfig{}
 	for _, ip4 := range ipv4conf {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -114,7 +114,7 @@ func (daemon *Daemon) CreateNetwork(name, driver string, ipam network.IPAM, opti
 		return nil, err
 	}
 
-	nwOptions = append(nwOptions, libnetwork.NetworkOptionIpam(ipam.Driver, "", v4Conf, v6Conf, nil))
+	nwOptions = append(nwOptions, libnetwork.NetworkOptionIpam(ipam.Driver, "", v4Conf, v6Conf, ipam.Options))
 	nwOptions = append(nwOptions, libnetwork.NetworkOptionDriverOpts(options))
 	if internal {
 		nwOptions = append(nwOptions, libnetwork.NetworkOptionInternalNetwork())

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -117,6 +117,10 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /networks/create` now supports restricting external access to the network by setting the `internal` field.
 * `POST /networks/(id)/disconnect` now includes a `Force` option to forcefully disconnect a container from network
 * `GET /containers/(id)/json` now returns the `NetworkID` of containers.
+* `POST /networks/create` Now supports an options field in the IPAM config that provides options 
+  for custom IPAM plugins.
+* `GET /networks/{network-id}` Now returns IPAM config options for custom IPAM plugins if any
+  are available.
 
 ### v1.21 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2956,7 +2956,10 @@ Content-Type: application/json
       {
         "Subnet": "172.17.0.0/16"
       }
-    ]
+    ],
+    "Options": {
+        "foo": "bar"
+    }
   },
   "Containers": {
     "39b69226f9d79f5634485fb236a23b2fe4e96a0a94128390a7fbbcc167065867": {
@@ -3003,7 +3006,10 @@ Content-Type: application/json
       "Subnet":"172.20.0.0/16",
       "IPRange":"172.20.10.0/24",
       "Gateway":"172.20.10.11"
-    }]
+    }],
+    "Options": {
+        "foo": "bar"
+    }
   },
   "Internal":true
 }

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -22,6 +22,7 @@ parent = "smn_cli"
     --ip-range=[]            Allocate container ip from a sub-range
     --ipam-driver=default    IP Address Management Driver
     -o --opt=map[]           Set custom network plugin options
+    --ipam-opt=map[]         Set custom IPAM plugin options
     --subnet=[]              Subnet in CIDR format that represents a network segment
 
 Creates a new network. The `DRIVER` accepts `bridge` or `overlay` which are the

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -523,6 +523,18 @@ func (s *DockerNetworkSuite) TestDockerNetworkCustomIpam(c *check.C) {
 	assertNwNotAvailable(c, "br0")
 }
 
+func (s *DockerNetworkSuite) TestDockerNetworkIpamOptions(c *check.C) {
+	// Create a bridge network using custom ipam driver and options
+	dockerCmd(c, "network", "create", "--ipam-driver", dummyIpamDriver, "--ipam-opt", "opt1=drv1", "--ipam-opt", "opt2=drv2", "br0")
+	assertNwIsAvailable(c, "br0")
+
+	// Verify expected network ipam options
+	nr := getNetworkResource(c, "br0")
+	opts := nr.IPAM.Options
+	c.Assert(opts["opt1"], checker.Equals, "drv1")
+	c.Assert(opts["opt2"], checker.Equals, "drv2")
+}
+
 func (s *DockerNetworkSuite) TestDockerNetworkInspect(c *check.C) {
 	// if unspecified, network gateway will be selected from inside preferred pool
 	dockerCmd(c, "network", "create", "--driver=bridge", "--subnet=172.28.0.0/16", "--ip-range=172.28.5.0/24", "--gateway=172.28.5.254", "br0")

--- a/man/docker-network-create.1.md
+++ b/man/docker-network-create.1.md
@@ -13,6 +13,7 @@ docker-network-create - create a new network
 [**--internal**]
 [**--ip-range**=*[]*]
 [**--ipam-driver**=*default*]
+[**--ipam-opt**=*map[]*]
 [**-o**|**--opt**=*map[]*]
 [**--subnet**=*[]*]
 NETWORK-NAME
@@ -147,6 +148,9 @@ If you want to create an externally isolated `overlay` network, you can specify 
 
 **--ipam-driver**=*default*
   IP Address Management Driver
+
+**--ipam-opt**=map[]
+  Set custom IPAM plugin options
 
 **-o**, **--opt**=map[]
   Set custom network plugin options


### PR DESCRIPTION
This should allow docker to pass through ipam config driver options to libnetwork.

~~I can't get my docker development environment working so I can't test this but it seems like it should work without breaking anything.~~ Fully tested and works with the API. Still needs discussion on how to implement on the cli.

Signed-off-by: Ryan Belgrave rmb1993@gmail.com
