### PR TITLE
Increase timeouts to fix integration-cli tests on ARM

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -759,7 +759,7 @@ ADD test_file .`,
 		close(errChan)
 	}()
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		c.Fatal("Build with adding to workdir timed out")
 	case err := <-errChan:
 		c.Assert(err, check.IsNil)
@@ -1408,7 +1408,7 @@ COPY test_file .`,
 		close(errChan)
 	}()
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		c.Fatal("Build with adding to workdir timed out")
 	case err := <-errChan:
 		c.Assert(err, check.IsNil)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -53,7 +53,7 @@ func (s *DockerSuite) TestEventsUntag(c *check.C) {
 	dockerCmd(c, "rmi", "utest:tag1")
 	dockerCmd(c, "rmi", "utest:tag2")
 	eventsCmd := exec.Command(dockerBinary, "events", "--since=1")
-	out, exitCode, _, err := runCommandWithOutputForDuration(eventsCmd, time.Duration(time.Millisecond*500))
+	out, exitCode, _, err := runCommandWithOutputForDuration(eventsCmd, time.Duration(time.Millisecond*2500))
 	c.Assert(err, checker.IsNil)
 	c.Assert(exitCode, checker.Equals, 0, check.Commentf("Failed to get events"))
 	events := strings.Split(out, "\n")

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -35,7 +35,7 @@ func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
 		c.Assert(err, checker.IsNil)
 		output := b.String()
 		c.Assert(strings.TrimSpace(output), checker.Equals, "hello")
-	case <-time.After(1 * time.Second):
+	case <-time.After(5 * time.Second):
 		c.Fatal("timed out running docker exec")
 	}
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -33,7 +33,7 @@ func (s *DockerSuite) TestStartAttachReturnsOnError(c *check.C) {
 	select {
 	case err := <-ch:
 		c.Assert(err, check.IsNil)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		c.Fatalf("Attach did not exit properly")
 	}
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1517,7 +1517,7 @@ func setupRegistry(c *check.C) *testRegistryV2 {
 	c.Assert(err, check.IsNil)
 
 	// Wait for registry to be ready to serve requests.
-	for i := 0; i != 5; i++ {
+	for i := 0; i != 50; i++ {
 		if err = reg.Ping(); err == nil {
 			break
 		}


### PR DESCRIPTION
This PR improves some integration-cli tests to **Support Docker on ARM** #17802.

We had to increase some of the timeouts as the Scaleway C1 or even a Raspberry Pi is a bit slower and the successful tests took longer than the defined timeout.

With this PR and #18131 we now are at

```
OOPS: 1002 passed, 42 skipped, 3 FAILED
```
