### PR TITLE
Verify Endpoint.Info() before accessing it

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -191,7 +191,11 @@ func buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {
 
 	epl := nw.Endpoints()
 	for _, e := range epl {
-		sb := e.Info().Sandbox()
+		ei := e.Info()
+		if ei == nil {
+			continue
+		}
+		sb := ei.Sandbox()
 		if sb == nil {
 			continue
 		}
@@ -233,7 +237,12 @@ func buildEndpointResource(e libnetwork.Endpoint) types.EndpointResource {
 	}
 
 	er.EndpointID = e.ID()
-	if iface := e.Info().Iface(); iface != nil {
+	ei := e.Info()
+	if ei == nil {
+		return er
+	}
+
+	if iface := ei.Iface(); iface != nil {
 		if mac := iface.MacAddress(); mac != nil {
 			er.MacAddress = mac.String()
 		}

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1191,7 +1191,11 @@ func (container *Container) disconnectFromNetwork(n libnetwork.Network) error {
 	)
 
 	s := func(current libnetwork.Endpoint) bool {
-		if sb := current.Info().Sandbox(); sb != nil {
+		epInfo := current.Info()
+		if epInfo == nil {
+			return false
+		}
+		if sb := epInfo.Sandbox(); sb != nil {
 			if sb.ContainerID() == container.ID {
 				ep = current
 				sbox = sb


### PR DESCRIPTION
- During concurrent stress operations in multi-host environment, it is possible to run into a nil `EndpointInfo` when running `docker network ls`. It is a valid situation. It just means the endpoint is no longer available in the datastore.

Signed-off-by: Alessandro Boch aboch@docker.com
