### PR TITLE
Phase 1: Initial seccomp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y \
 	libltdl-dev \
 	libsqlite3-dev \
 	libsystemd-journal-dev \
+	libtool \
 	mercurial \
 	parallel \
 	pkg-config \
@@ -125,6 +126,23 @@ RUN set -x \
 	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
 ENV PATH /osxcross/target/bin:$PATH
 
+# install seccomp
+# this can be changed to the ubuntu package libseccomp-dev if dockerinit is removed,
+# we need libseccomp.a (which the package does not provide) for dockerinit
+ENV SECCOMP_VERSION v2.2.3
+RUN set -x \
+	&& export SECCOMP_PATH=$(mktemp -d) \
+	&& git clone https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+	&& ( \
+		cd "$SECCOMP_PATH" \
+		&& git checkout "$SECCOMP_VERSION" \
+		&& ./autogen.sh \
+		&& ./configure --prefix=/usr \
+		&& make \
+		&& make install \
+	) \
+	&& rm -rf "$SECCOMP_PATH"
+
 # Install registry
 ENV REGISTRY_COMMIT ec87e9b6971d831f0eff752ddb54fb64693e51cd
 RUN set -x \
@@ -168,7 +186,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -51,6 +51,7 @@ type Container struct {
 	ShmPath         string
 	MqueuePath      string
 	ResolvConfPath  string
+	SeccompProfile  string
 }
 
 // CreateDaemonEnvironment returns the list of all environment variables given the list of

