### PR TITLE
Log an error at error log level

### DIFF
--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -177,7 +177,7 @@ func (d Docker) Copy(c *daemon.Container, destPath string, src builder.FileInfo,
 		if err := d.Archiver.UntarPath(srcPath, tarDest); err == nil {
 			return nil
 		} else if err != io.EOF {
-			logrus.Debugf("Couldn't untar to %s: %v", tarDest, err)
+			logrus.Errorf("Couldn't untar to %s: %v", tarDest, err)
 		}
 	}
 


### PR DESCRIPTION
Really I think this should bubble up the error to Docker build, but at minimum you shouldn't need to enable debug mode on the daemon.
