### PR TITLE
Let the api to choose the default network driver.

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -54,6 +54,13 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 		return err
 	}
 
+	// Set the default driver to "" if the user didn't set the value.
+	// That way we can know whether it was user input or not.
+	driver := *flDriver
+	if !cmd.IsSet("-driver") && !cmd.IsSet("d") {
+		driver = ""
+	}
+
 	ipamCfg, err := consolidateIpam(flIpamSubnet.GetAll(), flIpamIPRange.GetAll(), flIpamGateway.GetAll(), flIpamAux.GetAll())
 	if err != nil {
 		return err
@@ -62,7 +69,7 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 	// Construct network create request body
 	nc := types.NetworkCreate{
 		Name:           cmd.Arg(0),
-		Driver:         *flDriver,
+		Driver:         driver,
 		IPAM:           network.IPAM{Driver: *flIpamDriver, Config: ipamCfg},
 		Options:        flOpts.GetAll(),
 		CheckDuplicate: true,


### PR DESCRIPTION
That way swarm can understand the user's intention.

@tiborvass it turns out that we already have a bunch of tests in integration-cli/docker_api_network_test.go that already assume the driver is an empty string and let the daemon to select `bridge` as default network. I added an extra test here, but I don't think it's necessary.

Closes #17500

Signed-off-by: David Calavera david.calavera@gmail.com
