### PR TITLE
Remove "-linkmode external"

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -132,11 +132,7 @@ if [ -z "$DOCKER_DEBUG" ]; then
 	LDFLAGS='-w'
 fi
 
-LDFLAGS_STATIC='-linkmode external'
-# Cgo -H windows is incompatible with -linkmode external.
-if [ "$(go env GOOS)" == 'windows' ]; then
-	LDFLAGS_STATIC=''
-fi
+LDFLAGS_STATIC=''
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -14,7 +14,7 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 		windows/amd64)
 			export CC=x86_64-w64-mingw32-gcc
 			export CGO_ENABLED=1
-			export LDFLAGS_STATIC_DOCKER="${LDFLAGS_STATIC_DOCKER/-linkmode external/-linkmode internal} -extld=${CC}"
+			export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC_DOCKER -linkmode internal -extld=${CC}"
 			;;
 	esac
 fi


### PR DESCRIPTION
We're having to override it in so many places that it no longer seems worthwhile to bother.  On top of that, the reason we did it in the first place was for being able to compile devicemapper statically, which still works after this change (either due to other changes in the way we build, or improvements in Go itself).
