### PR TITLE
Dockerfile: add python-dev to fix Python.h errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
 	mercurial \
 	parallel \
 	pkg-config \
+	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y \
 	mercurial \
 	parallel \
 	pkg-config \
+	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
 	libsqlite3-dev \
 	mercurial \
 	parallel \
+	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
 	libsqlite3-dev \
 	mercurial \
 	parallel \
+	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
 	libsqlite3-dev \
 	mercurial \
 	parallel \
+	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \


### PR DESCRIPTION
This PR fixes the underlying issue which makes pip print errors during the installation of packages.
