### PR TITLE
Windows: Fix parsers kernel test

### DIFF
--- a/pkg/parsers/kernel/kernel_unix_test.go
+++ b/pkg/parsers/kernel/kernel_unix_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package kernel
 
 import (
@@ -19,6 +21,7 @@ func assertParseRelease(t *testing.T, release string, b *VersionInfo, result int
 	}
 }
 
+// TestParseRelease tests the ParseRelease() function
 func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0", &VersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
 	assertParseRelease(t, "3.4.54.longterm-1", &VersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
@@ -48,6 +51,7 @@ func assertKernelVersion(t *testing.T, a, b VersionInfo, result int) {
 	}
 }
 
+// TestCompareKernelVersion tests the CompareKernelVersion() function
 func TestCompareKernelVersion(t *testing.T) {
 	assertKernelVersion(t,
 		VersionInfo{Kernel: 3, Major: 8, Minor: 0},


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). There are several packages with compile errors on non-Linux. This fixes pkg\parsers\kernel so that go test on Windows doesn't throw an error
