### PR TITLE
Add new ppc64le image

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -81,7 +81,8 @@ ENV IMAGEREPO ppc64le
 COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	$IMAGEREPO/busybox:latest \
-	$IMAGEREPO/hello-world:frozen 
+	$IMAGEREPO/hello-world:frozen \ 
+	$IMAGEREPO/unshare:latest	
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]


### PR DESCRIPTION
Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

This PR adds a ppc64le unshare image, and was supposed to be in #18506. whoops. 
