### PR TITLE
Fix init layer chown of existing dir ownership

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -585,12 +585,12 @@ func setupInitLayer(initLayer string, rootUID, rootGID int) error {
 
 		if _, err := os.Stat(filepath.Join(initLayer, pth)); err != nil {
 			if os.IsNotExist(err) {
-				if err := idtools.MkdirAllAs(filepath.Join(initLayer, filepath.Dir(pth)), 0755, rootUID, rootGID); err != nil {
+				if err := idtools.MkdirAllNewAs(filepath.Join(initLayer, filepath.Dir(pth)), 0755, rootUID, rootGID); err != nil {
 					return err
 				}
 				switch typ {
 				case "dir":
-					if err := idtools.MkdirAllAs(filepath.Join(initLayer, pth), 0755, rootUID, rootGID); err != nil {
+					if err := idtools.MkdirAllNewAs(filepath.Join(initLayer, pth), 0755, rootUID, rootGID); err != nil {
 						return err
 					}
 				case "file":
@@ -598,8 +598,8 @@ func setupInitLayer(initLayer string, rootUID, rootGID int) error {
 					if err != nil {
 						return err
 					}
-					f.Close()
 					f.Chown(rootUID, rootGID)
+					f.Close()
 				default:
 					if err := os.Symlink(typ, filepath.Join(initLayer, pth)); err != nil {
 						return err


### PR DESCRIPTION
Closes: #17854 

This solves a bug where /etc may have pre-existing permissions from
build time, but init layer setup (reworked for user namespaces) was
assuming root ownership.  Adds a test as well to catch this situation in
the future.

Minor fix to wrong ordering of chown/close on files created during the
same initlayer setup.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
