### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/misc/deprecated/ where target removal dates can also
 be found.
 
-## 1.9.1
+## 1.9.1 (2015-11-21)
 
 ### Runtime
 


### PR DESCRIPTION
The RPM changelog generation needs a date value for the 1.9.1 release. The date is probably incorrect though, because of timezones and such, so please adjust to the actual correct date you want to use for the release of 1.9.1. 

Signed-off-by: Avi Miller avi.miller@gmail.com
