### PR TITLE
Fix docker network connect to container with portmapping

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -764,3 +764,10 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 		c.Assert(strings.TrimSpace(runningOut), checker.Equals, "true")
 	}
 }
+
+func (s *DockerNetworkSuite) TestDockerNetworkConnectWitpPortMapping(c *check.C) {
+	dockerCmd(c, "network", "create", "test1")
+	dockerCmd(c, "run", "-d", "--name", "c1", "-p", "5000:5000", "busybox", "top")
+	c.Assert(waitRun("c1"), check.IsNil)
+	dockerCmd(c, "network", "connect", "test1", "c1")
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

see #17824

IMO, port mapping should just work for `bridge` network driver.

..don't know if this is the right approach to fix this, maybe 
network team has other opinion, feel free to close , it doesn't matter.
