### PR TITLE
apt-cacher-ng example: add dockerhost explanation

### DIFF
--- a/docs/examples/apt-cacher-ng.md
+++ b/docs/examples/apt-cacher-ng.md
@@ -64,10 +64,10 @@ three things
 
 Where **dockerhost** can be:
 1. The Docker host IP that can be obtained:
-1.1. On the Docker host machine ````ip route|awk '/default/ { print  $3}')```` 
-1.2. Via docker-machine ````docker-machine ssh DOCKER_MACHINE_NAME ip route|awk '/default/ { print  $3}'````
+1.1. On the Docker host machine `ip route|awk '/default/ { print  $3}')` 
+1.2. Via docker-machine `docker-machine ssh DOCKER_MACHINE_NAME ip route|awk '/default/ { print  $3}'`
 2. The test_apt_cacher_ng container IP that can be obtained:
-2.1. ````docker inspect --format '{{ .NetworkSettings.IPAddress }}'````
+2.1. `docker inspect --format '{{ .NetworkSettings.IPAddress }}'`
 
 **Option 1** injects the settings safely into your apt configuration in
 a local version of a common base:

--- a/docs/examples/apt-cacher-ng.md
+++ b/docs/examples/apt-cacher-ng.md
@@ -62,6 +62,13 @@ three things
 3. Change your `sources.list` entries to start with
    `http://dockerhost:3142/`
 
+Where **dockerhost** can be:
+1. The Docker host IP that can be obtained:
+1.1. On the Docker host machine ````ip route|awk '/default/ { print  $3}')```` 
+1.2. Via docker-machine ````docker-machine ssh DOCKER_MACHINE_NAME ip route|awk '/default/ { print  $3}'````
+2. The test_apt_cacher_ng container IP that can be obtained:
+2.1. ````docker inspect --format '{{ .NetworkSettings.IPAddress }}'````
+
 **Option 1** injects the settings safely into your apt configuration in
 a local version of a common base:
 


### PR DESCRIPTION
Added a few lines to explain how to get the dockerhost IP.

Maybe it should be better to explain how to make it resolve?
