### PR TITLE
Add new flag to completely disable service discovery

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -48,6 +48,7 @@ type bridgeConfig struct {
 	DefaultGatewayIPv4          net.IP
 	DefaultGatewayIPv6          net.IP
 	InterContainerCommunication bool
+	ContainerDiscovery          bool
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -74,6 +75,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.Var(opts.NewIPOpt(&config.Bridge.DefaultGatewayIPv4, ""), []string{"-default-gateway"}, usageFn("Container default gateway IPv4 address"))
 	cmd.Var(opts.NewIPOpt(&config.Bridge.DefaultGatewayIPv6, ""), []string{"-default-gateway-v6"}, usageFn("Container default gateway IPv6 address"))
 	cmd.BoolVar(&config.Bridge.InterContainerCommunication, []string{"#icc", "-icc"}, true, usageFn("Enable inter-container communication"))
+	cmd.BoolVar(&config.Bridge.ContainerDiscovery, []string{"-container-discovery"}, true, usageFn("Enable container discovery implemented in Docker"))
 	cmd.Var(opts.NewIPOpt(&config.Bridge.DefaultIP, "0.0.0.0"), []string{"#ip", "-ip"}, usageFn("Default IP when binding container ports"))
 	cmd.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -860,7 +860,7 @@ func (container *Container) buildCreateEndpointOptions(n libnetwork.Network) ([]
 		createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
 	}
 
-	if n.Name() == "bridge" {
+	if !container.daemon.config().Bridge.ContainerDiscovery {
 		createOptions = append(createOptions, libnetwork.CreateOptionAnonymous())
 	}
 


### PR DESCRIPTION
This is an alternative approach to #17325.

The problem is the tension between:
1. people who want service discovery by default and now rely on it (me)
2. people who don't want service discovery at all (@thockin) 
3. people who want service discovery at a network granularity
4. people who want service discovery at a container granularity

3 and 4 are not relevant in this discussion since they're not available yet.
#17325 resolved the issue with corruption (#17190) by disabling discovery on the default network. This doesn't really help if you want to use networks.

This is a blunter (granularity on the daemon level), yet more configurable (it's not hardcoded) approach. I would expect this to, in time, be extended with granularity on the network level and granularity on the container level.

It
- doesn't break backwards compatibility
- allows totally disabling service discovery of any kind
- (I feel) is more aligned with "batteries included but removable".

@mavenugo @thaJeztah (not sure who else is interested)

(there will be test failures, I want feedback on design and whether this has hope in any incarnation of being merged)
