### PR TITLE
Fix error typo when --expose and --net are specified

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3429,7 +3429,7 @@ func (s *DockerSuite) TestRunContainerNetModeWithExposePort(c *check.C) {
 	}
 
 	out, _, err = dockerCmdWithError("run", "--expose", "5000", "--net=container:parent", "busybox")
-	if err == nil || !strings.Contains(out, "Conflicting options: --expose and the network mode (--expose)") {
+	if err == nil || !strings.Contains(out, "Conflicting options: --expose and the network mode (--net)") {
 		c.Fatalf("run --net=container with --expose should error out")
 	}
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -39,7 +39,7 @@ var (
 	// ErrConflictNetworkPublishPorts conflict between the pulbish options and the network mode
 	ErrConflictNetworkPublishPorts = fmt.Errorf("Conflicting options: -p, -P, --publish-all, --publish and the network mode (--net)")
 	// ErrConflictNetworkExposePorts conflict between the expose option and the network mode
-	ErrConflictNetworkExposePorts = fmt.Errorf("Conflicting options: --expose and the network mode (--expose)")
+	ErrConflictNetworkExposePorts = fmt.Errorf("Conflicting options: --expose and the network mode (--net)")
 )
 
 // Parse parses the specified args for the specified command and generates a Config,


### PR DESCRIPTION
Fixes a minor typo in the --expose/--net option conflict message.
