### PR TITLE
Added additional container information to "docker info".

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -25,6 +25,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	}
 
 	fmt.Fprintf(cli.out, "Containers: %d\n", info.Containers)
+	fmt.Fprintf(cli.out, " Running: %d\n", info.ContainersRunning)
+	fmt.Fprintf(cli.out, " Paused: %d\n", info.ContainersPaused)
+	fmt.Fprintf(cli.out, " Stopped: %d\n", info.ContainersStopped)
 	fmt.Fprintf(cli.out, "Images: %d\n", info.Images)
 	ioutils.FprintfIfNotEmpty(cli.out, "Server Version: %s\n", info.ServerVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Storage Driver: %s\n", info.Driver)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -193,6 +193,9 @@ type Version struct {
 type Info struct {
 	ID                 string
 	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
 	Images             int
 	Driver             string
 	DriverStatus       [][2]string

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -54,9 +54,24 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	initPath := utils.DockerInitPath("")
 	sysInfo := sysinfo.New(true)
 
+	var cRunning, cPaused, cStopped int
+	for _, c := range daemon.List() {
+		switch c.StateString() {
+		case "paused":
+			cPaused++
+		case "running":
+			cRunning++
+		default:
+			cStopped++
+		}
+	}
+
 	v := &types.Info{
 		ID:                 daemon.ID,
 		Containers:         len(daemon.List()),
+		ContainersRunning:  cRunning,
+		ContainersPaused:   cPaused,
+		ContainersStopped:  cStopped,
 		Images:             len(daemon.imageStore.Map()),
 		Driver:             daemon.GraphDriverName(),
 		DriverStatus:       daemon.layerStore.DriverStatus(),

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -21,6 +21,9 @@ For example:
 
     $ docker -D info
     Containers: 14
+     Running: 3
+     Paused: 1
+     Stopped: 10
     Images: 52
     Server Version: 1.9.0
     Storage Driver: aufs

--- a/docs/userguide/labels-custom-metadata.md
+++ b/docs/userguide/labels-custom-metadata.md
@@ -192,6 +192,9 @@ These labels appear as part of the `docker info` output for the daemon:
 
     $ docker -D info
     Containers: 12
+     Running: 5
+     Paused: 2
+     Stopped: 5
     Images: 672
     Server Version: 1.9.0
     Storage Driver: aufs

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -28,6 +28,7 @@ type DockerSuite struct {
 }
 
 func (s *DockerSuite) TearDownTest(c *check.C) {
+	unpauseAllContainers()
 	deleteAllContainers()
 	deleteAllImages()
 	deleteAllVolumes()

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -18,6 +18,9 @@ func (s *DockerSuite) TestInfoApi(c *check.C) {
 	stringsToCheck := []string{
 		"ID",
 		"Containers",
+		"ContainersRunning",
+		"ContainersPaused",
+		"ContainersStopped",
 		"Images",
 		"ExecutionDriver",
 		"LoggingDriver",

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -32,6 +32,9 @@ Here is a sample output:
 
     # docker info
     Containers: 14
+     Running: 3
+     Paused: 1
+     Stopped: 10
     Images: 52
     Server Version: 1.9.0
     Storage Driver: aufs


### PR DESCRIPTION
Instead of just showing the number of containers this patch will
show the number of running, paused and stopped containers as well.

Fixes: #15639

Signed-off-by: Kim Eik kim@heldig.org
