### PR TITLE
made location of "repositories-"+d.driver.String() configurable

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -32,6 +32,7 @@ type CommonConfig struct {
 	Pidfile        string
 	RemappedRoot   string
 	Root           string
+	Repositories   string
 	TrustKeyPath   string
 	DefaultNetwork string
 
@@ -59,6 +60,7 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.Var(opts.NewListOptsRef(&config.ExecOptions, nil), []string{"-exec-opt"}, usageFn("Set exec driver options"))
 	cmd.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, defaultPidFile, usageFn("Path to use for daemon PID file"))
 	cmd.StringVar(&config.Root, []string{"g", "-graph"}, defaultGraph, usageFn("Root of the Docker runtime"))
+	cmd.StringVar(&config.Repositories, []string{"-repositories"}, defaultGraph, usageFn("Root of the Repositories storage"))
 	cmd.StringVar(&config.ExecRoot, []string{"-exec-root"}, "/var/run/docker", usageFn("Root of the Docker execdriver"))
 	cmd.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, usageFn("--restart on the daemon has been deprecated in favor of --restart policies on docker run"))
 	cmd.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", usageFn("Storage driver to use"))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -745,7 +745,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 		Registry: registryService,
 		Events:   eventsService,
 	}
-	repositories, err := graph.NewTagStore(filepath.Join(config.Root, "repositories-"+d.driver.String()), tagCfg)
+	repositories, err := graph.NewTagStore(filepath.Join(config.Repositories, "repositories-"+d.driver.String()), tagCfg)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't create Tag store repositories-%s: %s", d.driver.String(), err)
 	}

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -115,7 +115,10 @@ func (store *TagStore) save() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(store.path, jsonData, 0600); err != nil {
+	if err := ioutil.WriteFile(store.path + ".tmp", jsonData, 0600); err != nil {
+		return err
+	}
+	if err := os.Rename(store.path + ".tmp", store.path); err != nil {
 		return err
 	}
 	return nil

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -115,10 +115,10 @@ func (store *TagStore) save() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(store.path + ".tmp", jsonData, 0600); err != nil {
+	if err := ioutil.WriteFile(store.path+".tmp", jsonData, 0600); err != nil {
 		return err
 	}
-	if err := os.Rename(store.path + ".tmp", store.path); err != nil {
+	if err := os.Rename(store.path+".tmp", store.path); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
made location of "repositories-"+d.driver.String() configurable, so it's easier to protected it when /var/lib/docker fills up.

If -repositories is not specified in daemon startup parameters, it will default back to use config.Root.

The one gap that may need to be addressed is usage of -g WITHOUT usage of -repositories. I figured I'd take it this far, then use the PR to start the discussion on the the best option for how to deal with those situations.
