### PR TITLE
Warning out when disalbe oom killer but not set the memory limit

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -63,6 +63,10 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		os.Exit(1)
 	}
 
+	if hostConfig.OomKillDisable && hostConfig.Memory == 0 {
+		fmt.Fprintf(cli.err, "WARNING: Dangerous only disable the OOM Killer on containers but not set the '-m/--memory' option\n")
+	}
+
 	if len(hostConfig.DNS) > 0 {
 		// check the DNS settings passed via --dns against
 		// localhost regexp to warn if they are trying to


### PR DESCRIPTION
It is always the best practice that only disable the OOM Killer where
you also set the `-m/--memory` option, otherwise it's dangerous.

Signed-off-by: Hu Keping hukeping@huawei.com
