### PR TITLE
Add format flag to network inspect

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1133,9 +1133,15 @@ _docker_network_disconnect() {
 }
 
 _docker_network_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
 			;;
 		*)
 			__docker_networks

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -309,9 +309,10 @@ __docker_network_subcommand() {
                 "($help)*"{-o=,--opt=}"[Set driver specific options]:key=value: " \
                 "($help -)1:Network Name: " && ret=0
             ;;
-        (inspect|rm)
+        (inspect)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help -f --format)"{-f=,--format=}"[Format the output using the given go template]:template: " \
                 "($help -)*:network:__docker_networks" && ret=0
             ;;
         (ls)
@@ -319,6 +320,11 @@ __docker_network_subcommand() {
                 $opts_help \
                 "($help)--no-trunc[Do not truncate the output]" \
                 "($help -q --quiet)"{-q,--quiet}"[Only display numeric IDs]" && ret=0
+            ;;
+        (rm)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help -)*:network:__docker_networks" && ret=0
             ;;
         (help)
             _arguments $(__docker_arguments) ":subcommand:__docker_network_commands" && ret=0

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -14,6 +14,7 @@ parent = "smn_cli"
 
     Displays detailed information on a network
 
+      -f, --format=       Format the output using the given go template.
       --help=false       Print usage
 
 Returns information about one or more networks. By default, this command renders all results in a JSON object. For example, if you connect two containers to a network:
@@ -26,7 +27,11 @@ $ sudo docker run -itd --name=container2 busybox
 bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727
 ```
 
-The `network inspect` command shows the containers, by id, in its results.
+The `network inspect` command shows the containers, by id, in its
+results. You can specify an alternate format to execute a given
+template for each result. Go's
+[text/template](http://golang.org/pkg/text/template/) package describes all the
+details of the format.
 
 ```bash
 $ sudo docker network inspect bridge

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -293,6 +293,17 @@ func (s *DockerSuite) TestDockerNetworkDeleteMultiple(c *check.C) {
 	assertNwIsAvailable(c, "testDelMulti2")
 }
 
+func (s *DockerSuite) TestDockerNetworkInspect(c *check.C) {
+	out, _ := dockerCmd(c, "network", "inspect", "host")
+	networkResources := []types.NetworkResource{}
+	err := json.Unmarshal([]byte(out), &networkResources)
+	c.Assert(err, check.IsNil)
+	c.Assert(networkResources, checker.HasLen, 1)
+
+	out, _ = dockerCmd(c, "network", "inspect", "--format='{{ .Name }}'", "host")
+	c.Assert(strings.TrimSpace(out), check.Equals, "host")
+}
+
 func (s *DockerSuite) TestDockerInspectMultipleNetwork(c *check.C) {
 	out, _ := dockerCmd(c, "network", "inspect", "host", "none")
 	networkResources := []types.NetworkResource{}

--- a/man/docker-network-inspect.1.md
+++ b/man/docker-network-inspect.1.md
@@ -6,6 +6,7 @@ docker-network-inspect - inspect a network
 
 # SYNOPSIS
 **docker network inspect**
+[**-f**|**--format**[=*FORMAT*]]
 [**--help**]
 NETWORK [NETWORK...]
 
@@ -21,7 +22,11 @@ $ sudo docker run -itd --name=container2 busybox
 bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727
 ```
 
-The `network inspect` command shows the containers, by id, in its results.
+The `network inspect` command shows the containers, by id, in its
+results. You can specify an alternate format to execute a given
+template for each result. Go's
+[text/template](http://golang.org/pkg/text/template/) package
+describes all the details of the format.
 
 ```bash
 $ sudo docker network inspect bridge
@@ -50,6 +55,8 @@ $ sudo docker network inspect bridge
 
 
 # OPTIONS
+**-f**, **--format**=""
+  Format the output using the given go template.
 
 **--help**
   Print usage statement


### PR DESCRIPTION
…for consistency as docker inspect and docker volume inspect supports it too 🐙.

``` bash
$ docker network inspect -f "{{.Name}}" bridge host
bridge
host
```

Closes #17446 

/ping @albers @mavenugo 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
