### PR TITLE
Add vendor/pkg to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 bundles
 .gopath
+vendor/pkg


### PR DESCRIPTION
It's in .gitignore too, so why not
