### PR TITLE
Windows: Factor out user in execdriver\driver

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -121,13 +121,6 @@ type ResourceStats struct {
 	SystemUsage uint64    `json:"system_usage"`
 }
 
-// User contains the uid and gid representing a Unix user
-// TODO Windows: Factor out User
-type User struct {
-	UID int `json:"root_uid"`
-	GID int `json:"root_gid"`
-}
-
 // ProcessConfig describes a process that will be run inside a container.
 type ProcessConfig struct {
 	exec.Cmd `json:"-"`

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -257,3 +257,9 @@ func Stats(containerDir string, containerMemoryLimit int64, machineMemory int64)
 		MemoryLimit: memoryLimit,
 	}, nil
 }
+
+// User contains the uid and gid representing a Unix user
+type User struct {
+	UID int `json:"root_uid"`
+	GID int `json:"root_gid"`
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Factors out the user struct which isn't used on Windows from daemon\execdriver\driver.go. Simply moves it to the unix version. And removes another //TODO Windows.
