### PR TITLE
Call it "containerization" instead of "virtualization" in the docs

### DIFF
--- a/docs/examples/mongodb.md
+++ b/docs/examples/mongodb.md
@@ -2,7 +2,7 @@
 +++
 title = "Dockerizing MongoDB"
 description = "Creating a Docker image with MongoDB pre-installed using a Dockerfile and sharing the image on Docker Hub"
-keywords = ["docker, dockerize, dockerizing, article, example, docker.io, platform, package, installation, networking, mongodb, containers, images, image, sharing, dockerfile, build, auto-building, virtualization,  framework"]
+keywords = ["docker, dockerize, dockerizing, article, example, docker.io, platform, package, installation, networking, mongodb, containers, images, image, sharing, dockerfile, build, auto-building,  framework"]
 [menu.main]
 parent = "smn_applied"
 +++

--- a/docs/installation/amazon.md
+++ b/docs/installation/amazon.md
@@ -2,7 +2,7 @@
 +++
 title = "Amazon EC2 Installation"
 description = "Installation instructions for Docker on Amazon EC2."
-keywords = ["amazon ec2, virtualization, cloud, docker, documentation,  installation"]
+keywords = ["amazon ec2, cloud, docker, documentation,  installation"]
 [menu.main]
 parent = "smn_cloud"
 +++

--- a/docs/installation/archlinux.md
+++ b/docs/installation/archlinux.md
@@ -2,7 +2,7 @@
 +++
 title = "Installation on Arch Linux"
 description = "Installation instructions for Docker on ArchLinux."
-keywords = ["arch linux, virtualization, docker, documentation,  installation"]
+keywords = ["arch linux, docker, documentation,  installation"]
 [menu.main]
 parent = "smn_linux"
 +++

--- a/docs/installation/cruxlinux.md
+++ b/docs/installation/cruxlinux.md
@@ -2,7 +2,7 @@
 +++
 title = "Installation on CRUX Linux"
 description = "Docker installation on CRUX Linux."
-keywords = ["crux linux, virtualization, Docker, documentation,  installation"]
+keywords = ["crux linux, Docker, documentation,  installation"]
 [menu.main]
 parent = "smn_linux"
 +++

--- a/docs/installation/frugalware.md
+++ b/docs/installation/frugalware.md
@@ -2,7 +2,7 @@
 +++
 title = "Installation on FrugalWare"
 description = "Installation instructions for Docker on FrugalWare."
-keywords = ["frugalware linux, virtualization, docker, documentation,  installation"]
+keywords = ["frugalware linux, docker, documentation,  installation"]
 [menu.main]
 parent = "smn_linux"
 +++

--- a/docs/installation/gentoolinux.md
+++ b/docs/installation/gentoolinux.md
@@ -2,7 +2,7 @@
 +++
 title = "Installation on Gentoo"
 description = "Installation instructions for Docker on Gentoo."
-keywords = ["gentoo linux, virtualization, docker, documentation,  installation"]
+keywords = ["gentoo linux, docker, documentation,  installation"]
 [menu.main]
 parent = "smn_linux"
 +++

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -111,7 +111,7 @@ and choosing "Open" from the pop-up menu.
 
 To run a Docker container, you:
 
-* create a new (or start an existing) Docker virtual machine
+* create a new (or start an existing) virtual machine that runs Docker.
 * switch your environment to your new VM
 * use the `docker` client to create, load, and manage containers
 

--- a/docs/installation/softlayer.md
+++ b/docs/installation/softlayer.md
@@ -2,7 +2,7 @@
 +++
 title = "Installation on IBM SoftLayer "
 description = "Installation instructions for Docker on IBM Softlayer."
-keywords = ["IBM SoftLayer, virtualization, cloud, docker, documentation,  installation"]
+keywords = ["IBM SoftLayer, cloud, docker, documentation,  installation"]
 [menu.main]
 parent = "smn_cloud"
 +++

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -25,9 +25,9 @@ You install Docker using Docker Toolbox. Docker Toolbox includes the following D
 Because the Docker daemon uses Linux-specific kernel features, you can't run
 Docker natively in Windows. Instead, you must use `docker-machine` to create and attach to a Docker VM on your machine. This VM hosts Docker for you on your Windows system.
 
-The Docker VM is lightweight Linux virtual machine made specifically to run the
-Docker daemon on Windows. The VirtualBox VM runs completely from RAM, is a
-small ~24MB download, and boots in approximately 5s.
+The virtual machine runs a lightweight Linux distribution made specifically to
+run the Docker daemon. The VirtualBox VM runs completely from RAM, is a small
+~24MB download, and boots in approximately 5s.
 
 ## Requirements
 

--- a/docs/introduction/understanding-docker.md
+++ b/docs/introduction/understanding-docker.md
@@ -18,8 +18,8 @@ infrastructure like a managed application. Docker helps you ship code faster,
 test faster, deploy faster, and shorten the cycle between writing code and
 running code.
 
