### PR TITLE
daemon: daemon_experimental.go: fix typo

### DIFF
--- a/daemon/daemon_experimental.go
+++ b/daemon/daemon_experimental.go
@@ -16,7 +16,7 @@ import (
 
 func setupRemappedRoot(config *Config) ([]idtools.IDMap, []idtools.IDMap, error) {
 	if runtime.GOOS != "linux" && config.RemappedRoot != "" {
-		return nil, nil, fmt.Errorf("User namespaces are not supported on Linux")
+		return nil, nil, fmt.Errorf("User namespaces are only supported on Linux")
 	}
 
 	// if the daemon was started with remapped root option, parse


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca runcom@redhat.com
