### PR TITLE
Deprecate -f flag from docker tag

### DIFF
--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -15,7 +15,7 @@ import (
 // Usage: docker tag [OPTIONS] IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]
 func (cli *DockerCli) CmdTag(args ...string) error {
 	cmd := Cli.Subcmd("tag", []string{"IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]"}, Cli.DockerCommands["tag"].Description, true)
-	force := cmd.Bool([]string{"f", "-force"}, false, "Force the tagging even if there's a conflict")
+	force := cmd.Bool([]string{"#f", "#-force"}, false, "Force the tagging even if there's a conflict")
 	cmd.Require(flag.Exact, 2)
 
 	cmd.ParseFlags(args, true)

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -466,7 +466,7 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 
 	for _, rt := range repoAndTags {
-		if err := s.daemon.TagImage(rt, imgID, true); err != nil {
+		if err := s.daemon.TagImage(rt, imgID); err != nil {
 			return errf(err)
 		}
 	}
@@ -550,8 +550,7 @@ func (s *router) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 			return err
 		}
 	}
-	force := httputils.BoolValue(r, "force")
-	if err := s.daemon.TagImage(newTag, vars["name"], force); err != nil {
+	if err := s.daemon.TagImage(newTag, vars["name"]); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusCreated)

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -136,7 +136,7 @@ func (daemon *Daemon) Commit(name string, c *ContainerCommitConfig) (string, err
 				return "", err
 			}
 		}
-		if err := daemon.TagImage(newTag, id.String(), true); err != nil {
+		if err := daemon.TagImage(newTag, id.String()); err != nil {
 			return "", err
 		}
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1017,15 +1017,14 @@ func (daemon *Daemon) changes(container *Container) ([]archive.Change, error) {
 }
 
 // TagImage creates a tag in the repository reponame, pointing to the image named
-// imageName. If force is true, an existing tag with the same name may be
-// overwritten.
-func (daemon *Daemon) TagImage(newTag reference.Named, imageName string, force bool) error {
+// imageName.
+func (daemon *Daemon) TagImage(newTag reference.Named, imageName string) error {
 	imageID, err := daemon.GetImageID(imageName)
 	if err != nil {
 		return err
 	}
 	newTag = registry.NormalizeLocalReference(newTag)
-	if err := daemon.tagStore.AddTag(newTag, imageID, force); err != nil {
+	if err := daemon.tagStore.AddTag(newTag, imageID, true); err != nil {
 		return err
 	}
 	daemon.EventsService.Log("tag", newTag.String(), "")

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -100,7 +100,7 @@ func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string
 
 	// FIXME: connect with commit code and call tagstore directly
 	if newRef != nil {
-		if err := daemon.TagImage(newRef, id.String(), true); err != nil {
+		if err := daemon.TagImage(newRef, id.String()); err != nil {
 			return err
 		}
 	}

--- a/docs/misc/deprecated.md
+++ b/docs/misc/deprecated.md
@@ -12,6 +12,13 @@ parent = "mn_use_docker"
 
 The following list of features are deprecated.
 
+### `-f` flag on `docker tag`
+**Deprecated In Release: v1.10**
+
+**Target For Removal In Release: v1.12**
+
+To make tagging consistent across the various `docker` commands, the `-f` flag on the `docker tag` command is deprecated. It is not longer necessary to specify `-f` to move a tag from one image to another. Nor will `docker` generate an error if the `-f` flag is missing and the specified tag is already in use.
+
 ### HostConfig at API container start
 **Deprecated In Release: v1.10**
 

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -14,7 +14,6 @@ parent = "smn_cli"
 
     Tag an image into a repository
 
-      -f, --force=false    Force the tagging even if there's a conflict
       --help=false         Print usage
 
 You can group your images together using names and tags, and then upload them

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -69,7 +69,7 @@ func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 	}
 }
 
-// tag an image with an existed tag name without -f option should fail
+// tag an image with an existed tag name without -f option should work
 func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
@@ -77,10 +77,6 @@ func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 	}
 
 	dockerCmd(c, "tag", "busybox:latest", "busybox:test")
-	out, _, err := dockerCmdWithError("tag", "busybox:latest", "busybox:test")
-
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "Conflict: Tag busybox:test is already set to image", check.Commentf("tag busybox busybox:test should have failed,because busybox:test is existed"))
 }
 
 // tag an image with an existed tag name with -f option should work