-Docker does this by combining a lightweight container virtualization platform
-with workflows and tooling that help you manage and deploy your applications.
+Docker does this by combining kernel containerization features with workflows
+and tooling that help you manage and deploy your applications.
 
 At its core, Docker provides a way to run almost any application securely
 isolated in a container. The isolation and security allow you to run many
@@ -27,8 +27,8 @@ containers simultaneously on your host. The lightweight nature of containers,
 which run without the extra load of a hypervisor, means you can get more out of
 your hardware.
 
-Surrounding the container virtualization are tooling and a platform which can
-help you in several ways:
+Surrounding the container is tooling and a platform which can help you in
+several ways:
 
 * getting your applications (and supporting components) into Docker containers
 * distributing and shipping those containers to your teams for further development
@@ -73,7 +73,7 @@ out of the resources you have.
 Docker has two major components:
 
 
-* Docker: the open source container virtualization platform.
+* Docker: the open source containerization platform.
 * [Docker Hub](https://hub.docker.com): our Software-as-a-Service
   platform for sharing and managing Docker containers.
 

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -29,12 +29,12 @@ https://github.com/docker/docker/blob/master/LICENSE)
 
 ### Does Docker run on Mac OS X or Windows?
 
-Docker currently runs only on Linux, but you can use VirtualBox to run Docker in
-a virtual machine on your box, and get the best of both worlds. Check out the
-[*Mac OS X*](../installation/mac.md) and [*Microsoft
+Docker currently runs only on Linux, but you can use VirtualBox to run Docker
+in a virtual machine on your box, and get the best of both worlds. Check out
+the [*Mac OS X*](../installation/mac.md) and [*Microsoft
 Windows*](../installation/windows.md) installation guides. The small Linux
-distribution Docker Machine can be run inside virtual machines on these two
-operating systems.
+distribution boot2docker can be set up using the Docker Machine tool to be run
+inside virtual machines on these two operating systems.
 
 >**Note:** if you are using a remote Docker daemon on a VM through Docker
 >Machine, then _do not_ type the `sudo` before the `docker` commands shown in

--- a/docs/misc/index.md
+++ b/docs/misc/index.md
@@ -20,9 +20,9 @@ as fast as possible.
 
 Docker consists of:
 
-* The Docker Engine - our lightweight and powerful open source container
-  virtualization technology combined with a work flow for building
-  and containerizing your applications.
+* The Docker Engine - our lightweight and powerful open source containerization
+  technology combined with a work flow for building and containerizing your
+  applications.
 * [Docker Hub](https://hub.docker.com) - our SaaS service for
   sharing and managing your application stacks.
 

--- a/docs/userguide/dockerimages.md
+++ b/docs/userguide/dockerimages.md
@@ -2,7 +2,7 @@
 +++
 title = "Build your own images"
 description = "How to work with Docker images."
-keywords = ["documentation, docs, the docker guide, docker guide, docker, docker platform, virtualization framework, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub,  collaboration"]
+keywords = ["documentation, docs, the docker guide, docker guide, docker, docker platform, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub,  collaboration"]
 [menu.main]
 parent = "smn_containers"
 weight = -4

--- a/docs/userguide/dockerizing.md
+++ b/docs/userguide/dockerizing.md
@@ -2,7 +2,7 @@
 +++
 title = "Hello world in a container"
 description = "A simple 'Hello world' exercise that introduced you to Docker."
-keywords = ["docker guide, docker, docker platform, virtualization framework, how to, dockerize, dockerizing apps, dockerizing applications, container,  containers"]
+keywords = ["docker guide, docker, docker platform, how to, dockerize, dockerizing apps, dockerizing applications, container,  containers"]
 [menu.main]
 parent="smn_containers"
 weight=-6

--- a/docs/userguide/index.md
+++ b/docs/userguide/index.md
@@ -2,7 +2,7 @@
 +++
 title = "The Docker user guide"
 description = "The Docker user guide home page"
-keywords = ["docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, virtualization, home,  intro"]
+keywords = ["docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, home,  intro"]
 [menu.main]
 parent = "mn_fun_docker"
 +++
@@ -37,8 +37,8 @@ Go to [Using Docker Hub](https://docs.docker.com/docker-hub).
 
 *How do I run applications inside containers?*
 
-Docker offers a *container-based* virtualization platform to power your
-applications. To learn how to Dockerize applications and run them:
+Docker offers a containerization platform to power your applications. To learn
+how to Dockerize applications and run them:
 
 Go to [Dockerizing Applications](dockerizing.md).
 


### PR DESCRIPTION
Updates to docs to remove references to docker as a virtualization platform.

Updated wording around docker-machine/boot2docker combo to increase clarity for times when a virtual machine _is_ present.
