### PR TITLE
docs: fixed typo in "Get started with multi-host networking"

### DIFF
--- a/docs/userguide/networking/get-started-overlay.md
+++ b/docs/userguide/networking/get-started-overlay.md
@@ -7,7 +7,7 @@ keywords = ["Examples, Usage, network, docker, documentation, user guide, multih
 parent = "smn_networking"
 weight=-3
 +++
-<![end-metadata]-->
+<--![end-metadata]-->
 
 # Get started with multi-host networking
 


### PR DESCRIPTION
Hali,

It is just a minimal HTML typo, HTML tag wasn't closed.
