### PR TITLE
Fixing last access time on Windows to unblock python.

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -304,7 +304,7 @@ func (b *Builder) download(srcURL string) (fi builder.FileInfo, err error) {
 		}
 	}
 
-	if err = system.Chtimes(tmpFileName, time.Time{}, mTime); err != nil {
+	if err = system.Chtimes(tmpFileName, mTime, mTime); err != nil {
 		return
 	}
 


### PR DESCRIPTION
@jstarks @jhowardmsft @darrenstahlmsft @tiborvass 

Last access time is not included in the tar header created by the GO language on Windows.  To avoid setting the last access time to the beginning of the Linux epoch, we will use last modified time instead (since last access time should always be at least last modified time, if not later).  This fix is required for python in Windows containers, since python will refuse to load any files with invalid last access times.

Confirmed the fix by testing python in a Windows container, which works with this change.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
