### PR TITLE
Add newlines to FormatProgress for JSON as well

### DIFF
--- a/pkg/streamformatter/streamformatter.go
+++ b/pkg/streamformatter/streamformatter.go
@@ -83,7 +83,7 @@ func (sf *StreamFormatter) FormatProgress(id, action string, progress *jsonmessa
 		if err != nil {
 			return nil
 		}
-		return b
+		return append(b, streamNewlineBytes...)
 	}
 	endl := "\r"
 	if progress.String() == "" {


### PR DESCRIPTION
Commit 060da572d20dfeee4fe02ce6b975a6cb33e50dbe has introduced newlines
to streamformatter to help parse Remote API responses. However,
FormatProgress method was omitted from the list of patched methods,
leaving progress messages in, say, /images/create without newlines.
