### PR TITLE
Use fs cgroups by default

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -74,9 +74,6 @@ func NewDriver(root, initPath string, options []string) (*Driver, error) {
 	// this makes sure there are no breaking changes to people
 	// who upgrade from versions without native.cgroupdriver opt
 	cgm := libcontainer.Cgroupfs
-	if systemd.UseSystemd() {
-		cgm = libcontainer.SystemdCgroups
-	}
 
 	// parse the options
 	for _, option := range options {

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -452,11 +452,11 @@ single `native.cgroupdriver` option is available.
 
 The `native.cgroupdriver` option specifies the management of the container's
 cgroups. You can specify `cgroupfs` or `systemd`. If you specify `systemd` and
-it is not available, the system uses `cgroupfs`. By default, if no option is
-specified, the execdriver first tries `systemd` and falls back to `cgroupfs`.
-This example sets the execdriver to `cgroupfs`:
+it is not available, the system uses `cgroupfs`. If you omit the
+`native.cgroupdriver` option,` cgroupfs` is used.
+This example sets the `cgroupdriver` to `systemd`:
 
-    $ sudo docker daemon --exec-opt native.cgroupdriver=cgroupfs
+    $ sudo docker daemon --exec-opt native.cgroupdriver=systemd
 
 Setting this option applies to all containers the daemon launches.
 


### PR DESCRIPTION
Our implementation of systemd cgroups is mixture of systemd api and
plain filesystem api. It's hard to keep it up to date with systemd and
it already contains some nasty bugs with new versions. Ideally it should
be replaced with some daemon flag which will allow to set parent systemd
slice.
