### PR TITLE
Fix docker inspect display odd gateway value for none network mode

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -714,7 +714,9 @@ func (container *Container) updateJoinInfo(n libnetwork.Network, ep libnetwork.E
 		// It is not an error to get an empty endpoint info
 		return nil
 	}
-	container.NetworkSettings.Networks[n.Name()].Gateway = epInfo.Gateway().String()
+	if epInfo.Gateway() != nil {
+		container.NetworkSettings.Networks[n.Name()].Gateway = epInfo.Gateway().String()
+	}
 	if epInfo.GatewayIPv6().To16() != nil {
 		container.NetworkSettings.Networks[n.Name()].IPv6Gateway = epInfo.GatewayIPv6().String()
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
When run container with `--net=none` and `docker inspect` display a odd `gateway`

<pre><code>"Networks": {
            "none": {
                "EndpointID": "05541c7ce1780e21baa735d01b70b116db8b2759ecc9f2b64eb6a538f23b9a64",
                "Gateway": "\u003cnil\u003e",
                "IPAddress": "",
                "IPPrefixLen": 0,
                "IPv6Gateway": "",
                "GlobalIPv6Address": "",
                "GlobalIPv6PrefixLen": 0,
                "MacAddress": ""
            }
        }
</code></pre>

the gateway is `"Gateway": "\u003cnil\u003e",`it should be `"Gateway": "",`
