### PR TITLE
Fix broken external links

### DIFF
--- a/docs/installation/cruxlinux.md
+++ b/docs/installation/cruxlinux.md
@@ -11,7 +11,7 @@ parent = "smn_linux"
 # CRUX Linux
 
 Installing on CRUX Linux can be handled via the contrib ports from
-[James Mills](http://prologic.shortcircuit.net.au/) and are included in the
+[James Mills](https://github.com/prologic) and are included in the
 official [contrib](http://crux.nu/portdb/?a=repo&q=contrib) ports:
 
 - docker
@@ -56,7 +56,7 @@ To start on system boot:
 
 ## Images
 
-There is a CRUX image maintained by [James Mills](http://prologic.shortcircuit.net.au/)
+There is a CRUX image maintained by [James Mills](https://github.com/prologic)
 as part of the Docker "Official Library" of images. To use this image simply pull it
 or use it as part of your `FROM` line in your `Dockerfile(s)`.
 


### PR DESCRIPTION
Updated James Mill's URL to his GitHub profile

~~Also updated the URL to Oracle Linux, their homepage performs some redirects which probably lead to the link-checker to fail. I updated the URL to the page the homepage redirects to :innocent:~~

update: removed the Oracle Linux change; looks like their page is just doing too many redirects (probably tracking), that may rely on cookies. Try it on this page; http://wheregoes.com
