### PR TITLE
Documentation for proposed authn features

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -18,4 +18,6 @@ Currently, you can extend Docker by adding a plugin. This section contains the f
 * [Understand Docker plugins](plugins.md)
 * [Write a volume plugin](plugins_volume.md)
 * [Write a network plugin](plugins_network.md)
+* [Write an authentication plugin](plugins_authn.md)
+* [Write a certificate mapping plugin](plugins_certmap.md)
 * [Docker plugin API](plugin_api.md)

--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -22,8 +22,9 @@ example, a [volume plugin](plugins_volume.md) might enable Docker
 volumes to persist across multiple Docker hosts and a
 [network plugin](plugins_network.md) might provide network plumbing.
 
-Currently Docker supports volume and network driver plugins. In the future it
-will support additional plugin types.
+Currently Docker supports volume, network driver, authentication, and
+certificate mapping plugins. In the future it will continue to add support for
+additional plugin types.
 
 ## Installing a plugin
 

--- a/docs/extend/plugins_authn.md
+++ b/docs/extend/plugins_authn.md
@@ -1,0 +1,79 @@
+<!--[metadata]>
++++
+title = "Authentication plugins"
+description = "How to authenticate clients with external authentication plugins"
+keywords = ["Examples, Usage, authn, docker, plugin, api"]
+[menu.main]
+parent = "mn_extend"
++++
+<![end-metadata]-->
+
+# Write an authentication plugin
+
+Docker authentication plugins enable Docker deployments to authenticate clients
+using HTTP authentication schemes which are not implemented by the Docker
+daemon itself, and to implement password checks for Basic authentication in
+different ways.  See the [plugin documentation](plugins.md) for more
+information.
+
+# Command-line changes
+
+An authentication plugin is enabled by using the `-a` flag and the
+`--authn-opt plugins` option with the `docker daemon` command.
+
+    $ docker daemon -a --authn-opt plugins=sss
+
+# Authentication protocol
+
+If a plugin registers itself as an `Authentication` plugin when activated, then
+it is expected to provide both `Authentication.GetChallenge` and
+`Authentication.CheckResponse` handlers.  Both handlers accept the same request
+type and return the same response type.
+
+**Request**:
+```
+{
+    "Method": "GET"/"POST",
+    "URL": {},
+    "Host": "",
+    "Header": {},
+    "Options": []
+}
+```
+#### The `Method` string is taken from the client request.
+#### The `URL` map contains `Scheme`, `Path`, `RawQuery`, and `Fragment`
+strings representing portions of the URL reconstructed from the request as
+received by the daemon.
+#### The `Header` map contains arrays of header values indexed by their names,
+taken from the request as received by the daemon.
+#### The `Options` array contains authentication options which were passed to
+the daemon at startup-time.
+Plugins which implement the "Basic" authentication scheme should take note of
+the "realm" setting, if one is set, in their `GetChallenge` handlers.
+
+**Response**:
+```
+{
+    "AuthedUser": {},
+    "Header": {}
+}
+```
+If authentication succeeded, the `AuthedUser` map should contain at least these items:
+#### Name: a string naming the client.  Can be empty if a UID is set.
+#### HaveUID: a boolean indicating whether or not a `UID` value is present.
+#### UID: an optional number containing the UID of the client.
+#### Groups: an optional array of names of groups of which the client is a member.
+#### Scheme: a string naming the HTTP authentication scheme.  If not set, the
+name of the plugin will be used, which is probably not what you want.
+
+### /Authentication.GetChallenge
+
+Produces challenge headers to be returned to the client along with a
+StatusUnauthorized error and returns them as elements in the `Header` map.  The
+`AuthedUser` field is ignored.
+
+### /Authentication.CheckResponse
+
+Checks client authentication information passed in through the `Header` map,
+either returning a populated `AuthedUser` field or a `Headers` map containing
+headers to be returned to the client along with a StatusUnauthorized error.

--- a/docs/extend/plugins_certmap.md
+++ b/docs/extend/plugins_certmap.md
@@ -1,0 +1,55 @@
+<!--[metadata]>
++++
+title = "Certificate mapping plugins"
+description = "How to map client TLS certificates to authenticated users"
+keywords = ["Examples, Usage, certificates, docker, plugin, api"]
+[menu.main]
+parent = "mn_extend"
++++
+<![end-metadata]-->
+
+# Write a certificate mapping plugin
+
+Docker certificate mapping plugins enable Docker deployments to authenticate
+clients by reading the client identity from a TLS client certificate, or by
+consulting an outside source.  See the [plugin documentation](plugins.md) for
+more information.
+
+# Command-line changes
+
+A certificate mapping plugin is enabled by using the `-a` flag and the
+`--authn-opt certmap` option with the `docker daemon` command.
+
+    $ docker daemon -a --authn-opt certmap=sss
+
+# Authentication protocol
+
+If a plugin registers itself as a `ClientCertificateMapper` plugin when
+activated, then it is expected to provide a
+`ClientCertificateMapper.MapClientCertificateToUser` handler.
+
+**Request**:
+```
+{
+    "Certificate": ""
+    "Options": []
+}
+```
+#### The `Certificate` string contains a base64-encoded copy of the client
+certificate.
+#### The `Options` array contains authentication options which were passed to
+the daemon at startup-time.
+
+**Response**:
+```
+{
+    "AuthedUser": {},
+}
+```
+If authentication succeeded, the `AuthedUser` map should contain at least these items:
+#### Name: a string naming the client.  Can be empty if a UID is set.
+#### HaveUID: a boolean indicating whether or not a `UID` value is present.
+#### UID: an optional number containing the UID of the client.
+#### Groups: an optional array of names of groups of which the client is a member.
+#### Scheme: a string naming the HTTP authentication scheme.  If not set, the
+name of the plugin will be used, which is probably not what you want.

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -51,6 +51,10 @@ by the `docker` command line:
 * `DOCKER_CONTENT_TRUST_SERVER` The URL of the Notary server to use. This defaults
   to the same URL as the registry.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
