### PR TITLE
Fix relabel for SELinux

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -135,9 +135,10 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 			bind.Driver = v.DriverName()
 			bind = setBindModeIfNull(bind)
 		}
-		shared := label.IsShared(bind.Mode)
-		if err := label.Relabel(bind.Source, container.MountLabel, shared); err != nil {
-			return err
+		if label.RelabelNeeded(bind.Mode) {
+			if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
+				return err
+			}
 		}
 		binds[bind.Destination] = true
 		mountPoints[bind.Destination] = bind


### PR DESCRIPTION
With the changes merged into runc/libcontainer, are now causing
SELinux to attempt a relabel always, even if the user did not
request the relabel.

If the user does not specify Z or z on the volume mount we should
not attempt a relabel.

Signed-off-by: Dan Walsh dwalsh@redhat.com
