### PR TITLE
Fix `--cluster-store` option parser

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -549,3 +549,28 @@ func TestParseSecurityOpt(t *testing.T) {
 		t.Fatal("Expected parseSecurityOpt error, got nil")
 	}
 }
+
+func TestNetworkOptions(t *testing.T) {
+	daemon := &Daemon{}
+	dconfigCorrect := &Config{
+		CommonConfig: CommonConfig{
+			DefaultNetwork:   "netPlugin:mynet:dev",
+			ClusterStore:     "consul://localhost:8500",
+			ClusterAdvertise: "192.168.0.1:8000",
+		},
+	}
+
+	if _, err := daemon.networkOptions(dconfigCorrect); err != nil {
+		t.Fatalf("Expect networkOptions sucess, got error: %v", err)
+	}
+
+	dconfigWrong := &Config{
+		CommonConfig: CommonConfig{
+			ClusterStore: "consul://localhost:8500://test://bbb",
+		},
+	}
+
+	if _, err := daemon.networkOptions(dconfigWrong); err == nil {
+		t.Fatalf("Expected networkOptions error, got nil")
+	}
+}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -333,11 +333,11 @@ func (daemon *Daemon) networkOptions(dconfig *Config) ([]nwconfig.Option, error)
 
 	if strings.TrimSpace(dconfig.ClusterStore) != "" {
 		kv := strings.Split(dconfig.ClusterStore, "://")
-		if len(kv) < 2 {
+		if len(kv) != 2 {
 			return nil, fmt.Errorf("kv store daemon config must be of the form KV-PROVIDER://KV-URL")
 		}
 		options = append(options, nwconfig.OptionKVProvider(kv[0]))
-		options = append(options, nwconfig.OptionKVProviderURL(strings.Join(kv[1:], "://")))
+		options = append(options, nwconfig.OptionKVProviderURL(kv[1]))
 	}
 	if len(dconfig.ClusterOpts) > 0 {
 		options = append(options, nwconfig.OptionKVOpts(dconfig.ClusterOpts))


### PR DESCRIPTION
`--cluster-store` is of form `KV-PROVIDER://KV-URL`, this commit makes
sure that KV-URL contains no `://`

Signed-off-by: Zhang Wei zhangwei555@huawei.com

I did a small test which shows that with original code docker daemon can accept format like `--cluster-store consul://localhost:8500://aaa://bbb`, but it will fail to create new network, I think it's strange to allow `KV-URL` to contain `://`, this commit will make sure it won't happen.
