### PR TITLE
Turn IPC unmount errors into warnings.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -341,9 +341,7 @@ func (streamConfig *streamConfig) StderrPipe() io.ReadCloser {
 func (container *Container) cleanup() {
 	container.releaseNetwork()
 
-	if err := container.unmountIpcMounts(detachMounted); err != nil {
-		logrus.Errorf("%s: Failed to umount ipc filesystems: %v", container.ID, err)
-	}
+	container.unmountIpcMounts(detachMounted)
 
 	container.conditionalUnmountOnCleanup()
 

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -177,8 +177,7 @@ func (container *Container) setupIpcDirs() error {
 	return nil
 }
 
-func (container *Container) unmountIpcMounts(unmount func(pth string) error) error {
-	return nil
+func (container *Container) unmountIpcMounts(unmount func(pth string) error) {
 }
 
 func detachMounted(path string) error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -226,9 +226,8 @@ func (daemon *Daemon) Register(container *Container) error {
 		}
 		daemon.execDriver.Terminate(cmd)
 
-		if err := container.unmountIpcMounts(mount.Unmount); err != nil {
-			logrus.Errorf("%s: Failed to umount ipc filesystems: %v", container.ID, err)
-		}
+		container.unmountIpcMounts(mount.Unmount)
+
 		if err := container.Unmount(); err != nil {
 			logrus.Debugf("unmount error %s", err)
 		}


### PR DESCRIPTION
And do not try to unmount empty paths.
Because nobody should be woken up in the middle of the night for them.

Fixes #17550

Signed-off-by: David Calavera david.calavera@gmail.com
