### PR TITLE
graph: do not error out if images can't be restored

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -182,10 +182,7 @@ func (graph *Graph) restore() error {
 		if graph.driver.Exists(id) {
 			img, err := graph.loadImage(id)
 			if err != nil {
-				if err != io.EOF {
-					return fmt.Errorf("could not restore image %s: %v", id, err)
-				}
-				logrus.Warnf("could not restore image %s due to corrupted files", id)
+				logrus.Warnf("ignoring image %s, it could not be restored: %v", id, err)
 				continue
 			}
 			graph.imageMutex.Lock(img.Parent)


### PR DESCRIPTION
Fix #17688 

Signed-off-by: Antonio Murdaca runcom@redhat.com
