### PR TITLE
Windows: TP4 fix cpu weight

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -18,7 +18,7 @@ const (
 	defaultVirtualSwitch = "Virtual Switch"
 	platformSupported    = true
 	windowsMinCPUShares  = 1
-	windowsMaxCPUShares  = 9
+	windowsMaxCPUShares  = 10000
 )
 
 func parseSecurityOpt(container *Container, config *runconfig.HostConfig) error {

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -74,7 +74,7 @@ type containerInit struct {
 	IgnoreFlushesDuringBoot bool        // Optimisation hint for container startup in Windows
 	LayerFolderPath         string      // Where the layer folders are located
 	Layers                  []layer     // List of storage layers
-	ProcessorWeight         int64       // CPU Shares 1..9 on Windows; or 0 is platform default.
+	ProcessorWeight         int64       `json:",omitempty"` // CPU Shares 0..10000 on Windows; where 0 will be ommited and HCS will default.
 	HostName                string      // Hostname
 	MappedDirectories       []mappedDir // List of mapped directories (volumes/mounts)
 	SandboxPath             string      // Location of unmounted sandbox (used for Hyper-V containers, not Windows Server containers)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

With apologies for the late PR for TP4. We have just realized this morning that the way in which HCS in TP4 maps processor weights causes issues when running VMs alongside Hyper-V containers. The old 1..9 value was a direct mapping for the job object settings for cpu weight. However, HCS really expects 0..10000, with zero being really zero, and does the mapping of 0..10000 to 1..9 for Windows Server Containers, or different mapping for Hyper-V containers. 

If the value is not specified in the HCS call (hence the omit empty), HCS will take its default (5 for job objects) which is what we really need for parity with Powershell/WMI management, and not unfairly disadvantage docker Hyper-V containers if running alongside powershell Hyper-V containers or Hyper-V VMs
