### PR TITLE
Carry 17293 add examples in search

### DIFF
--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -19,9 +19,19 @@ parent = "smn_cli"
       --no-trunc=false     Don't truncate output
       -s, --stars=0        Only displays with at least x stars
 
+Search [Docker Hub](https://hub.docker.com) for images
+
+See [*Find Public Images on Docker Hub*](../../userguide/dockerrepos.md#searching-for-images) for
+more details on finding shared images from the command line.
+
+> **Note:**
+> Search queries will only return up to 25 results
+
 ## Examples
 
-### Search images by keywords
+### Search images by name
+
+This example displays images with a name containing 'busybox':
 
     $ docker search busybox
     NAME                             DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
@@ -51,41 +61,37 @@ parent = "smn_cli"
     scottabernethy/busybox                                                           0                    [OK]
     marclop/busybox-solr
 
-This example will display images with the name containing busybox.
+### Search images by name and number of stars (-s, --stars)
 
-### Search images by limiting stars' number(-s OR --stars)
-    
-    $ docker search --stars 3 busybox
+This example displays images with a name containing 'busybox' and at
+least 3 stars:
+
+    $ docker search --stars=3 busybox
     NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
     busybox              Busybox base image.                             325       [OK]       
     progrium/busybox                                                     50                   [OK]
     radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
 
-This example will display images with the name containing busybox and at least 3 stars.
 
-### Search automated images(--automated)
+### Search automated images (--automated)
 
-    $ docker search --stars=3 --automated=true busybox
+This example displays images with a name containing 'busybox', at
+least 3 stars and are automated builds:
+
+    $ docker search --stars=3 --automated busybox
     NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
     progrium/busybox                                                     50                   [OK]
     radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
 
-This example will display images with at least 3 stars and automated builds.
 
-### Fully display 'DESCRIPTION'(--no-trunc=true)
+### Display non-truncated description (--no-trunc)
 
-    $ docker search --stars=3 --no-trunc=true busybox
+This example displays images with a name containing 'busybox',
+at least 3 stars and the description isn't truncated in the output:
+
+    $ docker search --stars=3 --no-trunc busybox
     NAME                 DESCRIPTION                                                                               STARS     OFFICIAL   AUTOMATED
     busybox              Busybox base image.                                                                       325       [OK]       
     progrium/busybox                                                                                               50                   [OK]
     radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
 
-This example will display images with at least 3 stars and the console output isn't truncated.
-
-Search [Docker Hub](https://hub.docker.com) for images
-
-See [*Find Public Images on Docker Hub*](../../userguide/dockerrepos.md#searching-for-images) for
-more details on finding shared images from the command line.
-
-> **Note:**
-> Search queries will only return up to 25 results

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -19,6 +19,69 @@ parent = "smn_cli"
       --no-trunc=false     Don't truncate output
       -s, --stars=0        Only displays with at least x stars
 
+## Examples
+
+### Search images by keywords
+
+    $ docker search busybox
+    NAME                             DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+    busybox                          Busybox base image.                             316       [OK]       
+    progrium/busybox                                                                 50                   [OK]
+    radial/busyboxplus               Full-chain, Internet enabled, busybox made...   8                    [OK]
+    odise/busybox-python                                                             2                    [OK]
+    azukiapp/busybox                 This image is meant to be used as the base...   2                    [OK]
+    ofayau/busybox-jvm               Prepare busybox to install a 32 bits JVM.       1                    [OK]
+    shingonoide/archlinux-busybox    Arch Linux, a lightweight and flexible Lin...   1                    [OK]
+    odise/busybox-curl                                                               1                    [OK]
+    ofayau/busybox-libc32            Busybox with 32 bits (and 64 bits) libs         1                    [OK]
+    peelsky/zulu-openjdk-busybox                                                     1                    [OK]
+    skomma/busybox-data              Docker image suitable for data volume cont...   1                    [OK]
+    elektritter/busybox-teamspeak    Leightweight teamspeak3 container based on...   1                    [OK]
+    socketplane/busybox                                                              1                    [OK]
+    oveits/docker-nginx-busybox      This is a tiny NginX docker image based on...   0                    [OK]
+    ggtools/busybox-ubuntu           Busybox ubuntu version with extra goodies       0                    [OK]
+    nikfoundas/busybox-confd         Minimal busybox based distribution of confd     0                    [OK]
+    openshift/busybox-http-app                                                       0                    [OK]
+    jllopis/busybox                                                                  0                    [OK]
+    swyckoff/busybox                                                                 0                    [OK]
+    powellquiring/busybox                                                            0                    [OK]
+    williamyeh/busybox-sh            Docker image for BusyBox's sh                   0                    [OK]
+    simplexsys/busybox-cli-powered   Docker busybox images, with a few often us...   0                    [OK]
+    fhisamoto/busybox-java           Busybox java                                    0                    [OK]
+    scottabernethy/busybox                                                           0                    [OK]
+    marclop/busybox-solr
+
+This example will display images with the name containing busybox.
+
+### Search images by limiting stars' number(-s OR --stars)
+    
+    $ docker search --stars 3 busybox
+    NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+    busybox              Busybox base image.                             325       [OK]       
+    progrium/busybox                                                     50                   [OK]
+    radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+
+This example will display images with the name containing busybox and at least 3 stars.
+
+### Search automated images(--automated)
+
+    $ docker search --stars=3 --automated=true busybox
+    NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+    progrium/busybox                                                     50                   [OK]
+    radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+
+This example will display images with at least 3 stars and automated builds.
+
+### Fully display 'DESCRIPTION'(--no-trunc=true)
+
+    $ docker search --stars=3 --no-trunc=true busybox
+    NAME                 DESCRIPTION                                                                               STARS     OFFICIAL   AUTOMATED
+    busybox              Busybox base image.                                                                       325       [OK]       
+    progrium/busybox                                                                                               50                   [OK]
+    radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
+
+This example will display images with at least 3 stars and the console output isn't truncated.
+
 Search [Docker Hub](https://hub.docker.com) for images
 
 See [*Find Public Images on Docker Hub*](../../userguide/dockerrepos.md#searching-for-images) for


### PR DESCRIPTION
This carries #17293 and makes some adjustments to that PR;
- The examples are added at the _end_ of the page
- Replace 'keyword' with 'name', because that's what's search on
- Some minor wording changes

Thanks @isgaojing for the original contribution!
