### PR TITLE
create generic backend to cut dependency on daemon 

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -1,0 +1,23 @@
+package network
+
+import (
+	// TODO: network config needs to be refactored out to a
+	// different location
+	"github.com/docker/docker/daemon/network"
+
+	"github.com/docker/libnetwork"
+)
+
+// Backend is all the methods that need to be implemented to provide
+// network specific functionality
+type Backend interface {
+	FindNetwork(idName string) (libnetwork.Network, error)
+	GetNetwork(idName string, by int) (libnetwork.Network, error)
+	GetNetworksByID(partialID string) []libnetwork.Network
+	CreateNetwork(name, driver string, ipam network.IPAM,
+		options map[string]string) (libnetwork.Network, error)
+	ConnectContainerToNetwork(containerName, networkName string) error
+	DisconnectContainerFromNetwork(containerName string,
+		network libnetwork.Network) error
+	NetworkControllerEnabled() bool
+}

--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -6,21 +6,20 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/router"
 	"github.com/docker/docker/api/server/router/local"
-	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/errors"
 	"golang.org/x/net/context"
 )
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
-	daemon *daemon.Daemon
-	routes []router.Route
+	backend Backend
+	routes  []router.Route
 }
 
 // NewRouter initializes a new network router
-func NewRouter(d *daemon.Daemon) router.Router {
+func NewRouter(b Backend) router.Router {
 	r := &networkRouter{
-		daemon: d,
+		backend: b,
 	}
 	r.initRoutes()
 	return r
@@ -46,7 +45,7 @@ func (r *networkRouter) initRoutes() {
 }
 
 func (r *networkRouter) controllerEnabledMiddleware(handler httputils.APIFunc) httputils.APIFunc {
-	if r.daemon.NetworkControllerEnabled() {
+	if r.backend.NetworkControllerEnabled() {
 		return handler
 	}
 	return networkControllerDisabled


### PR DESCRIPTION
seeing #17463 gave me the idea that at least somewhat the routers can be 'impl-ized' individually.

If we apply similar changes to the `local` router, that would successfully split the api.

This is just an sample of what the final version would look like. I am interested in what people think about splitting the different sections into separate routers and separate `Backends`, vs keeping them all as one, with a single `Backend`.

Names are subject to change, and I need to write a better commit message.
