### PR TITLE
Fix rmi -f removing multiple tags

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -84,6 +84,11 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		daemon.EventsService.Log("untag", img.ID, "")
 		records = append(records, untaggedRecord)
 
+		// If has remaining references then untag finishes the remove
+		if daemon.repositories.HasReferences(img) {
+			return records, nil
+		}
+
 		removedRepositoryRef = true
 	} else {
 		// If an ID reference was given AND there is exactly one


### PR DESCRIPTION
When an image has multiple tags and `docker rmi` is called with `-f` on a tag, only the single tag should be removed. The current behavior is broken and removes all tags and the image.
