### PR TITLE
Windows: Fix test-unit for local run

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -19,6 +19,7 @@ bundle_test_unit() {
 			{{.ImportPath}}
 		    {{end}}' \
 		"${BUILDFLAGS[@]}" $TEST_PATH \
+		| grep github.com/docker/docker \
 		| grep -v github.com/docker/docker/vendor \
 		| grep -v github.com/docker/docker/integration-cli)
 	go test $COVER $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @tianon Minor tweak to test-unit that allows me to run test-unit locally (outside of a container) for validation on Windows. Otherwise go list will include all other packages I have installed. This simply ensures only packages under docker/docker are included. 
