### PR TITLE
Libnetwork vendoring & overlay networking fixes

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork abc0807d72e309f53155ec4f6374a77fd6613849
+clone git github.com/docker/libnetwork 20351a84241aa1278493d74492db947336989be6
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_serf.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_serf.go
@@ -48,6 +48,7 @@ func (d *driver) serfInit() error {
 	config.UserQuiescentPeriod = 50 * time.Millisecond
 
 	config.LogOutput = &logWriter{}
+	config.MemberlistConfig.LogOutput = config.LogOutput
 
 	s, err := serf.Create(config)
 	if err != nil {


### PR DESCRIPTION
This brings in two fixes for overlay networking:
1. External connectivity tracked by the port-mapping issue in [ibnetwork](https://github.com/docker/libnetwork/issues/716)
2. /etc/hosts issue, #17465

Fixes #17465 
Vendoring also Fixes  #17449 
