### PR TITLE
daemon_unix: set golang runtime max threads

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -678,6 +678,10 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 	logrus.Debugf("Using default logging driver %s", config.LogConfig.Type)
 
+	if err := configureMaxThreads(config); err != nil {
+		logrus.Warnf("Failed to configure golang's threads limit: %v", err)
+	}
+
 	daemonRepo := filepath.Join(config.Root, "containers")
 	if err := idtools.MkdirAllAs(daemonRepo, 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return nil, err

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -115,6 +115,11 @@ func configureKernelSecuritySupport(config *Config, driverName string) error {
 	return nil
 }
 
+// configureMaxThreads sets the Go runtime max threads threshold
+func configureMaxThreads(config *Config) error {
+	return nil
+}
+
 func isBridgeNetworkDisabled(config *Config) bool {
 	return false
 }


### PR DESCRIPTION
set Go runtime max threads threshold to 90% of `/proc/sys/kernel/threads-max`
relates to #15256 and #15258 

/cc @jeremyeder

Signed-off-by: Antonio Murdaca runcom@redhat.com
