### PR TITLE
pkg/plugins/client.go: don't try to encode os decode if it's nil

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -60,17 +60,21 @@ type Client struct {
 // It will retry for 30 seconds if a failure occurs when calling.
 func (c *Client) Call(serviceMethod string, args interface{}, ret interface{}) error {
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(args); err != nil {
-		return err
+	if args != nil {
+		if err := json.NewEncoder(&buf).Encode(args); err != nil {
+			return err
+		}
 	}
 	body, err := c.callWithRetry(serviceMethod, &buf, true)
 	if err != nil {
 		return err
 	}
 	defer body.Close()
-	if err := json.NewDecoder(body).Decode(&ret); err != nil {
-		logrus.Errorf("%s: error reading plugin resp: %v", serviceMethod, err)
-		return err
+	if ret != nil {
+		if err := json.NewDecoder(body).Decode(&ret); err != nil {
+			logrus.Errorf("%s: error reading plugin resp: %v", serviceMethod, err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -63,6 +63,10 @@ func TestEchoInputOutput(t *testing.T) {
 	if !reflect.DeepEqual(output, m) {
 		t.Fatalf("Expected %v, was %v\n", m, output)
 	}
+	err = c.Call("Test.Echo", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBackoff(t *testing.T) {


### PR DESCRIPTION
When user call the `Call()` method, they don't always want to sent
some args or get the return value, so they use `nil` when call `Call()`
method and this will casue an error. It's better to not trying to
encode or decode if it's nil.

Signed-off-by: Lei Jitang leijitang@huawei.com

ping @cpuguy83 
