### PR TITLE
Don't dereference HostConfig.MemorySwapiness if nil

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -199,7 +199,11 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		BlkioThrottleReadBpsDevice:  readBpsDevice,
 		BlkioThrottleWriteBpsDevice: writeBpsDevice,
 		OomKillDisable:              c.HostConfig.OomKillDisable,
-		MemorySwappiness:            *c.HostConfig.MemorySwappiness,
+		MemorySwappiness:            -1,
+	}
+
+	if c.HostConfig.MemorySwappiness != nil {
+		resources.MemorySwappiness = *c.HostConfig.MemorySwappiness
 	}
 
 	processConfig := execdriver.ProcessConfig{


### PR DESCRIPTION
I ran into a panic a because of this on daemon start.  I was upgrading from 1.9 to 1.10.  I'm not 100% why MemorySwapiness was nil but it seems to be a case you can encounter.  One thing I was not sure is if MemorySwapiness is nil should the value in execdriver.Resources.MemorySwappiness be 0 or something like -1?
