### PR TITLE
Windows: Fix go test in execdriver\lxc

### DIFF
--- a/daemon/execdriver/lxc/lxc_init_unsupported.go
+++ b/daemon/execdriver/lxc/lxc_init_unsupported.go
@@ -2,6 +2,10 @@
 
 package lxc
 
+// InitArgs contains args provided to the init function for a driver
+type InitArgs struct {
+}
+
 func finalizeNamespace(args *InitArgs) error {
 	panic("Not supported on this platform")
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). There are several packages with compile errors on non-Linux. This fixes daemon\execdriver\lxc so that go test doesn't throw a compile error.
