### PR TITLE
Fixed link to contribution page in docs/README.md.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ on other branches by special arrangement with the Docker maintainers.
 
 If you are a new or beginner contributor, we encourage you to read through the
 [our detailed contributors
-guide](http://docs.docker.com/opensource/code/). The guide explains in
+guide](https://docs.docker.com/opensource/code/). The guide explains in
 detail, with examples, how to contribute. If you are an experienced contributor
 this quickstart should be enough to get you started.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ on other branches by special arrangement with the Docker maintainers.
 
 If you are a new or beginner contributor, we encourage you to read through the
 [our detailed contributors
-guide](who-written-for.md). The guide explains in
+guide](http://docs.docker.com/opensource/code/). The guide explains in
 detail, with examples, how to contribute. If you are an experienced contributor
 this quickstart should be enough to get you started.
 


### PR DESCRIPTION
This PR changes a broken internal md link in docs/README.md to the quickstart contribution tutorial on the website. 

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
