### PR TITLE
Fix for #17243 DockerSuite.TestExecAfterContainerRestart.

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -82,7 +82,9 @@ func (s *DockerSuite) TestExecAfterContainerRestart(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
+	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 	dockerCmd(c, "restart", cleanedContainerID)
+	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	out, _ = dockerCmd(c, "exec", cleanedContainerID, "echo", "hello")
 	outStr := strings.TrimSpace(out)


### PR DESCRIPTION
Added waitRun(containerID) statement after docker run -d and docker restart
to ensure the container is restarted before issuing a exec cmd.

Signed-off-by: Anil Belur askb23@gmail.com
