### PR TITLE
Don't build utils on Windows

### DIFF
--- a/daemon/execdriver/utils_unix.go
+++ b/daemon/execdriver/utils_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package execdriver
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Realised Windows daemon is pulling in github.com/syndtr/gocapability/capability via execdriver\utils.go, which only has Unix specific functionality. Renamed and factored out entirely on Windows.
