### PR TITLE
Add the memoryLimitSupport requirement to Events OOM tests

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -46,9 +46,7 @@ func (s *DockerSuite) TestEventsRedirectStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	testRequires(c, oomControl)
-	testRequires(c, NotGCCGO)
+	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotGCCGO)
 
 	errChan := make(chan error)
 	go func() {
@@ -82,9 +80,7 @@ func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	testRequires(c, oomControl)
-	testRequires(c, NotGCCGO)
+	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotGCCGO)
 
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
The docker run commands in these tests uses the -m flag,
so the tests should require that it's supported to run.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
