### PR TITLE
Align configuration of bash completion with existing values

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -21,8 +21,8 @@
 # setting environment variables.
 #
 # DOCKER_COMPLETION_SHOW_NETWORK_IDS
-#   "false" - Show names only (default)
-#   "true"  - Show names and ids
+#   "no"  - Show names only (default)
+#   "yes" - Show names and ids
 #
 # You can tailor completion for the "events", "history", "inspect", "run",
 # "rmi" and "save" commands by settings the following environment
@@ -147,9 +147,9 @@ __docker_containers_and_images() {
 
 __docker_networks() {
 	# By default, only network names are completed.
-	# Set DOCKER_COMPLETION_SHOW_NETWORK_IDS=true to also complete network IDs.
+	# Set DOCKER_COMPLETION_SHOW_NETWORK_IDS=yes to also complete network IDs.
 	local fields='$2'
-	[ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS}" = true ] && fields='$1,$2'
+	[ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS}" = yes ] && fields='$1,$2'
 	local networks=$(__docker_q network ls --no-trunc | awk "NR>1 {print $fields}")
 	COMPREPLY=( $(compgen -W "$networks" -- "$cur") )
 }


### PR DESCRIPTION
In #17270, I introduced configurable bash completion: the user can configure whether or not to include network IDs in network completions.
Sadly, I chose `true` and `false` where the existing configuation variables use `yes` and `no`, [see](https://github.com/docker/docker/blob/master/contrib/completion/bash/docker#L36-L38).
This PR restores consitency.

This feature is currently unreleased, so I think we can change it without notice.
