### PR TITLE
Windows [TP4] Fix push to not kill daemon

### DIFF
--- a/graph/push_v2.go
+++ b/graph/push_v2.go
@@ -135,6 +135,11 @@ func (p *v2Pusher) pushV2Tag(tag string) error {
 			break
 		}
 
+		// Skip the base layer on Windows. This cannot be pushed.
+		if allowBaseParentImage && layer.Parent == "" {
+			break
+		}
+
 		logrus.Debugf("Pushing layer: %s", layer.ID)
 
 		if layer.Config != nil && metadata.Image != layer.ID {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This fixes push (v2) in the Windows daemon.  (@tonistiigi It can be updated or merged with your PR https://github.com/docker/docker/pull/17945 to use allowBaseParentImage instead of the runtime.GOOS check)

Currently, without this fix the Windows daemon will SIGSEGV and die if it attempts to push to a DTR. So this is certainly a step in the right direction. The fix is to not attempt to push the base layer on Windows.

**However, even with cherry-picking your pull PR fix, the overall push/delete/pull workflow does not appear to work correctly as I cannot run anything from the pulled image.**

I have narrowed at least one problem down to the layer IDs being pushed to the repository. Removing a pulled image and re-pulling it will always get the same IDs for the layers. But they are different layer IDs to that in the image originally being pushed. 

So that suggests that something in the pull v2 code on Windows is altering the layer IDs as they are being pushed to the repository. My best guess (I really don't have enough knowledge of this code unfortunately and am still trying to find where) is that it is something to do with the v1 compatibility that is changing the IDs in the manifest. 

Here's an example of a clean-down, build an image and push:

![push](https://cloud.githubusercontent.com/assets/10522484/11166704/5ad6ef30-8af6-11e5-85b5-5048304c46ef.JPG)

Note that the image ID is 958eed.... and has another layer f94ce18, both of which are pushed to the DTR.

Now another clean-down and pull (after cherry-picking your commit obviously):

![pull](https://cloud.githubusercontent.com/assets/10522484/11166723/131257f6-8af7-11e5-83fb-086632c168de.JPG)

Notice how on both pull attempts, the layer IDs this time are fd2d54 and 3dcc15, and do **NOT** match what appeared to have been pushed.

@swernli @powersplay @aaronlehmann @tonistiigi
