### PR TITLE
ADD files to a folder doesn't set correct UID and GID

### DIFF
--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -127,6 +127,7 @@ func (d Docker) Release(sessionID string, activeImages []string) {
 func (d Docker) Copy(c *daemon.Container, destPath string, src builder.FileInfo, decompress bool) error {
 	srcPath := src.Path()
 	destExists := true
+	destDir := false
 	rootUID, rootGID := d.Daemon.GetRemappedUIDGID()
 
 	// Work in daemon-local OS specific file paths
@@ -140,6 +141,7 @@ func (d Docker) Copy(c *daemon.Container, destPath string, src builder.FileInfo,
 	// Preserve the trailing slash
 	// TODO: why are we appending another path separator if there was already one?
 	if strings.HasSuffix(destPath, string(os.PathSeparator)) || destPath == "." {
+		destDir = true
 		dest += string(os.PathSeparator)
 	}
 
@@ -182,7 +184,7 @@ func (d Docker) Copy(c *daemon.Container, destPath string, src builder.FileInfo,
 	}
 
 	// only needed for fixPermissions, but might as well put it before CopyFileWithTar
-	if destExists && destStat.IsDir() {
+	if destDir || (destExists && destStat.IsDir()) {
 		destPath = filepath.Join(destPath, src.Name())
 	}
 


### PR DESCRIPTION
Based on the documentation the line `ADD file foo/` in a Dockerfile should set the UID and GID of the foo/file to 0 ("All new files and directories are created with a UID and GID of 0."). This doesn't seem to be working correctly. If more than one file is ADDed to the folder, the first keep its original UID and GID but the rest are correctly set to 0.

`docker version`
Client:
 Version:      1.9.1
 API version:  1.21
 Go version:   go1.4.2
 Git commit:   a34a1d5
 Built:        Fri Nov 20 13:12:04 UTC 2015
 OS/Arch:      linux/amd64

Server:
 Version:      1.9.1
 API version:  1.21
 Go version:   go1.4.2
 Git commit:   a34a1d5
 Built:        Fri Nov 20 13:12:04 UTC 2015
 OS/Arch:      linux/amd64

`docker info`
Containers: 28
Images: 107
Server Version: 1.9.1
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: extfs
 Dirs: 163
 Dirperm1 Supported: true
Execution Driver: native-0.2
Logging Driver: json-file
Kernel Version: 3.19.0-33-generic
Operating System: Ubuntu 14.04.3 LTS
CPUs: 2
Total Memory: 1.96 GiB
Name: lubuntu
ID: 2RCA:JFZP:O6BW:Y4OS:SROP:JBXA:BWKU:ENOV:WUSN:QMC7:ZKH7:76IU

`uname -a`
Linux lubuntu 3.19.0-33-generic #38~14.04.1-Ubuntu SMP Fri Nov 6 18:17:28 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

Steps to Reproduce:
1. Create a Dockerfile with the following content
   `FROM ubuntu
   ADD file file2 foo/`
2. `touch file file2`
3. `sudo chown 1111:1111 file file2`
4. `docker build -t test-add-owner .`
5. `docker run -ti test-add-owner ls -l /foo`

Actual Result
The /foo/file owner and group are 1111 but /foo/file2 are 0 

Expected Result
For /foo/file and /foo/file2, the uid and gid is 0
