### PR TITLE
Fixing wrong word spelling in api/client/network.go

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -237,7 +237,7 @@ func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
 	return nil
 }
 
-// Consolidates the ipam configuration as a group from differnt related configurations
+// Consolidates the ipam configuration as a group from different related configurations
 // user can configure network with multiple non-overlapping subnets and hence it is
 // possible to corelate the various related parameters and consolidate them.
 // consoidateIpam consolidates subnets, ip-ranges, gateways and auxilary addresses into


### PR DESCRIPTION
There's a word spelling mistake in  api/client/network.go ,i fixed it .

Signed-off-by: Shuwei Hao haoshuwei24@gmail.com
