### PR TITLE
create backend interface for 'local' router

### DIFF
--- a/api/server/router/local/auth.go
+++ b/api/server/router/local/auth.go
@@ -17,7 +17,7 @@ func (s *router) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Re
 	if err != nil {
 		return err
 	}
-	status, err := s.daemon.AuthenticateToRegistry(config)
+	status, err := s.backend.AuthenticateToRegistry(config)
 	if err != nil {
 		return err
 	}

--- a/api/server/router/local/backend.go
+++ b/api/server/router/local/backend.go
@@ -1,0 +1,125 @@
+package local
+
+import (
+	"io"
+	"time"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/parsers/filters"
+
+	// TODO return types need to be refactored into pkg
+	// consists mainly of XYZConfig structs to pass information
+	"github.com/docker/docker/api/types"                // bunch of return types
+	"github.com/docker/docker/api/types/versions/v1p20" // container json
+	"github.com/docker/docker/cliconfig"                // auth config
+	"github.com/docker/docker/daemon"                   // many container configs
+	"github.com/docker/docker/daemon/events"            // event format
+	"github.com/docker/docker/graph"                    // image pull config
+	"github.com/docker/docker/registry"                 // registry.searchresults
+	"github.com/docker/docker/runconfig"                // container run config
+)
+
+// ImageBackend is the set of methods that provide image specific
+// functionality
+type ImageBackend interface {
+	ImageDelete(imageRef string, force, prune bool) ([]types.ImageDelete, error)
+	TagImage(repoName, tag, imageName string, force bool) error
+	PullImage(image string, tag string,
+		imagePullConfig *graph.ImagePullConfig) error
+	LoadImage(inTar io.ReadCloser, outStream io.Writer) error
+	LookupImage(name string) (*types.ImageInspect, error)
+
+	ImportImage(src, repo, tag, msg string, inConfig io.ReadCloser,
+		outStream io.Writer, containerConfig *runconfig.Config) error
+	ExportImage(names []string, outStream io.Writer) error
+	PushImage(localName string, imagePushConfig *graph.ImagePushConfig) error
+	ListImages(filterArgs, filter string, all bool) ([]*types.Image, error)
+	ImageHistory(name string) ([]*types.ImageHistory, error)
+	AuthenticateToRegistry(authConfig *cliconfig.AuthConfig) (string, error)
+	SearchRegistryForImages(term string,
+		authConfig *cliconfig.AuthConfig,
+		headers map[string][]string) (*registry.SearchResults, error)
+}
+
+// ContainerBackend is the set of methods that provide contianer
+// specific functionality
+type ContainerBackend interface {
+	Exists(id string) bool
+
+	ContainerCopy(name string, res string) (io.ReadCloser, error)
+	ContainerStatPath(name string,
+		path string) (stat *types.ContainerPathStat, err error)
+	ContainerArchivePath(name string,
+		path string) (content io.ReadCloser,
+		stat *types.ContainerPathStat, err error)
+	ContainerExtractToDir(name, path string, noOverwriteDirNonDir bool,
+		content io.Reader) error
+
+	ContainerInspect(name string, size bool) (*types.ContainerJSON, error)
+	ContainerInspect120(name string) (*v1p20.ContainerJSON, error)
+	// unix and windows have differing return types
+	InspectPre120Backend
+
+	Containers(config *daemon.ContainersConfig) ([]*types.Container, error)
+	ContainerStats(prefixOrName string,
+		config *daemon.ContainerStatsConfig) error
+	ContainerLogs(containerName string,
+		logsConfig *daemon.ContainerLogsConfig) error
+	ContainerExport(name string, out io.Writer) error
+
+	ContainerStart(name string, hostConfig *runconfig.HostConfig) error
+	ContainerStop(name string, seconds int) error
+	ContainerKill(name string, sig uint64) error
+	ContainerRestart(name string, seconds int) error
+	ContainerPause(name string) error
+	IsPaused(id string) bool
+	ContainerUnpause(name string) error
+	ContainerWait(name string, timeout time.Duration) (int, error)
+
+	ContainerChanges(name string) ([]archive.Change, error)
+
+	ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error)
+	ContainerRename(oldName, newName string) error
+
+	ContainerCreate(containerCreateConfig *daemon.ContainerCreateConfig) (types.ContainerCreateResponse, error)
+
+	ContainerRm(name string, config *daemon.ContainerRmConfig) error
+	ContainerResize(name string, height, width int) error
+	ContainerExecResize(name string, height, width int) error
+
+	ContainerAttachWithLogs(prefixOrName string,
+		c *daemon.ContainerAttachWithLogsConfig) error
+	ContainerWsAttachWithLogs(prefixOrName string,
+		c *daemon.ContainerWsAttachWithLogsConfig) error
+
+	ContainerExecStart(execName string, stdin io.ReadCloser,
+		stdout io.Writer, stderr io.Writer) error
+	// two different versions of ExecConfig, oi vey!
+	// TODO: investigate making these the same struct
+	ContainerExecCreate(config *runconfig.ExecConfig) (string, error)
+	ContainerExecInspect(id string) (*daemon.ExecConfig, error)
+
+	ExecExists(name string) (bool, error)
+
+	GetUIDGIDMaps() ([]idtools.IDMap, []idtools.IDMap)
+	GetRemappedUIDGID() (int, int)
+}
+
+// EngineBackend is the set of methods that provide engine specific
+// functionality.
+type EngineBackend interface {
+	SystemInfo() (*types.Info, error)
+
+	GetEventFilter(filter filters.Args) *events.Filter
+	SubscribeToEvents() ([]*jsonmessage.JSONMessage,
+		chan interface{}, func())
+}
+
+// Backend is all the methods that need to be implemented
+type Backend interface {
+	ImageBackend
+	ContainerBackend
+	EngineBackend
+}

