### PR TITLE
Better error message for invalid unix socket format

### DIFF
--- a/api/server/server_unix.go
+++ b/api/server/server_unix.go
@@ -38,7 +38,7 @@ func (s *Server) newServer(proto, addr string) ([]*HTTPServer, error) {
 	case "unix":
 		l, err := sockets.NewUnixSocket(addr, s.cfg.SocketGroup)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("can't create unix socket %s: %v", addr, err)
 		}
 		ls = append(ls, l)
 	default:


### PR DESCRIPTION
Close #18521 

Give more meaningful error prompts when user try to bind a directory as
unix socket.

New message printed:

```
$ sudo docker daemon -H unix:///tmp/test
FATA[0000] Error Unlink /tmp/test: is a directory 
```

Signed-off-by: Zhang Wei zhangwei555@huawei.com
