### PR TITLE
docker manifest [--digest] command

### DIFF
--- a/api/client/manifest.go
+++ b/api/client/manifest.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"github.com/docker/distribution/digest"
+	Cli "github.com/docker/docker/cli"
+	flag "github.com/docker/docker/pkg/mflag"
+	"io"
+)
+
+// CmdManifest outputs an image manifest or a digest reference for the input IMAGE argument
+//
+// Usage: docker manifest [--digest] IMAGE
+func (cli *DockerCli) CmdManifest(args ...string) (err error) {
+	cmd := Cli.Subcmd("manifest", nil, "Output manifest JSON or digest reference for the input IMAGE", true)
+	outdigest := cmd.Bool([]string{"-digest", "d"}, false, "Computes manifest digest instead of returning the manifest")
+	cmd.Require(flag.Min, 1)
+	cmd.ParseFlags(args, true)
+
+	if serverResp, err := cli.call("GET", "/images/"+cmd.Arg(0)+"/manifest", nil, nil); err == nil {
+		defer serverResp.body.Close()
+		if *outdigest {
+			digester := digest.Canonical.New()
+			if _, err := io.Copy(digester.Hash(), serverResp.body); err != nil {
+				cli.out.Write([]byte("Error writing response to stdout: " + err.Error() + "\n"))
+			} else {
+				cli.out.Write([]byte(digester.Digest().String() + "\n"))
+			}
+		} else {
+			if _, err := io.Copy(cli.out, serverResp.body); err != nil {
+				cli.out.Write([]byte("Error writing response to stdout: " + err.Error() + "\n"))
+			}
+		}
+	} else {
+		cli.out.Write([]byte(err.Error() + "\n"))
+	}
+
+	return
+}

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -461,6 +461,34 @@ func sanitizeRepoAndTags(names []string) ([]repoAndTag, error) {
 	return repoAndTags, nil
 }
 
+func (s *router) getImagesManifest(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	output := ioutils.NewWriteFlusher(w)
+	var (
+		name string
+	)
+
+	if _, ok := vars["name"]; ok {
+		name = vars["name"]
+	} else {
+		name = r.Form["names"][0]
+	}
+
+	repository, tag := parsers.ParseRepositoryTag(name)
+	manifest, err := s.daemon.GetImageManifest(name, repository, tag)
+	if err == nil {
+		output.Write(manifest)
+	}
+
+	return err
+}
+
 func (s *router) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err

--- a/api/server/router/local/local.go
+++ b/api/server/router/local/local.go
@@ -106,6 +106,7 @@ func (r *router) initRoutes() {
 		NewGetRoute("/images/{name:.*}/get", r.getImagesGet),
 		NewGetRoute("/images/{name:.*}/history", r.getImagesHistory),
 		NewGetRoute("/images/{name:.*}/json", r.getImagesByName),
+		NewGetRoute("/images/{name:.*}/manifest", r.getImagesManifest),
 		NewGetRoute("/containers/json", r.getContainersJSON),
 		NewGetRoute("/containers/{name:.*}/export", r.getContainersExport),
 		NewGetRoute("/containers/{name:.*}/changes", r.getContainersChanges),


### PR DESCRIPTION
Hello,

this adds `docker manifest [--digest]` command to either print out an unsigned manifest, or it's digest.
There are problems with repository name though. 
I guess it would also be nice to fix the repository problem without needing to work with remote registries like the `v2_pusher` does. That way we could refactor the common functionality out of `v2_pusher` and let the `manifest` command also use it.

Signed-off-by: Pavel Odvody podvody@redhat.com
