### PR TITLE
Make network connect idempotent

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -948,7 +948,8 @@ func (container *Container) connectToNetwork(idOrName string, updateSettings boo
 
 	ep, err := container.getEndpointInNetwork(n)
 	if err == nil {
-		return fmt.Errorf("container already connected to network %s", idOrName)
+		// container is already connected to this network
+		return nil
 	}
 
 	if _, ok := err.(libnetwork.ErrNoSuchEndpoint); !ok {


### PR DESCRIPTION
This changes the network connect command to be more idempotent by silently ignoring if the container was already connected to the network in stead of producing an error.

closes #17371
