### PR TITLE
fix format of man page

### DIFF
--- a/man/docker-cp.1.md
+++ b/man/docker-cp.1.md
@@ -8,6 +8,9 @@ docker-cp - Copy files/folders between a container and the local filesystem.
 **docker cp**
 [**--help**]
 CONTAINER:PATH LOCALPATH|-
+
+**docker cp**
+[**--help**]
 LOCALPATH|- CONTAINER:PATH
 
 # DESCRIPTION

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -79,10 +79,10 @@ The initial status of the container created with **docker create** is 'created'.
 **--add-host**=[]
    Add a custom host-to-IP mapping (host:ip)
 
-**--blkio-weight**=0
+**--blkio-weight**=*0*
    Block IO weight (relative weight) accepts a weight value between 10 and 1000.
 
-**--cpu-shares**=0
+**--cpu-shares**=*0*
    CPU shares (relative weight)
 
 **--cap-add**=[]
@@ -97,7 +97,7 @@ The initial status of the container created with **docker create** is 'created'.
 **--cidfile**=""
    Write the container ID to the file
 
-**--cpu-period**=0
+**--cpu-period**=*0*
     Limit the CPU CFS (Completely Fair Scheduler) period
 
 **--cpuset-cpus**=""
@@ -110,7 +110,7 @@ The initial status of the container created with **docker create** is 'created'.
 then processes in your Docker container will only use memory from the first
 two memory nodes.
 
-**--cpu-quota**=0
+**--cpu-quota**=*0*
    Limit the CPU CFS (Completely Fair Scheduler) quota
 
 **--device**=[]
@@ -173,7 +173,7 @@ millions of trillions.
    Add link to another container in the form of <name or id>:alias or just
    <name or id> in which case the alias will match the name.
 
-**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*none*"
+**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: the `docker logs` command works only for the `json-file` and
   `journald` logging drivers.
@@ -214,7 +214,7 @@ This value should always larger than **-m**, so you should always use this with 
 **--name**=""
    Assign a name to the container
 
-**--net**="bridge"
+**--net**="*bridge*"
    Set the Network mode for the container
                                'bridge': creates a new network stack for the container on the docker bridge
                                'none': no networking for this container
@@ -234,7 +234,7 @@ This value should always larger than **-m**, so you should always use this with 
                                When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                                (use 'docker port' to see the actual mapping)
 
-**--pid**=host
+**--pid**=*host*
    Set the PID mode for the container
      **host**: use the host's PID namespace inside the container.
      Note: the host mode gives the container full access to local PID and is therefore considered insecure.
@@ -245,13 +245,13 @@ This value should always larger than **-m**, so you should always use this with 
 **--read-only**=*true*|*false*
    Mount the container's root filesystem as read only.
 
-**--restart**="no"
+**--restart**="*no*"
    Restart policy to apply when a container exits (no, on-failure[:max-retry], always, unless-stopped).
 
 **--security-opt**=[]
    Security Options
 
-**--stop-signal**=SIGTERM
+**--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.
 
 **-t**, **--tty**=*true*|*false*
@@ -263,7 +263,7 @@ This value should always larger than **-m**, so you should always use this with 
 **--ulimit**=[]
    Ulimit options
 
-**--uts**=host
+**--uts**=*host*
    Set the UTS mode for the container
      **host**: use the host's UTS namespace inside the container.
      Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -130,7 +130,7 @@ format.
 **-g**, **--graph**=""
   Path to use as the root of the Docker runtime. Default is `/var/lib/docker`.
 