@@ -129,7 +125,7 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 	}
 
 	for _, name := range names {
-		out, exitCode, err := dockerCmdWithError("tag", "-f", "busybox:latest", name+":latest")
+		out, exitCode, err := dockerCmdWithError("tag", "busybox:latest", name+":latest")
 		if err != nil || exitCode != 0 {
 			c.Errorf("tag busybox %v should have worked: %s, %s", name, err, out)
 			continue
@@ -146,7 +142,7 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 	}
 
 	for _, name := range names {
-		_, exitCode, err := dockerCmdWithError("tag", "-f", name+":latest", "fooo/bar:latest")
+		_, exitCode, err := dockerCmdWithError("tag", name+":latest", "fooo/bar:latest")
 		if err != nil || exitCode != 0 {
 			c.Errorf("tag %v fooo/bar should have worked: %s", name, err)
 			continue
@@ -163,7 +159,7 @@ func (s *DockerSuite) TestTagMatchesDigest(c *check.C) {
 	}
 	digest := "busybox@sha256:abcdef76720241213f5303bda7704ec4c2ef75613173910a56fb1b6e20251507"
 	// test setting tag fails
-	_, _, err := dockerCmdWithError("tag", "-f", "busybox:latest", digest)
+	_, _, err := dockerCmdWithError("tag", "busybox:latest", digest)
 	if err == nil {
 		c.Fatal("digest tag a name should have failed")
 	}
@@ -181,7 +177,7 @@ func (s *DockerSuite) TestTagInvalidRepoName(c *check.C) {
 	}
 
 	// test setting tag fails
-	_, _, err := dockerCmdWithError("tag", "-f", "busybox:latest", "sha256:sometag")
+	_, _, err := dockerCmdWithError("tag", "busybox:latest", "sha256:sometag")
 	if err == nil {
 		c.Fatal("tagging with image named \"sha256\" should have failed")
 	}
@@ -214,7 +210,7 @@ func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
 	c.Logf("Built image: %s", imageID)
 
 	// test setting tag fails
-	_, _, err = dockerCmdWithError("tag", "-f", "busybox:latest", truncatedTag)
+	_, _, err = dockerCmdWithError("tag", "busybox:latest", truncatedTag)
 	if err != nil {
 		c.Fatalf("Error tagging with an image id: %s", err)
 	}

--- a/man/docker-tag.1.md
+++ b/man/docker-tag.1.md
@@ -6,7 +6,6 @@ docker-tag - Tag an image into a repository
 
 # SYNOPSIS
 **docker tag**
-[**-f**|**--force**[=*false*]]
 [**--help**]
 IMAGE[:TAG] [REGISTRY_HOST/][USERNAME/]NAME[:TAG]
 
@@ -18,9 +17,6 @@ If you do not specify a `REGISTRY_HOST`, the command uses Docker's public
 registry located at `registry-1.docker.io` by default. 
 
 # "OPTIONS"
-**-f**, **--force**=*true*|*false*
-   When set to true, force the alias. The default is *false*.
-
 **--help**
    Print usage statement.
 


### PR DESCRIPTION
Closes #9798

@maintainers please note that this is a change to the UX. We no longer
require the -f flag on `docker tag` to move a tag name from an existing image.
However, this does make us more consistent across our commands,
see https://github.com/docker/docker/issues/9798 for the history.

Signed-off-by: Doug Davis dug@us.ibm.com
