### PR TITLE
Windows: Refactor Process and MountLabel

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -252,6 +252,7 @@ type ContainerState struct {
 
 // ContainerJSONBase contains response of Remote API:
 // GET "/containers/{name:.*}/json"
+// TODO Windows: Refactor this for platform capabilities
 type ContainerJSONBase struct {
 	ID              string `json:"Id"`
 	Created         string

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -39,3 +39,9 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	// Then platform-specific install flags.
 	cmd.StringVar(&config.Bridge.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
 }
+
+// getMountLabel returns the mount label for the container. This is a no-op
+// on Windows
+func (container *Container) getMountLabel() string {
+	return ""
+}

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -126,10 +126,8 @@ func (daemon *Daemon) populateCommand(c *Container, env []string) error {
 			InitPath:      "/.dockerinit",
 			WorkingDir:    c.Config.WorkingDir,
 			Network:       en,
-			MountLabel:    c.getMountLabel(),
 			Resources:     resources,
 			ProcessConfig: processConfig,
-			ProcessLabel:  c.getProcessLabel(),
 		},
 		FirstStart:  !c.HasBeenStartedBefore,
 		LayerFolder: layerFolder,
@@ -200,5 +198,11 @@ func (daemon *Daemon) mountVolumes(container *Container) error {
 	return nil
 }
 func (container *Container) unmountVolumes(forceSyscall bool) error {
+	return nil
+}
+
+// reserveLabel reserves a label for the process label in the container. This
+// is a no-op on Windows
+func reserveLabel(container *Container) error {
 	return nil
 }

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -70,3 +70,21 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *Contain
 	}
 	return nil
 }
+
+// setSecurityOpt sets the security options for the container
+func (daemon *Daemon) setSecurityOpt(params *ContainerCreateConfig) error {
+	if params.HostConfig.SecurityOpt == nil {
+		if params.HostConfig.IpcMode.IsHost() || params.HostConfig.PidMode.IsHost() {
+			params.HostConfig.SecurityOpt = label.DisableSecOpt()
+			return nil
+		}
+		if ipcContainer := params.HostConfig.IpcMode.Container(); ipcContainer != "" {
+			c, err := daemon.Get(ipcContainer)
+			if err != nil {
+				return err
+			}
+			params.HostConfig.SecurityOpt = label.DupSecOpt(c.ProcessLabel)
+		}
+	}
+	return nil
+}

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -81,3 +81,9 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *Contain
 	}
 	return nil
 }
+
+// setSecurityOpt sets the security options for the container. This is a no-op
+// on Windows.
+func (daemon *Daemon) setSecurityOpt(params *ContainerCreateConfig) error {
+	return nil
+}

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -136,7 +136,7 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 		return derr.ErrorCodeRmExecDriver.WithArgs(container.ID, err)
 	}
 
-	selinuxFreeLxcContexts(container.ProcessLabel)
+	platformSpecificRm(container)
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
 

--- a/daemon/delete_unix.go
+++ b/daemon/delete_unix.go
@@ -1,0 +1,8 @@
+// +build linux freebsd
+
+package daemon
+
+// platformSpecificRm is a platform-specific helper function for rm/delete
+func platformSpecificRm(container *Container) {
+	selinuxFreeLxcContexts(container.ProcessLabel)
+}

