### PR TITLE
Windows: Pass store test-unit

### DIFF
--- a/volume/store/store_test.go
+++ b/volume/store/store_test.go
@@ -54,8 +54,8 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("Expected unknown driver error, got nil")
 	}
 
-	_, err = s.Create("fakeError", "fake", map[string]string{"error": "create error"})
-	expected := &OpErr{Op: "create", Name: "fakeError", Err: errors.New("create error")}
+	_, err = s.Create("fakeerror", "fake", map[string]string{"error": "create error"})
+	expected := &OpErr{Op: "create", Name: "fakeerror", Err: errors.New("create error")}
 	if err != nil && err.Error() != expected.Error() {
 		t.Fatalf("Expected create fakeError: create error, got %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes unit test for store on Windows. The change is because (if you guys recall), we ended up with Windows lower-casing regardless in the volumes PR #16433. @calavera @cpuguy83 
