### PR TITLE
Remove uncalled configureSysInit

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
@@ -89,11 +88,6 @@ func configureKernelSecuritySupport(config *Config, driverName string) error {
 
 func migrateIfDownlevel(driver graphdriver.Driver, root string) error {
 	return nil
-}
-
-func configureSysInit(config *Config, rootUID, rootGID int) (string, error) {
-	// TODO Windows.
-	return os.Getenv("TEMP"), nil
 }
 
 func isBridgeNetworkDisabled(config *Config) bool {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Was scanning for "TODO Windows" and noticed configureSysInit() is no longer called from anywhere in the docker code. Removed.
