### PR TITLE
docs: move API changes to the correct API version

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -95,6 +95,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.22](docker_remote_api_v1.22.md) documentation
 
 * `GET /containers/json` supports filter `isolation` on Windows.
+* `GET /info` Now returns `Architecture` and `OSType` fields, providing information
+  about the host architecture and operating system type that the daemon runs on.
 * `GET /networks/(name)` now returns a `Name` field for each container attached to the network.
 
 ### v1.21 API changes

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1903,7 +1903,6 @@ Display system-wide information
     Content-Type: application/json
 
     {
-        "Architecture": "x86_64",
         "Containers": 11,
         "CpuCfsPeriod": true,
         "CpuCfsQuota": true,
@@ -1935,7 +1934,6 @@ Display system-wide information
         "Name": "prod-server-42",
         "NoProxy": "9.81.1.160",
         "OomKillDisable": true,
-        "OSType": "linux",
         "OperatingSystem": "Boot2Docker",
         "RegistryConfig": {
             "IndexConfigs": {

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1907,6 +1907,7 @@ Display system-wide information
     Content-Type: application/json
 
     {
+        "Architecture": "x86_64",
         "Containers": 11,
         "CpuCfsPeriod": true,
         "CpuCfsQuota": true,
@@ -1948,6 +1949,7 @@ Display system-wide information
         "Name": "prod-server-42",
         "NoProxy": "9.81.1.160",
         "OomKillDisable": true,
+        "OSType": "linux",
         "OperatingSystem": "Boot2Docker",
         "RegistryConfig": {
             "IndexConfigs": {


### PR DESCRIPTION
These changes were made as part of https://github.com/docker/docker/pull/17478 but inadvertently added to the v1.21 API version.

Also added a short description to the API changelog.
