### PR TITLE
don't try to use default route MTU as container MTU

### DIFF
--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -162,10 +162,6 @@ func detachMounted(path string) error {
 	return nil
 }
 
-func getDefaultRouteMtu() (int, error) {
-	return -1, errSystemNotSupported
-}
-
 func killProcessDirectly(container *container.Container) error {
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1382,12 +1382,7 @@ func setDefaultMtu(config *Config) {
 		return
 	}
 	config.Mtu = defaultNetworkMtu
-	if routeMtu, err := getDefaultRouteMtu(); err == nil {
-		config.Mtu = routeMtu
-	}
 }
-
-var errNoDefaultRoute = errors.New("no default route was found")
 
 // verifyContainerSettings performs validation of the hostconfig and config
 // structures.

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -33,7 +33,6 @@ import (
 	"github.com/docker/libnetwork/types"
 	blkiodev "github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/label"
-	"github.com/vishvananda/netlink"
 )
 
 const (
@@ -668,25 +667,6 @@ func (daemon *Daemon) conditionalMountOnStart(container *container.Container) er
 // during the cleanup of a container to unmount.
 func (daemon *Daemon) conditionalUnmountOnCleanup(container *container.Container) {
 	daemon.Unmount(container)
-}
-
-// getDefaultRouteMtu returns the MTU for the default route's interface.
-func getDefaultRouteMtu() (int, error) {
-	routes, err := netlink.RouteList(nil, 0)
-	if err != nil {
-		return 0, err
-	}
-	for _, r := range routes {
-		// a nil Dst means that this is the default route.
-		if r.Dst == nil {
-			i, err := net.InterfaceByIndex(r.LinkIndex)
-			if err != nil {
-				continue
-			}
-			return i.MTU, nil
-		}
-	}
-	return 0, errNoDefaultRoute
 }
 
 func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Store, ts tag.Store) error {

--- a/docs/userguide/networking/default_network/custom-docker0.md
+++ b/docs/userguide/networking/default_network/custom-docker0.md
@@ -16,7 +16,7 @@ The information in this section explains how to customize the Docker default bri
 
 By default, the Docker server creates and configures the host system's `docker0` interface as an _Ethernet bridge_ inside the Linux kernel that can pass packets back and forth between other physical or virtual network interfaces so that they behave as a single Ethernet network.
 
-Docker configures `docker0` with an IP address, netmask and IP allocation range. The host machine can both receive and send packets to containers connected to the bridge, and gives it an MTU -- the _maximum transmission unit_ or largest packet length that the interface will allow -- of either 1,500 bytes or else a more specific value copied from the Docker host's interface that supports its default route.  These options are configurable at server startup:
+Docker configures `docker0` with an IP address, netmask and IP allocation range. The host machine can both receive and send packets to containers connected to the bridge, and gives it an MTU -- the _maximum transmission unit_ or largest packet length that the interface will allow -- of 1,500 bytes. These options are configurable at server startup:
 - `--bip=CIDR` -- supply a specific IP address and netmask for the `docker0` bridge, using standard CIDR notation like `192.168.1.5/24`.
 
 - `--fixed-cidr=CIDR` -- restrict the IP range from the `docker0` subnet, using the standard CIDR notation like `172.167.1.0/28`. This range must be an IPv4 range for fixed IPs (ex: 10.20.0.0/16) and must be a subset of the bridge IP range (`docker0` or set using `--bridge`). For example with `--fixed-cidr=192.168.1.0/25`, IPs for your containers will be chosen from the first half of `192.168.1.0/24` subnet.


### PR DESCRIPTION
Trying to use the default route's MTU as the container (bridge) MTU is a bad idea:
- The box can have multiple default routes with different MTUs.
- The default route and MTU can change after docker has started.
- Traffic from the container might not even go over the default route (alternate routes, virtual networks, & inter-container communication).

Aside from the issues trying to determine the MTU to use, it's also unnecessary. The kernel performs path MTU discovery to resolve this exact situation. So, this PR lets the kernel do its job.

It might even be a good idea to raise the default MTU to 9000. But this PR just fixes the bad behavior. We can improve things in another PR.

closes #7796
