### PR TITLE
Utillize build cache for Node.js web app example

### DIFF
--- a/docs/examples/nodejs_web_app.md
+++ b/docs/examples/nodejs_web_app.md
@@ -85,16 +85,17 @@ via-package-manager#rhelcentosscientific-linux-6):
     # Install Node.js and npm
     RUN     yum install -y nodejs npm
 
+Install your app dependencies using the `npm` binary:
+
+    # Install app dependencies
+    COPY package.json /src/package.json
+    RUN cd /src; npm install
+
 To bundle your app's source code inside the Docker image, use the `COPY`
 instruction:
 
     # Bundle app source
     COPY . /src
-
-Install your app dependencies using the `npm` binary:
-
-    # Install app dependencies
-    RUN cd /src; npm install
 
 Your app binds to port `8080` so you'll use the `EXPOSE` instruction to have
 it mapped by the `docker` daemon:
@@ -116,10 +117,12 @@ Your `Dockerfile` should now look like this:
     # Install Node.js and npm
     RUN     yum install -y nodejs npm
 
+    # Install app dependencies
+    COPY package.json /src/package.json
+    RUN cd /src; npm install
+
     # Bundle app source
     COPY . /src
-    # Install app dependencies
-    RUN cd /src; npm install
 
     EXPOSE  8080
     CMD ["node", "/src/index.js"]


### PR DESCRIPTION
This PR is just a minor adjustment of the documentation example for the Node.js web application to better adhere to Docker best practices and build cache utilisation. There are quite a bit of people who are asking us how to prevent Docker from installing their npm module each time they build their Node.js Docker image.

Much :heart: from the Node.js Docker Working Group :sparkles: :turtle: :rocket: :sparkles:

Signed-off-by: Hans Kristian Flaatten hans@starefossen.com
