### PR TITLE
bash completion for `docker {run,create} --volume-driver`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1397,6 +1397,7 @@ _docker_run() {
 		--ulimit
 		--user -u
 		--uts
+		--volume-driver
 		--volumes-from
 		--volume -v
 		--workdir -w
@@ -1539,6 +1540,10 @@ _docker_run() {
 					__docker_nospace
 					;;
 			esac
+			return
+			;;
+		--volume-driver)
+			COMPREPLY=( $( compgen -W "local" -- "$cur" ) )
 			return
 			;;
 		--volumes-from)


### PR DESCRIPTION
Ref. #17869 

ping @jfrazelle @tianon for review
/cc @thaJeztah 

This should be added to 1.9.1 as the corresponding feature is present in 1.9.0.
