### PR TITLE
Windows: [TP4] Allows --isolation on docker build

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -67,6 +67,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	flCgroupParent := cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 	flBuildArg := opts.NewListOpts(opts.ValidateEnv)
 	cmd.Var(&flBuildArg, []string{"-build-arg"}, "Set build-time variables")
+	isolation := cmd.String([]string{"-isolation"}, "", "Container isolation level")
 
 	ulimits := make(map[string]*ulimit.Ulimit)
 	flUlimits := opts.NewUlimitOpt(&ulimits)
@@ -234,6 +235,10 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	if *pull {
 		v.Set("pull", "1")
+	}
+
+	if !runconfig.IsolationLevel.IsDefault(runconfig.IsolationLevel(*isolation)) {
+		v.Set("isolation", *isolation)
 	}
 
 	v.Set("cpusetcpus", *flCPUSetCpus)

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -326,6 +326,13 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 	buildConfig.CPUSetMems = r.FormValue("cpusetmems")
 	buildConfig.CgroupParent = r.FormValue("cgroupparent")
 
+	if i := runconfig.IsolationLevel(r.FormValue("isolation")); i != "" {
+		if !runconfig.IsolationLevel.IsValid(i) {
+			return errf(fmt.Errorf("Unsupported isolation: %q", i))
+		}
+		buildConfig.Isolation = i
+	}
+
 	var buildUlimits = []*ulimit.Ulimit{}
 	ulimitsJSON := r.FormValue("ulimits")
 	if ulimitsJSON != "" {

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -54,6 +54,7 @@ type Config struct {
 	ForceRemove bool
 	Pull        bool
 	BuildArgs   map[string]string // build-time args received in build context for expansion/substitution and commands in 'run'.
+	Isolation   runconfig.IsolationLevel
 
 	// resource constraints
 	// TODO: factor out to be reused with Run ?

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -514,6 +514,7 @@ func (b *Builder) create() (*daemon.Container, error) {
 		Memory:       b.Memory,
 		MemorySwap:   b.MemorySwap,
 		Ulimits:      b.Ulimits,
+		Isolation:    b.Isolation,
 	}
 
 	config := *b.runConfig

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -103,7 +103,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flCgroupParent      = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 		flVolumeDriver      = cmd.String([]string{"-volume-driver"}, "", "Optional volume driver for the container")
 		flStopSignal        = cmd.String([]string{"-stop-signal"}, signal.DefaultStopSignal, fmt.Sprintf("Signal to stop a container, %v by default", signal.DefaultStopSignal))
-		flIsolation         = cmd.String([]string{"-isolation"}, "default", "Container isolation level")
+		flIsolation         = cmd.String([]string{"-isolation"}, "", "Container isolation level")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@crosbymichael This adds the ability to specify the isolation mode on docker build, so that a RUN command knows how to invoke the container correctly - this is particularly relevant in building a nanoserver image on a server core container host.
