### PR TITLE
Prevent the creation of "a.out" at the repo root

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -110,7 +110,7 @@ fi
 # test whether "btrfs/version.h" exists and apply btrfs_noversion appropriately
 if \
 	command -v gcc &> /dev/null \
-	&& ! gcc -E - &> /dev/null <<<'#include <btrfs/version.h>' \
+	&& ! gcc -E - -o /dev/null &> /dev/null <<<'#include <btrfs/version.h>' \
 ; then
 	DOCKER_BUILDTAGS+=' btrfs_noversion'
 fi
@@ -119,7 +119,7 @@ fi
 # functionality.
 if \
 	command -v gcc &> /dev/null \
-	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -ldevmapper -xc - &> /dev/null ) \
+	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -ldevmapper -xc - -o /dev/null &> /dev/null ) \
 ; then
        DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
 fi


### PR DESCRIPTION
Our clever "gcc" invocations were creating a spurious "a.out" file at the root of the repo (which just happened to be in ".gitignore" so we didn't notice it sooner).

A perfect example of why I'm a big fan of a very, very slim ".gitignore". :innocent:
