### PR TITLE
Windows: Don't follow junctions on Windows

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -219,6 +219,12 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 
 		if err != nil {
 			if os.IsPermission(err) {
+				// Fixes GH18120. Do not follow junction directories on Windows. Golang
+				// is not capable of following long-path (\\?\...) junctions on Windows.
+				// eg c:\users\username\documents\My Music
+				if runtime.GOOS == "windows" && f.IsDir() && f.Mode()|os.ModeSymlink != 0 {
+					return nil
+				}
 				return fmt.Errorf("can't stat '%s'", filePath)
 			}
 			if os.IsNotExist(err) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Don't follow junction directories on Windows. Fixes #18120 
