### PR TITLE
Carry#13921 : Expand /info: Expose OSType (GOOS), Architecture (GOARCH)

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -46,6 +46,8 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	ioutils.FprintfIfNotEmpty(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
 	ioutils.FprintfIfNotEmpty(cli.out, "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
+	ioutils.FprintfIfNotEmpty(cli.out, "OSType: %s\n", info.OSType)
+	ioutils.FprintfIfNotEmpty(cli.out, "Architecture: %s\n", info.Architecture)
 	fmt.Fprintf(cli.out, "CPUs: %d\n", info.NCPU)
 	fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(info.MemTotal)))
 	ioutils.FprintfIfNotEmpty(cli.out, "Name: %s\n", info.Name)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -207,6 +207,8 @@ type Info struct {
 	NEventsListener    int
 	KernelVersion      string
 	OperatingSystem    string
+	OSType             string
+	Architecture       string
 	IndexServerAddress string
 	RegistryConfig     *registry.ServiceConfig
 	InitSha1           string

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -75,6 +75,8 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		KernelVersion:      kernelVersion,
 		OperatingSystem:    operatingSystem,
 		IndexServerAddress: registry.IndexServer,
+		OSType:             runtime.GOOS,
+		Architecture:       runtime.GOARCH,
 		RegistryConfig:     daemon.RegistryService.Config,
 		InitSha1:           dockerversion.InitSHA1,
 		InitPath:           initPath,

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
+	"github.com/docker/docker/pkg/platform"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
@@ -75,8 +76,8 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		KernelVersion:      kernelVersion,
 		OperatingSystem:    operatingSystem,
 		IndexServerAddress: registry.IndexServer,
-		OSType:             runtime.GOOS,
-		Architecture:       runtime.GOARCH,
+		OSType:             platform.OSType,
+		Architecture:       platform.Architecture,
 		RegistryConfig:     daemon.RegistryService.Config,
 		InitSha1:           dockerversion.InitSHA1,
 		InitPath:           initPath,

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1884,6 +1884,7 @@ Display system-wide information
     Content-Type: application/json
 
     {
+        "Architecture": "amd64",
         "Containers": 11,
         "CpuCfsPeriod": true,
         "CpuCfsQuota": true,
@@ -1915,6 +1916,7 @@ Display system-wide information
         "Name": "prod-server-42",
         "NoProxy": "9.81.1.160",
         "OomKillDisable": true,
+        "OSType": "linux",
         "OperatingSystem": "Boot2Docker",
         "RegistryConfig": {
             "IndexConfigs": {

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1884,7 +1884,7 @@ Display system-wide information
     Content-Type: application/json
 
     {
-        "Architecture": "amd64",
+        "Architecture": "x86_64",
         "Containers": 11,
         "CpuCfsPeriod": true,
         "CpuCfsQuota": true,

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -31,6 +31,8 @@ For example:
     Execution Driver: native-0.2
     Logging Driver: json-file
     Kernel Version: 3.19.0-22-generic
+    OSType: linux
+    Architecture: amd64
     Operating System: Ubuntu 15.04
     CPUs: 24
     Total Memory: 62.86 GiB

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -32,7 +32,7 @@ For example:
     Logging Driver: json-file
     Kernel Version: 3.19.0-22-generic
     OSType: linux
-    Architecture: amd64
+    Architecture: x86_64
     Operating System: Ubuntu 15.04
     CPUs: 24
     Total Memory: 62.86 GiB

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -23,6 +23,8 @@ func (s *DockerSuite) TestInfoApi(c *check.C) {
 		"LoggingDriver",
 		"OperatingSystem",
 		"NCPU",
+		"OSType",
+		"Architecture",
 		"MemTotal",
 		"KernelVersion",
 		"Driver",

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -19,6 +19,8 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Containers:",
 		"Images:",
 		"Execution Driver:",
+		"OSType:",
+		"Architecture:",
 		"Logging Driver:",
 		"Operating System:",
 		"CPUs:",

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -42,7 +42,7 @@ Here is a sample output:
     Kernel Version: 3.13.0-24-generic
     Operating System: Ubuntu 14.04 LTS
     OSType: linux
-    Architecture: amd64
+    Architecture: x86_64
     CPUs: 1
     Total Memory: 2 GiB
 

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -41,6 +41,8 @@ Here is a sample output:
     Logging Driver: json-file
     Kernel Version: 3.13.0-24-generic
     Operating System: Ubuntu 14.04 LTS
+    OSType: linux
+    Architecture: amd64
     CPUs: 1
     Total Memory: 2 GiB
 

--- a/pkg/platform/architecture_freebsd.go
+++ b/pkg/platform/architecture_freebsd.go
@@ -1,0 +1,15 @@
+package platform
+
+import (
+	"os/exec"
+)
+
+// GetRuntimeArchitecture get the name of the current architecture (x86, x86_64, …)
+func GetRuntimeArchitecture() (string, error) {
+	cmd := exec.Command("uname", "-m")
+	machine, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(machine), nil
+}

--- a/pkg/platform/architecture_linux.go
+++ b/pkg/platform/architecture_linux.go
@@ -1,0 +1,28 @@
+// Package platform provides helper function to get the runtime architecture
+// for different platforms.
+package platform
+
+import (
+	"syscall"
+)
+
+// GetRuntimeArchitecture get the name of the current architecture (x86, x86_64, …)
+func GetRuntimeArchitecture() (string, error) {
+	utsname := &syscall.Utsname{}
+	if err := syscall.Uname(utsname); err != nil {
+		return "", err
+	}
+	return charsToString(utsname.Machine), nil
+}
+
+func charsToString(ca [65]int8) string {
+	s := make([]byte, len(ca))
+	var lens int
+	for ; lens < len(ca); lens++ {
+		if ca[lens] == 0 {
+			break
+		}
+		s[lens] = uint8(ca[lens])
+	}
+	return string(s[0:lens])
+}

--- a/pkg/platform/architecture_windows.go
+++ b/pkg/platform/architecture_windows.go
@@ -1,0 +1,52 @@
+package platform
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32       = syscall.NewLazyDLL("kernel32.dll")
+	procGetSystemInfo = modkernel32.NewProc("GetSystemInfo")
+)
+
+// see http://msdn.microsoft.com/en-us/library/windows/desktop/ms724958(v=vs.85).aspx
+type systeminfo struct {
+	wProcessorArchitecture      uint16
+	wReserved                   uint16
+	dwPageSize                  uint32
+	lpMinimumApplicationAddress uintptr
+	lpMaximumApplicationAddress uintptr
+	dwActiveProcessorMask       uintptr
+	dwNumberOfProcessors        uint32
+	dwProcessorType             uint32
+	dwAllocationGranularity     uint32
+	wProcessorLevel             uint16
+	wProcessorRevision          uint16
+}
+
+// Constants
+const (
+	ProcessorArchitecture64   = 9 // PROCESSOR_ARCHITECTURE_AMD64
+	ProcessorArchitectureIA64 = 6 // PROCESSOR_ARCHITECTURE_IA64
+	ProcessorArchitecture32   = 0 // PROCESSOR_ARCHITECTURE_INTEL
+	ProcessorArchitectureArm  = 5 // PROCESSOR_ARCHITECTURE_ARM
+)
+
+var sysinfo systeminfo
+
+// GetRuntimeArchitecture get the name of the current architecture (x86, x86_64, …)
+func GetRuntimeArchitecture() (string, error) {
+	syscall.Syscall(procGetSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(&sysinfo)), 0, 0)
+	switch sysinfo.wProcessorArchitecture {
+	case ProcessorArchitecture64, ProcessorArchitectureIA64:
+		return "x86_64", nil
+	case ProcessorArchitecture32:
+		return "i686", nil
+	case ProcessorArchitectureArm:
+		return "arm", nil
+	default:
+		return "", fmt.Errorf("Unknown processor architecture")
+	}
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,0 +1,23 @@
+package platform
+
+import (
+	"runtime"
+
+	"github.com/Sirupsen/logrus"
+)
+
+var (
+	// Architecture holds the runtime architecture of the process.
+	Architecture string
+	// OSType holds the runtime operating system type (Linux, …) of the process.
+	OSType string
+)
+
+func init() {
+	var err error
+	Architecture, err = GetRuntimeArchitecture()
+	if err != nil {
+		logrus.Errorf("Could no read system architecture info: %v", err)
+	}
+	OSType = runtime.GOOS
+}


### PR DESCRIPTION
This carry #13921 from 🌟 @olleolleolle to add `OSType` and `Architecture` to `/info` endpoint.

> This change amends the diagnostic output of /info, to add two more keys. This supports Swarm's effort of helping users target multi-architecture Swarm clusters. See #13634.
> 
> These keys were introduced:
> -  OSType (runtime.GOOS)
> - Architecture (runtime.GOARCH)

Trying to take into account the comment from @tiborvass in here : https://github.com/docker/docker/pull/13921#issuecomment-140270124

> - We can't use GOARCH, because https://github.com/docker/docker/pull/13921#issuecomment-130106474 , but GOOS does not have that problem so we should be able to rely on `runtime.GOOS`.
> - Let's find a way to detect runtime architecture for each OS:
>   - Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724381(v=vs.85).aspx
>   - Linux: `syscall.Uname()`
>   - Darwin/FreeBSD: `uname -m` (shell out)
> - After seeing "ostype" in `sysctl -a` on both linux and darwin, I think we could use `OSType` (as suggested by others in earlier comments). What's more, the word "type" does not exist in the /etc/os-release spec: http://www.freedesktop.org/software/systemd/man/os-release.html
> - So for `OSType`, we could use `runtime.GOOS`
> - For a prettier or more structured representation of OS information, I suggest let's not decide now on what scheme to adopt for a crossplatform solution. Instead let's introduce `OSType` and keep `OperatingSystem` for the pretty version, because that's what it already is today.

_/me hopes it builds on other platform_

🌟 @tiborvass @runcom 
