### PR TITLE
Remove 'TODO Windows' unnecessary comment

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -55,8 +55,8 @@ type Container struct {
 	AppArmorProfile string
 	HostnamePath    string
 	HostsPath       string
-	ShmPath         string // TODO Windows - Factor this out (GH15862)
-	MqueuePath      string // TODO Windows - Factor this out (GH15862)
+	ShmPath         string
+	MqueuePath      string
 	ResolvConfPath  string
 
 	Volumes   map[string]string // Deprecated since 1.7, kept for backwards compatibility


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Gets rid of some TODO Windows which shouldn't be there anymore as the fields are already factored out into a _unix.go file. No functional changes, just comment removal
