### PR TITLE
Validate adding digests to tagstore with go types

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -195,7 +195,7 @@ func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Stor
 				return err
 			}
 
-			if err := ts.Add(ref, id, true); err != nil {
+			if err := ts.AddTag(ref, id, true); err != nil {
 				return err
 			}
 

--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -332,7 +332,7 @@ func (p *v1Puller) pullImage(out io.Writer, v1ID, endpoint string, localNameRef 
 		return layersDownloaded, err
 	}
 
-	if err := p.config.TagStore.Add(localNameRef, imageID, true); err != nil {
+	if err := p.config.TagStore.AddTag(localNameRef, imageID, true); err != nil {
 		return layersDownloaded, err
 	}
 

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -406,7 +406,11 @@ func (p *v2Puller) pullV2Tag(out io.Writer, ref reference.Named) (tagUpdated boo
 	}
 
 	if tagUpdated {
-		if err = p.config.TagStore.Add(ref, imageID, true); err != nil {
+		if canonical, ok := ref.(reference.Canonical); ok {
+			if err = p.config.TagStore.AddDigest(canonical, imageID, true); err != nil {
+				return false, err
+			}
+		} else if err = p.config.TagStore.AddTag(ref, imageID, true); err != nil {
 			return false, err
 		}
 	}

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -128,7 +128,7 @@ func (l *tarexporter) setLoadedTag(ref reference.NamedTagged, imgID image.ID, ou
 		fmt.Fprintf(outStream, "The image %s already exists, renaming the old one with ID %s to empty string\n", ref.String(), string(prevID)) // todo: this message is wrong in case of multiple tags
 	}
 
-	if err := l.ts.Add(ref, imgID, true); err != nil {
+	if err := l.ts.AddTag(ref, imgID, true); err != nil {
 		return err
 	}
 	return nil

--- a/migrate/v1/migratev1_test.go
+++ b/migrate/v1/migratev1_test.go
@@ -289,12 +289,15 @@ type mockTagAdder struct {
 	refs map[string]string
 }
 
-func (t *mockTagAdder) Add(ref reference.Named, id image.ID, force bool) error {
+func (t *mockTagAdder) AddTag(ref reference.Named, id image.ID, force bool) error {
 	if t.refs == nil {
 		t.refs = make(map[string]string)
 	}
 	t.refs[ref.String()] = id.String()
 	return nil
+}
+func (t *mockTagAdder) AddDigest(ref reference.Canonical, id image.ID, force bool) error {
+	return t.AddTag(ref, id, force)
 }
 
 type mockRegistrar struct {


### PR DESCRIPTION
Adds different methods to tagstore for tag and digest references to make sure pull_v2 is the only code path that can add digest references. Also moves sha256 repo name validation to tagstore level.

cc @aaronlehmann 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
