### PR TITLE
Windows [TP4] Fix docker cp when volumes

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -20,7 +20,9 @@ import (
 	"github.com/docker/docker/daemon/network"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/directory"
+	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
@@ -1434,4 +1436,75 @@ func (container *Container) ipcMounts() []execdriver.Mount {
 
 func detachMounted(path string) error {
 	return syscall.Unmount(path, syscall.MNT_DETACH)
+}
+
+func (daemon *Daemon) mountVolumes(container *Container) error {
+	mounts, err := daemon.setupMounts(container)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range mounts {
+		dest, err := container.GetResourcePath(m.Destination)
+		if err != nil {
+			return err
+		}
+
+		var stat os.FileInfo
+		stat, err = os.Stat(m.Source)
+		if err != nil {
+			return err
+		}
+		if err = fileutils.CreateIfNotExists(dest, stat.IsDir()); err != nil {
+			return err
+		}
+
+		opts := "rbind,ro"
+		if m.Writable {
+			opts = "rbind,rw"
+		}
+
+		if err := mount.Mount(m.Source, dest, "bind", opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (container *Container) unmountVolumes(forceSyscall bool) error {
+	var (
+		volumeMounts []volume.MountPoint
+		err          error
+	)
+
+	for _, mntPoint := range container.MountPoints {
+		dest, err := container.GetResourcePath(mntPoint.Destination)
+		if err != nil {
+			return err
+		}
+
+		volumeMounts = append(volumeMounts, volume.MountPoint{Destination: dest, Volume: mntPoint.Volume})
+	}
+
+	// Append any network mounts to the list (this is a no-op on Windows)
+	if volumeMounts, err = appendNetworkMounts(container, volumeMounts); err != nil {
+		return err
+	}
+
+	for _, volumeMount := range volumeMounts {
+		if forceSyscall {
+			if err := system.Unmount(volumeMount.Destination); err != nil {
+				logrus.Warnf("%s unmountVolumes: Failed to force umount %v", container.ID, err)
+			}
+		}
+
+		if volumeMount.Volume != nil {
+			if err := volumeMount.Volume.Unmount(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -190,3 +190,16 @@ func (container *Container) ipcMounts() []execdriver.Mount {
 func getDefaultRouteMtu() (int, error) {
 	return -1, errSystemNotSupported
 }
+
+// TODO Windows: Fix Post-TP4. This is a hack to allow docker cp to work
+// against containers which have volumes. You will still be able to cp
+// to somewhere on the container drive, but not to any mounted volumes
+// inside the container. Without this fix, docker cp is broken to any
+// container which has a volume, regardless of where the file is inside the
+// container.
+func (daemon *Daemon) mountVolumes(container *Container) error {
+	return nil
+}
+func (container *Container) unmountVolumes(forceSyscall bool) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli. Some on-site partner teams found that docker cp was broken. We tracked it down to it failing when a container has a volume attached, it will fail regardless of the path inside the container. This PR is a workaround to allow this to work, as it does for containers which do not have any volumes. The real fix will be post TP4.

@thaJeztah Can you tag please :)

EDIT: Should have added, have run regression testing on the TestRun and TestVolume integration tests that I have ported to Windows, and they pass. And also smoke tested basic volume functionality manually and found no regression.
