### PR TITLE
Windows CI Fix: Timeout change

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -61,10 +61,12 @@ else
 fi
 
 # give it a little time to come up so it's "ready"
-tries=30
+tries=60
+echo "INFO: Waiting for daemon to start..."
 while ! docker version &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
+		printf "\n"
 		if [ -z "$DOCKER_HOST" ]; then
 			echo >&2 "error: daemon failed to start"
 			echo >&2 "  check $DEST/docker.log for details"
@@ -74,5 +76,7 @@ while ! docker version &> /dev/null; do
 		fi
 		false
 	fi
+	printf "."
 	sleep 2
 done
+printf "\n"


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @mikedougherty.  This increases the timeout to 2 minutes (60x2secs) while waiting for the daemon to start. This allows me to remove the redundant and un-necessary sleep for a minute in the Jenkins CI script once merged. The net effect is that Windows CI will run in a minute less. There are no other side effects. Verified locally on Azure CI node 1.

Note that (Windows) CI will still not run any tests until #18397 is merged and this is rebased.
