### PR TITLE
Enable ptrace in a container on apparmor below 2.9

### DIFF
--- a/daemon/execdriver/native/apparmor.go
+++ b/daemon/execdriver/native/apparmor.go
@@ -60,12 +60,13 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
+{{if ge .MajorVersion 2}}{{if ge .MinorVersion 8}}
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+{{end}}{{end}}
 {{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
   # docker daemon confinement requires explict allow rule for signal
   signal (receive) set=(kill,term) peer={{.ExecPath}},
-
-  # suppress ptrace denails when using 'docker ps'
-  ptrace (trace,read) peer=docker-default,
 {{end}}{{end}}
 }
 `


### PR DESCRIPTION
Ubuntu 14.04 LTS is on apparmor 2.8.95.
This line enables `ps` inside a container without causing
audit log entries on the host.

My use case: https://github.com/docker/docker/issues/7276#issuecomment-155460123
