### PR TITLE
remove journald to fix dynbinary build on ARM

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!arm
 
 // Package journald provides the log driver for forwarding server logs
 // to endpoints that receive the systemd format.

--- a/daemon/logger/journald/journald_unsupported.go
+++ b/daemon/logger/journald/journald_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux linux,arm
 
 package journald
 

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -1,4 +1,4 @@
-// +build linux,cgo,!static_build,journald
+// +build linux,cgo,!static_build,journald,!arm
 
 package journald
 

--- a/daemon/logger/journald/read_unsupported.go
+++ b/daemon/logger/journald/read_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux !cgo static_build !journald
+// +build !linux !cgo static_build !journald linux,arm
 
 package journald
 


### PR DESCRIPTION
This PR is part of the efforts of supporting Docker on ARM #17802.

Currently building a dynamic binary on ARM fails if journald is included which is described in this issue #18074.

To make progress in fixing the integration-test-cli and the building of debian packages we need a working dynamic Docker build. Thus until issue #18074 is solved this PR does disable journald in the dynamic build for ARM only.

To make it more convenient to create a dynamic binary we also added a separate make target.

This PR is the prerequisite for creating separate PR's that fix the tests and build the debian packages.
