### PR TITLE
replace t.Fatal to t.Error

### DIFF
--- a/api/client/ps/custom_test.go
+++ b/api/client/ps/custom_test.go
@@ -78,15 +78,18 @@ func TestContainerPsContext(t *testing.T) {
 				expMap[keyval[0]] = keyval[1]
 			}
 			if !reflect.DeepEqual(expMap, entriesMap) {
-				t.Fatalf("Expected entries: %v, got: %v", c.expValue, v)
+				t.Errorf("Expected entries: %v, got: %v", c.expValue, v)
+				continue
 			}
 		} else if v != c.expValue {
-			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+			t.Errorf("Expected %s, was %s\n", c.expValue, v)
+			continue
 		}
 
 		h := ctx.fullHeader()
 		if h != c.expHeader {
-			t.Fatalf("Expected %s, was %s\n", c.expHeader, h)
+			t.Errorf("Expected %s, was %s\n", c.expHeader, h)
+			continue
 		}
 	}
 

--- a/api/client/ps/formatter_test.go
+++ b/api/client/ps/formatter_test.go
@@ -149,15 +149,13 @@ size: 0 B
 		Format(context.context, containers)
 		actual := out.String()
 		if actual != context.expected {
-			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
+			t.Errorf("Expected \n%s, got \n%s", context.expected, actual)
+			continue
 		}
-		// Clean buffer
-		out.Reset()
 	}
 }
 
 func TestCustomFormatNoContainers(t *testing.T) {
-	out := bytes.NewBufferString("")
 	containers := []types.Container{}
 
 	contexts := []struct {
@@ -167,21 +165,18 @@ func TestCustomFormatNoContainers(t *testing.T) {
 		{
 			Context{
 				Format: "{{.Image}}",
-				Output: out,
 			},
 			"",
 		},
 		{
 			Context{
 				Format: "table {{.Image}}",
-				Output: out,
 			},
 			"IMAGE\n",
 		},
 		{
 			Context{
 				Format: "{{.Image}}",
-				Output: out,
 				Size:   true,
 			},
 			"",
@@ -189,7 +184,6 @@ func TestCustomFormatNoContainers(t *testing.T) {
 		{
 			Context{
 				Format: "table {{.Image}}",
-				Output: out,
 				Size:   true,
 			},
 			"IMAGE               SIZE\n",
@@ -197,12 +191,13 @@ func TestCustomFormatNoContainers(t *testing.T) {
 	}
 
 	for _, context := range contexts {
+		out := bytes.NewBufferString("")
+		context.context.Output = out
 		customFormat(context.context, containers)
 		actual := out.String()
 		if actual != context.expected {
-			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
+			t.Errorf("Expected \n%s, got \n%s", context.expected, actual)
+			continue
 		}
-		// Clean buffer
-		out.Reset()
 	}
 }

--- a/api/common_test.go
+++ b/api/common_test.go
@@ -251,7 +251,8 @@ func TestDisplayablePorts(t *testing.T) {
 	for _, port := range cases {
 		actual := DisplayablePorts(port.ports)
 		if port.expected != actual {
-			t.Fatalf("Expected %s, got %s.", port.expected, actual)
+			t.Errorf("Expected %s, got %s.", port.expected, actual)
+			continue
 		}
 	}
 }

--- a/api/server/httputils/form_test.go
+++ b/api/server/httputils/form_test.go
@@ -28,7 +28,8 @@ func TestBoolValue(t *testing.T) {
 
 		a := BoolValue(r, "test")
 		if a != e {
-			t.Fatalf("Value: %s, expected: %v, actual: %v", c, e, a)
+			t.Errorf("Value: %s, expected: %v, actual: %v", c, e, a)
+			continue
 		}
 	}
 }
@@ -64,7 +65,8 @@ func TestInt64ValueOrZero(t *testing.T) {
 
 		a := Int64ValueOrZero(r, "test")
 		if a != e {
-			t.Fatalf("Value: %s, expected: %v, actual: %v", c, e, a)
+			t.Errorf("Value: %s, expected: %v, actual: %v", c, e, a)
+			continue
 		}
 	}
 }
@@ -84,10 +86,12 @@ func TestInt64ValueOrDefault(t *testing.T) {
 
 		a, err := Int64ValueOrDefault(r, "test", -1)
 		if a != e {
-			t.Fatalf("Value: %s, expected: %v, actual: %v", c, e, a)
+			t.Errorf("Value: %s, expected: %v, actual: %v", c, e, a)
+			continue
 		}
 		if err != nil {
-			t.Fatalf("Error should be nil, but received: %s", err)
+			t.Errorf("Error should be nil, but received: %s", err)
+			continue
 		}
 	}
 }

--- a/builder/remote_test.go
+++ b/builder/remote_test.go
@@ -31,13 +31,15 @@ func TestSelectAcceptableMIME(t *testing.T) {
 
 	for _, m := range invalidMimeStrings {
 		if len(selectAcceptableMIME(m)) > 0 {
-			t.Fatalf("Should not have accepted %q", m)
+			t.Errorf("Should not have accepted %q", m)
+			continue
 		}
 	}
 
 	for _, m := range validMimeStrings {
 		if str := selectAcceptableMIME(m); str == "" {
-			t.Fatalf("Should have accepted %q", m)
+			t.Errorf("Should have accepted %q", m)
+			continue
 		}
 	}
 }
@@ -80,7 +82,8 @@ func TestInspectResponseBinary(t *testing.T) {
 	}
 	for i := range body {
 		if body[i] != binaryContext[i] {
-			t.Fatalf("Corrupted response body at byte index %d", i)
+			t.Errorf("Corrupted response body at byte index %d", i)
+			continue
 		}
 	}
 }


### PR DESCRIPTION
`Fatal` will halt the test function entirely, and subsequent test cases won't run, so that we could just find one potential bug. 

When running unit test, we want to find as many bug as possible. It's a better choice to use `Error` and `continue`,  so that subsequent test cases could run and find more.

Usually, `Fatal` is used in cases where some internal error occurs so that test can not go on.

Signed-off-by: mqliang mqliang.zju@gmail.com
