### PR TITLE
Windows: Volumes PR rename UnmountWithSyscall

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1172,7 +1172,7 @@ func (container *Container) unmountVolumes(forceSyscall bool) error {
 
 	for _, volumeMount := range volumeMounts {
 		if forceSyscall {
-			system.UnmountWithSyscall(volumeMount.Destination)
+			system.Unmount(volumeMount.Destination)
 		}
 
 		if volumeMount.Volume != nil {

--- a/pkg/system/syscall_unix.go
+++ b/pkg/system/syscall_unix.go
@@ -4,8 +4,8 @@ package system
 
 import "syscall"
 
-// UnmountWithSyscall is a platform-specific helper function to call
+// Unmount is a platform-specific helper function to call
 // the unmount syscall.
-func UnmountWithSyscall(dest string) {
+func Unmount(dest string) {
 	syscall.Unmount(dest, 0)
 }

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -1,6 +1,6 @@
 package system
 
-// UnmountWithSyscall is a platform-specific helper function to call
+// Unmount is a platform-specific helper function to call
 // the unmount syscall. Not supported on Windows
-func UnmountWithSyscall(dest string) {
+func Unmount(dest string) {
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@tiborvass Fixing one of the nits you mentioned on IRC for #16433. Renaming UnmountWithSyscall to Unmount.
