### PR TITLE
Set default MemorySwappiness when adapt

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -296,11 +296,7 @@ func (daemon *Daemon) populateCommand(c *Container, env []string) error {
 		Rlimits:           rlimits,
 		BlkioWeightDevice: weightDevices,
 		OomKillDisable:    c.hostConfig.OomKillDisable,
-		MemorySwappiness:  -1,
-	}
-
-	if c.hostConfig.MemorySwappiness != nil {
-		resources.MemorySwappiness = *c.hostConfig.MemorySwappiness
+		MemorySwappiness:  *c.hostConfig.MemorySwappiness,
 	}
 
 	processConfig := execdriver.ProcessConfig{

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -112,11 +112,7 @@ func checkKernel() error {
 
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
-func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, adjustCPUShares bool) {
-	if hostConfig == nil {
-		return
-	}
-
+func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, adjustCPUShares bool) error {
 	if adjustCPUShares && hostConfig.CPUShares > 0 {
 		// Handle unsupported CPUShares
 		if hostConfig.CPUShares < linuxMinCPUShares {
@@ -135,6 +131,15 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 		shmSize := runconfig.DefaultSHMSize
 		hostConfig.ShmSize = &shmSize
 	}
+	var err error
+	if hostConfig.SecurityOpt == nil {
+		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // verifyPlatformContainerSettings performs platform-specific validation of the

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -138,6 +138,10 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 			return err
 		}
 	}
+	if hostConfig.MemorySwappiness == nil {
+		defaultSwappiness := int64(-1)
+		hostConfig.MemorySwappiness = &defaultSwappiness
+	}
 
 	return nil
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -48,9 +48,9 @@ func checkKernel() error {
 
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
-func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, adjustCPUShares bool) {
+func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, adjustCPUShares bool) error {
 	if hostConfig == nil {
-		return
+		return nil
 	}
 
 	if hostConfig.CPUShares < 0 {
@@ -60,6 +60,8 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 		logrus.Warnf("Changing requested CPUShares of %d to maximum allowed of %d", hostConfig.CPUShares, windowsMaxCPUShares)
 		hostConfig.CPUShares = windowsMaxCPUShares
 	}
+
+	return nil
 }
 
 // verifyPlatformContainerSettings performs platform-specific validation of the

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -36,6 +36,9 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 				return err
 			}
 			container.Unlock()
+			if err := daemon.adaptContainerSettings(hostConfig, false); err != nil {
+				return err
+			}
 			if err := daemon.setHostConfig(container, hostConfig); err != nil {
 				return err
 			}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1434,7 +1434,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeHostConfigOmitted(c *check.
 	var containerJSON types.ContainerJSON
 	c.Assert(json.Unmarshal(body, &containerJSON), check.IsNil)
 
-	c.Assert(containerJSON.HostConfig.ShmSize, check.IsNil)
+	c.Assert(*containerJSON.HostConfig.ShmSize, check.Equals, runconfig.DefaultSHMSize)
 
 	out, _ := dockerCmd(c, "start", "-i", containerJSON.ID)
 	shmRegexp := regexp.MustCompile(`shm on /dev/shm type tmpfs(.*)size=65536k`)
@@ -1522,5 +1522,5 @@ func (s *DockerSuite) TestPostContainersCreateMemorySwappinessHostConfigOmitted(
 	var containerJSON types.ContainerJSON
 	c.Assert(json.Unmarshal(body, &containerJSON), check.IsNil)
 
-	c.Assert(containerJSON.HostConfig.MemorySwappiness, check.IsNil)
+	c.Assert(*containerJSON.HostConfig.MemorySwappiness, check.Equals, int64(-1))
 }


### PR DESCRIPTION
It makes the inspect result consistent between cli and REST api
when MemorySwappiness is not set.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
