### PR TITLE
Remove redundant check

### DIFF
--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -183,7 +183,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 			} else {
 				diff = len(ids) - line
 			}
-			if jm.ID != "" && isTerminal {
+			if isTerminal {
 				// NOTE: this appears to be necessary even if
 				// diff == 0.
 				// <ESC>[{diff}A = move cursor up diff rows


### PR DESCRIPTION
`jm.ID` is already checked in the outer "if", so theres no reason to check it again here.

Just a nit I noticed when looking at https://github.com/docker/docker/pull/18484 :sweat_smile: 
