### PR TITLE
Set OOMKilled state on any OOM event

### DIFF
--- a/container/monitor.go
+++ b/container/monitor.go
@@ -304,8 +304,7 @@ func (m *containerMonitor) shouldRestart(exitCode int) bool {
 // received ack from the execution drivers
 func (m *containerMonitor) callback(processConfig *execdriver.ProcessConfig, pid int, chOOM <-chan struct{}) error {
 	go func() {
-		_, ok := <-chOOM
-		if ok {
+		for range chOOM {
 			m.logEvent("oom")
 		}
 	}()

--- a/integration-cli/docker_cli_oom_killed_test.go
+++ b/integration-cli/docker_cli_oom_killed_test.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package main
+
+import (
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
+	testRequires(c, DaemonIsLinux, memoryLimitSupport)
+
+	name := "testoomkilled"
+	_, exitCode, _ := dockerCmdWithError("run", "--name", name, "-m", "10MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
+
+	c.Assert(exitCode, checker.Equals, 137, check.Commentf("OOM exit should be 137"))
+
+	oomKilled, err := inspectField(name, "State.OOMKilled")
+	c.Assert(oomKilled, checker.Equals, "true")
+	c.Assert(err, checker.IsNil)
+}
+
+func (s *DockerSuite) TestInspectOomKilledFalse(c *check.C) {
+	testRequires(c, DaemonIsLinux, memoryLimitSupport)
+
+	name := "testoomkilled"
+	dockerCmd(c, "run", "--name", name, "-m", "10MB", "busybox", "sh", "-c", "echo hello world")
+
+	oomKilled, err := inspectField(name, "State.OOMKilled")
+	c.Assert(oomKilled, checker.Equals, "false")
+	c.Assert(err, checker.IsNil)
+}

--- a/integration-cli/docker_cli_oom_killed_test.go
+++ b/integration-cli/docker_cli_oom_killed_test.go
@@ -11,7 +11,7 @@ func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
 	testRequires(c, DaemonIsLinux, memoryLimitSupport)
 
 	name := "testoomkilled"
-	_, exitCode, _ := dockerCmdWithError("run", "--name", name, "-m", "10MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
+	_, exitCode, _ := dockerCmdWithError("run", "--name", name, "--memory", "32MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
 
 	c.Assert(exitCode, checker.Equals, 137, check.Commentf("OOM exit should be 137"))
 
@@ -24,7 +24,7 @@ func (s *DockerSuite) TestInspectOomKilledFalse(c *check.C) {
 	testRequires(c, DaemonIsLinux, memoryLimitSupport)
 
 	name := "testoomkilled"
-	dockerCmd(c, "run", "--name", name, "-m", "10MB", "busybox", "sh", "-c", "echo hello world")
+	dockerCmd(c, "run", "--name", name, "--memory", "32MB", "busybox", "sh", "-c", "echo hello world")
 
 	oomKilled, err := inspectField(name, "State.OOMKilled")
 	c.Assert(oomKilled, checker.Equals, "false")


### PR DESCRIPTION
This restores the behavior that existed prior to #16235 for setting
OOMKilled, while retaining the additional benefits it introduced around
emitting oom events.

This also adds a test for the most obvious OOM cases which would have
caught this regression.

Fixes #18510

This also fixes #18470, via ranging over the channel, though I've only manually tested that.

I also wanted some input on whether it would be better to make the behavior differ from the original behavior by trying to figure out that an OOM event is for the init process / is the event that caused the container to exit, though after reading libcontainer and what the kernel's cgroup notifications give you, it seems like whatever we do there would probably be a heuristic at best.
