### PR TITLE
remove unnecessary echo from yum docs

### DIFF
--- a/docs/installation/centos.md
+++ b/docs/installation/centos.md
@@ -53,7 +53,7 @@ package manager.
 
 3. Add the yum repo.
 
-        $ echo | sudo tee /etc/yum.repos.d/docker.repo <<-EOF
+        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
         [dockerrepo]
         name=Docker Repository
         baseurl=https://yum.dockerproject.org/repo/main/centos/7

--- a/docs/installation/fedora.md
+++ b/docs/installation/fedora.md
@@ -48,7 +48,7 @@ There are two ways to install Docker Engine.  You can install with the `yum` pac
 
     For Fedora 21 run:
 
-        $ echo | sudo tee /etc/yum.repos.d/docker.repo <<-EOF
+        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
         [dockerrepo]
         name=Docker Repository
         baseurl=https://yum.dockerproject.org/repo/main/fedora/21

--- a/docs/installation/oracle.md
+++ b/docs/installation/oracle.md
@@ -40,7 +40,7 @@ btrfs storage engine on both Oracle Linux 6 and 7.
 
     For version 6:
 
-        $ echo | sudo tee /etc/yum.repos.d/docker.repo <<-EOF
+        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
         [dockerrepo]
         name=Docker Repository
         baseurl=https://yum.dockerproject.org/repo/main/oraclelinux/6

--- a/docs/installation/rhel.md
+++ b/docs/installation/rhel.md
@@ -47,7 +47,7 @@ There are two ways to install Docker Engine.  You can install with the `yum` pac
 
 3. Add the yum repo yourself.
 
-  		$ echo | sudo tee /etc/yum.repos.d/docker.repo <<-EOF
+        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
         [dockerrepo]
         name=Docker Repository
         baseurl=https://yum.dockerproject.org/repo/main/centos/7


### PR DESCRIPTION
#17419 added an unnecessary `echo |` to a few commands.
