### PR TITLE
Proposal: separate link graph by storage driver

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -80,6 +80,16 @@ type CommonContainer struct {
 }
 
 func (container *Container) fromDisk() error {
+	if err := container.loadConfig(); err != nil {
+		return err
+	}
+	if err := label.ReserveLabel(container.ProcessLabel); err != nil {
+		return err
+	}
+	return container.readHostConfig()
+}
+
+func (container *Container) loadConfig() error {
 	pth, err := container.jsonPath()
 	if err != nil {
 		return err
@@ -92,16 +102,7 @@ func (container *Container) fromDisk() error {
 	defer jsonSource.Close()
 
 	dec := json.NewDecoder(jsonSource)
-
-	// Load container settings
-	if err := dec.Decode(container); err != nil {
-		return err
-	}
-
-	if err := label.ReserveLabel(container.ProcessLabel); err != nil {
-		return err
-	}
-	return container.readHostConfig()
+	return dec.Decode(container)
 }
 
 func (container *Container) toDisk() error {

--- a/daemon/graphdb_factory.go
+++ b/daemon/graphdb_factory.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/graphdb"
+)
+
+// A helper factory of link graph for daemon initialization.
+// It's not thread safe because there's no concurrent calls in daemon initialization.
+type graphdbFactory struct {
+	dbs    map[string]*graphdb.Database
+	daemon *Daemon
+}
+
+func newGraphdbFactory(daemon *Daemon) *graphdbFactory {
+	return &graphdbFactory{
+		daemon: daemon,
+		dbs:    make(map[string]*graphdb.Database),
+	}
+}
+
+func (f *graphdbFactory) get(driverName string) (*graphdb.Database, error) {
+	if db, ok := f.dbs[driverName]; ok {
+		return db, nil
+	}
+	var graphdbPath string
+	if driverName == "legacy" {
+		graphdbPath = filepath.Join(f.daemon.root, "linkgraph.db")
+	} else {
+		graphdbPath = filepath.Join(f.daemon.root, "linkgraph-"+driverName+".db")
+	}
+	graph, err := graphdb.NewSqliteConn(graphdbPath)
+	if err != nil {
+		return nil, err
+	}
+	f.dbs[driverName] = graph
+	return graph, nil
+}
+
+func (f *graphdbFactory) migrate() error {
+	legacyGraphdbPath := filepath.Join(f.daemon.root, "linkgraph.db")
+	if _, err := os.Stat(legacyGraphdbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	legacyGraphdb, err := f.get("legacy")
+	if err != nil {
+		return err
+	}
+
+	for p, e := range legacyGraphdb.List("/", -1) {
+		cid := e.ID()
+		container := &Container{}
+		container.ID = cid
+		container.root = f.daemon.containerRoot(cid)
+		if err := container.loadConfig(); err != nil {
+			logrus.Warnf("failed to migrate the linkgraph record for container %s: %v", cid, err)
+			continue
+		}
+
+		graph, err := f.get(container.Driver)
+		if err == nil {
+			graph.Set(p, cid)
+		}
+	}
+	return os.Remove(legacyGraphdbPath)
+}


### PR DESCRIPTION
This PR splits the `linkgraph.db` into `linkgraph-STORAGE_DRIVER.db`  according to the storage driver of the containers. The idea is inspired by the image repositories DB file such as `repositories-aufs`, `repositories-overlay`, etc.
This enables the user to switch between different storage drivers without breaking the existing containers.

Without this patch, if the user switches the storage driver from devicemapper to aufs the containers created with devicemapper won't show in the output of `docker ps -a`, but if the user tries to use the same name to create new container, the command will fail with `Error response from daemon: Could not find container for entity id f2bd2b291853fe70c9b3cc378d2bbf04c2089d5c61893748761bcbfc795c5911`. This is really confusing.

Previously discussed at https://github.com/docker/docker/pull/17389#discussion_r43595659

I'll write test cases once the design is approved.

cc @thaJeztah @tonistiigi 
