### PR TITLE
Optimize Create Container to skip extra mount on Windows.

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -114,10 +114,6 @@ func (daemon *Daemon) create(params *ContainerCreateConfig) (retC *Container, re
 			}
 		}
 	}()
-	if err := daemon.Mount(container); err != nil {
-		return nil, err
-	}
-	defer daemon.Unmount(container)
 
 	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig, img); err != nil {
 		return nil, err

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -16,6 +16,11 @@ import (
 
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
 func (daemon *Daemon) createContainerPlatformSpecificSettings(container *Container, config *runconfig.Config, hostConfig *runconfig.HostConfig, img *image.Image) error {
+	if err := daemon.Mount(container); err != nil {
+		return err
+	}
+	defer daemon.Unmount(container)
+
 	for spec := range config.Volumes {
 		name := stringid.GenerateNonCryptoID()
 		destination := filepath.Clean(spec)


### PR DESCRIPTION
@jstarks @jhowardmsft @vbatts @tiborvass 

The container create code path calls Mount before calling into createContainerPlatformSpecificSettings, but this extra mount is unnecessary in Windows.  Moving it into createContainerPlatformSpecificSettings speeds up container creation noticeably in testing.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
