### PR TITLE
Make order of items in "docker images" deterministic

### DIFF
--- a/tag/store_test.go
+++ b/tag/store_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
@@ -102,18 +101,6 @@ func TestSave(t *testing.T) {
 		t.Fatalf("save output did not match expectations\nexpected:\n%s\ngot:\n%s", marshalledSaveLoadTestCases, jsonBytes)
 	}
 }
-
-type LexicalRefs []reference.Named
-
-func (a LexicalRefs) Len() int           { return len(a) }
-func (a LexicalRefs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a LexicalRefs) Less(i, j int) bool { return a[i].String() < a[j].String() }
-
-type LexicalAssociations []Association
-
-func (a LexicalAssociations) Len() int           { return len(a) }
-func (a LexicalAssociations) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a LexicalAssociations) Less(i, j int) bool { return a[i].Ref.String() < a[j].Ref.String() }
 
 func TestAddDeleteGet(t *testing.T) {
 	jsonFile, err := ioutil.TempFile("", "tag-store-test")
@@ -261,10 +248,11 @@ func TestAddDeleteGet(t *testing.T) {
 
 	// Check References
 	refs := store.References(testImageID1)
-	sort.Sort(LexicalRefs(refs))
 	if len(refs) != 3 {
 		t.Fatal("unexpected number of references")
 	}
+	// Looking for the references in this order verifies that they are
+	// returned lexically sorted.
 	if refs[0].String() != ref3.String() {
 		t.Fatalf("unexpected reference: %v", refs[0].String())
 	}
@@ -281,10 +269,11 @@ func TestAddDeleteGet(t *testing.T) {
 		t.Fatalf("could not parse reference: %v", err)
 	}
 	associations := store.ReferencesByName(repoName)
-	sort.Sort(LexicalAssociations(associations))
 	if len(associations) != 3 {
 		t.Fatal("unexpected number of associations")
 	}
+	// Looking for the associations in this order verifies that they are
+	// returned lexically sorted.
 	if associations[0].Ref.String() != ref3.String() {
 		t.Fatalf("unexpected reference: %v", associations[0].Ref.String())
 	}


### PR DESCRIPTION
The server-side portion of "docker images" sorts the images it returns
by creation timestamp so the list keeps a consistent order. However, it
does not sort the RepoTags and RepoDigests lists that each image carries
along with it. Since items in these lists are populated from a map,
their order will vary. If the user has a collection of tags which point
to overlapping IDs, for example tags that point to the same images on
different registries, the order will fluctuate between invocations of
"docker images". This can be disorienting with a long list of images.

Sort these references at the tag store level, so that the tag store's
References call always returns references in a lexically sorted order.
As well as giving the tag store more deterministic behavior, doing it at
this level simplifies the tag store unit tests.

Do the same for the ReferencesByName call. This will make push-all-tags
iterate over the tags in a consistent order.