+* `DOCKER_AUTHN_USERID` A user name to use when authenticating to the docker daemon.
+  This is typically expected to be set only when testing.
+* `DOCKER_AUTHN_PASSWORD` A password to use when authenticating to the docker daemon using the Basic authentication scheme.
+  This is typically expected to be set only when testing.
 
 Because Docker is developed using 'Go', you can also use any environment
 variables used by the 'Go' runtime. In particular, you may find these useful:
@@ -119,6 +123,58 @@ Certificate Authority, you need to place the certificate at
 
 Alternatively you can trust the certificate globally by adding it to your system's
 list of root Certificate Authorities.
+
+## Authentication
+
+If the docker daemon requires clients to authenticate to it before it will
+service their requests, a client may need to prompt for credentials to use.  If
+the docker client has a controlling TTY, it will prompt for credentials.  To
+avoid the prompts, the `--authn-opts` option can be used to pass in specific
+prompted-for values in the form of `key`=`value` ahead of time, or the
+`--authn-opts interactive=false` option can be used to treat any attempts to
+prompt for information as having failed, in much the same way that prompting
+for them would fail without a controlling TTY.
+
+### Authentication Options
+
+When a docker client is informed by a docker daemon that it needs to
+authenticate, these options affect its behavior.
+
+#### basic.username
+
+When Basic authentication is offered, this value will be supplied by the client
+as its user name.  If no value is set, the value of the `DOCKER_AUTHN_USERID`
+environment variable is used.  If it, too, is not set, the docker client will
+attempt to prompt for the user name.
+
+    $ docker run --authn-opt basic.username=testuser
+
+#### basic.password
+
+When Basic authentication is offered, this value will be supplied by the client
+as the password.  If no value is set, the value of the `DOCKER_AUTHN_PASSWORD`
+environment variable is used.  If it, too, is not set, the docker client will
+attempt to prompt for the user name.
+
+    $ docker run --authn-opt basic.password=this-is-not-a-good-password
+
+#### bearer.token
+
+When Bearer authentication is offered, this value will be supplied by the
+client as the token.
+
+    $ docker run --authn-opt bearer.token=WUVTLUktQU0tQS1CRUFS
+
+#### interactive
+
+When the docker client needs authentication information, by default it will
+prompt for that information if its standard input is connected to a terminal.
+If standard input is not connected to a terminal, it behave as if the attempt
+to prompt for information failed.  The `interactive` option can override this
+behavior, either preventing prompting when it would normally be used, or
+forcing prompting when it would normally not be attempted.
+
+    $ docker run --authn-opt interactive=false
 
 ## Help
 

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -16,7 +16,9 @@ weight = -1
     A self-sufficient runtime for linux containers.
 
     Options:
+      -a, --authn=false                      Require clients to authenticate
       --api-cors-header=""                   Set CORS headers in the remote API
+      --authn-opt=[]                         Set authentication options
       -b, --bridge=""                        Attach containers to a network bridge
       --bip=""                               Specify network bridge IP
       -D, --debug=false                      Enable debug mode

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -6,7 +6,9 @@ docker-daemon - Enable daemon mode
 
 # SYNOPSIS
 **docker daemon**
+[**-a**|**--authn**[=*false*]]
 [**--api-cors-header**=[=*API-CORS-HEADER*]]
