### PR TITLE
Add EnvironmentFile=/etc/default/docker for systemd unit

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,8 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
+EnvironmentFile=-/etc/default/docker
+ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Otherwise, local modifications are not sourced by the daemon
the "-" is here so, if the file does not exists, the service does not complain.
I figured this bug after upgrading to Ubuntu 15.10 (systemd based) from 14.10 (upstart based)
