### PR TITLE
Bring TESTDIRS back for unit-tests

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -9,11 +9,16 @@ set -e
 #
 bundle_test_unit() {
 	date
+	if [ -z "$TESTDIRS" ]; then
+		TEST_PATH=./...
+	else
+		TEST_PATH=./${TESTDIRS}
+	fi
 	pkg_list=$(go list -e \
 		-f '{{if ne .Name "github.com/docker/docker"}}
-				{{.ImportPath}}
-			{{end}}' \
-		"${BUILDFLAGS[@]}" ./... \
+			{{.ImportPath}}
+		    {{end}}' \
+		"${BUILDFLAGS[@]}" $TEST_PATH \
 		| grep -v github.com/docker/docker/vendor \
 		| grep -v github.com/docker/docker/integration-cli)
 	go test -cover $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list


### PR DESCRIPTION
Makes it simpler to test only one package. Was removed by #17491. 🐲

``` bash
$ TESTDIRS=api/client/ps make test-unit
# […]
---> Making bundle: test-unit (in bundles/1.9.0-dev/test-unit)
Mon Nov  2 18:21:05 UTC 2015
ok      github.com/docker/docker/api/client/ps  0.014s  coverage: 100.0% of statements
```

_Because I loved it :heart_eyes:_

/ping @LK4D4 @jfrazelle 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