--- a/daemon/delete_windows.go
+++ b/daemon/delete_windows.go
@@ -1,0 +1,6 @@
+package daemon
+
+// platformSpecificRm is a platform-specific helper function for rm/delete.
+// It is a no-op on Windows
+func platformSpecificRm(container *Container) {
+}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -128,12 +128,10 @@ type CommonProcessConfig struct {
 type CommonCommand struct {
 	ContainerPid  int           `json:"container_pid"` // the pid for the process inside a container
 	ID            string        `json:"id"`
-	InitPath      string        `json:"initpath"`    // dockerinit
-	MountLabel    string        `json:"mount_label"` // TODO Windows. More involved, but can be factored out
+	InitPath      string        `json:"initpath"` // dockerinit
 	Mounts        []Mount       `json:"mounts"`
 	Network       *Network      `json:"network"`
 	ProcessConfig ProcessConfig `json:"process_config"` // Describes the init process of the container.
-	ProcessLabel  string        `json:"process_label"`  // TODO Windows. More involved, but can be factored out
 	Resources     *Resources    `json:"resources"`
 	Rootfs        string        `json:"rootfs"` // root fs of the container
 	WorkingDir    string        `json:"working_dir"`

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -113,7 +113,9 @@ type Command struct {
 	GIDMapping         []idtools.IDMap   `json:"gidmapping"`
 	GroupAdd           []string          `json:"group_add"`
 	Ipc                *Ipc              `json:"ipc"`
+	MountLabel         string            `json:"mount_label"`
 	Pid                *Pid              `json:"pid"`
+	ProcessLabel       string            `json:"process_label"`
 	ReadonlyRootfs     bool              `json:"readonly_rootfs"`
 	RemappedRoot       *User             `json:"remap_root"`
 	UIDMapping         []idtools.IDMap   `json:"uidmapping"`

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -117,22 +117,7 @@ func (daemon *Daemon) getInspectData(container *Container, size bool) (*types.Co
 		FinishedAt: container.State.FinishedAt.Format(time.RFC3339Nano),
 	}
 
-	contJSONBase := &types.ContainerJSONBase{
-		ID:           container.ID,
-		Created:      container.Created.Format(time.RFC3339Nano),
-		Path:         container.Path,
-		Args:         container.Args,
-		State:        containerState,
-		Image:        container.ImageID,
-		LogPath:      container.LogPath,
-		Name:         container.Name,
-		RestartCount: container.RestartCount,
-		Driver:       container.Driver,
-		MountLabel:   container.MountLabel,
-		ProcessLabel: container.ProcessLabel,
-		ExecIDs:      container.getExecIDs(),
-		HostConfig:   &hostConfig,
-	}
+	contJSONBase := populateJSONBase(container, &hostConfig, containerState)
 
 	var (
 		sizeRw     int64

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -3,8 +3,11 @@
 package daemon
 
 import (
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p19"
+	"github.com/docker/docker/runconfig"
 )
 
 // This sets platform-specific fields
@@ -74,4 +77,26 @@ func addMountPoints(container *Container) []types.MountPoint {
 		})
 	}
 	return mountPoints
+}
+
+// populateJSONBase is a platform-specific helper function for inspect that
+// populates the ContainerJSONBase structure
+func populateJSONBase(container *Container, hostConfig *runconfig.HostConfig, containerState *types.ContainerState) *types.ContainerJSONBase {
+
+	return &types.ContainerJSONBase{
+		ID:           container.ID,
+		Created:      container.Created.Format(time.RFC3339Nano),
+		Path:         container.Path,
+		Args:         container.Args,
+		State:        containerState,
+		Image:        container.ImageID,
+		LogPath:      container.LogPath,
+		Name:         container.Name,
+		RestartCount: container.RestartCount,
+		Driver:       container.Driver,
+		MountLabel:   container.MountLabel,
+		ProcessLabel: container.ProcessLabel,
+		ExecIDs:      container.getExecIDs(),
+		HostConfig:   hostConfig,
+	}
 }

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -1,6 +1,11 @@
 package daemon
 
-import "github.com/docker/docker/api/types"
+import (
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/runconfig"
+)
 
 // This sets platform-specific fields
 func setPlatformSpecificContainerFields(container *Container, contJSONBase *types.ContainerJSONBase) *types.ContainerJSONBase {
@@ -24,4 +29,24 @@ func addMountPoints(container *Container) []types.MountPoint {
 // ContainerInspectPre120 get containers for pre 1.20 APIs.
 func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSON, error) {
 	return daemon.ContainerInspect(name, false)
+}
+
+// populateJSONBase is a platform-specific helper function for inspect that
+// populates the ContainerJSONBase structure
+func populateJSONBase(container *Container, hostConfig *runconfig.HostConfig, containerState *types.ContainerState) *types.ContainerJSONBase {
+
+	return &types.ContainerJSONBase{
+		ID:           container.ID,
+		Created:      container.Created.Format(time.RFC3339Nano),
+		Path:         container.Path,
+		Args:         container.Args,
+		State:        containerState,
+		Image:        container.ImageID,
+		LogPath:      container.LogPath,
+		Name:         container.Name,
+		RestartCount: container.RestartCount,
+		Driver:       container.Driver,
+		ExecIDs:      container.getExecIDs(),
+		HostConfig:   hostConfig,
+	}
 }

--- a/daemon/selinux_unsupported.go
+++ b/daemon/selinux_unsupported.go
@@ -5,9 +5,6 @@ package daemon
 func selinuxSetDisabled() {
 }
 
-func selinuxFreeLxcContexts(label string) {
-}
-
 func selinuxEnabled() bool {
 	return false
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -11,7 +11,6 @@ import (
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
-	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 var (
@@ -135,11 +134,10 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 			bind.Driver = v.DriverName()
 			bind = setBindModeIfNull(bind)
 		}
-		if label.RelabelNeeded(bind.Mode) {
-			if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
-				return err
-			}
+		if err := reLabelIfNeeded(bind, container); err != nil {
+			return err
 		}
+
 		binds[bind.Destination] = true
 		mountPoints[bind.Destination] = bind
 	}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/volume"
 	volumedrivers "github.com/docker/docker/volume/drivers"
 	"github.com/docker/docker/volume/local"
+	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 // copyExistingContents copies from the source to the destination and
@@ -249,4 +250,14 @@ func configureBackCompatStructures(daemon *Daemon, container *Container, mountPo
 func setBackCompatStructures(container *Container, bcVolumes map[string]string, bcVolumesRW map[string]bool) {
 	container.Volumes = bcVolumes
 	container.VolumesRW = bcVolumesRW
+}
+
+// reLabelIfNeeded is a platform specific helper to relabel binds.
+func reLabelIfNeeded(bind *volume.MountPoint, container *Container) error {
+	if label.RelabelNeeded(bind.Mode) {
+		if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -59,3 +59,9 @@ func configureBackCompatStructures(*Daemon, *Container, map[string]*volume.Mount
 // This is a no-op on Windows.
 func setBackCompatStructures(*Container, map[string]string, map[string]bool) {
 }
+
+// reLabelIfNeeded is a platform specific helper to relabel binds. This is a
+// no-op on Windows.
+func reLabelIfNeeded(bind *volume.MountPoint, container *Container) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Tackling more "TODO Windows" annotations. This factors out ProcessLabel and MountLabel which aren't relevant in the Windows daemon. Have run test-integration-cli and unit-test locally with no regressions.
