### PR TITLE
docs: add API v1.22 to the list again

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -30,8 +30,9 @@ as calling `/v1.22/info`. To call an older version of the API use
 
 Use the table below to find the API version for a Docker version:
 
-Docker version  | API version                                     | Changes
-----------------|-------------------------------------------------|-----------------------------
+Docker version  | API version                        | Changes
+----------------|------------------------------------|------------------------------------------------------
+1.10.x          | [1.22](docker_remote_api_v1.22.md) | [API changes](docker_remote_api.md#v1-22-api-changes)
 1.9.x           | [1.21](docker_remote_api_v1.21.md) | [API changes](docker_remote_api.md#v1-21-api-changes)
 1.8.x           | [1.20](docker_remote_api_v1.20.md) | [API changes](docker_remote_api.md#v1-20-api-changes)
 1.7.x           | [1.19](docker_remote_api_v1.19.md) | [API changes](docker_remote_api.md#v1-19-api-changes)


### PR DESCRIPTION
The 1.22 API was temporarily removed in e4d86c2c38f4c99660da8ed65a8103e283e07e23
to prevent it showing up in the 1.9 documentation.

This reverts that change and tweaks the aligning of the table headers in Markdown source.
