### PR TITLE
Docs: improve caching for make docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,11 +1,6 @@
 FROM docs/base:hugo-github-linking
 MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
 
-# To get the git info for this repo
-COPY . /src
-
-COPY . /docs/content/engine
-
 RUN svn checkout https://github.com/docker/compose/trunk/docs /docs/content/compose
 RUN svn checkout https://github.com/docker/swarm/trunk/docs /docs/content/swarm
 RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/machine
@@ -14,3 +9,7 @@ RUN svn checkout https://github.com/kitematic/kitematic/trunk/docs /docs/content
 RUN svn checkout https://github.com/docker/tutorials/trunk/docs /docs/content/
 RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content/opensource
 
+# To get the git info for this repo
+COPY . /src
+
+COPY . /docs/content/engine


### PR DESCRIPTION
Use caching for all other repositories, instead of doing a svn checkout each time.

This may result in showing  outdated docs for other repositories, but --no-cache can be
used if the latest docs are needed.
