### PR TITLE
Change casting of utsname.Machine to fix make binary for ARM

### DIFF
--- a/pkg/platform/architecture_linux.go
+++ b/pkg/platform/architecture_linux.go
@@ -14,15 +14,3 @@ func GetRuntimeArchitecture() (string, error) {
 	}
 	return charsToString(utsname.Machine), nil
 }
-
-func charsToString(ca [65]int8) string {
-	s := make([]byte, len(ca))
-	var lens int
-	for ; lens < len(ca); lens++ {
-		if ca[lens] == 0 {
-			break
-		}
-		s[lens] = uint8(ca[lens])
-	}
-	return string(s[0:lens])
-}

--- a/pkg/platform/utsname_int8.go
+++ b/pkg/platform/utsname_int8.go
@@ -1,0 +1,18 @@
+// +build linux,386 linux,amd64 linux,arm64
+// see golang's sources src/syscall/ztypes_linux_*.go that use int8
+
+package platform
+
+// Convert the OS/ARCH-specific utsname.Machine to string
+// given as an array of signed int8
+func charsToString(ca [65]int8) string {
+	s := make([]byte, len(ca))
+	var lens int
+	for ; lens < len(ca); lens++ {
+		if ca[lens] == 0 {
+			break
+		}
+		s[lens] = uint8(ca[lens])
+	}
+	return string(s[0:lens])
+}

--- a/pkg/platform/utsname_uint8.go
+++ b/pkg/platform/utsname_uint8.go
@@ -1,0 +1,18 @@
+// +build linux,arm linux,ppc64 linux,ppc64le s390x
+// see golang's sources src/syscall/ztypes_linux_*.go that use uint8
+
+package platform
+
+// Convert the OS/ARCH-specific utsname.Machine to string
+// given as an array of unsigned uint8
+func charsToString(ca [65]uint8) string {
+	s := make([]byte, len(ca))
+	var lens int
+	for ; lens < len(ca); lens++ {
+		if ca[lens] == 0 {
+			break
+		}
+		s[lens] = ca[lens]
+	}
+	return string(s[0:lens])
+}


### PR DESCRIPTION
The PR #17478 breaks `make binary` for ARM.

On a Scaleway machine we now get this error:

```
pkg/platform/architecture_linux.go:15: cannot use utsname.Machine (type [65]uint8) as type [65]int8 in argument to charsToString
```

The reason is that utsname is defined differently for ARM and AMD64:
- AMD64: https://golang.org/src/syscall/ztypes_linux_amd64.go?s=9792:9941#L560 
- ARM: https://golang.org/src/syscall/ztypes_linux_arm.go?#L542

To make it work again we need to cast it correctly for both architectures.

This PR is also needed to continue with the work on **Support Docker on ARM** #17802
