### PR TITLE
bug fix for test cases

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -201,7 +201,8 @@ func isNwPresent(c *check.C, name string) bool {
 	out, _ := dockerCmd(c, "network", "ls")
 	lines := strings.Split(out, "\n")
 	for i := 1; i < len(lines)-1; i++ {
-		if strings.Contains(lines[i], name) {
+		netFields := strings.Fields(lines[i])
+		if netFields[1] == name {
 			return true
 		}
 	}


### PR DESCRIPTION
Fix bug that `isNwPresent` can't distinguish network names with same
prefix.

for example:

```
$ docker network ls
NETWORK ID          NAME                DRIVER
8f5fef6b4fbe        bridge              bridge
4ea38297b9e0        none                null
b6de21cdf378        host                host
bd7c03661db0        dev                 bridge
c8587c446f70        dev1                bridge
```

current implementation can't distinguish `dev` and `dev1` clearly, if you remove network `dev`, this function will still report `dev` exists because string `dev1` contains string `dev`. That's where the bug is. 

Signed-off-by: Zhang Wei zhangwei555@huawei.com
