### PR TITLE
Remove GOARCH to support integration test on other arch

### DIFF
--- a/hack/make/.ensure-httpserver
+++ b/hack/make/.ensure-httpserver
@@ -8,7 +8,7 @@ dir="$DEST/httpserver"
 mkdir -p "$dir"
 (
 	cd "$dir"
-	GOOS=linux GOARCH=amd64 go build -o httpserver github.com/docker/docker/contrib/httpserver
+	go build -o httpserver github.com/docker/docker/contrib/httpserver
 	cp ../../../../contrib/httpserver/Dockerfile .
 	docker build -qt httpserver . > /dev/null
 )


### PR DESCRIPTION
It's not necessary, and will cause error on other architectures
when running integration tests.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
