### PR TITLE
Move errcode handling for resize upper

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -244,9 +244,6 @@ func (container *Container) ExitOnNext() {
 // Resize changes the TTY of the process running inside the container
 // to the given height and width. The container must be running.
 func (container *Container) Resize(h, w int) error {
-	if !container.IsRunning() {
-		return derr.ErrorCodeNotRunning.WithArgs(container.ID)
-	}
 	if err := container.command.ProcessConfig.Terminal.Resize(h, w); err != nil {
 		return err
 	}

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -1,11 +1,17 @@
 package daemon
 
+import derr "github.com/docker/docker/errors"
+
 // ContainerResize changes the size of the TTY of the process running
 // in the container with the given name to the given height and width.
 func (daemon *Daemon) ContainerResize(name string, height, width int) error {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return err
+	}
+
+	if !container.IsRunning() {
+		return derr.ErrorCodeNotRunning.WithArgs(container.ID)
 	}
 
 	if err = container.Resize(height, width); err == nil {


### PR DESCRIPTION
It'll allow to separate daemon layer more cleanly later.
