### PR TITLE
split Docker interface in builder to remove direct daemon reference

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -106,9 +106,18 @@ func (fi *HashedFileInfo) SetHash(h string) {
 	fi.FileHash = h
 }
 
+// ContainerCommitter is a backend which supports commiting a
+// container to an image.
+type ContainerCommitter interface {
+	// Commit creates a new Docker image from an existing Docker container.
+	Commit(string, *types.ContainerCommitConfig) (string, error)
+}
+
 // Docker abstracts calls to a Docker Daemon.
 type Docker interface {
 	// TODO: use digest reference instead of name
+
+	ContainerCommitter
 
 	// LookupImage looks up a Docker image referenced by `name`.
 	LookupImage(name string) (*image.Image, error)
@@ -122,8 +131,6 @@ type Docker interface {
 	Create(*runconfig.Config, *runconfig.HostConfig) (*container.Container, []string, error)
 	// Remove removes a container specified by `id`.
 	Remove(id string, cfg *types.ContainerRmConfig) error
-	// Commit creates a new Docker image from an existing Docker container.
-	Commit(string, *types.ContainerCommitConfig) (string, error)
 	// Copy copies/extracts a source FileInfo to a destination path inside a container
 	// specified by a container object.
 	// TODO: make an Extract method instead of passing `decompress`

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
-	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/ulimit"
 	"github.com/docker/docker/runconfig"
@@ -258,7 +257,7 @@ func BuildFromConfig(config *runconfig.Config, changes []string) (*runconfig.Con
 
 // Commit will create a new image from a container's changes
 // TODO: remove daemon, make Commit a method on *Builder ?
-func Commit(containerName string, d *daemon.Daemon, c *CommitConfig) (string, error) {
+func Commit(containerName string, d builder.ContainerCommitter, c *CommitConfig) (string, error) {
 	if c.Config == nil {
 		c.Config = &runconfig.Config{}
 	}


### PR DESCRIPTION
I'm wondering if we should split the Docker interface into one or two sub-interfaces. One containing everything that is satisfied by the base daemon, and one that has the renamed and changed functions.

I only went as far as needed to achieve my goal. No more daemon references in the builder.

```
λ ag /daemon builder/
λ
```
