### PR TITLE
fix docker inspect return unconsistent network settings  of created container and stopped container

### DIFF
--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -16,6 +16,11 @@ func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]s
 	return nil, nil
 }
 
+// updateContainerNetworkSettings update the network settings
+func (daemon *Daemon) updateContainerNetworkSettings(container *container.Container) error {
+	return nil
+}
+
 func (daemon *Daemon) initializeNetworking(container *container.Container) error {
 	return nil
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -106,6 +106,10 @@ func (daemon *Daemon) create(params *ContainerCreateConfig) (retC *container.Con
 		return nil, err
 	}
 
+	if err := daemon.updateContainerNetworkSettings(container); err != nil {
+		return nil, err
+	}
+
 	if err := container.ToDiskLocking(); err != nil {
 		logrus.Errorf("Error saving new container to disk: %v", err)
 		return nil, err

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -891,3 +891,22 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectWithMac(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(mac2), checker.Not(checker.Equals), strings.TrimSpace(mac1))
 }
+
+func (s *DockerNetworkSuite) TestDockerNetworkInspectCreatedContainer(c *check.C) {
+	dockerCmd(c, "create", "--name", "test", "busybox")
+	networks, err := inspectField("test", "NetworkSettings.Networks")
+	c.Assert(err, checker.IsNil)
+	c.Assert(networks, checker.Contains, "bridge", check.Commentf("Should return 'bridge' network"))
+}
+
+func (s *DockerNetworkSuite) TestDockerNetworkRestartWithMulipleNetworks(c *check.C) {
+	dockerCmd(c, "network", "create", "test")
+	dockerCmd(c, "run", "--name=foo", "-d", "busybox", "top")
+	c.Assert(waitRun("foo"), checker.IsNil)
+	dockerCmd(c, "network", "connect", "test", "foo")
+	dockerCmd(c, "restart", "foo")
+	networks, err := inspectField("foo", "NetworkSettings.Networks")
+	c.Assert(err, checker.IsNil)
+	c.Assert(networks, checker.Contains, "bridge", check.Commentf("Should contain 'bridge' network"))
+	c.Assert(networks, checker.Contains, "test", check.Commentf("Should contain 'test' netwokr"))
+}


### PR DESCRIPTION
To make docker inspect return a consistent result of networksettings
for created container and stopped container, it's better to update
the network settings on container creating. Or else `docker inspect` a created 
container will not return the network settings.

<pre><code>$ docker create --name foo -ti busybox
4b5600da39e0350a3bb872f1d6a790443b327c87a2baa21300cf8e6abc09c85f
docker inspect foo
.
.
"NetworkSettings": {
        "Bridge": "",
        "SandboxID": "",
        "HairpinMode": false,
        "LinkLocalIPv6Address": "",
        "LinkLocalIPv6PrefixLen": 0,
        "Ports": null,
        "SandboxKey": "",
        "SecondaryIPAddresses": null,
        "SecondaryIPv6Addresses": null,
        "EndpointID": "",
        "Gateway": "",
        "GlobalIPv6Address": "",
        "GlobalIPv6PrefixLen": 0,
        "IPAddress": "",
        "IPPrefixLen": 0,
        "IPv6Gateway": "",
        "MacAddress": "",
        "Networks": null
    }
</code></pre>

as you can see `Networks` filed is `null`, it should has the network `bridge`, but if start it and then stop it, then `docker inspect` will return `Networks`

<pre><code>$ docker start foo
foo
$ docker stop foo
foo
$ docker inspect foo
.
.
"Networks": {
            "bridge": {
                "EndpointID": "",
                "Gateway": "",
                "IPAddress": "",
                "IPPrefixLen": 0,
                "IPv6Gateway": "",
                "GlobalIPv6Address": "",
                "GlobalIPv6PrefixLen": 0,
                "MacAddress": ""
            }
        }
</code></pre>

It should have the consistent result.
Signed-off-by: Lei Jitang leijitang@huawei.com
