### PR TITLE
Windows: Volume integration tests

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -595,7 +595,7 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(string, regist
 
 			repoInfo, err := registry.ParseRepositoryInfo(repo)
 			if err != nil {
-				return nil, nil, fmt.Errorf("unable to parse repository info: %v", err)
+				return nil, nil, fmt.Errorf("unable to parse repository info %q: %v", repo, err)
 			}
 
 			ref := registry.ParseReference(tag)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -425,7 +425,7 @@ func (s *DockerSuite) TestLinksPingLinkedContainersOnRename(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunExecDir(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
@@ -489,8 +489,7 @@ func (s *DockerSuite) TestRunExecDir(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunMutableNetworkFiles(c *check.C) {
-	testRequires(c, SameHostDaemon)
-
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 	for _, fn := range []string{"resolv.conf", "hosts"} {
 		deleteAllContainers()
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	if daemonPlatform == "windows" {
+		testRequires(c, WindowsDaemonSupportsVolumes)
+	}
 	dockerCmd(c, "volume", "create")
 
 	_, err := runCommand(exec.Command(dockerBinary, "volume", "create", "-d", "nosuchdriver"))
@@ -23,6 +25,9 @@ func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliCreateOptionConflict(c *check.C) {
+	if daemonPlatform == "windows" {
+		testRequires(c, WindowsDaemonSupportsVolumes)
+	}
 	dockerCmd(c, "volume", "create", "--name=test")
 	out, _, err := dockerCmdWithError("volume", "create", "--name", "test", "--driver", "nosuchdriver")
 	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use with another driver"))
@@ -35,7 +40,9 @@ func (s *DockerSuite) TestVolumeCliCreateOptionConflict(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	if daemonPlatform == "windows" {
+		testRequires(c, WindowsDaemonSupportsVolumes)
+	}
 	c.Assert(
 		exec.Command(dockerBinary, "volume", "inspect", "doesntexist").Run(),
 		check.Not(check.IsNil),
@@ -53,33 +60,40 @@ func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	prefix := ""
+	if daemonPlatform == "windows" {
+		prefix = "c:"
+		testRequires(c, WindowsDaemonSupportsVolumes)
+	}
 	out, _ := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 
 	dockerCmd(c, "volume", "create", "--name", "test")
-	dockerCmd(c, "run", "-v", "/foo", "busybox", "ls", "/")
+	dockerCmd(c, "run", "-v", prefix+"/foo", "busybox", "ls", "/")
 
 	out, _ = dockerCmd(c, "volume", "ls")
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(outArr), check.Equals, 4, check.Commentf("\n%s", out))
 
-	// Since there is no guarentee of ordering of volumes, we just make sure the names are in the output
+	// Since there is no guarantee of ordering of volumes, we just make sure the names are in the output
 	c.Assert(strings.Contains(out, id+"\n"), check.Equals, true)
 	c.Assert(strings.Contains(out, "test\n"), check.Equals, true)
 }
 
 func (s *DockerSuite) TestVolumeCliLsFilterDangling(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-
+	prefix := ""
+	if daemonPlatform == "windows" {
+		prefix = "c:"
+		testRequires(c, WindowsDaemonSupportsVolumes)
+	}
 	dockerCmd(c, "volume", "create", "--name", "testnotinuse1")
 	dockerCmd(c, "volume", "create", "--name", "testisinuse1")
 	dockerCmd(c, "volume", "create", "--name", "testisinuse2")
 
 	// Make sure both "created" (but not started), and started
 	// containers are included in reference counting
-	dockerCmd(c, "run", "--name", "volume-test1", "-v", "testisinuse1:/foo", "busybox", "true")
-	dockerCmd(c, "create", "--name", "volume-test2", "-v", "testisinuse2:/foo", "busybox", "true")
+	dockerCmd(c, "run", "--name", "volume-test1", "-v", "testisinuse1:"+prefix+"/foo", "busybox", "true")
+	dockerCmd(c, "create", "--name", "volume-test2", "-v", "testisinuse2:"+prefix+"/foo", "busybox", "true")
 
 	out, _ := dockerCmd(c, "volume", "ls")
 
@@ -104,7 +118,11 @@ func (s *DockerSuite) TestVolumeCliLsFilterDangling(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	prefix := ""
+	if daemonPlatform == "windows" {
+		prefix = "c:"
+		testRequires(c, WindowsDaemonSupportsVolumes)
+	}
 	out, _ := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 
@@ -117,7 +135,7 @@ func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("%s\n", out))
 
 	volumeID := "testing"
-	dockerCmd(c, "run", "-v", volumeID+":/foo", "--name=test", "busybox", "sh", "-c", "echo hello > /foo/bar")
+	dockerCmd(c, "run", "-v", volumeID+":"+prefix+"/foo", "--name=test", "busybox", "sh", "-c", "echo hello > /foo/bar")
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "volume", "rm", "testing"))
 	c.Assert(
 		err,
@@ -130,7 +148,7 @@ func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
 	dockerCmd(c, "volume", "inspect", volumeID)
 	dockerCmd(c, "rm", "-f", "test")
 
-	out, _ = dockerCmd(c, "run", "--name=test2", "-v", volumeID+":/foo", "busybox", "sh", "-c", "cat /foo/bar")
+	out, _ = dockerCmd(c, "run", "--name=test2", "-v", volumeID+":"+prefix+"/foo", "busybox", "sh", "-c", "cat /foo/bar")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello", check.Commentf("volume data was removed"))
 	dockerCmd(c, "rm", "test2")
 

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -34,6 +34,12 @@ var (
 	// a version call to the daemon and examining the response header.
 	daemonPlatform string
 
+	// windowsDaemonKV is used on Windows to distinguish between different
+	// versions. This is necessary to enable certain tests based on whether
+	// the platform supports it. For example, Windows Server 2016 TP3 does
+	// not support volumes, but TP4 does.
+	windowsDaemonKV int
+
 	// daemonDefaultImage is the name of the default image to use when running
 	// tests. This is platform dependent.
 	daemonDefaultImage string

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -637,6 +637,29 @@ func init() {
 	if daemonPlatform != "linux" && daemonPlatform != "windows" {
 		panic("Cannot run tests against platform: " + daemonPlatform)
 	}
+
+	// On Windows, extract out the version as we need to make selective
+	// decisions during integration testing as and when features are implemented.
+	if daemonPlatform == "windows" {
+		if body, err := ioutil.ReadAll(res.Body); err == nil {
+			var server types.Version
+			if err := json.Unmarshal(body, &server); err == nil {
+				// eg in "10.0 10550 (10550.1000.amd64fre.branch.date-time)" we want 10550
+				windowsDaemonKV, _ = strconv.Atoi(strings.Split(server.KernelVersion, " ")[1])
+			}
+		}
+	}
+
+	// Now we know the daemon platform, can set paths used by tests.
+	if daemonPlatform == "windows" {
+		dockerBasePath = `c:\programdata\docker`
+		volumesConfigPath = dockerBasePath + `\volumes`
+		containerStoragePath = dockerBasePath + `\containers`
+	} else {
+		dockerBasePath = "/var/lib/docker"
+		volumesConfigPath = dockerBasePath + "/volumes"
+		containerStoragePath = dockerBasePath + "/containers"
+	}
 }
 
 func deleteAllImages() error {

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -29,6 +29,18 @@ var (
 		func() bool { return daemonPlatform == "windows" },
 		"Test requires a Windows daemon",
 	}
+	WindowsDaemonSupportsVolumes = testRequirement{
+		func() bool {
+			if daemonPlatform != "windows" {
+				return false
+			}
+			if windowsDaemonKV == 0 {
+				panic("windowsDaemonKV is not set")
+			}
+			return windowsDaemonKV >= 10559
+		},
+		"Test requires a Windows daemon that supports volumes",
+	}
 	DaemonIsLinux = testRequirement{
 		func() bool { return daemonPlatform == "linux" },
 		"Test requires a Linux daemon",


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@tiborvass @calavera @cpuguy83 

This adds Windows CI support (against a Windows daemon) for volumes. This is a follow-up to #16433. With this PR, the pass results are 12 of 14 TestVol_, and 51 of TestRun_ (several of which are volume/bind-mount related) pass. More tests can be enabled post TP4, once Windows supports features such as read-only mapped directories.

E:\go\src\github.com\docker\docker>runtest wl TestVol
Running test TestVol
DOCKER_TEST_HOST=tcp://localhost:2375
=== RUN Test
INFO: Testing against a local daemon
PASS: docker_cli_volume_test.go:13: DockerSuite.TestVolumeCliCreate     15.233s
PASS: docker_cli_volume_test.go:27: DockerSuite.TestVolumeCliCreateOptionConflict       0.241s
PASS: docker_cli_volume_test.go:42: DockerSuite.TestVolumeCliInspect    0.358s
PASS: docker_cli_volume_test.go:62: DockerSuite.TestVolumeCliLs 4.462s
PASS: docker_cli_volume_test.go:83: DockerSuite.TestVolumeCliLsFilterDangling   5.279s
PASS: docker_cli_volume_test.go:163: DockerSuite.TestVolumeCliNoArgs    0.138s
PASS: docker_cli_volume_test.go:120: DockerSuite.TestVolumeCliRm        14.007s
PASS: docker_cli_run_test.go:2973: DockerSuite.TestVolumeFromMixedRWOptions     8.245s
PASS: docker_api_volumes_test.go:31: DockerSuite.TestVolumesApiCreate   0.009s
PASS: docker_api_volumes_test.go:77: DockerSuite.TestVolumesApiInspect  0.028s
PASS: docker_api_volumes_test.go:13: DockerSuite.TestVolumesApiList     3.530s
PASS: docker_api_volumes_test.go:49: DockerSuite.TestVolumesApiRemove   3.809s
SKIP: docker_cli_run_test.go:357: DockerSuite.TestVolumesFromGetsProperMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2126: DockerSuite.TestVolumesNoCopyData (Test requires a Linux daemon)
OK: 12 passed, 2 skipped
--- PASS: Test (59.39s)
PASS
ok      github.com/docker/docker/integration-cli        59.555s

E:\go\src\github.com\docker\docker>runtest wl TestRun
Running test TestRun
DOCKER_TEST_HOST=tcp://localhost:2375
=== RUN Test
INFO: Testing against a local daemon
SKIP: docker_cli_run_test.go:1482: DockerSuite.TestRunAddHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1042: DockerSuite.TestRunAddingOptionalDevices (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1060: DockerSuite.TestRunAddingOptionalDevicesInvalidMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1051: DockerSuite.TestRunAddingOptionalDevicesNoSrc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2005: DockerSuite.TestRunAllocatePortInReservedRange (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1101: DockerSuite.TestRunAllowBindMountingRoot     4.307s
SKIP: docker_cli_run_test.go:2229: DockerSuite.TestRunAllowPortRangeThroughExpose (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2595: DockerSuite.TestRunAllowPortRangeThroughPublish (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:408: DockerSuite.TestRunApplyVolumesFromBeforeVolumes      7.903s
PASS: docker_cli_run_test.go:1494: DockerSuite.TestRunAttachStdErrOnlyTTYMode   4.010s
PASS: docker_cli_run_test.go:1510: DockerSuite.TestRunAttachStdOutAndErrTTYMode 4.049s
PASS: docker_cli_run_test.go:1502: DockerSuite.TestRunAttachStdOutOnlyTTYMode   4.007s
PASS: docker_cli_run_test.go:1519: DockerSuite.TestRunAttachWithDetach  0.044s
PASS: docker_cli_run_test.go:1819: DockerSuite.TestRunBindMounts        4.097s
SKIP: docker_cli_run_test.go:923: DockerSuite.TestRunCapAddALLCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:933: DockerSuite.TestRunCapAddALLDropNetAdminCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2961: DockerSuite.TestRunCapAddCHOWN (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:913: DockerSuite.TestRunCapAddCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:904: DockerSuite.TestRunCapAddInvalid (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3311: DockerSuite.TestRunCapAddSYSTIME (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:894: DockerSuite.TestRunCapDropALLAddMknodCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:882: DockerSuite.TestRunCapDropALLCannotMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:856: DockerSuite.TestRunCapDropCannotMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:869: DockerSuite.TestRunCapDropCannotMknodLowerCase (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:847: DockerSuite.TestRunCapDropInvalid (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1901: DockerSuite.TestRunCidFileCheckIDLength      3.074s
PASS: docker_cli_run_test.go:1873: DockerSuite.TestRunCidFileCleanupIfEmpty     0.067s
PASS: docker_cli_run_test.go:1615: DockerSuite.TestRunCleanupCmdOnEntrypoint    10.678s
SKIP: docker_cli_run_test.go:3443: DockerSuite.TestRunContainerNetModeWithDnsMacHosts (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3467: DockerSuite.TestRunContainerNetModeWithExposePort (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:792: DockerSuite.TestRunContainerNetwork   3.763s
SKIP: docker_cli_run_test.go:3434: DockerSuite.TestRunContainerNetworkModeToSelf (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3418: DockerSuite.TestRunContainerWithCgroupMountRO (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3359: DockerSuite.TestRunContainerWithCgroupParent (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3389: DockerSuite.TestRunContainerWithCgroupParentAbsPath (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2706: DockerSuite.TestRunContainerWithReadonlyEtcHostsAndLinkedContainer (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:2657: DockerSuite.TestRunContainerWithReadonlyRootfs (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:2730: DockerSuite.TestRunContainerWithReadonlyRootfsWithAddHostFlag (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:2719: DockerSuite.TestRunContainerWithReadonlyRootfsWithDnsFlag (Test requires the native (libcontainer) exec driver.)
PASS: docker_cli_run_test.go:2775: DockerSuite.TestRunContainerWithRmFlagCannotStartContainer   4.588s
PASS: docker_cli_run_test.go:2758: DockerSuite.TestRunContainerWithRmFlagExitCodeNotEqualToZero 4.126s
PASS: docker_cli_run_test.go:2653: DockerSuite.TestRunContainerWithWritableRootfs       4.152s
SKIP: docker_cli_run_test.go:1595: DockerSuite.TestRunCopyVolumeContent (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1572: DockerSuite.TestRunCopyVolumeUidGid (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3319: DockerSuite.TestRunCreateContainerFailedCleanUp (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:449: DockerSuite.TestRunCreateVolume       4.512s
SKIP: docker_cli_run_test.go:2105: DockerSuite.TestRunCreateVolumeEtc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:460: DockerSuite.TestRunCreateVolumeWithSymlink (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:256: DockerSuite.TestRunCreateVolumesInSymlinkDir  23.493s
SKIP: docker_cli_run_test.go:1964: DockerSuite.TestRunDeallocatePortOnMissingIptablesRule (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:112: DockerSuite.TestRunDetachedContainerIDPrinting        4.379s
SKIP: docker_cli_run_test.go:1011: DockerSuite.TestRunDeviceNumbers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1111: DockerSuite.TestRunDisallowBindMountingRootToRoot    0.070s
SKIP: docker_cli_run_test.go:1126: DockerSuite.TestRunDnsDefaultOptions (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1160: DockerSuite.TestRunDnsOptions (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1194: DockerSuite.TestRunDnsOptionsBasedOnHostResolvConf (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1184: DockerSuite.TestRunDnsRepeatOptions (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:37: DockerSuite.TestRunEchoNamedContainer  3.898s
PASS: docker_cli_run_test.go:29: DockerSuite.TestRunEchoStdout  4.175s
PASS: docker_cli_run_test.go:1801: DockerSuite.TestRunEntrypoint        4.563s
SKIP: docker_cli_run_test.go:665: DockerSuite.TestRunEnvironment (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:710: DockerSuite.TestRunEnvironmentErase (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:751: DockerSuite.TestRunEnvironmentOverride (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:427: DockerSuite.TestRunExecDir (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:535: DockerSuite.TestRunExitCode   4.522s
PASS: docker_cli_run_test.go:76: DockerSuite.TestRunExitCodeOne 4.061s
PASS: docker_cli_run_test.go:70: DockerSuite.TestRunExitCodeZero        3.957s
PASS: docker_cli_run_test.go:1654: DockerSuite.TestRunExitOnStdinClose  4.397s
PASS: docker_cli_run_test.go:2254: DockerSuite.TestRunExposePort        0.045s
SKIP: docker_cli_run_test.go:818: DockerSuite.TestRunFullHostnameSet (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:945: DockerSuite.TestRunGroupAdd (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1941: DockerSuite.TestRunInspectMacAddress (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:46: DockerSuite.TestRunLeakyFileDescriptors (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3488: DockerSuite.TestRunLinkToContainerNetMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:197: DockerSuite.TestRunLinksContainerWithContainerId (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:181: DockerSuite.TestRunLinksContainerWithContainerName (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:58: DockerSuite.TestRunLookupGoogleDns     4.711s
SKIP: docker_cli_run_test.go:3498: DockerSuite.TestRunLoopbackOnlyExistsWhenNetworkingDisabled (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3524: DockerSuite.TestRunLoopbackWhenNetworkDisabled       3.333s
SKIP: docker_cli_run_test.go:1069: DockerSuite.TestRunModeHostname (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2312: DockerSuite.TestRunModeIpcContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2344: DockerSuite.TestRunModeIpcContainerNotExists (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2353: DockerSuite.TestRunModeIpcContainerNotRunning (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2290: DockerSuite.TestRunModeIpcHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3532: DockerSuite.TestRunModeNetContainerHostname (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2405: DockerSuite.TestRunModePidHost (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:2427: DockerSuite.TestRunModeUTSHost (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:2026: DockerSuite.TestRunMountOrdering (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2366: DockerSuite.TestRunMountShmMqueueFromHost (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:418: DockerSuite.TestRunMultipleVolumesFrom        12.425s
SKIP: docker_cli_exec_test.go:491: DockerSuite.TestRunMutableNetworkFiles (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3330: DockerSuite.TestRunNamedVolume (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2577: DockerSuite.TestRunNetContainerWhichHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2546: DockerSuite.TestRunNetHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:801: DockerSuite.TestRunNetHostNotAllowedWithLinks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2568: DockerSuite.TestRunNetHostTwiceSameName (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3032: DockerSuite.TestRunNetworkFilesBindMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3051: DockerSuite.TestRunNetworkFilesBindMountRO (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3068: DockerSuite.TestRunNetworkFilesBindMountROFilesystem (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3545: DockerSuite.TestRunNetworkNotInitializedNoneMode (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:377: DockerSuite.TestRunNoDupVolumes       0.712s
PASS: docker_cli_run_test.go:2150: DockerSuite.TestRunNoOutputFromPullInStdout  1.311s
PASS: docker_cli_run_test.go:2528: DockerSuite.TestRunNonLocalMacAddress        4.121s
SKIP: docker_cli_run_test.go:1277: DockerSuite.TestRunNonRootUserResolvName (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2792: DockerSuite.TestRunPidHostWithChildIsKillable (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2467: DockerSuite.TestRunPortFromDockerRangeInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1986: DockerSuite.TestRunPortInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:827: DockerSuite.TestRunPrivilegedCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:956: DockerSuite.TestRunPrivilegedCanMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:995: DockerSuite.TestRunProcNotWritableInNonPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1003: DockerSuite.TestRunProcWritableInPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2935: DockerSuite.TestRunPublishPort (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2872: DockerSuite.TestRunReadFilteredProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:2851: DockerSuite.TestRunReadProcLatency (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:2836: DockerSuite.TestRunReadProcTimer (Test requires the native (libcontainer) exec driver.)
SKIP: docker_cli_run_test.go:1302: DockerSuite.TestRunResolvconfUpdate (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2628: DockerSuite.TestRunRestartMaxRetries 12.536s
SKIP: docker_cli_run_test.go:2075: DockerSuite.TestRunReuseBindVolumeThatIsSymlink (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1090: DockerSuite.TestRunRootWorkdir       3.884s
PASS: docker_cli_run_test.go:2619: DockerSuite.TestRunSetDefaultRestartPolicy   3.617s
PASS: docker_cli_run_test.go:1925: DockerSuite.TestRunSetMacAddress     4.127s
SKIP: docker_cli_run_test.go:2204: DockerSuite.TestRunSlowStdoutConsumer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1529: DockerSuite.TestRunState (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3725: DockerSuite.TestRunStdinBlockedAfterContainerExit    4.157s
SKIP: docker_cli_run_test.go:88: DockerSuite.TestRunStdinPipe (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:979: DockerSuite.TestRunSysNotWritableInNonPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:987: DockerSuite.TestRunSysWritableInPrivilegedContainers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2449: DockerSuite.TestRunTLSverify 0.156s
SKIP: docker_cli_run_test.go:1027: DockerSuite.TestRunThatCharacterDevicesActLikeCharacterDevices (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2499: DockerSuite.TestRunTtyWithPipe       0.045s
SKIP: docker_cli_run_test.go:631: DockerSuite.TestRunTwoConcurrentContainers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2262: DockerSuite.TestRunUnknownCommand    4.309s
SKIP: docker_cli_run_test.go:837: DockerSuite.TestRunUnprivilegedCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:966: DockerSuite.TestRunUnprivilegedCannotMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1036: DockerSuite.TestRunUnprivilegedWithChroot (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2912: DockerSuite.TestRunUnshareProc (unstable test: is apparmor in a container reliable?)
SKIP: docker_cli_run_test.go:572: DockerSuite.TestRunUserByID (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:582: DockerSuite.TestRunUserByIDBig (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:595: DockerSuite.TestRunUserByIDNegative (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:608: DockerSuite.TestRunUserByIDZero (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:562: DockerSuite.TestRunUserByName (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:551: DockerSuite.TestRunUserDefaults       3.959s
SKIP: docker_cli_run_test.go:621: DockerSuite.TestRunUserNotFound (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:430: DockerSuite.TestRunVerifyContainerID  3.271s
PASS: docker_cli_run_test.go:2163: DockerSuite.TestRunVolumesCleanPaths 8.193s
PASS: docker_cli_run_test.go:332: DockerSuite.TestRunVolumesFromInReadWriteMode 12.850s
SKIP: docker_cli_run_test.go:307: DockerSuite.TestRunVolumesFromInReadonlyModeFails (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2741: DockerSuite.TestRunVolumesFromRestartAfterRemoved    10.300s
PASS: docker_cli_run_test.go:496: DockerSuite.TestRunVolumesFromSymlinkPath     32.558s
SKIP: docker_cli_run_test.go:298: DockerSuite.TestRunVolumesMountedAsReadonly (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1786: DockerSuite.TestRunWithBadDevice (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:214: DockerSuite.TestRunWithDaemonFlags    0.062s
PASS: docker_cli_run_test.go:1956: DockerSuite.TestRunWithInvalidMacAddress     0.050s
SKIP: docker_cli_run_test.go:2815: DockerSuite.TestRunWithTooSmallMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3348: DockerSuite.TestRunWithUlimits (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:225: DockerSuite.TestRunWithVolumesFromExited      7.760s
PASS: docker_cli_run_test.go:153: DockerSuite.TestRunWithoutNetworking  6.878s
PASS: docker_cli_run_test.go:1640: DockerSuite.TestRunWorkdirExistsAndIsFile    4.183s
SKIP: docker_cli_run_test.go:127: DockerSuite.TestRunWorkingDirectory (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3005: DockerSuite.TestRunWriteFilteredProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:1755: DockerSuite.TestRunWriteHostnameFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1713: DockerSuite.TestRunWriteHostsFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1771: DockerSuite.TestRunWriteResolvFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2827: DockerSuite.TestRunWriteToProcAsound (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3745: DockerSuite.TestRunWrongCpusetCpusFlagValue (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3754: DockerSuite.TestRunWrongCpusetMemsFlagValue (Test requires a Linux daemon)
SKIP: docker_cli_by_digest_test.go:141: DockerRegistrySuite.TestRunByDigest
SKIP: docker_cli_run_test.go:3147: DockerTrustSuite.TestRunWhenCertExpired
OK: 51 passed, 117 skipped
--- PASS: Test (366.00s)
PASS
ok      github.com/docker/docker/integration-cli        366.185s

E:\go\src\github.com\docker\docker>
