### PR TITLE
Windows CI Fix: Allow bash v4

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -56,6 +56,13 @@ while [ $# -gt 0 ]; do
 	layersFs=$(echo "$manifestJson" | jq --raw-output '.fsLayers | .[] | .blobSum')
 
 	IFS=$'\n'
+	# bash v4 on Windows CI requires CRLF seperator
+	if [ "$(go env GOHOSTOS)" = 'windows' ]; then
+		major=$(echo ${BASH_VERSION%%[^0.9]} | cut -d. -f1)
+		if [ "$major" -ge 4 ]; then
+			IFS=$'\r\n'
+		fi
+	fi	
 	layers=( ${layersFs} )
 	unset IFS
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @mikedougherty After upgrading Azure Node 1 to git 2.6.3 (which contains bash 4 - finally!!), hack/make.sh test-integration-cli won't work downloading the frozen images as it assumes it's using Linux EOL semantics (LF), whereas lines being parsed in this code block will end with Windows EOL semantics (CRLF).

Verified with a clear down of containers and images and a CI run on node 1. Should not affect other CI nodes which are currently running bash 3. Also verified with a full clear-down the same on node 2 (on bash 3.1).

(Note some tests failed in the local CI run, but unrelated to this change)
