### PR TITLE
Fixed docker network link in faq

### DIFF
--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -135,7 +135,7 @@ thousands or even millions of containers running in parallel.
 
 ### How do I connect Docker containers?
 
-Currently the recommended way to connect containers is via the Docker network feature. You can see details of how to [work with Docker networks here](https://docs.docker.com/networking).
+Currently the recommended way to connect containers is via the Docker network feature. You can see details of how to [work with Docker networks here](../userguide/networking/work-with-networks.md).
 
 Also useful for more flexible service portability is the [Ambassador linking
 pattern](../articles/ambassador_pattern_linking.md).


### PR DESCRIPTION
Fixed a link to docker networks on the FAQ page.
Also it's worth noting, a lot of incorrect links aren't showing up in make docs via LinkResolver. I'd be happy to look at it, if you can point me in the right direction :)

ping @thaJeztah @moxiegirl
Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
