### PR TITLE
Windows: Fix daemon\graphdriver\graphtest

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -1,3 +1,5 @@
+// +build linux freebsd
+
 package graphtest
 
 import (

--- a/daemon/graphdriver/graphtest/graphtest_windows.go
+++ b/daemon/graphdriver/graphtest/graphtest_windows.go
@@ -1,0 +1,1 @@
+package graphtest


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). There are several packages with compile errors on non-Linux. This fixes daemon\graphdriver\graphtest so that go test and compile on Windows doesn't throw an error
