### PR TITLE
install.sh: fix for multiarch deb/ubuntu

### DIFF
--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -75,6 +75,11 @@ from the new repository:
 
             deb https://apt.dockerproject.org/repo debian-stretch main
 
+    > **Note**: Docker does not provide packages for all architectures. To install docker on
+    > a multi-architecture system, add an `[arch=...]` clause to the entry. Refer to the
+    > [Debian Multiarch wiki](https://wiki.debian.org/Multiarch/HOWTO#Setting_up_apt_sources)
+    > for details.
+
  8. Save and close the file.
 
  9. Update the `apt` package index.

--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -83,6 +83,11 @@ packages from the new repository:
 
             deb https://apt.dockerproject.org/repo ubuntu-wily main
 
+    > **Note**: Docker does not provide packages for all architectures. To install docker on
+    > a multi-architecture system, add an `[arch=...]` clause to the entry. Refer to the
+    > [Debian Multiarch wiki](https://wiki.debian.org/Multiarch/HOWTO#Setting_up_apt_sources)
+    > for details.
+
 7. Save and close the `/etc/apt/sources.list.d/docker.list` file.
 
 8. Update the `apt` package index.

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -372,7 +372,7 @@ do_install() {
 			set -x
 			$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
-			$sh_c "echo deb https://apt.dockerproject.org/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
+			$sh_c "echo deb [arch=$(dpkg --print-architecture)] https://apt.dockerproject.org/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'
 			)
 			echo_docker_as_nonroot


### PR DESCRIPTION
Currently, the Docker repos will trigger apt-get errors on a
multiarch-configured deb system because the repos don't contain all
architectures. For example, on a multiarch system supporting amd64 and
armhf, apt-get will look for armhf Docker packages, fail to find them,
and error out.

Fix this by qualifying the repo line with the currently active
architecture.

This fixes issue #18207.

Signed-off-by: Martin Kelly martin@surround.io
