### PR TITLE
Use Option missingkey=error to fail on missing template keys.

### DIFF
--- a/api/client/inspect_test.go
+++ b/api/client/inspect_test.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestDecodeRawInspect(t *testing.T) {
+	cases := []struct {
+		input  string
+		tmpl   string
+		fail   bool
+		output string
+	}{
+		{`{"HostConfig": {"Dns": "8.8.8.8"}}`, "{{.HostConfig.Dns}}", false, "8.8.8.8"},
+		{`{"HostConfig": {"Dns": null}}`, "{{.HostConfig.Dns}}", false, "<no value>"},
+		{`{"HostConfig": {"Dns": "8.8.8.8"}}`, "{{.HostConfig.Foo}}", true, ""},
+	}
+
+	for _, cs := range cases {
+		r := strings.NewReader(cs.input)
+		d := json.NewDecoder(r)
+
+		tmpl, err := template.New("").Parse(cs.tmpl)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		out, err := decodeRawInspect(tmpl, d)
+		if cs.fail {
+			if err == nil {
+				t.Fatalf("Template parsing expected to fail, got nil error. Template: %s, input: %s", cs.tmpl, cs.input)
+			}
+		} else {
+			if out.String() != cs.output {
+				t.Fatalf("Template parsing expected output %s, got %s", cs.output, out.String())
+			}
+		}
+
+	}
+}

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -329,3 +329,12 @@ func (s *DockerSuite) TestInspectTempateError(c *check.C) {
 	c.Assert(err, check.Not(check.IsNil))
 	c.Assert(out, checker.Contains, "Template parsing error")
 }
+
+func (s *DockerSuite) TestInspectJSONFields(c *check.C) {
+	dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "top")
+	out, _, err := dockerCmdWithError("inspect", "--type=container", "--format='{{.HostConfig.Dns}}'", "busybox")
+
+	c.Assert(err, check.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), "Template parsing error")
+	c.Assert(out, checker.Contains, "<no value>")
+}


### PR DESCRIPTION
Instead of failing because the value is missing. That was a hack we had
to support only before building docker with go 1.5.

:warning: :rotating_light: :warning:

This patch only works on master, where we're using go 1.5 already.
I'm working on a similar patch for the 1.9 release branch but it's much more complicated, because the template doesn't have any options.

Signed-off-by: David Calavera david.calavera@gmail.com
