### PR TITLE
Removing the restriction to push to an 'official' repo

### DIFF
--- a/api/client/push.go
+++ b/api/client/push.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/docker/distribution/reference"
@@ -45,17 +44,6 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	}
 	// Resolve the Auth config relevant for this server
 	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, repoInfo.Index)
-	// If we're not using a custom registry, we know the restrictions
-	// applied to repository names and can warn the user in advance.
-	// Custom repositories can have different rules, and we must also
-	// allow pushing by image ID.
-	if repoInfo.Official {
-		username := authConfig.Username
-		if username == "" {
-			username = "<user>"
-		}
-		return fmt.Errorf("You cannot push a \"root\" repository. Please rename your repository to <user>/<repo> (ex: %s/%s)", username, repoInfo.LocalName)
-	}
 
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(repoInfo.Index, "push")
 	if isTrusted() {


### PR DESCRIPTION
Registry itself verifies whether or not a user has permission to push to a specific namespace.

Removing the hard-coded check that doesn't allow us to push in the app, and deferring to `registry` to make the access decision.

Signed-off-by: Toli Kuznets toli@docker.com
