### PR TITLE
integration-cli: add _test suffix to test file

### DIFF
--- a/integration-cli/docker_cli_v2_only_test.go
+++ b/integration-cli/docker_cli_v2_only_test.go
@@ -123,5 +123,4 @@ func (s *DockerRegistrySuite) TestV1(c *check.C) {
 
 	s.d.Cmd("pull", repoName)
 	c.Assert(v1Repo, check.Equals, 3, check.Commentf("Expected v1 repository access after pull"))
-
 }


### PR DESCRIPTION
Now it reports the correct test's file path and test's line number:

```
PASS: docker_cli_v2_only_test.go:71: DockerRegistrySuite.TestV1 0.802s
PASS: docker_cli_v2_only_test.go:38: DockerRegistrySuite.TestV2Only 0.757s
```

Before:

```
[...]
PASS: docker_cli_by_digest_test.go:136: DockerRegistrySuite.TestRemoveImageByDigest 1.074s
PASS: docker_cli_by_digest_test.go:117: DockerRegistrySuite.TestRunByDigest 1.381s
PASS: docker_cli_by_digest_test.go:188: DockerRegistrySuite.TestTagByDigest 1.012s

PASS: github.com/docker/docker/integration-cli/_test/_obj_test/docker_cli_v2_only.go:86: DockerRegistrySuite.TestV1 0.801s
PASS: github.com/docker/docker/integration-cli/_test/_obj_test/docker_cli_v2_only.go:48: DockerRegistrySuite.TestV2Only 0.762s

PASS: docker_cli_daemon_test.go:1826: DockerDaemonSuite.TestBridgeIPIsExcludedFromAllocatorPool 3.796s
PASS: docker_cli_daemon_test.go:1532: DockerDaemonSuite.TestCleanupMountsAfterCrash 1.664s
PASS: docker_cli_proxy_test.go:26: DockerDaemonSuite.TestCliProxyProxyTCPSock   0.575s
[...]
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
