### PR TITLE
Windows: [TP4] Fix docker login

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -32,6 +33,11 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	cmd.StringVar(&email, []string{"e", "-email"}, "", "Email")
 
 	cmd.ParseFlags(args, true)
+
+	// On Windows, force the use of the regular OS stdin stream. Fixes #14336/#14210
+	if runtime.GOOS == "windows" {
+		cli.in = os.Stdin
+	}
 
 	serverAddress := registry.IndexServer
 	if len(cmd.Args()) > 0 {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@thaJeztah Fixes #14336 and #14210. This allows interactive docker login to work again on Windows. Verified under cmd and PowerShell. Previously, it was impossible to type anything, it would hang on the username prompt. The only workaround was to control-C and type all the parameters on a single line.

![login](https://cloud.githubusercontent.com/assets/10522484/10985080/077943a8-83d3-11e5-8a97-5fe7b6455a91.JPG)
