### PR TITLE
PS Improvements: ignore linked names and image lookup cache.

### DIFF
--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -64,6 +64,11 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		v.Set("size", "1")
 	}
 
+	trunc := !*noTrunc
+	if trunc {
+		v.Set("ignoreLinks", "1")
+	}
+
 	// Consolidate all filter flags, and sanity check them.
 	// They'll get processed in the daemon/server.
 	for _, f := range flFilter.GetAll() {
@@ -107,7 +112,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		Format: f,
 		Quiet:  *quiet,
 		Size:   *size,
-		Trunc:  !*noTrunc,
+		Trunc:  trunc,
 	}
 
 	ps.Format(psCtx, containers)

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -30,11 +30,12 @@ func (s *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 	}
 
 	config := &daemon.ContainersConfig{
-		All:     httputils.BoolValue(r, "all"),
-		Size:    httputils.BoolValue(r, "size"),
-		Since:   r.Form.Get("since"),
-		Before:  r.Form.Get("before"),
-		Filters: r.Form.Get("filters"),
+		All:         httputils.BoolValue(r, "all"),
+		Size:        httputils.BoolValue(r, "size"),
+		Since:       r.Form.Get("since"),
+		Before:      r.Form.Get("before"),
+		Filters:     r.Form.Get("filters"),
+		IgnoreLinks: httputils.BoolValue(r, "ignoreLinks"),
 	}
 
 	if tmpLimit := r.Form.Get("limit"); tmpLimit != "" {

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -117,6 +117,7 @@ Query Parameters:
   -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`|`dead`)
   -   `label=key` or `label="key=value"` of a container label
   -   `isolation=`(`default`|`process`|`hyperv`)   (Windows daemon only)
+-   **ignoreLinks** - 1/True/true or 0/False/false, ignore linked containers generated names
 
 Status Codes:
 

--- a/integration-cli/docker_api_containers_list_test.go
+++ b/integration-cli/docker_api_containers_list_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/docker/pkg/parsers/filters"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestContainerApiGetIgnoreLinks(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	name := "links-parent"
+	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
+	dockerCmd(c, "run", "--name", "links-child", "--link", name, "-d", "busybox", "top")
+
+	var err error
+	filter := filters.Args{}
+
+	filter, err = filters.ParseFlag("name=links-parent", filter)
+	c.Assert(err, check.IsNil)
+
+	param, err := filters.ToParam(filter)
+	c.Assert(err, check.IsNil)
+
+	var inspectJSON []struct {
+		Names []string
+	}
+
+	// Request ignoring links
+	status, body, err := sockRequest("GET", "/containers/json?ignoreLinks=1&filters="+param, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
+
+	err = json.Unmarshal(body, &inspectJSON)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(inspectJSON, checker.HasLen, 1)
+	c.Assert(inspectJSON[0].Names, checker.Not(checker.IsNil))
+	c.Assert(inspectJSON[0].Names, checker.HasLen, 1)
+	c.Assert(inspectJSON[0].Names[0], checker.Equals, "/links-parent")
+
+	// Request showing links
+	status, body, err = sockRequest("GET", "/containers/json?filters="+param, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
+
+	err = json.Unmarshal(body, &inspectJSON)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(inspectJSON, checker.HasLen, 1)
+	c.Assert(inspectJSON[0].Names, checker.Not(checker.IsNil))
+	c.Assert(inspectJSON[0].Names, checker.HasLen, 2)
+	c.Assert(inspectJSON[0].Names[0], checker.Equals, "/links-child/links-parent")
+	c.Assert(inspectJSON[0].Names[1], checker.Equals, "/links-parent")
+}

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -638,3 +638,24 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
 	}
 
 }
+
+func (s *DockerSuite) TestPsIgnoreLink(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	dockerCmd(c, "run", "--name", "links-parent", "-d", "busybox", "top")
+
+	out, _ := dockerCmd(c, "ps", "--filter", "name=links-parent", "--format", "{{.Names}}")
+	name := strings.TrimSpace(out)
+	c.Assert(name, checker.Equals, "links-parent")
+
+	dockerCmd(c, "run", "--name", "links-child", "--link", "links-parent", "-d", "busybox", "top")
+
+	// truncate output, no show link names
+	out, _ = dockerCmd(c, "ps", "--filter", "name=links-parent", "--format", "{{.Names}}")
+	name = strings.TrimSpace(out)
+	c.Assert(name, checker.Equals, "links-parent")
+
+	// no truncate output, show link names
+	out, _ = dockerCmd(c, "ps", "--filter", "name=links-parent", "--no-trunc", "--format", "{{.Names}}")
+	name = strings.TrimSpace(out)
+	c.Assert(name, checker.Equals, "links-child/links-parent,links-parent")
+}


### PR DESCRIPTION
- Ignore linked container names in the api when they are not necessary.
  This avoids an O(N) traversal of the container tree when we're not
  going to display the linked names for containers. `docker ps` ignores
  those names by default, so we don't need them in 99% of the cases.
- Cache image name lookup. Same image names are going to be resolved
  to the same id for a given list of containers. We can cache the result
  of the first operation avoiding an O(N) lookup of images.

Signed-off-by: David Calavera david.calavera@gmail.com
