### PR TITLE
Modified cpuset test for unicore test environment

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -791,7 +791,7 @@ func (s *DockerSuite) TestContainerApiCreateWithCpuSharesCpuset(c *check.C) {
 	config := map[string]interface{}{
 		"Image":      "busybox",
 		"CpuShares":  512,
-		"CpusetCpus": "0,1",
+		"CpusetCpus": "0",
 	}
 
 	status, body, err := sockRequest("POST", "/containers/create", config)
@@ -817,7 +817,7 @@ func (s *DockerSuite) TestContainerApiCreateWithCpuSharesCpuset(c *check.C) {
 
 	outCpuset, errCpuset := inspectField(containerJSON.ID, "HostConfig.CpusetCpus")
 	c.Assert(errCpuset, check.IsNil, check.Commentf("Output: %s", outCpuset))
-	c.Assert(outCpuset, check.Equals, "0,1")
+	c.Assert(outCpuset, check.Equals, "0")
 }
 
 func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {

--- a/integration-cli/docker_api_inspect_unix_test.go
+++ b/integration-cli/docker_api_inspect_unix_test.go
@@ -16,7 +16,7 @@ func (s *DockerSuite) TestInspectApiCpusetInConfigPre120(c *check.C) {
 	testRequires(c, cgroupCpuset)
 
 	name := "cpusetinconfig-pre120"
-	dockerCmd(c, "run", "--name", name, "--cpuset-cpus", "0-1", "busybox", "true")
+	dockerCmd(c, "run", "--name", name, "--cpuset-cpus", "0", "busybox", "true")
 
 	status, body, err := sockRequest("GET", fmt.Sprintf("/v1.19/containers/%s/json", name), nil)
 	c.Assert(status, check.Equals, http.StatusOK)


### PR DESCRIPTION
 fixed 2 problem on #17972

On the unicore process environment cpuset test is failed. 

if i read code correctly  purpose of `TestContainerApiCreateWithCpuSharesCpuset` and `TestInspectApiCpusetInConfigPre120` is only check configuration file is written  correctly or not.
so i think test with `--cpuset-cpus 0` options is enough.

If i wrong, maybe it have to change to skip on the unicore environment or using different option(0 when unicore, 0-1 or 0,2 when other environment). 
