### PR TITLE
Disable timeout for systemd

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,6 +11,7 @@ MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With content addressability update starting upgraded
daemon for the first time can take a long time if
graph dir was not prepared with a migration tool before.
This avoids systemd timeouts while the migration is
taking place.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com

@jfrazelle @LK4D4 @runcom 
