### PR TITLE
Fix rm container error in aufs and devicemapper after daemon crash

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -332,6 +332,14 @@ func (a *Driver) Put(id string) error {
 
 	m := a.active[id]
 	if m == nil {
+		// but it might be still here
+		if a.Exists(id) {
+			path := path.Join(a.rootPath(), "mnt", id)
+			err := Unmount(path)
+			if err != nil {
+				logrus.Debugf("Failed to unmount %s aufs: %v", id, err)
+			}
+		}
 		return nil
 	}
 	if count := m.referenceCount; count > 1 {

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -186,7 +186,7 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 
 	rootFs := path.Join(mp, "rootfs")
 	if err := idtools.MkdirAllAs(rootFs, 0755, uid, gid); err != nil && !os.IsExist(err) {
-		d.DeviceSet.UnmountDevice(id)
+		d.DeviceSet.UnmountDevice(id, mp)
 		return "", err
 	}
 
@@ -195,7 +195,7 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 		// Create an "id" file with the container/image id in it to help reconscruct this in case
 		// of later problems
 		if err := ioutil.WriteFile(idFile, []byte(id), 0600); err != nil {
-			d.DeviceSet.UnmountDevice(id)
+			d.DeviceSet.UnmountDevice(id, mp)
 			return "", err
 		}
 	}
@@ -205,7 +205,8 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 
 // Put unmounts a device and removes it.
 func (d *Driver) Put(id string) error {
-	err := d.DeviceSet.UnmountDevice(id)
+	mp := path.Join(d.home, "mnt", id)
+	err := d.DeviceSet.UnmountDevice(id, mp)
 	if err != nil {
 		logrus.Errorf("Error unmounting device %s: %s", id, err)
 	}


### PR DESCRIPTION
This patchset is simaler to 3916561619d45a3d8ca17dfa467149824111023a(Fix Put without Get in overlay).

If there are running containers when daemon crash. After daemon restarts. We can not remove containers due to "device is busy"  in aufs and devicemapper.
#### Take devicemapper as an example.
-  Run a container

``` bash
# docker run -tid busybox sh
fdca994bec2100335c912d56540acc6df271b36b2554270c606836277e159e15
```
-  kill daemon and restart

``` bash
# killall  -9 docker
# docker daemon -s devicemapper 
ERRO[0001] Error unmounting container fdca994bec2100335c912d56540acc6df271b36b2554270c606836277e159e15: UnmountDevice: device not-mounted id 780117718cc91335dc4c7fb4e3246f9b06fbeff654782c9ff0277555c21d437e
```
- Then I can not remove container `fdca994bec21`

``` bash
 docker rm -f fdca994bec21
Error response from daemon: Driver devicemapper failed to remove root filesystem fdca994bec2100335c912d56540acc6df271b36b2554270c606836277e159e15: Device is Busy
Error: failed to remove containers: [fdca994bec21]
```

Guys in issue #4036 has encountered this problem.
