### PR TITLE
Include container names in `network inspect`

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -237,6 +237,7 @@ func buildEndpointResource(e libnetwork.Endpoint) types.EndpointResource {
 	}
 
 	er.EndpointID = e.ID()
+	er.Name = e.Name()
 	ei := e.Info()
 	if ei == nil {
 		return er

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -361,6 +361,7 @@ type NetworkResource struct {
 
 // EndpointResource contains network resources allocated and used for a container in a network
 type EndpointResource struct {
+	Name        string
 	EndpointID  string
 	MacAddress  string
 	IPv4Address string


### PR DESCRIPTION
Fixes #17404

This commit makes `docker network inspect` print container names as
service discovery is based on container name.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

Test cases are still on working. :)
