### PR TITLE
Fix broken Windows CI

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -70,7 +70,11 @@ if command -v git &> /dev/null && git rev-parse &> /dev/null; then
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-dirty"
 	fi
-	BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/')
+	! BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
+	if [ -z $BUILDTIME ]; then
+		# If using bash 3.1 which doesn't support --rfc-3389, eg Windows CI
+		BUILDTIME=$(date -u)
+	fi
 elif [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 else


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Unfortunately https://github.com/docker/docker/pull/18309 has broken Windows CI. Windows CI uses bash 3.1, which does not support RFC-3339 date formatting. This change traps the error, and reverts back to the old formatting before #18309 was merged. Verified it runs locally on Azure CI node 1, and it should pass Jenkins too.

@vdemeester @tiborvass @calavera @jfrazelle 
