### PR TITLE
Windows: Add isolation to ps filter

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -234,6 +234,11 @@ func includeContainerInList(container *Container, ctx *listContext) iterationAct
 		return excludeContainer
 	}
 
+	// Do not include container if the isolation mode doesn't match
+	if excludeContainer == excludeByIsolation(container, ctx) {
+		return excludeContainer
+	}
+
 	// Do not include container if it's in the list before the filter container.
 	// Set the filter container to nil to include the rest of containers after this one.
 	if ctx.beforeContainer != nil {

--- a/daemon/list_unix.go
+++ b/daemon/list_unix.go
@@ -1,0 +1,9 @@
+// +build linux freebsd
+
+package daemon
+
+// excludeByIsolation is a platform specific helper function to support PS
+// filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
+func excludeByIsolation(container *Container, ctx *listContext) iterationAction {
+	return includeContainer
+}

--- a/daemon/list_windows.go
+++ b/daemon/list_windows.go
@@ -1,0 +1,16 @@
+package daemon
+
+import "strings"
+
+// excludeByIsolation is a platform specific helper function to support PS
+// filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
+func excludeByIsolation(container *Container, ctx *listContext) iterationAction {
+	i := strings.ToLower(string(container.hostConfig.Isolation))
+	if i == "" {
+		i = "default"
+	}
+	if !ctx.filters.Match("isolation", i) {
+		return excludeContainer
+	}
+	return includeContainer
+}

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -94,6 +94,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.22](docker_remote_api_v1.22.md) documentation
 
+* `GET /containers/json` supports filter `isolation` on Windows.
 
 ### v1.21 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -116,6 +116,7 @@ Query Parameters:
   -   `exited=<int>`; -- containers with exit code of  `<int>` ;
   -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`)
   -   `label=key` or `label="key=value"` of a container label
+  -   `isolation=`(`default`|`hyperv`)   (Windows daemon only)
 
 Status Codes:
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -51,6 +51,7 @@ The currently supported filters are:
 * exited (int - the code of exited containers. Only useful with `--all`)
 * status (created|restarting|running|paused|exited)
 * ancestor (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters containers that were created from the given image or a descendant.
+* isolation (default|hyperv)   (Windows daemon only)
 
 
 #### Label


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Related to #16412 and #17529, this adds a filter for docker ps for isolation. eg docker ps --filter "isolation=hyperv"
