### PR TITLE
Fix apparmor path to network/files

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -28,7 +28,7 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   owner /** rw,
   @{DOCKER_GRAPH_PATH}/** rwl,
   @{DOCKER_GRAPH_PATH}/linkgraph.db k,
-  @{DOCKER_GRAPH_PATH}/network/files/boltdb.db k,
+  /var/lib/docker/network/files/boltdb.db k,
 
   # For non-root client use:
   /dev/urandom r,


### PR DESCRIPTION
This path is actually hard coded in libnetwork to
`/var/lib/docker/network/files`. See
https://github.com/docker/libnetwork/search?utf8=%E2%9C%93&q=var%2Flib%2Fdocker%2Fnetwork%2Ffiles.

ping @calavera @ewindisch 
