### PR TITLE
Windows: Fix dockerfile\parser TestTestData unit test

### DIFF
--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -1,10 +1,12 @@
 package parser
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -64,6 +66,11 @@ func TestTestData(t *testing.T) {
 		content, err := ioutil.ReadFile(resultfile)
 		if err != nil {
 			t.Fatalf("Error reading %s's result file: %v", dir, err)
+		}
+
+		if runtime.GOOS == "windows" {
+			// CRLF --> CR to match Unix behaviour
+			content = bytes.Replace(content, []byte{'\x0d', '\x0a'}, []byte{'\x0a'}, -1)
 		}
 
 		if ast.Dump()+"\n" != string(content) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I'm going through trying to get unit tests running on Windows (make test-unit). TestTestData in dockerfile\parser\parser_test fails on Windows due to it using CRLF rather than LF in Unix. The fix is to do a conversion of the byte stream to take account of this.
