### PR TITLE
docs: fixups for plugin drivers in docker info

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1915,16 +1915,16 @@ Display system-wide information
         "DockerRootDir": "/var/lib/docker",
         "Driver": "btrfs",
         "DriverStatus": [[""]],
-	"Plugins": {
-		"Volume": [
-			"local"
-		],
-		"Network": [
-			"null",
-			"host",
-			"bridge"
-		]
-	},
+        "Plugins": {
+            "Volume": [
+                "local"
+            ],
+            "Network": [
+                "null",
+                "host",
+                "bridge"
+            ]
+        },
         "ExecutionDriver": "native-0.1",
         "ExperimentalBuild": false,
         "HttpProxy": "http://test:test@localhost:8080",

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -30,6 +30,9 @@ For example:
      Dirperm1 Supported: true
     Execution Driver: native-0.2
     Logging Driver: json-file
+    Plugins:
+     Volume: local
+     Network: bridge null host
     Kernel Version: 3.19.0-22-generic
     OSType: linux
     Architecture: x86_64


### PR DESCRIPTION
Plugin drivers were added to docker info in https://github.com/docker/docker/pull/17300 but not added to the example output in the online docs.

Also fixed mixed tabs/spaces in the API documentation introduced by that PR.
