### PR TITLE
Add endpoint to API to delete all images

### DIFF
--- a/api/server/router/local/local.go
+++ b/api/server/router/local/local.go
@@ -103,6 +103,7 @@ func (r *router) initRoutes() {
 		NewPostRoute("/images/{name:.*}/push", r.postImagesPush),
 		NewPostRoute("/images/{name:.*}/tag", r.postImagesTag),
 		// DELETE
+		NewDeleteRoute("/images/_all", r.deleteAllImages),
 		NewDeleteRoute("/images/{name:.*}", r.deleteImages),
 	}
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -73,6 +73,13 @@ type ImageDelete struct {
 	Deleted  string `json:",omitempty"`
 }
 
+// ImageDeleteAll contains response of RemoteAPI:
+// DELETE "/images/_all"
+type ImageDeleteAll struct {
+	Failed       int
+	FailedImages map[string]string
+}
+
 // Image contains response of Remote API:
 // GET "/images/json"
 type Image struct {


### PR DESCRIPTION
This patch creates an endpoint to delete all images. 

I ran into some issues with the order of tests and images needed by other tests being deleted, so I skipped the `TestApiImagesDeleteAll` test.

Fixes #10867

Signed-off-by: Peter Malmgren ptmalmgren@gmail.com
