### PR TITLE
Fix connect to host and prevent disconnect from host for host network

### DIFF
--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -22,6 +22,8 @@ var (
 	ErrConflictUserDefinedNetworkAndLinks = fmt.Errorf("Conflicting options: --net=<NETWORK> can't be used with links. This would result in undefined behavior")
 	// ErrConflictSharedNetwork conflict between private and other networks
 	ErrConflictSharedNetwork = fmt.Errorf("Container sharing network namespace with another container or host cannot be connected to any other network")
+	// ErrConflictHostNetwork conflict from being disconnected from host network or connected to host network.
+	ErrConflictHostNetwork = fmt.Errorf("Container cannot be disconnected from host network or connected to host network")
 	// ErrConflictNoNetwork conflict between private and other networks
 	ErrConflictNoNetwork = fmt.Errorf("Container cannot be connected to multiple networks with one of the networks in --none mode")
 	// ErrConflictNetworkAndDNS conflict between --dns and the network mode


### PR DESCRIPTION
There are two commits in this PR.
The first one is to fix connect to host. If a container start with default network(`bridge`) or `none`
it can't be connect to `host` as desired. but if disconnect the container from `bridge` or `none`, you can
connect to `host`, but this will cause some problem.

<pre><code>$ docker run -ti --rm --name container1 busybox
$ docker network disconnect bridge container1
$ docker network connect host container1
</code></pre>

we able to connect to host after the container disconnect from `bridge`
but actually, the container still use its own network namespace, docker inspect still show its own private sandbox the container use and `ifconfig` in the container still the information of its own private network namespace. 
From what I understand the container has private network namespace cannot connect to other network namespace, https://github.com/docker/docker/blob/master/daemon/container_unix.go#L742 is supposed to do thar but may not go there because `container.NetworkSettings.Networks` could be nil ,correct me if I'm wrong :) @mavenugo 

The second commit is to prevent from disconnecting from host for a container start with `--net=host`. if a container with `--net=host` disconnect from `host`,  it still in the host network namespace, but able to connect to other network, and cause some problem.

<pre><code>
$ docker run -ti --rm --net=host --name container1 busybox
$ docker network disconnect host container1
$ docker network connect bridge container1
Error response from daemon: failed to set gateway while updating gateway: network is unreachable
</code></pre>

though connect to `bridge` failed, but it has create a `eth0` network interface on my host

<pre><code>eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.17.0.2  netmask 255.255.0.0  broadcast 0.0.0.0
        inet6 fe80::42:acff:fe11:2  prefixlen 64  scopeid 0x20<link>
        ether 02:42:ac:11:00:02  txqueuelen 0  (Ethernet)
        RX packets 8  bytes 648 (648.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 10  bytes 732 (732.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0</code></pre>

and docker inspect show the endpoint information

<pre><code>"Networks": {
            "bridge": {
                "EndpointID": "ddc8cd9e738f9255fc3288c82d77adf6d226ed1ec0e1c8000935b0269e39080a",
                "Gateway": "",
                "IPAddress": "172.17.0.2",
                "IPPrefixLen": 16,
                "IPv6Gateway": "",
                "GlobalIPv6Address": "",
                "GlobalIPv6PrefixLen": 0,
                "MacAddress": "02:42:ac:11:00:02"
            }
        }</code></pre> 


So I think we should prevent user from disconnect from host  
ping @tiborvass 
