### PR TITLE
Fix overlay + user namespaces underlay dir permissions

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -270,10 +270,10 @@ func (d *Driver) Create(id, parent, mountLabel string) (retErr error) {
 	parentRoot := path.Join(parentDir, "root")
 
 	if s, err := os.Lstat(parentRoot); err == nil {
-		if err := os.Mkdir(path.Join(dir, "upper"), s.Mode()); err != nil {
+		if err := idtools.MkdirAs(path.Join(dir, "upper"), s.Mode(), rootUID, rootGID); err != nil {
 			return err
 		}
-		if err := os.Mkdir(path.Join(dir, "work"), 0700); err != nil {
+		if err := idtools.MkdirAs(path.Join(dir, "work"), 0700, rootUID, rootGID); err != nil {
 			return err
 		}
 		if err := idtools.MkdirAs(path.Join(dir, "merged"), 0700, rootUID, rootGID); err != nil {
@@ -303,10 +303,10 @@ func (d *Driver) Create(id, parent, mountLabel string) (retErr error) {
 	}
 
 	upperDir := path.Join(dir, "upper")
-	if err := os.Mkdir(upperDir, s.Mode()); err != nil {
+	if err := idtools.MkdirAs(upperDir, s.Mode(), rootUID, rootGID); err != nil {
 		return err
 	}
-	if err := os.Mkdir(path.Join(dir, "work"), 0700); err != nil {
+	if err := idtools.MkdirAs(path.Join(dir, "work"), 0700, rootUID, rootGID); err != nil {
 		return err
 	}
 	if err := idtools.MkdirAs(path.Join(dir, "merged"), 0700, rootUID, rootGID); err != nil {


### PR DESCRIPTION
All underlay dirs need proper remapped ownership. This bug was masked by the
fact that the setupInitLayer code was chown'ing the dirs at startup
time. Since that bug is now fixed (via #18436), this permissions issue was revealed.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
