### PR TITLE
Adjust TestDockerCmdWithTimeout timeout to improve reliability

### DIFF
--- a/pkg/integration/dockerCmd_utils_test.go
+++ b/pkg/integration/dockerCmd_utils_test.go
@@ -387,7 +387,7 @@ func TestHelperProcess(t *testing.T) {
 			fmt.Fprintf(os.Stderr, "an error has occurred")
 			os.Exit(1)
 		case "a command that times out":
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(10 * time.Second)
 			fmt.Fprintf(os.Stdout, "too long, should be killed")
 			// A random exit code (that should never happened in tests)
 			os.Exit(7)


### PR DESCRIPTION
I saw a failure of TestDockerCmdWithTimeout. This test starts a command
that produces output after 10 ms, but uses a 5 ms timeout, so normally
the command will be killed before the output. The time intervals are so
small that the timeout may not reliably trigger before the output, which
can cause the test to fail.

This commit changes the test to only fail if the process is still alive
after 10 seconds. This means the test will confirm that the timeouts are
happening, but not attempt to gauge that the timeouts are happening
within milliseconds of when they are expected (which can't be done
reliably).
