### PR TITLE
hack/make/.build-deb/control: add missing fields

### DIFF
--- a/hack/make/.build-deb/control
+++ b/hack/make/.build-deb/control
@@ -1,5 +1,8 @@
 Source: docker-engine
+Section: admin
+Priority: optional
 Maintainer: Docker <support@docker.com>
+Standards-Version: 3.9.6
 Homepage: https://dockerproject.org
 Vcs-Browser: https://github.com/docker/docker
 Vcs-Git: git://github.com/docker/docker.git


### PR DESCRIPTION
Without section/priority, you can't upload generated packages to a reprepro managed repository. reprepro will throw an error like:

No section found for 'docker-engine' ('docker-engine_1.9.1~git20151028.004945.0.653c366-0~jessie.dsc' in 'docker-engine_1.9.1~git20151028.004945.0.653c366-0~jessie_arm64.changes')!

Add sections identical to the Debian docker.io packages

Signed-off-by: Riku Voipio riku.voipio@linaro.org
