### PR TITLE
Lazy initialize Volume on container Mount object

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -269,10 +269,6 @@ func (daemon *Daemon) Register(container *container.Container) error {
 		}
 	}
 
-	if err := daemon.prepareMountPoints(container); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -8,19 +8,6 @@ import (
 	volumestore "github.com/docker/docker/volume/store"
 )
 
-func (daemon *Daemon) prepareMountPoints(container *container.Container) error {
-	for _, config := range container.MountPoints {
-		if len(config.Driver) > 0 {
-			v, err := daemon.createVolume(config.Name, config.Driver, nil)
-			if err != nil {
-				return err
-			}
-			config.Volume = v
-		}
-	}
-	return nil
-}
-
 func (daemon *Daemon) removeMountPoints(container *container.Container, rm bool) error {
 	var rmErrors []string
 	for _, m := range container.MountPoints {

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -19,6 +19,14 @@ import (
 func (daemon *Daemon) setupMounts(container *container.Container) ([]execdriver.Mount, error) {
 	var mounts []execdriver.Mount
 	for _, m := range container.MountPoints {
+		// Lazy initialize m.Volume if needed.  This happens after a daemon restart
+		if len(m.Driver) > 0 && m.Volume == nil {
+			v, err := daemon.createVolume(m.Name, m.Driver, nil)
+			if err != nil {
+				return nil, err
+			}
+			m.Volume = v
+		}
 		path, err := m.Setup()
 		if err != nil {
 			return nil, err

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -18,6 +18,14 @@ import (
 func (daemon *Daemon) setupMounts(container *container.Container) ([]execdriver.Mount, error) {
 	var mnts []execdriver.Mount
 	for _, mount := range container.MountPoints { // type is volume.MountPoint
+		// Lazy initialize m.Volume if needed.  This happens after a daemon restart
+		if len(m.Driver) > 0 && m.Volume == nil {
+			v, err := daemon.createVolume(m.Name, m.Driver, nil)
+			if err != nil {
+				return nil, err
+			}
+			m.Volume = v
+		}
 		// If there is no source, take it from the volume path
 		s := mount.Source
 		if s == "" && mount.Volume != nil {


### PR DESCRIPTION
Currently on daemon start volumes are "created" which involves invoking
a volume driver if needed.  If this process fails the mount is left in a
bad state in which there is no source or Volume set.  This now becomes
an unrecoverable state in which that container can not be started.  The
only way to fix is to restart the daemon and hopefully you don't get
another error on startup.

This change moves "createVolume" to be done at container start.  If the
start fails it leaves it in the state in which you can try another
start.  If the second start can contact the volume driver everything
will recover fine.

Signed-off-by: Darren Shepherd darren@rancher.com
