### PR TITLE
Better error message for network connect

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -616,7 +616,7 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 
 	ep, err := container.GetEndpointInNetwork(n)
 	if err == nil {
-		return fmt.Errorf("container already connected to network %s", idOrName)
+		return fmt.Errorf("Conflict. A container with name %q is already connected to network %s.", strings.TrimPrefix(container.Name, "/"), idOrName)
 	}
 
 	if _, ok := err.(libnetwork.ErrNoSuchEndpoint); !ok {


### PR DESCRIPTION
Fixes  #18257
Relative comment: https://github.com/docker/docker/issues/18257#issuecomment-159959301

Use better error message when user want to connect container with same
name to one network, this can help avoid confusion.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

ping @thaJeztah @zhaoxpZTE, WDYT of this?
