### PR TITLE
hack: make.sh: opt-in for pkcs11

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -97,7 +97,10 @@ fi
 if [ "$DOCKER_EXPERIMENTAL" ] || [ "$DOCKER_REMAP_ROOT" ]; then
 	echo >&2 '# WARNING! DOCKER_EXPERIMENTAL is set: building experimental features'
 	echo >&2
-	DOCKER_BUILDTAGS+=" experimental pkcs11"
+	DOCKER_BUILDTAGS+=" experimental"
+	if [ "$PKCS11" ]; then
+		DOCKER_BUILDTAGS+=" pkcs11"
+	fi
 fi
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then


### PR DESCRIPTION
I always build with:

```
AUTO_GOPATH=1 BUILDFLAGS="-race" DOCKER_EXPERIMENTAL=1 DOCKER_BUILDTAGS="selinux journald exclude_graphdriver_btrfs exclude_graphdriver_zfs exclude_graphdriver_aufs exclude_graphdriver_devicemapper" ./hack/make.sh dynbinary
```

And now with the experimental flag comes `pkcs11`. This patch just introduces a new `PKCS11` env which enables it on build otherwise I'm getting no headers found. @jfrazelle is it ok to opt-in for this? 

Signed-off-by: Antonio Murdaca runcom@redhat.com
