### PR TITLE
Change dockerhost to test_apt_cacher_ng

### DIFF
--- a/docs/examples/apt-cacher-ng.md
+++ b/docs/examples/apt-cacher-ng.md
@@ -28,7 +28,7 @@ Use the following Dockerfile:
     # Run: docker run -d -p 3142:3142 --name apt-cacher-run apt-cacher
     #
     # and then you can run containers with:
-    #   docker run -t -i --rm -e http_proxy http://dockerhost:3142/ debian bash
+    #   docker run -t -i --rm -e http_proxy http://test_apt_cacher_ng:3142/ debian bash
     #
     FROM        ubuntu
     MAINTAINER  SvenDowideit@docker.com
@@ -56,17 +56,17 @@ To get your Debian-based containers to use the proxy, you can do one of
 three things
 
 1. Add an apt Proxy setting
-   `echo 'Acquire::http { Proxy "http://dockerhost:3142"; };' >> /etc/apt/conf.d/01proxy`
+   `echo 'Acquire::http { Proxy "http://test_apt_cacher_ng:3142"; };' >> /etc/apt/conf.d/01proxy`
 2. Set an environment variable:
-   `http_proxy=http://dockerhost:3142/`
+   `http_proxy=http://test_apt_cacher_ng:3142/`
 3. Change your `sources.list` entries to start with
-   `http://dockerhost:3142/`
+   `http://test_apt_cacher_ng:3142/`
 
 **Option 1** injects the settings safely into your apt configuration in
 a local version of a common base:
 
     FROM ubuntu
-    RUN  echo 'Acquire::http { Proxy "http://dockerhost:3142"; };' >> /etc/apt/apt.conf.d/01proxy
+    RUN  echo 'Acquire::http { Proxy "http://test_apt_cacher_ng:3142"; };' >> /etc/apt/apt.conf.d/01proxy
     RUN apt-get update && apt-get install -y vim git
 
     # docker build -t my_ubuntu .
@@ -74,7 +74,7 @@ a local version of a common base:
 **Option 2** is good for testing, but will break other HTTP clients
 which obey `http_proxy`, such as `curl`, `wget` and others:
 
-    $ docker run --rm -t -i -e http_proxy=http://dockerhost:3142/ debian bash
+    $ docker run --rm -t -i -e http_proxy=http://test_apt_cacher_ng:3142/ debian bash
 
 **Option 3** is the least portable, but there will be times when you
 might need to do it and you can do it from your `Dockerfile`


### PR DESCRIPTION
Signed-off-by: Thomas Decaux ebuildy@gmail.com

---

In the example, "dockerhost" is nothing, instead *\* test_apt_cacher_ng*\* resolves to the apt-cacher container.
