### PR TITLE
builder: dockerfile: allow LABEL w/o a value

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3812,3 +3812,12 @@ func (s *DockerSuite) TestRunWithOomScoreAdjInvalidRange(c *check.C) {
 		c.Fatalf("Expected output to contain %q, got %q instead", expected, out)
 	}
 }
+
+func (s *DockerSuite) TestRunWithLabelNameOnly(c *check.C) {
+	name := "label-name-only"
+	label := "testing"
+	dockerCmd(c, "run", "--name", name, "--label", label, "busybox", "true")
+	nameonly, err := inspectFieldMap(name, "Config.Labels", label)
+	c.Assert(err, check.IsNil)
+	c.Assert(nameonly, check.Equals, "")
+}


### PR DESCRIPTION
Also add a bunch of tests about labels

Fix #16526 
I don't see why the Dockerfile shouldn't allow `LABEL` w/o value, if anyone remembers this was intentional I'll close this
I also noticed we're allowing the old `KEY name value` format for `LABEL` which seems wrong given we should allow `LABEL` w/o value

Signed-off-by: Antonio Murdaca runcom@redhat.com
