### PR TITLE
The loggingMiddleware function is adding lots of messages to the log

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -25,7 +25,7 @@ type middleware func(handler httputils.APIFunc) httputils.APIFunc
 func (s *Server) loggingMiddleware(handler httputils.APIFunc) httputils.APIFunc {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		if s.cfg.Logging {
-			logrus.Infof("%s %s", r.Method, r.RequestURI)
+			logrus.Debugf("%s %s", r.Method, r.RequestURI)
 		}
 		return handler(ctx, w, r, vars)
 	}


### PR DESCRIPTION
When tools like kubernetes and cockpit are talking to the docker daemon
actively, we are seeing large number of log messages that look like debug
information.

For example

docker info adds the following line to journald.

Nov 26 07:09:23 dhcp-10-19-62-196.boston.devel.redhat.com docker[32686]: time="2015-11-26T07:09:23.124503455-05:00" level=info msg="GET /v1.22/info"

We think this should be Debug level not Info level.

Signed-off-by: Dan Walsh dwalsh@redhat.com
