### PR TITLE
17411 restart error

### DIFF
--- a/graph/tags.go
+++ b/graph/tags.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/graph/tags"
@@ -108,6 +109,15 @@ func (store *TagStore) reload() error {
 		return err
 	}
 	defer f.Close()
+	finfo, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	// check file is empty and continue with warning
+	if size := finfo.Size(); size == 0 {
+		logrus.Warnf("Tag store is empty: %s, image tags may have been lost.", store.path)
+		return nil
+	}
 	if err := json.NewDecoder(f).Decode(&store); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #17411 - daemon start error when `/var/lib/docker/repositories-aufs` is an empty file. Now on daemon start up a warning message is printed if a file is missing or empty. Have modified the `reload()` function to handle both cases and continue starting docker daemon.

Includes test cases added for #17411
-   Test Daemon start when the repositories-aufs file is removed
-   Test Daemon start when the repositories-aufs file is empty
