### PR TITLE
Skip aufs whiteout files on userns translation to container

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -304,8 +304,9 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	}
 
 	//handle re-mapping container ID mappings back to host ID mappings before
-	//writing tar headers/files
-	if ta.UIDMaps != nil || ta.GIDMaps != nil {
+	//writing tar headers/files. We skip whiteout files because they were written
+	//by the kernel and already have proper ownership relative to the host
+	if !strings.HasPrefix(filepath.Base(hdr.Name), WhiteoutPrefix) && (ta.UIDMaps != nil || ta.GIDMaps != nil) {
 		uid, gid, err := getFileUIDGID(fi.Sys())
 		if err != nil {
 			return err


### PR DESCRIPTION
aufs kernel module creates whiteout files on upper layer delete (and
other situations) and those files already are 'translated' regarding
ownership in host terms (e.g. they are already "0:0" owned), so when
these layers are copied around with pkg/archive we don't want to try and
translate these files regarding ownership.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
