### PR TITLE
Fix opq whiteouts problems for files with dot prefix

### DIFF
--- a/pkg/archive/diff_test.go
+++ b/pkg/archive/diff_test.go
@@ -2,7 +2,14 @@ package archive
 
 import (
 	"archive/tar"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/docker/docker/pkg/ioutils"
 )
 
 func TestApplyLayerInvalidFilenames(t *testing.T) {
@@ -187,4 +194,177 @@ func TestApplyLayerInvalidSymlink(t *testing.T) {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
+}
+
+func TestApplyLayerWhiteouts(t *testing.T) {
+	wd, err := ioutil.TempDir("", "graphdriver-test-whiteouts")
+	if err != nil {
+		return
+	}
+	defer os.RemoveAll(wd)
+
+	base := []string{
+		".baz",
+		"bar/",
+		"bar/bax",
+		"bar/bay/",
+		"baz",
+		"foo/",
+		"foo/.abc",
+		"foo/.bcd/",
+		"foo/.bcd/a",
+		"foo/cde/",
+		"foo/cde/def",
+		"foo/cde/efg",
+		"foo/fgh",
+		"foobar",
+	}
+
+	type tcase struct {
+		change, expected []string
+	}
+
+	tcases := []tcase{
+		{
+			base,
+			base,
+		},
+		{
+			[]string{
+				".bay",
+				".wh.baz",
+				"foo/",
+				"foo/.bce",
+				"foo/.wh..wh..opq",
+				"foo/cde/",
+				"foo/cde/efg",
+			},
+			[]string{
+				".bay",
+				".baz",
+				"bar/",
+				"bar/bax",
+				"bar/bay/",
+				"foo/",
+				"foo/.bce",
+				"foo/cde/",
+				"foo/cde/efg",
+				"foobar",
+			},
+		},
+		{
+			[]string{
+				".bay",
+				".wh..baz",
+				".wh.foobar",
+				"foo/",
+				"foo/.abc",
+				"foo/.wh.cde",
+				"bar/",
+			},
+			[]string{
+				".bay",
+				"bar/",
+				"bar/bax",
+				"bar/bay/",
+				"foo/",
+				"foo/.abc",
+				"foo/.bce",
+			},
+		},
+		{
+			[]string{
+				".abc",
+				".wh..wh..opq",
+				"foobar",
+			},
+			[]string{
+				".abc",
+				"foobar",
+			},
+		},
+	}
+
+	for i, tc := range tcases {
+		l, err := makeTestLayer(tc.change)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = UnpackLayer(wd, l, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = l.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		paths, err := readDirContents(wd)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(tc.expected, paths) {
+			t.Fatalf("invalid files for layer %d: expected %q, got %q", i, tc.expected, paths)
+		}
+	}
+
+}
+
+func makeTestLayer(paths []string) (rc io.ReadCloser, err error) {
+	tmpDir, err := ioutil.TempDir("", "graphdriver-test-mklayer")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tmpDir)
+		}
+	}()
+	for _, p := range paths {
+		if p[len(p)-1] == filepath.Separator {
+			if err = os.MkdirAll(filepath.Join(tmpDir, p), 0700); err != nil {
+				return
+			}
+		} else {
+			if err = ioutil.WriteFile(filepath.Join(tmpDir, p), nil, 0600); err != nil {
+				return
+			}
+		}
+	}
+	archive, err := Tar(tmpDir, Uncompressed)
+	if err != nil {
+		return
+	}
+	return ioutils.NewReadCloserWrapper(archive, func() error {
+		err := archive.Close()
+		os.RemoveAll(tmpDir)
+		return err
+	}), nil
+}
+
+func readDirContents(root string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			rel = rel + "/"
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
 }


### PR DESCRIPTION
Fixes #17766

Previously, opaque directory whiteouts on non-native
graphdrivers depended on the file order, meaning
files added with the same layer before the whiteout
file `.wh..wh..opq` were also removed.

If that file happened to have subdirs, then calling
chtimes on those dirs after unpack would fail the pull.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com

The problem that we don't know if directory is opaque until we reach a subfile is quite problematic to solve safely and efficiently unless we think its acceptable to scan a file twice. Hopefully in the future we can define a more limited specification for the tarball (this has come up with other issues as well) with forced ordering, required parent folders, forbidden duplicate files etc., that would make it a bit more easier.

The current method may not work if files added with the opaque whiteout don't have records for their parent folders, but docker doesn't generate such tarballs.
