### PR TITLE
Fix for the issue #17225 flaky test DockerSuite.TestExecEnv test case.

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -127,6 +127,7 @@ func (s *DockerSuite) TestExecEnv(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-e", "LALA=value1", "-e", "LALA=value2",
 		"-d", "--name", "testing", "busybox", "top")
+	c.Assert(waitRun("testing"), check.IsNil)
 
 	out, _ := dockerCmd(c, "exec", "testing", "env")
 	if strings.Contains(out, "LALA=value1") ||


### PR DESCRIPTION
This is done by calling waitRun() followed by the docker run, which ensures the container is loaded
before calling docker exec to obtain the env variable set previously. Fixes #17225

Signed-off-by: Anil Belur askb23@gmail.com
