### PR TITLE
Include xfsprogs in build environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install -y \
 	ruby1.9.1-dev \
 	s3cmd=1.1.0* \
 	ubuntu-zfs \
+	xfsprogs \
 	libzfs-dev \
 	--no-install-recommends
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		e2fsprogs \
 		iptables \
 		procps \
+		xfsprogs \
 		xz-utils \
 		\
 		aufs-tools \

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -260,11 +260,11 @@ options for `zfs` start with `zfs`.
 *  `dm.fs`
 
     Specifies the filesystem type to use for the base device. The supported
-    options are "ext4" and "xfs". The default is "ext4"
+    options are "ext4" and "xfs". The default is "xfs"
 
     Example use:
 
-        $ docker daemon --storage-opt dm.fs=xfs
+        $ docker daemon --storage-opt dm.fs=ext4
 
 *  `dm.mkfsarg`
 

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -266,7 +266,8 @@ installed and available at runtime:
 
 * iptables version 1.4 or later
 * procps (or similar provider of a "ps" executable)
-* e2fsprogs version 1.4.12 or later (in use: mkfs.ext4, mkfs.xfs, tune2fs)
+* e2fsprogs version 1.4.12 or later (in use: mkfs.ext4, tune2fs)
+* xfsprogs (in use: mkfs.xfs)
 * XZ Utils version 4.9 or later
 * a [properly
   mounted](https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount)


### PR DESCRIPTION
devmapper uses xfs by default now. So include xfsprogs in build
environment. Also update docs to reflect the new default.

Signed-off-by: Anusha Ragunathan anusha@docker.com
