### PR TITLE
graph: enhance err message on failed image restore

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -182,7 +182,7 @@ func (graph *Graph) restore() error {
 		if graph.driver.Exists(id) {
 			img, err := graph.loadImage(id)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not restore image %s: %v", id, err)
 			}
 			graph.imageMutex.Lock(img.Parent)
 			graph.parentRefs[img.Parent]++


### PR DESCRIPTION
Yesterday I had a bad time trying to figure out why master was not running on my system.
I had a system crash while building images and on reboot Docker refused to start just saying me:

```
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07+01:00" level=warning msg="Running experimental build"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.274024027+01:00" level=debug msg="Server created for HTTP on fd ()"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.274106627+01:00" level=warning msg="/!\\ DON'T BIND ON ANY IP ADDRESS WITHOUT setting -tlsverify IF YOU DON
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.274393869+01:00" level=debug msg="Server created for HTTP on tcp (127.0.0.1:2375)"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.274878595+01:00" level=info msg="API listen on 127.0.0.1:2375"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.275046072+01:00" level=info msg="API listen on /var/run/docker.sock"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.275464135+01:00" level=debug msg="Creating actual daemon root: /var/lib/docker/0.0"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.275616759+01:00" level=debug msg="[graphdriver] trying provided driver \"overlay\""
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.279302277+01:00" level=debug msg="Using graph driver overlay"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.279413414+01:00" level=debug msg="Using default logging driver journald"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.279537324+01:00" level=debug msg="Creating images graph"
Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.303048509+01:00" level=debug msg="Cleaning up old shm/mqueue mounts: start."


Nov 02 10:15:07 localhost.localdomain docker[11730]: time="2015-11-02T10:15:07.303239884+01:00" level=fatal msg="Error starting daemon: EOF"
```

Turns out that on system crash the `json` file of the images I was building is empty because of the crash.
`graph.restore()` now calls `loadImage()` which tries to decode the `json` file and return an error if it couldn't. It was returning `io.EOF` because I had an empty `json` file under `./0.0/graph/f6f5123d07895c66e8eac297cb2665a9e56a1034fe5798c56f6c6b9c56338395/json` (always because of the crash)

This patch just adds a more descriptive debug message if something goes wrong restoring an image on daemon startup but I'm wondering if it makes sense to also ignore failed restored image and just skip and log them. `loadImage` is also used in another place in `graph/graph` so this could happen in other situations as well. Any thoughts? 
To me, pre https://github.com/docker/docker/pull/16890 the restore process couldn't actually fail so I think it makes sense to just skip failed to restore imgs.

Signed-off-by: Antonio Murdaca runcom@redhat.com
