### PR TITLE
fix documentation inconsistency for volume create

### DIFF
--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -25,7 +25,7 @@ Creates a new volume that containers can consume and store data in. If a name is
   hello
   $ docker run -d -v hello:/world busybox ls /world
 
-The mount is created inside the container's `/src` directory. Docker does not support relative paths for mount points inside the container.
+The mount is created inside the container's `/world` directory. Docker does not support relative paths for mount points inside the container.
 
 Multiple containers can use the same volume in the same time period. This is useful if two containers need access to shared data. For example, if one container writes and the other reads the data.
 


### PR DESCRIPTION
the example command uses `/world` but the description refers to `/src`
