### PR TITLE
Event PubSub topics + linear filtering.

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -26,7 +26,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 
 	var (
 		v               = url.Values{}
-		eventFilterArgs = filters.Args{}
+		eventFilterArgs = filters.NewArgs()
 	)
 
 	// Consolidate all filter flags, and sanity check them early.
@@ -53,7 +53,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 		}
 		v.Set("until", ts)
 	}
-	if len(eventFilterArgs) > 0 {
+	if eventFilterArgs.Len() > 0 {
 		filterJSON, err := filters.ToParam(eventFilterArgs)
 		if err != nil {
 			return err

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -36,7 +36,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 
 	// Consolidate all filter flags, and sanity check them early.
 	// They'll get process in the daemon/server.
-	imageFilterArgs := filters.Args{}
+	imageFilterArgs := filters.NewArgs()
 	for _, f := range flFilter.GetAll() {
 		var err error
 		imageFilterArgs, err = filters.ParseFlag(f, imageFilterArgs)
@@ -47,7 +47,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 
 	matchName := cmd.Arg(0)
 	v := url.Values{}
-	if len(imageFilterArgs) > 0 {
+	if imageFilterArgs.Len() > 0 {
 		filterJSON, err := filters.ToParam(imageFilterArgs)
 		if err != nil {
 			return err

--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -20,7 +20,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 	var (
 		err error
 
-		psFilterArgs = filters.Args{}
+		psFilterArgs = filters.NewArgs()
 		v            = url.Values{}
 
 		cmd      = Cli.Subcmd("ps", nil, Cli.DockerCommands["ps"].Description, true)
@@ -72,7 +72,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		}
 	}
 
-	if len(psFilterArgs) > 0 {
+	if psFilterArgs.Len() > 0 {
 		filterJSON, err := filters.ToParam(psFilterArgs)
 		if err != nil {
 			return err

--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -54,7 +54,7 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 	cmd.Require(flag.Exact, 0)
 	cmd.ParseFlags(args, true)
 
-	volFilterArgs := filters.Args{}
+	volFilterArgs := filters.NewArgs()
 	for _, f := range flFilter.GetAll() {
 		var err error
 		volFilterArgs, err = filters.ParseFlag(f, volFilterArgs)
@@ -64,7 +64,7 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 	}
 
 	v := url.Values{}
-	if len(volFilterArgs) > 0 {
+	if volFilterArgs.Len() > 0 {
 		filterJSON, err := filters.ToParam(volFilterArgs)
 		if err != nil {
 			return err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -536,12 +536,11 @@ func (daemon *Daemon) GetByName(name string) (*Container, error) {
 func (daemon *Daemon) GetEventFilter(filter filters.Args) *events.Filter {
 	// incoming container filter can be name, id or partial id, convert to
 	// a full container id
-	for i, cn := range filter["container"] {
+	for _, cn := range filter.Get("container") {
 		c, err := daemon.Get(cn)
-		if err != nil {
-			filter["container"][i] = ""
-		} else {
-			filter["container"][i] = c.ID
+		filter.Del("container", cn)
+		if err == nil {
+			filter.Add("container", c.ID)
 		}
 	}
 	return events.NewFilter(filter, daemon.GetLabels)

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -8,7 +8,10 @@ import (
 	"github.com/docker/docker/pkg/pubsub"
 )
 
-const eventsLimit = 64
+const (
+	eventsLimit = 64
+	bufferSize  = 1024
+)
 
 // Events is pubsub channel for *jsonmessage.JSONMessage
 type Events struct {
@@ -21,7 +24,7 @@ type Events struct {
 func New() *Events {
 	return &Events{
 		events: make([]*jsonmessage.JSONMessage, 0, eventsLimit),
-		pub:    pubsub.NewPublisher(100*time.Millisecond, 1024),
+		pub:    pubsub.NewPublisher(100*time.Millisecond, bufferSize),
 	}
 }
 
@@ -40,6 +43,41 @@ func (e *Events) Subscribe() ([]*jsonmessage.JSONMessage, chan interface{}, func
 		e.Evict(l)
 	}
 	return current, l, cancel
+}
+
+// SubscribeTopic adds new listener to events, returns slice of 64 stored
+// last events, a channel in which you can expect new events (in form
+// of interface{}, so you need type assertion).
+func (e *Events) SubscribeTopic(since, sinceNano int64, ef *Filter) ([]*jsonmessage.JSONMessage, chan interface{}) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var buffered []*jsonmessage.JSONMessage
+	topic := func(m interface{}) bool {
+		return ef.Include(m.(*jsonmessage.JSONMessage))
+	}
+
+	if since != -1 {
+		for i := len(e.events) - 1; i >= 0; i-- {
+			ev := e.events[i]
+			if ev.Time < since || ((ev.Time == since) && (ev.TimeNano < sinceNano)) {
+				break
+			}
+			if ef.filter.Len() == 0 || topic(ev) {
+				buffered = append([]*jsonmessage.JSONMessage{ev}, buffered...)
+			}
+		}
+	}
+
+	var ch chan interface{}
+	if ef.filter.Len() > 0 {
+		ch = e.pub.SubscribeTopic(topic)
+	} else {
+		// Subscribe to all events if there are no filters
+		ch = e.pub.Subscribe()
+	}
+
+	return buffered, ch
 }
 
 // Evict evicts listener from pubsub

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
-	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/nat"
@@ -136,64 +135,65 @@ func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error)
 	}
 
 	var filtExited []int
-	if i, ok := psFilters["exited"]; ok {
-		for _, value := range i {
-			code, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, err
-			}
-			filtExited = append(filtExited, code)
+	err = psFilters.WalkValues("exited", func(value string) error {
+		code, err := strconv.Atoi(value)
+		if err != nil {
+			return err
 		}
+		filtExited = append(filtExited, code)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	if i, ok := psFilters["status"]; ok {
-		for _, value := range i {
-			if !isValidStateString(value) {
-				return nil, errors.New("Unrecognised filter value for status")
-			}
-
-			config.All = true
+	err = psFilters.WalkValues("status", func(value string) error {
+		if !isValidStateString(value) {
+			return fmt.Errorf("Unrecognised filter value for status: %s", value)
 		}
+
+		config.All = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	var beforeContFilter, sinceContFilter *Container
-	if i, ok := psFilters["before"]; ok {
-		for _, value := range i {
-			beforeContFilter, err = daemon.Get(value)
-			if err != nil {
-				return nil, err
-			}
-		}
+	err = psFilters.WalkValues("before", func(value string) error {
+		beforeContFilter, err = daemon.Get(value)
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	if i, ok := psFilters["since"]; ok {
-		for _, value := range i {
-			sinceContFilter, err = daemon.Get(value)
-			if err != nil {
-				return nil, err
-			}
-		}
+	err = psFilters.WalkValues("since", func(value string) error {
+		sinceContFilter, err = daemon.Get(value)
+		return err
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	imagesFilter := map[image.ID]bool{}
 	var ancestorFilter bool
-	if ancestors, ok := psFilters["ancestor"]; ok {
+	if psFilters.Include("ancestor") {
 		ancestorFilter = true
-		// The idea is to walk the graph down the most "efficient" way.
-		for _, ancestor := range ancestors {
-			// First, get the imageId of the ancestor filter (yay)
+		psFilters.WalkValues("ancestor", func(ancestor string) error {
 			id, err := daemon.GetImageID(ancestor)
 			if err != nil {
 				logrus.Warnf("Error while looking up for image %v", ancestor)
-				continue
+				return nil
 			}
 			if imagesFilter[id] {
 				// Already seen this ancestor, skip it
-				continue
+				return nil
 			}
 			// Then walk down the graph and put the imageIds in imagesFilter
 			populateImageFilterByParents(imagesFilter, id, daemon.imageStore.Children)
-		}
+			return nil
+		})
 	}
 
 	names := make(map[string][]string)
@@ -202,14 +202,14 @@ func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error)
 		return nil
 	}, 1)
 
-	if config.Before != "" {
+	if config.Before != "" && beforeContFilter == nil {
 		beforeContFilter, err = daemon.Get(config.Before)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if config.Since != "" {
+	if config.Since != "" && sinceContFilter == nil {
 		sinceContFilter, err = daemon.Get(config.Since)
 		if err != nil {
 			return nil, err
@@ -397,17 +397,8 @@ func (daemon *Daemon) Volumes(filter string) ([]*types.Volume, error) {
 		return nil, err
 	}
 
-	filterUsed := false
-	if i, ok := volFilters["dangling"]; ok {
-		if len(i) > 1 {
-			return nil, derr.ErrorCodeDanglingOne
-		}
-
-		filterValue := i[0]
-		if strings.ToLower(filterValue) == "true" || filterValue == "1" {
-			filterUsed = true
-		}
-	}
+	filterUsed := volFilters.Include("dangling") &&
+		(volFilters.ExactMatch("dangling", "true") || volFilters.ExactMatch("dangling", "1"))
 
 	volumes := daemon.volumes.List()
 	for _, v := range volumes {

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -230,9 +230,9 @@ func isNetworkAvailable(c *check.C, name string) bool {
 func getNetworkIDByName(c *check.C, name string) string {
 	var (
 		v          = url.Values{}
-		filterArgs = filters.Args{}
+		filterArgs = filters.NewArgs()
 	)
-	filterArgs["name"] = []string{name}
+	filterArgs.Add("name", name)
 	filterJSON, err := filters.ToParam(filterArgs)
 	c.Assert(err, checker.IsNil)
 	v.Set("filters", filterJSON)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1891,9 +1891,7 @@ func (s *DockerSuite) TestBuildCancellationKillsSleep(c *check.C) {
 
 	startEpoch := daemonTime(c).Unix()
 	// Watch for events since epoch.
-	eventsCmd := exec.Command(
-		dockerBinary, "events",
-		"--since", strconv.FormatInt(startEpoch, 10))
+	eventsCmd := exec.Command(dockerBinary, "events", "--since", strconv.FormatInt(startEpoch, 10))
 	stdout, err := eventsCmd.StdoutPipe()
 	if err != nil {
 		c.Fatal(err)
@@ -1932,12 +1930,12 @@ func (s *DockerSuite) TestBuildCancellationKillsSleep(c *check.C) {
 		c.Fatalf("failed to run build: %s", err)
 	}
 
-	matchCID := regexp.MustCompile("Running in ")
+	matchCID := regexp.MustCompile("Running in (.+)")
 	scanner := bufio.NewScanner(stdoutBuild)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if ok := matchCID.MatchString(line); ok {
-			containerID <- line[len(line)-12:]
+		if matches := matchCID.FindStringSubmatch(line); len(matches) > 0 {
+			containerID <- matches[1]
 			break
 		}
 	}

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestImagesErrorWithInvalidFilterNameTest(c *check.C) {
 	c.Assert(out, checker.Contains, "Invalid filter")
 }
 
-func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
+func (s *DockerSuite) TestImagesFilterLabelMatch(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageName1 := "images_filter_test1"
 	imageName2 := "images_filter_test2"

--- a/pkg/parsers/filters/parse.go
+++ b/pkg/parsers/filters/parse.go
@@ -5,6 +5,7 @@ package filters
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -15,7 +16,14 @@ import (
 // in an slice.
 // e.g given -f 'label=label1=1' -f 'label=label2=2' -f 'image.name=ubuntu'
 // the args will be {'label': {'label1=1','label2=2'}, 'image.name', {'ubuntu'}}
-type Args map[string][]string
+type Args struct {
+	fields map[string]map[string]bool
+}
+
+// NewArgs initializes a new Args struct.
+func NewArgs() Args {
+	return Args{fields: map[string]map[string]bool{}}
+}
 
 // ParseFlag parses the argument to the filter flag. Like
 //
@@ -25,9 +33,6 @@ type Args map[string][]string
 // map is created.
 func ParseFlag(arg string, prev Args) (Args, error) {
 	filters := prev
-	if prev == nil {
-		filters = Args{}
-	}
 	if len(arg) == 0 {
 		return filters, nil
 	}
@@ -37,9 +42,11 @@ func ParseFlag(arg string, prev Args) (Args, error) {
 	}
 
 	f := strings.SplitN(arg, "=", 2)
+
 	name := strings.ToLower(strings.TrimSpace(f[0]))
 	value := strings.TrimSpace(f[1])
-	filters[name] = append(filters[name], value)
+
+	filters.Add(name, value)
 
 	return filters, nil
 }
@@ -50,11 +57,11 @@ var ErrBadFormat = errors.New("bad format of filter (expected name=value)")
 // ToParam packs the Args into an string for easy transport from client to server.
 func ToParam(a Args) (string, error) {
 	// this way we don't URL encode {}, just empty space
-	if len(a) == 0 {
+	if a.Len() == 0 {
 		return "", nil
 	}
 
-	buf, err := json.Marshal(a)
+	buf, err := json.Marshal(a.fields)
 	if err != nil {
 		return "", err
 	}
@@ -63,23 +70,71 @@ func ToParam(a Args) (string, error) {
 
 // FromParam unpacks the filter Args.
 func FromParam(p string) (Args, error) {
-	args := Args{}
 	if len(p) == 0 {
-		return args, nil
+		return NewArgs(), nil
 	}
-	if err := json.NewDecoder(strings.NewReader(p)).Decode(&args); err != nil {
-		return nil, err
+
+	r := strings.NewReader(p)
+	d := json.NewDecoder(r)
+
+	m := map[string]map[string]bool{}
+	if err := d.Decode(&m); err != nil {
+		r.Seek(0, 0)
+
+		// Allow parsing old arguments in slice format.
+		// Because other libraries might be sending them in this format.
+		deprecated := map[string][]string{}
+		if deprecatedErr := d.Decode(&deprecated); deprecatedErr == nil {
+			m = deprecatedArgs(deprecated)
+		} else {
+			return NewArgs(), err
+		}
 	}
-	return args, nil
+	return Args{m}, nil
+}
+
+// Get returns the list of values associates with a field.
+// It returns a slice of strings to keep backwards compatibility with old code.
+func (filters Args) Get(field string) []string {
+	values := filters.fields[field]
+	if values == nil {
+		return make([]string, 0)
+	}
+	slice := make([]string, 0, len(values))
+	for key := range values {
+		slice = append(slice, key)
+	}
+	return slice
+}
+
+// Add adds a new value to a filter field.
+func (filters Args) Add(name, value string) {
+	if _, ok := filters.fields[name]; ok {
+		filters.fields[name][value] = true
+	} else {
+		filters.fields[name] = map[string]bool{value: true}
+	}
+}
+
+// Del removes a value from a filter field.
+func (filters Args) Del(name, value string) {
+	if _, ok := filters.fields[name]; ok {
+		delete(filters.fields[name], value)
+	}
+}
+
+// Len returns the number of fields in the arguments.
+func (filters Args) Len() int {
+	return len(filters.fields)
 }
 
 // MatchKVList returns true if the values for the specified field maches the ones
 // from the sources.
 // e.g. given Args are {'label': {'label1=1','label2=1'}, 'image.name', {'ubuntu'}},
-//      field is 'label' and sources are {'label':{'label1=1','label2=2','label3=3'}}
+//      field is 'label' and sources are {'label1': '1', 'label2': '2'}
 //      it returns true.
 func (filters Args) MatchKVList(field string, sources map[string]string) bool {
-	fieldValues := filters[field]
+	fieldValues := filters.fields[field]
 
 	//do not filter if there is no filter set or cannot determine filter
 	if len(fieldValues) == 0 {
@@ -90,21 +145,16 @@ func (filters Args) MatchKVList(field string, sources map[string]string) bool {
 		return false
 	}
 
-outer:
-	for _, name2match := range fieldValues {
+	for name2match := range fieldValues {
 		testKV := strings.SplitN(name2match, "=", 2)
 
-		for k, v := range sources {
-			if len(testKV) == 1 {
-				if k == testKV[0] {
-					continue outer
-				}
-			} else if k == testKV[0] && v == testKV[1] {
-				continue outer
-			}
+		v, ok := sources[testKV[0]]
+		if !ok {
+			return false
 		}
-
-		return false
+		if len(testKV) == 2 && testKV[1] != v {
+			return false
+		}
 	}
 
 	return true
@@ -115,13 +165,12 @@ outer:
 //      field is 'image.name' and source is 'ubuntu'
 //      it returns true.
 func (filters Args) Match(field, source string) bool {
-	fieldValues := filters[field]
-
-	//do not filter if there is no filter set or cannot determine filter
-	if len(fieldValues) == 0 {
+	if filters.ExactMatch(field, source) {
 		return true
 	}
-	for _, name2match := range fieldValues {
+
+	fieldValues := filters.fields[field]
+	for name2match := range fieldValues {
 		match, err := regexp.MatchString(name2match, source)
 		if err != nil {
 			continue
@@ -131,4 +180,62 @@ func (filters Args) Match(field, source string) bool {
 		}
 	}
 	return false
+}
+
+// ExactMatch returns true if the source matches exactly one of the filters.
+func (filters Args) ExactMatch(field, source string) bool {
+	fieldValues, ok := filters.fields[field]
+	//do not filter if there is no filter set or cannot determine filter
+	if !ok || len(fieldValues) == 0 {
+		return true
+	}
+
+	// try to march full name value to avoid O(N) regular expression matching
+	if fieldValues[source] {
+		return true
+	}
+	return false
+}
+
+// Include returns true if the name of the field to filter is in the filters.
+func (filters Args) Include(field string) bool {
+	_, ok := filters.fields[field]
+	return ok
+}
+
+// Validate ensures that all the fields in the filter are valid.
+// It returns an error as soon as it finds an invalid field.
+func (filters Args) Validate(accepted map[string]bool) error {
+	for name := range filters.fields {
+		if !accepted[name] {
+			return fmt.Errorf("Invalid filter '%s'", name)
+		}
+	}
+	return nil
+}
+
+// WalkValues iterates over the list of filtered values for a field.
+// It stops the iteration if it finds an error and it returns that error.
+func (filters Args) WalkValues(field string, op func(value string) error) error {
+	if _, ok := filters.fields[field]; !ok {
+		return nil
+	}
+	for v := range filters.fields[field] {
+		if err := op(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
+	m := map[string]map[string]bool{}
+	for k, v := range d {
+		values := map[string]bool{}
+		for _, vv := range v {
+			values[vv] = true
+		}
+		m[k] = values
+	}
+	return m
 }

--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -13,11 +13,12 @@ func NewPublisher(publishTimeout time.Duration, buffer int) *Publisher {
 	return &Publisher{
 		buffer:      buffer,
 		timeout:     publishTimeout,
-		subscribers: make(map[subscriber]struct{}),
+		subscribers: make(map[subscriber]topicFunc),
 	}
 }
 
 type subscriber chan interface{}
+type topicFunc func(v interface{}) bool
 
 // Publisher is basic pub/sub structure. Allows to send events and subscribe
 // to them. Can be safely used from multiple goroutines.
@@ -25,7 +26,7 @@ type Publisher struct {
 	m           sync.RWMutex
 	buffer      int
 	timeout     time.Duration
-	subscribers map[subscriber]struct{}
+	subscribers map[subscriber]topicFunc
 }
 
 // Len returns the number of subscribers for the publisher
@@ -38,9 +39,14 @@ func (p *Publisher) Len() int {
 
 // Subscribe adds a new subscriber to the publisher returning the channel.
 func (p *Publisher) Subscribe() chan interface{} {
+	return p.SubscribeTopic(nil)
+}
+
+// SubscribeTopic adds a new subscriber that filters messages sent by a topic.
+func (p *Publisher) SubscribeTopic(topic topicFunc) chan interface{} {
 	ch := make(chan interface{}, p.buffer)
 	p.m.Lock()
-	p.subscribers[ch] = struct{}{}
+	p.subscribers[ch] = topic
 	p.m.Unlock()
 	return ch
 }
@@ -56,20 +62,13 @@ func (p *Publisher) Evict(sub chan interface{}) {
 // Publish sends the data in v to all subscribers currently registered with the publisher.
 func (p *Publisher) Publish(v interface{}) {
 	p.m.RLock()
-	for sub := range p.subscribers {
-		// send under a select as to not block if the receiver is unavailable
-		if p.timeout > 0 {
-			select {
-			case sub <- v:
-			case <-time.After(p.timeout):
-			}
-			continue
-		}
-		select {
-		case sub <- v:
-		default:
-		}
+	wg := new(sync.WaitGroup)
+	for sub, topic := range p.subscribers {
+		wg.Add(1)
+
+		go p.sendTopic(sub, topic, v, wg)
 	}
+	wg.Wait()
 	p.m.RUnlock()
 }
 
@@ -81,4 +80,25 @@ func (p *Publisher) Close() {
 		close(sub)
 	}
 	p.m.Unlock()
+}
+
+func (p *Publisher) sendTopic(sub subscriber, topic topicFunc, v interface{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+	if topic != nil && !topic(v) {
+		return
+	}
+
+	// send under a select as to not block if the receiver is unavailable
+	if p.timeout > 0 {
+		select {
+		case sub <- v:
+		case <-time.After(p.timeout):
+		}
+		return
+	}
+
+	select {
+	case sub <- v:
+	default:
+	}
 }


### PR DESCRIPTION
Although these two changes could go separatedly, I rather put them together because they are very related. Our filtering system is very inneficient at matching results. This can slow down the events API with complicated filters. Moreover, that API performs operations in linear complexity at best, and exponencial at worst, when we can do constant time at best and linear at worst.

I separated both commits and wrote explanation of the changes in each of them, but I'm copying both messages here for easy reading:

```
Add PubSub topics.

A TopicFunc is an interface to let the pubisher decide whether it needs to
send a message to a subscriber or not. It returns true if the publisher
must send the message and false otherwise.

Users of the pubsub package can create a subscriber with a topic function
by calling `pubsub.SubscribeTopic`.

Message delivery has also been modified to use concurrent channels per
subscriber. That way, topic verification and message delivery is not o(N+M)
anymore, based on the number of subscribers and topic verification
complexity.

Using pubsub topics, the API stops controlling the message delivery,
delegating that function to a topic generated with the filtering provided
by the user. The publisher sends every message to the subscriber if there
is no filter, but the api doesn't have to select messages to return
anymore.
```

```
Make filtering a linear operation.

Improves the current filtering implementation complixity. Currently, the
best case is O(N) and worst case O(N^2) for key-value filtering. In the new
implementation, the best case is O(1) and worst case O(N), again for
key-value filtering.
```