-**-H**, **--host**=[unix:///var/run/docker.sock]: tcp://[host:port] to bind or
+**-H**, **--host**=[*unix:///var/run/docker.sock*]: tcp://[host:port] to bind or
 unix://[/path/to/socket] to use.
   The socket(s) to bind to in daemon mode specified using one or more
   tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
@@ -165,7 +165,7 @@ unix://[/path/to/socket] to use.
 **--ipv6**=*true*|*false*
   Enable IPv6 support. Default is false. Docker will create an IPv6-enabled bridge with address fe80::1 which will allow you to create IPv6-enabled containers. Use together with `--fixed-cidr-v6` to provide globally routable IPv6 addresses. IPv6 forwarding will be enabled if not used with `--ip-forward=false`. This may collide with your host's current IPv6 settings. For more information please consult the documentation about "Advanced Networking - IPv6".
 
-**-l**, **--log-level**="*debug*|*info*|*warn*|*error*|*fatal*""
+**-l**, **--log-level**="*debug*|*info*|*warn*|*error*|*fatal*"
   Set the logging level. Default is `info`.
 
 **--label**="[]"
@@ -178,13 +178,13 @@ unix://[/path/to/socket] to use.
 **--log-opt**=[]
   Logging driver specific options.
 
-**--mtu**=VALUE
+**--mtu**=*0*
   Set the containers network mtu. Default is `0`.
 
 **-p**, **--pidfile**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
 
-**--registry-mirror**=<scheme>://<host>
+**--registry-mirror**=*<scheme>://<host>*
   Prepend a registry mirror to be used for image pulls. May be specified multiple times.
 
 **-s**, **--storage-driver**=""
@@ -199,13 +199,13 @@ unix://[/path/to/socket] to use.
 **--tls**=*true*|*false*
   Use TLS; implied by --tlsverify. Default is false.
 
-**--tlscacert**=~/.docker/ca.pem
+**--tlscacert**=*~/.docker/ca.pem*
   Trust certs signed only by this CA.
 
-**--tlscert**=~/.docker/cert.pem
+**--tlscert**=*~/.docker/cert.pem*
   Path to TLS certificate file.
 
-**--tlskey**=~/.docker/key.pem
+**--tlskey**=*~/.docker/key.pem*
   Path to TLS key file.
 
 **--tlsverify**=*true*|*false*

--- a/man/docker-inspect.1.md
+++ b/man/docker-inspect.1.md
@@ -26,10 +26,10 @@ each result.
 **-f**, **--format**=""
     Format the output using the given Go template.
 
-**-s**, **--size**=false
+**-s**, **--size**=*false*
     Display total file sizes if the type is container.
 
-**--type**=*container*|*image*
+**--type**="*container*|*image*"
     Return JSON for specified type, permissible values are "image" or "container"
 
 # EXAMPLES

--- a/man/docker-kill.1.md
+++ b/man/docker-kill.1.md
@@ -19,7 +19,7 @@ The main process inside each container specified will be sent SIGKILL,
 **--help**
   Print usage statement
 
-**-s**, **--signal**="KILL"
+**-s**, **--signal**="*KILL*"
    Signal to send to the container
 
 # HISTORY

--- a/man/docker-logs.1.md
+++ b/man/docker-logs.1.md
@@ -39,7 +39,7 @@ logging drivers.
 **-t**, **--timestamps**=*true*|*false*
    Show timestamps. The default is *false*.
 
-**--tail**="all"
+**--tail**="*all*"
    Output the specified number of lines at the end of logs (defaults to all logs)
 
 The `--since` option shows only the container logs generated after

--- a/man/docker-network-connect.1.md
+++ b/man/docker-network-connect.1.md
@@ -5,9 +5,9 @@
 docker-network-connect - connect a container to a network
 
 # SYNOPSIS
-**docker network connect NAME CONTAINER**
-
+**docker network connect**
 [**--help**]
+NETWORK CONTAINER
 
 # DESCRIPTION
 
@@ -42,8 +42,8 @@ You can connect a container to one or more networks. The networks need not be th
 
 
 # OPTIONS
-**NAME**
-  Specify network driver name
+**NETWORK**
+  Specify network name
 
 **CONTAINER**
   Specify container name

--- a/man/docker-network-create.1.md
+++ b/man/docker-network-create.1.md
@@ -6,15 +6,15 @@ docker-network-create - create a new network
 
 # SYNOPSIS
 **docker network create**
-
-**--aux-address=map[]**    
-**-d** | **--driver=DRIVER**       
-**--gateway=[]**             
-**--help=false**             
-**--ip-range=[]**            
-**--ipam-driver=default**    
-**-o** | **--opt=map[]**           
-**--subnet=[]**              
+[**--aux-address**=*map[]*]
+[**-d**|**--driver**=*DRIVER*]
+[**--gateway**=*[]*]
+[**--help**]
+[**--ip-range**=*[]*]
+[**--ipam-driver**=*default*]
+[**-o**|**--opt**=*map[]*]
+[**--subnet**=*[]*]
+NETWORK-NAME
 
 # DESCRIPTION
 
@@ -97,7 +97,7 @@ specify subnetwork values directly using the the `--subnet` option. On a
 `bridge` network you can only create a single subnet:
 
 ```bash
-docker network create -d --subnet=192.168.0.0/16
+docker network create -d bridge --subnet=192.168.0.0/16 br0
 ```
 Additionally, you also specify the `--gateway` `--ip-range` and `--aux-address` options.
 
@@ -121,28 +121,28 @@ docker network create -d overlay
 Be sure that your subnetworks do not overlap. If they do, the network create fails and Engine returns an error.
 
 # OPTIONS
-**--aux-address=map[]**     
+**--aux-address**=map[]
   Auxiliary ipv4 or ipv6 addresses used by network driver
 
-**-d** | **--driver=DRIVER**       
+**-d**, **--driver**=*DRIVER*
   Driver to manage the Network bridge or overlay. The default is bridge.
 
-**--gateway=[] **            
+**--gateway**=[]
   ipv4 or ipv6 Gateway for the master subnet
 
-**--help=false **            
+**--help**
   Print usage
 
-**--ip-range=[] **           
+**--ip-range**=[]
   Allocate container ip from a sub-range
 
-**--ipam-driver=default **   
+**--ipam-driver**=*default*
   IP Address Management Driver
 
-**-o | --opt=map[]**           
+**-o**, **--opt**=map[]
   Set custom network plugin options
 
-**--subnet=[]**              
+**--subnet**=[]
   Subnet in CIDR format that represents a network segment
 
 # HISTORY

--- a/man/docker-network-disconnect.1.md
+++ b/man/docker-network-disconnect.1.md
@@ -5,9 +5,9 @@
 docker-network-disconnect - disconnect a container from a network
 
 # SYNOPSIS
-**docker network disconnect NETWORK CONTAINER**
-
+**docker network disconnect**
 [**--help**]
+NETWORK CONTAINER
 
 # DESCRIPTION
 

--- a/man/docker-network-inspect.1.md
+++ b/man/docker-network-inspect.1.md
@@ -5,9 +5,9 @@
 docker-network-inspect - inspect a network
 
 # SYNOPSIS
-**docker network inspect NETWORK [NETWORK...]**
-
+**docker network inspect**
 [**--help**]
+NETWORK [NETWORK...]
 
 # DESCRIPTION
 

--- a/man/docker-network-ls.1.md
+++ b/man/docker-network-ls.1.md
@@ -6,9 +6,8 @@ docker-network-ls - list networks
 
 # SYNOPSIS
 **docker network ls**
-
-[**--no-trunc**]
-[**-q** | **--quiet**]
+[**--no-trunc**[=*true*|*false*]]
+[**-q**|**--quiet**[=*true*|*false*]]
 [**--help**]
 
 # DESCRIPTION
@@ -38,10 +37,10 @@ c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host         
 
 # OPTIONS
 
-[**--no-trunc**]
+**--no-trunc**=*true*|*false*
   Do not truncate the output
 
-[**-q** | **--quiet**]
+**-q**, **--quiet**=*true*|*false*
   Only display numeric IDs
 
 **--help**

--- a/man/docker-network-rm.1.md
+++ b/man/docker-network-rm.1.md
@@ -5,9 +5,9 @@
 docker-network-rm - remove a new network
 
 # SYNOPSIS
-**docker network rm NETWORK**
-
+**docker network rm**
 [**--help**]
+NETWORK
 
 # DESCRIPTION
 
@@ -16,7 +16,6 @@ Removes a network by name or identifier. To remove a network, you must first dis
 ```
   $ docker network rm my-network
 ```
-
 
 # OPTIONS
 **NETWORK**

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -40,7 +40,7 @@ the running containers.
                           ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - filters containers that were
                           created from the given image or a descendant.
 
-**--format**=*"TEMPLATE"*
+**--format**="*TEMPLATE*"
    Pretty-print containers using a Go template.
    Valid placeholders:
       .ID - Container ID
@@ -60,7 +60,7 @@ the running containers.
 **-l**, **--latest**=*true*|*false*
    Show only the latest created container, include non-running ones. The default is *false*.
 
-**-n**=-1
+**-n**=*-1*
    Show n last created containers, include non-running ones.
 
 **--no-trunc**=*true*|*false*

--- a/man/docker-restart.1.md
+++ b/man/docker-restart.1.md
@@ -17,7 +17,7 @@ Restart each container listed.
 **--help**
   Print usage statement
 
-**-t**, **--time**=10
+**-t**, **--time**=*10*
    Number of seconds to try to stop for before killing the container. Once killed it will then be restarted. Default is 10 seconds.
 
 # HISTORY

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -96,10 +96,10 @@ each of stdin, stdout, and stderr.
    Add a line to /etc/hosts. The format is hostname:ip.  The **--add-host**
 option can be set multiple times.
 
-**--blkio-weight**=0
+**--blkio-weight**=*0*
    Block IO weight (relative weight) accepts a weight value between 10 and 1000.
 
-**--cpu-shares**=0
+**--cpu-shares**=*0*
    CPU shares (relative weight)
 
    By default, all containers get the same proportion of CPU cycles. This proportion
@@ -147,7 +147,7 @@ division of CPU shares:
 **--cidfile**=""
    Write the container ID to the file
 
-**--cpu-period**=0
+**--cpu-period**=*0*
    Limit the CPU CFS (Completely Fair Scheduler) period
 
    Limit the container's CPU usage. This flag tell the kernel to restrict the container's CPU usage to the period you specify.
@@ -162,7 +162,7 @@ division of CPU shares:
 then processes in your Docker container will only use memory from the first
 two memory nodes.
 
-**--cpu-quota**=0
+**--cpu-quota**=*0*
    Limit the CPU CFS (Completely Fair Scheduler) quota
 
    Limit the container's CPU usage. By default, containers run with the full
@@ -273,7 +273,7 @@ container can access the exposed port via a private networking interface. Docker
 will set some environment variables in the client container to help indicate
 which interface and port to use.
 
-**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*none*"
+**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: the `docker logs` command works only for the `json-file` and
   `journald` logging drivers.
@@ -326,7 +326,7 @@ string name. The name is useful when defining links (see **--link**) (or any
 other place you need to identify a container). This works for both background
 and foreground Docker containers.
 
-**--net**="bridge"
+**--net**="*bridge*"
    Set the Network mode for the container
                                'bridge': creates a new network stack for the container on the docker bridge
                                'none': no networking for this container
@@ -358,12 +358,12 @@ but not `docker run -p 1230-1236:1230-1240 --name RangeContainerPortsBiggerThanR
 With ip: `docker run -p 127.0.0.1:$HOSTPORT:$CONTAINERPORT --name CONTAINER -t someimage`
 Use `docker port` to see the actual mapping: `docker port CONTAINER $CONTAINERPORT`
 
-**--pid**=host
+**--pid**=*host*
    Set the PID mode for the container
      **host**: use the host's PID namespace inside the container.
      Note: the host mode gives the container full access to local PID and is therefore considered insecure.
 
-**--uts**=host
+**--uts**=*host*
    Set the UTS mode for the container
      **host**: use the host's UTS namespace inside the container.
      Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
@@ -388,7 +388,7 @@ outside of a container on the host.
 to write files anywhere.  By specifying the `--read-only` flag the container will have
 its root filesystem mounted as read only prohibiting any writes.
 
-**--restart**="no"
+**--restart**="*no*"
    Restart policy to apply when a container exits (no, on-failure[:max-retry], always, unless-stopped).
 
 **--rm**=*true*|*false*
@@ -403,7 +403,7 @@ its root filesystem mounted as read only prohibiting any writes.
     "label:level:LEVEL" : Set the label level for the container
     "label:disable"     : Turn off label confinement for the container
 
-**--stop-signal**=SIGTERM
+**--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.
 
 **--sig-proxy**=*true*|*false*
@@ -430,7 +430,7 @@ standard input.
 
    Without this argument the command will be run as root in the container.
 
-""--ulimit""=[]
+**--ulimit**=[]
     Ulimit options
 
 **-v**, **--volume**=[] Create a bind mount

--- a/man/docker-search.1.md
+++ b/man/docker-search.1.md
@@ -30,7 +30,7 @@ of stars awarded, whether the image is official, and whether it is automated.
 **--no-trunc**=*true*|*false*
    Don't truncate output. The default is *false*.
 
-**-s**, **--stars**=X
+**-s**, **--stars**=*X*
    Only displays with at least X stars. The default is zero.
 
 # EXAMPLES

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -22,8 +22,8 @@ Display a live stream of one or more containers' resource usage statistics
 **--help**
   Print usage statement
 
-**--no-stream**="false"
-  Disable streaming stats and only pull the first result
+**--no-stream**=*true*|*false*
+  Disable streaming stats and only pull the first result, default setting is false.
 
 # EXAMPLES
 

--- a/man/docker-stop.1.md
+++ b/man/docker-stop.1.md
@@ -18,7 +18,7 @@ Stop a container (Send SIGTERM, and then SIGKILL after
 **--help**
   Print usage statement
 
-**-t**, **--time**=10
+**-t**, **--time**=*10*
   Number of seconds to wait for the container to stop before killing it. Default is 10 seconds.
 
 #See also

--- a/man/docker-volume-create.1.md
+++ b/man/docker-volume-create.1.md
@@ -39,7 +39,7 @@ different volume drivers may do different things (or nothing at all).
 *Note*: The built-in `local` volume driver does not currently accept any options.
 
 # OPTIONS
-**-d**, **--driver**="local"
+**-d**, **--driver**="*local*"
   Specify volume driver name
 
 **--help**

--- a/man/docker-volume-ls.1.md
+++ b/man/docker-volume-ls.1.md
@@ -23,7 +23,7 @@ There is a single supported filter `dangling=value` which takes a boolean of `tr
 **--help**
   Print usage statement
 
-**-q**, **--quiet**=false
+**-q**, **--quiet**=*true*|*false*
   Only display volume names
 
 # HISTORY

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -7,9 +7,9 @@ docker \- Docker image and container command line interface
 # SYNOPSIS
 **docker** [OPTIONS] COMMAND [arg...]
 
-**docker** daemon [ --help | ... ]
+**docker** daemon [--help|...]
 
-**docker** [ --help | -v | --version ]
+**docker** [--help|-v|--version]
 
 # DESCRIPTION
 **docker** has two distinct functions. It is used for starting the Docker
@@ -36,26 +36,26 @@ To see the man page for a command run **man docker <command>**.
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.
 
-**-H**, **--host**=[unix:///var/run/docker.sock]: tcp://[host]:[port][path] to bind or
+**-H**, **--host**=[*unix:///var/run/docker.sock*]: tcp://[host]:[port][path] to bind or
 unix://[/path/to/socket] to use.
   The socket(s) to bind to in daemon mode specified using one or more
   tcp://host:port/path, unix:///path/to/socket, fd://* or fd://socketfd.
   If the tcp port is not specified, then it will default to either `2375` when
   `--tls` is off, or `2376` when `--tls` is on, or `--tlsverify` is specified.
 
-**-l**, **--log-level**="*debug*|*info*|*warn*|*error*|*fatal*""
+**-l**, **--log-level**="*debug*|*info*|*warn*|*error*|*fatal*"
   Set the logging level. Default is `info`.
 
 **--tls**=*true*|*false*
   Use TLS; implied by --tlsverify. Default is false.
 
-**--tlscacert**=~/.docker/ca.pem
+**--tlscacert**=*~/.docker/ca.pem*
   Trust certs signed only by this CA.
 
-**--tlscert**=~/.docker/cert.pem
+**--tlscert**=*~/.docker/cert.pem*
   Path to TLS certificate file.
 
-**--tlskey**=~/.docker/key.pem
+**--tlskey**=*~/.docker/key.pem*
   Path to TLS key file.
 
 **--tlsverify**=*true*|*false*


### PR DESCRIPTION
This commit fixes some format problems of man page, most about the
`docker network` command, also add some contents and fix minor typo.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

There are still some other format problems which can't be solved by editing the `md` files, I'll open a new issue to illustrate it.
@cpuguy83 
