### PR TITLE
daemon: add --no-volumes flag

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -33,6 +33,7 @@ type CommonConfig struct {
 	RemappedRoot  string
 	Root          string
 	TrustKeyPath  string
+	NoVolumes     bool
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
 	// multihost networking (to store networks and endpoints information) and by the node discovery
@@ -73,4 +74,5 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.StringVar(&config.ClusterAdvertise, []string{"-cluster-advertise"}, "", usageFn("Address or interface name to advertise"))
 	cmd.StringVar(&config.ClusterStore, []string{"-cluster-store"}, "", usageFn("Set the cluster store"))
 	cmd.Var(opts.NewMapOpts(config.ClusterOpts, nil), []string{"-cluster-store-opt"}, usageFn("Set cluster store options"))
+	cmd.BoolVar(&config.NoVolumes, []string{"-no-volumes"}, false, usageFn("Do not run containers with volumes"))
 }

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -94,7 +94,6 @@ func (d *Driver) Status() [][2]string {
 // GetMetadata returns a map of information about the device.
 func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 	m, err := d.DeviceSet.exportDeviceMetadata(id)
-
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -78,6 +78,25 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 		return derr.ErrorCodeContainerBeingRemoved
 	}
 
+	if daemon.configStore.NoVolumes {
+		// when --no-volumes is set do not allow volumes from images
+		if container.ImageID != "" { // not FROM scratch
+			img, err := daemon.imageStore.Get(container.ImageID)
+			if err != nil {
+				return err
+			}
+			if len(img.Config.Volumes) > 0 {
+				return derr.ErrorCodeCantStart.WithArgs(container.ID, "volumes are not allowed")
+			}
+		}
+		// when --no-volumes is set do not allow container run with -v unless it's a bind
+		for _, m := range container.MountPoints {
+			if m.Driver != "" {
+				return derr.ErrorCodeCantStart.WithArgs(container.ID, "volumes are not allowed")
+			}
+		}
+	}
+
 	// if we encounter an error during start we need to ensure that any other
 	// setup has been cleaned up properly
 	defer func() {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1861,7 +1861,6 @@ func (s *DockerSuite) TestBuildForceRm(c *check.C) {
 	if containerCountBefore != containerCountAfter {
 		c.Fatalf("--force-rm shouldn't have left containers behind")
 	}
-
 }
 
 // Test that an infinite sleep during a build is killed if the client disconnects.

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -41,6 +41,7 @@ docker-daemon - Enable daemon mode
 [**--log-driver**[=*json-file*]]
 [**--log-opt**[=*map[]*]]
 [**--mtu**[=*0*]]
+[**--no-volumes**[=*false*]]
 [**-p**|**--pidfile**[=*/var/run/docker.pid*]]
 [**--registry-mirror**[=*[]*]]
 [**-s**|**--storage-driver**[=*STORAGE-DRIVER*]]
@@ -184,6 +185,9 @@ unix://[/path/to/socket] to use.
 
 **--mtu**=*0*
   Set the containers network mtu. Default is `0`.
+
+**--no-volumes**=*true*|*false*
+    Prevent running containers from images that have been built using the VOLUME instruction or running containers with volumes. Default is false.
 
 **-p**, **--pidfile**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`


### PR DESCRIPTION
Prevents running containers with volumes. This patch will block running
containers from images built with VOLUME(s) instructions. It will also
block running cotainers that define a volume (docker run -v). docker
create -v won't error out instead.
This patch adds a --no-volumes flag to the docker daemon which prevents
what said above. The feature is opt-in, otherwise the engine will run
as it was.
This will allow operators to allow users to use their own images but
want to control where users can write.

Signed-off-by: Antonio Murdaca runcom@redhat.com
