### PR TITLE
Update networkingcontainers.md

### DIFF
--- a/docs/userguide/networkingcontainers.md
+++ b/docs/userguide/networkingcontainers.md
@@ -214,7 +214,7 @@ Now, open a shell to your running `db` container:
     --- 172.17.0.2 ping statistics ---
     44 packets transmitted, 0 received, 100% packet loss, time 43185ms
 
-After a bit, use CTRL-C to end the `ping` and you'll find the ping failed. That is because the two container are running on different networks. You can fix that. Then, use CTRL-C to exit the container.
+After a bit, use CTRL-C to end the `ping` and you'll find the ping failed. That is because the two container are running on different networks. You can fix that - use the `exit` command to exit the container.
 
 Docker networking allows you to attach a container to as many networks as you like. You can also attach an already running container. Go ahead and attach your running `web` app to the `my-bridge-network`.
 


### PR DESCRIPTION
updated line on how to exit the container after the ping test - in my environment (Ubuntu 14.04.1, bash) ctrl-c does not work to exit the shell, and `exit` must be used instead.

Signed-off-by: Troy Denton trdenton@gmail.com
