### PR TITLE
update go-md2man because code.google.com needs to go away

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,8 +186,8 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
-	&& git clone -b v1.2 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
+	&& git clone -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \
 	&& rm -rf "$GOPATH"


### PR DESCRIPTION
see: https://github.com/russross/blackfriday/compare/2e7d690972283d45aadc7a5ea304841e26529433...0b647d0506a698cca42caca173e55559b12a69f2

code.google.com is acting up now but will be gone come january 2016 https://code.google.com/p/support/wiki/ReadOnlyTransition
