### PR TITLE
IGNORE: Debugging Windows CI

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -19,6 +19,8 @@ func main() {
 		return
 	}
 
+	//NOOP Change JJHx
+
 	// Set terminal emulation based on platform as required.
 	stdin, stdout, stderr := term.StdStreams()
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ignore this PR. Debugging Windows CI failure reasons. Think it's at a higher layer and the way in which Jenkins invokes CI - locally run from the node itself, azure node 1 is reliable. 