--- a/contrib/builder/deb/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/debian-jessie/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/debian-jessie/Dockerfile
@@ -4,7 +4,30 @@
 
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+&& rm -rf /var/lib/apt/lists/* \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH" \
+&& apt-get purge -y --auto-remove $buildDeps
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -12,4 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux

--- a/contrib/builder/deb/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/debian-stretch/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS apparmor selinux
+
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux

--- a/contrib/builder/deb/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/debian-wheezy/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM debian:wheezy-backports
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/generate.sh
+++ b/contrib/builder/deb/generate.sh
@@ -68,9 +68,8 @@ for version in "${versions[@]}"; do
 	esac
 
 	# debian wheezy & ubuntu precise do not have the right libseccomp libs
-	# debian jessie & ubuntu trusty/vivid do not have a libseccomp.a for compiling static dockerinit
 	case "$suite" in
-		jessie|precise|trusty|vivid|wheezy)
+		precise|wheezy)
 			packages=( "${packages[@]/libseccomp-dev}" )
 			;;
 		*)
@@ -104,6 +103,41 @@ for version in "${versions[@]}"; do
 	echo "RUN apt-get update && apt-get install -y ${packages[*]} --no-install-recommends && rm -rf /var/lib/apt/lists/*" >> "$version/Dockerfile"
 
 	echo >> "$version/Dockerfile"
+
+	# debian jessie & ubuntu trusty/vivid do not have a libseccomp.a for compiling static dockerinit
+	# ONLY install libseccomp.a from source, this can be removed once dockerinit is removed
+	# TODO remove this manual seccomp compilation once dockerinit is gone or no longer needs to be statically compiled
+	case "$suite" in
+		jessie|trusty|vivid)
+			awk '$1 == "ENV" && $2 == "SECCOMP_VERSION" { print; exit }' ../../../Dockerfile >> "$version/Dockerfile"
+			cat <<-'EOF' >> "$version/Dockerfile"
+			RUN buildDeps=' \
+				automake \
+				libtool \
+			' \
+			&& set -x \
+			&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& export SECCOMP_PATH=$(mktemp -d) \
+			&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+			&& ( \
+				cd "$SECCOMP_PATH" \
+				&& ./autogen.sh \
+				&& ./configure --prefix=/usr \
+				&& make \
+				&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+				&& chmod 644 /usr/lib/libseccomp.a \
+				&& ranlib /usr/lib/libseccomp.a \
+				&& ldconfig -n /usr/lib \
+			) \
+			&& rm -rf "$SECCOMP_PATH" \
+			&& apt-get purge -y --auto-remove $buildDeps
+			EOF
+
+			echo >> "$version/Dockerfile"
+			;;
+		*) ;;
+	esac
 
 	awk '$1 == "ENV" && $2 == "GO_VERSION" { print; exit }' ../../../Dockerfile >> "$version/Dockerfile"
 	echo 'RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local' >> "$version/Dockerfile"

--- a/contrib/builder/deb/generate.sh
+++ b/contrib/builder/deb/generate.sh
@@ -58,6 +58,7 @@ for version in "${versions[@]}"; do
 		libdevmapper-dev # for "libdevmapper.h"
 		libltdl-dev # for pkcs11 "ltdl.h"
 		libsqlite3-dev # for "sqlite3.h"
+		libseccomp-dev  # for "seccomp.h" & "libseccomp.so"
 	)
 	# packaging for "sd-journal.h" and libraries varies
 	case "$suite" in
@@ -65,6 +66,18 @@ for version in "${versions[@]}"; do
 		sid|stretch|wily) packages+=( libsystemd-dev );;
 		*) packages+=( libsystemd-journal-dev );;
 	esac
+
+	# debian wheezy & ubuntu precise do not have the right libseccomp libs
+	# debian jessie & ubuntu trusty/vivid do not have a libseccomp.a for compiling static dockerinit
+	case "$suite" in
+		jessie|precise|trusty|vivid|wheezy)
+			packages=( "${packages[@]/libseccomp-dev}" )
+			;;
+		*)
+			extraBuildTags+=' seccomp'
+			;;
+	esac
+
 
 	if [ "$suite" = 'precise' ]; then
 		# precise has a few package issues
@@ -99,5 +112,11 @@ for version in "${versions[@]}"; do
 	echo >> "$version/Dockerfile"
 
 	echo 'ENV AUTO_GOPATH 1' >> "$version/Dockerfile"
-	awk '$1 == "ENV" && $2 == "DOCKER_BUILDTAGS" { print $0 "'"$extraBuildTags"'"; exit }' ../../../Dockerfile >> "$version/Dockerfile"
+
+	echo >> "$version/Dockerfile"
+
+	# print build tags in alphabetical order
+	buildTags=$( echo "apparmor selinux $extraBuildTags" | xargs -n1 | sort -n | tr '\n' ' ' | sed -e 's/[[:space:]]*$//' )
+
+	echo "ENV DOCKER_BUILDTAGS $buildTags" >> "$version/Dockerfile"
 done

--- a/contrib/builder/deb/ubuntu-precise/Dockerfile
+++ b/contrib/builder/deb/ubuntu-precise/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM ubuntu:precise
 
-RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor  git libapparmor-dev  libltdl-dev libsqlite3-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor  git libapparmor-dev  libltdl-dev libsqlite3-dev  --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS apparmor selinux exclude_graphdriver_devicemapper exclude_graphdriver_btrfs
+
+ENV DOCKER_BUILDTAGS apparmor exclude_graphdriver_btrfs exclude_graphdriver_devicemapper selinux

--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
@@ -4,7 +4,30 @@
 
 FROM ubuntu:trusty
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+&& rm -rf /var/lib/apt/lists/* \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH" \
+&& apt-get purge -y --auto-remove $buildDeps
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -12,4 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux

--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM ubuntu:trusty
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/ubuntu-vivid/Dockerfile
+++ b/contrib/builder/deb/ubuntu-vivid/Dockerfile
@@ -4,7 +4,30 @@
 
 FROM ubuntu:vivid
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+&& rm -rf /var/lib/apt/lists/* \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH" \
+&& apt-get purge -y --auto-remove $buildDeps
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -12,4 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux

--- a/contrib/builder/deb/ubuntu-vivid/Dockerfile
+++ b/contrib/builder/deb/ubuntu-vivid/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM ubuntu:vivid
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/ubuntu-wily/Dockerfile
+++ b/contrib/builder/deb/ubuntu-wily/Dockerfile
@@ -4,11 +4,12 @@
 
 FROM ubuntu:wily
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS apparmor selinux
+
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux

--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -6,11 +6,12 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -6,7 +6,28 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& yum install -y $buildDeps \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH"
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -14,4 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS seccomp selinux

--- a/contrib/builder/rpm/fedora-21/Dockerfile
+++ b/contrib/builder/rpm/fedora-21/Dockerfile
@@ -5,11 +5,12 @@
 FROM fedora:21
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/fedora-21/Dockerfile
+++ b/contrib/builder/rpm/fedora-21/Dockerfile
@@ -5,7 +5,28 @@
 FROM fedora:21
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& yum install -y $buildDeps \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH"
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -13,4 +34,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS seccomp selinux

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -5,7 +5,28 @@
 FROM fedora:22
 
 RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& yum install -y $buildDeps \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH"
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -13,4 +34,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS seccomp selinux

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -5,11 +5,12 @@
 FROM fedora:22
 
 RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/fedora-23/Dockerfile
+++ b/contrib/builder/rpm/fedora-23/Dockerfile
@@ -5,7 +5,28 @@
 FROM fedora:23
 
 RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& yum install -y $buildDeps \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH"
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -13,4 +34,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS seccomp selinux

--- a/contrib/builder/rpm/fedora-23/Dockerfile
+++ b/contrib/builder/rpm/fedora-23/Dockerfile
@@ -5,11 +5,12 @@
 FROM fedora:23
 
 RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/opensuse-13.2/Dockerfile
@@ -5,11 +5,12 @@
 FROM opensuse:13.2
 
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
-RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-6/Dockerfile
@@ -5,11 +5,12 @@
 FROM oraclelinux:6
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -5,11 +5,12 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
+
 ENV DOCKER_BUILDTAGS selinux

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -5,7 +5,28 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& yum install -y $buildDeps \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& chmod 644 /usr/lib/libseccomp.a \
+&& ranlib /usr/lib/libseccomp.a \
+&& ldconfig -n /usr/lib \
+) \
+&& rm -rf "$SECCOMP_PATH"
 
 ENV GO_VERSION 1.5.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -13,4 +34,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS seccomp selinux

--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -184,6 +184,9 @@ echo 'Optional Features:'
 	check_flags USER_NS
 }
 {
+	check_flags SECCOMP
+}
+{
 	check_flags MEMCG_KMEM MEMCG_SWAP MEMCG_SWAP_ENABLED
 	if  is_set MEMCG_SWAP && ! is_set MEMCG_SWAP_ENABLED; then
 		echo "    $(wrap_color '(note that cgroup swap accounting is not enabled in your kernel config, you can enable it by setting boot option "swapaccount=1")' bold black)"

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1544,7 +1544,7 @@ _docker_run() {
 					fi
 					;;
 				*)
-					COMPREPLY=( $( compgen -W "label apparmor" -S ":" -- "$cur") )
+					COMPREPLY=( $( compgen -W "label apparmor seccomp" -S ":" -- "$cur") )
 					__docker_nospace
 					;;
 			esac

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -236,6 +236,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		Pid:                pid,
 		ReadonlyRootfs:     c.HostConfig.ReadonlyRootfs,
 		RemappedRoot:       remappedRoot,
+		SeccompProfile:     c.SeccompProfile,
 		UIDMapping:         uidMap,
 		UTS:                uts,
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -152,6 +152,16 @@ func TestParseSecurityOpt(t *testing.T) {
 		t.Fatalf("Unexpected AppArmorProfile, expected: \"test_profile\", got %q", container.AppArmorProfile)
 	}
 
+	// test seccomp
+	sp := "/path/to/seccomp_test.json"
+	config.SecurityOpt = []string{"seccomp:" + sp}
+	if err := parseSecurityOpt(container, config); err != nil {
+		t.Fatalf("Unexpected parseSecurityOpt error: %v", err)
+	}
+	if container.SeccompProfile != sp {
+		t.Fatalf("Unexpected AppArmorProfile, expected: %q, got %q", sp, container.SeccompProfile)
+	}
+
 	// test valid label
 	config.SecurityOpt = []string{"label:user:USER"}
 	if err := parseSecurityOpt(container, config); err != nil {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -74,6 +74,8 @@ func parseSecurityOpt(container *container.Container, config *runconfig.HostConf
 			labelOpts = append(labelOpts, con[1])
 		case "apparmor":
 			container.AppArmorProfile = con[1]
+		case "seccomp":
+			container.SeccompProfile = con[1]
 		default:
 			return fmt.Errorf("Invalid --security-opt: %q", opt)
 		}

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -118,6 +118,7 @@ type Command struct {
 	Pid                *Pid              `json:"pid"`
 	ReadonlyRootfs     bool              `json:"readonly_rootfs"`
 	RemappedRoot       *User             `json:"remap_root"`
+	SeccompProfile     string            `json:"seccomp_profile"`
 	UIDMapping         []idtools.IDMap   `json:"uidmapping"`
 	UTS                *UTS              `json:"uts"`
 }

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -19,8 +19,8 @@ import (
 
 // createContainer populates and configures the container type with the
 // data provided by the execdriver.Command
-func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) (*configs.Config, error) {
-	container := execdriver.InitContainer(c)
+func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) (container *configs.Config, err error) {
+	container = execdriver.InitContainer(c)
 
 	if err := d.createIpc(container, c); err != nil {
 		return nil, err
@@ -82,6 +82,12 @@ func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) 
 		container.AppArmorProfile = c.AppArmorProfile
 	}
 
+	if c.SeccompProfile != "" {
+		container.Seccomp, err = loadSeccompProfile(c.SeccompProfile)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if err := execdriver.SetupCgroups(container, c); err != nil {
 		return nil, err
 	}

--- a/daemon/execdriver/native/seccomp.go
+++ b/daemon/execdriver/native/seccomp.go
@@ -1,0 +1,94 @@
+// +build linux
+
+package native
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/seccomp"
+	"github.com/opencontainers/specs"
+)
+
+func loadSeccompProfile(path string) (*configs.Seccomp, error) {
+	f, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Opening seccomp profile failed: %v", err)
+	}
+
+	var config specs.Seccomp
+	if err := json.Unmarshal(f, &config); err != nil {
+		return nil, fmt.Errorf("Decoding seccomp profile failed: %v", err)
+	}
+
+	return setupSeccomp(&config)
+}
+
+func setupSeccomp(config *specs.Seccomp) (newConfig *configs.Seccomp, err error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	// No default action specified, no syscalls listed, assume seccomp disabled
+	if config.DefaultAction == "" && len(config.Syscalls) == 0 {
+		return nil, nil
+	}
+
+	newConfig = new(configs.Seccomp)
+	newConfig.Syscalls = []*configs.Syscall{}
+
+	// if config.Architectures == 0 then libseccomp will figure out the architecture to use
+	if len(config.Architectures) > 0 {
+		newConfig.Architectures = []string{}
+		for _, arch := range config.Architectures {
+			newArch, err := seccomp.ConvertStringToArch(string(arch))
+			if err != nil {
+				return nil, err
+			}
+			newConfig.Architectures = append(newConfig.Architectures, newArch)
+		}
+	}
+
+	// Convert default action from string representation
+	newConfig.DefaultAction, err = seccomp.ConvertStringToAction(string(config.DefaultAction))
+	if err != nil {
+		return nil, err
+	}
+
+	// Loop through all syscall blocks and convert them to libcontainer format
+	for _, call := range config.Syscalls {
+		newAction, err := seccomp.ConvertStringToAction(string(call.Action))
+		if err != nil {
+			return nil, err
+		}
+
+		newCall := configs.Syscall{
+			Name:   call.Name,
+			Action: newAction,
+			Args:   []*configs.Arg{},
+		}
+
+		// Loop through all the arguments of the syscall and convert them
+		for _, arg := range call.Args {
+			newOp, err := seccomp.ConvertStringToOperator(string(arg.Op))
+			if err != nil {
+				return nil, err
+			}
+
+			newArg := configs.Arg{
+				Index:    arg.Index,
+				Value:    arg.Value,
+				ValueTwo: arg.ValueTwo,
+				Op:       newOp,
+			}
+
+			newCall.Args = append(newCall.Args, &newArg)
+		}
+
+		newConfig.Syscalls = append(newConfig.Syscalls, &newCall)
+	}
+
+	return newConfig, nil
+}

--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -1,0 +1,64 @@
+<!-- [metadata]>
++++
+title = "Seccomp security profiles for Docker"
+description = "Enabling seccomp in Docker"
+keywords = ["seccomp, security, docker, documentation"]
++++
+<![end-metadata]-->
+
+Seccomp security profiles for Docker
+------------------------------------
+
+The seccomp() system call operates on the Secure Computing (seccomp)
+state of the calling process.
+
+This operation is available only if the kernel is configured
+with `CONFIG_SECCOMP` enabled.
+
+This allows for allowing or denying of certain syscalls in a container.
+
+Passing a profile for a container
+---------------------------------
+
+Users may pass a seccomp profile using the `security-opt` option
+(per-container).
+
+The profile has layout in the following form:
+
+```
+{
+    "defaultAction": "SCMP_ACT_ALLOW",
+    "syscalls": [
+        {
+            "name": "getcwd",
+            "action": "SCMP_ACT_ERRNO"
+        },
+        {
+            "name": "mount",
+            "action": "SCMP_ACT_ERRNO"
+        },
+        {
+            "name": "setns",
+            "action": "SCMP_ACT_ERRNO"
+        },
+        {
+            "name": "create_module",
+            "action": "SCMP_ACT_ERRNO"
+        },
+        {
+            "name": "chown",
+            "action": "SCMP_ACT_ERRNO"
+        },
+        {
+            "name": "chmod",
+            "action": "SCMP_ACT_ERRNO"
+        }
+    ]
+}
+```
+
+Then you can run with:
+
+```
+$ docker run --rm -it --security-opt seccomp:/path/to/seccomp/profile.json hello-world
+```

--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -85,6 +85,7 @@ clean() {
 		''
 		'experimental'
 		'pkcs11'
+		'seccomp'
 		"$dockerBuildTags"
 		"daemon $dockerBuildTags"
 		"daemon cgo $dockerBuildTags"
@@ -94,6 +95,9 @@ clean() {
 		"pkcs11 $dockerBuildTags"
 		"pkcs11 daemon $dockerBuildTags"
 		"pkcs11 daemon cgo $dockerBuildTags"
+		"seccomp $dockerBuildTags"
+		"seccomp daemon $dockerBuildTags"
+		"seccomp daemon cgo $dockerBuildTags"
 	)
 
 	echo

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -50,6 +50,8 @@ clone git github.com/jfrazelle/go v1.5.1-1
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
 clone git github.com/opencontainers/runc v0.0.5 # libcontainer
+clone git github.com/opencontainers/specs 46d949ea81080c5f60dfb72ee91468b1e9fb2998 # specs
+clone git github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v4
 clone git github.com/godbus/dbus v3

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3789,3 +3789,59 @@ func (s *DockerSuite) TestRunWithOomScoreAdjInvalidRange(c *check.C) {
 		c.Fatalf("Expected output to contain %q, got %q instead", expected, out)
 	}
 }
+
+// TestRunSeccompProfileDenyUnshare checks that 'docker run --security-opt seccomp:/tmp/profile.json jess/unshare unshare' exits with operation not permitted.
+func (s *DockerSuite) TestRunSeccompProfileDenyUnshare(c *check.C) {
+	testRequires(c, SameHostDaemon)
+	jsonData := `{
+	"defaultAction": "SCMP_ACT_ALLOW",
+	"syscalls": [
+		{
+			"name": "unshare",
+			"action": "SCMP_ACT_ERRNO"
+		}
+	]
+}`
+	tmpFile, err := ioutil.TempFile("", "profile.json")
+	defer tmpFile.Close()
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if _, err := tmpFile.Write([]byte(jsonData)); err != nil {
+		c.Fatal(err)
+	}
+	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp:"+tmpFile.Name(), "jess/unshare", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
+	out, _, _ := runCommandWithOutput(runCmd)
+	if !strings.Contains(out, "Operation not permitted") {
+		c.Fatalf("expected unshare with seccomp profile denied to fail, got %s", out)
+	}
+}
+
+// TestRunSeccompProfileDenyChmod checks that 'docker run --security-opt seccomp:/tmp/profile.json busybox chmod 400 /etc/hostname' exits with operation not permitted.
+func (s *DockerSuite) TestRunSeccompProfileDenyChmod(c *check.C) {
+	testRequires(c, SameHostDaemon)
+	jsonData := `{
+	"defaultAction": "SCMP_ACT_ALLOW",
+	"syscalls": [
+		{
+			"name": "chmod",
+			"action": "SCMP_ACT_ERRNO"
+		}
+	]
+}`
+	tmpFile, err := ioutil.TempFile("", "profile.json")
+	defer tmpFile.Close()
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	if _, err := tmpFile.Write([]byte(jsonData)); err != nil {
+		c.Fatal(err)
+	}
+	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp:"+tmpFile.Name(), "busybox", "chmod", "400", "/etc/hostname")
+	out, _, _ := runCommandWithOutput(runCmd)
+	if !strings.Contains(out, "Operation not permitted") {
+		c.Fatalf("expected chmod with seccomp profile denied to fail, got %s", out)
+	}
+}

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -304,6 +304,7 @@ by having support for them in the kernel or userspace. A few examples include:
   least the "auplink" utility from aufs-tools)
 * BTRFS graph driver (requires BTRFS support enabled in the kernel)
 * ZFS graph driver (requires userspace zfs-utils and a corresponding kernel module)
+* Libseccomp to allow running seccomp profiles with containers
 
 ## Daemon Init Script
 

--- a/vendor/src/github.com/opencontainers/specs/.travis.yml
+++ b/vendor/src/github.com/opencontainers/specs/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+go:
+  - 1.5.1
+  - 1.4.3
+  - 1.3.3
+
+sudo: false
+
+before_install:
+  - go get golang.org/x/tools/cmd/vet
+  - go get github.com/golang/lint/golint
+  - go get github.com/vbatts/git-validation
+
+install: true
+
+script:
+  - go vet -x ./...
+  - $HOME/gopath/bin/golint ./...
+  - $HOME/gopath/bin/git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}

--- a/vendor/src/github.com/opencontainers/specs/LICENSE
+++ b/vendor/src/github.com/opencontainers/specs/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 The Linux Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/src/github.com/opencontainers/specs/MAINTAINERS
+++ b/vendor/src/github.com/opencontainers/specs/MAINTAINERS
@@ -1,0 +1,8 @@
+Michael Crosby <michael@docker.com> (@crosbymichael)
+Alexander Morozov <lk4d4@docker.com> (@LK4D4)
+Vishnu Kannan <vishnuk@google.com> (@vishnuk)
+Mrunal Patel <mpatel@redhat.com> (@mrunalp)
+Vincent Batts <vbatts@redhat.com> (@vbatts)
+Daniel, Dao Quang Minh <dqminh89@gmail.com> (@dqminh)
+Brandon Philips <brandon.philips@coreos.com> (@philips)
+Tianon Gravi <admwiggin@gmail.com> (@tianon)

--- a/vendor/src/github.com/opencontainers/specs/README.md
+++ b/vendor/src/github.com/opencontainers/specs/README.md
@@ -1,0 +1,144 @@
+# Open Container Specifications
+
+[Open Container Initiative](http://www.opencontainers.org/) Specifications for standards on Operating System process and application containers.
+
+
+Table of Contents
+
+- [Container Principles](principles.md)
+- [Filesystem Bundle](bundle.md)
+- Configuration
+  - [Container Configuration](config.md)
+  - [Container Configuration (Linux-specific)](config-linux.md)
+  - [Runtime Configuration](runtime-config.md)
+  - [Runtime Configuration (Linux-specific)](runtime-config-linux.md)
+- [Runtime and Lifecycle](runtime.md)
+  - [Linux Specific Runtime](runtime-linux.md)
+- [Implementations](implementations.md)
+
+# Use Cases
+
+To provide context for users the following section gives example use cases for each part of the spec.
+
+## Filesystem Bundle & Configuration
+
+- A user can create a root filesystem and configuration, with low-level OS and host specific details, and launch it as a container under an Open Container runtime.
+
+# Releases
+
+There is a loose [Road Map](https://github.com/opencontainers/specs/wiki/RoadMap:) on the wiki.
+During the `0.x` series of OCI releases we make no backwards compatibility guarantees and intend to break the schema during this series.
+
+# Contributing
+
+Development happens on GitHub for the spec.
+Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
+
+The specification and code is licensed under the Apache 2.0 license found in the `LICENSE` file of this repository.
+
+## Code of Conduct
+
+Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct](code-of-conduct.md).
+
+## Discuss your design
+
+The project welcomes submissions, but please let everyone know what you are working on.
+
+Before undertaking a nontrivial change to this specification, send mail to the [mailing list](#mailing-list) to discuss what you plan to do.
+This gives everyone a chance to validate the design, helps prevent duplication of effort, and ensures that the idea fits.
+It also guarantees that the design is sound before code is written; a GitHub pull-request is not the place for high-level discussions.
+
+Typos and grammatical errors can go straight to a pull-request.
+When in doubt, start on the [mailing-list](#mailing-list).
+
+## Weekly Call
+
+The contributors and maintainers of the project have a weekly meeting Wednesdays at 10:00 AM PST.
+Everyone is welcome to participate in the [BlueJeans call][BlueJeans].
+An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/specs/wiki) for those who are unable to join the call.
+
+## Mailing List
+
+You can subscribe and join the mailing list on [Google Groups](https://groups.google.com/a/opencontainers.org/forum/#!forum/dev).
+
+## IRC
+
+OCI discussion happens on #opencontainers on Freenode.
+
+## Markdown style
+
+To keep consistency throughout the Markdown files in the Open Container spec all files should be formatted one sentence per line.
+This fixes two things: it makes diffing easier with git and it resolves fights about line wrapping length.
+For example, this paragraph will span three lines in the Markdown source.
+
+## Git commit
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch, which certifies that you wrote it or otherwise have the right to pass it on as an open-source patch.
+The rules are pretty simple: if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.
+
+### Commit Style
+
+Simple house-keeping for clean git history.
+Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) or the Discussion section of [`git-commit(1)`](http://git-scm.com/docs/git-commit).
+
+1. Separate the subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
+  * If there was important/useful/essential conversation or information, copy or include a reference
+8. When possible, one keyword to scope the change in the subject (i.e. "README: ...", "runtime: ...")
+
+[BlueJeans]: https://bluejeans.com/1771332256/

--- a/vendor/src/github.com/opencontainers/specs/ROADMAP.md
+++ b/vendor/src/github.com/opencontainers/specs/ROADMAP.md
@@ -1,0 +1,96 @@
+# OCI Specs Roadmap
+
+This document serves to provide a long term roadmap on our quest to a 1.0 version of the OCI container specification.
+Its goal is to help both maintainers and contributors find meaningful tasks to focus on and create a low noise environment.
+The items in the 1.0 roadmap can be broken down into smaller milestones that are easy to accomplish.
+The topics below are broad and small working groups will be needed for each to define scope and requirements or if the feature is required at all for the OCI level.
+Topics listed in the roadmap do not mean that they will be implemented or added but are areas that need discussion to see if they fit in to the goals of the OCI.
+
+## 1.0
+
+### Digest and Hashing
+
+A bundle is designed to be moved between hosts.
+Although OCI doesn't define a transport method we should have a cryptographic digest of the on-disk bundle that can be used to verify that a bundle is not corrupted and in an expected configuration.
+
+*Owner:* philips
+
+### Review the need for runtime.json
+
+There are some discussions about having `runtime.json` being optional for containers and specifying defaults.
+Runtimes would use this standard set of defaults for containers and `runtime.json` would provide overrides for fine tuning of these extra host or platform specific settings.
+
+*Owner:*
+
+### Define Container Lifecycle
+
+Containers have a lifecycle and being able to identify and document the lifecycle of a container is very helpful for implementations of the spec.
+The lifecycle events of a container also help identify areas to implement hooks that are portable across various implementations and platforms.
+
+*Owner:* mrunalp
+
+### Define Standard Container Actions
+
+Define what type of actions a runtime can perform on a container without imposing hardships on authors of platforms that do not support advanced options.
+
+*Owner:*
+
+### Clarify rootfs requirement in base spec
+
+Is the rootfs needed or should it just be expected in the bundle without having a field in the spec?
+
+*Owner:*
+
+### Container Definition
+
+Define what a software container is and its attributes in a cross platform way.
+
+*Owner:*
+
+### Live Container Updates
+
+Should we allow dynamic container updates to runtime options?
+
+*Owner:* vishh
+
+### Protobuf Config
+
+We currently have only one language binding for the spec and that is Go.
+If we change the specs format in the respository to be something like protobuf then the generation for multiple language bindings become effortless.
+
+*Owner:* vbatts
+
+### Validation Tooling
+
+Provide validation tooling for compliance with OCI spec and runtime environment.
+
+*Owner:* mrunalp
+
+### Version Schema
+
+Decide on a robust versioning schema for the spec as it evolves.
+
+*Owner:*
+
+### Printable/Compiled Spec
+
+Reguardless of how the spec is written, ensure that it is easy to read and follow for first time users.
+
+*Owner:* vbatts
+
+### Base Config Compatibility
+
+Ensure that the base configuration format is viable for various platforms.
+
+Systems:
+
+* Solaris
+* Windows
+* Linux
+
+*Owner:*
+
+### Full Lifecycle Hooks
+Ensure that we have lifecycle hooks in the correct places with full coverage over the container lifecycle.
+
+*Owner:*

--- a/vendor/src/github.com/opencontainers/specs/bundle.md
+++ b/vendor/src/github.com/opencontainers/specs/bundle.md
@@ -1,0 +1,30 @@
+# Filesystem Bundle
+
+## Container Format
+
+This section defines a format for encoding a container as a *filesystem bundle* - a set of files organized in a certain way, and containing all the necessary data and metadata for any compliant runtime to perform all standard operations against it.
+See also [OS X application bundles](http://en.wikipedia.org/wiki/Bundle_%28OS_X%29) for a similar use of the term *bundle*.
+
+The definition of a bundle is only concerned with how a container, and its configuration data, are stored on a local file system so that it can be consumed by a compliant runtime.
+
+A Standard Container bundle contains all the information needed to load and run a container.
+This includes the following three artifacts which MUST all reside in the same directory on the local filesystem:
+
+1. `config.json` : contains host independent configuration data.
+This REQUIRED file, which MUST be named `config.json`, contains settings that are host independent and application specific such as security permissions, environment variables and arguments.
+When the bundle is packaged up for distribution, this file MUST be included.
+See [`config.json`](config.md) for more details.
+
+2. `runtime.json` : contains host-specific configuration data.
+This REQUIRED file, which MUST be named `runtime.json`, contains settings that are host specific such as mount sources and hooks.
+The goal is that the bundle can be moved as a unit to another runtime and run the same application once a host-specific `runtime.json` is defined.
+When the bundle is packaged up for distribution, this file MUST NOT be included.
+See [`runtime.json`](runtime-config.md) for more details.
+
+3. A directory representing the root filesystem of the container.
+While the name of this REQUIRED directory may be arbitrary, users should consider using a conventional name, such as `rootfs`.
+When the bundle is packaged up for distribution, this directory MUST be included.
+This directory MUST be referenced from within the `config.json` file.
+
+While these three artifacts MUST all be present in a single directory on the local filesytem, that directory itself is not part of the bundle.
+In other words, a tar archive of a *bundle* will have these artifacts at the root of the archive, not nested within a top-level directory.

--- a/vendor/src/github.com/opencontainers/specs/code-of-conduct.md
+++ b/vendor/src/github.com/opencontainers/specs/code-of-conduct.md
@@ -1,0 +1,37 @@
+# OpenContainers Code of Conduct
+
+Behave as a community member, follow the code of conduct.
+
+## Code of Conduct
+
+The OpenContainers community is made up of a mixture of professionals and volunteers from all over the world.
+
+When we disagree, we try to understand why.
+Disagreements, both social and technical, happen all the time and OpenContainers is no exception.
+It is important that we resolve disagreements and differing views constructively.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Participants should be aware of these concerns.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+The OpenContainers team does not condone any statements by speakers contrary to these standards.
+The OpenContainers team reserves the right to deny participation any individual found to be engaging in discriminatory or harassing actions.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project.
+
+## Thanks
+
+Thanks to the [Fedora Code of Conduct](https://getfedora.org/code-of-conduct) and [Contributor Covenant](http://contributor-covenant.org) for inspiration and ideas.
+
+Portions of this Code of Conduct are adapted from the Contributor Covenant, version 1.2.0, available at http://contributor-covenant.org/version/1/2/0/

--- a/vendor/src/github.com/opencontainers/specs/config-linux.md
+++ b/vendor/src/github.com/opencontainers/specs/config-linux.md
@@ -1,0 +1,63 @@
+# Linux-specific Container Configuration
+
+The Linux container specification uses various kernel features like namespaces, cgroups, capabilities, LSM, and file system jails to fulfill the spec.
+Additional information is needed for Linux over the [default spec configuration](config.md) in order to configure these various kernel features.
+
+## Capabilities
+
+Capabilities is an array that specifies Linux capabilities that can be provided to the process inside the container.
+Valid values are the strings for capabilities defined in [the man page](http://man7.org/linux/man-pages/man7/capabilities.7.html)
+
+```json
+   "capabilities": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
+    ]
+```
+
+## User namespace mappings
+
+```json
+    "uidMappings": [
+        {
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
+        }
+    ],
+    "gidMappings": [
+        {
+            "hostID": 1000,
+            "containerID": 0,
+            "size": 10
+        }
+    ]
+```
+
+uid/gid mappings describe the user namespace mappings from the host to the container.
+The mappings represent how the bundle `rootfs` expects the user namespace to be setup and the runtime SHOULD NOT modify the permissions on the rootfs to realize the mapping.
+*hostID* is the starting uid/gid on the host to be mapped to *containerID* which is the starting uid/gid in the container and *size* refers to the number of ids to be mapped.
+There is a limit of 5 mappings which is the Linux kernel hard limit.
+
+## Default Devices and File Systems
+
+The Linux ABI includes both syscalls and several special file paths.
+Applications expecting a Linux environment will very likely expect these files paths to be setup correctly.
+
+The following devices and filesystems MUST be made available in each application's filesystem
+
+|     Path     |  Type  |  Notes  |
+| ------------ | ------ | ------- |
+| /proc        | [procfs](https://www.kernel.org/doc/Documentation/filesystems/proc.txt)    | |
+| /sys         | [sysfs](https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt)    | |
+| /dev/null    | [device](http://man7.org/linux/man-pages/man4/null.4.html)                 | |
+| /dev/zero    | [device](http://man7.org/linux/man-pages/man4/zero.4.html)                 | |
+| /dev/full    | [device](http://man7.org/linux/man-pages/man4/full.4.html)                 | |
+| /dev/random  | [device](http://man7.org/linux/man-pages/man4/random.4.html)               | |
+| /dev/urandom | [device](http://man7.org/linux/man-pages/man4/random.4.html)               | |
+| /dev/tty     | [device](http://man7.org/linux/man-pages/man4/tty.4.html)                  | |
+| /dev/console | [device](http://man7.org/linux/man-pages/man4/console.4.html)              | |
+| /dev/pts     | [devpts](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt)  | |
+| /dev/ptmx    | [device](https://www.kernel.org/doc/Documentation/filesystems/devpts.txt)  | Bind-mount or symlink of /dev/pts/ptmx |
+| /dev/shm     | [tmpfs](https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt)    | |

--- a/vendor/src/github.com/opencontainers/specs/config.go
+++ b/vendor/src/github.com/opencontainers/specs/config.go
@@ -1,0 +1,59 @@
+package specs
+
+// Spec is the base configuration for the container.  It specifies platform
+// independent configuration. This information must be included when the
+// bundle is packaged for distribution.
+type Spec struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"version"`
+	// Platform is the host information for OS and Arch.
+	Platform Platform `json:"platform"`
+	// Process is the container's main process.
+	Process Process `json:"process"`
+	// Root is the root information for the container's filesystem.
+	Root Root `json:"root"`
+	// Hostname is the container's host name.
+	Hostname string `json:"hostname"`
+	// Mounts profile configuration for adding mounts to the container's filesystem.
+	Mounts []MountPoint `json:"mounts"`
+}
+
+// Process contains information to start a specific application inside the container.
+type Process struct {
+	// Terminal creates an interactive terminal for the container.
+	Terminal bool `json:"terminal"`
+	// User specifies user information for the process.
+	User User `json:"user"`
+	// Args specifies the binary and arguments for the application to execute.
+	Args []string `json:"args"`
+	// Env populates the process environment for the process.
+	Env []string `json:"env"`
+	// Cwd is the current working directory for the process and must be
+	// relative to the container's root.
+	Cwd string `json:"cwd"`
+}
+
+// Root contains information about the container's root filesystem on the host.
+type Root struct {
+	// Path is the absolute path to the container's root filesystem.
+	Path string `json:"path"`
+	// Readonly makes the root filesystem for the container readonly before the process is executed.
+	Readonly bool `json:"readonly"`
+}
+
+// Platform specifies OS and arch information for the host system that the container
+// is created for.
+type Platform struct {
+	// OS is the operating system.
+	OS string `json:"os"`
+	// Arch is the architecture
+	Arch string `json:"arch"`
+}
+
+// MountPoint describes a directory that may be fullfilled by a mount in the runtime.json.
+type MountPoint struct {
+	// Name is a unique descriptive identifier for this mount point.
+	Name string `json:"name"`
+	// Path specifies the path of the mount. The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
+	Path string `json:"path"`
+}

--- a/vendor/src/github.com/opencontainers/specs/config.md
+++ b/vendor/src/github.com/opencontainers/specs/config.md
@@ -1,0 +1,128 @@
+# Container Configuration file
+
+The container's top-level directory MUST contain a configuration file called `config.json`.
+For now the canonical schema is defined in [config.go](config.go) and [config_linux.go](config_linux.go), but this will be moved to a formal JSON schema over time.
+
+The configuration file contains metadata necessary to implement standard operations against the container.
+This includes the process to run, environment variables to inject, sandboxing features to use, etc.
+
+Below is a detailed description of each field defined in the configuration format.
+
+## Manifest version
+
+* **`version`** (string, required) must be in [SemVer v2.0.0](http://semver.org/spec/v2.0.0.html) format and specifies the version of the OCF specification with which the container bundle complies. The Open Container spec follows semantic versioning and retains forward and backward compatibility within major versions. For example, if an implementation is compliant with version 1.0.1 of the spec, it is compatible with the complete 1.x series.
+
+*Example*
+
+```json
+    "version": "0.1.0"
+```
+
+## Root Configuration
+
+Each container has exactly one *root filesystem*, specified in the *root* object:
+
+* **`path`** (string, required) Specifies the path to the root filesystem for the container, relative to the path where the manifest is. A directory MUST exist at the relative path declared by the field.
+* **`readonly`** (bool, optional) If true then the root filesystem MUST be read-only inside the container. Defaults to false.
+
+*Example*
+
+```json
+"root": {
+    "path": "rootfs",
+    "readonly": true
+}
+```
+
+## Mount Points
+
+You can add array of mount points inside container as `mounts`.
+Each record in this array must have configuration in [runtime config](runtime-config.md#mount-configuration).
+The runtime MUST mount entries in the listed order.
+
+* **`name`** (string, required) Name of mount point. Used for config lookup.
+* **`path`** (string, required) Destination of mount point: path inside container.
+
+*Example*
+
+```json
+"mounts": [
+    {
+        "name": "proc",
+        "path": "/proc"
+    },
+    {
+        "name": "dev",
+        "path": "/dev"
+    },
+    {
+        "name": "devpts",
+        "path": "/dev/pts"
+    },
+    {
+        "name": "data",
+        "path": "/data"
+    }
+]
+```
+
+## Process configuration
+
+* **`terminal`** (bool, optional) specifies whether you want a terminal attached to that process. Defaults to false.
+* **`cwd`** (string, optional) is the working directory that will be set for the executable.
+* **`env`** (array of strings, optional) contains a list of variables that will be set in the process's environment prior to execution. Elements in the array are specified as Strings in the form "KEY=value". The left hand side must consist solely of letters, digits, and underscores `_` as outlined in [IEEE Std 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
+* **`args`** (string, required) executable to launch and any flags as an array. The executable is the first element and must be available at the given path inside of the rootfs. If the executable path is not an absolute path then the search $PATH is interpreted to find the executable.
+
+The user for the process is a platform-specific structure that allows specific control over which user the process runs as.
+For Linux-based systems the user structure has the following fields:
+
+* **`uid`** (int, required) specifies the user id.
+* **`gid`** (int, required) specifies the group id.
+* **`additionalGids`** (array of ints, optional) specifies additional group ids to be added to the process.
+
+*Example (Linux)*
+
+```json
+"process": {
+    "terminal": true,
+    "user": {
+        "uid": 1,
+        "gid": 1,
+        "additionalGids": [5, 6]
+    },
+    "env": [
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "TERM=xterm"
+    ],
+    "cwd": "/root",
+    "args": [
+        "sh"
+    ]
+}
+```
+
+
+## Hostname
+
+* **`hostname`** (string, optional) as it is accessible to processes running inside.
+
+*Example*
+
+```json
+"hostname": "mrsdalloway"
+```
+
+## Platform-specific configuration
+
+* **`os`** (string, required) specifies the operating system family this image must run on. Values for os must be in the list specified by the Go Language document for [`$GOOS`](https://golang.org/doc/install/source#environment).
+* **`arch`** (string, required) specifies the instruction set for which the binaries in the image have been compiled. Values for arch must be in the list specified by the Go Language document for [`$GOARCH`](https://golang.org/doc/install/source#environment).
+
+```json
+"platform": {
+    "os": "linux",
+    "arch": "amd64"
+}
+```
+
+Interpretation of the platform section of the JSON file is used to find which platform-specific sections may be available in the document.
+For example, if `os` is set to `linux`, then a JSON object conforming to the [Linux-specific schema](config-linux.md) SHOULD be found at the key `linux` in the `config.json`.

--- a/vendor/src/github.com/opencontainers/specs/config_linux.go
+++ b/vendor/src/github.com/opencontainers/specs/config_linux.go
@@ -1,0 +1,25 @@
+package specs
+
+// LinuxSpec is the full specification for linux containers.
+type LinuxSpec struct {
+	Spec
+	// Linux is platform specific configuration for linux based containers.
+	Linux Linux `json:"linux"`
+}
+
+// Linux contains platform specific configuration for linux based containers.
+type Linux struct {
+	// Capabilities are linux capabilities that are kept for the container.
+	Capabilities []string `json:"capabilities"`
+}
+
+// User specifies linux specific user and group information for the container's
+// main process.
+type User struct {
+	// UID is the user id.
+	UID uint32 `json:"uid"`
+	// GID is the group id.
+	GID uint32 `json:"gid"`
+	// AdditionalGids are additional group ids set for the container's process.
+	AdditionalGids []uint32 `json:"additionalGids"`
+}

--- a/vendor/src/github.com/opencontainers/specs/implementations.md
+++ b/vendor/src/github.com/opencontainers/specs/implementations.md
@@ -1,0 +1,21 @@
+# Implementations
+
+The following sections link to associated projects, some of which are maintained by the OCI and some of which are maintained by external organizations.
+If you know of any associated projects that are not listed here, please file a pull request adding a link to that project.
+
+## Runtime (Container)
+
+* [opencontainers/runc](https://github.com/opencontainers/runc) - Reference implementation of OCI runtime
+
+## Runtime (Virtual Machine)
+
+* [hyperhq/runv](https://github.com/hyperhq/runv) - Hypervisor-based runtime for OCI
+
+## Bundle authoring
+
+* [kunalkushwaha/octool](https://github.com/kunalkushwaha/octool) - A config linter and validator.
+* [mrunalp/ocitools](https://github.com/mrunalp/ocitools) - A config generator.
+
+## Testing
+
+* [huawei-openlab/oct](https://github.com/huawei-openlab/oct) - Open Container Testing framework for OCI configuration and runtime

--- a/vendor/src/github.com/opencontainers/specs/principles.md
+++ b/vendor/src/github.com/opencontainers/specs/principles.md
@@ -1,0 +1,46 @@
+# The 5 principles of Standard Containers
+
+Define a unit of software delivery called a Standard Container.
+The goal of a Standard Container is to encapsulate a software component and all its dependencies in a format that is self-describing and portable, so that any compliant runtime can run it without extra dependencies, regardless of the underlying machine and the contents of the container.
+
+The specification for Standard Containers defines:
+
+1. configuration file formats
+2. a set of standard operations
+3. an execution environment.
+
+A great analogy for this is the physical shipping container used by the transportation industry.
+Shipping containers are a fundamental unit of delivery, they can be lifted, stacked, locked, loaded, unloaded and labelled.
+Irrespective of their contents, by standardizing the container itself it allowed for a consistent, more streamlined and efficient set of processes to be defined.
+For software Standard Containers offer similar functionality by being the fundamental, standardized, unit of delivery for a software package.
+
+## 1. Standard operations
+
+Standard Containers define a set of STANDARD OPERATIONS.
+They can be created, started, and stopped using standard container tools; copied and snapshotted using standard filesystem tools; and downloaded and uploaded using standard network tools.
+
+## 2. Content-agnostic
+
+Standard Containers are CONTENT-AGNOSTIC: all standard operations have the same effect regardless of the contents.
+They are started in the same way whether they contain a postgres database, a php application with its dependencies and application server, or Java build artifacts.
+
+## 3. Infrastructure-agnostic
+
+Standard Containers are INFRASTRUCTURE-AGNOSTIC: they can be run in any OCI supported infrastructure.
+For example, a standard container can be bundled on a laptop, uploaded to cloud storage, downloaded, run and snapshotted by a build server at a fiber hotel in Virginia, uploaded to 10 staging servers in a home-made private cloud cluster, then sent to 30 production instances across 3 public cloud regions.
+
+## 4. Designed for automation
+
+Standard Containers are DESIGNED FOR AUTOMATION: because they offer the same standard operations regardless of content and infrastructure, Standard Containers, are extremely well-suited for automation.
+In fact, you could say automation is their secret weapon.
+
+Many things that once required time-consuming and error-prone human effort can now be programmed.
+Before Standard Containers, by the time a software component ran in production, it had been individually built, configured, bundled, documented, patched, vendored, templated, tweaked and instrumented by 10 different people on 10 different computers.
+Builds failed, libraries conflicted, mirrors crashed, post-it notes were lost, logs were misplaced, cluster updates were half-broken.
+The process was slow, inefficient and cost a fortune - and was entirely different depending on the language and infrastructure provider.
+
+## 5. Industrial-grade delivery
+
+Standard Containers make INDUSTRIAL-GRADE DELIVERY of software a reality.
+Leveraging all of the properties listed above, Standard Containers are enabling large and small enterprises to streamline and automate their software delivery pipelines.
+Whether it is in-house devOps flows, or external customer-based software delivery mechanisms, Standard Containers are changing the way the community thinks about software packaging and delivery.

--- a/vendor/src/github.com/opencontainers/specs/runtime-config-linux.md
+++ b/vendor/src/github.com/opencontainers/specs/runtime-config-linux.md
@@ -1,0 +1,502 @@
+# Linux-specific Runtime Configuration
+
+## Namespaces
+
+A namespace wraps a global system resource in an abstraction that makes it appear to the processes within the namespace that they have their own isolated instance of the global resource.
+Changes to the global resource are visible to other processes that are members of the namespace, but are invisible to other processes.
+For more information, see [the man page](http://man7.org/linux/man-pages/man7/namespaces.7.html).
+
+Namespaces are specified as an array of entries inside the `namespaces` root field.
+The following parameters can be specified to setup namespaces:
+
+* **`type`** *(string, required)* - namespace type. The following namespaces types are supported:
+    * **`pid`** processes inside the container will only be able to see other processes inside the same container
+    * **`network`** the container will have its own network stack
+    * **`mount`** the container will have an isolated mount table
+    * **`ipc`** processes inside the container will only be able to communicate to other processes inside the same container via system level IPC
+    * **`uts`** the container will be able to have its own hostname and domain name
+    * **`user`** the container will be able to remap user and group IDs from the host to local users and groups within the container
+
+* **`path`** *(string, optional)* - path to namespace file
+
+If a path is specified, that particular file is used to join that type of namespace.
+Also, when a path is specified, a runtime MUST assume that the setup for that particular namespace has already been done and error out if the config specifies anything else related to that namespace.
+
+###### Example
+
+```json
+    "namespaces": [
+        {
+            "type": "pid",
+            "path": "/proc/1234/ns/pid"
+        },
+        {
+            "type": "network",
+            "path": "/var/run/netns/neta"
+        },
+        {
+            "type": "mount"
+        },
+        {
+            "type": "ipc"
+        },
+        {
+            "type": "uts"
+        },
+        {
+            "type": "user"
+        }
+    ]
+```
+
+## Devices
+
+`devices` is an array specifying the list of devices to be created in the container.
+
+The following parameters can be specified:
+
+* **`type`** *(char, required)* - type of device: `c`, `b`, `u` or `p`. More info in `man mknod`.
+
+* **`path`** *(string, optional)* - full path to device inside container
+
+* **`major, minor`** *(int64, required)* - major, minor numbers for device. More info in `man mknod`. There is a special value: `-1`, which means `*` for `device` cgroup setup.
+
+* **`permissions`** *(string, optional)* - cgroup permissions for device. A composition of `r` (*read*), `w` (*write*), and `m` (*mknod*).
+
+* **`fileMode`** *(uint32, optional)* - file mode for device file
+
+* **`uid`** *(uint32, optional)* - uid of device owner
+
+* **`gid`** *(uint32, optional)* - gid of device owner
+
+**`fileMode`**, **`uid`** and **`gid`** are required if **`path`** is given and are otherwise not allowed.
+
+###### Example
+
+```json
+   "devices": [
+        {
+            "path": "/dev/random",
+            "type": "c",
+            "major": 1,
+            "minor": 8,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/urandom",
+            "type": "c",
+            "major": 1,
+            "minor": 9,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/null",
+            "type": "c",
+            "major": 1,
+            "minor": 3,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/zero",
+            "type": "c",
+            "major": 1,
+            "minor": 5,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/tty",
+            "type": "c",
+            "major": 5,
+            "minor": 0,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        },
+        {
+            "path": "/dev/full",
+            "type": "c",
+            "major": 1,
+            "minor": 7,
+            "permissions": "rwm",
+            "fileMode": 0666,
+            "uid": 0,
+            "gid": 0
+        }
+    ]
+```
+
+## Control groups
+
+Also known as cgroups, they are used to restrict resource usage for a container and handle device access.
+cgroups provide controls to restrict cpu, memory, IO, pids and network for the container.
+For more information, see the [kernel cgroups documentation](https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt).
+
+The path to the cgroups can be specified in the Spec via `cgroupsPath`.
+`cgroupsPath` is expected to be relative to the cgroups mount point.
+If not specified, cgroups will be created under '/'.
+Implementations of the Spec can choose to name cgroups in any manner.
+The Spec does not include naming schema for cgroups.
+The Spec does not support [split hierarchy](https://www.kernel.org/doc/Documentation/cgroups/unified-hierarchy.txt).
+The cgroups will be created if they don't exist.
+
+```json
+   "cgroupsPath": "/myRuntime/myContainer"
+```
+
+`cgroupsPath` can be used to either control the cgroups hierarchy for containers or to run a new process in an existing container.
+
+You can configure a container's cgroups via the `resources` field of the Linux configuration.
+Do not specify `resources` unless limits have to be updated.
+For example, to run a new process in an existing container without updating limits, `resources` need not be specified.
+
+#### Disable out-of-memory killer
+
+`disableOOMKiller` contains a boolean (`true` or `false`) that enables or disables the Out of Memory killer for a cgroup.
+If enabled (`false`), tasks that attempt to consume more memory than they are allowed are immediately killed by the OOM killer.
+The OOM killer is enabled by default in every cgroup using the `memory` subsystem.
+To disable it, specify a value of `true`.
+For more information, see [the memory cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/memory.txt).
+
+* **`disableOOMKiller`** *(bool, optional)* - enables or disables the OOM killer
+
+###### Example
+
+```json
+    "disableOOMKiller": false
+```
+
+#### Set oom_score_adj
+
+More information on `oom_score_adj` available [here](https://www.kernel.org/doc/Documentation/filesystems/proc.txt).
+
+```json
+    "oomScoreAdj": 0
+```
+
+#### Memory
+
+`memory` represents the cgroup subsystem `memory` and it's used to set limits on the container's memory usage.
+For more information, see [the memory cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/memory.txt).
+
+The following parameters can be specified to setup the controller:
+
+* **`limit`** *(uint64, optional)* - sets limit of memory usage
+
+* **`reservation`** *(uint64, optional)* - sets soft limit of memory usage
+
+* **`swap`** *(uint64, optional)* - sets limit of memory+Swap usage
+
+* **`kernel`** *(uint64, optional)* - sets hard limit for kernel memory
+
+* **`swappiness`** *(uint64, optional)* - sets swappiness parameter of vmscan (See sysctl's vm.swappiness)
+
+###### Example
+
+```json
+    "memory": {
+        "limit": 0,
+        "reservation": 0,
+        "swap": 0,
+        "kernel": 0,
+        "swappiness": -1
+    }
+```
+
+#### CPU
+
+`cpu` represents the cgroup subsystems `cpu` and `cpusets`.
+For more information, see [the cpusets cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/cpusets.txt).
+
+The following parameters can be specified to setup the controller:
+
+* **`shares`** *(uint64, optional)* - specifies a relative share of CPU time available to the tasks in a cgroup
+
+* **`quota`** *(uint64, optional)* - specifies the total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by **`period`** below)
+
+* **`period`** *(uint64, optional)* - specifies a period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated (CFS scheduler only)
+
+* **`realtimeRuntime`** *(uint64, optional)* - specifies a period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources
+
+* **`realtimePeriod`** *(uint64, optional)* - same as **`period`** but applies to realtime scheduler only
+
+* **`cpus`** *(cpus, optional)* - list of CPUs the container will run in
+
+* **`mems`** *(mems, optional)* - list of Memory Nodes the container will run in
+
+###### Example
+
+```json
+    "cpu": {
+        "shares": 0,
+        "quota": 0,
+        "period": 0,
+        "realtimeRuntime": 0,
+        "realtimePeriod": 0,
+        "cpus": "",
+        "mems": ""
+    }
+```
+
+#### Block IO Controller
+
+`blockIO` represents the cgroup subsystem `blkio` which implements the block io controller.
+For more information, see [the kernel cgroups documentation about blkio](https://www.kernel.org/doc/Documentation/cgroups/blkio-controller.txt).
+
+The following parameters can be specified to setup the controller:
+
+* **`blkioWeight`** *(uint16, optional)* - specifies per-cgroup weight. This is default weight of the group on all devices until and unless overridden by per-device rules. The range is from 10 to 1000.
+
+* **`blkioLeafWeight`** *(uint16, optional)* - equivalents of `blkioWeight` for the purpose of deciding how much weight tasks in the given cgroup has while competing with the cgroup's child cgroups. The range is from 10 to 1000.
+
+* **`blkioWeightDevice`** *(array, optional)* - specifies the list of devices which will be bandwidth rate limited. The following parameters can be specified per-device:
+    * **`major, minor`** *(int64, required)* - major, minor numbers for device. More info in `man mknod`.
+    * **`weight`** *(uint16, optional)* - bandwidth rate for the device, range is from 10 to 1000
+    * **`leafWeight`** *(uint16, optional)* - bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+
+    You must specify at least one of `weight` or `leafWeight` in a given entry, and can specify both.
+
+* **`blkioThrottleReadBpsDevice`**, **`blkioThrottleWriteBpsDevice`**, **`blkioThrottleReadIOPSDevice`**, **`blkioThrottleWriteIOPSDevice`** *(array, optional)* - specify the list of devices which will be IO rate limited. The following parameters can be specified per-device:
+    * **`major, minor`** *(int64, required)* - major, minor numbers for device. More info in `man mknod`.
+    * **`rate`** *(uint64, required)* - IO rate limit for the device
+
+###### Example
+
+```json
+    "blockIO": {
+        "blkioWeight": 0,
+        "blkioLeafWeight": 0,
+        "blkioWeightDevice": [
+            {
+                "major": 8,
+                "minor": 0,
+                "weight": 500,
+                "leafWeight": 300
+            },
+            {
+                "major": 8,
+                "minor": 16,
+                "weight": 500
+            }
+        ],
+        "blkioThrottleReadBpsDevice": [
+            {
+                "major": 8,
+                "minor": 0,
+                "rate": 600
+            }
+        ],
+        "blkioThrottleWriteIOPSDevice": [
+            {
+                "major": 8,
+                "minor": 16,
+                "rate": 300
+            }
+        ]
+    }
+```
+
+#### Huge page limits
+
+`hugepageLimits` represents the `hugetlb` controller which allows to limit the
+HugeTLB usage per control group and enforces the controller limit during page fault.
+For more information, see the [kernel cgroups documentation about HugeTLB](https://www.kernel.org/doc/Documentation/cgroups/hugetlb.txt).
+
+`hugepageLimits` is an array of entries, each having the following structure:
+
+* **`pageSize`** *(string, required)* - hugepage size
+
+* **`limit`** *(uint64, required)* - limit in bytes of *hugepagesize* HugeTLB usage
+
+###### Example
+
+```json
+   "hugepageLimits": [
+        {
+            "pageSize": "2MB",
+            "limit": 9223372036854771712
+        }
+   ]
+```
+
+#### Network
+
+`network` represents the cgroup subsystems `net_cls` and `net_prio`.
+For more information, see [the net\_cls cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/net_cls.txt) and [the net\_prio cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/net_prio.txt).
+
+The following parameters can be specified to setup these cgroup controllers:
+
+* **`classID`** *(string, optional)* - is the network class identifier the cgroup's network packets will be tagged with
+
+* **`priorities`** *(array, optional)* - specifies a list of objects of the priorities assigned to traffic originating from
+processes in the group and egressing the system on various interfaces. The following parameters can be specified per-priority:
+    * **`name`** *(string, required)* - interface name
+    * **`priority`** *(uint32, required)* - priority applied to the interface
+
+###### Example
+
+```json
+   "network": {
+        "classID": "0x100001",
+        "priorities": [
+            {
+                "name": "eth0",
+                "priority": 500
+            },
+            {
+                "name": "eth1",
+                "priority": 1000
+            }
+        ]
+   }
+```
+
+#### PIDs
+
+`pids` represents the cgroup subsystem `pids`.
+For more information, see [the pids cgroup man page](https://www.kernel.org/doc/Documentation/cgroups/pids.txt
+).
+
+The following paramters can be specified to setup the controller:
+
+* **`limit`** *(int64, required)* - specifies the maximum number of tasks in the cgroup
+
+###### Example
+
+```json
+   "pids": {
+        "limit": 32771
+   }
+```
+
+## Sysctl
+
+sysctl allows kernel parameters to be modified at runtime for the container.
+For more information, see [the man page](http://man7.org/linux/man-pages/man8/sysctl.8.html)
+
+###### Example
+
+```json
+   "sysctl": {
+        "net.ipv4.ip_forward": "1",
+        "net.core.somaxconn": "256"
+   }
+```
+
+## Rlimits
+
+rlimits allow setting resource limits.
+`type` is a string with a value from those defined in [the man page](http://man7.org/linux/man-pages/man2/setrlimit.2.html).
+The kernel enforces the `soft` limit for a resource while the `hard` limit acts as a ceiling for that value that could be set by an unprivileged process.
+
+###### Example
+
+```json
+   "rlimits": [
+        {
+            "type": "RLIMIT_NPROC",
+            "soft": 1024,
+            "hard": 102400
+        }
+   ]
+```
+
+## SELinux process label
+
+SELinux process label specifies the label with which the processes in a container are run.
+For more information about SELinux, see  [Selinux documentation](http://selinuxproject.org/page/Main_Page)
+
+###### Example
+
+```json
+   "selinuxProcessLabel": "system_u:system_r:svirt_lxc_net_t:s0:c124,c675"
+```
+
+## Apparmor profile
+
+Apparmor profile specifies the name of the apparmor profile that will be used for the container.
+For more information about Apparmor, see [Apparmor documentation](https://wiki.ubuntu.com/AppArmor)
+
+###### Example
+
+```json
+   "apparmorProfile": "acme_secure_profile"
+```
+
+## seccomp
+
+Seccomp provides application sandboxing mechanism in the Linux kernel.
+Seccomp configuration allows one to configure actions to take for matched syscalls and furthermore also allows matching on values passed as arguments to syscalls.
+For more information about Seccomp, see [Seccomp kernel documentation](https://www.kernel.org/doc/Documentation/prctl/seccomp_filter.txt)
+The actions, architectures, and operators are strings that match the definitions in seccomp.h from [libseccomp](https://github.com/seccomp/libseccomp) and are translated to corresponding values.
+A valid list of constants as of Libseccomp v2.2.3 is contained below.
+
+Architecture Constants
+* `SCMP_ARCH_X86`
+* `SCMP_ARCH_X86_64`
+* `SCMP_ARCH_X32`
+* `SCMP_ARCH_ARM`
+* `SCMP_ARCH_AARCH64`
+* `SCMP_ARCH_MIPS`
+* `SCMP_ARCH_MIPS64`
+* `SCMP_ARCH_MIPS64N32`
+* `SCMP_ARCH_MIPSEL`
+* `SCMP_ARCH_MIPSEL64`
+* `SCMP_ARCH_MIPSEL64N32`
+
+Action Constants:
+* `SCMP_ACT_KILL`
+* `SCMP_ACT_TRAP`
+* `SCMP_ACT_ERRNO`
+* `SCMP_ACT_TRACE`
+* `SCMP_ACT_ALLOW`
+
+Operator Constants:
+* `SCMP_CMP_NE`
+* `SCMP_CMP_LT`
+* `SCMP_CMP_LE`
+* `SCMP_CMP_EQ`
+* `SCMP_CMP_GE`
+* `SCMP_CMP_GT`
+* `SCMP_CMP_MASKED_EQ`
+
+###### Example
+
+```json
+   "seccomp": {
+       "defaultAction": "SCMP_ACT_ALLOW",
+       "architectures": [
+           "SCMP_ARCH_X86"
+       ],
+       "syscalls": [
+           {
+               "name": "getcwd",
+               "action": "SCMP_ACT_ERRNO"
+           }
+       ]
+   }
+```
+
+## Rootfs Mount Propagation
+
+rootfsPropagation sets the rootfs's mount propagation.
+Its value is either slave, private, or shared.
+[The kernel doc](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) has more information about mount propagation.
+
+###### Example
+
+```json
+    "rootfsPropagation": "slave",
+```

--- a/vendor/src/github.com/opencontainers/specs/runtime-config.md
+++ b/vendor/src/github.com/opencontainers/specs/runtime-config.md
@@ -1,0 +1,121 @@
+# Runtime Configuration
+
+## Hooks
+
+Lifecycle hooks allow custom events for different points in a container's runtime.
+Presently there are `Prestart`, `Poststart` and `Poststop`.
+
+* [`Prestart`](#prestart) is a list of hooks to be run before the container process is executed
+* [`Poststart`](#poststart) is a list of hooks to be run immediately after the container process is started
+* [`Poststop`](#poststop) is a list of hooks to be run after the container process exits
+
+Hooks allow one to run code before/after various lifecycle events of the container.
+Hooks MUST be called in the listed order.
+The state of the container is passed to the hooks over stdin, so the hooks could get the information they need to do their work.
+
+Hook paths are absolute and are executed from the host's filesystem.
+
+### Prestart
+
+The pre-start hooks are called after the container process is spawned, but before the user supplied command is executed.
+They are called after the container namespaces are created on Linux, so they provide an opportunity to customize the container.
+In Linux, for e.g., the network namespace could be configured in this hook.
+
+If a hook returns a non-zero exit code, then an error including the exit code and the stderr is returned to the caller and the container is torn down.
+
+### Poststart
+
+The post-start hooks are called after the user process is started.
+For example this hook can notify user that real process is spawned.
+
+If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
+
+### Poststop
+
+The post-stop hooks are called after the container process is stopped.
+Cleanup or debugging could be performed in such a hook.
+If a hook returns a non-zero exit code, then an error is logged and the remaining hooks are executed.
+
+*Example*
+
+```json
+    "hooks" : {
+        "prestart": [
+            {
+                "path": "/usr/bin/fix-mounts",
+                "args": ["arg1", "arg2"],
+                "env":  [ "key1=value1"]
+            },
+            {
+                "path": "/usr/bin/setup-network"
+            }
+        ],
+        "poststart": [
+            {
+                "path": "/usr/bin/notify-start"
+            }
+        ],
+        "poststop": [
+            {
+                "path": "/usr/sbin/cleanup.sh",
+                "args": ["-f"]
+            }
+        ]
+    }
+```
+
+`path` is required for a hook.
+`args` and `env` are optional.
+
+## Mount Configuration
+
+Additional filesystems can be declared as "mounts", specified in the *mounts* object.
+Keys in this object are names of mount points from portable config.
+Values are objects with configuration of mount points.
+The parameters are similar to the ones in [the Linux mount system call](http://man7.org/linux/man-pages/man2/mount.2.html).
+Only [mounts from the portable config](config.md#mount-points) will be mounted.
+
+* **`type`** (string, required) Linux, *filesystemtype* argument supported by the kernel are listed in */proc/filesystems* (e.g., "minix", "ext2", "ext3", "jfs", "xfs", "reiserfs", "msdos", "proc", "nfs", "iso9660"). Windows: ntfs
+* **`source`** (string, required) a device name, but can also be a directory name or a dummy. Windows, the volume name that is the target of the mount point. \\?\Volume\{GUID}\ (on Windows source is called target)
+* **`options`** (list of strings, optional) in the fstab format [https://wiki.archlinux.org/index.php/Fstab](https://wiki.archlinux.org/index.php/Fstab).
+
+*Example (Linux)*
+
+```json
+"mounts": {
+    "proc": {
+        "type": "proc",
+        "source": "proc",
+        "options": []
+    },
+    "dev": {
+        "type": "tmpfs",
+        "source": "tmpfs",
+        "options": ["nosuid","strictatime","mode=755","size=65536k"]
+    },
+    "devpts": {
+        "type": "devpts",
+        "source": "devpts",
+        "options": ["nosuid","noexec","newinstance","ptmxmode=0666","mode=0620","gid=5"]
+    },
+    "data": {
+        "type": "bind",
+        "source": "/volumes/testing",
+        "options": ["rbind","rw"]
+    }
+}
+```
+
+*Example (Windows)*
+
+```json
+"mounts": {
+    "myfancymountpoint": {
+        "type": "ntfs",
+        "source": "\\\\?\\Volume\\{2eca078d-5cbc-43d3-aff8-7e8511f60d0e}\\",
+        "options": []
+    }
+}
+```
+
+See links for details about [mountvol](http://ss64.com/nt/mountvol.html) and [SetVolumeMountPoint](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365561(v=vs.85).aspx) in Windows.

--- a/vendor/src/github.com/opencontainers/specs/runtime-linux.md
+++ b/vendor/src/github.com/opencontainers/specs/runtime-linux.md
@@ -1,0 +1,8 @@
+# Linux Runtime
+
+## File descriptors
+By default, only the `stdin`, `stdout` and `stderr` file descriptors are kept open for the application by the runtime.
+
+The runtime may pass additional file descriptors to the application to support features such as [socket activation](http://0pointer.de/blog/projects/socket-activated-containers.html).
+
+Some of the file descriptors may be redirected to `/dev/null` even though they are open.

--- a/vendor/src/github.com/opencontainers/specs/runtime.md
+++ b/vendor/src/github.com/opencontainers/specs/runtime.md
@@ -1,0 +1,56 @@
+# Runtime and Lifecycle
+
+## State
+
+Runtime MUST store container metadata on disk so that external tools can consume and act on this information.
+It is recommended that this data be stored in a temporary filesystem so that it can be removed on a system reboot.
+On Linux/Unix based systems the metadata MUST be stored under `/run/opencontainer/containers`.
+For non-Linux/Unix based systems the location of the root metadata directory is currently undefined.
+Within that directory there MUST be one directory for each container created, where the name of the directory MUST be the ID of the container.
+For example: for a Linux container with an ID of `173975398351`, there will be a corresponding directory: `/run/opencontainer/containers/173975398351`.
+Within each container's directory, there MUST be a JSON encoded file called `state.json` that contains the runtime state of the container.
+For example: `/run/opencontainer/containers/173975398351/state.json`.
+
+The `state.json` file MUST contain all of the following properties:
+
+* **`version`**: (string) is the OCF specification version used when creating the container.
+* **`id`**: (string) is the container's ID.
+This MUST be unique across all containers on this host.
+There is no requirement that it be unique across hosts.
+The ID is provided in the state because hooks will be executed with the state as the payload.
+This allows the hooks to perform cleanup and teardown logic after the runtime destroys its own state.
+* **`pid`**: (int) is the ID of the main process within the container, as seen by the host.
+* **`bundlePath`**: (string) is the absolute path to the container's bundle directory.
+This is provided so that consumers can find the container's configuration and root filesystem on the host.
+
+*Example*
+
+```json
+{
+    "id": "oc-container",
+    "pid": 4422,
+    "root": "/containers/redis"
+}
+```
+
+## Lifecycle
+
+### Create
+
+Creates the container: file system, namespaces, cgroups, capabilities.
+
+### Start (process)
+
+Runs a process in a container.
+Can be invoked several times.
+
+### Stop (process)
+
+Not sure we need that from runc cli.
+Process is killed from the outside.
+
+This event needs to be captured by runc to run onstop event handlers.
+
+## Hooks
+
+See [runtime configuration for hooks](./runtime-config.md)

--- a/vendor/src/github.com/opencontainers/specs/runtime_config.go
+++ b/vendor/src/github.com/opencontainers/specs/runtime_config.go
@@ -1,0 +1,42 @@
+package specs
+
+// RuntimeSpec contains host-specific configuration information for
+// a container. This information must not be included when the bundle
+// is packaged for distribution.
+type RuntimeSpec struct {
+	// Mounts is a mapping of names to mount configurations.
+	// Which mounts will be mounted and where should be chosen with MountPoints
+	// in Spec.
+	Mounts map[string]Mount `json:"mounts"`
+	// Hooks are the commands run at various lifecycle events of the container.
+	Hooks Hooks `json:"hooks"`
+}
+
+// Hook specifies a command that is run at a particular event in the lifecycle of a container
+type Hook struct {
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+	Env  []string `json:"env"`
+}
+
+// Hooks for container setup and teardown
+type Hooks struct {
+	// Prestart is a list of hooks to be run before the container process is executed.
+	// On Linux, they are run after the container namespaces are created.
+	Prestart []Hook `json:"prestart"`
+	// Poststart is a list of hooks to be run after the container process is started.
+	Poststart []Hook `json:"poststart"`
+	// Poststop is a list of hooks to be run after the container process exits.
+	Poststop []Hook `json:"poststop"`
+}
+
+// Mount specifies a mount for a container
+type Mount struct {
+	// Type specifies the mount kind.
+	Type string `json:"type"`
+	// Source specifies the source path of the mount.  In the case of bind mounts on
+	// linux based systems this would be the file on the host.
+	Source string `json:"source"`
+	// Options are fstab style mount options.
+	Options []string `json:"options"`
+}

--- a/vendor/src/github.com/opencontainers/specs/runtime_config_linux.go
+++ b/vendor/src/github.com/opencontainers/specs/runtime_config_linux.go
@@ -1,0 +1,301 @@
+package specs
+
+import "os"
+
+// LinuxStateDirectory holds the container's state information
+const LinuxStateDirectory = "/run/opencontainer/containers"
+
+// LinuxRuntimeSpec is the full specification for linux containers.
+type LinuxRuntimeSpec struct {
+	RuntimeSpec
+	// LinuxRuntime is platform specific configuration for linux based containers.
+	Linux LinuxRuntime `json:"linux"`
+}
+
+// LinuxRuntime hosts the Linux-only runtime information
+type LinuxRuntime struct {
+	// UIDMapping specifies user mappings for supporting user namespaces on linux.
+	UIDMappings []IDMapping `json:"uidMappings"`
+	// GIDMapping specifies group mappings for supporting user namespaces on linux.
+	GIDMappings []IDMapping `json:"gidMappings"`
+	// Rlimits specifies rlimit options to apply to the container's process.
+	Rlimits []Rlimit `json:"rlimits"`
+	// Sysctl are a set of key value pairs that are set for the container on start
+	Sysctl map[string]string `json:"sysctl"`
+	// Resources contain cgroup information for handling resource constraints
+	// for the container
+	Resources *Resources `json:"resources"`
+	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
+	// The path is expected to be relative to the cgroups mountpoint.
+	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
+	CgroupsPath string `json:"cgroupsPath"`
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	Namespaces []Namespace `json:"namespaces"`
+	// Devices are a list of device nodes that are created and enabled for the container
+	Devices []Device `json:"devices"`
+	// ApparmorProfile specified the apparmor profile for the container.
+	ApparmorProfile string `json:"apparmorProfile"`
+	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
+	SelinuxProcessLabel string `json:"selinuxProcessLabel"`
+	// Seccomp specifies the seccomp security settings for the container.
+	Seccomp Seccomp `json:"seccomp"`
+	// RootfsPropagation is the rootfs mount propagation mode for the container
+	RootfsPropagation string `json:"rootfsPropagation"`
+}
+
+// Namespace is the configuration for a linux namespace
+type Namespace struct {
+	// Type is the type of Linux namespace
+	Type NamespaceType `json:"type"`
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	Path string `json:"path"`
+}
+
+// NamespaceType is one of the linux namespaces
+type NamespaceType string
+
+const (
+	// PIDNamespace for isolating process IDs
+	PIDNamespace NamespaceType = "pid"
+	// NetworkNamespace for isolating network devices, stacks, ports, etc
+	NetworkNamespace = "network"
+	// MountNamespace for isolating mount points
+	MountNamespace = "mount"
+	// IPCNamespace for isolating System V IPC, POSIX message queues
+	IPCNamespace = "ipc"
+	// UTSNamespace for isolating hostname and NIS domain name
+	UTSNamespace = "uts"
+	// UserNamespace for isolating user and group IDs
+	UserNamespace = "user"
+)
+
+// IDMapping specifies UID/GID mappings
+type IDMapping struct {
+	// HostID is the UID/GID of the host user or group
+	HostID uint32 `json:"hostID"`
+	// ContainerID is the UID/GID of the container's user or group
+	ContainerID uint32 `json:"containerID"`
+	// Size is the length of the range of IDs mapped between the two namespaces
+	Size uint32 `json:"size"`
+}
+
+// Rlimit type and restrictions
+type Rlimit struct {
+	// Type of the rlimit to set
+	Type string `json:"type"`
+	// Hard is the hard limit for the specified type
+	Hard uint64 `json:"hard"`
+	// Soft is the soft limit for the specified type
+	Soft uint64 `json:"soft"`
+}
+
+// HugepageLimit structure corresponds to limiting kernel hugepages
+type HugepageLimit struct {
+	// Pagesize is the hugepage size
+	Pagesize string `json:"pageSize"`
+	// Limit is the limit of "hugepagesize" hugetlb usage
+	Limit uint64 `json:"limit"`
+}
+
+// InterfacePriority for network interfaces
+type InterfacePriority struct {
+	// Name is the name of the network interface
+	Name string `json:"name"`
+	// Priority for the interface
+	Priority uint32 `json:"priority"`
+}
+
+// blockIODevice holds major:minor format supported in blkio cgroup
+type blockIODevice struct {
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+}
+
+// WeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+type WeightDevice struct {
+	blockIODevice
+	// Weight is the bandwidth rate for the device, range is from 10 to 1000
+	Weight uint16 `json:"weight"`
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	LeafWeight uint16 `json:"leafWeight"`
+}
+
+// ThrottleDevice struct holds a `major:minor rate_per_second` pair
+type ThrottleDevice struct {
+	blockIODevice
+	// Rate is the IO rate limit per cgroup per device
+	Rate uint64 `json:"rate"`
+}
+
+// BlockIO for Linux cgroup 'blkio' resource management
+type BlockIO struct {
+	// Specifies per cgroup weight, range is from 10 to 1000
+	Weight uint16 `json:"blkioWeight"`
+	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	LeafWeight uint16 `json:"blkioLeafWeight"`
+	// Weight per cgroup per device, can override BlkioWeight
+	WeightDevice []*WeightDevice `json:"blkioWeightDevice"`
+	// IO read rate limit per cgroup per device, bytes per second
+	ThrottleReadBpsDevice []*ThrottleDevice `json:"blkioThrottleReadBpsDevice"`
+	// IO write rate limit per cgroup per device, bytes per second
+	ThrottleWriteBpsDevice []*ThrottleDevice `json:"blkioThrottleWriteBpsDevice"`
+	// IO read rate limit per cgroup per device, IO per second
+	ThrottleReadIOPSDevice []*ThrottleDevice `json:"blkioThrottleReadIOPSDevice"`
+	// IO write rate limit per cgroup per device, IO per second
+	ThrottleWriteIOPSDevice []*ThrottleDevice `json:"blkioThrottleWriteIOPSDevice"`
+}
+
+// Memory for Linux cgroup 'memory' resource management
+type Memory struct {
+	// Memory limit (in bytes)
+	Limit uint64 `json:"limit"`
+	// Memory reservation or soft_limit (in bytes)
+	Reservation uint64 `json:"reservation"`
+	// Total memory usage (memory + swap); set `-1' to disable swap
+	Swap uint64 `json:"swap"`
+	// Kernel memory limit (in bytes)
+	Kernel uint64 `json:"kernel"`
+	// How aggressive the kernel will swap memory pages. Range from 0 to 100. Set -1 to use system default
+	Swappiness uint64 `json:"swappiness"`
+}
+
+// CPU for Linux cgroup 'cpu' resource management
+type CPU struct {
+	// CPU shares (relative weight vs. other cgroups with cpu shares)
+	Shares uint64 `json:"shares"`
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period
+	Quota uint64 `json:"quota"`
+	// CPU period to be used for hardcapping (in usecs). 0 to use system default
+	Period uint64 `json:"period"`
+	// How many time CPU will use in realtime scheduling (in usecs)
+	RealtimeRuntime uint64 `json:"realtimeRuntime"`
+	// CPU period to be used for realtime scheduling (in usecs)
+	RealtimePeriod uint64 `json:"realtimePeriod"`
+	// CPU to use within the cpuset
+	Cpus string `json:"cpus"`
+	// MEM to use within the cpuset
+	Mems string `json:"mems"`
+}
+
+// Pids for Linux cgroup 'pids' resource management (Linux 4.3)
+type Pids struct {
+	// Maximum number of PIDs. A value <= 0 indicates "no limit".
+	Limit int64 `json:"limit"`
+}
+
+// Network identification and priority configuration
+type Network struct {
+	// Set class identifier for container's network packets
+	// this is actually a string instead of a uint64 to overcome the json
+	// limitation of specifying hex numbers
+	ClassID string `json:"classID"`
+	// Set priority of network traffic for container
+	Priorities []InterfacePriority `json:"priorities"`
+}
+
+// Resources has container runtime resource constraints
+type Resources struct {
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	DisableOOMKiller bool `json:"disableOOMKiller"`
+	// Specify an oom_score_adj for the container. Optional.
+	OOMScoreAdj int `json:"oomScoreAdj"`
+	// Memory restriction configuration
+	Memory Memory `json:"memory"`
+	// CPU resource restriction configuration
+	CPU CPU `json:"cpu"`
+	// Task resource restriction configuration.
+	Pids Pids `json:"pids"`
+	// BlockIO restriction configuration
+	BlockIO BlockIO `json:"blockIO"`
+	// Hugetlb limit (in bytes)
+	HugepageLimits []HugepageLimit `json:"hugepageLimits"`
+	// Network restriction configuration
+	Network Network `json:"network"`
+}
+
+// Device represents the information on a Linux special device file
+type Device struct {
+	// Path to the device.
+	Path string `json:"path"`
+	// Device type, block, char, etc.
+	Type rune `json:"type"`
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+	// Cgroup permissions format, rwm.
+	Permissions string `json:"permissions"`
+	// FileMode permission bits for the device.
+	FileMode os.FileMode `json:"fileMode"`
+	// UID of the device.
+	UID uint32 `json:"uid"`
+	// Gid of the device.
+	GID uint32 `json:"gid"`
+}
+
+// Seccomp represents syscall restrictions
+type Seccomp struct {
+	DefaultAction Action     `json:"defaultAction"`
+	Architectures []Arch     `json:"architectures"`
+	Syscalls      []*Syscall `json:"syscalls"`
+}
+
+// Additional architectures permitted to be used for system calls
+// By default only the native architecture of the kernel is permitted
+type Arch string
+
+const (
+	ArchX86         Arch = "SCMP_ARCH_X86"
+	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
+	ArchX32         Arch = "SCMP_ARCH_X32"
+	ArchARM         Arch = "SCMP_ARCH_ARM"
+	ArchAARCH64     Arch = "SCMP_ARCH_AARCH64"
+	ArchMIPS        Arch = "SCMP_ARCH_MIPS"
+	ArchMIPS64      Arch = "SCMP_ARCH_MIPS64"
+	ArchMIPS64N32   Arch = "SCMP_ARCH_MIPS64N32"
+	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
+	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
+	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+)
+
+// Action taken upon Seccomp rule match
+type Action string
+
+const (
+	ActKill  Action = "SCMP_ACT_KILL"
+	ActTrap  Action = "SCMP_ACT_TRAP"
+	ActErrno Action = "SCMP_ACT_ERRNO"
+	ActTrace Action = "SCMP_ACT_TRACE"
+	ActAllow Action = "SCMP_ACT_ALLOW"
+)
+
+// Operator used to match syscall arguments in Seccomp
+type Operator string
+
+const (
+	OpNotEqual     Operator = "SCMP_CMP_NE"
+	OpLessThan     Operator = "SCMP_CMP_LT"
+	OpLessEqual    Operator = "SCMP_CMP_LE"
+	OpEqualTo      Operator = "SCMP_CMP_EQ"
+	OpGreaterEqual Operator = "SCMP_CMP_GE"
+	OpGreaterThan  Operator = "SCMP_CMP_GT"
+	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
+)
+
+// Arg used for matching specific syscall arguments in Seccomp
+type Arg struct {
+	Index    uint     `json:"index"`
+	Value    uint64   `json:"value"`
+	ValueTwo uint64   `json:"valueTwo"`
+	Op       Operator `json:"op"`
+}
+
+// Syscall is used to match a syscall in Seccomp
+type Syscall struct {
+	Name   string `json:"name"`
+	Action Action `json:"action"`
+	Args   []*Arg `json:"args"`
+}

--- a/vendor/src/github.com/opencontainers/specs/state.go
+++ b/vendor/src/github.com/opencontainers/specs/state.go
@@ -1,0 +1,16 @@
+package specs
+
+// State holds information about the runtime state of the container.
+// This information will be stored in a file called `state.json`.
+// The location of this file will be operating system specific. On Linux
+// it will be in `/run/opencontainers/runc/<containerID>/state.json`
+type State struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"version"`
+	// ID is the container ID
+	ID string `json:"id"`
+	// Pid is the process id for the container's main process.
+	Pid int `json:"pid"`
+	// BundlePath is the path to the container's bundle directory.
+	BundlePath string `json:"bundlePath"`
+}

--- a/vendor/src/github.com/opencontainers/specs/version.go
+++ b/vendor/src/github.com/opencontainers/specs/version.go
@@ -1,0 +1,15 @@
+package specs
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 0
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 2
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)

--- a/vendor/src/github.com/seccomp/libseccomp-golang/LICENSE
+++ b/vendor/src/github.com/seccomp/libseccomp-golang/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015 Matthew Heon <mheon@redhat.com>
+Copyright (c) 2015 Paul Moore <pmoore@redhat.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/src/github.com/seccomp/libseccomp-golang/README
+++ b/vendor/src/github.com/seccomp/libseccomp-golang/README
@@ -1,0 +1,26 @@
+libseccomp-golang: Go Language Bindings for the libseccomp Project
+===============================================================================
+https://github.com/seccomp/libseccomp-golang
+https://github.com/seccomp/libseccomp
+
+The libseccomp library provides an easy to use, platform independent, interface
+to the Linux Kernel's syscall filtering mechanism.  The libseccomp API is
+designed to abstract away the underlying BPF based syscall filter language and
+present a more conventional function-call based filtering interface that should
+be familiar to, and easily adopted by, application developers.
+
+The libseccomp-golang library provides a Go based interface to the libseccomp
+library.
+
+* Online Resources
+
+The library source repository currently lives on GitHub at the following URLs:
+
+	-> https://github.com/seccomp/libseccomp-golang
+	-> https://github.com/seccomp/libseccomp
+
+The project mailing list is currently hosted on Google Groups at the URL below,
+please note that a Google account is not required to subscribe to the mailing
+list.
+
+	-> https://groups.google.com/d/forum/libseccomp

--- a/vendor/src/github.com/seccomp/libseccomp-golang/seccomp.go
+++ b/vendor/src/github.com/seccomp/libseccomp-golang/seccomp.go
@@ -1,0 +1,827 @@
+// +build linux
+
+// Public API specification for libseccomp Go bindings
+// Contains public API for the bindings
+
+// Package seccomp rovides bindings for libseccomp, a library wrapping the Linux
+// seccomp syscall. Seccomp enables an application to restrict system call use
+// for itself and its children.
+package seccomp
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+// C wrapping code
+
+// #cgo LDFLAGS: -lseccomp
+// #include <stdlib.h>
+// #include <seccomp.h>
+import "C"
+
+// Exported types
+
+// ScmpArch represents a CPU architecture. Seccomp can restrict syscalls on a
+// per-architecture basis.
+type ScmpArch uint
+
+// ScmpAction represents an action to be taken on a filter rule match in
+// libseccomp
+type ScmpAction uint
+
+// ScmpCompareOp represents a comparison operator which can be used in a filter
+// rule
+type ScmpCompareOp uint
+
+// ScmpCondition represents a rule in a libseccomp filter context
+type ScmpCondition struct {
+	Argument uint          `json:"argument,omitempty"`
+	Op       ScmpCompareOp `json:"operator,omitempty"`
+	Operand1 uint64        `json:"operand_one,omitempty"`
+	Operand2 uint64        `json:"operand_two,omitempty"`
+}
+
+// ScmpSyscall represents a Linux System Call
+type ScmpSyscall int32
+
+// Exported Constants
+
+const (
+	// Valid architectures recognized by libseccomp
+	// ARM64 and all MIPS architectures are unsupported by versions of the
+	// library before v2.2 and will return errors if used
+
+	// ArchInvalid is a placeholder to ensure uninitialized ScmpArch
+	// variables are invalid
+	ArchInvalid ScmpArch = iota
+	// ArchNative is the native architecture of the kernel
+	ArchNative ScmpArch = iota
+	// ArchX86 represents 32-bit x86 syscalls
+	ArchX86 ScmpArch = iota
+	// ArchAMD64 represents 64-bit x86-64 syscalls
+	ArchAMD64 ScmpArch = iota
+	// ArchX32 represents 64-bit x86-64 syscalls (32-bit pointers)
+	ArchX32 ScmpArch = iota
+	// ArchARM represents 32-bit ARM syscalls
+	ArchARM ScmpArch = iota
+	// ArchARM64 represents 64-bit ARM syscalls
+	ArchARM64 ScmpArch = iota
+	// ArchMIPS represents 32-bit MIPS syscalls
+	ArchMIPS ScmpArch = iota
+	// ArchMIPS64 represents 64-bit MIPS syscalls
+	ArchMIPS64 ScmpArch = iota
+	// ArchMIPS64N32 represents 64-bit MIPS syscalls (32-bit pointers)
+	ArchMIPS64N32 ScmpArch = iota
+	// ArchMIPSEL represents 32-bit MIPS syscalls (little endian)
+	ArchMIPSEL ScmpArch = iota
+	// ArchMIPSEL64 represents 64-bit MIPS syscalls (little endian)
+	ArchMIPSEL64 ScmpArch = iota
+	// ArchMIPSEL64N32 represents 64-bit MIPS syscalls (little endian,
+	// 32-bit pointers)
+	ArchMIPSEL64N32 ScmpArch = iota
+)
+
+const (
+	// Supported actions on filter match
+
+	// ActInvalid is a placeholder to ensure uninitialized ScmpAction
+	// variables are invalid
+	ActInvalid ScmpAction = iota
+	// ActKill kills the process
+	ActKill ScmpAction = iota
+	// ActTrap throws SIGSYS
+	ActTrap ScmpAction = iota
+	// ActErrno causes the syscall to return a negative error code. This
+	// code can be set with the SetReturnCode method
+	ActErrno ScmpAction = iota
+	// ActTrace causes the syscall to notify tracing processes with the
+	// given error code. This code can be set with the SetReturnCode method
+	ActTrace ScmpAction = iota
+	// ActAllow permits the syscall to continue execution
+	ActAllow ScmpAction = iota
+)
+
+const (
+	// These are comparison operators used in conditional seccomp rules
+	// They are used to compare the value of a single argument of a syscall
+	// against a user-defined constant
+
+	// CompareInvalid is a placeholder to ensure uninitialized ScmpCompareOp
+	// variables are invalid
+	CompareInvalid ScmpCompareOp = iota
+	// CompareNotEqual returns true if the argument is not equal to the
+	// given value
+	CompareNotEqual ScmpCompareOp = iota
+	// CompareLess returns true if the argument is less than the given value
+	CompareLess ScmpCompareOp = iota
+	// CompareLessOrEqual returns true if the argument is less than or equal
+	// to the given value
+	CompareLessOrEqual ScmpCompareOp = iota
+	// CompareEqual returns true if the argument is equal to the given value
+	CompareEqual ScmpCompareOp = iota
+	// CompareGreaterEqual returns true if the argument is greater than or
+	// equal to the given value
+	CompareGreaterEqual ScmpCompareOp = iota
+	// CompareGreater returns true if the argument is greater than the given
+	// value
+	CompareGreater ScmpCompareOp = iota
+	// CompareMaskedEqual returns true if the argument is equal to the given
+	// value, when masked (bitwise &) against the second given value
+	CompareMaskedEqual ScmpCompareOp = iota
+)
+
+// Helpers for types
+
+// GetArchFromString returns an ScmpArch constant from a string representing an
+// architecture
+func GetArchFromString(arch string) (ScmpArch, error) {
+	switch strings.ToLower(arch) {
+	case "x86":
+		return ArchX86, nil
+	case "amd64", "x86-64", "x86_64", "x64":
+		return ArchAMD64, nil
+	case "x32":
+		return ArchX32, nil
+	case "arm":
+		return ArchARM, nil
+	case "arm64", "aarch64":
+		return ArchARM64, nil
+	case "mips":
+		return ArchMIPS, nil
+	case "mips64":
+		return ArchMIPS64, nil
+	case "mips64n32":
+		return ArchMIPS64N32, nil
+	case "mipsel":
+		return ArchMIPSEL, nil
+	case "mipsel64":
+		return ArchMIPSEL64, nil
+	case "mipsel64n32":
+		return ArchMIPSEL64N32, nil
+	default:
+		return ArchInvalid, fmt.Errorf("cannot convert unrecognized string %s", arch)
+	}
+}
+
+// String returns a string representation of an architecture constant
+func (a ScmpArch) String() string {
+	switch a {
+	case ArchX86:
+		return "x86"
+	case ArchAMD64:
+		return "amd64"
+	case ArchX32:
+		return "x32"
+	case ArchARM:
+		return "arm"
+	case ArchARM64:
+		return "arm64"
+	case ArchMIPS:
+		return "mips"
+	case ArchMIPS64:
+		return "mips64"
+	case ArchMIPS64N32:
+		return "mips64n32"
+	case ArchMIPSEL:
+		return "mipsel"
+	case ArchMIPSEL64:
+		return "mipsel64"
+	case ArchMIPSEL64N32:
+		return "mipsel64n32"
+	case ArchNative:
+		return "native"
+	case ArchInvalid:
+		return "Invalid architecture"
+	default:
+		return "Unknown architecture"
+	}
+}
+
+// String returns a string representation of a comparison operator constant
+func (a ScmpCompareOp) String() string {
+	switch a {
+	case CompareNotEqual:
+		return "Not equal"
+	case CompareLess:
+		return "Less than"
+	case CompareLessOrEqual:
+		return "Less than or equal to"
+	case CompareEqual:
+		return "Equal"
+	case CompareGreaterEqual:
+		return "Greater than or equal to"
+	case CompareGreater:
+		return "Greater than"
+	case CompareMaskedEqual:
+		return "Masked equality"
+	case CompareInvalid:
+		return "Invalid comparison operator"
+	default:
+		return "Unrecognized comparison operator"
+	}
+}
+
+// String returns a string representation of a seccomp match action
+func (a ScmpAction) String() string {
+	switch a & 0xFFFF {
+	case ActKill:
+		return "Action: Kill Process"
+	case ActTrap:
+		return "Action: Send SIGSYS"
+	case ActErrno:
+		return fmt.Sprintf("Action: Return error code %d", (a >> 16))
+	case ActTrace:
+		return fmt.Sprintf("Action: Notify tracing processes with code %d",
+			(a >> 16))
+	case ActAllow:
+		return "Action: Allow system call"
+	default:
+		return "Unrecognized Action"
+	}
+}
+
+// SetReturnCode adds a return code to a supporting ScmpAction, clearing any
+// existing code Only valid on ActErrno and ActTrace. Takes no action otherwise.
+// Accepts 16-bit return code as argument.
+// Returns a valid ScmpAction of the original type with the new error code set.
+func (a ScmpAction) SetReturnCode(code int16) ScmpAction {
+	aTmp := a & 0x0000FFFF
+	if aTmp == ActErrno || aTmp == ActTrace {
+		return (aTmp | (ScmpAction(code)&0xFFFF)<<16)
+	}
+	return a
+}
+
+// GetReturnCode returns the return code of an ScmpAction
+func (a ScmpAction) GetReturnCode() int16 {
+	return int16(a >> 16)
+}
+
+// General utility functions
+
+// GetLibraryVersion returns the version of the library the bindings are built
+// against.
+// The version is formatted as follows: Major.Minor.Micro
+func GetLibraryVersion() (major, minor, micro int) {
+	return verMajor, verMinor, verMicro
+}
+
+// Syscall functions
+
+// GetName retrieves the name of a syscall from its number.
+// Acts on any syscall number.
+// Returns either a string containing the name of the syscall, or an error.
+func (s ScmpSyscall) GetName() (string, error) {
+	return s.GetNameByArch(ArchNative)
+}
+
+// GetNameByArch retrieves the name of a syscall from its number for a given
+// architecture.
+// Acts on any syscall number.
+// Accepts a valid architecture constant.
+// Returns either a string containing the name of the syscall, or an error.
+// if the syscall is unrecognized or an issue occurred.
+func (s ScmpSyscall) GetNameByArch(arch ScmpArch) (string, error) {
+	if err := sanitizeArch(arch); err != nil {
+		return "", err
+	}
+
+	cString := C.seccomp_syscall_resolve_num_arch(arch.toNative(), C.int(s))
+	if cString == nil {
+		return "", fmt.Errorf("could not resolve syscall name")
+	}
+	defer C.free(unsafe.Pointer(cString))
+
+	finalStr := C.GoString(cString)
+	return finalStr, nil
+}
+
+// GetSyscallFromName returns the number of a syscall by name on the kernel's
+// native architecture.
+// Accepts a string containing the name of a syscall.
+// Returns the number of the syscall, or an error if no syscall with that name
+// was found.
+func GetSyscallFromName(name string) (ScmpSyscall, error) {
+	cString := C.CString(name)
+	defer C.free(unsafe.Pointer(cString))
+
+	result := C.seccomp_syscall_resolve_name(cString)
+	if result == scmpError {
+		return 0, fmt.Errorf("could not resolve name to syscall")
+	}
+
+	return ScmpSyscall(result), nil
+}
+
+// GetSyscallFromNameByArch returns the number of a syscall by name for a given
+// architecture's ABI.
+// Accepts the name of a syscall and an architecture constant.
+// Returns the number of the syscall, or an error if an invalid architecture is
+// passed or a syscall with that name was not found.
+func GetSyscallFromNameByArch(name string, arch ScmpArch) (ScmpSyscall, error) {
+	if err := sanitizeArch(arch); err != nil {
+		return 0, err
+	}
+
+	cString := C.CString(name)
+	defer C.free(unsafe.Pointer(cString))
+
+	result := C.seccomp_syscall_resolve_name_arch(arch.toNative(), cString)
+	if result == scmpError {
+		return 0, fmt.Errorf("could not resolve name to syscall")
+	}
+
+	return ScmpSyscall(result), nil
+}
+
+// MakeCondition creates and returns a new condition to attach to a filter rule.
+// Associated rules will only match if this condition is true.
+// Accepts the number the argument we are checking, and a comparison operator
+// and value to compare to.
+// The rule will match if argument $arg (zero-indexed) of the syscall is
+// $COMPARE_OP the provided comparison value.
+// Some comparison operators accept two values. Masked equals, for example,
+// will mask $arg of the syscall with the second value provided (via bitwise
+// AND) and then compare against the first value provided.
+// For example, in the less than or equal case, if the syscall argument was
+// 0 and the value provided was 1, the condition would match, as 0 is less
+// than or equal to 1.
+// Return either an error on bad argument or a valid ScmpCondition struct.
+func MakeCondition(arg uint, comparison ScmpCompareOp, values ...uint64) (ScmpCondition, error) {
+	var condStruct ScmpCondition
+
+	if comparison == CompareInvalid {
+		return condStruct, fmt.Errorf("invalid comparison operator")
+	} else if arg > 5 {
+		return condStruct, fmt.Errorf("syscalls only have up to 6 arguments")
+	} else if len(values) > 2 {
+		return condStruct, fmt.Errorf("conditions can have at most 2 arguments")
+	} else if len(values) == 0 {
+		return condStruct, fmt.Errorf("must provide at least one value to compare against")
+	}
+
+	condStruct.Argument = arg
+	condStruct.Op = comparison
+	condStruct.Operand1 = values[0]
+	if len(values) == 2 {
+		condStruct.Operand2 = values[1]
+	} else {
+		condStruct.Operand2 = 0 // Unused
+	}
+
+	return condStruct, nil
+}
+
+// Utility Functions
+
+// GetNativeArch returns architecture token representing the native kernel
+// architecture
+func GetNativeArch() (ScmpArch, error) {
+	arch := C.seccomp_arch_native()
+
+	return archFromNative(arch)
+}
+
+// Public Filter API
+
+// ScmpFilter represents a filter context in libseccomp.
+// A filter context is initially empty. Rules can be added to it, and it can
+// then be loaded into the kernel.
+type ScmpFilter struct {
+	filterCtx C.scmp_filter_ctx
+	valid     bool
+	lock      sync.Mutex
+}
+
+// NewFilter creates and returns a new filter context.
+// Accepts a default action to be taken for syscalls which match no rules in
+// the filter.
+// Returns a reference to a valid filter context, or nil and an error if the
+// filter context could not be created or an invalid default action was given.
+func NewFilter(defaultAction ScmpAction) (*ScmpFilter, error) {
+	if err := sanitizeAction(defaultAction); err != nil {
+		return nil, err
+	}
+
+	fPtr := C.seccomp_init(defaultAction.toNative())
+	if fPtr == nil {
+		return nil, fmt.Errorf("could not create filter")
+	}
+
+	filter := new(ScmpFilter)
+	filter.filterCtx = fPtr
+	filter.valid = true
+	runtime.SetFinalizer(filter, filterFinalizer)
+
+	return filter, nil
+}
+
+// IsValid determines whether a filter context is valid to use.
+// Some operations (Release and Merge) render filter contexts invalid and
+// consequently prevent further use.
+func (f *ScmpFilter) IsValid() bool {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	return f.valid
+}
+
+// Reset resets a filter context, removing all its existing state.
+// Accepts a new default action to be taken for syscalls which do not match.
+// Returns an error if the filter or action provided are invalid.
+func (f *ScmpFilter) Reset(defaultAction ScmpAction) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if err := sanitizeAction(defaultAction); err != nil {
+		return err
+	} else if !f.valid {
+		return errBadFilter
+	}
+
+	retCode := C.seccomp_reset(f.filterCtx, defaultAction.toNative())
+	if retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// Release releases a filter context, freeing its memory. Should be called after
+// loading into the kernel, when the filter is no longer needed.
+// After calling this function, the given filter is no longer valid and cannot
+// be used.
+// Release() will be invoked automatically when a filter context is garbage
+// collected, but can also be called manually to free memory.
+func (f *ScmpFilter) Release() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return
+	}
+
+	f.valid = false
+	C.seccomp_release(f.filterCtx)
+}
+
+// Merge merges two filter contexts.
+// The source filter src will be released as part of the process, and will no
+// longer be usable or valid after this call.
+// To be merged, filters must NOT share any architectures, and all their
+// attributes (Default Action, Bad Arch Action, No New Privs and TSync bools)
+// must match.
+// The filter src will be merged into the filter this is called on.
+// The architectures of the src filter not present in the destination, and all
+// associated rules, will be added to the destination.
+// Returns an error if merging the filters failed.
+func (f *ScmpFilter) Merge(src *ScmpFilter) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	src.lock.Lock()
+	defer src.lock.Unlock()
+
+	if !src.valid || !f.valid {
+		return fmt.Errorf("one or more of the filter contexts is invalid or uninitialized")
+	}
+
+	// Merge the filters
+	retCode := C.seccomp_merge(f.filterCtx, src.filterCtx)
+	if syscall.Errno(-1*retCode) == syscall.EINVAL {
+		return fmt.Errorf("filters could not be merged due to a mismatch in attributes or invalid filter")
+	} else if retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	src.valid = false
+
+	return nil
+}
+
+// IsArchPresent checks if an architecture is present in a filter.
+// If a filter contains an architecture, it uses its default action for
+// syscalls which do not match rules in it, and its rules can match syscalls
+// for that ABI.
+// If a filter does not contain an architecture, all syscalls made to that
+// kernel ABI will fail with the filter's default Bad Architecture Action
+// (by default, killing the process).
+// Accepts an architecture constant.
+// Returns true if the architecture is present in the filter, false otherwise,
+// and an error on an invalid filter context, architecture constant, or an
+// issue with the call to libseccomp.
+func (f *ScmpFilter) IsArchPresent(arch ScmpArch) (bool, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if err := sanitizeArch(arch); err != nil {
+		return false, err
+	} else if !f.valid {
+		return false, errBadFilter
+	}
+
+	retCode := C.seccomp_arch_exist(f.filterCtx, arch.toNative())
+	if syscall.Errno(-1*retCode) == syscall.EEXIST {
+		// -EEXIST is "arch not present"
+		return false, nil
+	} else if retCode != 0 {
+		return false, syscall.Errno(-1 * retCode)
+	}
+
+	return true, nil
+}
+
+// AddArch adds an architecture to the filter.
+// Accepts an architecture constant.
+// Returns an error on invalid filter context or architecture token, or an
+// issue with the call to libseccomp.
+func (f *ScmpFilter) AddArch(arch ScmpArch) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if err := sanitizeArch(arch); err != nil {
+		return err
+	} else if !f.valid {
+		return errBadFilter
+	}
+
+	// Libseccomp returns -EEXIST if the specified architecture is already
+	// present. Succeed silently in this case, as it's not fatal, and the
+	// architecture is present already.
+	retCode := C.seccomp_arch_add(f.filterCtx, arch.toNative())
+	if retCode != 0 && syscall.Errno(-1*retCode) != syscall.EEXIST {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// RemoveArch removes an architecture from the filter.
+// Accepts an architecture constant.
+// Returns an error on invalid filter context or architecture token, or an
+// issue with the call to libseccomp.
+func (f *ScmpFilter) RemoveArch(arch ScmpArch) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if err := sanitizeArch(arch); err != nil {
+		return err
+	} else if !f.valid {
+		return errBadFilter
+	}
+
+	// Similar to AddArch, -EEXIST is returned if the arch is not present
+	// Succeed silently in that case, this is not fatal and the architecture
+	// is not present in the filter after RemoveArch
+	retCode := C.seccomp_arch_remove(f.filterCtx, arch.toNative())
+	if retCode != 0 && syscall.Errno(-1*retCode) != syscall.EEXIST {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// Load loads a filter context into the kernel.
+// Returns an error if the filter context is invalid or the syscall failed.
+func (f *ScmpFilter) Load() error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return errBadFilter
+	}
+
+	if retCode := C.seccomp_load(f.filterCtx); retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// GetDefaultAction returns the default action taken on a syscall which does not
+// match a rule in the filter, or an error if an issue was encountered
+// retrieving the value.
+func (f *ScmpFilter) GetDefaultAction() (ScmpAction, error) {
+	action, err := f.getFilterAttr(filterAttrActDefault)
+	if err != nil {
+		return 0x0, err
+	}
+
+	return actionFromNative(action)
+}
+
+// GetBadArchAction returns the default action taken on a syscall for an
+// architecture not in the filter, or an error if an issue was encountered
+// retrieving the value.
+func (f *ScmpFilter) GetBadArchAction() (ScmpAction, error) {
+	action, err := f.getFilterAttr(filterAttrActBadArch)
+	if err != nil {
+		return 0x0, err
+	}
+
+	return actionFromNative(action)
+}
+
+// GetNoNewPrivsBit returns the current state the No New Privileges bit will be set
+// to on the filter being loaded, or an error if an issue was encountered
+// retrieving the value.
+// The No New Privileges bit tells the kernel that new processes run with exec()
+// cannot gain more privileges than the process that ran exec().
+// For example, a process with No New Privileges set would be unable to exec
+// setuid/setgid executables.
+func (f *ScmpFilter) GetNoNewPrivsBit() (bool, error) {
+	noNewPrivs, err := f.getFilterAttr(filterAttrNNP)
+	if err != nil {
+		return false, err
+	}
+
+	if noNewPrivs == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// GetTsyncBit returns whether Thread Synchronization will be enabled on the
+// filter being loaded, or an error if an issue was encountered retrieving the
+// value.
+// Thread Sync ensures that all members of the thread group of the calling
+// process will share the same Seccomp filter set.
+// Tsync is a fairly recent addition to the Linux kernel and older kernels
+// lack support. If the running kernel does not support Tsync and it is
+// requested in a filter, Libseccomp will not enable TSync support and will
+// proceed as normal.
+// This function is unavailable before v2.2 of libseccomp and will return an
+// error.
+func (f *ScmpFilter) GetTsyncBit() (bool, error) {
+	tSync, err := f.getFilterAttr(filterAttrTsync)
+	if err != nil {
+		return false, err
+	}
+
+	if tSync == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// SetBadArchAction sets the default action taken on a syscall for an
+// architecture not in the filter, or an error if an issue was encountered
+// setting the value.
+func (f *ScmpFilter) SetBadArchAction(action ScmpAction) error {
+	if err := sanitizeAction(action); err != nil {
+		return err
+	}
+
+	return f.setFilterAttr(filterAttrActBadArch, action.toNative())
+}
+
+// SetNoNewPrivsBit sets the state of the No New Privileges bit, which will be
+// applied on filter load, or an error if an issue was encountered setting the
+// value.
+// Filters with No New Privileges set to 0 can only be loaded if the process
+// has the CAP_SYS_ADMIN capability.
+func (f *ScmpFilter) SetNoNewPrivsBit(state bool) error {
+	var toSet C.uint32_t = 0x0
+
+	if state {
+		toSet = 0x1
+	}
+
+	return f.setFilterAttr(filterAttrNNP, toSet)
+}
+
+// SetTsync sets whether Thread Synchronization will be enabled on the filter
+// being loaded. Returns an error if setting Tsync failed, or the filter is
+// invalid.
+// Thread Sync ensures that all members of the thread group of the calling
+// process will share the same Seccomp filter set.
+// Tsync is a fairly recent addition to the Linux kernel and older kernels
+// lack support. If the running kernel does not support Tsync and it is
+// requested in a filter, Libseccomp will not enable TSync support and will
+// proceed as normal.
+// This function is unavailable before v2.2 of libseccomp and will return an
+// error.
+func (f *ScmpFilter) SetTsync(enable bool) error {
+	var toSet C.uint32_t = 0x0
+
+	if enable {
+		toSet = 0x1
+	}
+
+	return f.setFilterAttr(filterAttrTsync, toSet)
+}
+
+// SetSyscallPriority sets a syscall's priority.
+// This provides a hint to the filter generator in libseccomp about the
+// importance of this syscall. High-priority syscalls are placed
+// first in the filter code, and incur less overhead (at the expense of
+// lower-priority syscalls).
+func (f *ScmpFilter) SetSyscallPriority(call ScmpSyscall, priority uint8) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return errBadFilter
+	}
+
+	if retCode := C.seccomp_syscall_priority(f.filterCtx, C.int(call),
+		C.uint8_t(priority)); retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// AddRule adds a single rule for an unconditional action on a syscall.
+// Accepts the number of the syscall and the action to be taken on the call
+// being made.
+// Returns an error if an issue was encountered adding the rule.
+func (f *ScmpFilter) AddRule(call ScmpSyscall, action ScmpAction) error {
+	return f.addRuleGeneric(call, action, false, nil)
+}
+
+// AddRuleExact adds a single rule for an unconditional action on a syscall.
+// Accepts the number of the syscall and the action to be taken on the call
+// being made.
+// No modifications will be made to the rule, and it will fail to add if it
+// cannot be applied to the current architecture without modification.
+// The rule will function exactly as described, but it may not function identically
+// (or be able to be applied to) all architectures.
+// Returns an error if an issue was encountered adding the rule.
+func (f *ScmpFilter) AddRuleExact(call ScmpSyscall, action ScmpAction) error {
+	return f.addRuleGeneric(call, action, true, nil)
+}
+
+// AddRuleConditional adds a single rule for a conditional action on a syscall.
+// Returns an error if an issue was encountered adding the rule.
+// All conditions must match for the rule to match.
+// There is a bug in library versions below v2.2.1 which can, in some cases,
+// cause conditions to be lost when more than one are used. Consequently,
+// AddRuleConditional is disabled on library versions lower than v2.2.1
+func (f *ScmpFilter) AddRuleConditional(call ScmpSyscall, action ScmpAction, conds []ScmpCondition) error {
+	return f.addRuleGeneric(call, action, false, conds)
+}
+
+// AddRuleConditionalExact adds a single rule for a conditional action on a
+// syscall.
+// No modifications will be made to the rule, and it will fail to add if it
+// cannot be applied to the current architecture without modification.
+// The rule will function exactly as described, but it may not function identically
+// (or be able to be applied to) all architectures.
+// Returns an error if an issue was encountered adding the rule.
+// There is a bug in library versions below v2.2.1 which can, in some cases,
+// cause conditions to be lost when more than one are used. Consequently,
+// AddRuleConditionalExact is disabled on library versions lower than v2.2.1
+func (f *ScmpFilter) AddRuleConditionalExact(call ScmpSyscall, action ScmpAction, conds []ScmpCondition) error {
+	return f.addRuleGeneric(call, action, true, conds)
+}
+
+// ExportPFC output PFC-formatted, human-readable dump of a filter context's
+// rules to a file.
+// Accepts file to write to (must be open for writing).
+// Returns an error if writing to the file fails.
+func (f *ScmpFilter) ExportPFC(file *os.File) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	fd := file.Fd()
+
+	if !f.valid {
+		return errBadFilter
+	}
+
+	if retCode := C.seccomp_export_pfc(f.filterCtx, C.int(fd)); retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// ExportBPF outputs Berkeley Packet Filter-formatted, kernel-readable dump of a
+// filter context's rules to a file.
+// Accepts file to write to (must be open for writing).
+// Returns an error if writing to the file fails.
+func (f *ScmpFilter) ExportBPF(file *os.File) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	fd := file.Fd()
+
+	if !f.valid {
+		return errBadFilter
+	}
+
+	if retCode := C.seccomp_export_bpf(f.filterCtx, C.int(fd)); retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}

--- a/vendor/src/github.com/seccomp/libseccomp-golang/seccomp_internal.go
+++ b/vendor/src/github.com/seccomp/libseccomp-golang/seccomp_internal.go
@@ -1,0 +1,461 @@
+// +build linux
+
+// Internal functions for libseccomp Go bindings
+// No exported functions
+
+package seccomp
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Unexported C wrapping code - provides the C-Golang interface
+// Get the seccomp header in scope
+// Need stdlib.h for free() on cstrings
+
+// #cgo LDFLAGS: -lseccomp
+/*
+#include <stdlib.h>
+#include <seccomp.h>
+
+#if SCMP_VER_MAJOR < 2
+#error Minimum supported version of Libseccomp is v2.1.0
+#elif SCMP_VER_MAJOR == 2 && SCMP_VER_MINOR < 1
+#error Minimum supported version of Libseccomp is v2.1.0
+#endif
+
+#define ARCH_BAD ~0
+
+const uint32_t C_ARCH_BAD = ARCH_BAD;
+
+#ifndef SCMP_ARCH_AARCH64
+#define SCMP_ARCH_AARCH64 ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_MIPS
+#define SCMP_ARCH_MIPS ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_MIPS64
+#define SCMP_ARCH_MIPS64 ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_MIPS64N32
+#define SCMP_ARCH_MIPS64N32 ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_MIPSEL
+#define SCMP_ARCH_MIPSEL ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_MIPSEL64
+#define SCMP_ARCH_MIPSEL64 ARCH_BAD
+#endif
+
+#ifndef SCMP_ARCH_MIPSEL64N32
+#define SCMP_ARCH_MIPSEL64N32 ARCH_BAD
+#endif
+
+const uint32_t C_ARCH_NATIVE       = SCMP_ARCH_NATIVE;
+const uint32_t C_ARCH_X86          = SCMP_ARCH_X86;
+const uint32_t C_ARCH_X86_64       = SCMP_ARCH_X86_64;
+const uint32_t C_ARCH_X32          = SCMP_ARCH_X32;
+const uint32_t C_ARCH_ARM          = SCMP_ARCH_ARM;
+const uint32_t C_ARCH_AARCH64      = SCMP_ARCH_AARCH64;
+const uint32_t C_ARCH_MIPS         = SCMP_ARCH_MIPS;
+const uint32_t C_ARCH_MIPS64       = SCMP_ARCH_MIPS64;
+const uint32_t C_ARCH_MIPS64N32    = SCMP_ARCH_MIPS64N32;
+const uint32_t C_ARCH_MIPSEL       = SCMP_ARCH_MIPSEL;
+const uint32_t C_ARCH_MIPSEL64     = SCMP_ARCH_MIPSEL64;
+const uint32_t C_ARCH_MIPSEL64N32  = SCMP_ARCH_MIPSEL64N32;
+
+const uint32_t C_ACT_KILL          = SCMP_ACT_KILL;
+const uint32_t C_ACT_TRAP          = SCMP_ACT_TRAP;
+const uint32_t C_ACT_ERRNO         = SCMP_ACT_ERRNO(0);
+const uint32_t C_ACT_TRACE         = SCMP_ACT_TRACE(0);
+const uint32_t C_ACT_ALLOW         = SCMP_ACT_ALLOW;
+
+// If TSync is not supported, make sure it doesn't map to a supported filter attribute
+// Don't worry about major version < 2, the minimum version checks should catch that case
+#if SCMP_VER_MAJOR == 2 && SCMP_VER_MINOR < 2
+#define SCMP_FLTATR_CTL_TSYNC _SCMP_CMP_MIN
+#endif
+
+const uint32_t C_ATTRIBUTE_DEFAULT = (uint32_t)SCMP_FLTATR_ACT_DEFAULT;
+const uint32_t C_ATTRIBUTE_BADARCH = (uint32_t)SCMP_FLTATR_ACT_BADARCH;
+const uint32_t C_ATTRIBUTE_NNP     = (uint32_t)SCMP_FLTATR_CTL_NNP;
+const uint32_t C_ATTRIBUTE_TSYNC   = (uint32_t)SCMP_FLTATR_CTL_TSYNC;
+
+const int      C_CMP_NE            = (int)SCMP_CMP_NE;
+const int      C_CMP_LT            = (int)SCMP_CMP_LT;
+const int      C_CMP_LE            = (int)SCMP_CMP_LE;
+const int      C_CMP_EQ            = (int)SCMP_CMP_EQ;
+const int      C_CMP_GE            = (int)SCMP_CMP_GE;
+const int      C_CMP_GT            = (int)SCMP_CMP_GT;
+const int      C_CMP_MASKED_EQ     = (int)SCMP_CMP_MASKED_EQ;
+
+const int      C_VERSION_MAJOR     = SCMP_VER_MAJOR;
+const int      C_VERSION_MINOR     = SCMP_VER_MINOR;
+const int      C_VERSION_MICRO     = SCMP_VER_MICRO;
+
+typedef struct scmp_arg_cmp* scmp_cast_t;
+
+// Wrapper to create an scmp_arg_cmp struct
+void*
+make_struct_arg_cmp(
+                    unsigned int arg,
+                    int compare,
+                    uint64_t a,
+                    uint64_t b
+                   )
+{
+	struct scmp_arg_cmp *s = malloc(sizeof(struct scmp_arg_cmp));
+
+	s->arg = arg;
+	s->op = compare;
+	s->datum_a = a;
+	s->datum_b = b;
+
+	return s;
+}
+*/
+import "C"
+
+// Nonexported types
+type scmpFilterAttr uint32
+
+// Nonexported constants
+
+const (
+	filterAttrActDefault scmpFilterAttr = iota
+	filterAttrActBadArch scmpFilterAttr = iota
+	filterAttrNNP        scmpFilterAttr = iota
+	filterAttrTsync      scmpFilterAttr = iota
+)
+
+const (
+	// An error return from certain libseccomp functions
+	scmpError C.int = -1
+	// Comparison boundaries to check for architecture validity
+	archStart ScmpArch = ArchNative
+	archEnd   ScmpArch = ArchMIPSEL64N32
+	// Comparison boundaries to check for action validity
+	actionStart ScmpAction = ActKill
+	actionEnd   ScmpAction = ActAllow
+	// Comparison boundaries to check for comparison operator validity
+	compareOpStart ScmpCompareOp = CompareNotEqual
+	compareOpEnd   ScmpCompareOp = CompareMaskedEqual
+)
+
+var (
+	// Error thrown on bad filter context
+	errBadFilter = fmt.Errorf("filter is invalid or uninitialized")
+	// Constants representing library major, minor, and micro versions
+	verMajor = int(C.C_VERSION_MAJOR)
+	verMinor = int(C.C_VERSION_MINOR)
+	verMicro = int(C.C_VERSION_MICRO)
+)
+
+// Nonexported functions
+
+// Check if library version is greater than or equal to the given one
+func checkVersionAbove(major, minor, micro int) bool {
+	return (verMajor > major) ||
+		(verMajor == major && verMinor > minor) ||
+		(verMajor == major && verMinor == minor && verMicro >= micro)
+}
+
+// Init function: Verify library version is appropriate
+func init() {
+	if !checkVersionAbove(2, 1, 0) {
+		fmt.Fprintf(os.Stderr, "Libseccomp version too low: minimum supported is 2.1.0, detected %d.%d.%d", C.C_VERSION_MAJOR, C.C_VERSION_MINOR, C.C_VERSION_MICRO)
+		os.Exit(-1)
+	}
+}
+
+// Filter helpers
+
+// Filter finalizer - ensure that kernel context for filters is freed
+func filterFinalizer(f *ScmpFilter) {
+	f.Release()
+}
+
+// Get a raw filter attribute
+func (f *ScmpFilter) getFilterAttr(attr scmpFilterAttr) (C.uint32_t, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return 0x0, errBadFilter
+	}
+
+	if !checkVersionAbove(2, 2, 0) && attr == filterAttrTsync {
+		return 0x0, fmt.Errorf("the thread synchronization attribute is not supported in this version of the library")
+	}
+
+	var attribute C.uint32_t
+
+	retCode := C.seccomp_attr_get(f.filterCtx, attr.toNative(), &attribute)
+	if retCode != 0 {
+		return 0x0, syscall.Errno(-1 * retCode)
+	}
+
+	return attribute, nil
+}
+
+// Set a raw filter attribute
+func (f *ScmpFilter) setFilterAttr(attr scmpFilterAttr, value C.uint32_t) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return errBadFilter
+	}
+
+	if !checkVersionAbove(2, 2, 0) && attr == filterAttrTsync {
+		return fmt.Errorf("the thread synchronization attribute is not supported in this version of the library")
+	}
+
+	retCode := C.seccomp_attr_set(f.filterCtx, attr.toNative(), value)
+	if retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// DOES NOT LOCK OR CHECK VALIDITY
+// Assumes caller has already done this
+// Wrapper for seccomp_rule_add_... functions
+func (f *ScmpFilter) addRuleWrapper(call ScmpSyscall, action ScmpAction, exact bool, cond C.scmp_cast_t) error {
+	var length C.uint
+	if cond != nil {
+		length = 1
+	} else {
+		length = 0
+	}
+
+	var retCode C.int
+	if exact {
+		retCode = C.seccomp_rule_add_exact_array(f.filterCtx, action.toNative(), C.int(call), length, cond)
+	} else {
+		retCode = C.seccomp_rule_add_array(f.filterCtx, action.toNative(), C.int(call), length, cond)
+	}
+
+	if syscall.Errno(-1*retCode) == syscall.EFAULT {
+		return fmt.Errorf("unrecognized syscall")
+	} else if syscall.Errno(-1*retCode) == syscall.EPERM {
+		return fmt.Errorf("requested action matches default action of filter")
+	} else if retCode != 0 {
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
+// Generic add function for filter rules
+func (f *ScmpFilter) addRuleGeneric(call ScmpSyscall, action ScmpAction, exact bool, conds []ScmpCondition) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return errBadFilter
+	}
+
+	if len(conds) == 0 {
+		if err := f.addRuleWrapper(call, action, exact, nil); err != nil {
+			return err
+		}
+	} else {
+		// We don't support conditional filtering in library version v2.1
+		if !checkVersionAbove(2, 2, 1) {
+			return fmt.Errorf("conditional filtering requires libseccomp version >= 2.2.1")
+		}
+
+		for _, cond := range conds {
+			cmpStruct := C.make_struct_arg_cmp(C.uint(cond.Argument), cond.Op.toNative(), C.uint64_t(cond.Operand1), C.uint64_t(cond.Operand2))
+			defer C.free(cmpStruct)
+
+			if err := f.addRuleWrapper(call, action, exact, C.scmp_cast_t(cmpStruct)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Generic Helpers
+
+// Helper - Sanitize Arch token input
+func sanitizeArch(in ScmpArch) error {
+	if in < archStart || in > archEnd {
+		return fmt.Errorf("unrecognized architecture")
+	}
+
+	if in.toNative() == C.C_ARCH_BAD {
+		return fmt.Errorf("architecture is not supported on this version of the library")
+	}
+
+	return nil
+}
+
+func sanitizeAction(in ScmpAction) error {
+	inTmp := in & 0x0000FFFF
+	if inTmp < actionStart || inTmp > actionEnd {
+		return fmt.Errorf("unrecognized action")
+	}
+
+	if inTmp != ActTrace && inTmp != ActErrno && (in&0xFFFF0000) != 0 {
+		return fmt.Errorf("highest 16 bits must be zeroed except for Trace and Errno")
+	}
+
+	return nil
+}
+
+func sanitizeCompareOp(in ScmpCompareOp) error {
+	if in < compareOpStart || in > compareOpEnd {
+		return fmt.Errorf("unrecognized comparison operator")
+	}
+
+	return nil
+}
+
+func archFromNative(a C.uint32_t) (ScmpArch, error) {
+	switch a {
+	case C.C_ARCH_X86:
+		return ArchX86, nil
+	case C.C_ARCH_X86_64:
+		return ArchAMD64, nil
+	case C.C_ARCH_X32:
+		return ArchX32, nil
+	case C.C_ARCH_ARM:
+		return ArchARM, nil
+	case C.C_ARCH_NATIVE:
+		return ArchNative, nil
+	case C.C_ARCH_AARCH64:
+		return ArchARM64, nil
+	case C.C_ARCH_MIPS:
+		return ArchMIPS, nil
+	case C.C_ARCH_MIPS64:
+		return ArchMIPS64, nil
+	case C.C_ARCH_MIPS64N32:
+		return ArchMIPS64N32, nil
+	case C.C_ARCH_MIPSEL:
+		return ArchMIPSEL, nil
+	case C.C_ARCH_MIPSEL64:
+		return ArchMIPSEL64, nil
+	case C.C_ARCH_MIPSEL64N32:
+		return ArchMIPSEL64N32, nil
+	default:
+		return 0x0, fmt.Errorf("unrecognized architecture")
+	}
+}
+
+// Only use with sanitized arches, no error handling
+func (a ScmpArch) toNative() C.uint32_t {
+	switch a {
+	case ArchX86:
+		return C.C_ARCH_X86
+	case ArchAMD64:
+		return C.C_ARCH_X86_64
+	case ArchX32:
+		return C.C_ARCH_X32
+	case ArchARM:
+		return C.C_ARCH_ARM
+	case ArchARM64:
+		return C.C_ARCH_AARCH64
+	case ArchMIPS:
+		return C.C_ARCH_MIPS
+	case ArchMIPS64:
+		return C.C_ARCH_MIPS64
+	case ArchMIPS64N32:
+		return C.C_ARCH_MIPS64N32
+	case ArchMIPSEL:
+		return C.C_ARCH_MIPSEL
+	case ArchMIPSEL64:
+		return C.C_ARCH_MIPSEL64
+	case ArchMIPSEL64N32:
+		return C.C_ARCH_MIPSEL64N32
+	case ArchNative:
+		return C.C_ARCH_NATIVE
+	default:
+		return 0x0
+	}
+}
+
+// Only use with sanitized ops, no error handling
+func (a ScmpCompareOp) toNative() C.int {
+	switch a {
+	case CompareNotEqual:
+		return C.C_CMP_NE
+	case CompareLess:
+		return C.C_CMP_LT
+	case CompareLessOrEqual:
+		return C.C_CMP_LE
+	case CompareEqual:
+		return C.C_CMP_EQ
+	case CompareGreaterEqual:
+		return C.C_CMP_GE
+	case CompareGreater:
+		return C.C_CMP_GT
+	case CompareMaskedEqual:
+		return C.C_CMP_MASKED_EQ
+	default:
+		return 0x0
+	}
+}
+
+func actionFromNative(a C.uint32_t) (ScmpAction, error) {
+	aTmp := a & 0xFFFF
+	switch a & 0xFFFF0000 {
+	case C.C_ACT_KILL:
+		return ActKill, nil
+	case C.C_ACT_TRAP:
+		return ActTrap, nil
+	case C.C_ACT_ERRNO:
+		return ActErrno.SetReturnCode(int16(aTmp)), nil
+	case C.C_ACT_TRACE:
+		return ActTrace.SetReturnCode(int16(aTmp)), nil
+	case C.C_ACT_ALLOW:
+		return ActAllow, nil
+	default:
+		return 0x0, fmt.Errorf("unrecognized action")
+	}
+}
+
+// Only use with sanitized actions, no error handling
+func (a ScmpAction) toNative() C.uint32_t {
+	switch a & 0xFFFF {
+	case ActKill:
+		return C.C_ACT_KILL
+	case ActTrap:
+		return C.C_ACT_TRAP
+	case ActErrno:
+		return C.C_ACT_ERRNO | (C.uint32_t(a) >> 16)
+	case ActTrace:
+		return C.C_ACT_TRACE | (C.uint32_t(a) >> 16)
+	case ActAllow:
+		return C.C_ACT_ALLOW
+	default:
+		return 0x0
+	}
+}
+
+// Internal only, assumes safe attribute
+func (a scmpFilterAttr) toNative() uint32 {
+	switch a {
+	case filterAttrActDefault:
+		return uint32(C.C_ATTRIBUTE_DEFAULT)
+	case filterAttrActBadArch:
+		return uint32(C.C_ATTRIBUTE_BADARCH)
+	case filterAttrNNP:
+		return uint32(C.C_ATTRIBUTE_NNP)
+	case filterAttrTsync:
+		return uint32(C.C_ATTRIBUTE_TSYNC)
+	default:
+		return 0x0
+	}
+}


### PR DESCRIPTION
This is a phase 1 of the security profiles described in https://github.com/docker/docker/issues/17142#issuecomment-148974642. 

It allows for passing a seccomp profile in the form of:

```
{
     "defaultAction": "SCMP_ACT_ALLOW",
     "syscalls": [
         {
             "name": "getcwd",
             "action": "SCMP_ACT_ERRNO"
         }
     ]
 }
```

based off the runc runtime spec https://github.com/opencontainers/specs/blob/master/runtime-config-linux.md#seccomp

**Example:**

```
$ docker run --rm -it --security-ops seccomp:/path/to/container-profile.json jess/i-am-malicious
```

@LK4D4 @crosbymichael let me know if we are not ready to import the spec quite yet for this, but I didn't want to repeat the structs unless you deemed necessary :)

**TODO:** obviously this needs moarrr tests and docs, coming super soon ;)

I feel like there was something else I wanted to note, but I forgot... so... coming soon as well....
