### PR TITLE
Fix markup typos

### DIFF
--- a/docs/userguide/storagedriver/aufs-driver.md
+++ b/docs/userguide/storagedriver/aufs-driver.md
@@ -87,7 +87,7 @@ DOCKER_OPTS="--storage-driver=aufs"
 Once your daemon is running, verify the storage driver with the `docker info` command.
 
 ```bash
-$ sudo docker info
+$ docker info
 Containers: 1
 Images: 4
 Storage Driver: aufs
@@ -97,7 +97,7 @@ Storage Driver: aufs
  Dirperm1 Supported: false
 Execution Driver: native-0.2
 ...output truncated...
-````
+```
 
 The output above shows that the Docker daemon is running the AUFS storage driver on top of an existing ext4 backing filesystem.
 

--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -221,7 +221,7 @@ The procedure below will create a 90GB data volume and 4GB metadata volume to us
         INFO[0027] Daemon has completed initialization
         INFO[0027] Docker daemon                                 commit=0a8c2e3 execdriver=native-0.2 graphdriver=devicemapper version=1.8.2
 
-    It is also possible to set the `--storage-driver` and `--storage-opt` flags in the Docker config file and start the daemon normally using the `service` or `systemd` commands.
+  It is also possible to set the `--storage-driver` and `--storage-opt` flags in the Docker config file and start the daemon normally using the `service` or `systemd` commands.
 
 6. Use the `docker info` command to verify that the daemon is using `data` and `metadata` devices you created.
 


### PR DESCRIPTION
I noticed bad rendering while reading https://docs.docker.com/engine/userguide/storagedriver/aufs-driver/#configure-docker-with-aufs ; it’s an extra backtick that the GitHub parser seems to ignore but your doc tools don’t.

I also removed an unnecessary sudo, but that’s just one of my pet peeves.

Finally, I’d like to note that it wasn’t obvious how to find which file to edit in order to submit a fix: find the right repo, git branch and file (tree doesn’t match URI space).
