### PR TITLE
Improvement of docker top Man Page

### DIFF
--- a/man/docker-top.1.md
+++ b/man/docker-top.1.md
@@ -11,8 +11,9 @@ CONTAINER [ps OPTIONS]
 
 # DESCRIPTION
 
-Display the running process of the container. ps-OPTION can be any of the
- options you would pass to a Linux ps command.
+Display the running process of the container. ps-OPTION can be any of the options you would pass to a Linux ps command.
+
+All displayed information is from host's point of view.
 
 # OPTIONS
 **--help**
@@ -32,3 +33,4 @@ April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 June 2015, updated by Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>
+December 2015, updated by Pavel Pospisil <pospispa@gmail.com>


### PR DESCRIPTION
Some users expect that the `docker top $CONT` command displays information from the inside container perspective.
They expect that the `docker top $CONT` command displays same information as the `docker exec $CONT ps -ef` command. But it does not.

That's why the `docker top` man page shall explicitly state that the `docker top $CONT` displays information from the host's point of view.
