### PR TITLE
Fix bash completion on systems where extglob is not set

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -49,6 +49,9 @@
 # options immediately following their corresponding long form.
 # This order should be applied to lists, alternatives and code blocks.
 
+__docker_previous_extglob_setting=$(shopt -p extglob)
+shopt -s extglob
+
 __docker_q() {
 	docker ${host:+-H "$host"} ${config:+--config "$config"} 2>/dev/null "$@"
 }
@@ -1889,5 +1892,8 @@ _docker() {
 	eval "$previous_extglob_setting"
 	return 0
 }
+
+eval "$__docker_previous_extglob_setting"
+unset __docker_previous_extglob_setting
 
 complete -F _docker docker


### PR DESCRIPTION
Dockers bash completion makes use of the bash `extglob` feature (extended globbing).
This usually is not a problem as the current bash completion base package explicitly sets this option.

To ensure that Dockers bash completion also works on systems where for some strange reason `extglob` is unset, the main completion function temporarily sets this option and restores the previous setting at its end.

As reported in #17768 and #17791, it is not sufficient to set `extglob` during execution, it also has to be set when the script is being sourced.
