### PR TITLE
Added c.Assert statements to docker_api_create_test.go

### DIFF
--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
 
@@ -18,9 +19,7 @@ func (s *DockerSuite) TestApiCreateWithNotExistImage(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNotFound)
 	expected := "No such image: test456:v1"
-	if !strings.Contains(string(resp), expected) {
-		c.Fatalf("expected: %s, got: %s", expected, string(resp))
-	}
+	c.Assert(strings.TrimSpace(string(resp)), checker.Contains, expected)
 
 	config2 := map[string]interface{}{
 		"Image":   "test456",
@@ -31,8 +30,6 @@ func (s *DockerSuite) TestApiCreateWithNotExistImage(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNotFound)
 	expected = "No such image: test456:latest"
-	if !strings.Contains(string(resp), expected) {
-		c.Fatalf("expected: %s, got: %s", expected, string(resp))
-	}
+	c.Assert(strings.TrimSpace(string(resp)), checker.Equals, expected)
 
 }


### PR DESCRIPTION
Summary: Modified tests to remove if .. else blocks and add c.Assert statements.

Referenced Issue #16756

Signed-off-by: Zuhayr Elahi elahi.zuhayr@gmail.com
