### PR TITLE
increase the maxJSONDecodeRetry in json log reader

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -28,7 +28,7 @@ import (
 const (
 	// Name is the name of the file that the jsonlogger logs to.
 	Name               = "json-file"
-	maxJSONDecodeRetry = 10
+	maxJSONDecodeRetry = 20000
 )
 
 // JSONFileLogger is Logger implementation for default Docker logging.


### PR DESCRIPTION
This is another try to fix the flaky tests `TestLogsFollowSlowStdoutConsumer` and `TestRunSlowStdoutConsumer`
The previous one is #17537

![screenshot from 2015-11-02 17 53 13](https://cloud.githubusercontent.com/assets/1496652/10878733/a8854b98-818a-11e5-82f7-6ba4b5dc7ed5.png)

I noticed another failure in one of the PRs after #17537 was merged but it seems that the test was re-triggered and I couldn't find the exact failed URL in jenkins.

If I add the following debug lines after https://github.com/docker/docker/blob/master/daemon/logger/jsonfilelog/jsonfilelog.go#L370

``` go
        buf, _ := ioutil.ReadAll(dec.Buffered())
        logrus.Errorf("failed to decode log entry after %d retries. buffered: |||%s|||, Error: %v", retries, string(buf), err)
```

when the test fails, I can see the following error log:

```
time="2015-11-02T08:23:17.008895080Z" level=error msg="failed to decode log entry after 11 retries. buffered: |||\n{\"log\":\"X\\n\",\"stream\":\"stdout\",\"time\":\"2015-11|||, Error: unexpected EOF"
time="2015-11-02T08:23:17.008955856Z" level=error msg="Error streaming logs: unexpected EOF"
```

After changed `maxJSONDecodeRetry` to 20000 I run the test for 300 times locally and all succeed. 
Before the change it usually fails within 100 times. 

/cc @cpuguy83 @LK4D4 
