### PR TITLE
Cap the amount of buffering done by BytesPipe

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -244,15 +244,15 @@ func (streamConfig *streamConfig) StdinPipe() io.WriteCloser {
 }
 
 func (streamConfig *streamConfig) StdoutPipe() io.ReadCloser {
-	reader, writer := io.Pipe()
-	streamConfig.stdout.Add(writer)
-	return ioutils.NewBufReader(reader)
+	bytesPipe := ioutils.NewBytesPipe(nil)
+	streamConfig.stdout.Add(bytesPipe)
+	return bytesPipe
 }
 
 func (streamConfig *streamConfig) StderrPipe() io.ReadCloser {
-	reader, writer := io.Pipe()
-	streamConfig.stderr.Add(writer)
-	return ioutils.NewBufReader(reader)
+	bytesPipe := ioutils.NewBytesPipe(nil)
+	streamConfig.stderr.Add(bytesPipe)
+	return bytesPipe
 }
 
 // ExitOnNext signals to the monitor that it should not restart the container


### PR DESCRIPTION
Previously, BytesPipe would grow without a limit. This was dangerous if
data was written to it faster than it was read, it would exhaust available
memory.

Turn BytesPipe's Read and Write functions into blocking, goroutine-safe
functions. Add a CloseWithError function to propagate an error code to
the Read function.

Adjust tests to work with the blocking Read and Write functions.

Remove BufReader, since now its users can use BytesPipe directly.

This version of the commit hardcodes a 1 MB threshold for blocking on writes. I'm hoping that we can do some testing around this and determine if this number should be tweaked or made configurable.

cc @unclejack @vcaputo @jonathanperret
