### PR TITLE
Improve bash completion for `docker network disconnect`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -157,6 +157,11 @@ __docker_networks() {
 	COMPREPLY=( $(compgen -W "$networks" -- "$cur") )
 }
 
+__docker_containers_in_network() {
+	local containers=$(__docker_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1")
+	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
+}
+
 __docker_volumes() {
 	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
 }
@@ -1092,7 +1097,7 @@ _docker_network_connect() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--tail')
+			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
 				__docker_networks
 			elif [ $cword -eq $(($counter + 1)) ]; then
@@ -1127,9 +1132,19 @@ _docker_network_create() {
 }
 
 _docker_network_disconnect() {
-	# TODO disconnect should only complete running containers connected
-	# to the specified network.
-	_docker_network_connect
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_networks
+			elif [ $cword -eq $(($counter + 1)) ]; then
+				__docker_containers_in_network "$prev"
+			fi
+			;;
+	esac
 }
 
 _docker_network_inspect() {


### PR DESCRIPTION
Picks up #17997.
#17615 and #17481 allow an improvement of the completion of the container argument to docker network disconnect:

Currently, completion lists all running containers, whether they are connected to the specified network or not. This patch narrows completion to those containers that are actually connected to the specified network.

ping @jfrazelle @tianon for review.
@sdurrheimer Perhaps you can reuse this in zsh completion.
