### PR TITLE
Fix DockerSuite.TestVolumeCliInspectMulti

### DIFF
--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -54,7 +54,8 @@ func (s *DockerSuite) TestVolumeCliInspectMulti(c *check.C) {
 	dockerCmd(c, "volume", "create", "--name", "test1")
 	dockerCmd(c, "volume", "create", "--name", "test2")
 
-	out, _ := dockerCmd(c, "volume", "inspect", "--format='{{ .Name }}'", "test1", "test2", "doesntexist")
+	out, _, err := dockerCmdWithError("volume", "inspect", "--format='{{ .Name }}'", "test1", "test2", "doesntexist")
+	c.Assert(err, checker.NotNil)
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(outArr), check.Equals, 3, check.Commentf("\n%s", out))
 


### PR DESCRIPTION
Use `dockerCmdWithError` now that `docker volume inspect nonexistent` actually returns an error code.

Fixes master after #17788. The test should probably check the error but I was lazy tonight, tell me if we want it to or not :wink:.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
