### PR TITLE
Windows: Fix journald compile error

### DIFF
--- a/daemon/logger/journald/journald_unsupported.go
+++ b/daemon/logger/journald/journald_unsupported.go
@@ -1,3 +1,6 @@
 // +build !linux
 
 package journald
+
+type journald struct {
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). There are several packages with compile errors on non-Linux. This fixes daemon\logger\journald so that go test or even just a regular compile on Windows doesn't throw an error
