### PR TITLE
Add an alternate gpg server to the documentation for Ubuntu and Debian.

### DIFF
--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -51,7 +51,7 @@ from the new repository:
 
  4. Add the new `gpg` key.
 
-         $ apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+         $ apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
  5. Open the `/etc/apt/sources.list.d/docker.list` file in your favorite editor.
 

--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -55,7 +55,7 @@ packages from the new repository:
 
 3. Add the new `gpg` key.
 
-        $ sudo apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+        $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
 4. Open the `/etc/apt/sources.list.d/docker.list` file in your favorite editor.
 


### PR DESCRIPTION
I have been upgrading all my Ubuntu machines, and much of the time the mit pgp server has not responded until you try about five times, giving

```
gpg: requesting key 2C52609D from hkp server pgp.mit.edu
gpgkeys: key 58118E89F3A912897C070ADBF76221572C52609D can't be retrieved
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
```

I thought I was probably not the only person this happens to so I thought it would be helpful to suggest a fallback for the user who does not know what to do here.
