### PR TITLE
Windows: Fix docker device tool

### DIFF
--- a/contrib/docker-device-tool/device_tool.go
+++ b/contrib/docker-device-tool/device_tool.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (

--- a/contrib/docker-device-tool/device_tool_windows.go
+++ b/contrib/docker-device-tool/device_tool_windows.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). There are several packages with compile errors on non-Linux. This fixes contrib\docker-device-tool so that go test and compile on Windows doesn't throw an error
