### PR TITLE
"docker --log-driver=XXX" in reference missing 'daemon'

### DIFF
--- a/docs/reference/logging/awslogs.md
+++ b/docs/reference/logging/awslogs.md
@@ -21,7 +21,7 @@ and Command Line Tools](http://docs.aws.amazon.com/cli/latest/reference/logs/ind
 You can configure the default logging driver by passing the `--log-driver`
 option to the Docker daemon:
 
-    docker --log-driver=awslogs
+    docker daemon --log-driver=awslogs
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:

--- a/docs/reference/logging/fluentd.md
+++ b/docs/reference/logging/fluentd.md
@@ -39,7 +39,7 @@ Some options are supported by specifying `--log-opt` as many times as needed:
 Configure the default logging driver by passing the
 `--log-driver` option to the Docker daemon:
 
-    docker --log-driver=fluentd
+    docker daemon --log-driver=fluentd
 
 To set the logging driver for a specific container, pass the
 `--log-driver` option to `docker run`:

--- a/docs/reference/logging/journald.md
+++ b/docs/reference/logging/journald.md
@@ -29,7 +29,7 @@ driver stores the following metadata in the journal with each message:
 You can configure the default logging driver by passing the
 `--log-driver` option to the Docker daemon:
 
-    docker --log-driver=journald
+    docker daemon --log-driver=journald
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:

--- a/docs/reference/logging/splunk.md
+++ b/docs/reference/logging/splunk.md
@@ -20,7 +20,7 @@ in Splunk Enterprise and Splunk Cloud.
 You can configure the default logging driver by passing the `--log-driver`
 option to the Docker daemon:
 
-    docker --log-driver=splunk
+    docker daemon --log-driver=splunk
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:


### PR DESCRIPTION
$ docker --log-driver=journald
docker: the daemon flag '--log-driver' must follow the 'docker daemon' command.

doc missing daemon
Signed-off-by: Kun Zhang zkazure@gmail.com
