### PR TITLE
Fix network inspect for default networks.

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -286,6 +286,7 @@ type ContainerJSON struct {
 // NetworkSettings exposes the network settings in the api
 type NetworkSettings struct {
 	NetworkSettingsBase
+	DefaultNetworkSettings
 	Networks map[string]*network.EndpointSettings
 }
 
@@ -300,6 +301,20 @@ type NetworkSettingsBase struct {
 	SandboxKey             string
 	SecondaryIPAddresses   []network.Address
 	SecondaryIPv6Addresses []network.Address
+}
+
+// DefaultNetworkSettings holds network information
+// during the 2 release deprecation period.
+// It will be removed in Docker 1.11.
+type DefaultNetworkSettings struct {
+	EndpointID          string
+	Gateway             string
+	GlobalIPv6Address   string
+	GlobalIPv6PrefixLen int
+	IPAddress           string
+	IPPrefixLen         int
+	IPv6Gateway         string
+	MacAddress          string
 }
 
 // MountPoint represents a mount point configuration inside the container.

--- a/api/types/versions/v1p20/types.go
+++ b/api/types/versions/v1p20/types.go
@@ -36,12 +36,5 @@ type StatsJSON struct {
 // NetworkSettings is a backward compatible struct for APIs prior to 1.21
 type NetworkSettings struct {
 	types.NetworkSettingsBase
-	EndpointID          string
-	Gateway             string
-	GlobalIPv6Address   string
-	GlobalIPv6PrefixLen int
-	IPAddress           string
-	IPPrefixLen         int
-	IPv6Gateway         string
-	MacAddress          string
+	types.DefaultNetworkSettings
 }

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -50,7 +50,7 @@ func (daemon *Daemon) ContainerInspectPre120(name string) (*v1p19.ContainerJSON,
 		container.hostConfig.CPUShares,
 		container.hostConfig.CpusetCpus,
 	}
-	networkSettings := getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
+	networkSettings := daemon.getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
 
 	return &v1p19.ContainerJSON{base, volumes, volumesRW, config, networkSettings}, nil
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1587,3 +1587,11 @@ func waitInspect(name, expr, expected string, timeout time.Duration) error {
 	}
 	return nil
 }
+
+func getInspectBody(c *check.C, version, id string) []byte {
+	endpoint := fmt.Sprintf("/%s/containers/%s/json", version, id)
+	status, body, err := sockRequest("GET", endpoint, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	return body
+}


### PR DESCRIPTION
- Keep old fields in NetworkSetting to respect the deprecation policy.

@tiborvass, @mavenugo please, take a look.

Fixes #17494

Signed-off-by: David Calavera david.calavera@gmail.com
