### PR TITLE
explicit way to express that docker.list are different choices and not just one big file

### DIFF
--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -63,12 +63,20 @@ from the new repository:
 
      The possible entries are:
 
-         # Debian Wheezy
-        deb https://apt.dockerproject.org/repo debian-wheezy main
-        # Debian Jessie
-        deb https://apt.dockerproject.org/repo debian-jessie main
-        # Debian Stretch/Sid
-        deb https://apt.dockerproject.org/repo debian-stretch main
+     - On Debian Wheezy
+
+            # Debian Wheezy
+            deb https://apt.dockerproject.org/repo debian-wheezy main
+
+    - On Debian Jessie
+
+            # Debian Jessie
+            deb https://apt.dockerproject.org/repo debian-jessie main
+
+    - On Debian Stretch/Sid
+
+            # Debian Stretch/Sid
+            deb https://apt.dockerproject.org/repo debian-stretch main
 
  8. Save and close the file.
 

--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -65,17 +65,14 @@ from the new repository:
 
      - On Debian Wheezy
 
-            # Debian Wheezy
             deb https://apt.dockerproject.org/repo debian-wheezy main
 
     - On Debian Jessie
 
-            # Debian Jessie
             deb https://apt.dockerproject.org/repo debian-jessie main
 
     - On Debian Stretch/Sid
 
-            # Debian Stretch/Sid
             deb https://apt.dockerproject.org/repo debian-stretch main
 
  8. Save and close the file.

--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -69,22 +69,18 @@ packages from the new repository:
 
     - On Ubuntu Precise 12.04 (LTS)
 
-            # Ubuntu Precise 12.04 (LTS)
             deb https://apt.dockerproject.org/repo ubuntu-precise main
 
     - On Ubuntu Trusty 14.04 (LTS)
 
-            # Ubuntu Trusty 14.04 (LTS)
             deb https://apt.dockerproject.org/repo ubuntu-trusty main
 
     - On Ubuntu Vivid 15.04
 
-            # Ubuntu Vivid 15.04
             deb https://apt.dockerproject.org/repo ubuntu-vivid main
 
     - Ubuntu Wily 15.10
 
-            # Ubuntu Wily 15.10
             deb https://apt.dockerproject.org/repo ubuntu-wily main
 
 7. Save and close the `/etc/apt/sources.list.d/docker.list` file.

--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -67,14 +67,25 @@ packages from the new repository:
 
     The possible entries are:
 
-        # Ubuntu Precise 12.04 (LTS)
-        deb https://apt.dockerproject.org/repo ubuntu-precise main
-        # Ubuntu Trusty 14.04 (LTS)
-        deb https://apt.dockerproject.org/repo ubuntu-trusty main
-        # Ubuntu Vivid 15.04
-        deb https://apt.dockerproject.org/repo ubuntu-vivid main
-        # Ubuntu Wily 15.10
-        deb https://apt.dockerproject.org/repo ubuntu-wily main
+    - On Ubuntu Precise 12.04 (LTS)
+
+            # Ubuntu Precise 12.04 (LTS)
+            deb https://apt.dockerproject.org/repo ubuntu-precise main
+
+    - On Ubuntu Trusty 14.04 (LTS)
+
+            # Ubuntu Trusty 14.04 (LTS)
+            deb https://apt.dockerproject.org/repo ubuntu-trusty main
+
+    - On Ubuntu Vivid 15.04
+
+            # Ubuntu Vivid 15.04
+            deb https://apt.dockerproject.org/repo ubuntu-vivid main
+
+    - Ubuntu Wily 15.10
+
+            # Ubuntu Wily 15.10
+            deb https://apt.dockerproject.org/repo ubuntu-wily main
 
 7. Save and close the `/etc/apt/sources.list.d/docker.list` file.
 


### PR DESCRIPTION
I ran in the same issue as described in #15692 

My problem was that when I followed the installation instructions, I went too fast and didn't realize that the docker.list file in the ubuntu instructions was 4 choices. I copied the whole content (as there was one big `code` block) thinking that `apt` would find the right line based on the current distribution I use.

I'm sure with just 4 `code` blocks I wouldn't have that problem.

Related documentation page: http://docs.docker.com/engine/installation/ubuntulinux/

Note: The pull request also contains change for debian as it's exactly the same problem.
