### PR TITLE
Fix duplicate steps in "Get started with multi-host networking"

### DIFF
--- a/docs/userguide/networking/get-started-overlay.md
+++ b/docs/userguide/networking/get-started-overlay.md
@@ -345,14 +345,6 @@ You can try starting a second network on your existing Swarm cluster using Docke
 
 	Upon success, the browser should display the web application.
 
-7. Get the Swarm master's IP address.
-
-		$ docker-machine ip mhs-demo0
-
-8. Put the IP address into your web browser.
-
-	Upon success, the browser should display the web application.
-
 ## Related information
 
 * [Understand Docker container networks](dockernetworks.md)


### PR DESCRIPTION
These lines were cherry-picked twice.

closes https://github.com/docker/docker/issues/18482
