### PR TITLE
fix the Dockerfile.gccgo for new dependency

### DIFF
--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	git \
 	iptables \
+	jq \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \


### PR DESCRIPTION
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com

This fixes master(gccgo) build failures.
