### PR TITLE
Windows: [TP4] docker info crashes

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -152,6 +152,9 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 func (daemon *Daemon) GetNetworkDriverList() map[string]bool {
 	pluginList := make(map[string]bool)
 
+	if !daemon.NetworkControllerEnabled() {
+		return nil
+	}
 	c := daemon.netController
 	networks := c.Networks()
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ugh. Just found this this morning. Docker info will cause a SIGSEGV on the info thread in the daemon due to attempting to dereference through the netController which may be nil (is nil on Windows).

@swernli @calavera @tiborvass
