### PR TITLE
Fix link to installation instructions

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -439,7 +439,7 @@ do_install() {
 	  a package for Docker.  Please visit the following URL for more detailed
 	  installation instructions:
 
-	    https://docs.docker.com/en/latest/installation/
+	    https://docs.docker.com/engine/installation/
 
 	EOF
 	exit 1


### PR DESCRIPTION
Fix #17872:

> The script at https://get.docker.com/ links to https://docs.docker.com/en/latest/installation/, which gives a 404 error. The correct link is https://docs.docker.com/engine/installation/.

(I did not actually test this change, just reviewed it).
