### PR TITLE
Bump go 1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,15 +84,9 @@ RUN cd /usr/src/lxc \
 
 # Install Go
 ENV GO_VERSION 1.5.1
-RUN curl -sSL https://golang.org/dl/go1.4.3.src.tar.gz | tar -v -C /usr/local -xz \
-	&& cd /usr/local/ && mv go go1.4.3
-RUN cd /usr/local/go1.4.3/src/ && ./make.bash
-ENV GOROOT_BOOTSTRAP /usr/local/go1.4.3
-RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
-	&& mkdir -p /go/bin
+RUN curl -sSL  "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar -v -C /usr/local -xz
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
-RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 
 # Compile Go for cross compilation
 ENV DOCKER_CROSSPLATFORMS \
@@ -103,13 +97,6 @@ ENV DOCKER_CROSSPLATFORMS \
 
 # (set an explicit GOARM of 5 for maximum compatibility)
 ENV GOARM 5
-RUN cd /usr/local/go/src \
-	&& set -x \
-	&& for platform in $DOCKER_CROSSPLATFORMS; do \
-		GOOS=${platform%/*} \
-		GOARCH=${platform##*/} \
-			./make.bash --no-clean 2>&1; \
-	done
 
 # This has been commented out and kept as reference because we don't support compiling with older Go anymore.
 # ENV GOFMT_VERSION 1.3.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,11 @@ RUN cd /usr/src/lxc \
 	&& ldconfig
 
 # Install Go
-ENV GO_VERSION 1.4.3
+ENV GO_VERSION 1.5.1
+RUN curl -sSL https://golang.org/dl/go1.4.3.src.tar.gz | tar -v -C /usr/local -xz \
+	&& cd /usr/local/ && mv go go1.4.3
+RUN cd /usr/local/go1.4.3/src/ && ./make.bash
+ENV GOROOT_BOOTSTRAP /usr/local/go1.4.3
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
 	&& mkdir -p /go/bin
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -14,7 +14,7 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 		windows/amd64)
 			export CC=x86_64-w64-mingw32-gcc
 			export CGO_ENABLED=1
-			export LDFLAGS_STATIC_DOCKER="${LDFLAGS_STATIC_DOCKER/-linkmode external/} -extld=${CC}"
+			export LDFLAGS_STATIC_DOCKER="${LDFLAGS_STATIC_DOCKER/-linkmode external/-linkmode internal} -extld=${CC}"
 			;;
 	esac
 fi

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -74,6 +74,18 @@ func ParseTCPAddr(tryAddr string, defaultAddr string) (string, error) {
 		return "", fmt.Errorf("Invalid proto, expected tcp: %s", tryAddr)
 	}
 
+	defaultAddr = strings.TrimPrefix(defaultAddr, "tcp://")
+	defaultHost, defaultPort, err := net.SplitHostPort(defaultAddr)
+	if err != nil {
+		return "", err
+	}
+	// url.Parse fails for trailing colon on IPv6 brackets on Go 1.5, but
+	// not 1.4. See https://github.com/golang/go/issues/12200 and
+	// https://github.com/golang/go/issues/6530.
+	if strings.HasSuffix(addr, "]:") {
+		addr += defaultPort
+	}
+
 	u, err := url.Parse("tcp://" + addr)
 	if err != nil {
 		return "", err
@@ -82,12 +94,6 @@ func ParseTCPAddr(tryAddr string, defaultAddr string) (string, error) {
 	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
 		return "", fmt.Errorf("Invalid bind address format: %s", tryAddr)
-	}
-
-	defaultAddr = strings.TrimPrefix(defaultAddr, "tcp://")
-	defaultHost, defaultPort, err := net.SplitHostPort(defaultAddr)
-	if err != nil {
-		return "", err
 	}
 
 	if host == "" {


### PR DESCRIPTION
Bumping Docker to use Go 1.5
- uses binaries for go compiling, speeding up cache busts
- fixes statically compiling windows
- fixes IPv6 URL parsing
- closes #15703
