### PR TITLE
adjust test sleep timing to avoid spurious failure

### DIFF
--- a/pkg/integration/utils_test.go
+++ b/pkg/integration/utils_test.go
@@ -363,7 +363,7 @@ func TestConsumeWithSpeed(t *testing.T) {
 	reader := strings.NewReader("1234567890")
 	chunksize := 2
 
-	bytes1, err := ConsumeWithSpeed(reader, chunksize, 1*time.Millisecond, nil)
+	bytes1, err := ConsumeWithSpeed(reader, chunksize, 1*time.Second, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestConsumeWithSpeedWithStop(t *testing.T) {
 		stopIt <- true
 	}()
 
-	bytes1, err := ConsumeWithSpeed(reader, chunksize, 2*time.Millisecond, stopIt)
+	bytes1, err := ConsumeWithSpeed(reader, chunksize, 20*time.Millisecond, stopIt)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This unit test annoys me when it fails.

Unfortunately we can't force it to run exactly one loop. With 20ms I saw no failures in ~40k runs of the test. Which is much better than the ~1 in 20 I was seeing before.

If tests that require 'waiting' start to dominate test runtime, enabling the tests to run in parallel should be investigated. (This is only if all the tests we are waiting on are in the same package, multiple packages run in parallel automatically.)
