### PR TITLE
docs: fix pull by digest example

### DIFF
--- a/docs/userguide/dockerimages.md
+++ b/docs/userguide/dockerimages.md
@@ -504,13 +504,13 @@ unchanged, the digest value is predictable. To list image digest values, use
 the `--digests` flag:
 
     $ docker images --digests | head
-    REPOSITORY                         TAG                 DIGEST                                                                     IMAGE ID            CREATED             VIRTUAL SIZE
-    ouruser/sinatra                    latest              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf    5db5f8471261        11 hours ago        446.7 MB
+    REPOSITORY        TAG      DIGEST                                                                     IMAGE ID      CREATED       VIRTUAL SIZE
+    ouruser/sinatra   latest   sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf    5db5f8471261  11 hours ago  446.7 MB
 
 When pushing or pulling to a 2.0 registry, the `push` or `pull` command
 output includes the image digest. You can `pull` using a digest value.
 
-    $ docker pull ouruser/sinatra@cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    $ docker pull ouruser/sinatra@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
 
 You can also reference by digest in `create`, `run`, and `rmi` commands, as well as the
 `FROM` image reference in a Dockerfile.


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/18441

This fixes the "pull by digest" example. Also reduced the column spacing in the output, so that more output is visible in the documentation.

Thanks @capen for reporting this in https://github.com/docker/docs.docker.com/issues/51!
