### PR TITLE
Removing made up word from docs

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -121,7 +121,7 @@ and pass along signals. All of that is configurable:
 
     -a=[]           : Attach to `STDIN`, `STDOUT` and/or `STDERR`
     -t=false        : Allocate a pseudo-tty
-    --sig-proxy=true: Proxify all received signal to the process (non-TTY mode only)
+    --sig-proxy=true: Proxy all received signals to the process (non-TTY mode only)
     -i=false        : Keep STDIN open even if not attached
 
 If you do not specify `-a` then Docker will [attach all standard


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@thaJeztah @moxiegirl http://dictionary.reference.com/misspelling?term=proxify&s=ts. "Proxify" isn't a real word lol, and signal should be plural
