### PR TITLE
Windows [TP4] Require build 10586+

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -71,6 +71,9 @@ func checkSystem() error {
 	if osv.MajorVersion < 10 {
 		return fmt.Errorf("This version of Windows does not support the docker daemon")
 	}
+	if osv.Build < 10586 {
+		return fmt.Errorf("The Windows daemon requires Windows Server 2016 Technical Preview 4, build 10586 or later")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This patch requires the daemon to be running build 10586 or later of TP4 (10586 is the current final build number). As of TP4, we won't be supporting running the daemon on any TP3 or pre-release TP4 builds.
