### PR TITLE
Fixes for building on ppc64le and 390x due to ensure-frozen-images

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	git \
 	iptables \
+	jq \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
@@ -77,8 +78,8 @@ WORKDIR /go/src/github.com/docker/docker
 ENV DOCKER_BUILDTAGS apparmor selinux
 
 ENV IMAGEREPO ppc64le
-COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/
-RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
+COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
+RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	$IMAGEREPO/busybox:latest \
 	$IMAGEREPO/hello-world:frozen 
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	git \
 	iptables \
+	jq \
 	net-tools \
 	libapparmor-dev \
 	libcap-dev \
@@ -76,8 +77,8 @@ WORKDIR /go/src/github.com/docker/docker
 ENV DOCKER_BUILDTAGS apparmor selinux
 
 ENV IMAGEREPO s390x
-COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/
-RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
+COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
+RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	$IMAGEREPO/busybox:latest \
 	$IMAGEREPO/hello-world:frozen 
 

--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -1,21 +1,37 @@
 #!/bin/bash
 set -e
 
-# this list should match roughly what's in the Dockerfile (minus the explicit image IDs, of course)
-images=(
-	busybox:latest
-	hello-world:latest
-	jess/unshare:latest
-)
-
-# on ARM we need images that work for the ARM architecture
-if [ "$DOCKER_ENGINE_OSARCH" = "linux/arm" ]; then
-	images=(
-		hypriot/armhf-busybox@ea0800bb83571c585c5652b53668e76b29c7c0eef719892f9d0a48607984f9e1
-		hypriot/armhf-hello-world@508c59a4f8b23c77bbcf43296c3f580873dc7eecb1f0d680cea3067e221fd4c2
-		hypriot/armhf-unshare@3f1db65f8bbabc743fd739cf7145a56c35b2a0979ae3174e9d79b7fa4b00fca1
-	)
-fi
+# image lists for different archs that should match what's in the Dockerfile (minus the explicit images IDs)
+case "$DOCKER_ENGINE_OSARCH" in
+	linux/arm) 
+		images=(
+                	hypriot/armhf-busybox@ea0800bb83571c585c5652b53668e76b29c7c0eef719892f9d0a48607984f9e1
+			hypriot/armhf-hello-world@508c59a4f8b23c77bbcf43296c3f580873dc7eecb1f0d680cea3067e221fd4c2
+                	hypriot/armhf-unshare@3f1db65f8bbabc743fd739cf7145a56c35b2a0979ae3174e9d79b7fa4b00fca1
+        	)
+		;;
+	linux/ppc64le)
+		images=(
+                	ppc64le/busybox:latest
+                	ppc64le/hello-world:frozen
+                	ppc64le/unshare:latest
+        	)
+		;;
+	linux/s390x)
+		images=(
+			s390x/busybox:latest
+			s390x/hello-world:frozen
+			s390x/unshare:latest	
+		)
+		;;
+	*)
+		images=(
+                	busybox:latest
+                	hello-world:latest
+                	jess/unshare:latest
+        	)
+		;;
+esac
 
 if ! docker inspect "${images[@]}" &> /dev/null; then
 	hardCodedDir='/docker-frozen-images'
@@ -46,16 +62,34 @@ if ! docker inspect "${images[@]}" &> /dev/null; then
 	fi
 fi
 
-if [ "$DOCKER_ENGINE_OSARCH" = "linux/arm" ]; then
-	# tag images to ensure that all integrations work with the defined image names
-	docker tag hypriot/armhf-busybox:latest busybox:latest
-	docker tag hypriot/armhf-hello-world:latest hello-world:frozen
-	docker tag hypriot/armhf-unshare:latest jess/unshare:latest
-
-	# remove orignal tags as these make problems with later tests: TestInspectApiImageResponse
-	docker rmi hypriot/armhf-busybox:latest
-	docker rmi hypriot/armhf-hello-world:latest
-	docker rmi hypriot/armhf-unshare:latest
-else
-	docker tag hello-world:latest hello-world:frozen
-fi
+# tag images to ensure that all integrations work with the defined image names
+# then remove original tags as these make problems with later tests (e.g., TestInspectApiImageResponse)
+case "$DOCKER_ENGINE_OSARCH" in
+	linux/arm)
+		docker tag hypriot/armhf-busybox:latest busybox:latest
+        	docker tag hypriot/armhf-hello-world:latest hello-world:frozen
+        	docker tag hypriot/armhf-unshare:latest jess/unshare:latest		
+		docker rmi hypriot/armhf-busybox:latest
+        	docker rmi hypriot/armhf-hello-world:latest
+        	docker rmi hypriot/armhf-unshare:latest
+		;;
+	linux/ppc64le)
+		docker tag ppc64le/busybox:latest busybox:latest
+        	docker tag ppc64le/hello-world:frozen hello-world:frozen
+		docker tag ppc64le/unshare:latest jess/unshare:latest
+		docker rmi ppc64le/busybox:latest
+        	docker rmi ppc64le/hello-world:frozen
+		docker rmi ppc64le/unshare:latest		
+		;;
+	linux/s390x)
+		docker tag s390x/busybox:latest busybox:latest
+		docker tag s390x/hello-world:frozen hello-world:frozen
+		docker tag s390x/unshare:latest jess/unshare:latest
+		docker rmi s390x/busybox:latest
+		docker rmi s390x/hello-world:frozen
+		docker rmi s390x/unshare:latest
+		;;
+	*)
+		docker tag hello-world:latest hello-world:frozen
+		;;
+esac

--- a/hack/make/.ensure-images
+++ b/hack/make/.ensure-images
@@ -1,9 +1,0 @@
-for image in `docker images | awk '{print $1}'`; do
-if ( [ -z "${image##$IMAGEREPO/busybox}" ] ); then
-	docker tag $image busybox:latest
-	docker rmi $image
-elif ( [ -z "${image##$IMAGEREPO/hello-world}" ] ); then
-	docker tag $image:frozen hello-world:frozen
-	docker rmi $image:frozen
-fi
-done

--- a/hack/make/.integration-daemon-setup
+++ b/hack/make/.integration-daemon-setup
@@ -2,5 +2,4 @@
 
 bundle .ensure-emptyfs
 bundle .ensure-frozen-images
-bundle .ensure-images
 bundle .ensure-httpserver


### PR DESCRIPTION
Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

This PR fixes build issues on power and z systems due to recent changes to ensure-frozen-images from #18315.

ping @tianon @jfrazelle 
