### PR TITLE
Proposal: Add container networks list to /containers/json

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -140,6 +140,7 @@ type Container struct {
 	HostConfig struct {
 		NetworkMode string `json:",omitempty"`
 	}
+	NetworkSettings *SummaryNetworkSettings
 }
 
 // CopyConfig contains request body of Remote API:
@@ -300,6 +301,12 @@ type ContainerJSON struct {
 type NetworkSettings struct {
 	NetworkSettingsBase
 	DefaultNetworkSettings
+	Networks map[string]*network.EndpointSettings
+}
+
+// SummaryNetworkSettings provides a summary of container's networks
+// in /containers/json
+type SummaryNetworkSettings struct {
 	Networks map[string]*network.EndpointSettings
 }
 

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -351,6 +351,7 @@ func (daemon *Daemon) transformContainer(container *container.Container, ctx *li
 	newC.Created = container.Created.Unix()
 	newC.Status = container.State.String()
 	newC.HostConfig.NetworkMode = string(container.HostConfig.NetworkMode)
+	newC.NetworkSettings = &types.SummaryNetworkSettings{container.NetworkSettings.Networks}
 
 	newC.Ports = []types.Port{}
 	for port, bindings := range container.NetworkSettings.Ports {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -96,6 +96,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.22](docker_remote_api_v1.22.md) documentation
 
 * `GET /containers/json` supports filter `isolation` on Windows.
+* `GET /containers/json` now returns the list of networks of containers.
 * `GET /info` Now returns `Architecture` and `OSType` fields, providing information
   about the host architecture and operating system type that the daemon runs on.
 * `GET /networks/(name)` now returns a `Name` field for each container attached to the network.

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -57,7 +57,21 @@ List containers
                          "com.example.version": "1.0"
                  },
                  "SizeRw": 12288,
-                 "SizeRootFs": 0
+                 "SizeRootFs": 0,
+                 "NetworkSettings": {
+                         "Networks": {
+                                 "bridge": {
+                                          "EndpointID": "2cdc4edb1ded3631c81f57966563e5c8525b81121bb3706a9a9a3ae102711f3f",
+                                          "Gateway": "172.17.0.1",
+                                          "IPAddress": "172.17.0.2",
+                                          "IPPrefixLen": 16,
+                                          "IPv6Gateway": "",
+                                          "GlobalIPv6Address": "",
+                                          "GlobalIPv6PrefixLen": 0,
+                                          "MacAddress": "02:42:ac:11:00:02"
+                                  }
+                         }
+                 }
          },
          {
                  "Id": "9cd87474be90",
@@ -70,7 +84,22 @@ List containers
                  "Ports": [],
                  "Labels": {},
                  "SizeRw": 12288,
-                 "SizeRootFs": 0
+                 "SizeRootFs": 0,
+                 "NetworkSettings": {
+                         "Networks": {
+                                 "bridge": {
+                                          "EndpointID": "88eaed7b37b38c2a3f0c4bc796494fdf51b270c2d22656412a2ca5d559a64d7a",
+                                          "Gateway": "172.17.0.1",
+                                          "IPAddress": "172.17.0.8",
+                                          "IPPrefixLen": 16,
+                                          "IPv6Gateway": "",
+                                          "GlobalIPv6Address": "",
+                                          "GlobalIPv6PrefixLen": 0,
+                                          "MacAddress": "02:42:ac:11:00:08"
+                                  }
+                         }
+                 }
+
          },
          {
                  "Id": "3176a2479c92",
@@ -83,7 +112,22 @@ List containers
                  "Ports":[],
                  "Labels": {},
                  "SizeRw":12288,
-                 "SizeRootFs":0
+                 "SizeRootFs":0,
+                 "NetworkSettings": {
+                         "Networks": {
+                                 "bridge": {
+                                          "EndpointID": "8b27c041c30326d59cd6e6f510d4f8d1d570a228466f956edf7815508f78e30d",
+                                          "Gateway": "172.17.0.1",
+                                          "IPAddress": "172.17.0.6",
+                                          "IPPrefixLen": 16,
+                                          "IPv6Gateway": "",
+                                          "GlobalIPv6Address": "",
+                                          "GlobalIPv6PrefixLen": 0,
+                                          "MacAddress": "02:42:ac:11:00:06"
+                                  }
+                         }
+                 }
+
          },
          {
                  "Id": "4cb07b47f9fb",
@@ -96,7 +140,22 @@ List containers
                  "Ports": [],
                  "Labels": {},
                  "SizeRw": 12288,
-                 "SizeRootFs": 0
+                 "SizeRootFs": 0,
+                 "NetworkSettings": {
+                         "Networks": {
+                                 "bridge": {
+                                          "EndpointID": "d91c7b2f0644403d7ef3095985ea0e2370325cd2332ff3a3225c4247328e66e9",
+                                          "Gateway": "172.17.0.1",
+                                          "IPAddress": "172.17.0.5",
+                                          "IPPrefixLen": 16,
+                                          "IPv6Gateway": "",
+                                          "GlobalIPv6Address": "",
+                                          "GlobalIPv6PrefixLen": 0,
+                                          "MacAddress": "02:42:ac:11:00:05"
+                                  }
+                         }
+                 }
+
          }
     ]
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -68,6 +68,7 @@ func (s *DockerSuite) TestContainerApiGetJSONNoFieldsOmitted(c *check.C) {
 		"Ports",
 		"Labels",
 		"Status",
+		"NetworkSettings",
 	}
 
 	// decoding into types.Container do not work since it eventually unmarshal


### PR DESCRIPTION
After addition of multi-host networking in Docker 1.9, Docker Remote
API is still returning the network name specified during creation
of the container in the “List Containers” (`/containers/json`) endpoint and
not a list of networks:

```
...
"HostConfig": {
  "NetworkMode": "default"
},
```

The list of networks containers are attached to is only available at
each container's Get Container (`/containers/<id>/json`) endpoint.
This does not allow development of applications utilizing multi-host
networking info to be built on top of the Docker Remote API.

Therefore I added a simple `"NetworkSettings"` section to the
`/containers/json` endpoint. This is not identical to the NetworkSettings
returned in Get Container (`/containers/<id>/json`) endpoint. It only
contains a single field `"Networks"`, which is essentially the same
value shown in inspect output of a container.

This change adds the following section to the `/containers/json`:

```
"NetworkSettings": {
  "Networks": {
    "bridge": {
      "EndpointID": "2cdc4edb1ded3631c81f57966563e...",
      "Gateway": "172.17.0.1",
      "IPAddress": "172.17.0.2",
      "IPPrefixLen": 16,
      "IPv6Gateway": "",
      "GlobalIPv6Address": "",
      "GlobalIPv6PrefixLen": 0,
      "MacAddress": "02:42:ac:11:00:02"
    }
  }
}
```

This is of type `api/types#SummaryNetworkSettings`, a minimal version of
`api/types#NetworkSettings`.

Actually all I need is the network name and the IPAddress fields. If folks
find this addition too big, I can create a `SummaryEndpointSettings` field
as well, containing just the IPAddress field.

Signed-off-by: Ahmet Alp Balkan
