### PR TITLE
Modifed 'Configuring DNS options to provide instructions for Ubuntu

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -349,6 +349,11 @@ To avoid this warning, you can specify a DNS server for use by Docker
 containers. Or, you can disable `dnsmasq` in NetworkManager. Though, disabling
 `dnsmasq` might make DNS resolution slower on some networks.
 
+The instructions below describe how to configure the Docker daemon running on
+Ubuntu 14.10 or below. Ubuntu 15.04 and above use systemd as its boot
+and service manager. Refer to [control and configure Docker with systemd](../articles/systemd.md#custom-docker-daemon-options)
+to configure a daemon controled by systemd.
+
 To specify a DNS server for use by Docker:
 
 1. Log into Ubuntu as a user with `sudo` privileges.


### PR DESCRIPTION
Modified ubuntulinux.md for instructions to configure DNS for Ubuntu 15.04 or greater. For Ubuntu 15.04 the user needs to use a drop-in file to configure the DNS Server.  I provided instructions on where to place the drop-in file for this.

@moxiegirl and @thaJeztah as of now I added it as a note, but I was thinking that if you guys wanted I could change step 2 to use the drop-in file instead of modifying the file at /etc/default/docker

Let me know what you guys think.  I also provided the minimum amount of information to get this to work for the users so if I missed any steps I am happy to add them. Finally let me know if I am missing any information

Ref Issue #17586 

Signed-off-by: Zuhayr Elahi elahi.zuhayr@gmail.com
