### PR TITLE
7477-adds_small_flag

### DIFF
--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -25,6 +25,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 
 		cmd      = Cli.Subcmd("ps", nil, Cli.DockerCommands["ps"].Description, true)
 		quiet    = cmd.Bool([]string{"q", "-quiet"}, false, "Only display numeric IDs")
+		small	 = cmd.Bool([]string{"small", "-small"}, false, "Only display important columns")
 		size     = cmd.Bool([]string{"s", "-size"}, false, "Display total file sizes")
 		all      = cmd.Bool([]string{"a", "-all"}, false, "Show all containers (default shows just running)")
 		noTrunc  = cmd.Bool([]string{"#notrunc", "-no-trunc"}, false, "Don't truncate output")
@@ -106,6 +107,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		Output: cli.out,
 		Format: f,
 		Quiet:  *quiet,
+		Small: *small,
 		Size:   *size,
 		Trunc:  !*noTrunc,
 	}

--- a/api/client/ps/formatter.go
+++ b/api/client/ps/formatter.go
@@ -17,6 +17,7 @@ const (
 
 	defaultTableFormat = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}} ago\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
 	defaultQuietFormat = "{{.ID}}"
+	defaultSmallFormat = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.Names}}"
 )
 
 // Context contains information required by the formatter to print the output as desired.
@@ -29,6 +30,8 @@ type Context struct {
 	Size bool
 	// Quiet when set to true will simply print minimal information.
 	Quiet bool
+	// Small when set to true will print only important information, less wide.
+	Small bool
 	// Trunc when set to true will truncate the output of certain fields such as Container ID.
 	Trunc bool
 }
@@ -72,6 +75,8 @@ func tableFormat(ctx Context, containers []types.Container) {
 	ctx.Format = defaultTableFormat
 	if ctx.Quiet {
 		ctx.Format = defaultQuietFormat
+	} else if ctx.Small {
+		ctx.Format = defaultSmallFormat
 	}
 
 	customFormat(ctx, containers)


### PR DESCRIPTION
Added a `--small` flag to `docker ps` to only display more important columns so output looks nice on an 80 char terminal window.
