### PR TITLE
Fix Markdown syntax error in aufs-driver.md

### DIFF
--- a/docs/userguide/storagedriver/aufs-driver.md
+++ b/docs/userguide/storagedriver/aufs-driver.md
@@ -97,7 +97,7 @@ Storage Driver: aufs
  Dirperm1 Supported: false
 Execution Driver: native-0.2
 ...output truncated...
-````
+```
 
 The output above shows that the Docker daemon is running the AUFS storage driver on top of an existing ext4 backing filesystem.
 


### PR DESCRIPTION
Fix Markdown syntax error in `aufs-driver.md`.

The fourth code block in https://docs.docker.com/engine/userguide/storagedriver/aufs-driver/#configure-docker-with-aufs is broken.
