### PR TITLE
In practice, I needed docker-engine

### DIFF
--- a/docs/installation/oracle.md
+++ b/docs/installation/oracle.md
@@ -62,7 +62,7 @@ btrfs storage engine on both Oracle Linux 6 and 7.
 
 4. Install the Docker package.
 
-        $ sudo yum install docker
+        $ sudo yum install docker-engine
 
 5. Start the Docker daemon.
 


### PR DESCRIPTION
I just did this on an OEL7u1 machine and found I needed "docker-engine" not "docker" as the argument to yum install.
