### PR TITLE
Enhance `docker network rm` to delete multi net

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -87,19 +87,28 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 	return nil
 }
 
-// CmdNetworkRm deletes a network
+// CmdNetworkRm deletes one or more networks
 //
-// Usage: docker network rm <NETWORK-NAME | NETWORK-ID>
+// Usage: docker network rm NETWORK-NAME|NETWORK-ID [NETWORK-NAME|NETWORK-ID...]
 func (cli *DockerCli) CmdNetworkRm(args ...string) error {
-	cmd := Cli.Subcmd("network rm", []string{"NETWORK"}, "Deletes a network", false)
-	cmd.Require(flag.Exact, 1)
+	cmd := Cli.Subcmd("network rm", []string{"NETWORK [NETWORK...]"}, "Deletes one or more networks", false)
+	cmd.Require(flag.Min, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
 		return err
 	}
-	_, _, err = readBody(cli.call("DELETE", "/networks/"+cmd.Arg(0), nil, nil))
-	if err != nil {
-		return err
+
+	status := 0
+	for _, net := range cmd.Args() {
+		_, _, err = readBody(cli.call("DELETE", "/networks/"+net, nil, nil))
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			status = 1
+			continue
+		}
+	}
+	if status != 0 {
+		return Cli.StatusError{StatusCode: status}
 	}
 	return nil
 }
@@ -193,7 +202,7 @@ func (cli *DockerCli) CmdNetworkLs(args ...string) error {
 //
 // Usage: docker network inspect [OPTIONS] <NETWORK> [NETWORK...]
 func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
-	cmd := Cli.Subcmd("network inspect", []string{"NETWORK [NETWORK...]"}, "Displays detailed information on a network", false)
+	cmd := Cli.Subcmd("network inspect", []string{"NETWORK [NETWORK...]"}, "Displays detailed information on one or more networks", false)
 	cmd.Require(flag.Min, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
@@ -208,7 +217,7 @@ func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
 			if strings.Contains(err.Error(), "not found") {
 				fmt.Fprintf(cli.err, "Error: No such network: %s\n", name)
 			} else {
-				fmt.Fprintf(cli.err, "%s", err)
+				fmt.Fprintf(cli.err, "%s\n", err)
 			}
 			status = 1
 			continue

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -10,17 +10,32 @@ parent = "smn_cli"
 
 # network rm
 
-    Usage:  docker network rm [OPTIONS] NAME | ID
+    Usage:  docker network rm [OPTIONS] NETWORK [NETWORK...]
 
-    Deletes a network
+    Deletes one or more networks
 
       --help=false       Print usage
 
-Removes a network by name or identifier. To remove a network, you must first disconnect any containers connected to it.
+Removes one or more networks by name or identifier. To remove a network,
+you must first disconnect any containers connected to it.
+To remove the network named 'my-network':
 
 ```bash
   $ docker network rm my-network
 ```
+
+To delete multiple networks in a single `docker network rm` command, provide
+multiple network names or id's. The following example deletes a network with id
+`3695c422697f` and a network named `my-network`:
+
+```bash
+  $ docker network rm 3695c422697f my-network
+```
+
+When you specify multiple networks, the command attempts to delete each in turn.
+If the deletion of one network fails, the command continues to the next on the
+list and tries to delete that. The command reports success or failure for each
+deletion.
 
 ## Related information
 

--- a/man/docker-network-rm.1.md
+++ b/man/docker-network-rm.1.md
@@ -2,24 +2,39 @@
 % Docker Community
 % OCT 2015
 # NAME
-docker-network-rm - remove a new network
+docker-network-rm - remove one or more networks
 
 # SYNOPSIS
-**docker network rm**
+**docker network rm** 
 [**--help**]
-NETWORK
+NETWORK [NETWORK...]
 
 # DESCRIPTION
 
-Removes a network by name or identifier. To remove a network, you must first disconnect any containers connected to it.
+Removes one or more networks by name or identifier. To remove a network,
+you must first disconnect any containers connected to it.
+To remove the network named 'my-network':
 
-```
+```bash
   $ docker network rm my-network
 ```
 
+To delete multiple networks in a single `docker network rm` command, provide
+multiple network names or id's. The following example deletes a network with id
+`3695c422697f` and a network named `my-network`:
+
+```bash
+  $ docker network rm 3695c422697f my-network
+```
+
+When you specify multiple networks, the command attempts to delete each in turn.
+If the deletion of one network fails, the command continues to the next on the
+list and tries to delete that. The command reports success or failure for each
+deletion.
+
 # OPTIONS
 **NETWORK**
-  Specify network name
+  Specify network name or id
 
 **--help**
   Print usage statement


### PR DESCRIPTION
This commit enhance `docker network rm` command to allow user to delete
multi networks at the same time.

As now `docker network inspect` command can accept multi params at the same time just like `docker rmi` or `docker rm` do, I think `docker network rm` should also be able to delete multi-networks at the same time.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
