### PR TITLE
Remove yum cache to reduce image size

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -39,8 +39,6 @@ if [[ -z $name ]]; then
     usage
 fi
 
-#--------------------
-
 target=$(mktemp -d --tmpdir $(basename $0).XXXXXX)
 
 set -x
@@ -72,21 +70,23 @@ NETWORKING=yes
 HOSTNAME=localhost.localdomain
 EOF
 
-# effectively: febootstrap-minimize --keep-zoneinfo --keep-rpmdb
-# --keep-services "$target".  Stolen from mkimage-rinse.sh
+# effectively: febootstrap-minimize --keep-zoneinfo --keep-rpmdb --keep-services "$target".
 #  locales
 rm -rf "$target"/usr/{{lib,share}/locale,{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
-#  docs
+#  docs and man pages
 rm -rf "$target"/usr/share/{man,doc,info,gnome/help}
 #  cracklib
 rm -rf "$target"/usr/share/cracklib
 #  i18n
 rm -rf "$target"/usr/share/i18n
+#  yum cache
+rm -rf "$target"/var/cache/yum
+mkdir -p --mode=0755 "$target"/var/cache/yum
 #  sln
 rm -rf "$target"/sbin/sln
 #  ldconfig
-rm -rf "$target"/etc/ld.so.cache
-rm -rf "$target"/var/cache/ldconfig/*
+rm -rf "$target"/etc/ld.so.cache "$target"/var/cache/ldconfig
+mkdir -p --mode=0755 "$target"/var/cache/ldconfig
 
 version=
 for file in "$target"/etc/{redhat,system}-release
@@ -103,6 +103,7 @@ if [ -z "$version" ]; then
 fi
 
 tar --numeric-owner -c -C "$target" . | docker import - $name:$version
+
 docker run -i -t $name:$version echo success
 
 rm -rf "$target"


### PR DESCRIPTION
mkimage-yum.sh has a lot in common with mkimage-rinse.sh, including extra
files clean up. Sync with mkimage-rinse.sh by removing yum cache to reduce
the image size.

Minor changes to reduce also the delta/diff and make it easier to sync with
mkimage-rinse.sh script.

Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
