### PR TITLE
Added environment variables for published ports

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -137,6 +137,16 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	if container.Config.Tty {
 		env = append(env, "TERM=xterm")
 	}
+
+	// Set exposed ports as environment variables
+	exposedPorts := container.NetworkSettings.Ports
+	for localPort, exposedPort := range exposedPorts {
+		// if the exposedPort array is empty, then the port has not been published
+		if len(exposedPort) > 0 {
+			env = append(env, "PORT_" + localPort.Port() + "=" + string(exposedPort[0].HostPort))
+		}
+	}
+
 	env = append(env, linkedEnv...)
 	// because the env on the container can override certain default values
 	// we need to replace the 'env' keys where they match and append anything

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -143,7 +143,7 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	for localPort, exposedPort := range exposedPorts {
 		// if the exposedPort array is empty, then the port has not been published
 		if len(exposedPort) > 0 {
-			env = append(env, "PORT_" + localPort.Port() + "=" + string(exposedPort[0].HostPort))
+			env = append(env, "PORT_"+localPort.Port()+"="+string(exposedPort[0].HostPort))
 		}
 	}
 


### PR DESCRIPTION
Hello!

We use Docker a lot at my company and I would like to contribute something back to the community. This is my first pull request, so I am happy about every feedback :)

I would like to solve docker#3778 and docker#1270 which is a feature that we would like to have, too. It improves service discovery by allowing services that are running inside a container to register itself with their external port where they can be reached.

What is a good place to document this behavior? The `docker run` command reference?

For our use-case it is sufficient to only set the port. Is there a use-case where the host-IP also needs to be set? Can it be something other than `0.0.0.0`?

Thank you a lot!
