### PR TITLE
Remove README reference to interactive tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,6 @@ Docker can be installed on your local machine as well as servers - both
 bare metal and virtualized.  It is available as a binary on most modern
 Linux systems, or as a VM on Windows, Mac and other systems.
 
-We also offer an [interactive tutorial](https://www.docker.com/tryit/)
-for quickly learning the basics of using Docker.
-
 For up-to-date install instructions, see the [Docs](https://docs.docker.com).
 
 Usage examples


### PR DESCRIPTION
The interactive tuturial doesn't exist any more; it just redirects to getting started (which is super unfortunate)
