### PR TITLE
Concurrent `docker ps` reducer.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -102,6 +102,29 @@ func (c *contStore) List() []*Container {
 	return *containers
 }
 
+// Filter returns a list of containers in the store filtered by
+// the context. It limits the list of results returned based
+// of the limit attribute after applying the rest of the filters
+// on the complete list.
+func (c *contStore) Filter(ctx *listContext) []*Container {
+	containers := new(History)
+	c.Lock()
+	for _, cont := range c.s {
+		// filter containers to return
+		if includeContainerInList(cont, ctx) {
+			containers.Add(cont)
+		}
+	}
+	c.Unlock()
+	containers.sort()
+
+	cl := *containers
+	if ctx.Limit > 0 && len(cl) > ctx.Limit {
+		return cl[0:ctx.Limit]
+	}
+	return cl
+}
+
 // Daemon holds information about the Docker daemon.
 type Daemon struct {
 	ID               string

--- a/daemon/list_unix.go
+++ b/daemon/list_unix.go
@@ -4,6 +4,6 @@ package daemon
 
 // excludeByIsolation is a platform specific helper function to support PS
 // filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
-func excludeByIsolation(container *Container, ctx *listContext) iterationAction {
-	return includeContainer
+func excludeByIsolation(container *Container, ctx *listContext) bool {
+	return false
 }

--- a/daemon/list_windows.go
+++ b/daemon/list_windows.go
@@ -4,13 +4,13 @@ import "strings"
 
 // excludeByIsolation is a platform specific helper function to support PS
 // filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
-func excludeByIsolation(container *Container, ctx *listContext) iterationAction {
+func excludeByIsolation(container *Container, ctx *listContext) bool {
 	i := strings.ToLower(string(container.hostConfig.Isolation))
 	if i == "" {
 		i = "default"
 	}
 	if !ctx.filters.Match("isolation", i) {
-		return excludeContainer
+		return true
 	}
-	return includeContainer
+	return false
 }


### PR DESCRIPTION
It makes the time spent transforming the container struct into a
valid api struct constant-ish rather than O(N).

**Preliminary timing benchmarks:**

Host information: 12 CPUs, 32GB RAM DO dropplet.
Daemon information: 38 containers.
- docker ps -a (MASTER):

```
➜  /usr/bin/time -p sh -c "docker ps -a | wc -l"
38
real 0.12
user 0.05
sys 0.05
```
- docker ps -a --size (MASTER):

```
➜  /usr/bin/time -p sh -c "docker ps -as | wc -l"
38
real 82.36
user 0.02
sys 0.03
```
- docker ps -a (CONCURRENT_PS):

```
➜  /usr/bin/time -p sh -c "bundles/1.10.0-dev/binary/docker ps -a | wc -l"
38
real 0.07
user 0.04
sys 0.05
```
- docker ps -a --size (CONCURRENT_PS):

```
➜  /usr/bin/time -p sh -c "bundles/1.10.0-dev/binary/docker ps -as | wc -l"
38
real 34.93
user 0.09
sys 0.05
```

Signed-off-by: David Calavera david.calavera@gmail.com
