### PR TITLE
Small Markdown Fixes to storage driver/commands ref

### DIFF
--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -1,6 +1,6 @@
 <!-- [metadata]>
 +++
-title = "Using the command line"
+title = "Docker Engine Commands"
 description = "Docker's CLI command description and usage"
 keywords = ["Docker, Docker documentation, CLI,  command line"]
 [menu.main]
@@ -12,7 +12,7 @@ parent = "mn_reference"
 
 # The Docker commands
 
-This section contains reference information on using Docker's command line client. Each command has a reference page along with samples. If you are unfamiliar with the command line, you should start by reading about how to ["Use the Docker command line"](cli.md).  
+This section contains reference information on using Docker's command line client. Each command has a reference page along with samples. If you are unfamiliar with the command line, you should start by reading about how to [Use the Docker command line](cli.md).  
 
 You start the Docker daemon with the command line. How you start the daemon affects your Docker containers. For that reason you should also make sure to read the [`daemon`](daemon.md) reference page.
 

--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -210,18 +210,20 @@ The procedure below will create a 90GB data volume and 4GB metadata volume to us
 
 5. Start the Docker daemon with the `devicemapper` storage driver and the `--storage-opt` flags.
 
-  The `data` and `metadata` devices that you pass to the `--storage-opt` options were created in the previous steps.
+    The `data` and `metadata` devices that you pass to the `--storage-opt` options were created in the previous steps.
 
-        $ sudo docker daemon --storage-driver=devicemapper --storage-opt dm.datadev=/dev/vg-docker/data --storage-opt dm.metadatadev=/dev/vg-docker/metadata &
-        [1] 2163
-        [root@ip-10-0-0-75 centos]# INFO[0000] Listening for HTTP on unix (/var/run/docker.sock)
-        INFO[0027] Option DefaultDriver: bridge
-        INFO[0027] Option DefaultNetwork: bridge
-        <output truncated>
-        INFO[0027] Daemon has completed initialization
-        INFO[0027] Docker daemon                                 commit=0a8c2e3 execdriver=native-0.2 graphdriver=devicemapper version=1.8.2
+          $ sudo docker daemon --storage-driver=devicemapper --storage-opt dm.datadev=/dev/vg-docker/data --storage-opt dm.metadatadev=/dev/vg-docker/metadata &
+          [1] 2163
+          [root@ip-10-0-0-75 centos]# INFO[0000] Listening for HTTP on unix (/var/run/docker.sock)
+          INFO[0027] Option DefaultDriver: bridge
+          INFO[0027] Option DefaultNetwork: bridge
+          <output truncated>
+          INFO[0027] Daemon has completed initialization
+          INFO[0027] Docker daemon commit=0a8c2e3 execdriver=native-0.2 graphdriver=devicemapper version=1.8.2
 
-    It is also possible to set the `--storage-driver` and `--storage-opt` flags in the Docker config file and start the daemon normally using the `service` or `systemd` commands.
+    It is also possible to set the `--storage-driver` and `--storage-opt` flags in
+    the Docker config file and start the daemon normally using the `service` or
+    `systemd` commands.
 
 6. Use the `docker info` command to verify that the daemon is using `data` and `metadata` devices you created.
 

--- a/docs/userguide/storagedriver/zfs-driver.md
+++ b/docs/userguide/storagedriver/zfs-driver.md
@@ -137,7 +137,7 @@ Once ZFS is installed and loaded, you're ready to configure ZFS for Docker.
 
         $ sudo zpool create -f zpool-docker /dev/xvdb
 
-  The command creates the `zpool` and gives it the name "zpool-docker". The name is arbitrary.
+    The command creates the `zpool` and gives it the name "zpool-docker". The name is arbitrary.
 
 2. Check that the `zpool` exists.
 
@@ -156,7 +156,7 @@ Once ZFS is installed and loaded, you're ready to configure ZFS for Docker.
         zpool-docker         93.5K  3.84G    19K  /zpool-docker
         zpool-docker/docker  19K    3.84G    19K  /var/lib/docker
 
-  Now that you have a ZFS filesystem mounted to `/var/lib/docker`, the daemon should automatically load with the `zfs` storage driver.
+    Now that you have a ZFS filesystem mounted to `/var/lib/docker`, the daemon should automatically load with the `zfs` storage driver.
 
 5. Start the Docker daemon.
 
@@ -185,9 +185,9 @@ Once ZFS is installed and loaded, you're ready to configure ZFS for Docker.
         Execution Driver: native-0.2
         [...]
 
-  The output of the command above shows that the Docker daemon is using the
-  `zfs` storage driver and that the parent dataset is the `zpool-docker/docker`
-  filesystem created earlier.
+    The output of the command above shows that the Docker daemon is using the
+    `zfs` storage driver and that the parent dataset is the `zpool-docker/docker`
+    filesystem created earlier.
 
 Your Docker host is now using ZFS to store to manage its images and containers.
 
@@ -207,7 +207,7 @@ using them with ZFS.
 
 * **ZFS Caching**. ZFS caches disk blocks in a memory structure called the adaptive replacement cache (ARC). The *Single Copy ARC* feature of ZFS allows a single cached copy of a block to be shared by multiple clones of a filesystem. This means that multiple running containers can share a single copy of cached block. This means that ZFS is a good option for PaaS and other high density use cases.
 
-- **Fragmentation**. Fragmentation is a natural byproduct of copy-on-write filesystems like ZFS. However, ZFS writes in 128K blocks and allocates *slabs* (multiple 128K blocks) to CoW operations in an attempt to reduce fragmentation. The ZFS intent log (ZIL) and the coalescing of writes (delayed writes) also help to reduce fragmentation. 
+- **Fragmentation**. Fragmentation is a natural byproduct of copy-on-write filesystems like ZFS. However, ZFS writes in 128K blocks and allocates *slabs* (multiple 128K blocks) to CoW operations in an attempt to reduce fragmentation. The ZFS intent log (ZIL) and the coalescing of writes (delayed writes) also help to reduce fragmentation.
 
 - **Use the native ZFS driver for Linux**. Although the Docker `zfs` storage driver supports the ZFS FUSE implementation, it is not recommended when high performance is required. The native ZFS on Linux driver tends to perform better than the FUSE implementation.
 


### PR DESCRIPTION
- There was some bad markdown in the storage driver material
- Also the commands ref menu label was wrong

Signed-off-by: Mary Anthony mary@docker.com
