### PR TITLE
fix 2 corner cases in container create cleanup and container removal

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -76,7 +76,7 @@ func (daemon *Daemon) create(params *ContainerCreateConfig) (retC *Container, re
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.rm(container, false); err != nil {
+			if err := daemon.rm(container, true); err != nil {
 				logrus.Errorf("Clean up Error! Cannot destroy container %s: %v", container.ID, err)
 			}
 		}


### PR DESCRIPTION
The probability of failure when deleting from the graphdb is far less than that of `daemon.layerStore.DeleteMount` or `daemon.execDriver.Clean`. So I think we should delete from the graphdb after the other deletion jobs are done.
Otherwise if the `rm` fails after https://github.com/docker/docker/blob/master/daemon/delete.go#L118 there will be a `dead` container with no records in the graphdb. Thus the `daemon.reserveName` might reuse the name of the `dead` container.
This also causes some side effects to the container list API. See https://github.com/docker/swarm/pull/1465

---

Problems this PR fixes:
- avoid empty Names in container list API when fails to remove a container
- avoid dead containers when fails to create a container (https://github.com/docker/docker/pull/18308#discussion_r46233724)
