### PR TITLE
Update `network inspect` usage

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -184,10 +184,10 @@ func (cli *DockerCli) CmdNetworkLs(args ...string) error {
 
 // CmdNetworkInspect inspects the network object for more details
 //
-// Usage: docker network inspect <NETWORK> [<NETWORK>]
+// Usage: docker network inspect [OPTIONS] NETWORK [NETWORK...]
 // CmdNetworkInspect handles Network inspect UI
 func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
-	cmd := Cli.Subcmd("network inspect", []string{"NETWORK"}, "Displays detailed information on a network", false)
+	cmd := Cli.Subcmd("network inspect", []string{"NETWORK [NETWORK...]"}, "Displays detailed information on a network", false)
 	cmd.Require(flag.Min, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {


### PR DESCRIPTION
As `network inspect` command can accept multiple networks now, the command
line usage should be updated accordingly.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

Related PR: #17218

original `docker network inspect` usage:

```
$ docker network inspect --help

Usage:  docker network inspect [OPTIONS] NETWORK
```

After applying this fix:

```
$ docker network inspect --help

Usage:  docker network inspect [OPTIONS] NETWORK [NETWORK...]
```

It's a small nit, I believe that you probably have forgotten it. @vdemeester  :smile:  
