### PR TITLE
Fix image deletion conflicts with search

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -212,6 +212,9 @@ func (is *store) Delete(id ID) ([]layer.Metadata, error) {
 		delete(is.images[parent].children, id)
 	}
 
+	if err := is.digestSet.Remove(digest.Digest(id)); err != nil {
+		logrus.Errorf("error removing %s from digest set: %q", id, err)
+	}
 	delete(is.images, id)
 	is.fs.Delete(id)
 

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -348,11 +348,11 @@ func (s *DockerSuite) TestInspectByPrefix(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(id, checker.HasPrefix, "sha256:")
 
-	id2, err := inspectField(id[:10], "Id")
+	id2, err := inspectField(id[:12], "Id")
 	c.Assert(err, checker.IsNil)
 	c.Assert(id, checker.Equals, id2)
 
-	id3, err := inspectField(strings.TrimPrefix(id, "sha256:")[:10], "Id")
+	id3, err := inspectField(strings.TrimPrefix(id, "sha256:")[:12], "Id")
 	c.Assert(err, checker.IsNil)
 	c.Assert(id, checker.Equals, id3)
 }


### PR DESCRIPTION
Removed images were not cleaned up from the
digest-set that is used for the search index.

This also caused a flaky test in #18437

Fixes #18437

@aaronlehmann @dmcgowan @estesp 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
