### PR TITLE
Unmount recursively to unmount volumes

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1511,8 +1511,8 @@ func (container *Container) unmountVolumes(forceSyscall bool) error {
 
 	for _, volumeMount := range volumeMounts {
 		if forceSyscall {
-			if err := system.Unmount(volumeMount.Destination); err != nil {
-				logrus.Warnf("%s unmountVolumes: Failed to force umount %v", container.ID, err)
+			if err := detachMounted(volumeMount.Destination); err != nil {
+				logrus.Warnf("%s unmountVolumes: Failed to do lazy umount %v", container.ID, err)
 			}
 		}
 


### PR DESCRIPTION
Fixes #17823 

Bind mounted volumes are bind mounted recursively. That means any mounts
under top mount also becomes visible under destination mount point. And
that also means that simple umount(dest) will fail as it has other mount
points underneath it. Instead use utitlity "umount -R dest" for recursively
unmounting all the mounts under dest.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
