### PR TITLE
Move defaultSHMSize in daemon pkg

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -357,17 +358,20 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 	buildConfig.ForceRemove = httputils.BoolValue(r, "forcerm")
 	buildConfig.MemorySwap = httputils.Int64ValueOrZero(r, "memswap")
 	buildConfig.Memory = httputils.Int64ValueOrZero(r, "memory")
-	shmSize, err := httputils.Int64ValueOrDefault(r, "shmsize", runconfig.DefaultSHMSize)
-	if err != nil {
-		return errf(err)
-	}
-	buildConfig.ShmSize = &shmSize
 	buildConfig.CPUShares = httputils.Int64ValueOrZero(r, "cpushares")
 	buildConfig.CPUPeriod = httputils.Int64ValueOrZero(r, "cpuperiod")
 	buildConfig.CPUQuota = httputils.Int64ValueOrZero(r, "cpuquota")
 	buildConfig.CPUSetCpus = r.FormValue("cpusetcpus")
 	buildConfig.CPUSetMems = r.FormValue("cpusetmems")
 	buildConfig.CgroupParent = r.FormValue("cgroupparent")
+
+	if r.Form.Get("shmsize") != "" {
+		shmSize, err := strconv.ParseInt(r.Form.Get("shmsize"), 10, 64)
+		if err != nil {
+			return errf(err)
+		}
+		buildConfig.ShmSize = &shmSize
+	}
 
 	if i := runconfig.IsolationLevel(r.FormValue("isolation")); i != "" {
 		if !runconfig.IsolationLevel.IsValid(i) {

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -39,10 +39,15 @@ import (
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
-// DefaultPathEnv is unix style list of directories to search for
-// executables. Each directory is separated from the next by a colon
-// ':' character .
-const DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+const (
+	// DefaultPathEnv is unix style list of directories to search for
+	// executables. Each directory is separated from the next by a colon
+	// ':' character .
+	DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+	// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
+	DefaultSHMSize int64 = 67108864
+)
 
 // Container holds the fields specific to unixen implementations. See
 // CommonContainer for standard fields common to all containers.
@@ -1358,7 +1363,7 @@ func (daemon *Daemon) setupIpcDirs(container *Container) error {
 			return err
 		}
 
-		shmSize := runconfig.DefaultSHMSize
+		shmSize := DefaultSHMSize
 		if container.hostConfig.ShmSize != nil {
 			shmSize = *container.hostConfig.ShmSize
 		}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -132,7 +132,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 		hostConfig.MemorySwap = hostConfig.Memory * 2
 	}
 	if hostConfig.ShmSize == nil {
-		shmSize := runconfig.DefaultSHMSize
+		shmSize := DefaultSHMSize
 		hostConfig.ShmSize = &shmSize
 	}
 }

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1464,7 +1464,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeOmitted(c *check.C) {
 	var containerJSON types.ContainerJSON
 	c.Assert(json.Unmarshal(body, &containerJSON), check.IsNil)
 
-	c.Assert(*containerJSON.HostConfig.ShmSize, check.Equals, runconfig.DefaultSHMSize)
+	c.Assert(*containerJSON.HostConfig.ShmSize, check.Equals, int64(67108864))
 
 	out, _ := dockerCmd(c, "start", "-i", containerJSON.ID)
 	shmRegexp := regexp.MustCompile(`shm on /dev/shm type tmpfs(.*)size=65536k`)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -42,9 +42,6 @@ var (
 	ErrConflictNetworkExposePorts = fmt.Errorf("Conflicting options: --expose and the network mode (--net)")
 )
 
-// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
-const DefaultSHMSize int64 = 67108864
-
 // Parse parses the specified args for the specified command and generates a Config,
 // a HostConfig and returns them with the specified command.
 // If the specified args are not valid, it will return an error.


### PR DESCRIPTION
it shouldn't break anything and basically just moves `DefaultSHMSize` to `daemon` because it isn't used anywhere in runconfig but it's something the daemon applies if shmsize is nil (let's see if tests agree with me)

/cc @estesp @cpuguy83 

Followup of: https://github.com/docker/docker/pull/18261#issuecomment-161027959

Signed-off-by: Antonio Murdaca runcom@redhat.com
