### PR TITLE
Fix test file paths

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -86,6 +86,15 @@ func init() {
 	dockerBasePath = info.DockerRootDir
 	volumesConfigPath = filepath.Join(dockerBasePath, "volumes")
 	containerStoragePath = filepath.Join(dockerBasePath, "containers")
+	// Make sure in context of daemon, not the local platform. Note we can't
+	// use filepath.FromSlash or ToSlash here as they are a no-op on Unix.
+	if daemonPlatform == "windows" {
+		volumesConfigPath = strings.Replace(volumesConfigPath, `/`, `\`, -1)
+		containerStoragePath = strings.Replace(containerStoragePath, `/`, `\`, -1)
+	} else {
+		volumesConfigPath = strings.Replace(volumesConfigPath, `\`, `/`, -1)
+		containerStoragePath = strings.Replace(containerStoragePath, `\`, `/`, -1)
+	}
 }
 
 // Daemon represents a Docker daemon for the testing framework.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ugly as it comes, but I can't think of a better way of doing this, and the built-in filepath operations won't work in this context. Imagine a Windows client targeting a Linux daemon. Here, the path returned from the API will be something like /var/lib/docker.

However, the filepath.Join will convert it to \var\lib\docker\volumes. While I could use path.Join, that also still wouldn't solve the problem for the Linux to Windows case.

So instead, we do an explicit replace to ensure it's in the daemon platforms path semantics.

@thaJeztah @jfrazelle 
