### PR TITLE
Probably fix flaky test TestExecTTY

### DIFF
--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -49,7 +49,7 @@ func (s *DockerSuite) TestExecTTY(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer p.Close()
 
-	_, err = p.Write([]byte("cat /foo && exit\n"))
+	_, err = p.Write([]byte("cat /foo && sleep 2 && exit\n"))
 	c.Assert(err, checker.IsNil)
 
 	chErr := make(chan error)


### PR DESCRIPTION
sleep 2 seconds before exec exit to make sure
the output of `cat /foo` will be read

Signed-off-by: Lei Jitang leijitang@huawei.com
