### PR TITLE
Fix for #17168 issue

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1880,3 +1880,30 @@ func (s *DockerDaemonSuite) TestBridgeIPIsExcludedFromAllocatorPool(c *check.C) 
 		cont++
 	}
 }
+
+// Test daemon for no space left on device error
+func (s *DockerDaemonSuite) TestDaemonNoSpaceleftOnDeviceError(c *check.C) {
+	// create a 2MiB image and mount it as graph root
+	cmd := exec.Command("dd", "of=/tmp/testfs.img", "bs=1M", "seek=2", "count=0")
+	if err := cmd.Run(); err != nil {
+		c.Fatalf("dd failed: %v", err)
+	}
+	cmd = exec.Command("mkfs.ext4", "-F", "/tmp/testfs.img")
+	if err := cmd.Run(); err != nil {
+		c.Fatalf("mkfs.ext4 failed: %v", err)
+	}
+	cmd = exec.Command("mkdir", "-p", "/tmp/testfs-mount")
+	if err := cmd.Run(); err != nil {
+		c.Fatalf("mkdir failed: %v", err)
+	}
+	cmd = exec.Command("mount", "-t", "ext4", "-no", "loop,rw", "/tmp/testfs.img", "/tmp/testfs-mount")
+	if err := cmd.Run(); err != nil {
+		c.Fatalf("mount failed: %v", err)
+	}
+	err := s.d.Start("--graph", "/tmp/testfs-mount")
+	c.Assert(err, check.IsNil)
+
+	// pull a repository large enough to fill the mount point
+	out, err := s.d.Cmd("pull", "registry:2")
+	c.Assert(out, check.Not(check.Equals), 1, check.Commentf("no space left on device"))
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -219,6 +220,10 @@ func ContinueOnError(err error) bool {
 		return shouldV2Fallback(v)
 	case *client.UnexpectedHTTPResponseError:
 		return true
+	case error:
+		if val := strings.Contains(err.Error(), strings.ToLower(syscall.ENOSPC.Error())); val {
+			return false
+		}
 	}
 	// let's be nice and fallback if the error is a completely
 	// unexpected one.


### PR DESCRIPTION
Now `lastErr` saves the errors returned from subsequent attempts from `puller.Pull()`, when trying to look for a image in same endpoint with different version (v2,v1,v0). The returned error value is appended to the `lastErr`, which is returned to the caller and in turn to the client. This would ensure the client gets the correct error messages and not only the most recent (v0) message during the pull request.

fixes https://github.com/docker/docker/issues/17168
