### PR TITLE
Fixing wrong volume doc format

### DIFF
--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -21,9 +21,10 @@ parent = "smn_cli"
 
 Creates a new volume that containers can consume and store data in. If a name is not specified, Docker generates a random name. You create a volume and then configure the container to use it, for example:
 
-  $ docker volume create --name hello
-  hello
-  $ docker run -d -v hello:/world busybox ls /world
+    $ docker volume create --name hello
+    hello
+
+    $ docker run -d -v hello:/world busybox ls /world
 
 The mount is created inside the container's `/world` directory. Docker does not support relative paths for mount points inside the container.
 
@@ -41,7 +42,7 @@ If you specify a volume name already in use on the current driver, Docker assume
 
 Some volume drivers may take options to customize the volume creation. Use the `-o` or `--opt` flags to pass driver options:
 
-  $ docker volume create --driver fake --opt tardis=blue --opt timey=wimey
+    $ docker volume create --driver fake --opt tardis=blue --opt timey=wimey
 
 These options are passed directly to the volume driver. Options for
 different volume drivers may do different things (or nothing at all).

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -37,4 +37,4 @@ Example output:
     ]
 
     $ docker volume inspect --format '{{ .Mountpoint }}' 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
-    "/var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data"
+    /var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -18,5 +18,5 @@ parent = "smn_cli"
 
 Removes one or more volumes. You cannot remove a volume that is in use by a container.
 
-  $ docker volume rm hello
-  hello
+    $ docker volume rm hello
+    hello


### PR DESCRIPTION
The volume command line doc is not correct for related spaces and output. Fixes #17820 
Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
