### PR TITLE
Don't set mem soft limit if not specifiecd

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -115,9 +115,6 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 		// By default, MemorySwap is set to twice the size of Memory.
 		hostConfig.MemorySwap = hostConfig.Memory * 2
 	}
-	if hostConfig.MemoryReservation == 0 && hostConfig.Memory > 0 {
-		hostConfig.MemoryReservation = hostConfig.Memory
-	}
 }
 
 // verifyPlatformContainerSettings performs platform-specific validation of the


### PR DESCRIPTION
You cannot do this for individual cgroups for all the containers.  Only
set the reservation if the user requested it.  The error you will
receive is an EINTVAL when you try to set a large limit like we were in
the memory limit.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
