### PR TITLE
Work around a linking problem on 32-bit arches

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -1,4 +1,4 @@
-// +build linux,!arm
+// +build linux
 
 // Package journald provides the log driver for forwarding server logs
 // to endpoints that receive the systemd format.

--- a/daemon/logger/journald/journald_unsupported.go
+++ b/daemon/logger/journald/journald_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux linux,arm
+// +build !linux
 
 package journald
 

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -1,4 +1,4 @@
-// +build linux,cgo,!static_build,journald,!arm
+// +build linux,cgo,!static_build,journald
 
 package journald
 

--- a/daemon/logger/journald/read_unsupported.go
+++ b/daemon/logger/journald/read_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux !cgo static_build !journald linux,arm
+// +build !linux !cgo static_build !journald
 
 package journald
 

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -25,6 +25,22 @@ if [ "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" == "windows/amd64" ] && [ "$(go e
 	export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC_DOCKER -linkmode=internal"
 fi
 
+if [ "$(go env GOOS)" == "linux" ] ; then
+	case "$(go env GOARCH)" in
+		arm*|386)
+			# linking for Linux on arm or x86 needs external linking to avoid
+			# https://github.com/golang/go/issues/9510 until we move to Go 1.6
+			if [ "$IAMSTATIC" == "true" ] ; then
+				export EXTLDFLAGS_STATIC="$EXTLDFLAGS_STATIC -zmuldefs"
+				export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC -extldflags \"$EXTLDFLAGS_STATIC\""
+
+			else
+				export LDFLAGS="$LDFLAGS -extldflags -zmuldefs"
+			fi
+			;;
+	esac
+fi
+
 if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ] && [ "$DOCKER_EXPERIMENTAL" ]; then
 	if  [ "${GOOS}/${GOARCH}" == "darwin/amd64" ]; then
 		export CGO_ENABLED=1


### PR DESCRIPTION
This should let us avoid triggering the linking error we were seeing in https://github.com/docker/docker/pull/18104, at least for now (future additions could trigger the bug, too).  We won't need this workaround once we switch to Go 1.6.
