### PR TITLE
Better daemon log on docker load

### DIFF
--- a/graph/load.go
+++ b/graph/load.go
@@ -125,8 +125,10 @@ func (s *TagStore) recursiveLoad(address, tmpImageDir string) error {
 		if err := s.graph.Register(v1Descriptor{img}, layer); err != nil {
 			return err
 		}
+		logrus.Debugf("Completed processing %s", address)
+		return nil
 	}
-	logrus.Debugf("Completed processing %s", address)
+	logrus.Debugf("already loaded %s", address)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Minor change, just make the log more clear, the previous log is a bit of confused, `Completed processing %s` could show twice for some layer.
for example when I do `docker load -i ubuntu.tar` the daemon log is  

<pre><code>DEBU[0016] Loading 0ea0d582fd9027540c1f50c7f0149b237ed483d2b95ac8d107f9db5a912b4240
DEBU[0016] Loading d92c3c92fa73ba974eb409217bb86d8317b0727f42b73ef5a05153b729aaf96b
DEBU[0016] Loading 9942dd43ff211ba917d03637006a83934e847c003bef900e4808be8021dca7bd
DEBU[0016] Loading 1c9383292a8ff4c4196ff4ffa36e5ff24cb217606a8d1f471f4ad27c4690e290
DEBU[0016] Loading 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
DEBU[0016] Start untar layer
DEBU[0016] Untar time: 0.049447524s
DEBU[0016] Completed processing 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
DEBU[0020] Completed processing 1c9383292a8ff4c4196ff4ffa36e5ff24cb217606a8d1f471f4ad27c4690e290
DEBU[0020] Completed processing 9942dd43ff211ba917d03637006a83934e847c003bef900e4808be8021dca7bd
DEBU[0021] Completed processing d92c3c92fa73ba974eb409217bb86d8317b0727f42b73ef5a05153b729aaf96b
DEBU[0029] Completed processing 0ea0d582fd9027540c1f50c7f0149b237ed483d2b95ac8d107f9db5a912b4240
DEBU[0029] Completed processing 1c9383292a8ff4c4196ff4ffa36e5ff24cb217606a8d1f471f4ad27c4690e290
DEBU[0029] Completed processing 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
DEBU[0029] Completed processing 9942dd43ff211ba917d03637006a83934e847c003bef900e4808be8021dca7bd
DEBU[0029] Loading c4ff7513909dedf4ddf3a450aea68cd817c42e698ebccf54755973576525c416
DEBU[0029] Loading cc58e55aa5a53b572f3b9009eb07e50989553b95a1545a27dcec830939892dba
DEBU[0030] Completed processing cc58e55aa5a53b572f3b9009eb07e50989553b95a1545a27dcec830939892dba
DEBU[0031] Completed processing c4ff7513909dedf4ddf3a450aea68cd817c42e698ebccf54755973576525c416
DEBU[0031] Completed processing cc58e55aa5a53b572f3b9009eb07e50989553b95a1545a27dcec830939892dba
DEBU[0031] Completed processing d92c3c92fa73ba974eb409217bb86d8317b0727f42b73ef5a05153b729aaf96b</code></pre>

some layer is showed twice and make the develop confuse
