### PR TITLE
Add support for installation on Kali Linux 2.0

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -83,7 +83,7 @@ check_forked() {
 				lsb_dist=debian
 				dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 				case "$dist_version" in
-					8)
+					8|'Kali Linux 2')
 						dist_version="jessie"
 					;;
 					7)


### PR DESCRIPTION
It used to be possible to install docker on Kali 2.0 via the install script at https://get.docker.com/ubuntu. However, since that script was deprecated, a way to install on Kali is needed (even if the distro is not technically supported by docker). This modification to the install script treats a Kali Linux 2.0 (sana) installation like a Debian Linux 8.0 (jessie) installation, so that the install completes instead of erroring out with an "unknown distro" message.
