### PR TITLE
Remove defaults for flags/options that expect no value

### DIFF
--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -126,7 +126,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 			out, stderr, _, err = runCommandWithStdoutStderr(helpCmd)
 			c.Assert(len(stderr), checker.Equals, 0, check.Commentf("Error on %q help. non-empty stderr:%q", cmd, stderr))
 			c.Assert(out, checker.Not(checker.HasSuffix), "\n\n", check.Commentf("Should not have blank line on %q\n", cmd))
-			c.Assert(out, checker.Contains, "--help=false", check.Commentf("Should show full usage on %q\n", cmd))
+			c.Assert(out, checker.Contains, "--help", check.Commentf("All commands should mention '--help'. Command '%v' did not.\n", cmd))
 
 			c.Assert(err, checker.IsNil, check.Commentf(out))
 

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -520,6 +520,20 @@ func Set(name, value string) error {
 	return CommandLine.Set(name, value)
 }
 
+// isZeroValue guesses whether the string represents the zero
+// value for a flag. It is not accurate but in practice works OK.
+func isZeroValue(value string) bool {
+	switch value {
+	case "false":
+		return true
+	case "":
+		return true
+	case "0":
+		return true
+	}
+	return false
+}
+
 // PrintDefaults prints, to standard error unless configured
 // otherwise, the default values of all defined flags in the set.
 func (fs *FlagSet) PrintDefaults() {
@@ -537,7 +551,6 @@ func (fs *FlagSet) PrintDefaults() {
 	}
 
 	fs.VisitAll(func(flag *Flag) {
-		format := "  -%s=%s"
 		names := []string{}
 		for _, name := range flag.Names {
 			if name[0] != '#' {
@@ -551,7 +564,13 @@ func (fs *FlagSet) PrintDefaults() {
 				val = homedir.GetShortcutString() + val[len(home):]
 			}
 
-			fmt.Fprintf(writer, format, strings.Join(names, ", -"), val)
+			if isZeroValue(val) {
+				format := "  -%s"
+				fmt.Fprintf(writer, format, strings.Join(names, ", -"))
+			} else {
+				format := "  -%s=%s"
+				fmt.Fprintf(writer, format, strings.Join(names, ", -"), val)
+			}
 			for i, line := range strings.Split(flag.Usage, "\n") {
 				if i != 0 {
 					line = "  " + line


### PR DESCRIPTION
see #9406, specifically https://github.com/docker/docker/issues/9406#issuecomment-81176423

Closes #9406

I took the whole isZeroValue function, which covers more than just the boolean values. If that oversteps what is desired I can take out the functionality for strings and numbers.
