### PR TITLE
Added additional guidance for signing off git commits when contributing

### DIFF
--- a/docs/project/set-up-git.md
+++ b/docs/project/set-up-git.md
@@ -92,8 +92,9 @@ You indicate your agreement by signing your `git` commits like this:
 
 To create a signature, you configure your username and email address in Git.
 You can set these globally or locally on just your `docker-fork` repository.
-You must sign with your real name. We don't accept anonymous contributions or
-contributions through pseudonyms.
+You must sign with your real name. You can sign your git commit automatically
+with `git commit -s`. We don't accept anonymous contributions or contributions
+through pseudonyms.
 
 As you change code in your fork, you'll want to keep it in sync with the changes
 others make in the `docker/docker` repository. To make syncing easier, you'll
@@ -118,7 +119,7 @@ To configure your username, email, and add a remote:
 
         $ git remote add upstream https://github.com/docker/docker.git
 
-7. Check the result in your `git` configuration.
+5. Check the result in your `git` configuration.
 
         $ git config --local -l
         core.repositoryformatversion=0


### PR DESCRIPTION
I realize that signing off git commits is explained in a few other places in the documentation, but I feel that an explanation of the `--signoff` flag is warranted in the "Set your signature and an upstream remote" section.
