### PR TITLE
daemon: remove sysInitPath, lxc leftover

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -122,7 +122,6 @@ func (c *contStore) List() []*Container {
 type Daemon struct {
 	ID                        string
 	repository                string
-	sysInitPath               string
 	containers                *contStore
 	execCommands              *exec.Store
 	tagStore                  tag.Store
@@ -811,8 +810,6 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	d.containerGraphDB = graph
 
-	var sysInitPath string
-
 	sysInfo := sysinfo.New(false)
 	// Check if Devices cgroup is mounted, it is hard requirement for container security,
 	// on Linux/FreeBSD.
@@ -820,7 +817,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 		return nil, fmt.Errorf("Devices cgroup isn't mounted")
 	}
 
-	ed, err := execdrivers.NewDriver(config.ExecOptions, config.ExecRoot, config.Root, sysInitPath, sysInfo)
+	ed, err := execdrivers.NewDriver(config.ExecOptions, config.ExecRoot, config.Root, sysInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +832,6 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	d.trustKey = trustKey
 	d.idIndex = truncindex.NewTruncIndex([]string{})
 	d.configStore = config
-	d.sysInitPath = sysInitPath
 	d.execDriver = ed
 	d.statsCollector = d.newStatsCollector(1 * time.Second)
 	d.defaultLogConfig = config.LogConfig
@@ -1273,10 +1269,6 @@ func (daemon *Daemon) GetImage(refOrID string) (*image.Image, error) {
 
 func (daemon *Daemon) config() *Config {
 	return daemon.configStore
-}
-
-func (daemon *Daemon) systemInitPath() string {
-	return daemon.sysInitPath
 }
 
 // GraphDriver returns the currently used driver for processing

--- a/daemon/execdriver/execdrivers/execdrivers_freebsd.go
+++ b/daemon/execdriver/execdrivers/execdrivers_freebsd.go
@@ -10,6 +10,6 @@ import (
 )
 
 // NewDriver returns a new execdriver.Driver from the given name configured with the provided options.
-func NewDriver(options []string, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+func NewDriver(options []string, root, libPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	return nil, fmt.Errorf("jail driver not yet supported on FreeBSD")
 }

--- a/daemon/execdriver/execdrivers/execdrivers_linux.go
+++ b/daemon/execdriver/execdrivers/execdrivers_linux.go
@@ -11,6 +11,6 @@ import (
 )
 
 // NewDriver returns a new execdriver.Driver from the given name configured with the provided options.
-func NewDriver(options []string, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
-	return native.NewDriver(path.Join(root, "execdriver", "native"), initPath, options)
+func NewDriver(options []string, root, libPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+	return native.NewDriver(path.Join(root, "execdriver", "native"), options)
 }

--- a/daemon/execdriver/execdrivers/execdrivers_windows.go
+++ b/daemon/execdriver/execdrivers/execdrivers_windows.go
@@ -9,6 +9,6 @@ import (
 )
 
 // NewDriver returns a new execdriver.Driver from the given name configured with the provided options.
-func NewDriver(options []string, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
-	return windows.NewDriver(root, initPath, options)
+func NewDriver(options []string, root, libPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+	return windows.NewDriver(root, options)
 }

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -38,7 +38,6 @@ const (
 // it implements execdriver.Driver.
 type Driver struct {
 	root             string
-	initPath         string
 	activeContainers map[string]libcontainer.Container
 	machineMemory    int64
 	factory          libcontainer.Factory
@@ -46,7 +45,7 @@ type Driver struct {
 }
 
 // NewDriver returns a new native driver, called from NewDriver of execdriver.
-func NewDriver(root, initPath string, options []string) (*Driver, error) {
+func NewDriver(root string, options []string) (*Driver, error) {
 	meminfo, err := sysinfo.ReadMemInfo()
 	if err != nil {
 		return nil, err
@@ -114,7 +113,6 @@ func NewDriver(root, initPath string, options []string) (*Driver, error) {
 
 	return &Driver{
 		root:             root,
-		initPath:         initPath,
 		activeContainers: make(map[string]libcontainer.Container),
 		machineMemory:    meminfo.MemTotal,
 		factory:          f,

--- a/daemon/execdriver/windows/windows.go
+++ b/daemon/execdriver/windows/windows.go
@@ -42,7 +42,6 @@ type activeContainer struct {
 // it implements execdriver.Driver
 type Driver struct {
 	root             string
-	initPath         string
 	activeContainers map[string]*activeContainer
 	sync.Mutex
 }
@@ -53,7 +52,7 @@ func (d *Driver) Name() string {
 }
 
 // NewDriver returns a new windows driver, called from NewDriver of execdriver.
-func NewDriver(root, initPath string, options []string) (*Driver, error) {
+func NewDriver(root string, options []string) (*Driver, error) {
 
 	for _, option := range options {
 		key, val, err := parsers.ParseKeyValueOpt(option)
@@ -92,7 +91,6 @@ func NewDriver(root, initPath string, options []string) (*Driver, error) {
 
 	return &Driver{
 		root:             root,
-		initPath:         initPath,
 		activeContainers: make(map[string]*activeContainer),
 	}, nil
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -52,11 +52,6 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	// that's more intuitive (the copied path is trivial to derive
 	// by hand given VERSION)
 	initPath := utils.DockerInitPath("")
-	if initPath == "" {
-		// if that fails, we'll just return the path from the daemon
-		initPath = daemon.systemInitPath()
-	}
-
 	sysInfo := sysinfo.New(true)
 
 	v := &types.Info{


### PR DESCRIPTION
it's always initialized and/or set to an empty string because it was lxc only in the past https://github.com/docker/docker/commit/3b5fac462d21ca164b3778647420016315289034#diff-1a1f3e7ad9b1d7584e2d3e7d0c4c3db9L789

docker info now either return an empty string or the result from `utils.DockerInitPath` directly (which could be an empty string as well)

Signed-off-by: Antonio Murdaca runcom@redhat.com
