### PR TITLE
modify docker inspect output name with prefix slash ("/")

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -139,7 +140,7 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 		State:        containerState,
 		Image:        container.ImageID.String(),
 		LogPath:      container.LogPath,
-		Name:         container.Name,
+		Name:         strings.TrimLeft(container.Name, "/"),
 		RestartCount: container.RestartCount,
 		Driver:       container.Driver,
 		MountLabel:   container.MountLabel,

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -867,7 +867,7 @@ func (s *DockerSuite) TestContainerApiRename(c *check.C) {
 	c.Assert(statusCode, checker.Equals, http.StatusNoContent)
 
 	name, err := inspectField(containerID, "Name")
-	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container"))
+	c.Assert(name, checker.Equals, newName, check.Commentf("Failed to rename container"))
 }
 
 func (s *DockerSuite) TestContainerApiKill(c *check.C) {

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -21,7 +21,7 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 
 	name, err = inspectField(cleanedContainerID, "Name")
 	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
-	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
+	c.Assert(name, checker.Equals, newName, check.Commentf("Failed to rename container %s", name))
 
 }
 
@@ -35,7 +35,7 @@ func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
 
 	name, err := inspectField(cleanedContainerID, "Name")
 	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
-	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
+	c.Assert(name, checker.Equals, newName, check.Commentf("Failed to rename container %s", name))
 }
 
 func (s *DockerSuite) TestRenameRunningContainerAndReuse(c *check.C) {
@@ -49,14 +49,14 @@ func (s *DockerSuite) TestRenameRunningContainerAndReuse(c *check.C) {
 
 	name, err := inspectField(ContainerID, "Name")
 	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
-	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container"))
+	c.Assert(name, checker.Equals, newName, check.Commentf("Failed to rename container"))
 
 	out, _ = dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "top")
 	c.Assert(waitRun("first_name"), check.IsNil)
 	newContainerID := strings.TrimSpace(out)
 	name, err = inspectField(newContainerID, "Name")
 	c.Assert(err, checker.IsNil, check.Commentf("Failed to reuse container name"))
-	c.Assert(name, checker.Equals, "/first_name", check.Commentf("Failed to reuse container name"))
+	c.Assert(name, checker.Equals, "first_name", check.Commentf("Failed to reuse container name"))
 }
 
 func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
@@ -68,7 +68,7 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 
 	name, err := inspectField(newName, "Name")
 	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
-	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
+	c.Assert(name, checker.Equals, newName, check.Commentf("Failed to rename container %s", name))
 
 	name, err = inspectField("first_name", "Name")
 	c.Assert(err, checker.NotNil, check.Commentf(name))


### PR DESCRIPTION
When using "docker inspect " or "docker insepct --format='{{ .Name }}' "a container,i get the name with "/" ,just like below:

root@edd8b33ea055:/go/src/github.com/docker/docker# docker inspect --format='{{ .Name }}' container1
/container1

the container's name is not "container1"  but "/container1",so i think we should trim the "/" before return.

Signed-off-by: Shuwei Hao haosw@cn.ibm.com
