### PR TITLE
Vendoring libnetwork to fix #17526 & #17527

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -945,7 +945,13 @@ func (container *Container) ConnectToNetwork(idOrName string) error {
 	if !container.Running {
 		return derr.ErrorCodeNotRunning.WithArgs(container.ID)
 	}
-	return container.connectToNetwork(idOrName, true)
+	if err := container.connectToNetwork(idOrName, true); err != nil {
+		return err
+	}
+	if err := container.toDiskLocking(); err != nil {
+		return fmt.Errorf("Error saving container to disk: %v", err)
+	}
+	return nil
 }
 
 func (container *Container) connectToNetwork(idOrName string, updateSettings bool) error {
@@ -1177,7 +1183,14 @@ func (container *Container) DisconnectFromNetwork(n libnetwork.Network) error {
 		return derr.ErrorCodeNotRunning.WithArgs(container.ID)
 	}
 
-	return container.disconnectFromNetwork(n)
+	if err := container.disconnectFromNetwork(n); err != nil {
+		return err
+	}
+
+	if err := container.toDiskLocking(); err != nil {
+		return fmt.Errorf("Error saving container to disk: %v", err)
+	}
+	return nil
 }
 
 func (container *Container) disconnectFromNetwork(n libnetwork.Network) error {

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 5fc6ba506daa7914f4d58befb38480ec8e9c9f70
+clone git github.com/docker/libnetwork 47edb73dd3e64cfcc04234b073872205cd79694a
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/controller.go
+++ b/vendor/src/github.com/docker/libnetwork/controller.go
@@ -507,13 +507,14 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (S
 		return nil, err
 	}
 
+	c.Lock()
 	if sb.osSbox == nil && !sb.config.useExternalKey {
 		if sb.osSbox, err = osl.NewSandbox(sb.Key(), !sb.config.useDefaultSandBox); err != nil {
+			c.Unlock()
 			return nil, fmt.Errorf("failed to create new osl sandbox: %v", err)
 		}
 	}
 
-	c.Lock()
 	c.sandboxes[sb.id] = sb
 	c.Unlock()
 	defer func() {

--- a/vendor/src/github.com/docker/libnetwork/ipam/allocator.go
+++ b/vendor/src/github.com/docker/libnetwork/ipam/allocator.go
@@ -195,7 +195,7 @@ func (a *Allocator) getAddrSpace(as string) (*addrSpace, error) {
 	defer a.Unlock()
 	aSpace, ok := a.addrSpaces[as]
 	if !ok {
-		return nil, types.BadRequestErrorf("cannot find address space %s (most likey the backing datastore is not configured)", as)
+		return nil, types.BadRequestErrorf("cannot find address space %s (most likely the backing datastore is not configured)", as)
 	}
 	return aSpace, nil
 }

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -479,7 +479,7 @@ func (sb *sandbox) populateNetworkResources(ep *endpoint) error {
 	for _, gwep := range sb.getConnectedEndpoints() {
 		if len(gwep.Gateway()) > 0 {
 			if gwep != ep {
-				return nil
+				break
 			}
 			if err := sb.updateGateway(gwep); err != nil {
 				return err


### PR DESCRIPTION
This PR fixes #17526
- Ungraceful docker daemon restart results in container with multiple networks losing connectivity
  if a container is connected to multiple networks, the config is not saved to the disk immediately. It was handled when the container is brought down (either during stop or daemon is gracefully brought down).
  When the daemon is ungracefully restarted, the configs goes missing. The fix is to write the config to the disk when the configuration succeeds. Also fixed a corresponding issue in libnetwork where during ungraceful restarts, the newly connected endpoints using `network connect` is not honored (because the sandbox was updated later to the controller DB).

Also fixes #17527
- Fixed a race in host sandbox creation
