### PR TITLE
Improve bash completion for `docker network disconnect`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -157,6 +157,17 @@ __docker_networks() {
 	COMPREPLY=( $(compgen -W "$networks" -- "$cur") )
 }
 
+__docker_containers_in_network() {
+	local sed_name_command='s/^ \+"Name": "\(.*\)",\?/\1/p'
+	local sed_id_command='s/^ \+"\([0-9a-f]\{64\}\)":.*/\1/'
+	[ ${DOCKER_COMPLETION_SHOW_IMAGE_IDS:-none} != "none" ] && sed_id_command=${sed_id_command}p
+
+	local containers=$(__docker_q network inspect $1 \
+		| awk '/^        "Containers"/,/^        },/' \
+		| sed -n -e "$sed_name_command" -e "$sed_id_command")
+	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
+}
+
 __docker_volumes() {
 	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
 }
@@ -1092,7 +1103,7 @@ _docker_network_connect() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--tail')
+			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
 				__docker_networks
 			elif [ $cword -eq $(($counter + 1)) ]; then
@@ -1127,9 +1138,19 @@ _docker_network_create() {
 }
 
 _docker_network_disconnect() {
-	# TODO disconnect should only complete running containers connected
-	# to the specified network.
-	_docker_network_connect
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_networks
+			elif [ $cword -eq $(($counter + 1)) ]; then
+				__docker_containers_in_network "$prev"
+			fi
+			;;
+	esac
 }
 
 _docker_network_inspect() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -158,13 +158,10 @@ __docker_networks() {
 }
 
 __docker_containers_in_network() {
-	local sed_name_command='s/^ \+"Name": "\(.*\)",\?/\1/p'
-	local sed_id_command='s/^ \+"\([0-9a-f]\{64\}\)":.*/\1/'
-	[ ${DOCKER_COMPLETION_SHOW_IMAGE_IDS:-none} != "none" ] && sed_id_command=${sed_id_command}p
-
 	local containers=$(__docker_q network inspect $1 \
 		| awk '/^        "Containers"/,/^        },/' \
-		| sed -n -e "$sed_name_command" -e "$sed_id_command")
+		| sed -n -e 's/^ \+"Name": "\(.*\)",\?/\1/p' \
+		         -e 's/^ \+"\([0-9a-f]\{64\}\)":.*/\1/p')
 	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
 }
 


### PR DESCRIPTION
#17615 allows an improvement of the completion of the container argument to `docker network disconnect`:

Currently, completion lists all running containers, whether they are connected to the specified network or not. 
This patch narrows completion to those containers that are actually connected to the specified network.

~~Container IDs are shown depending on the setting of `$DOCKER_COMPLETION_SHOW_IMAGE_IDS`.~~

ping @jfrazelle @tianon for review.
@sdurrheimer Perhaps you can reuse this in zsh completion.

This is an improvement for an existing feature, no need to consider for 1.9.1.
