### PR TITLE
Proposal: New logging driver that logs to tcp, udp and unix domain sockets

### DIFF
--- a/daemon/logger/socket/socket.go
+++ b/daemon/logger/socket/socket.go
@@ -1,0 +1,147 @@
+// +build linux
+
+// Package socket provides the log driver for writing logs to a unix domain socket
+package socket
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/daemon/logger"
+)
+
+const name = "socket"
+
+type SocketLogger struct {
+	destination url.URL
+	connection  net.Conn
+	mutex       sync.Mutex
+}
+
+type LogstashMessage struct {
+	Timestamp   time.Time `json:"@timestamp"`
+	Version     int       `json:"@version"`
+	Hostname	string    `json:"hostname"`
+	ContainerID string    `json:"containerID"`
+	Message     string    `json:"message"`
+	Source      string    `json:"source"`
+}
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func connect(s *SocketLogger) error {
+	switch s.destination.Scheme {
+	case "unix":
+		conn, err := net.Dial("unix", s.destination.Path)
+		if err != nil {
+			return err
+		}
+		s.connection = conn
+
+	case "tcp", "udp":
+		conn, err := net.Dial(s.destination.Scheme, s.destination.Host)
+		if err != nil {
+			return err
+		}
+		s.connection = conn
+	}
+
+	return nil
+}
+
+func New(ctx logger.Context) (logger.Logger, error) {
+	u, err := url.Parse(ctx.Config["destination"])
+	if err != nil {
+		return nil, err
+	}
+
+	s := &SocketLogger{
+		destination: *u,
+		connection:  nil,
+		mutex:       sync.Mutex{},
+	}
+
+	if err := connect(s); err != nil {
+		return s, err
+	}
+
+	return s, nil
+}
+
+func (s *SocketLogger) Log(msg *logger.Message) error {
+	res := LogstashMessage{
+		Timestamp:   msg.Timestamp,
+		Version:     1,
+		Hostname:    "",
+		ContainerID: msg.ContainerID,
+		Message:     string(msg.Line),
+		Source:      msg.Source,
+	}
+
+	json, err := json.Marshal(res)
+	if err != nil {
+		return err
+	}
+
+	json = append(json, '\n')
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	_, err = s.connection.Write([]byte(json))
+	if err != nil {
+		if err := connect(s); err != nil {
+			return err
+		} else {
+			_, err = s.connection.Write([]byte(json))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *SocketLogger) Name() string {
+	return name
+}
+
+func (s *SocketLogger) Close() error {
+	if s.connection != nil {
+		err := s.connection.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateLogOpt looks for socket specific log options.
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case "destination":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for socket log driver", key)
+		}
+	}
+
+	if _, ok := cfg["destination"]; !ok {
+		return fmt.Errorf("missing log opt 'destination'")
+	}
+
+	return nil
+}

--- a/daemon/logger/socket/socket.go
+++ b/daemon/logger/socket/socket.go
@@ -26,7 +26,7 @@ type SocketLogger struct {
 type LogstashMessage struct {
 	Timestamp   time.Time `json:"@timestamp"`
 	Version     int       `json:"@version"`
-	Hostname	string    `json:"hostname"`
+	Hostname    string    `json:"hostname"`
 	ContainerID string    `json:"containerID"`
 	Message     string    `json:"message"`
 	Source      string    `json:"source"`

--- a/daemon/logger/socket/socket_unsupported.go
+++ b/daemon/logger/socket/socket_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package socket

--- a/docs/reference/logging/overview.md
+++ b/docs/reference/logging/overview.md
@@ -25,6 +25,7 @@ container's logging driver. The following options are supported:
 | `fluentd`   | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                          |
 | `awslogs`   | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs.                              |
 | `splunk`    | Splunk logging driver for Docker. Writes log messages to `splunk` using HTTP Event Collector.                                 |
+| `socket`    | Socket logging driver for Docker. Writes log messages to TCP, UDP and Unix domain sockets.                                                |
 
 The `docker logs`command is available only for the `json-file` and `journald`
 logging drivers.
@@ -184,3 +185,19 @@ The Splunk logging driver requires the following options:
 
 For detailed information about working with this logging driver, see the [Splunk logging driver](splunk.md)
 reference documentation.
+
+## Socket options
+
+The socket logging driver requires the following options:
+
+    --log-opt destination=unix:///path/to/socket
+    --log-opt format=json
+
+The destination can take the following forms:
+
+ - unix:///path/to/socket
+ - tcp://example.com:1337
+ - udp://example.com:1337
+
+Currently the only supported format is JSON-objects written on a single line, separated by '\n'. This makes it possible for
+another application to listen on the socket, and process log entries as they arrive.


### PR DESCRIPTION
I'm proposing to add a new logging driver, that can log to a tcp, udp or unix domain socket.

The purpose is to make it easy to do custom processing of logs: Instead of writing yet another logging driver for Docker, this feature would make it easy to write a separate daemon to process logs.

A range of formats could be supported, but I suggest starting with a json-based format, where each logentry is delimited with \n, inspired by the [Logstash json_lines codec](https://www.elastic.co/guide/en/logstash/current/plugins-codecs-json_lines.html) and the [Logstash json format](https://gist.github.com/jordansissel/2996677). 
The resulting log entires will thus end up looking like:

```
{"@timestamp":"2015-11-16T01:23:00.233368446Z","@version":1,"hostname":"foo.example.com","containerID":"fe6bf90dcde1420588fded941fc4ed0122640723d893af53aa2449deeb4d1a73","message":"Hello from Docker.","source":"stdout"}
```

The reason for suggesting this particular format, is that I assume more people are familiar with JSON than many of the alternatives (such as MessagePack), and that this format is already used by Logstash.

I would like to give implementing it a shot on my own. I already made a proof-of-concept implementation of the current proposal.

ping @cpuguy83 
