### PR TITLE
JSONMessage terminal display fixes

### DIFF
--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -150,11 +150,11 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 // each line and move the cursor while displaying.
 func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool) error {
 	var (
-		dec  = json.NewDecoder(in)
-		ids  = make(map[string]int)
-		diff = 0
+		dec = json.NewDecoder(in)
+		ids = make(map[string]int)
 	)
 	for {
+		diff := 0
 		var jm JSONMessage
 		if err := dec.Decode(&jm); err != nil {
 			if err == io.EOF {
@@ -180,11 +180,12 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 				if isTerminal {
 					fmt.Fprintf(out, "\n")
 				}
-				diff = 0
 			} else {
 				diff = len(ids) - line
 			}
 			if jm.ID != "" && isTerminal {
+				// NOTE: this appears to be necessary even if
+				// diff == 0.
 				// <ESC>[{diff}A = move cursor up diff rows
 				fmt.Fprintf(out, "%c[%dA", 27, diff)
 			}
@@ -198,6 +199,8 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 		}
 		err := jm.Display(out, isTerminal)
 		if jm.ID != "" && isTerminal {
+			// NOTE: this appears to be necessary even if
+			// diff == 0.
 			// <ESC>[{diff}B = move cursor down diff rows
 			fmt.Fprintf(out, "%c[%dB", 27, diff)
 		}


### PR DESCRIPTION
This PR contains two fixes for JSONMessage's terminal output code. The first one fixes glitching with docker pull -a and docker push -a. The second is not a user-visible change.
- _Don't update lines on the terminal from a previous operation._
  When we handle a message that isn't tracked in the "line" map (for
  example, one with no ID), clear the line map. This means we won't update
  lines that were part of a previous, completed set of operations when
  doing something like pull -a. It also has the beneficial side effect
  of avoiding terminal glitching in these types of situations, since
  messages that don't get tracked in the "line" map cause the count of the
  number of lines to get out of sync.
- _Fix the scoping of "diff" so its value doesn't leak between loop iterations._
  In the existing code, "diff" has function scope and the value from the
  previous iteration may be used if it is not reset. This appears to be an
  oversight. This commit changes its scope to the for loop body.
  One confusing point is that the cursor movement escape sequences appear
  to be necessary even if the requested movement is 0. I haven't been able
  to figure out why this makes a difference.
