### PR TITLE
Handled escaped characters sent by a client

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -110,8 +111,14 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 	w.Header().Set("Content-Type", "application/json")
 
 	if image != "" { //pull
+		// Handles the unescape characters.
+		unescapedImage, err := url.QueryUnescape(image)
+		if err != nil {
+			unescapedImage = image
+		}
+
 		if tag == "" {
-			image, tag = parsers.ParseRepositoryTag(image)
+			image, tag = parsers.ParseRepositoryTag(unescapedImage)
 		}
 		metaHeaders := map[string][]string{}
 		for k, v := range r.Header {
@@ -128,8 +135,14 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 
 		err = s.daemon.PullImage(image, tag, imagePullConfig)
 	} else { //import
+		// Handles the unescape characters.
+		unescapedRepo, err := url.QueryUnescape(repo)
+		if err != nil {
+			unescapedRepo = image
+		}
+
 		if tag == "" {
-			repo, tag = parsers.ParseRepositoryTag(repo)
+			repo, tag = parsers.ParseRepositoryTag(unescapedRepo)
 		}
 
 		src := r.Form.Get("fromSrc")

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -136,8 +136,8 @@ func (m *containerMonitor) Start() error {
 	defer func() {
 		if afterRun {
 			m.container.Lock()
-			m.container.setStopped(&exitStatus)
 			defer m.container.Unlock()
+			m.container.setStopped(&exitStatus)
 		}
 		m.Close()
 	}()

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -46,9 +46,7 @@ func (s *DockerSuite) TestEventsRedirectStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	testRequires(c, oomControl)
-	testRequires(c, NotGCCGO)
+	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotGCCGO)
 
 	errChan := make(chan error)
 	go func() {
@@ -82,9 +80,7 @@ func (s *DockerSuite) TestEventsOOMDisableFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	testRequires(c, oomControl)
-	testRequires(c, NotGCCGO)
+	testRequires(c, DaemonIsLinux, oomControl, memoryLimitSupport, NotGCCGO)
 
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
Originally discussed in https://github.com/docker/docker/pull/17204 (CLOSED)

When the request was sent from a HTTP client, the tag value may be escaped. This is to unescape the value first before parse the tag value.

**How to reproduce:**
1. Use docker-py's Client to build an image with a tag like "john/doe".
2. When you run `docker images -a`, you will notice that the new image does not have the tag "john/doe".

Signed-off-by: Juti Noppornpitak jnopporn@shiroyuki.com
