### PR TITLE
Fixing a case of dangling endpoint during ungraceful daemon restart

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -910,6 +910,13 @@ func createNetwork(controller libnetwork.NetworkController, dnet string, driver 
 }
 
 func (container *Container) allocateNetwork() error {
+	sb := container.getNetworkSandbox()
+	if sb != nil {
+		// Cleanup any stale sandbox left over due to ungraceful daemon shutdown
+		if err := sb.Delete(); err != nil {
+			logrus.Errorf("failed to cleanup up stale network sandbox for container %s", container.ID)
+		}
+	}
 	updateSettings := false
 	if len(container.NetworkSettings.Networks) == 0 {
 		mode := container.hostConfig.NetworkMode
@@ -934,6 +941,18 @@ func (container *Container) allocateNetwork() error {
 	}
 
 	return container.writeHostConfig()
+}
+
+func (container *Container) getNetworkSandbox() libnetwork.Sandbox {
+	var sb libnetwork.Sandbox
+	container.daemon.netController.WalkSandboxes(func(s libnetwork.Sandbox) bool {
+		if s.ContainerID() == container.ID {
+			sb = s
+			return true
+		}
+		return false
+	})
+	return sb
 }
 
 // ConnectToNetwork connects a container to a netork
@@ -1001,14 +1020,7 @@ func (container *Container) connectToNetwork(idOrName string, updateSettings boo
 		return err
 	}
 
-	var sb libnetwork.Sandbox
-	controller.WalkSandboxes(func(s libnetwork.Sandbox) bool {
-		if s.ContainerID() == container.ID {
-			sb = s
-			return true
-		}
-		return false
-	})
+	sb := container.getNetworkSandbox()
 	if sb == nil {
 		options, err := container.buildSandboxOptions(n)
 		if err != nil {

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 20351a84241aa1278493d74492db947336989be6
+clone git github.com/docker/libnetwork 5fc6ba506daa7914f4d58befb38480ec8e9c9f70
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/joinleave.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/joinleave.go
@@ -118,6 +118,12 @@ func (d *driver) Leave(nid, eid string) error {
 		return fmt.Errorf("could not find network with id %s", nid)
 	}
 
+	ep := n.endpoint(eid)
+
+	if ep == nil {
+		return types.InternalMaskableErrorf("could not find endpoint with id %s", eid)
+	}
+
 	if d.notifyCh != nil {
 		d.notifyCh <- ovNotify{
 			action: "leave",


### PR DESCRIPTION
fixes #17413

As described in #17413 , its a tricky reproduction case & writing an IT for this case is a bit more involved.
We rely on the e2e libnetwork IT for any overlay related cases (also some of the ungraceful restart scenarios).
