### PR TITLE
Fix bug in initializeNetwork()

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -914,6 +914,13 @@ func (container *Container) allocateNetwork() error {
 		if mode.IsDefault() {
 			networkName = controller.Config().Daemon.DefaultNetwork
 		}
+		if mode.IsUserDefined() {
+			n, err := container.daemon.FindNetwork(networkName)
+			if err != nil {
+				return err
+			}
+			networkName = n.Name()
+		}
 		container.NetworkSettings.Networks = make(map[string]*network.EndpointSettings)
 		container.NetworkSettings.Networks[networkName] = new(network.EndpointSettings)
 		updateSettings = true
@@ -954,9 +961,7 @@ func (container *Container) ConnectToNetwork(idOrName string) error {
 	return nil
 }
 
-func (container *Container) connectToNetwork(idOrName string, updateSettings bool) error {
-	var err error
-
+func (container *Container) connectToNetwork(idOrName string, updateSettings bool) (err error) {
 	if container.hostConfig.NetworkMode.IsContainer() {
 		return runconfig.ErrConflictSharedNetwork
 	}

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -733,3 +733,8 @@ func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksUngracefulDaemonRe
 
 	verifyContainerIsConnectedToNetworks(c, s.d, cName, nwList)
 }
+
+func (s *DockerNetworkSuite) TestDockerNetworkRunNetByID(c *check.C) {
+	out, _ := dockerCmd(c, "network", "create", "one")
+	dockerCmd(c, "run", "-d", "--net", strings.TrimSpace(out), "busybox", "top")
+}


### PR DESCRIPTION
- On `docker run --net <network id> ...`
  the bug would cause the container to attempt
  to connect to the network two times
- Also made sure endpoint creation rollback will
  be executed on failures in `func (container *Container) connectToNetwork()`

Fixes #17543 

Signed-off-by: Alessandro Boch aboch@docker.com
