### PR TITLE
Fix docker status incorrectly reports containerized

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -36,7 +36,7 @@ func IsContainerized() (bool, error) {
 		return false, err
 	}
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
-		if len(line) > 0 && !bytes.HasSuffix(line, []byte{'/'}) {
+		if len(line) > 0 && !bytes.HasSuffix(line, []byte{'/'}) && !bytes.HasSuffix(line, []byte("init.scope")) {
 			return true, nil
 		}
 	}

--- a/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
@@ -68,7 +68,17 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
 
 func TestIsContainerized(t *testing.T) {
 	var (
-		backup                      = proc1Cgroup
+		backup                                = proc1Cgroup
+		nonContainerizedProc1Cgroupsystemd226 = []byte(`9:memory:/init.scope
+8:net_cls,net_prio:/
+7:cpuset:/
+6:freezer:/
+5:devices:/init.scope
+4:blkio:/init.scope
+3:cpu,cpuacct:/init.scope
+2:perf_event:/
+1:name=systemd:/init.scope
+`)
 		nonContainerizedProc1Cgroup = []byte(`14:name=systemd:/
 13:hugetlb:/
 12:net_prio:/
@@ -111,6 +121,17 @@ func TestIsContainerized(t *testing.T) {
 	}
 	if inContainer {
 		t.Fatal("Wrongly assuming containerized")
+	}
+
+	if err := ioutil.WriteFile(proc1Cgroup, nonContainerizedProc1Cgroupsystemd226, 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", proc1Cgroup, err)
+	}
+	inContainer, err = IsContainerized()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inContainer {
+		t.Fatal("Wrongly assuming containerized for systemd /init.scope cgroup layout")
 	}
 
 	if err := ioutil.WriteFile(proc1Cgroup, containerizedProc1Cgroup, 0600); err != nil {


### PR DESCRIPTION
Fixes #17037

Added a check for the systemd 226 `init.scope` so that docker won't incorrectly report the operating system as being containerized when the command `docker info` is run.
