### PR TITLE
Move image builder logic out of the api.

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -43,10 +43,18 @@ var BuiltinAllowedBuildArgs = map[string]bool{
 	"no_proxy":    true,
 }
 
+// RepoAndTag is a helper struct for holding the parsed repositories and tags of
+// the input "t" argument.
+type RepoAndTag struct {
+	Repo, Tag string
+}
+
 // Config constitutes the configuration for a Dockerfile builder.
 type Config struct {
 	// only used if Dockerfile has to be extracted from Context
 	DockerfileName string
+	RemoteURL      string
+	ReposAndTags   []RepoAndTag
 
 	Verbose     bool
 	UseCache    bool

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -269,17 +269,12 @@ func (b *Builder) download(srcURL string) (fi builder.FileInfo, err error) {
 		return
 	}
 
+	formattedOut := b.Stdout.(*streamformatter.StdoutFormattedWriter)
+
+	progress := progressreader.NewReaderWithFormatter(formattedOut, resp.Body, resp.ContentLength, true, "", "Downloading")
+
 	// Download and dump result to tmp file
-	if _, err = io.Copy(tmpFile, progressreader.New(progressreader.Config{
-		In: resp.Body,
-		// TODO: make progressreader streamformatter agnostic
-		Out:       b.Stdout.(*streamformatter.StdoutFormatter).Writer,
-		Formatter: b.Stdout.(*streamformatter.StdoutFormatter).StreamFormatter,
-		Size:      resp.ContentLength,
-		NewLines:  true,
-		ID:        "",
-		Action:    "Downloading",
-	})); err != nil {
+	if _, err = io.Copy(tmpFile, progress); err != nil {
 		tmpFile.Close()
 		return
 	}

--- a/daemon/daemonbuilder/image_build.go
+++ b/daemon/daemonbuilder/image_build.go
@@ -1,0 +1,96 @@
+package daemonbuilder
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/builder"
+	"github.com/docker/docker/builder/dockerfile"
+	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/chrootarchive"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/utils"
+)
+
+// BuildImage uses the docker daemon to build and tag images.
+// It detects the dockerfile supplied based on the remoteURL in the configuration.
+// When that URL is not supplied, it assumes the body is a tar file and it's extracted on the host.
+func BuildImage(daemon *daemon.Daemon, buildConfig *dockerfile.Config, authConfigs map[string]cliconfig.AuthConfig, bodyReader io.ReadCloser, respWriter io.Writer, size int64) error {
+	respFlusher := ioutils.NewWriteFlusher(respWriter)
+	defer respFlusher.Close()
+
+	context, dockerfileName, err := detectContextFromRemoteURL(bodyReader, respFlusher, buildConfig.RemoteURL, size)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := context.Close(); err != nil {
+			logrus.Debugf("[BUILDER] failed to remove temporary context: %v", err)
+		}
+	}()
+
+	uidMaps, gidMaps := daemon.GetUIDGIDMaps()
+	defaultArchiver := &archive.Archiver{
+		Untar:   chrootarchive.Untar,
+		UIDMaps: uidMaps,
+		GIDMaps: gidMaps,
+	}
+
+	docker := Docker{daemon, respFlusher, authConfigs, defaultArchiver}
+
+	b, err := dockerfile.NewBuilder(buildConfig, docker, builder.DockerIgnoreContext{context}, nil)
+	if err != nil {
+		return err
+	}
+	formattedOut := streamformatter.NewStdoutJSONFormattedWriter(respFlusher)
+
+	b.Stdout = formattedOut
+	b.Stderr = streamformatter.NewStderrJSONFormattedWriter(respFlusher)
+
+	if closeNotifier, ok := respWriter.(http.CloseNotifier); ok {
+		finished := make(chan struct{})
+		defer close(finished)
+		go func() {
+			select {
+			case <-finished:
+			case <-closeNotifier.CloseNotify():
+				logrus.Info("Client disconnected, cancelling job: build")
+				b.Cancel()
+			}
+		}()
+	}
+
+	if len(dockerfileName) > 0 {
+		b.DockerfileName = dockerfileName
+	}
+
+	imgID, err := b.Build()
+	if err != nil {
+		if !respFlusher.Flushed() {
+			return err
+		}
+
+		fErr := errors.New(utils.GetErrorMessage(err))
+		formattedOut.WriteError(fErr)
+		return nil
+	}
+
+	for _, r := range buildConfig.ReposAndTags {
+		if err := daemon.TagImage(r.Repo, r.Tag, imgID, true); err != nil {
+			if !respFlusher.Flushed() {
+				return err
+			}
+
+			fErr := errors.New(utils.GetErrorMessage(err))
+			formattedOut.WriteError(fErr)
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -364,7 +364,7 @@ func createRootFilesystemInDriver(graph *Graph, id, parent string) error {
 // TempLayerArchive creates a temporary archive of the given image's filesystem layer.
 //   The archive is stored on disk and will be automatically deleted as soon as has been read.
 //   If output is not nil, a human-readable progress bar will be written to it.
-func (graph *Graph) TempLayerArchive(id string, sf *streamformatter.StreamFormatter, output io.Writer) (*archive.TempArchive, error) {
+func (graph *Graph) TempLayerArchive(id string, output *streamformatter.StdoutFormattedWriter) (*archive.TempArchive, error) {
 	image, err := graph.Get(id)
 	if err != nil {
 		return nil, err
@@ -378,15 +378,7 @@ func (graph *Graph) TempLayerArchive(id string, sf *streamformatter.StreamFormat
 	if err != nil {
 		return nil, err
 	}
-	progressReader := progressreader.New(progressreader.Config{
-		In:        a,
-		Out:       output,
-		Formatter: sf,
-		Size:      0,
-		NewLines:  false,
-		ID:        stringid.TruncateID(id),
-		Action:    "Buffering to disk",
-	})
+	progressReader := progressreader.NewReaderWithFormatter(output, a, 0, false, stringid.TruncateID(id), "Buffering to disk")
 	defer progressReader.Close()
 	return archive.NewTempArchive(progressReader, tmp)
 }

--- a/pkg/progressreader/progressreader_test.go
+++ b/pkg/progressreader/progressreader_test.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
-
-	"github.com/docker/docker/pkg/streamformatter"
 )
 
 func TestOutputOnPrematureClose(t *testing.T) {
@@ -16,16 +14,7 @@ func TestOutputOnPrematureClose(t *testing.T) {
 	reader := ioutil.NopCloser(bytes.NewReader(content))
 	writer := bufio.NewWriter(&outBuf)
 
-	prCfg := Config{
-		In:        reader,
-		Out:       writer,
-		Formatter: streamformatter.NewStreamFormatter(),
-		Size:      int64(len(content)),
-		NewLines:  true,
-		ID:        "Test",
-		Action:    "Read",
-	}
-	pr := New(prCfg)
+	pr := NewReader(writer, reader, int64(len(content)), true, "Test", "Read")
 
 	part := make([]byte, 4, 4)
 	_, err := io.ReadFull(pr, part)
@@ -56,16 +45,7 @@ func TestCompleteSilently(t *testing.T) {
 	reader := ioutil.NopCloser(bytes.NewReader(content))
 	writer := bufio.NewWriter(&outBuf)
 
-	prCfg := Config{
-		In:        reader,
-		Out:       writer,
-		Formatter: streamformatter.NewStreamFormatter(),
-		Size:      int64(len(content)),
-		NewLines:  true,
-		ID:        "Test",
-		Action:    "Read",
-	}
-	pr := New(prCfg)
+	pr := NewReader(writer, reader, int64(len(content)), true, "Test", "Read")
 
 	out, err := ioutil.ReadAll(pr)
 	if err != nil {


### PR DESCRIPTION
- Refactor a bunch of duplicated logic to remove streamformatter
  initializations and injections.
- Refactor progressreader to use a streamformatter directly rather than
  keeping refereces to the output writer and the formatter.
- Move logic coupled in the api to the daemonbuilder.

@tiborvass you're either going to :scream: or :heart: this. :raised_hands: 

/cc @MHBauer 

Signed-off-by: David Calavera david.calavera@gmail.com
