### PR TITLE
Consolidate time format for API

### DIFF
--- a/api/client/version.go
+++ b/api/client/version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"runtime"
 	"text/template"
+	"time"
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -72,6 +73,16 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	}
 
 	defer func() {
+		// first we need to make BuildTime more human friendly
+		t, errTime := time.Parse(time.RFC3339Nano, vd.Client.BuildTime)
+		if errTime == nil {
+			vd.Client.BuildTime = t.Format(time.ANSIC)
+		}
+		t, errTime = time.Parse(time.RFC3339Nano, vd.Server.BuildTime)
+		if errTime == nil {
+			vd.Server.BuildTime = t.Format(time.ANSIC)
+		}
+
 		if err2 := tmpl.Execute(cli.out, vd); err2 != nil && err == nil {
 			err = err2
 		}

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -99,6 +99,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /info` Now returns `Architecture` and `OSType` fields, providing information
   about the host architecture and operating system type that the daemon runs on.
 * `GET /networks/(name)` now returns a `Name` field for each container attached to the network.
+* `GET /version` now returns the `BuildTime` field in RFC3339Nano format to make it 
+  consistent with other date/time values returned by the API.
 
 ### v1.21 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1990,14 +1990,15 @@ Show the docker version information
     Content-Type: application/json
 
     {
-         "Version": "1.5.0",
+         "Version": "1.10.0-dev",
          "Os": "linux",
-         "KernelVersion": "3.18.5-tinycore64",
-         "GoVersion": "go1.4.1",
-         "GitCommit": "a8a31ef",
+         "KernelVersion": "3.19.0-23-generic",
+         "GoVersion": "go1.4.2",
+         "GitCommit": "e75da4b",
          "Arch": "amd64",
-         "ApiVersion": "1.20",
-         "Experimental": false
+         "ApiVersion": "1.22",
+         "BuildTime": "2015-12-01T07:09:13.444803460+00:00",
+         "Experimental": true
     }
 
 Status Codes:

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -70,7 +70,7 @@ if command -v git &> /dev/null && git rev-parse &> /dev/null; then
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-dirty"
 	fi
-	BUILDTIME=$(date -u)
+	BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/')
 elif [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 else


### PR DESCRIPTION
Fixes #18276

Consolidate all the API to same time format: RFC3339, and it will be
client's responsibility to present it in more user friendly way.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

This is an initial commit for fixing the issue, I believe that there must be other time related struct elements need to be formatted, also am investigating the influence on other components...
I will update in following commit.
