### PR TITLE
Update upstart init script to start on filesystem (not only on local ones).

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -1,6 +1,6 @@
 description "Docker daemon"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
+start on (filesystem and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 limit nofile 524288 1048576
 limit nproc 524288 1048576


### PR DESCRIPTION
This PR implements my current workaround for #17485.
