### PR TITLE
Add support multiple network mode on docker create/run

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -138,7 +138,8 @@ type Container struct {
 	Labels     map[string]string
 	Status     string
 	HostConfig struct {
-		NetworkMode string `json:",omitempty"`
+		NetworkMode  string `json:",omitempty"`
+		NetworkModes string `json:",omitempty"`
 	}
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -176,7 +176,7 @@ func TestLoadWithVolume(t *testing.T) {
 
 	hostConfig := `{"Binds":[],"ContainerIDFile":"","Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
-"Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
+"Devices":[],"NetworkModes":["bridge"],"IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
 "SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
@@ -264,7 +264,7 @@ func TestLoadWithBindMount(t *testing.T) {
 
 	hostConfig := `{"Binds":["/vol1:/vol1"],"ContainerIDFile":"","Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
-"Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
+"Devices":[],"NetworkModes":["bridge"],"IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
 "SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
@@ -355,7 +355,7 @@ func TestLoadWithVolume17RC(t *testing.T) {
 
 	hostConfig := `{"Binds":[],"ContainerIDFile":"","Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
-"Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
+"Devices":[],"NetworkModes":["bridge"],"IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
 "SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)
@@ -460,7 +460,7 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 
 	hostConfig := `{"Binds":[],"ContainerIDFile":"","Memory":0,"MemorySwap":0,"CpuShares":0,"CpusetCpus":"",
 "Privileged":false,"PortBindings":{},"Links":null,"PublishAllPorts":false,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"VolumesFrom":null,
-"Devices":[],"NetworkMode":"bridge","IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
+"Devices":[],"NetworkModes":["bridge"],"IpcMode":"","PidMode":"","CapAdd":null,"CapDrop":null,"RestartPolicy":{"Name":"no","MaximumRetryCount":0},
 "SecurityOpt":null,"ReadonlyRootfs":false,"Ulimits":null,"LogConfig":{"Type":"","Config":null},"CgroupParent":""}`
 	if err = ioutil.WriteFile(filepath.Join(containerPath, "hostconfig.json"), []byte(hostConfig), 0644); err != nil {
 		t.Fatal(err)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -567,14 +567,14 @@ func (daemon *Daemon) registerLinks(container *Container, hostConfig *runconfig.
 			//An error from daemon.Get() means this name could not be found
 			return fmt.Errorf("Could not get container for %s", name)
 		}
-		for child.hostConfig.NetworkMode.IsContainer() {
-			parts := strings.SplitN(string(child.hostConfig.NetworkMode), ":", 2)
+		for child.hostConfig.NetworkModes[0].IsContainer() {
+			parts := strings.SplitN(string(child.hostConfig.NetworkModes[0]), ":", 2)
 			child, err = daemon.Get(parts[1])
 			if err != nil {
 				return fmt.Errorf("Could not get container for %s", parts[1])
 			}
 		}
-		if child.hostConfig.NetworkMode.IsHost() {
+		if child.hostConfig.NetworkModes[0].IsHost() {
 			return runconfig.ErrConflictHostNetworkAndLinks
 		}
 		if err := daemon.registerLink(container, child, alias); err != nil {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -345,6 +345,7 @@ func (daemon *Daemon) transformContainer(container *Container, ctx *listContext)
 	newC.Created = container.Created.Unix()
 	newC.Status = container.State.String()
 	newC.HostConfig.NetworkMode = string(container.hostConfig.NetworkMode)
+	newC.HostConfig.NetworkModes = fmt.Sprintf("%s", container.hostConfig.NetworkModes)
 
 	newC.Ports = []types.Port{}
 	for port, bindings := range container.NetworkSettings.Ports {

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -781,7 +781,7 @@ func UtilCreateNetworkMode(c *check.C, networkMode string) {
 		c.Fatal(err)
 	}
 
-	if containerJSON.HostConfig.NetworkMode != runconfig.NetworkMode(networkMode) {
+	if containerJSON.HostConfig.NetworkModes[0] != runconfig.NetworkMode(networkMode) {
 		c.Fatalf("Mismatched NetworkMode, Expected %s, Actual: %s ", networkMode, containerJSON.HostConfig.NetworkMode)
 	}
 }

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -109,8 +109,8 @@ func callDecodeContainerConfigIsolation(isolation string) (*Config, *HostConfig,
 	w := ContainerConfigWrapper{
 		Config: &Config{},
 		HostConfig: &HostConfig{
-			NetworkMode: "none",
-			Isolation:   IsolationLevel(isolation)},
+			NetworkModes: []NetworkMode{"none"},
+			Isolation:    IsolationLevel(isolation)},
 	}
 	if b, err = json.Marshal(w); err != nil {
 		return nil, nil, fmt.Errorf("Error on marshal %s", err.Error())

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -192,7 +192,8 @@ type HostConfig struct {
 	ExtraHosts        []string              // List of extra hosts
 	VolumesFrom       []string              // List of volumes to take from other container
 	Devices           []DeviceMapping       // List of devices to map inside the container
-	NetworkMode       NetworkMode           // Network namespace to use for the container
+	NetworkMode       NetworkMode           // Network namespace to use for the container, deprecated by Networks
+	NetworkModes      []NetworkMode         // Networks used for container
 	IpcMode           IpcMode               // IPC namespace to use for the container	// Unix specific
 	PidMode           PidMode               // PID namespace to use for the container	// Unix specific
 	UTSMode           UTSMode               // UTS namespace to use for the container	// Unix specific
@@ -230,8 +231,12 @@ func DecodeHostConfig(src io.Reader) (*HostConfig, error) {
 // docker daemon.
 func SetDefaultNetModeIfBlank(hc *HostConfig) *HostConfig {
 	if hc != nil {
-		if hc.NetworkMode == NetworkMode("") {
+		if len(hc.NetworkModes) == 0 && hc.NetworkMode == NetworkMode("") {
+			hc.NetworkModes = []NetworkMode{"default"}
 			hc.NetworkMode = NetworkMode("default")
+		}
+		if len(hc.NetworkModes) == 0 && hc.NetworkMode != NetworkMode("") {
+			hc.NetworkModes = append(hc.NetworkModes, hc.NetworkMode)
 		}
 	}
 	return hc

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -292,8 +292,8 @@ func callDecodeContainerConfig(volumes []string, binds []string) (*Config, *Host
 			Volumes: map[string]struct{}{},
 		},
 		HostConfig: &HostConfig{
-			NetworkMode: "none",
-			Binds:       binds,
+			NetworkModes: []NetworkMode{"none"},
+			Binds:        binds,
 		},
 	}
 	for _, v := range volumes {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

fixes #17750
fixes https://github.com/docker/docker/issues/17289

This PR is to make docker run/create supporting multiple network.
Design principle of this PR: 
- `host` `container` `none` are not supported in multiple network modes.
- `--link` is only supported if there is `bridge` network modes.

/cc @cpuguy83  @mavenugo @mrjana
