### PR TITLE
Update docker network inspect help syntax

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -184,10 +184,9 @@ func (cli *DockerCli) CmdNetworkLs(args ...string) error {
 
 // CmdNetworkInspect inspects the network object for more details
 //
-// Usage: docker network inspect <NETWORK> [<NETWORK>]
-// CmdNetworkInspect handles Network inspect UI
+// Usage: docker network inspect [OPTIONS] <NETWORK> [NETWORK...]
 func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
-	cmd := Cli.Subcmd("network inspect", []string{"NETWORK"}, "Displays detailed information on a network", false)
+	cmd := Cli.Subcmd("network inspect", []string{"NETWORK [NETWORK...]"}, "Displays detailed information on a network", false)
 	cmd.Require(flag.Min, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {


### PR DESCRIPTION
Closes  #17318 🐹. Missed that when adding support of multiple network in inspect :sweat:.
Thanks @moxiegirl :wink: 

``` bash
$ docker network inspect --help
docker network inspect [OPTIONS] NETWORK [NETWORK...]
```

Removed duplicate `golint` comment.

Signed-off-by: Vincent Demeester vincent@sbr.pm
