### PR TITLE
Added flag to ignore fluentd connect error on container start

### DIFF
--- a/daemon/logger/loggerutils/log_option_helpers.go
+++ b/daemon/logger/loggerutils/log_option_helpers.go
@@ -1,0 +1,26 @@
+package loggerutils
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/docker/docker/daemon/logger"
+)
+
+const (
+	defaultFailOnStartupError = true // So that we do not break existing behaviour
+)
+
+// ParseFailOnStartupErrorFlag parses a log driver flag that determines if
+// the driver should ignore possible connection errors during startup
+func ParseFailOnStartupErrorFlag(ctx logger.Context) (bool, error) {
+	failOnStartupError := ctx.Config["fail-on-startup-error"]
+	if failOnStartupError == "" {
+		return defaultFailOnStartupError, nil
+	}
+	failOnStartupErrorFlag, err := strconv.ParseBool(failOnStartupError)
+	if err != nil {
+		return defaultFailOnStartupError, fmt.Errorf("invalid connect error flag %s: %s", failOnStartupError, err)
+	}
+	return failOnStartupErrorFlag, nil
+}

--- a/daemon/logger/loggerutils/log_option_helpers_test.go
+++ b/daemon/logger/loggerutils/log_option_helpers_test.go
@@ -1,0 +1,51 @@
+package loggerutils
+
+import (
+	"testing"
+
+	"github.com/docker/docker/daemon/logger"
+)
+
+func TestParseDefaultIgnoreFlag(t *testing.T) {
+	ctx := buildContext(map[string]string{})
+	flag, e := ParseFailOnStartupErrorFlag(ctx)
+	assertFlag(t, e, flag, true)
+}
+
+func TestParseIgnoreFlagWhenFalse(t *testing.T) {
+	ctx := buildContext(map[string]string{"fail-on-startup-error": "false"})
+	flag, e := ParseFailOnStartupErrorFlag(ctx)
+	assertFlag(t, e, flag, false)
+}
+
+func TestParseIgnoreFlagWhenTrue(t *testing.T) {
+	ctx := buildContext(map[string]string{"fail-on-startup-error": "true"})
+	flag, e := ParseFailOnStartupErrorFlag(ctx)
+	assertFlag(t, e, flag, true)
+}
+
+func TestParseIgnoreFlagWithError(t *testing.T) {
+	ctx := buildContext(map[string]string{"fail-on-startup-error": "maybe :)"})
+	flag, e := ParseFailOnStartupErrorFlag(ctx)
+	if e == nil {
+		t.Fatalf("Error should have happened")
+	}
+	assertFlag(t, nil, flag, true)
+}
+
+// Helpers
+
+func buildConfig(cfg map[string]string) logger.Context {
+	return logger.Context{
+		Config: cfg,
+	}
+}
+
+func assertFlag(t *testing.T, e error, flag bool, expected bool) {
+	if e != nil {
+		t.Fatalf("Error parsing ignore connect error flag: %q", e)
+	}
+	if flag != expected {
+		t.Fatalf("Wrong flag: %t, should be %t", flag, expected)
+	}
+}

--- a/docs/admin/logging/fluentd.md
+++ b/docs/admin/logging/fluentd.md
@@ -35,7 +35,8 @@ Some options are supported by specifying `--log-opt` as many times as needed:
 
  - `fluentd-address`: specify `host:port` to connect `localhost:24224`
  - `tag`: specify tag for fluentd message, which interpret some markup, ex `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` `docker.{{.ID}}`
-
+ - `fail-on-startup-error`: true/false; Should the logging driver fail container startup in case of connect error during startup. Default: true (backwards compatible)
+ - `buffer-limit`: Size limit (bytes) for the buffer which is used to buffer messages in case of connection outages. Default: 1M
 
 Configure the default logging driver by passing the
 `--log-driver` option to the Docker daemon:
@@ -78,6 +79,20 @@ the log tag format.
 
 The `labels` and `env` options each take a comma-separated list of keys. If there is collision between `label` and `env` keys, the value of the `env` takes precedence. Both options add additional fields to the extra attributes of a logging message.
 
+### fail-on-startup-error
+
+By default, if the logging driver cannot connect to the backend it will fail the entire startup of the container. If you wish to ignore potential connect error during container startup supply the `fail-on-startup-error` flag.
+
+    docker run --log-driver=fluentd --log-opt fail-on-startup-error=false
+
+
+### buffer-limit
+
+When fluent driver loses connection, or cannot connect at container startup, it will buffer the log events locally for re-transmission. Buffer limit option controls how much data will be buffered locally, **per container**. Specified in bytes.
+
+    docker run --log-driver=fluentd --log-opt buffer-limit=5242880
+
+The above would result to use 5M buffer locally. Keep in mind that during possible connection errors all your containers will start buffering locally and thus might result in considerable memory usage.
 
 ## Fluentd daemon management with Docker
 

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -172,6 +172,8 @@ You can use the `--log-opt NAME=VALUE` flag to specify these additional Fluentd 
 
  - `fluentd-address`: specify `host:port` to connect [localhost:24224]
  - `tag`: specify tag for `fluentd` message,
+ - `fail-on-startup-error`: true/false; Should the logging driver fail container startup in case of connect error during startup. Default: true (backwards compatible)
+ - `buffer-limit`: Size limit (bytes) for the buffer which is used to buffer messages in case of connection outages. Default: 1M
 
 For example, to specify both additional options:
 


### PR DESCRIPTION
Added flag to ignore fluentd connect error during container start. The default is to fail the container start as with current log-drivers do.

Added also a flag to set the buffer limit for fluent client as that controls how much data the client will buffer while trying to reconnect.

Fixes #15757
Implements the flag as log-opt as requested in PR #17182

Signed-of-by: Jussi Nummelin jussi.nummelin@gmail.com
