### PR TITLE
Add a log file driver for plaintext files

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -335,7 +335,8 @@ __docker_log_driver_options() {
 	local json_file_options="env labels max-file max-size"
 	local syslog_options="syslog-address syslog-facility tag"
 	local splunk_options="splunk-caname splunk-capath splunk-index splunk-insecureskipverify splunk-source splunk-sourcetype splunk-token splunk-url"
-
+	local plain_text_options="log-path max-file max-size"
+  
 	local all_options="$fluentd_options $gelf_options $journald_options $json_file_options $syslog_options $splunk_options"
 
 	case $(__docker_value_of_option --log-driver) in
@@ -362,6 +363,9 @@ __docker_log_driver_options() {
 			;;
 		splunk)
 			COMPREPLY=( $( compgen -W "$splunk_options" -S = -- "$cur" ) )
+			;;
+		plain-text)
+			COMPREPLY=( $( compgen -W "$plain_text_options" -S = -- "$cur" ) )
 			;;
 		*)
 			return

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -436,7 +436,7 @@ __docker_subcommand() {
         "($help)--kernel-memory[Kernel memory limit in bytes.]:Memory limit: "
         "($help)*--link=[Add link to another container]:link:->link"
         "($help)*"{-l=,--label=}"[Set meta data on a container]:label: "
-        "($help)--log-driver=[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd awslogs splunk none)"
+        "($help)--log-driver=[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd awslogs splunk plain-text none)"
         "($help)*--log-opt=[Log driver specific options]:log driver options: "
         "($help)*--lxc-conf=[Add custom lxc options]:lxc options: "
         "($help)--mac-address=[Container MAC address]:MAC address: "
@@ -558,7 +558,7 @@ __docker_subcommand() {
                 "($help)--ipv6[Enable IPv6 networking]" \
                 "($help -l --log-level)"{-l=,--log-level=}"[Set the logging level]:level:(debug info warn error fatal)" \
                 "($help)*--label=[Set key=value labels to the daemon]:label: " \
-                "($help)--log-driver=[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd awslogs splunk none)" \
+                "($help)--log-driver=[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd awslogs splunk plain-text none)" \
                 "($help)*--log-opt=[Log driver specific options]:log driver options: " \
                 "($help)--mtu=[Set the containers network MTU]:mtu:(0 576 1420 1500 9000)" \
                 "($help -p --pidfile)"{-p=,--pidfile=}"[Path to use for daemon PID file]:PID file:_files" \

--- a/daemon/logdrivers_linux.go
+++ b/daemon/logdrivers_linux.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/docker/docker/daemon/logger/gelf"
 	_ "github.com/docker/docker/daemon/logger/journald"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
+	_ "github.com/docker/docker/daemon/logger/plaintextlog"
 	_ "github.com/docker/docker/daemon/logger/splunk"
 	_ "github.com/docker/docker/daemon/logger/syslog"
 )

--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -5,4 +5,5 @@ import (
 	// therefore they register themselves to the logdriver factory.
 	_ "github.com/docker/docker/daemon/logger/awslogs"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
+	_ "github.com/docker/docker/daemon/logger/plaintextlog"
 )

--- a/daemon/logger/plaintextlog/plaintextlog.go
+++ b/daemon/logger/plaintextlog/plaintextlog.go
@@ -1,0 +1,181 @@
+package plaintextlog
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/pkg/units"
+)
+
+const (
+	driverName = "plain-text"
+)
+
+type plainTextLogger struct {
+	buf      *bytes.Buffer
+	f        *os.File   // store for closing
+	mu       sync.Mutex // protects buffer
+	capacity int64      //maximum size of each file
+	n        int        //maximum number of files
+	ctx      logger.Context
+}
+
+func init() {
+	if err := logger.RegisterLogDriver(driverName, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(driverName, ValidateLogOpt); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// New creates new plainTextLogger which writes to filename passed in
+// on given context.
+func New(ctx logger.Context) (logger.Logger, error) {
+	log, err := os.OpenFile(ctx.Config["log-path"], os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	var capval int64 = -1
+	if capacity, ok := ctx.Config["max-size"]; ok {
+		var err error
+		capval, err = units.FromHumanSize(capacity)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var maxFiles = 1
+	if maxFileString, ok := ctx.Config["max-file"]; ok {
+		maxFiles, err = strconv.Atoi(maxFileString)
+		if err != nil {
+			return nil, err
+		}
+		if maxFiles < 1 {
+			return nil, fmt.Errorf("max-file cannot be less than 1")
+		}
+	}
+
+	return &plainTextLogger{
+		f:        log,
+		buf:      bytes.NewBuffer(nil),
+		ctx:      ctx,
+		capacity: capval,
+		n:        maxFiles,
+	}, nil
+}
+
+func (l *plainTextLogger) Log(msg *logger.Message) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	logString := fmt.Sprintf("%s : %s\n", msg.Timestamp.String(), string(msg.Line))
+	l.buf.WriteString(logString)
+
+	_, err := writeLog(l)
+	return err
+}
+
+func writeLog(l *plainTextLogger) (int64, error) {
+	if l.capacity == -1 {
+		return writeToBuf(l)
+	}
+	meta, err := l.f.Stat()
+	if err != nil {
+		return -1, err
+	}
+	if meta.Size() >= l.capacity {
+		name := l.f.Name()
+		if err := l.f.Close(); err != nil {
+			return -1, err
+		}
+		if err := rotate(name, l.n); err != nil {
+			return -1, err
+		}
+		file, err := os.OpenFile(name, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
+		if err != nil {
+			return -1, err
+		}
+		l.f = file
+	}
+	return writeToBuf(l)
+}
+
+func writeToBuf(l *plainTextLogger) (int64, error) {
+	i, err := l.buf.WriteTo(l.f)
+	if err != nil {
+		l.buf = bytes.NewBuffer(nil)
+	}
+	return i, err
+}
+
+func rotate(name string, n int) error {
+	if n < 2 {
+		return nil
+	}
+	for i := n - 1; i > 1; i-- {
+		oldFile := name + "." + strconv.Itoa(i)
+		replacingFile := name + "." + strconv.Itoa(i-1)
+		if err := backup(oldFile, replacingFile); err != nil {
+			return err
+		}
+	}
+	if err := backup(name+".1", name); err != nil {
+		return err
+	}
+	return nil
+}
+
+// backup renames a file from curr to old, creating an empty file curr if it does not exist.
+func backup(old, curr string) error {
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		err := os.Remove(old)
+		if err != nil {
+			return err
+		}
+	}
+	if _, err := os.Stat(curr); os.IsNotExist(err) {
+		f, err := os.Create(curr)
+		if err != nil {
+			return err
+		}
+		f.Close()
+	}
+	return os.Rename(curr, old)
+}
+
+// ValidateLogOpt looks for log-path, max-size, max-file
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case "log-path":
+		case "max-file":
+		case "max-size":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for plain-text log driver", key)
+		}
+	}
+
+	if cfg["log-path"] == "" {
+		return fmt.Errorf("must specify a value for log-path")
+	}
+
+	return nil
+}
+
+// Close closes underlying file and signals all readers to stop.
+func (l *plainTextLogger) Close() error {
+	l.mu.Lock()
+	err := l.f.Close()
+	l.mu.Unlock()
+	return err
+}
+
+// Name returns name of this logger.
+func (l *plainTextLogger) Name() string {
+	return driverName
+}

