### PR TITLE
Use name instead of container in Commit

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -114,7 +114,7 @@ type Docker interface {
 	// Remove removes a container specified by `id`.
 	Remove(id string, cfg *daemon.ContainerRmConfig) error
 	// Commit creates a new Docker image from an existing Docker container.
-	Commit(*daemon.Container, *daemon.ContainerCommitConfig) (*image.Image, error)
+	Commit(string, *daemon.ContainerCommitConfig) (*image.Image, error)
 	// Copy copies/extracts a source FileInfo to a destination path inside a container
 	// specified by a container object.
 	// TODO: make an Extract method instead of passing `decompress`

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -60,7 +60,6 @@ func (b *Builder) commit(id string, autoCmd *stringutils.StrSlice, comment strin
 		} else if hit {
 			return nil
 		}
-
 		container, err := b.create()
 		if err != nil {
 			return err
@@ -71,11 +70,6 @@ func (b *Builder) commit(id string, autoCmd *stringutils.StrSlice, comment strin
 			return err
 		}
 		defer b.docker.Unmount(container)
-	}
-
-	container, err := b.docker.Container(id)
-	if err != nil {
-		return err
 	}
 
 	// Note: Actually copy the struct
@@ -89,7 +83,7 @@ func (b *Builder) commit(id string, autoCmd *stringutils.StrSlice, comment strin
 	}
 
 	// Commit the container
-	image, err := b.docker.Commit(container, commitCfg)
+	image, err := b.docker.Commit(id, commitCfg)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -106,8 +106,8 @@ func (d Docker) Remove(id string, cfg *daemon.ContainerRmConfig) error {
 }
 
 // Commit creates a new Docker image from an existing Docker container.
-func (d Docker) Commit(c *daemon.Container, cfg *daemon.ContainerCommitConfig) (*image.Image, error) {
-	return d.Daemon.Commit(c, cfg)
+func (d Docker) Commit(name string, cfg *daemon.ContainerCommitConfig) (*image.Image, error) {
+	return d.Daemon.Commit(name, cfg)
 }
 
 // Retain retains an image avoiding it to be removed or overwritten until a corresponding Release() call.


### PR DESCRIPTION
It will make daemon interface separation easier later.
