### PR TITLE
Change TestRunNonRootUserResolvName Fail log.

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1331,7 +1331,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	}
 
 	if bytes.Equal(containerResolv, resolvConfSystem) {
-		c.Fatalf("Restarting  a container after container updated resolv.conf should not pick up host changes; expected %q, got %q", string(containerResolv), string(resolvConfSystem))
+		c.Fatalf("Container's resolv.conf should not have been updated with host resolv.conf: %q", string(containerResolv))
 	}
 
 	//3. test that a running container's resolv.conf is not modified while running


### PR DESCRIPTION
Test Case is Fine. but when test is fail, log message is weird.

```
if bytes.Equal(containerResolv, resolvConfSystem) {
        c.Fatalf("Restarting  a container after container updated resolv.conf should not pick up host changes; expected %q, got %q", string(containerResolv), string(resolvConfSystem))
    }
```

Above code, test is fail when `containerResolv` and `resolvConfSystem` equal. but in the log message expected/got used same value. and this test check `containerResolv` not `resolvConfSystem`.

if i understand correctly, expected values is  `/etc/resolv.conf` with new line `search mylittlepony.com`
