### PR TITLE
Fix race causing autorestart turning off on restart

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -503,7 +503,7 @@ func (container *Container) Stop(seconds int) error {
 		// 3. If it doesn't, then send SIGKILL
 		if err := container.Kill(); err != nil {
 			container.WaitStop(-1 * time.Second)
-			return err
+			logrus.Warn(err) // Don't return error because we only care that container is stopped, not what function stopped it
 		}
 	}
 


### PR DESCRIPTION
When application takes a long time to handle `SIGTERM` there can be a race between application closing by itself and docker calling `container.Kill()`. If application closes first, `Kill()` will error because container is already stopped. This will also mean that `docker restart` will error after container is stopped and restart policies will not try to restart it.

cc @crosbymichael @andrewnguyen

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
