### PR TITLE
Use /usr/lib/os-release if /etc/os-release is missing.

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -19,13 +19,22 @@ var (
 
 	// file to check to determine Operating System
 	etcOsRelease = "/etc/os-release"
+
+	// used by stateless systems like Clear Linux
+	altOsRelease = "/usr/lib/os-release"
 )
 
 // GetOperatingSystem gets the name of the current operating system.
 func GetOperatingSystem() (string, error) {
 	osReleaseFile, err := os.Open(etcOsRelease)
 	if err != nil {
-		return "", err
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("Error opening %s: %v", etcOsRelease, err)
+		}
+		osReleaseFile, err = os.Open(altOsRelease)
+		if err != nil {
+			return "", fmt.Errorf("Error opening %s: %v", altOsRelease, err)
+		}
 	}
 	defer osReleaseFile.Close()
 

--- a/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_unix_test.go
@@ -195,3 +195,32 @@ func TestIsContainerized(t *testing.T) {
 		t.Fatal("Wrongly assuming non-containerized")
 	}
 }
+
+func TestOsReleaseFallback(t *testing.T) {
+	var backup = etcOsRelease
+	var altBackup = altOsRelease
+	dir := os.TempDir()
+	etcOsRelease = filepath.Join(dir, "etcOsRelease")
+	altOsRelease = filepath.Join(dir, "altOsRelease")
+
+	defer func() {
+		os.Remove(dir)
+		etcOsRelease = backup
+		altOsRelease = altBackup
+	}()
+	content := `NAME=Gentoo
+ID=gentoo
+PRETTY_NAME="Gentoo/Linux"
+ANSI_COLOR="1;32"
+HOME_URL="http://www.gentoo.org/"
+SUPPORT_URL="http://www.gentoo.org/main/en/support.xml"
+BUG_REPORT_URL="https://bugs.gentoo.org/"
+`
+	if err := ioutil.WriteFile(altOsRelease, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write to %s: %v", etcOsRelease, err)
+	}
+	s, err := GetOperatingSystem()
+	if err != nil || s != "Gentoo/Linux" {
+		t.Fatalf("Expected %q, got %q (err: %v)", "Gentoo/Linux", s, err)
+	}
+}


### PR DESCRIPTION
As per os-release spec, /usr/lib/os-release file should be tried if
/etc/os-release is missing.

http://www.freedesktop.org/software/systemd/man/os-release.html

Thanks James Hunt james.o.hunt@intel.com and
Dimitri John Ledkov dimitri.j.ledkov@intel.com for contribution.

Close #17174

Signed-off-by: Alexander Morozov lk4d4@docker.com
