### PR TITLE
Checkers on docker_api_inspect_unix_test.go

### DIFF
--- a/integration-cli/docker_api_inspect_unix_test.go
+++ b/integration-cli/docker_api_inspect_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
 
@@ -23,16 +24,12 @@ func (s *DockerSuite) TestInspectApiCpusetInConfigPre120(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	var inspectJSON map[string]interface{}
-	if err = json.Unmarshal(body, &inspectJSON); err != nil {
-		c.Fatalf("unable to unmarshal body for version 1.19: %v", err)
-	}
+	err = json.Unmarshal(body, &inspectJSON)
+	c.Assert(err, checker.IsNil, check.Commentf("unable to unmarshal body for version 1.19"))
 
 	config, ok := inspectJSON["Config"]
-	if !ok {
-		c.Fatal("Unable to find 'Config'")
-	}
+	c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
 	cfg := config.(map[string]interface{})
-	if _, ok := cfg["Cpuset"]; !ok {
-		c.Fatal("Api version 1.19 expected to include Cpuset in 'Config'")
-	}
+	_, ok = cfg["Cpuset"]
+	c.Assert(ok, checker.True, check.Commentf("Api version 1.19 expected to include Cpuset in 'Config'"))
 }


### PR DESCRIPTION
Applying #16756 to integration-cli/docker_api_inspect_unix_test.go

Signed-off-by: Aditi Rajagopal arajagopal@us.ibm.com
