### PR TITLE
Add support cpu realtime scheduler runtime and period

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -293,6 +293,8 @@ func (daemon *Daemon) populateCommand(c *Container, env []string) error {
 		CpusetMems:        c.hostConfig.CpusetMems,
 		CPUPeriod:         c.hostConfig.CPUPeriod,
 		CPUQuota:          c.hostConfig.CPUQuota,
+		CPURTPeriod:       c.hostConfig.CPURTPeriod,
+		CPURTRuntime:      c.hostConfig.CPURTRuntime,
 		Rlimits:           rlimits,
 		BlkioWeightDevice: weightDevices,
 		OomKillDisable:    c.hostConfig.OomKillDisable,

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -208,6 +208,16 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 		logrus.Warnf("Your kernel does not support CPU cfs quota. Quota discarded.")
 		hostConfig.CPUQuota = 0
 	}
+	if hostConfig.CPURTPeriod > 0 && !sysInfo.CPURTPeriod {
+		warnings = append(warnings, "Your kernel does not support CPU realtime scheduler perioad. Period discarded.")
+		logrus.Warnf("Your kernel does not support CPU realtime scheduler perioad. Period discarded.")
+		hostConfig.CPURTPeriod = 0
+	}
+	if hostConfig.CPURTRuntime > 0 && !sysInfo.CPURTRuntime {
+		warnings = append(warnings, "Your kernel does not support CPU realtime scheduler runtime. Runtime discarded.")
+		logrus.Warnf("Your kernel does not support CPU realtime scheduler runtime. Runtime discarded.")
+		hostConfig.CPURTRuntime = 0
+	}
 	if (hostConfig.CpusetCpus != "" || hostConfig.CpusetMems != "") && !sysInfo.Cpuset {
 		warnings = append(warnings, "Your kernel does not support cpuset. Cpuset discarded.")
 		logrus.Warnf("Your kernel does not support cpuset. Cpuset discarded.")

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -44,9 +44,12 @@ type Resources struct {
 	CpusetCpus        string                   `json:"cpuset_cpus"`
 	CpusetMems        string                   `json:"cpuset_mems"`
 	CPUPeriod         int64                    `json:"cpu_period"`
-	Rlimits           []*ulimit.Rlimit         `json:"rlimits"`
-	OomKillDisable    bool                     `json:"oom_kill_disable"`
-	MemorySwappiness  int64                    `json:"memory_swappiness"`
+	CPURTPeriod       int64                    `json:"cpu_rt_period"`
+	CPURTRuntime      int64                    `json:"cpu_rt_runtime"`
+
+	Rlimits          []*ulimit.Rlimit `json:"rlimits"`
+	OomKillDisable   bool             `json:"oom_kill_disable"`
+	MemorySwappiness int64            `json:"memory_swappiness"`
 }
 
 // ProcessConfig is the platform specific structure that describes a process
@@ -140,6 +143,8 @@ func InitContainer(c *Command) *configs.Config {
 	// Default parent cgroup is "docker". Override if required.
 	if c.CgroupParent != "" {
 		container.Cgroups.Parent = c.CgroupParent
+	} else if c.Resources.CPURTRuntime != 0 {
+		container.Cgroups.Parent = ""
 	}
 	return container
 }
@@ -165,6 +170,8 @@ func SetupCgroups(container *configs.Config, c *Command) error {
 		container.Cgroups.CpusetMems = c.Resources.CpusetMems
 		container.Cgroups.CpuPeriod = c.Resources.CPUPeriod
 		container.Cgroups.CpuQuota = c.Resources.CPUQuota
+		container.Cgroups.CpuRtPeriod = c.Resources.CPURTPeriod
+		container.Cgroups.CpuRtRuntime = c.Resources.CPURTRuntime
 		container.Cgroups.BlkioWeight = c.Resources.BlkioWeight
 		container.Cgroups.BlkioWeightDevice = c.Resources.BlkioWeightDevice
 		container.Cgroups.OomKillDisable = c.Resources.OomKillDisable

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -55,6 +55,12 @@ type cgroupCPUInfo struct {
 
 	// Whether CPU CFS(Completely Fair Scheduler) quota is supported or not
 	CPUCfsQuota bool
+
+	// Whether CPU realtime scheduler period is supported or not
+	CPURTPeriod bool
+
+	// Whether CPU realtime scheduler runtime is supported or not
+	CPURTRuntime bool
 }
 
 type cgroupBlkioInfo struct {

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -100,10 +100,22 @@ func checkCgroupCPU(quiet bool) cgroupCPUInfo {
 	if !quiet && !cpuCfsQuota {
 		logrus.Warn("Your kernel does not support cgroup cfs quotas")
 	}
+
+	cpuRtPeriod := cgroupEnabled(mountPoint, "cpu.rt_period_us")
+	if !quiet && !cpuRtPeriod {
+		logrus.Warn("Your kernel does not support cgroup realtime scheduler period")
+	}
+
+	cpuRtRuntime := cgroupEnabled(mountPoint, "cpu.rt_runtime_us")
+	if !quiet && !cpuRtRuntime {
+		logrus.Warn("Your kernel does not support cgroup realtime scheduler runtime")
+	}
 	return cgroupCPUInfo{
 		CPUShares:    cpuShares,
 		CPUCfsPeriod: cpuCfsPeriod,
 		CPUCfsQuota:  cpuCfsQuota,
+		CPURTPeriod:  cpuRtPeriod,
+		CPURTRuntime: cpuRtRuntime,
 	}
 }
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -174,8 +174,10 @@ type Resources struct {
 	CgroupParent      string // Parent cgroup.
 	BlkioWeight       uint16 // Block IO weight (relative weight vs. other containers)
 	BlkioWeightDevice []*blkiodev.WeightDevice
-	CPUPeriod         int64            `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
-	CPUQuota          int64            `json:"CpuQuota"`  // CPU CFS (Completely Fair Scheduler) quota
+	CPUPeriod         int64            `json:"CpuPeriod"`    // CPU CFS (Completely Fair Scheduler) period
+	CPUQuota          int64            `json:"CpuQuota"`     // CPU CFS (Completely Fair Scheduler) quota
+	CPURTPeriod       int64            `json:"CpuRtPeriod"`  // CPU realtime scheduler period
+	CPURTRuntime      int64            `json:"CpuRtRuntime"` // CPU realtime scheduler runtime
 	CpusetCpus        string           // CpusetCpus 0-2, 0,1
 	CpusetMems        string           // CpusetMems 0-2, 0,1
 	Devices           []DeviceMapping  // List of devices to map inside the container

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -91,6 +91,8 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flCPUShares         = cmd.Int64([]string{"#c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCPUPeriod         = cmd.Int64([]string{"-cpu-period"}, 0, "Limit CPU CFS (Completely Fair Scheduler) period")
 		flCPUQuota          = cmd.Int64([]string{"-cpu-quota"}, 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
+		flCPURTPeriod       = cmd.Int64([]string{"-cpu-rt-period"}, 0, "CPU realtime scheduler period")
+		flCPURTRuntime      = cmd.Int64([]string{"-cpu-rt-runtime"}, 0, "CPU realtime scheduler runtime")
 		flCpusetCpus        = cmd.String([]string{"-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flCpusetMems        = cmd.String([]string{"-cpuset-mems"}, "", "MEMs in which to allow execution (0-3, 0,1)")
 		flBlkioWeight       = cmd.Uint16([]string{"-blkio-weight"}, 0, "Block IO (relative weight), between 10 and 1000")
@@ -335,6 +337,8 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		CpusetCpus:        *flCpusetCpus,
 		CpusetMems:        *flCpusetMems,
 		CPUQuota:          *flCPUQuota,
+		CPURTPeriod:       *flCPURTPeriod,
+		CPURTRuntime:      *flCPURTRuntime,
 		BlkioWeight:       *flBlkioWeight,
 		BlkioWeightDevice: flBlkioWeightDevice.GetList(),
 		Ulimits:           flUlimits.GetList(),


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

`sched-rt-group` is a bit of different from other cgroup, `cpu.rt_runtime_us` can't propagate to children. For more information of cpu realtime scheduler group see https://www.kernel.org/doc/Documentation/scheduler/sched-rt-group.txt

To enable container cgroup could setup `cpu.rt_runtime_us`, the cgroup of this container should at the root hierarchy since the default cgroup parent `docker` does not setup `cpu.rt_runtime_us`. So the design is to make `container.Cgroups.Parent = ""` when `c.Resources.CPURTRuntime != 0`

This is a initial design, any comments are welcome. Tests and docs will add if we decide to move forward.
