### PR TITLE
setting device-mapper-libs version dependency for centos 7 rpm

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -43,7 +43,7 @@ Requires: iptables
 Requires: libcgroup
 Requires: tar
 Requires: xz
-%if 0%{?fedora} >= 21
+%if 0%{?fedora} >= 21 || 0%{?centos} >= 7
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1
 %endif

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -43,7 +43,7 @@ Requires: iptables
 Requires: libcgroup
 Requires: tar
 Requires: xz
-%if 0%{?fedora} >= 21 || 0%{?centos} >= 7
+%if 0%{?fedora} >= 21 || 0%{?centos} >= 7 || 0%{?rhel} >= 7 || 0%{?oraclelinux} >= 7
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1
 %endif


### PR DESCRIPTION
resolves #17379
