### PR TITLE
Follow-up of 17478, unexport runtimeArchitecture method

### DIFF
--- a/pkg/platform/architecture_freebsd.go
+++ b/pkg/platform/architecture_freebsd.go
@@ -4,8 +4,8 @@ import (
 	"os/exec"
 )
 
-// GetRuntimeArchitecture get the name of the current architecture (x86, x86_64, …)
-func GetRuntimeArchitecture() (string, error) {
+// runtimeArchitecture get the name of the current architecture (x86, x86_64, …)
+func runtimeArchitecture() (string, error) {
 	cmd := exec.Command("uname", "-m")
 	machine, err := cmd.Output()
 	if err != nil {

--- a/pkg/platform/architecture_linux.go
+++ b/pkg/platform/architecture_linux.go
@@ -6,8 +6,8 @@ import (
 	"syscall"
 )
 
-// GetRuntimeArchitecture get the name of the current architecture (x86, x86_64, …)
-func GetRuntimeArchitecture() (string, error) {
+// runtimeArchitecture get the name of the current architecture (x86, x86_64, …)
+func runtimeArchitecture() (string, error) {
 	utsname := &syscall.Utsname{}
 	if err := syscall.Uname(utsname); err != nil {
 		return "", err

--- a/pkg/platform/architecture_windows.go
+++ b/pkg/platform/architecture_windows.go
@@ -36,8 +36,8 @@ const (
 
 var sysinfo systeminfo
 
-// GetRuntimeArchitecture get the name of the current architecture (x86, x86_64, …)
-func GetRuntimeArchitecture() (string, error) {
+// runtimeArchitecture get the name of the current architecture (x86, x86_64, …)
+func runtimeArchitecture() (string, error) {
 	syscall.Syscall(procGetSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(&sysinfo)), 0, 0)
 	switch sysinfo.wProcessorArchitecture {
 	case ProcessorArchitecture64, ProcessorArchitectureIA64:

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -15,7 +15,7 @@ var (
 
 func init() {
 	var err error
-	Architecture, err = GetRuntimeArchitecture()
+	Architecture, err = runtimeArchitecture()
 	if err != nil {
 		logrus.Errorf("Could no read system architecture info: %v", err)
 	}


### PR DESCRIPTION
Taking in account @tiborvass's comment (https://github.com/docker/docker/pull/17478#discussion_r44867405) and un-export and rename `GetRuntimeArchitecture` to `runtimeArchitecture`

Signed-off-by: Vincent Demeester vincent@sbr.pm
