### PR TITLE
use variable instead of hardcoding version in repo

### DIFF
--- a/docs/installation/centos.md
+++ b/docs/installation/centos.md
@@ -53,10 +53,10 @@ package manager.
 
 3. Add the yum repo.
 
-        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
+        $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
         [dockerrepo]
         name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/centos/7
+        baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
         enabled=1
         gpgcheck=1
         gpgkey=https://yum.dockerproject.org/gpg

--- a/docs/installation/fedora.md
+++ b/docs/installation/fedora.md
@@ -46,23 +46,10 @@ There are two ways to install Docker Engine.  You can install with the `yum` pac
 
 3. Add the yum repo yourself.
 
-    For Fedora 21 run:
-
-        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
+        $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
         [dockerrepo]
         name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/fedora/21
-        enabled=1
-        gpgcheck=1
-        gpgkey=https://yum.dockerproject.org/gpg
-        EOF
-
-    For Fedora 22 run:
-
-        $ cat >/etc/yum.repos.d/docker.repo <<-EOF
-        [dockerrepo]
-        name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/fedora/22
+        baseurl=https://yum.dockerproject.org/repo/main/fedora/$releasever/
         enabled=1
         gpgcheck=1
         gpgkey=https://yum.dockerproject.org/gpg


### PR DESCRIPTION
this simplifies the documentation for fedora so it is copy and paste for all versions of fedora.
