### PR TITLE
Windows: [TP4] Fix regression on second or later container starts

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -124,7 +124,11 @@ func (daemon *Daemon) containerStart(container *Container) (err error) {
 	mounts = append(mounts, container.ipcMounts()...)
 
 	container.command.Mounts = mounts
-	return daemon.waitForStart(container)
+	if err := daemon.waitForStart(container); err != nil {
+		return err
+	}
+	container.HasBeenStartedBefore = true
+	return nil
 }
 
 func (daemon *Daemon) waitForStart(container *Container) error {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

It looks like https://github.com/docker/docker/pull/16370/files, and more likely a PR before it, as the code removed in that PR was dead, somehow stopped the daemon saving the first boot optimization once the container has been started for the first time. I need to go back in history further to find the original PR which broke it. The key is that HasBeenStartBefore is no longer being updated in the container config.

The net effect of this is that the daemon always tells HCS to ignore flushes during boot, regardless of whether a container has been started before. This could cause potential data loss on second and subsequent starts of a container.
