### PR TITLE
Windows: Fix unit tests parsers\os

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
@@ -1,3 +1,5 @@
+// +build linux freebsd
+
 package operatingsystem
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). There are several packages with compile errors on non-Linux. This fixes pkg\parsers\operatingsystem so that go test on Windows doesn't throw an error
