### PR TITLE
Windows: Native make test-unit

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -25,7 +25,8 @@ bundle_test_unit() {
 	go test $COVER $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list
 }
 
-if [[ "$(go version)" =~ "gccgo" ]]; then
+
+if [[ "$(go version)" == *"gccgo"* ]]; then
 	GCCGOFLAGS=-gccgoflags="-lpthread"
 else
 	COVER=-cover


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This allows sh hack/make.sh test-unit to be able to run again on Windows natively. 

Following the merge of #17578, it became broken as mingw64 msys doesn't support the regex operator =~ and fails 'conditional binary operator expected'.

Changed to contains gccgo instead. @brahmaroutu @LK4D4 @vdemeester
