### PR TITLE
Windows: Refactor exitStatus structure

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -52,15 +52,6 @@ type Terminal interface {
 	Resize(height, width int) error
 }
 
-// ExitStatus provides exit reasons for a container.
-type ExitStatus struct {
-	// The exit code with which the container exited.
-	ExitCode int
-
-	// Whether the container encountered an OOM.
-	OOMKilled bool
-}
-
 // Driver is an interface for drivers to implement
 // including all basic functions a driver should have
 type Driver interface {

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -262,3 +262,12 @@ type User struct {
 	UID int `json:"root_uid"`
 	GID int `json:"root_gid"`
 }
+
+// ExitStatus provides exit reasons for a container.
+type ExitStatus struct {
+	// The exit code with which the container exited.
+	ExitCode int
+
+	// Whether the container encountered an OOM.
+	OOMKilled bool
+}

--- a/daemon/execdriver/driver_windows.go
+++ b/daemon/execdriver/driver_windows.go
@@ -46,3 +46,9 @@ type Command struct {
 	LayerPaths  []string `json:"layer_paths"`  // Layer paths for a command
 	Isolated    bool     `json:"isolated"`     // True if a Hyper-V container
 }
+
+// ExitStatus provides exit reasons for a container.
+type ExitStatus struct {
+	// The exit code with which the container exited.
+	ExitCode int
+}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -201,8 +201,7 @@ func (s *State) setStopped(exitStatus *execdriver.ExitStatus) {
 	s.Restarting = false
 	s.Pid = 0
 	s.FinishedAt = time.Now().UTC()
-	s.ExitCode = exitStatus.ExitCode
-	s.OOMKilled = exitStatus.OOMKilled
+	s.setFromExitStatus(exitStatus)
 	close(s.waitChan) // fire waiters for stop
 	s.waitChan = make(chan struct{})
 }
@@ -222,8 +221,7 @@ func (s *State) setRestarting(exitStatus *execdriver.ExitStatus) {
 	s.Restarting = true
 	s.Pid = 0
 	s.FinishedAt = time.Now().UTC()
-	s.ExitCode = exitStatus.ExitCode
-	s.OOMKilled = exitStatus.OOMKilled
+	s.setFromExitStatus(exitStatus)
 	close(s.waitChan) // fire waiters for stop
 	s.waitChan = make(chan struct{})
 }

--- a/daemon/state_unix.go
+++ b/daemon/state_unix.go
@@ -1,0 +1,12 @@
+// +build linux freebsd
+
+package daemon
+
+import "github.com/docker/docker/daemon/execdriver"
+
+// setFromExitStatus is a platform specific helper function to set the state
+// based on the ExitStatus structure.
+func (s *State) setFromExitStatus(exitStatus *execdriver.ExitStatus) {
+	s.ExitCode = exitStatus.ExitCode
+	s.OOMKilled = exitStatus.OOMKilled
+}

--- a/daemon/state_windows.go
+++ b/daemon/state_windows.go
@@ -1,0 +1,9 @@
+package daemon
+
+import "github.com/docker/docker/daemon/execdriver"
+
+// setFromExitStatus is a platform specific helper function to set the state
+// based on the ExitStatus structure.
+func (s *State) setFromExitStatus(exitStatus *execdriver.ExitStatus) {
+	s.ExitCode = exitStatus.ExitCode
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR refactors the exitStatus structure in the daemon, as OOMKilled is not applicable on the Windows platform. 
