### PR TITLE
Use DiffSize instead of Size in v1 push

### DIFF
--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -432,7 +432,7 @@ func (p *v1Pusher) pushImage(v1Image v1Image, ep string) (checksum string, err e
 	defer arch.Close()
 
 	// don't care if this fails; best effort
-	size, _ := l.Size()
+	size, _ := l.DiffSize()
 
 	// Send the layer
 	logrus.Debugf("rendered layer for %s of [%d] size", v1ID, size)


### PR DESCRIPTION
The v1 push code was querying the size of the layer chain up to the
layer it was pushing, rather than just that layer. This made the
progress indicator inaccurate.
