### PR TITLE
Use /docker as cgroup parent instead of docker

### DIFF
--- a/daemon/execdriver/native/template/default_template_linux.go
+++ b/daemon/execdriver/native/template/default_template_linux.go
@@ -37,7 +37,7 @@ func New() *configs.Config {
 			{Type: "NEWUSER"},
 		}),
 		Cgroups: &configs.Cgroup{
-			Parent:           "docker",
+			Parent:           "/docker",
 			AllowAllDevices:  false,
 			MemorySwappiness: -1,
 		},


### PR DESCRIPTION
It means that containers will be created under root cgroup and not under
daemon cgroup.
