### PR TITLE
add a note around restart policies only working in detached mode

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -498,9 +498,14 @@ Or, to get the last time the container was (re)started;
     $ docker inspect -f "{{ .State.StartedAt }}" my-container
     # 2015-03-04T23:47:07.691840179Z
 
-You cannot set any restart policy in combination with
-["clean up (--rm)"](#clean-up-rm). Setting both `--restart` and `--rm`
-results in an error.
+
+You cannot combine the `--restart` (restart policy) with the `--rm` (clean
+up) flag. Setting both `--restart` and `--rm` results in an error.  On container
+restart, attached clients are disconnected.  See the examples on using the
+[`--rm` (clean up)](#clean-up-rm) flag later in this page.
+
+Note that restart policies only apply when running
+in [detached mode](#detached-d).
 
 ### Examples
 


### PR DESCRIPTION
I didn't realize this was the case at first, and (when running in foreground mode) was confused by why the container would simply die. Tested with the following:

``` javascript
// server.js

// create basic Node "Hello World" server
var http = require('http');
var requestListener = function(req, res) {
  res.writeHead(200);
  res.end('Hello, World!\n');
};
var server = http.createServer(requestListener);
server.listen(8080, function() {
  console.log("Server listening on port 8080.");
});

// die after six seconds
setTimeout(function() {
  console.log("Exiting.");
  process.exit(1);
}, 6000);
```

``` dockerfile
# Dockerfile
# adapted from https://github.com/nodejs/docker-node/blob/3622304ad09a84826521e81cb7ddf253c020d89e/5.1/onbuild/Dockerfile
FROM node:5-slim

RUN mkdir -p /usr/src/app
WORKDIR /usr/src/app

COPY . /usr/src/app

EXPOSE 8080
CMD node server.js
```

```
$ docker --version
Docker version 1.9.1, build a34a1d5
$ docker build -t docker-node-restart .
$ docker run -p 8080:8080 --restart=always docker-node-restart
# exits after six seconds
$ docker run -d -p 8080:8080 --restart=always docker-node-restart
# restarts
```

Thanks!
