### PR TITLE
Force IPC mount to unmount on daemon shutdown/init

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -337,7 +337,7 @@ func (streamConfig *streamConfig) StderrPipe() io.ReadCloser {
 func (container *Container) cleanup() {
 	container.releaseNetwork()
 
-	if err := container.unmountIpcMounts(); err != nil {
+	if err := container.unmountIpcMounts(detachMounted); err != nil {
 		logrus.Errorf("%s: Failed to umount ipc filesystems: %v", container.ID, err)
 	}
 

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1359,7 +1359,7 @@ func (container *Container) setupIpcDirs() error {
 	return nil
 }
 
-func (container *Container) unmountIpcMounts() error {
+func (container *Container) unmountIpcMounts(unmount func(pth string) error) error {
 	if container.hostConfig.IpcMode.IsContainer() || container.hostConfig.IpcMode.IsHost() {
 		return nil
 	}
@@ -1372,7 +1372,7 @@ func (container *Container) unmountIpcMounts() error {
 			logrus.Error(err)
 			errors = append(errors, err.Error())
 		} else {
-			if err := detachMounted(shmPath); err != nil {
+			if err := unmount(shmPath); err != nil {
 				logrus.Errorf("failed to umount %s: %v", shmPath, err)
 				errors = append(errors, err.Error())
 			}
@@ -1386,7 +1386,7 @@ func (container *Container) unmountIpcMounts() error {
 			logrus.Error(err)
 			errors = append(errors, err.Error())
 		} else {
-			if err := detachMounted(mqueuePath); err != nil {
+			if err := unmount(mqueuePath); err != nil {
 				logrus.Errorf("failed to umount %s: %v", mqueuePath, err)
 				errors = append(errors, err.Error())
 			}

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -185,7 +185,11 @@ func (container *Container) setupIpcDirs() error {
 	return nil
 }
 
-func (container *Container) unmountIpcMounts() error {
+func (container *Container) unmountIpcMounts(unmount func(pth string) error) error {
+	return nil
+}
+
+func detachMounted(path string) error {
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -39,6 +39,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/parsers/filters"
@@ -223,7 +224,7 @@ func (daemon *Daemon) Register(container *Container) error {
 		}
 		daemon.execDriver.Terminate(cmd)
 
-		if err := container.unmountIpcMounts(); err != nil {
+		if err := container.unmountIpcMounts(mount.Unmount); err != nil {
 			logrus.Errorf("%s: Failed to umount ipc filesystems: %v", container.ID, err)
 		}
 		if err := container.Unmount(); err != nil {

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/mount"
 )
 
 // cleanupMounts umounts shm/mqueue mounts for old containers
@@ -20,7 +21,7 @@ func (daemon *Daemon) cleanupMounts() error {
 	}
 	defer f.Close()
 
-	return daemon.cleanupMountsFromReader(f, detachMounted)
+	return daemon.cleanupMountsFromReader(f, mount.Unmount)
 }
 
 func (daemon *Daemon) cleanupMountsFromReader(reader io.Reader, unmount func(target string) error) error {


### PR DESCRIPTION
Instead of using `MNT_DETACH` to unmount the container's mqueue/shm
mounts, force it... but only on daemon init and shutdown.

This makes sure that these IPC mounts are cleaned up even when the
daemon is killed.
