### PR TITLE
Fix typo in container-start error message

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -223,10 +223,10 @@ func (daemon *Daemon) populateCommand(c *Container, env []string) error {
 		ipc.HostIpc = c.hostConfig.IpcMode.IsHost()
 		if ipc.HostIpc {
 			if _, err := os.Stat("/dev/shm"); err != nil {
-				return fmt.Errorf("/dev/shm is not mounted, but must be for --host=ipc")
+				return fmt.Errorf("/dev/shm is not mounted, but must be for --ipc=host")
 			}
 			if _, err := os.Stat("/dev/mqueue"); err != nil {
-				return fmt.Errorf("/dev/mqueue is not mounted, but must be for --host=ipc")
+				return fmt.Errorf("/dev/mqueue is not mounted, but must be for --ipc=host")
 			}
 			c.ShmPath = "/dev/shm"
 			c.MqueuePath = "/dev/mqueue"


### PR DESCRIPTION
Since the `--host` option takes a socket (and probably isn't relevant here), and there is an `--ipc` option that takes `host` as a value, I believe this is a typo.
