### PR TITLE
Fix integration-cli tests 

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -753,7 +753,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksGracefulDaemonRest
 	cName := "bb"
 	nwList := []string{"nw1", "nw2", "nw3"}
 
-	s.d.Start()
+	s.d.StartWithBusybox()
 
 	connectContainerToNetworks(c, s.d, cName, nwList)
 	verifyContainerIsConnectedToNetworks(c, s.d, cName, nwList)
@@ -771,7 +771,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksUngracefulDaemonRe
 	cName := "cc"
 	nwList := []string{"nw1", "nw2", "nw3"}
 
-	s.d.Start()
+	s.d.StartWithBusybox()
 
 	connectContainerToNetworks(c, s.d, cName, nwList)
 	verifyContainerIsConnectedToNetworks(c, s.d, cName, nwList)
@@ -796,7 +796,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkRunNetByID(c *check.C) {
 
 func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c *check.C) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	s.d.Start()
+	s.d.StartWithBusybox()
 
 	// Run a few containers on host network
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Fixes #18124 by starting the test-specific docker daemon with the preloaded `busybox` image.

The three tests
- TestDockerNetworkMultipleNetworksGracefulDaemonRest
- TestDockerNetworkMultipleNetworksUngracefulDaemonRestart
- TestDockerNetworkHostModeUngracefulDaemonRestart

now also run fine on ARM.
