### PR TITLE
Modify docker volume inspect to return existed volumes and the names of the unexsited volumes

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"text/tabwriter"
 	"text/template"
@@ -127,7 +128,12 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 	for _, name := range cmd.Args() {
 		resp, err := cli.call("GET", "/volumes/"+name, nil, nil)
 		if err != nil {
-			return err
+			if resp.statusCode != http.StatusNotFound {
+				return err
+			}
+			status = 1
+			fmt.Fprintf(cli.err, "Error: No such volume: %s\n", name)
+			continue
 		}
 
 		var volume types.Volume

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -50,6 +50,19 @@ func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
 	c.Assert(strings.TrimSpace(out), check.Equals, "test")
 }
 
+func (s *DockerSuite) TestVolumeCliInspectMulti(c *check.C) {
+	dockerCmd(c, "volume", "create", "--name", "test1")
+	dockerCmd(c, "volume", "create", "--name", "test2")
+
+	out, _ := dockerCmd(c, "volume", "inspect", "--format='{{ .Name }}'", "test1", "test2", "doesntexist")
+	outArr := strings.Split(strings.TrimSpace(out), "\n")
+	c.Assert(len(outArr), check.Equals, 3, check.Commentf("\n%s", out))
+
+	c.Assert(strings.Contains(out, "test1\n"), check.Equals, true)
+	c.Assert(strings.Contains(out, "test2\n"), check.Equals, true)
+	c.Assert(strings.Contains(out, "Error: No such volume: doesntexist\n"), check.Equals, true)
+}
+
 func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
 	prefix := ""
 	if daemonPlatform == "windows" {


### PR DESCRIPTION
When I used the "docker volume inspect" command to get the info about volumes,I found that if I give an existed volume name and an unexisted volume name,it returns only error infos,like below:

root@324fca3aedab:/go/src/github.com/docker/docker# docker volume ls
DRIVER              VOLUME NAME
local               hao
local               hao1
local               hao3

root@324fca3aedab:/go/src/github.com/docker/docker# docker volume inspect hao
[
    {
        "Name": "hao",
        "Driver": "local",
        "Mountpoint": "/var/lib/docker/volumes/hao/_data"
    }
]

root@324fca3aedab:/go/src/github.com/docker/docker# docker volume inspect hao hao2
Error response from daemon: no such volume

So I modify the command to return the existed volumes even when I give an unexisted volume name,like below:
root@3c7deed66fd2:/go/src/github.com/docker/docker# docker volume inspect hao1 hao4
Error:No such volume: hao4
[
    {
        "Name": "hao1",
        "Driver": "local",
        "Mountpoint": "/var/lib/docker/volumes/hao1/_data"
    }
]

Signed-off-by: Shuwei Hao haoshuwei24@gmail.com