--- a/daemon/logger/plaintextlog/plaintextlog_test.go
+++ b/daemon/logger/plaintextlog/plaintextlog_test.go
@@ -1,0 +1,130 @@
+package plaintextlog
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/docker/docker/daemon/logger"
+)
+
+func TestPlainTextLogger(t *testing.T) {
+	cid := "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"
+	tmp, err := ioutil.TempDir("", "docker-logger-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	filename := filepath.Join(tmp, "container.log")
+	config := map[string]string{"log-path": filename}
+	l, err := New(logger.Context{
+		ContainerID: cid,
+		LogPath:     filename,
+		Config:      config,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line1"), Source: "src1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line2"), Source: "src2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line3"), Source: "src3"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `0001-01-01 00:00:00 +0000 UTC : line1
+0001-01-01 00:00:00 +0000 UTC : line2
+0001-01-01 00:00:00 +0000 UTC : line3
+`
+
+	if string(res) != expected {
+		t.Fatalf("Wrong log content: %q, expected %q", res, expected)
+	}
+}
+
+func TestPlainTextLoggerWithOpts(t *testing.T) {
+	cid := "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"
+	tmp, err := ioutil.TempDir("", "docker-logger-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+	filename := filepath.Join(tmp, "container.log")
+	config := map[string]string{"log-path": filename, "max-file": "2", "max-size": "1k"}
+	l, err := New(logger.Context{
+		ContainerID: cid,
+		LogPath:     filename,
+		Config:      config,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	for i := 0; i < 30; i++ {
+		if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line" + strconv.Itoa(i)), Source: "src1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	penUlt, err := ioutil.ReadFile(filename + ".1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPenultimate := `0001-01-01 00:00:00 +0000 UTC : line0
+0001-01-01 00:00:00 +0000 UTC : line1
+0001-01-01 00:00:00 +0000 UTC : line2
+0001-01-01 00:00:00 +0000 UTC : line3
+0001-01-01 00:00:00 +0000 UTC : line4
+0001-01-01 00:00:00 +0000 UTC : line5
+0001-01-01 00:00:00 +0000 UTC : line6
+0001-01-01 00:00:00 +0000 UTC : line7
+0001-01-01 00:00:00 +0000 UTC : line8
+0001-01-01 00:00:00 +0000 UTC : line9
+0001-01-01 00:00:00 +0000 UTC : line10
+0001-01-01 00:00:00 +0000 UTC : line11
+0001-01-01 00:00:00 +0000 UTC : line12
+0001-01-01 00:00:00 +0000 UTC : line13
+0001-01-01 00:00:00 +0000 UTC : line14
+0001-01-01 00:00:00 +0000 UTC : line15
+0001-01-01 00:00:00 +0000 UTC : line16
+0001-01-01 00:00:00 +0000 UTC : line17
+0001-01-01 00:00:00 +0000 UTC : line18
+0001-01-01 00:00:00 +0000 UTC : line19
+0001-01-01 00:00:00 +0000 UTC : line20
+0001-01-01 00:00:00 +0000 UTC : line21
+0001-01-01 00:00:00 +0000 UTC : line22
+0001-01-01 00:00:00 +0000 UTC : line23
+0001-01-01 00:00:00 +0000 UTC : line24
+0001-01-01 00:00:00 +0000 UTC : line25
+`
+
+	expected := `0001-01-01 00:00:00 +0000 UTC : line26
+0001-01-01 00:00:00 +0000 UTC : line27
+0001-01-01 00:00:00 +0000 UTC : line28
+0001-01-01 00:00:00 +0000 UTC : line29
+`
+
+	if string(res) != expected {
+		t.Fatalf("Wrong log content: %q, expected %q", res, expected)
+	}
+	if string(penUlt) != expectedPenultimate {
+		t.Fatalf("Wrong log content: %q, expected %q", penUlt, expectedPenultimate)
+	}
+
+}

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -309,7 +309,7 @@ Json Parameters:
         systems, such as SELinux.
     -   **LogConfig** - Log configuration for the container, specified as a JSON object in the form
           `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
-          Available types: `json-file`, `syslog`, `journald`, `gelf`, `awslogs`, `splunk`, `none`.
+          Available types: `json-file`, `syslog`, `journald`, `gelf`, `awslogs`, `splunk`, `plain-text`, `none`.
           `json-file` logging driver.
     -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
     -   **VolumeDriver** - Driver that this container users to mount volumes.

--- a/docs/reference/logging/overview.md
+++ b/docs/reference/logging/overview.md
@@ -25,6 +25,7 @@ container's logging driver. The following options are supported:
 | `fluentd`   | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                          |
 | `awslogs`   | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs.                              |
 | `splunk`    | Splunk logging driver for Docker. Writes log messages to `splunk` using HTTP Event Collector.                                 |
+| `plain-text`| Plain Text logging driver for Docker. Writes log messages to file.                                                            |
 
 The `docker logs`command is available only for the `json-file` logging driver.
 
@@ -183,3 +184,15 @@ The Splunk logging driver requires the following options:
 
 For detailed information about working with this logging driver, see the [Splunk logging driver](splunk.md)
 reference documentation.
+
+## plain-text options
+
+The following logging options are supported for the `plain-text` logging driver:
+
+    --log-opt log-path=<log_file_path>
+    --log-opt max-size=[0-9+][k|m|g]
+    --log-opt max-file=[0-9+]
+
+Logs that reach `max-size` are rolled over. You can set the size in kilobytes(k), megabytes(m), or gigabytes(g). eg `--log-opt max-size=50m`. If `max-size` is not set, then logs are not rolled over.
+
+`max-file` specifies the maximum number of files that a log is rolled over before being discarded. eg `--log-opt max-file=100`. If `max-size` is not set, then `max-file` is not honored.

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1072,6 +1072,7 @@ container's logging driver. The following options are supported:
 | `fluentd`   | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                          |
 | `awslogs`   | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs                               |
 | `splunk`    | Splunk logging driver for Docker. Writes log messages to `splunk` using Event Http Collector.                                 |
+| `plain-text`| Plain Text logging driver for Docker. Writes log messages to file.                                                            |
 
 The `docker logs` command is available only for the `json-file` and `journald`
 logging drivers.  For detailed information on working with logging drivers, see

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -174,7 +174,7 @@ millions of trillions.
    Add link to another container in the form of <name or id>:alias or just
    <name or id> in which case the alias will match the name.
 
-**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*none*"
+**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*plain-text*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: the `docker logs` command works only for the `json-file` and
   `journald` logging drivers.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -277,7 +277,7 @@ which interface and port to use.
 **--lxc-conf**=[]
    (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
 
-**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*none*"
+**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*plain-text*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: the `docker logs` command works only for the `json-file` and
   `journald` logging drivers.


### PR DESCRIPTION
issues #17020 Added a log file driver for plaintext files
Write code based on json-file logger,

```
$docker run -t -d --log-driver=plain-text --log-opt max-file=5 --log-opt max-size=2k --log-opt log-path="/tmp/plain-text"  ubuntu /bin/bash -c 'while true; do echo "Hello"; sleep 1; done'

$cat /tmp/plain-text
2015-11-01 02:15:02.938127472 +0000 UTC : Hello
2015-11-01 02:15:03.939715607 +0000 UTC : Hello
```

Writed test code and docs too.

Signed-off-by: Daehyeok Mun daehyeok@gmail.com
