### PR TITLE
Registry tiny code improvements

### DIFF
--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -8,7 +8,9 @@ const (
 
 	// DefaultV2Registry is the URI of the default v2 registry
 	DefaultV2Registry = "https://registry-1.docker.io"
+)
 
+var (
 	// CertsDir is the directory where certificates are stored
 	CertsDir = "/etc/docker/certs.d"
 )

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -62,7 +62,7 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 
 	tlsConfig.InsecureSkipVerify = !isSecure
 
-	if isSecure {
+	if isSecure && CertsDir != "" {
 		hostDir := filepath.Join(CertsDir, cleanPath(hostname))
 		logrus.Debugf("hostDir: %s", hostDir)
 		if err := ReadCertsDirectory(&tlsConfig, hostDir); err != nil {


### PR DESCRIPTION
I am working on tool that works with registries. I tried to use as much of a docker code as possible. That way I could use already stored credentials and didn't have to implement registry configuration options (cli flags).

**What went wrong:**
If docker daemon is present on host using `github.com/docker/docker/registry` package for accessing registry will result in error even if `/etc/docker` does not have `certs.d` directory (because of access rights). 

```
open /etc/docker/certs.d/<registry>: permission denied
```

**Why:**
Registry package uses `CertsDir` for reading per registry certificates and it can't be changed (on unix) or turned off.

**Suggestion:**
- Check if `CertsDir` is not empty because on windows it is a variable  
  I understand why you would rather have CertsDir as const and that on windows it was necessary.
- Make `CertsDir` variable also on unix  
  This allows to set it to something else then `/etc/docker/certs.d/`. 
