### PR TITLE
move configs structs to remove dependency on deamon

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -38,7 +38,7 @@ type stateBackend interface {
 	ContainerRename(oldName, newName string) error
 	ContainerResize(name string, height, width int) error
 	ContainerRestart(name string, seconds int) error
-	ContainerRm(name string, config *daemon.ContainerRmConfig) error
+	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerStart(name string, hostConfig *runconfig.HostConfig) error
 	ContainerStop(name string, seconds int) error
 	ContainerUnpause(name string) error

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -358,7 +358,7 @@ func (s *containerRouter) deleteContainers(ctx context.Context, w http.ResponseW
 	}
 
 	name := vars["name"]
-	config := &daemon.ContainerRmConfig{
+	config := &types.ContainerRmConfig{
 		ForceRemove:  httputils.BoolValue(r, "force"),
 		RemoveVolume: httputils.BoolValue(r, "v"),
 		RemoveLink:   httputils.BoolValue(r, "link"),

--- a/api/types/configs.go
+++ b/api/types/configs.go
@@ -1,0 +1,29 @@
+package types
+
+// configs holds structs used for internal communication between the
+// frontend (such as an http server) and the backend (such as the
+// docker daemon).
+
+import (
+	"github.com/docker/docker/runconfig"
+)
+
+// ContainerRmConfig holds arguments for the container remove
+// operation. This struct is used to tell the backend what operations
+// to perform.
+type ContainerRmConfig struct {
+	ForceRemove, RemoveVolume, RemoveLink bool
+}
+
+// ContainerCommitConfig contains build configs for commit operation,
+// and is used when making a commit with the current state of the container.
+type ContainerCommitConfig struct {
+	Pause   bool
+	Repo    string
+	Tag     string
+	Author  string
+	Comment string
+	// merge container config into commit config before commit
+	MergeConfigs bool
+	Config       *runconfig.Config
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -8,9 +8,8 @@ import (
 	"io"
 	"os"
 
-	// TODO: remove dependency on daemon
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/runconfig"
 )
@@ -122,9 +121,9 @@ type Docker interface {
 	// TODO: put warnings in the error
 	Create(*runconfig.Config, *runconfig.HostConfig) (*container.Container, []string, error)
 	// Remove removes a container specified by `id`.
-	Remove(id string, cfg *daemon.ContainerRmConfig) error
+	Remove(id string, cfg *types.ContainerRmConfig) error
 	// Commit creates a new Docker image from an existing Docker container.
-	Commit(string, *daemon.ContainerCommitConfig) (string, error)
+	Commit(string, *types.ContainerCommitConfig) (string, error)
 	// Copy copies/extracts a source FileInfo to a destination path inside a container
 	// specified by a container object.
 	// TODO: make an Extract method instead of passing `decompress`

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/daemon"
@@ -267,7 +268,7 @@ func Commit(containerName string, d *daemon.Daemon, c *CommitConfig) (string, er
 		return "", err
 	}
 
-	commitCfg := &daemon.ContainerCommitConfig{
+	commitCfg := &types.ContainerCommitConfig{
 		Pause:        c.Pause,
 		Repo:         c.Repo,
 		Tag:          c.Tag,

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/httputils"
@@ -77,7 +77,7 @@ func (b *Builder) commit(id string, autoCmd *stringutils.StrSlice, comment strin
 	autoConfig := *b.runConfig
 	autoConfig.Cmd = autoCmd
 
-	commitCfg := &daemon.ContainerCommitConfig{
+	commitCfg := &types.ContainerCommitConfig{
 		Author: b.maintainer,
 		Pause:  true,
 		Config: &autoConfig,
@@ -586,7 +586,7 @@ func (b *Builder) run(c *container.Container) error {
 }
 
 func (b *Builder) removeContainer(c string) error {
-	rmConfig := &daemon.ContainerRmConfig{
+	rmConfig := &types.ContainerRmConfig{
 		ForceRemove:  true,
 		RemoveVolume: true,
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
@@ -17,22 +18,9 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
-// ContainerCommitConfig contains build configs for commit operation,
-// and is used when making a commit with the current state of the container.
-type ContainerCommitConfig struct {
-	Pause   bool
-	Repo    string
-	Tag     string
-	Author  string
-	Comment string
-	// merge container config into commit config before commit
-	MergeConfigs bool
-	Config       *runconfig.Config
-}
-
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository.
-func (daemon *Daemon) Commit(name string, c *ContainerCommitConfig) (string, error) {
+func (daemon *Daemon) Commit(name string, c *types.ContainerCommitConfig) (string, error) {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return "", err

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -74,7 +74,7 @@ func (daemon *Daemon) create(params *ContainerCreateConfig) (retC *container.Con
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.ContainerRm(container.ID, &ContainerRmConfig{ForceRemove: true}); err != nil {
+			if err := daemon.ContainerRm(container.ID, &types.ContainerRmConfig{ForceRemove: true}); err != nil {
 				logrus.Errorf("Clean up Error! Cannot destroy container %s: %v", container.ID, err)
 			}
 		}

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/container"
@@ -105,12 +106,12 @@ func (d Docker) Create(cfg *runconfig.Config, hostCfg *runconfig.HostConfig) (*c
 }
 
 // Remove removes a container specified by `id`.
-func (d Docker) Remove(id string, cfg *daemon.ContainerRmConfig) error {
+func (d Docker) Remove(id string, cfg *types.ContainerRmConfig) error {
 	return d.Daemon.ContainerRm(id, cfg)
 }
 
 // Commit creates a new Docker image from an existing Docker container.
-func (d Docker) Commit(name string, cfg *daemon.ContainerCommitConfig) (string, error) {
+func (d Docker) Commit(name string, cfg *types.ContainerCommitConfig) (string, error) {
 	return d.Daemon.Commit(name, cfg)
 }
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -5,22 +5,18 @@ import (
 	"path"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/layer"
 	volumestore "github.com/docker/docker/volume/store"
 )
 
-// ContainerRmConfig is a holder for passing in runtime config.
-type ContainerRmConfig struct {
-	ForceRemove, RemoveVolume, RemoveLink bool
-}
-
 // ContainerRm removes the container id from the filesystem. An error
 // is returned if the container is not found, or if the remove
 // fails. If the remove succeeds, the container name is released, and
 // network links are removed.
-func (daemon *Daemon) ContainerRm(name string, config *ContainerRmConfig) error {
+func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) error {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return err

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/runconfig"
 )
@@ -37,7 +38,7 @@ func TestContainerDoubleDelete(t *testing.T) {
 
 	// Try to remove the container when it's start is removalInProgress.
 	// It should ignore the container and not return an error.
-	if err := daemon.ContainerRm(container.ID, &ContainerRmConfig{ForceRemove: true}); err != nil {
+	if err := daemon.ContainerRm(container.ID, &types.ContainerRmConfig{ForceRemove: true}); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
- Moved the following config structs
  - ContainerRmConfig
  - ContainerCommitConfig
- New top-level package for holding the config structs

The base builder code now no-longer has a dependency on daemon. The dockerfile builder still does have a dependency on daemon.

This is solely moving code around. It stands alone as a change. It can be the first of several other commits that consolidate config structs used to communicate between a server and a deamon backend, or I can continue to consolidate code movement in this commit.

I would like to have a short discussion to make a decision on where the config structs are to be finally placed. They are currently placed in a top-level package. If `api/server` is to be moved into `pkg/` in the future, this config struct package will need to move into `pkg/` as well.