--- a/api/server/router/local/copy.go
+++ b/api/server/router/local/copy.go
@@ -29,7 +29,7 @@ func (s *router) postContainersCopy(ctx context.Context, w http.ResponseWriter, 
 		return fmt.Errorf("Path cannot be empty")
 	}
 
-	data, err := s.daemon.ContainerCopy(vars["name"], cfg.Resource)
+	data, err := s.backend.ContainerCopy(vars["name"], cfg.Resource)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "no such id") {
 			w.WriteHeader(http.StatusNotFound)
@@ -71,7 +71,7 @@ func (s *router) headContainersArchive(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
-	stat, err := s.daemon.ContainerStatPath(v.Name, v.Path)
+	stat, err := s.backend.ContainerStatPath(v.Name, v.Path)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (s *router) getContainersArchive(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	tarArchive, stat, err := s.daemon.ContainerArchivePath(v.Name, v.Path)
+	tarArchive, stat, err := s.backend.ContainerArchivePath(v.Name, v.Path)
 	if err != nil {
 		return err
 	}
@@ -108,5 +108,5 @@ func (s *router) putContainersArchive(ctx context.Context, w http.ResponseWriter
 	}
 
 	noOverwriteDirNonDir := httputils.BoolValue(r, "noOverwriteDirNonDir")
-	return s.daemon.ContainerExtractToDir(v.Name, v.Path, noOverwriteDirNonDir, r.Body)
+	return s.backend.ContainerExtractToDir(v.Name, v.Path, noOverwriteDirNonDir, r.Body)
 }

--- a/api/server/router/local/exec.go
+++ b/api/server/router/local/exec.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *router) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	eConfig, err := s.daemon.ContainerExecInspect(vars["id"])
+	eConfig, err := s.backend.ContainerExecInspect(vars["id"])
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (s *router) postContainerExecCreate(ctx context.Context, w http.ResponseWri
 	}
 
 	// Register an instance of Exec in container.
-	id, err := s.daemon.ContainerExecCreate(execConfig)
+	id, err := s.backend.ContainerExecCreate(execConfig)
 	if err != nil {
 		logrus.Errorf("Error setting up exec command in container %s: %s", name, err)
 		return err
@@ -79,7 +79,7 @@ func (s *router) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
-	if exists, err := s.daemon.ExecExists(execName); !exists {
+	if exists, err := s.backend.ExecExists(execName); !exists {
 		return err
 	}
 
@@ -109,7 +109,7 @@ func (s *router) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 	}
 
 	// Now run the user process in container.
-	if err := s.daemon.ContainerExecStart(execName, stdin, stdout, stderr); err != nil {
+	if err := s.backend.ContainerExecStart(execName, stdin, stdout, stderr); err != nil {
 		if execStartCheck.Detach {
 			return err
 		}
@@ -131,5 +131,5 @@ func (s *router) postContainerExecResize(ctx context.Context, w http.ResponseWri
 		return err
 	}
 
-	return s.daemon.ContainerExecResize(vars["name"], height, width)
+	return s.backend.ContainerExecResize(vars["name"], height, width)
 }

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -64,7 +64,7 @@ func (s *router) postCommit(ctx context.Context, w http.ResponseWriter, r *http.
 		Config:  c,
 	}
 
-	if !s.daemon.Exists(cname) {
+	if !s.backend.Exists(cname) {
 		return derr.ErrorCodeNoSuchContainer.WithArgs(cname)
 	}
 
@@ -126,7 +126,7 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			OutStream:   output,
 		}
 
-		err = s.daemon.PullImage(image, tag, imagePullConfig)
+		err = s.backend.PullImage(image, tag, imagePullConfig)
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)
@@ -143,7 +143,7 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			return err
 		}
 
-		err = s.daemon.ImportImage(src, repo, tag, message, r.Body, output, newConfig)
+		err = s.backend.ImportImage(src, repo, tag, message, r.Body, output, newConfig)
 	}
 	if err != nil {
 		if !output.Flushed() {
@@ -195,7 +195,7 @@ func (s *router) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if err := s.daemon.PushImage(name, imagePushConfig); err != nil {
+	if err := s.backend.PushImage(name, imagePushConfig); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -221,7 +221,7 @@ func (s *router) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 		names = r.Form["names"]
 	}
 
-	if err := s.daemon.ExportImage(names, output); err != nil {
+	if err := s.backend.ExportImage(names, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -232,7 +232,7 @@ func (s *router) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 }
 
 func (s *router) postImagesLoad(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return s.daemon.LoadImage(r.Body, w)
+	return s.backend.LoadImage(r.Body, w)
 }
 
 func (s *router) deleteImages(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -249,7 +249,7 @@ func (s *router) deleteImages(ctx context.Context, w http.ResponseWriter, r *htt
 	force := httputils.BoolValue(r, "force")
 	prune := !httputils.BoolValue(r, "noprune")
 
-	list, err := s.daemon.ImageDelete(name, force, prune)
+	list, err := s.backend.ImageDelete(name, force, prune)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func (s *router) deleteImages(ctx context.Context, w http.ResponseWriter, r *htt
 }
 
 func (s *router) getImagesByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	imageInspect, err := s.daemon.LookupImage(vars["name"])
+	imageInspect, err := s.backend.LookupImage(vars["name"])
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 		}
 	}()
 
-	uidMaps, gidMaps := s.daemon.GetUIDGIDMaps()
+	uidMaps, gidMaps := s.backend.GetUIDGIDMaps()
 	defaultArchiver := &archive.Archiver{
 		Untar:   chrootarchive.Untar,
 		UIDMaps: uidMaps,
@@ -427,7 +427,7 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 
 	for _, rt := range repoAndTags {
-		if err := s.daemon.TagImage(rt.repo, rt.tag, string(imgID), true); err != nil {
+		if err := s.backend.TagImage(rt.repo, rt.tag, string(imgID), true); err != nil {
 			return errf(err)
 		}
 	}
@@ -483,7 +483,7 @@ func (s *router) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *ht
 	}
 
 	// FIXME: The filter parameter could just be a match filter
-	images, err := s.daemon.ListImages(r.Form.Get("filters"), r.Form.Get("filter"), httputils.BoolValue(r, "all"))
+	images, err := s.backend.ListImages(r.Form.Get("filters"), r.Form.Get("filter"), httputils.BoolValue(r, "all"))
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func (s *router) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *ht
 
 func (s *router) getImagesHistory(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	name := vars["name"]
-	history, err := s.daemon.ImageHistory(name)
+	history, err := s.backend.ImageHistory(name)
 	if err != nil {
 		return err
 	}
@@ -509,7 +509,7 @@ func (s *router) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 	tag := r.Form.Get("tag")
 	name := vars["name"]
 	force := httputils.BoolValue(r, "force")
-	if err := s.daemon.TagImage(repo, tag, name, force); err != nil {
+	if err := s.backend.TagImage(repo, tag, name, force); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -539,7 +539,7 @@ func (s *router) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *
 			headers[k] = v
 		}
 	}
-	query, err := s.daemon.SearchRegistryForImages(r.Form.Get("term"), config, headers)
+	query, err := s.backend.SearchRegistryForImages(r.Form.Get("term"), config, headers)
 	if err != nil {
 		return err
 	}

--- a/api/server/router/local/info.go
+++ b/api/server/router/local/info.go
@@ -44,7 +44,7 @@ func (s *router) getVersion(ctx context.Context, w http.ResponseWriter, r *http.
 }
 
 func (s *router) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	info, err := s.daemon.SystemInfo()
+	info, err := s.backend.SystemInfo()
 	if err != nil {
 		return err
 	}
@@ -91,10 +91,10 @@ func (s *router) getEvents(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	enc := json.NewEncoder(output)
 
-	current, l, cancel := s.daemon.SubscribeToEvents()
+	current, l, cancel := s.backend.SubscribeToEvents()
 	defer cancel()
 
-	eventFilter := s.daemon.GetEventFilter(ef)
+	eventFilter := s.backend.GetEventFilter(ef)
 	handleEvent := func(ev *jsonmessage.JSONMessage) error {
 		if eventFilter.Include(ev) {
 			if err := enc.Encode(ev); err != nil {

--- a/api/server/router/local/inspect.go
+++ b/api/server/router/local/inspect.go
@@ -18,11 +18,11 @@ func (s *router) getContainersByName(ctx context.Context, w http.ResponseWriter,
 
 	switch {
 	case version.LessThan("1.20"):
-		json, err = s.daemon.ContainerInspectPre120(vars["name"])
+		json, err = s.backend.ContainerInspectPre120(vars["name"])
 	case version.Equal("1.20"):
-		json, err = s.daemon.ContainerInspect120(vars["name"])
+		json, err = s.backend.ContainerInspect120(vars["name"])
 	default:
-		json, err = s.daemon.ContainerInspect(vars["name"], displaySize)
+		json, err = s.backend.ContainerInspect(vars["name"], displaySize)
 	}
 
 	if err != nil {

--- a/api/server/router/local/inspect_backend_unix.go
+++ b/api/server/router/local/inspect_backend_unix.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package local
+
+import "github.com/docker/docker/api/types/versions/v1p19" // container json
+
+// InspectPre120Backend holds the definition of the container inspect
+// call, responding with pre 1.20 API values. Windows has a different
+// return type.
+type InspectPre120Backend interface {
+	ContainerInspectPre120(name string) (*v1p19.ContainerJSON, error)
+}

--- a/api/server/router/local/inspect_backend_windows.go
+++ b/api/server/router/local/inspect_backend_windows.go
@@ -1,0 +1,10 @@
+package local
+
+import "github.com/docker/docker/api/types" // container json
+
+// InspectPre120Backend holds the definition of the container inspect
+// call, responding with pre 1.20 API values. Windows has a different
+// return type.
+type InspectPre120Backend interface {
+	ContainerInspectPre120(name string) (*types.ContainerJSON, error)
+}

--- a/api/server/router/local/local.go
+++ b/api/server/router/local/local.go
@@ -12,8 +12,9 @@ import (
 
 // router is a docker router that talks with the local docker daemon.
 type router struct {
-	daemon *daemon.Daemon
-	routes []dkrouter.Route
+	daemon  *daemon.Daemon
+	backend Backend
+	routes  []dkrouter.Route
 }
 
 // localRoute defines an individual API route to connect with the docker daemon.
@@ -77,7 +78,8 @@ func NewHeadRoute(path string, handler httputils.APIFunc) dkrouter.Route {
 // NewRouter initializes a local router with a new daemon.
 func NewRouter(daemon *daemon.Daemon) dkrouter.Router {
 	r := &router{
-		daemon: daemon,
+		daemon:  daemon,
+		backend: daemon,
 	}
 	r.initRoutes()
 	return r


### PR DESCRIPTION
- split into three interfaces
  - image
  - container
  - engine
- switched most dependencies from concrete daemon implementation to
   abstract backend interface
- daemon reference is still required for building an image

reference #17736 which this will conflict with, somewhat.

This is how I would do the backend, if we're not ready to split it off. I tried to group the functions as best I could see. Ended up with Image & Container as the main grouping, and split off the Engine info into it's own.

Until the builder+deamonbuilder changes are settled in image.go, the daemon reference can't be fully expunged as it was in the volume and network routers.
