### PR TITLE
Fix header levels for 1.9 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ be found.
 
 ## 1.9.0 (2015-11-03)
 
-## Runtime
+### Runtime
 
 + `docker stats` now returns block IO metrics (#15005)
 + `docker stats` now details network stats per interface (#15786)
@@ -37,11 +37,11 @@ with `ro` option (#14965)
 - Fix an issue with incorrect template execution in `docker inspect` (#17284)
 - DEPRECATE `-c` short flag variant for `--cpu-shares` in docker run (#16271)
 
-## Client
+### Client
 
 + Allow `docker import` to import from local files (#11907)
 
-## Builder
+### Builder
 
 + Add a `STOPSIGNAL` Dockerfile instruction allowing to set a different
 stop-signal for the container process (#15307)
@@ -49,7 +49,7 @@ stop-signal for the container process (#15307)
 that allows to add build-time environment variables (#15182)
 - Improve cache miss performance (#16890)
 
-## Storage
+### Storage
 
 - devicemapper: Implement deferred deletion capability (#16381)
 
@@ -71,7 +71,7 @@ that allows to add build-time environment variables (#15182)
   Those are now specific to the `bridge` network. Use `NetworkSettings.Networks` to inspect
   the networking settings of a container per network.
 
-## Volumes
+### Volumes
 
 + New top-level `volume` subcommand and API (#14242)
 - Move API volume driver settings to host-specific config (#15798)
@@ -80,7 +80,7 @@ that allows to add build-time environment variables (#15182)
 (#15507)
 - DEPRECATE auto-creating missing host paths for bind mounts (#16349)
 
-## Logging
+### Logging
 
 + Add `awslogs` logging driver for Amazon CloudWatch (#15495)
 + Add generic `tag` log option to allow customizing container/image
@@ -88,7 +88,7 @@ information passed to driver (e.g. show container names) (#15384)
 - Implement the `docker logs` endpoint for the journald driver (#13707)
 - DEPRECATE driver-specific log tags (e.g. `syslog-tag`, etc.) (#15384)
 
-## Distribution
+### Distribution
 
 + `docker search` now works with partial names (#16509)
 - Push optimization: avoid buffering to file (#15493)
@@ -101,7 +101,7 @@ by another client (#15489)
 `DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE` and
 `DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE` (#16894)
 
-## Security
+### Security
 
 + Add SELinux profiles to the rpm package (#15832)
 - Fix various issues with AppArmor profiles provided in the deb package


### PR DESCRIPTION
This way, parsers like allmychanges.com will be able to extract structured information about release
