### PR TITLE
Fix "./docker" package name on freebsd

### DIFF
--- a/docker/daemon_freebsd.go
+++ b/docker/daemon_freebsd.go
@@ -1,6 +1,6 @@
 // +build daemon
 
-package docker
+package main
 
 // notifySystem sends a message to the host when the server is ready to be used
 func notifySystem() {


### PR DESCRIPTION
This fixes "can't load package: package ./docker: found packages client.go (main) and daemon_freebsd.go (docker)"
