### PR TITLE
add sort option to docker stats

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -200,7 +200,7 @@ func (s *containerStats) Display(w io.Writer) error {
 func (cli *DockerCli) CmdStats(args ...string) error {
 	cmd := Cli.Subcmd("stats", []string{"[CONTAINER...]"}, Cli.DockerCommands["stats"].Description, true)
 	all := cmd.Bool([]string{"a", "-all"}, false, "Show all containers (default shows just running)")
-	sortField := cmd.String([]string{"s", "-sort"}, "", "Sort stats by given field in descending order")
+	sortField := cmd.String([]string{"o", "-order-by"}, "", "Sort stats by given field in descending order")
 	noStream := cmd.Bool([]string{"-no-stream"}, false, "Disable streaming stats and only pull the first result")
 
 	cmd.ParseFlags(args, true)

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -17,7 +17,7 @@ parent = "smn_cli"
       -a, --all=false    Show all containers (default shows just running)
       --help=false       Print usage
       --no-stream=false  Disable streaming stats and only pull the first result
-	  -s, --sort         Sort stats by given field in descending order
+      -o, --order-by     Sort stats by given field in descending order
 
 The `docker stats` command returns a live data stream for running containers. To limit data to one or more specific containers, specify a list of container names or ids separated by a space. You can specify a stopped container but stopped containers do not return any data.
 

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -17,6 +17,7 @@ parent = "smn_cli"
       -a, --all=false    Show all containers (default shows just running)
       --help=false       Print usage
       --no-stream=false  Disable streaming stats and only pull the first result
+	  -s, --sort         Sort stats by given field in descending order
 
 The `docker stats` command returns a live data stream for running containers. To limit data to one or more specific containers, specify a list of container names or ids separated by a space. You can specify a stopped container but stopped containers do not return any data.
 

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -9,6 +9,7 @@ docker-stats - Display a live stream of one or more containers' resource usage s
 [**-a**|**--all**[=*false*]]
 [**--help**]
 [**--no-stream**[=*false*]]
+[**-s**|**--sort**[=*SORT-FIELD*]]
 [CONTAINER...]
 
 # DESCRIPTION
@@ -24,6 +25,10 @@ Display a live stream of one or more containers' resource usage statistics
 
 **--no-stream**=*true*|*false*
   Disable streaming stats and only pull the first result, default setting is false.
+
+**-s**, **--sort**=""
+  Sort field (valid fields are Name, CPUPercentage, Memory, MemoryLimit, MemoryPercentage,
+  NetworkRx, NetworkTx, BlockRead, BlockWrite)
 
 # EXAMPLES
 

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -9,7 +9,7 @@ docker-stats - Display a live stream of one or more containers' resource usage s
 [**-a**|**--all**[=*false*]]
 [**--help**]
 [**--no-stream**[=*false*]]
-[**-s**|**--sort**[=*SORT-FIELD*]]
+[**-o**|**--order-by**[=*SORT-FIELD*]]
 [CONTAINER...]
 
 # DESCRIPTION
@@ -26,9 +26,11 @@ Display a live stream of one or more containers' resource usage statistics
 **--no-stream**=*true*|*false*
   Disable streaming stats and only pull the first result, default setting is false.
 
-**-s**, **--sort**=""
-  Sort field (valid fields are Name, CPUPercentage, Memory, MemoryLimit, MemoryPercentage,
-  NetworkRx, NetworkTx, BlockRead, BlockWrite)
+**-o**, **--order-by**=""
+  Sort output by the given field (valid fields are Name, CPUPercentage, Memory, MemoryLimit,
+  MemoryPercentage, NetworkRx, NetworkTx, BlockRead, BlockWrite).
+  You can prepend '+' or '-' to change the sort order, a leading '+' will result in descending
+  order (default), a leading '-' will give you ascending order.
 
 # EXAMPLES
 


### PR DESCRIPTION
I though it would be nice if docker stats allowed to sort its output by different fields (like classic top), so I've added a command line option to get some basic sorting. Please be aware, I'm a golang newbie.
