### PR TITLE
docs: revert README changes in vendored files

### DIFF
--- a/vendor/src/github.com/docker/notary/tuf/README.md
+++ b/vendor/src/github.com/docker/notary/tuf/README.md
@@ -1,6 +1,6 @@
-# GOTUF
+# GOTUF 
 
-This is still a work in progress but will shortly be a fully compliant
+This is still a work in progress but will shortly be a fully compliant 
 Go implementation of [The Update Framework (TUF)](http://theupdateframework.com/).
 
 ## Where's the CLI
@@ -16,7 +16,7 @@ from Docker should be considered the official CLI to be used with this implement
 - [ ] Ensure consistent capitalization in naming (TUF\_\_\_ vs Tuf\_\_\_)
 - [X] Make caching of metadata files smarter - PR #5
 - [ ] ~~Add configuration for CLI commands. Order of configuration priority from most to least: flags, config file, defaults~~ Notary should be the official CLI
-- [X] Reassess organization of data types. Possibly consolidate a few things into the data package but break up package into a few more distinct files
+- [X] Reasses organization of data types. Possibly consolidate a few things into the data package but break up package into a few more distinct files
 - [ ] Comprehensive test cases
 - [ ] Delete files no longer in use
 - [ ] Fix up errors. Some have to be instantiated, others don't, the inconsistency is annoying.
@@ -32,5 +32,5 @@ without the code becoming overly convoluted.
 Some features such as pluggable verifiers have alreayd been merged upstream to flynn/go-tuf
 and we are in discussion with [titanous](https://github.com/titanous) about working to merge the 2 implementations.
 
-This implementation retains the same 3 Clause BSD license present on
+This implementation retains the same 3 Clause BSD license present on 
 the original flynn implementation.

--- a/vendor/src/github.com/hashicorp/memberlist/README.md
+++ b/vendor/src/github.com/hashicorp/memberlist/README.md
@@ -127,8 +127,8 @@ The changes from SWIM are noted here:
   also will periodically send out dedicated gossip messages on their own. This
   feature lets you have a higher gossip rate (for example once per 200ms)
   and a slower failure detection rate (such as once per second), resulting
-  in overall faster convergence rates and data propagation speeds. This feature
-  can be totally disabled as well, if you wish.
+  in overall faster convergence rates and data propogation speeds. This feature
+  can be totally disabed as well, if you wish.
 
 * memberlist stores around the state of dead nodes for a set amount of time,
   so that when full syncs are requested, the requester also receives information

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/nsenter/README.md
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/nsenter/README.md
@@ -18,7 +18,7 @@ which will give the process of the container that should be joined. Namespaces f
 be found from `/proc/[pid]/ns` and set by `setns` syscall.
 
 And then get the pipe number from `_LIBCONTAINER_INITPIPE`, error message could
-be transferred through it. If tty is added, `_LIBCONTAINER_CONSOLE_PATH` will 
+be transfered through it. If tty is added, `_LIBCONTAINER_CONSOLE_PATH` will 
 have value and start a console for output.
 
 Finally, `nsexec()` will clone a child process , exit the parent process and let 

--- a/vendor/src/github.com/philhofer/fwd/README.md
+++ b/vendor/src/github.com/philhofer/fwd/README.md
@@ -26,7 +26,7 @@ in the stream, and uses the `io.Seeker` interface if the underlying
 stream implements it. `(*fwd.Reader).Next` returns a slice pointing
 to the next `n` bytes in the read buffer (like `Peek`), but also
 increments the read position. This allows users to process streams
-in arbitrary block sizes without having to manage appropriately-sized
+in aribtrary block sizes without having to manage appropriately-sized
 slices. Additionally, obviating the need to copy the data from the
 buffer to another location in memory can improve performance dramatically
 in CPU-bound applications.
@@ -174,7 +174,7 @@ func (r *Reader) Skip(n int) (int, error)
 ```
 Skip moves the reader forward 'n' bytes.
 Returns the number of bytes skipped and any
-errors encountered. It is analogous to Seek(n, 1).
+errors encountered. It is analagous to Seek(n, 1).
 If the underlying reader implements io.Seeker, then
 that method will be used to skip forward.
 

--- a/vendor/src/github.com/ugorji/go/codec/README.md
+++ b/vendor/src/github.com/ugorji/go/codec/README.md
@@ -68,7 +68,7 @@ Rich Feature Set includes:
   - Encode/Decode from/to chan types (for iterative streaming support)
   - Drop-in replacement for encoding/json. `json:` key in struct tag supported.
   - Provides a RPC Server and Client Codec for net/rpc communication protocol.
-  - Handle unique idiosyncrasies of codecs e.g. 
+  - Handle unique idiosynchracies of codecs e.g. 
     - For messagepack, configure how ambiguities in handling raw bytes are resolved 
     - For messagepack, provide rpc server/client codec to support
       msgpack-rpc protocol defined at:


### PR DESCRIPTION
PR https://github.com/docker/docker/pull/17986 inadvertently included changes to some vendored files. This reverts those changes, but keeps the other fixes
