### PR TITLE
Windows: Native build without link errors

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -19,6 +19,12 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 	esac
 fi
 
+if [ "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" == "windows/amd64" ] && [ "$(go env GOOS)" == "windows" ]; then
+	# native compilation of Windows on Windows with golang 1.5+ needs linkmode internal
+	# https://github.com/golang/go/issues/13070
+	export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC_DOCKER -linkmode=internal"
+fi
+
 echo "Building: $DEST/$BINARY_FULLNAME"
 go build \
 	-o "$DEST/$BINARY_FULLNAME" \


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @tianon This is a similar fix to the one done in #15459 to ensure Windows can cross-compile using golang 1.5.1 from Linux. This solves the same problem for native build of Windows on Windows avoiding the link error.

![native build](https://cloud.githubusercontent.com/assets/10522484/10858639/d292f4cc-7f13-11e5-97c7-071a52a2b07a.JPG)
