### PR TITLE
update mkimage-yum.sh to support dnf

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -18,7 +18,7 @@ EOOPTS
 
 # option defaults
 
-if [ -e /etc/dnf/dnf.conf ] ; then
+if [ -f /etc/dnf/dnf.conf ] ; then
 	yum_config=/etc/dnf/dnf.conf
 else
 	yum_config=/etc/yum.conf
@@ -68,7 +68,7 @@ if [ -d /etc/yum/vars ]; then
 	cp -a /etc/yum/vars "$target"/etc/yum/
 fi
 
-if [ -e /etc/dnf/dnf.conf ] ; then 
+if [ -f /etc/dnf/dnf.conf ] ; then 
 	dnf -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
 		--setopt=group_package_types=mandatory -y groupinstall Core
 	dnf -c "$yum_config" --installroot="$target" -y clean all

--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -11,13 +11,19 @@ usage() {
 $(basename $0) [OPTIONS] <name>
 OPTIONS:
   -y <yumconf>  The path to the yum config to install packages from. The
-                default is /etc/yum.conf.
+                default is /etc/yum.conf for Centos/RHEL and /etc/dnf/dnf.conf for Fedora 
 EOOPTS
     exit 1
 }
 
 # option defaults
 yum_config=/etc/yum.conf
+
+if [ -f /etc/dnf/dnf.conf ] && command -v dnf &> /dev/null; then
+	yum_config=/etc/dnf/dnf.conf
+	alias yum=dnf
+fi 
+
 while getopts ":y:h" opt; do
     case $opt in
         y)
@@ -64,7 +70,7 @@ if [ -d /etc/yum/vars ]; then
 fi
 
 yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-    --setopt=group_package_types=mandatory -y groupinstall Core
+    		--setopt=group_package_types=mandatory -y groupinstall Core
 yum -c "$yum_config" --installroot="$target" -y clean all
 
 cat > "$target"/etc/sysconfig/network <<EOF

--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -17,12 +17,13 @@ EOOPTS
 }
 
 # option defaults
+yum_config=/etc/yum.conf
 
-if [ -f /etc/dnf/dnf.conf ] ; then
+if [ -f /etc/dnf/dnf.conf ] && command -v dnf &> /dev/null; then
 	yum_config=/etc/dnf/dnf.conf
-else
-	yum_config=/etc/yum.conf
+	alias yum=dnf
 fi 
+
 while getopts ":y:h" opt; do
     case $opt in
         y)
@@ -68,15 +69,9 @@ if [ -d /etc/yum/vars ]; then
 	cp -a /etc/yum/vars "$target"/etc/yum/
 fi
 
-if [ -f /etc/dnf/dnf.conf ] ; then 
-	dnf -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-		--setopt=group_package_types=mandatory -y groupinstall Core
-	dnf -c "$yum_config" --installroot="$target" -y clean all
-else
-	yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
+yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
     		--setopt=group_package_types=mandatory -y groupinstall Core
-	yum -c "$yum_config" --installroot="$target" -y clean all
-fi 
+yum -c "$yum_config" --installroot="$target" -y clean all
 
 cat > "$target"/etc/sysconfig/network <<EOF
 NETWORKING=yes

--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -11,7 +11,7 @@ usage() {
 $(basename $0) [OPTIONS] <name>
 OPTIONS:
   -y <yumconf>  The path to the yum config to install packages from. The
-                default is /etc/yum.conf for Centos/RHEL and /etc/dnf/dnf.conf for Fedora 
+                default is /etc/yum.conf for Centos/RHEL and /etc/dnf/dnf.conf for Fedora linux
 EOOPTS
     exit 1
 }

--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -11,13 +11,18 @@ usage() {
 $(basename $0) [OPTIONS] <name>
 OPTIONS:
   -y <yumconf>  The path to the yum config to install packages from. The
-                default is /etc/yum.conf.
+                default is /etc/yum.conf for Centos/RHEL and /etc/dnf/dnf.conf for Fedora 
 EOOPTS
     exit 1
 }
 
 # option defaults
-yum_config=/etc/yum.conf
+
+if [ -e /etc/dnf/dnf.conf ] ; then
+	yum_config=/etc/dnf/dnf.conf
+else
+	yum_config=/etc/yum.conf
+fi 
 while getopts ":y:h" opt; do
     case $opt in
         y)
@@ -63,9 +68,15 @@ if [ -d /etc/yum/vars ]; then
 	cp -a /etc/yum/vars "$target"/etc/yum/
 fi
 
-yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
-    --setopt=group_package_types=mandatory -y groupinstall Core
-yum -c "$yum_config" --installroot="$target" -y clean all
+if [ -e /etc/dnf/dnf.conf ] ; then 
+	dnf -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
+		--setopt=group_package_types=mandatory -y groupinstall Core
+	dnf -c "$yum_config" --installroot="$target" -y clean all
+else
+	yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
+    		--setopt=group_package_types=mandatory -y groupinstall Core
+	yum -c "$yum_config" --installroot="$target" -y clean all
+fi 
 
 cat > "$target"/etc/sysconfig/network <<EOF
 NETWORKING=yes


### PR DESCRIPTION
Updated mkimage-yum.sh to to support dnf - for Fedora users, currently mkimage-yum.sh only supports yum. Fedora 22 and never use dnf 
