### PR TITLE
Update kill.md

### DIFF
--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -19,3 +19,8 @@ parent = "smn_cli"
 
 The main process inside the container will be sent `SIGKILL`, or any
 signal specified with option `--signal`.
+
+> **Note:**
+> `ENTRYPOINT` and `CMD` in the *shell* form run as a subcommand of `/bin/sh -c`,
+> which does not pass signals. This means that the executable is not the container’s PID 1
+> and does not receive Unix signals.


### PR DESCRIPTION
Added Note to show users that signals will not propagate to the container if the preferred exec form isn't used.

I couldn't figure out why my signals weren't propagating and searched the docs to no avail. Eventually posted http://stackoverflow.com/questions/33379567/sending-signals-to-golang-application-in-docker/33396870 and was pointed in the right direction. I think it would be useful to add this note the `kill` docs.
