### PR TITLE
Add missing bounds check in ContinueOnError

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -213,6 +213,9 @@ func (e ErrNoSupport) Error() string {
 func ContinueOnError(err error) bool {
 	switch v := err.(type) {
 	case errcode.Errors:
+		if len(v) == 0 {
+			return true
+		}
 		return ContinueOnError(v[0])
 	case ErrNoSupport:
 		return ContinueOnError(v.Err)


### PR DESCRIPTION
ContinueOnError assumes that something of type errcode.Errors contains
at least one error. This is generally true, but might not be true if the
remote registry returns an empty error body or invalid JSON. Add the
bounds check, and in the case where it fails, allow fallbacks to v1.

Fixes #18481