+[**--authn-opt**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
 [**--cluster-store**[=*[]*]]
@@ -67,8 +69,14 @@ format.
 
 # OPTIONS
 
+**-a**, **--authn**=*true*|*false*
+  Require clients to authenticate to the docker daemon when issuing requests; the historical default is false
+
 **--api-cors-header**=""
   Set CORS headers in the remote API. Default is cors disabled. Give urls like "http://foo, http://bar, ...". Give "*" to allow all.
+
+**--authn-opt=**=[]
+  Set authentication options.  See AUTHENTICATION OPTIONS.
 
 **-b**, **--bridge**=""
   Attach containers to a pre\-existing network bridge; use 'none' to disable container networking
@@ -214,6 +222,80 @@ unix://[/path/to/socket] to use.
 
 **--userland-proxy**=*true*|*false*
     Rely on a userland proxy implementation for inter-container and outside-to-container loopback communications. Default is true.
+
+# AUTHENTICATION OPTIONS
+
+The Docker daemon provides multiple methods for authenticating its clients.
+Authentication is enabled by using the **-a** flag, and particular
+authentication schemes can be enabled and configured with **--authn-opt**
+flags.  When the **-H** option is used to configure a "unix" listening socket,
+the **local-auth** option is recommended.
+
+Here is the list of authentication options:
+
+#### certmap
+
+When a client connects using TLS with a client certificate, pass the client's
+certificate to the named plugin or plugins to determine the client's identity.
+
+Example use: `docker daemon --authn-opt certmap=sss`
+
+#### htpasswd
+
+Offer HTTP authentication using the `Basic` scheme, and check user names and
+passwords supplied by clients by running the external `htpasswd` command and
+using the specified file.
+
+Example use: `docker daemon --authn-opt htpasswd=/etc/docker/htpasswd`
+
+#### keytab
+
+When offering HTTP authentication using the `Negotiate` scheme, use the
+specified keytab instead of the host system's default keytab.  By default,
+docker uses the library's default keytab, which is typically
+`FILE:/etc/krb5.keytab`.
+
+Support for `Negotiate` is available only in dynamic builds, and only when the
+necessary development files are detected at build-time.  It is offered to
+clients only if the daemon can confirm that it has acceptor credentials at
+startup-time.
+
+Example use: `docker daemon --authn-opt keytab=FILE:/etc/docker/docker.keytab`
+
+#### libsasl2
+
+Offer HTTP authentication using the `Basic` scheme, and check user names and
+passwords supplied by clients by passing them to libsasl2, which can in turn be
+configured to consult a local `saslauthd` daemon, among other options.  The
+service name which is passed to the library is `docker`.
+
+This option is only available in dynamic builds, and only when the necessary
+development files are detected at build-time.
+
+Example use: `docker daemon --authn-opt libsasl2=true`
+
+#### local-auth
+
+When a client connects over a "unix" socket, ask the host system's kernel for
+help in determining the client's identity.  On Linux systems, this is
+accomplished by reading the peer credentials for the client connection.
+
+Example use: `docker daemon --authn-opt local-auth=true`
+
+#### plugins
+
+In addition to authentication schemes implemented in and offered by the daemon,
+call the named plugin or plugins to produce challenges and check client
+responses in order to authenticate clients.
+
+Example use: `docker daemon --authn-opt plugins=sss`
+
+#### realm
+
+When offering HTTP authentication using the `Basic` scheme, use the specified
+name as the name of the authentication "realm".  The default is `localhost`.
+
+Example use: `docker daemon --authn-opt realm=example.com`
 
 # STORAGE DRIVER OPTIONS
 


### PR DESCRIPTION
This patch contains the documentation portions of proposed authentication changes discussed in #13697, to get some feedback on what the end-result should look like.  To sum up the changes being proposed:
- If the daemon is started with the `-a`/`--authn` flag, it requires clients to authenticate to it.  If not, it doesn't, preserving the previous behavior.
- The daemon will offer support for HTTP Basic authentication if the daemon is started with either the `--libsasl2` or `--htpasswd` options, using a "realm" name specified using the `--realm` option.
- If the daemon is started with the `--htpasswd` option, it will attempt to run an "htpasswd" helper binary to check passwords using the specified htpasswd file.
- If the daemon is started with the `--libsasl2` option and built with support for it, it will call the SASL library to check passwords for the `docker` service.  The library can, in turn, be configured to ask `saslauthd` to check passwords using whatever facilities it's configured to use.
- If the daemon is built with GSSAPI support, it will check the default keytab file, or one specified using the `--keytab` option, for acceptor creds, and if it finds them, will offer Negotiate authentication.
- If the daemon is started with the `-U`/`--local-auth` flag, it will attempt to authenticate clients by asking the kernel to identify the client user.  On Linux systems, this is done by reading the client's UnixCredentials, and is only supported for "unix" connections.
- If the daemon is started with the `--certmap` option, it will attempt to use specified Docker plugins to identify HTTPS clients by their client certificates.
- If the daemon is started with the `--authn-plugins` option, it will also call out to authenticators implemented by the specified Docker plugins.
- When a daemon responds to a client request with a 401 error code, the client will attempt to authenticate using whatever scheme the daemon offers as part of the error message and try again.
- When attempting Basic authentication, the client will use values passed in as values for the `--basicusername` and `--basicpassword` options.  If either the password or both values are not specified on the command line, it will attempt to read the values to use from the `$DOCKER_AUTHN_USERID` and `$DOCKER_AUTHN_PASSWORD` variables in the environment.  If those are not set, and the client has a controlling terminal, it will prompt for the values.
