### PR TITLE
Add initial support building Windows docker in docker

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,57 @@
+# This file describes the standard way to build Docker, using docker on TP4
+#
+# Usage:
+#
+# # Assemble the full dev environment. This is slow the first time.
+# docker build -t docker -f Dockerfile.windows .
+#
+# # Mount your source in an interactive container for quick testing:
+# docker run -it -v ${pwd}\bundles:c:/go/src/github.com/docker/docker/bundles docker cmd
+#
+
+FROM windowsservercore
+
+ENV GOLANG_VERSION=1.5.2 \
+    GIT_VERSION=2.7.0 \
+    RSRC_COMMIT=e48dbf1b7fc464a9e85fcec450dddf80816b76e0 \
+    GOPATH=C:/go;C:/go/src/github.com/docker/docker/vendor \
+    FROM_DOCKERFILE=1
+
+WORKDIR c:/windows/temp
+
+RUN powershell -command \
+    sleep 2 ; \
+    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
+RUN powershell -command \
+    sleep 2 ; \
+    choco install curl -y -v ; \
+    choco install git -y -v --version=%GIT_VERSION% -params '"/GitAndUnixToolsOnPath"'
+
+RUN setx /M Path "c:\ProgramData\chocolatey\bin;c:\Program Files\Git\usr\bin;%Path%;c:\gcc\bin"
+
+RUN powershell -command \
+    sleep 2; \
+    curl.exe -L -k -o go.msi https://storage.googleapis.com/golang/go%GOLANG_VERSION%.windows-amd64.msi; \
+    curl.exe -L -k -o gcc.zip http://downloads.sourceforge.net/project/tdm-gcc/TDM-GCC%205%20series/5.1.0-tdm64-1/gcc-5.1.0-tdm64-1-core.zip ; \
+    curl.exe -L -k -o runtime.zip http://downloads.sourceforge.net/project/tdm-gcc/MinGW-w64%20runtime/GCC%205%20series/mingw64runtime-v4-git20150618-gcc5-tdm64-1.zip ; \
+    curl.exe -L -k -o binutils.zip http://downloads.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-2.25-tdm64-1.zip
+
+RUN powershell -command \
+    .\go.msi /quiet ; \
+    Expand-Archive gcc.zip \gcc -Force ; \
+    Expand-Archive runtime.zip \gcc -Force ; \
+    Expand-Archive binutils.zip \gcc -Force
+
+RUN del go.msi gcc.zip runtime.zip binutils.zip
+
+RUN powershell -Command \
+    sleep 2 ; \
+    git clone https://github.com/akavel/rsrc.git c:\go\src\github.com\akavel\rsrc ; \
+    cd \go\src\github.com\akavel\rsrc ; \
+    git checkout -q $env:RSRC_COMMIT ; \
+    go install -v
+
+WORKDIR c:/go/src/github.com/docker/docker
+
+COPY . /go/src/github.com/docker/docker


### PR DESCRIPTION
This PR is a proof of concept to simplify setting up a Windows build environment to build the Docker Engine for Windows.

After following the discussion in #18206 and reading the documentation http://docs.docker.com/opensource/project/software-req-win/ by @jfrazelle I thought there should be an easier way for anybody in the community who wants to start contributing to the effort to bring docker to the Windows platform.

And after testing Docker on TP4 for a while I was sure the time has come to use Docker for a first real task to solve. So I tried to build docker in docker on Windows to keep the host machine clean.

I agree with @jhowardmsft to use just native Windows tools and PowerShell to work on a Windows host. So I tried to follow that path, keeping away from MinGW/Cygwin shells and just use the tools given on Windows plus an absolute minimum number external tools.

To reproduce the build you need
1. Windows Server 2016 TP4 with Docker installed
2. Git for Windows to clone the GitHub repo.
3. There is no step three.

These are the detailed steps by using Chocolatey to install git and clone the PR branch:

``` powershell
iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
choco install -y git -params "/GitAndUnixToolsOnPath"
git clone -b add-dockerfile-for-windows https://github.com/hypriot/docker
cd docker
.\hack\make.ps1
```

The `hack\make.ps1` script is used both on the host as well inside the Docker container. 
- First a Docker image is built with the `Dockerfile.windows` file to install the tools needed like Go 1.5.1, rsrc, TDM-GCC and so on.
- Then the script starts a Docker container with a volume mounted to the bundles directory and the final docker binary will be copied to the host into `bundles\docker.exe`.
- Inside the container I encountered a small bash script `hack\make\.go-autogen` which the PowerShell script just converts to PowerShell and runs these steps as well.

Then as an admin you can replace your Docker Engine with

``` powershell
stop-service docker
cd C:\Windows\system32
copy docker.exe docker-tp4.exe
copy $env:USERPROFILE\docker\bundles\docker.exe docker.exe
start-service docker
```

After updating the Docker EngineI had the effect that some Container images get lost and I had to tag the base container images with the latest tag again. But this stills proofs me that Docker on Windows is the right thing to do and to push forward. And it will change the way we develop and work on Windows as we can see it on Linux.
Thanks to all the effort of the Microsoft team (@ahmetalpbalkan @darrenstahlmsft @taylorb-microsoft ...) to get to this point!

<img width="936" alt="docker-in-docker-works" src="https://cloud.githubusercontent.com/assets/207759/11514728/4bb65d4c-987a-11e5-8316-23d65844221c.png">

PS: Now I can start contributing as well and not just annoy you with GitHub issues ;-)
