### PR TITLE
Add token pass-thru for AuthConfig

### DIFF
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -51,6 +51,7 @@ type AuthConfig struct {
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
 // ConfigFile ~/.docker/config.json file info

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -1,0 +1,95 @@
+package distribution
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/registry"
+	"github.com/docker/docker/utils"
+)
+
+func TestTokenPassThru(t *testing.T) {
+	authConfig := &cliconfig.AuthConfig{
+		RegistryToken: "mysecrettoken",
+	}
+	gotToken := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Authorization"), authConfig.RegistryToken) {
+			logrus.Debug("Detected registry token in auth header")
+			gotToken = true
+		}
+		if r.RequestURI == "/v2/" {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="foorealm"`)
+			w.WriteHeader(401)
+		}
+	}
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	tmp, err := utils.TestDirectory("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	endpoint := registry.APIEndpoint{
+		Mirror:       false,
+		URL:          ts.URL,
+		Version:      2,
+		Official:     false,
+		TrimHostname: false,
+		TLSConfig:    nil,
+		//VersionHeader: "verheader",
+		Versions: []auth.APIVersion{
+			{
+				Type:    "registry",
+				Version: "2",
+			},
+		},
+	}
+	n, _ := reference.ParseNamed("testremotename")
+	repoInfo := &registry.RepositoryInfo{
+		Index: &registry.IndexInfo{
+			Name:     "testrepo",
+			Mirrors:  nil,
+			Secure:   false,
+			Official: false,
+		},
+		RemoteName:    n,
+		LocalName:     n,
+		CanonicalName: n,
+		Official:      false,
+	}
+	imagePullConfig := &ImagePullConfig{
+		MetaHeaders: http.Header{},
+		AuthConfig:  authConfig,
+	}
+	sf := streamformatter.NewJSONStreamFormatter()
+	puller, err := newPuller(endpoint, repoInfo, imagePullConfig, sf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := puller.(*v2Puller)
+	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logrus.Debug("About to pull")
+	// We expect it to fail, since we haven't mock'd the full registry exchange in our handler above
+	tag, _ := reference.WithTag(n, "tag_goes_here")
+	_ = p.pullV2Repository(tag)
+
+	if !gotToken {
+		t.Fatal("Failed to receive registry token")
+	}
+
+}

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -101,6 +101,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /networks/(name)` now returns a `Name` field for each container attached to the network.
 * `GET /version` now returns the `BuildTime` field in RFC3339Nano format to make it 
   consistent with other date/time values returned by the API.
+* `AuthConfig` now supports a `registrytoken` for token based authentication
 
 ### v1.21 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1532,7 +1532,24 @@ Query Parameters:
 
     Request Headers:
 
--   **X-Registry-Auth** – base64-encoded AuthConfig object
+-   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
+    - Credential based login:
+
+        ```
+    {
+            "username": "jdoe",
+            "password": "secret",
+            "email": "jdoe@acme.com",
+    }
+        ```
+
+    - Token based login:
+
+        ```
+    {
+            "registrytoken": "9cbaf023786cd7..."
+    }
+        ```
 
 Status Codes:
 
@@ -1741,8 +1758,24 @@ Query Parameters:
 
 Request Headers:
 
--   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
-        object.
+-   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
+    - Credential based login:
+
+        ```
+    {
+            "username": "jdoe",
+            "password": "secret",
+            "email": "jdoe@acme.com",
+    }
+        ```
+
+    - Token based login:
+
+        ```
+    {
+            "registrytoken": "9cbaf023786cd7..."
+    }
+        ```
 
 Status Codes:
 


### PR DESCRIPTION
This change allows API clients to retrieve an authentication token from
a registry, and then pass that token directly to the API.

Example usage:

```
REPO_USER=dhiltgen
read -s PASSWORD
REPO=privateorg/repo
AUTH_URL=https://auth.docker.io/token
TOKEN=$(curl -s -u "${REPO_USER}:${PASSWORD}" "${AUTH_URL}?scope=repository:${REPO}:pull&service=registry.docker.io" |
    jq -r ".token")

HEADER=$(echo "{\"registrytoken\":\"${TOKEN}\"}"|base64 -w 0 )
curl -s -D - -H "X-Registry-Auth: ${HEADER}" -X POST "http://localhost:2376/images/create?fromImage=${REPO}"
```

Signed-off-by: Daniel Hiltgen daniel.hiltgen@docker.com
