### PR TITLE
Remove ipc rule in docker-engine apparmor profile

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -25,7 +25,6 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   signal (receive) peer=unconfined,
   signal (send),
 {{end}}{{end}}
-  ipc rw,
   network,
   capability,
   owner /** rw,


### PR DESCRIPTION
On a ubuntu 15.04 machine with apparmor_parser version 2.10 I get

```
Syntax Error: Unknown line found in file:
/etc/apparmor.d/docker-engine line: 26
```

when running `aa-complain /etc/apparmor.d/docker-engine`.

It's super weird because ipc is documented in the apparmor manual, but it
doesn't seem to be working at all. Tested on a few servers.

Reference: http://wiki.apparmor.net/index.php/TechnicalDoc#IPC

ping @ewindisch who might know what is happening. Just testing this a 
bunch since we are going to be shipping this profile now.

Signed-off-by: Jessica Frazelle acidburn@docker.com
