### PR TITLE
api: server: reply with application/json; boundary=NL

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -106,7 +106,7 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 		output = ioutils.NewWriteFlusher(w)
 	)
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; boundary=NL")
 
 	if image != "" { //pull
 		if tag == "" {
@@ -191,7 +191,7 @@ func (s *router) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 		OutStream:   output,
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; boundary=NL")
 
 	if err := s.daemon.PushImage(name, imagePushConfig); err != nil {
 		if !output.Flushed() {
@@ -279,7 +279,7 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; boundary=NL")
 
 	version := httputils.VersionFromContext(ctx)
 	output := ioutils.NewWriteFlusher(w)

--- a/api/server/router/local/info.go
+++ b/api/server/router/local/info.go
@@ -53,7 +53,7 @@ func (s *router) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Req
 }
 
 func buildOutputEncoder(w http.ResponseWriter) *json.Encoder {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; boundary=NL")
 	outStream := ioutils.NewWriteFlusher(w)
 	// Write an empty chunk of data.
 	// This is to ensure that the HTTP status code is sent immediately,


### PR DESCRIPTION
For routes that are streaming line delimited JSON it makes sense to
reply with a `Content-Type` of `application/json; boundary=NL` instead of
just plain `application/json`

Close #16925

Signed-off-by: Antonio Murdaca runcom@redhat.com
