### PR TITLE
Return error code when `volume inspect` fails with a template.

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -124,6 +124,7 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 
 	var status = 0
 	var volumes []*types.Volume
+
 	for _, name := range cmd.Args() {
 		resp, err := cli.call("GET", "/volumes/"+name, nil, nil)
 		if err != nil {
@@ -132,9 +133,9 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 
 		var volume types.Volume
 		if err := json.NewDecoder(resp.body).Decode(&volume); err != nil {
-			fmt.Fprintf(cli.err, "%s\n", err)
+			fmt.Fprintf(cli.err, "Unable to read inspect data: %v\n", err)
 			status = 1
-			continue
+			break
 		}
 
 		if tmpl == nil {
@@ -142,29 +143,28 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 			continue
 		}
 
-		if err := tmpl.Execute(cli.out, &volume); err != nil {
-			if err := tmpl.Execute(cli.out, &volume); err != nil {
-				fmt.Fprintf(cli.err, "%s\n", err)
-				status = 1
-				continue
-			}
+		buf := bytes.NewBufferString("")
+		if err := tmpl.Execute(buf, &volume); err != nil {
+			fmt.Fprintf(cli.err, "Template parsing error: %v\n", err)
+			status = 1
+			break
+		}
+
+		cli.out.Write(buf.Bytes())
+		cli.out.Write([]byte{'\n'})
+	}
+
+	if tmpl == nil {
+		b, err := json.MarshalIndent(volumes, "", "    ")
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(cli.out, bytes.NewReader(b))
+		if err != nil {
+			return err
 		}
 		io.WriteString(cli.out, "\n")
 	}
-
-	if tmpl != nil {
-		return nil
-	}
-
-	b, err := json.MarshalIndent(volumes, "", "    ")
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(cli.out, bytes.NewReader(b))
-	if err != nil {
-		return err
-	}
-	io.WriteString(cli.out, "\n")
 
 	if status != 0 {
 		return Cli.StatusError{StatusCode: status}

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -165,3 +165,13 @@ func (s *DockerSuite) TestVolumeCliNoArgs(c *check.C) {
 	c.Assert(stderr, checker.Contains, usage)
 	c.Assert(stderr, checker.Contains, "flag provided but not defined: --no-such-flag")
 }
+
+func (s *DockerSuite) TestVolumeCliInspectTmplError(c *check.C) {
+	out, _ := dockerCmd(c, "volume", "create")
+	name := strings.TrimSpace(out)
+
+	out, exitCode, err := dockerCmdWithError("volume", "inspect", "--format='{{ .FooBar }}'", name)
+	c.Assert(err, checker.NotNil, check.Commentf("Output: %s", out))
+	c.Assert(exitCode, checker.Equals, 1, check.Commentf("Output: %s", out))
+	c.Assert(out, checker.Contains, "Template parsing error")
+}


### PR DESCRIPTION
Following `docker inspect` conventions:
- Keep partial info in a buffer to not print incomplete template outputs.
- Break execution when template parsing or decoding fail.

Fixes #18328

Signed-off-by: David Calavera david.calavera@gmail.com
