### PR TITLE
remove unnecessary logs from daemon

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/pkg/version"
-	"github.com/docker/docker/utils"
 )
 
 // APIVersionKey is the client's requested API version.
@@ -155,7 +154,6 @@ func WriteError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusInternalServerError
 	}
 
-	logrus.WithFields(logrus.Fields{"statusCode": statusCode, "err": utils.GetErrorMessage(err)}).Error("HTTP Error")
 	http.Error(w, errMsg, statusCode)
 }
 


### PR DESCRIPTION
if daemon encounters removing-file error. It will record two
similar logs as following . The later is meaningful for client, But not for
daemon. So remove it.
-  This first  

```
Handler for DELETE /v1.22/containers/ad512513d453 returned error: Driver aufs failed to remove
root filesystem
41c492094536f7478e055389db778a7fa398c9437da6ec204d5879a7c574971f: rename
/home/docker/aufs/mnt/41c492094536f7478e055389db778a7fa398c9437da6ec204d5879a7c574971f
/home/docker/aufs/mnt/41c492094536f7478e055389db778a7fa398c9437da6ec204d5879a7c574971f-removing:
device or resource busy
```
- the second

```
ERRO[1366] HTTP Error                                    err=Driver aufs
failed to remove root filesystem
41c492094536f7478e055389db778a7fa398c9437da6ec204d5879a7c574971f: rename
/home/docker/aufs/mnt/41c492094536f7478e055389db778a7fa398c9437da6ec204d5879a7c574971f
/home/docker/aufs/mnt/41c492094536f7478e055389db778a7fa398c9437da6ec204d5879a7c574971f-removing:
device or resource busy statusCode=500
```
