### PR TITLE
Improve reference validation

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -522,21 +522,9 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(reference.Name
 			if err != nil {
 				return nil, nil, err
 			}
-
-			digested := false
-			switch ref.(type) {
-			case reference.NamedTagged:
-			case reference.Canonical:
-				digested = true
-			default:
-				ref, err = reference.WithTag(ref, reference.DefaultTag)
-				if err != nil {
-					return nil, nil, err
-				}
-			}
-
-			if !digested && isTrusted() {
-				trustedRef, err := translator(ref.(reference.NamedTagged))
+			ref = reference.WithDefaultTag(ref)
+			if ref, ok := ref.(reference.NamedTagged); ok && isTrusted() {
+				trustedRef, err := translator(ref)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -544,7 +532,7 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(reference.Name
 				line = dockerfileFromLinePattern.ReplaceAllLiteralString(line, fmt.Sprintf("FROM %s", trustedRef.String()))
 				resolvedTags = append(resolvedTags, &resolvedTag{
 					digestRef: trustedRef,
-					tagRef:    ref.(reference.NamedTagged),
+					tagRef:    ref,
 				})
 			}
 		}

--- a/api/client/build.go
+++ b/api/client/build.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/dockerignore"
@@ -29,8 +28,8 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/ulimit"
 	"github.com/docker/docker/pkg/urlutil"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	tagpkg "github.com/docker/docker/tag"
 	"github.com/docker/docker/utils"
 	"github.com/docker/go-units"
 )
@@ -532,11 +531,11 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(reference.Name
 
 			digested := false
 			switch ref.(type) {
-			case reference.Tagged:
-			case reference.Digested:
+			case reference.NamedTagged:
+			case reference.Canonical:
 				digested = true
 			default:
-				ref, err = reference.WithTag(ref, tagpkg.DefaultTag)
+				ref, err = reference.WithTag(ref, reference.DefaultTag)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/api/client/build.go
+++ b/api/client/build.go
@@ -29,7 +29,6 @@ import (
 	"github.com/docker/docker/pkg/ulimit"
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/docker/reference"
-	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 	"github.com/docker/go-units"
 )
@@ -477,7 +476,6 @@ func (td *trustedDockerfile) Close() error {
 // resolvedTag records the repository, tag, and resolved digest reference
 // from a Dockerfile rewrite.
 type resolvedTag struct {
-	repoInfo  *registry.RepositoryInfo
 	digestRef reference.Canonical
 	tagRef    reference.NamedTagged
 }
@@ -537,11 +535,6 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(reference.Name
 				}
 			}
 
-			repoInfo, err := registry.ParseRepositoryInfo(ref)
-			if err != nil {
-				return nil, nil, fmt.Errorf("unable to parse repository info %q: %v", ref.String(), err)
-			}
-
 			if !digested && isTrusted() {
 				trustedRef, err := translator(ref.(reference.NamedTagged))
 				if err != nil {
@@ -550,7 +543,6 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(reference.Name
 
 				line = dockerfileFromLinePattern.ReplaceAllLiteralString(line, fmt.Sprintf("FROM %s", trustedRef.String()))
 				resolvedTags = append(resolvedTags, &resolvedTag{
-					repoInfo:  repoInfo,
 					digestRef: trustedRef,
 					tagRef:    ref.(reference.NamedTagged),
 				})

--- a/api/client/build.go
+++ b/api/client/build.go
@@ -260,12 +260,8 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 // validateTag checks if the given image name can be resolved.
 func validateTag(rawRepo string) (string, error) {
-	ref, err := reference.ParseNamed(rawRepo)
+	_, err := reference.ParseNamed(rawRepo)
 	if err != nil {
-		return "", err
-	}
-
-	if err := registry.ValidateRepositoryName(ref); err != nil {
 		return "", err
 	}
 

--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 )
@@ -51,9 +51,9 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 		repositoryName = ref.Name()
 
 		switch x := ref.(type) {
-		case reference.Digested:
+		case reference.Canonical:
 			return errors.New("cannot commit to digest reference")
-		case reference.Tagged:
+		case reference.NamedTagged:
 			tag = x.Tag()
 		}
 	}

--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/reference"
-	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -42,9 +41,6 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	if repositoryAndTag != "" {
 		ref, err := reference.ParseNamed(repositoryAndTag)
 		if err != nil {
-			return err
-		}
-		if err := registry.ValidateRepositoryName(ref); err != nil {
 			return err
 		}
 

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -6,13 +6,13 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/reference"
 	"github.com/docker/go-units"
 )
 
@@ -98,9 +98,9 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 				repo = ref.Name()
 
 				switch x := ref.(type) {
-				case reference.Digested:
+				case reference.Canonical:
 					digest = x.Digest().String()
-				case reference.Tagged:
+				case reference.NamedTagged:
 					tag = x.Tag()
 				}
 			}

--- a/api/client/import.go
+++ b/api/client/import.go
@@ -12,7 +12,6 @@ import (
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/docker/reference"
-	"github.com/docker/docker/registry"
 )
 
 // CmdImport creates an empty filesystem image, imports the contents of the tarball into the image, and optionally tags the image.
@@ -45,11 +44,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	if repository != "" {
 		//Check if the given image name can be resolved
-		ref, err := reference.ParseNamed(repository)
-		if err != nil {
-			return err
-		}
-		if err := registry.ValidateRepositoryName(ref); err != nil {
+		if _, err := reference.ParseNamed(repository); err != nil {
 			return err
 		}
 	}

--- a/api/client/import.go
+++ b/api/client/import.go
@@ -5,13 +5,13 @@ import (
 	"io"
 	"os"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/urlutil"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 )
 

--- a/api/client/import.go
+++ b/api/client/import.go
@@ -59,7 +59,6 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 		}
 		defer file.Close()
 		in = file
-
 	}
 
 	options := types.ImageImportOptions{

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -4,14 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	tagpkg "github.com/docker/docker/tag"
 )
 
 var errTagCantBeUsed = errors.New("tag can't be used with --all-tags/-a")
@@ -35,19 +34,19 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 
 	var tag string
 	switch x := distributionRef.(type) {
-	case reference.Digested:
+	case reference.Canonical:
 		if *allTags {
 			return errTagCantBeUsed
 		}
 		tag = x.Digest().String()
-	case reference.Tagged:
+	case reference.NamedTagged:
 		if *allTags {
 			return errTagCantBeUsed
 		}
 		tag = x.Tag()
 	default:
 		if !*allTags {
-			tag = tagpkg.DefaultTag
+			tag = reference.DefaultTag
 			distributionRef, err = reference.WithTag(distributionRef, tag)
 			if err != nil {
 				return err

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"io"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 )
 
@@ -30,9 +30,9 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 
 	var tag string
 	switch x := ref.(type) {
-	case reference.Digested:
+	case reference.Canonical:
 		return errors.New("cannot push a digest reference")
-	case reference.Tagged:
+	case reference.NamedTagged:
 		tag = x.Tag()
 	}
 

--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -28,9 +28,8 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 		return errors.New("refusing to create a tag with a digest reference")
 	}
 
-	tag := ""
-	tagged, isTagged := ref.(reference.NamedTagged)
-	if isTagged {
+	var tag string
+	if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
 		tag = tagged.Tag()
 	}
 

--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -3,10 +3,10 @@ package client
 import (
 	"errors"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 )
 
@@ -25,13 +25,12 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 		return err
 	}
 
-	_, isDigested := ref.(reference.Digested)
-	if isDigested {
+	if _, isCanonical := ref.(reference.Canonical); isCanonical {
 		return errors.New("refusing to create a tag with a digest reference")
 	}
 
 	tag := ""
-	tagged, isTagged := ref.(reference.Tagged)
+	tagged, isTagged := ref.(reference.NamedTagged)
 	if isTagged {
 		tag = tagged.Tag()
 	}

--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -7,7 +7,6 @@ import (
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/reference"
-	"github.com/docker/docker/registry"
 )
 
 // CmdTag tags an image into a repository.
@@ -33,11 +32,6 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 	tagged, isTagged := ref.(reference.NamedTagged)
 	if isTagged {
 		tag = tagged.Tag()
-	}
-
-	//Check if the given image name can be resolved
-	if err := registry.ValidateRepositoryName(ref); err != nil {
-		return err
 	}
 
 	options := types.ImageTagOptions{

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -334,9 +334,11 @@ func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registr
 				return err
 			}
 			trustedRef, err := reference.WithDigest(repoInfo, r.digest)
+			if err != nil {
+				return err
+			}
 			if err := cli.tagTrusted(trustedRef, tagged); err != nil {
 				return err
-
 			}
 		}
 	}

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/client/lib"
@@ -30,6 +29,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/tlsconfig"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/passphrase"

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
@@ -25,8 +24,8 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/ulimit"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/runconfig"
-	tagpkg "github.com/docker/docker/tag"
 	"github.com/docker/docker/utils"
 	"golang.org/x/net/context"
 )
@@ -156,7 +155,7 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			}
 
 			switch newRef.(type) {
-			case reference.Digested:
+			case reference.Canonical:
 				return errors.New("cannot import digest reference")
 			}
 
@@ -498,12 +497,12 @@ func sanitizeRepoAndTags(names []string) ([]reference.Named, error) {
 			return nil, err
 		}
 
-		if _, isDigested := ref.(reference.Digested); isDigested {
-			return nil, errors.New("build tag cannot be a digest")
+		if _, isCanonical := ref.(reference.Canonical); isCanonical {
+			return nil, errors.New("build tag cannot contain a digest")
 		}
 
-		if _, isTagged := ref.(reference.Tagged); !isTagged {
-			ref, err = reference.WithTag(ref, tagpkg.DefaultTag)
+		if _, isTagged := ref.(reference.NamedTagged); !isTagged {
+			ref, err = reference.WithTag(ref, reference.DefaultTag)
 		}
 
 		nameWithTag := ref.String()

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -154,8 +154,7 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 				return err
 			}
 
-			switch newRef.(type) {
-			case reference.Canonical:
+			if _, isCanonical := newRef.(reference.Canonical); isCanonical {
 				return errors.New("cannot import digest reference")
 			}
 
@@ -496,13 +495,10 @@ func sanitizeRepoAndTags(names []string) ([]reference.Named, error) {
 		if err != nil {
 			return nil, err
 		}
+		ref = reference.WithDefaultTag(ref)
 
 		if _, isCanonical := ref.(reference.Canonical); isCanonical {
 			return nil, errors.New("build tag cannot contain a digest")
-		}
-
-		if _, isTagged := ref.(reference.NamedTagged); !isTagged {
-			ref, err = reference.WithTag(ref, reference.DefaultTag)
 		}
 
 		nameWithTag := ref.String()

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/dockerversion"
@@ -15,6 +14,7 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/runconfig"
 )
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1043,7 +1043,6 @@ func (daemon *Daemon) TagImage(newTag reference.Named, imageName string) error {
 	if err != nil {
 		return err
 	}
-	newTag = registry.NormalizeLocalReference(newTag)
 	if err := daemon.referenceStore.AddTag(newTag, imageID, true); err != nil {
 		return err
 	}
@@ -1301,7 +1300,6 @@ func (daemon *Daemon) GetImageID(refOrID string) (image.ID, error) {
 
 	// Treat it as a possible tag or digest reference
 	if ref, err := reference.ParseNamed(refOrID); err == nil {
-		ref = registry.NormalizeLocalReference(ref)
 		if id, err := daemon.referenceStore.Get(ref); err == nil {
 			return id, nil
 		}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -22,8 +22,8 @@ import (
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/sysinfo"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/runconfig"
-	"github.com/docker/docker/tag"
 	"github.com/docker/libnetwork"
 	nwconfig "github.com/docker/libnetwork/config"
 	"github.com/docker/libnetwork/drivers/bridge"
@@ -694,7 +694,7 @@ func (daemon *Daemon) conditionalUnmountOnCleanup(container *container.Container
 	daemon.Unmount(container)
 }
 
-func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Store, ts tag.Store) error {
+func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Store, rs reference.Store) error {
 	// Unix has no custom images to register
 	return nil
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -9,13 +9,12 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/tag"
+	"github.com/docker/docker/reference"
 	// register the windows graph driver
 	"github.com/docker/docker/daemon/graphdriver/windows"
 	"github.com/docker/docker/pkg/system"
@@ -153,7 +152,7 @@ func (daemon *Daemon) conditionalUnmountOnCleanup(container *container.Container
 	}
 }
 
-func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Store, ts tag.Store) error {
+func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Store, rs reference.Store) error {
 	if wd, ok := driver.(*windows.Driver); ok {
 		imageInfos, err := wd.GetCustomImageInfos()
 		if err != nil {
@@ -206,7 +205,7 @@ func restoreCustomImage(driver graphdriver.Driver, is image.Store, ls layer.Stor
 				return err
 			}
 
-			if err := ts.AddTag(ref, id, true); err != nil {
+			if err := rs.AddTag(ref, id, true); err != nil {
 				return err
 			}
 

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
@@ -20,6 +19,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/urlutil"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 )
@@ -42,8 +42,8 @@ func (d Docker) Pull(name string) (*image.Image, error) {
 		return nil, err
 	}
 	switch ref.(type) {
-	case reference.Tagged:
-	case reference.Digested:
+	case reference.NamedTagged:
+	case reference.Canonical:
 	default:
 		ref, err = reference.WithTag(ref, "latest")
 		if err != nil {

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -41,15 +41,7 @@ func (d Docker) Pull(name string) (*image.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	switch ref.(type) {
-	case reference.NamedTagged:
-	case reference.Canonical:
-	default:
-		ref, err = reference.WithTag(ref, "latest")
-		if err != nil {
-			return nil, err
-		}
-	}
+	ref = reference.WithDefaultTag(ref)
 
 	pullRegistryAuth := &types.AuthConfig{}
 	if len(d.AuthConfigs) > 0 {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -3,9 +3,8 @@ package daemon
 import (
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	derr "github.com/docker/docker/errors"
-	tagpkg "github.com/docker/docker/tag"
+	"github.com/docker/docker/reference"
 )
 
 func (d *Daemon) imageNotExistToErrcode(err error) error {
@@ -13,12 +12,12 @@ func (d *Daemon) imageNotExistToErrcode(err error) error {
 		if strings.Contains(dne.RefOrID, "@") {
 			return derr.ErrorCodeNoSuchImageHash.WithArgs(dne.RefOrID)
 		}
-		tag := tagpkg.DefaultTag
+		tag := reference.DefaultTag
 		ref, err := reference.ParseNamed(dne.RefOrID)
 		if err != nil {
 			return derr.ErrorCodeNoSuchImageTag.WithArgs(dne.RefOrID, tag)
 		}
-		if tagged, isTagged := ref.(reference.Tagged); isTagged {
+		if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
 			tag = tagged.Tag()
 		}
 		return derr.ErrorCodeNoSuchImageTag.WithArgs(ref.Name(), tag)

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -1,9 +1,9 @@
 package events
 
 import (
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/reference"
 )
 
 // Filter can filter out docker events from a stream

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -149,17 +149,7 @@ func (daemon *Daemon) getContainerUsingImage(imageID image.ID) *container.Contai
 // optional tag or digest reference. If tag or digest is omitted, the default
 // tag is used. Returns the resolved image reference and an error.
 func (daemon *Daemon) removeImageRef(ref reference.Named) (reference.Named, error) {
-	switch ref.(type) {
-	case reference.NamedTagged:
-	case reference.Canonical:
-	default:
-		var err error
-		ref, err = reference.WithTag(ref, reference.DefaultTag)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+	ref = reference.WithDefaultTag(ref)
 	// Ignore the boolean value returned, as far as we're concerned, this
 	// is an idempotent operation and it's okay if the reference didn't
 	// exist in the first place.

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
-	tagpkg "github.com/docker/docker/tag"
+	"github.com/docker/docker/reference"
 )
 
 // ImageDelete deletes the image referenced by the given imageRef from this
@@ -58,7 +57,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		return nil, daemon.imageNotExistToErrcode(err)
 	}
 
-	repoRefs := daemon.tagStore.References(imgID)
+	repoRefs := daemon.referenceStore.References(imgID)
 
 	var removedRepositoryRef bool
 	if !isImageIDPrefix(imgID.String(), imageRef) {
@@ -151,11 +150,11 @@ func (daemon *Daemon) getContainerUsingImage(imageID image.ID) *container.Contai
 // tag is used. Returns the resolved image reference and an error.
 func (daemon *Daemon) removeImageRef(ref reference.Named) (reference.Named, error) {
 	switch ref.(type) {
-	case reference.Tagged:
-	case reference.Digested:
+	case reference.NamedTagged:
+	case reference.Canonical:
 	default:
 		var err error
-		ref, err = reference.WithTag(ref, tagpkg.DefaultTag)
+		ref, err = reference.WithTag(ref, reference.DefaultTag)
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +163,7 @@ func (daemon *Daemon) removeImageRef(ref reference.Named) (reference.Named, erro
 	// Ignore the boolean value returned, as far as we're concerned, this
 	// is an idempotent operation and it's okay if the reference didn't
 	// exist in the first place.
-	_, err := daemon.tagStore.Delete(ref)
+	_, err := daemon.referenceStore.Delete(ref)
 
 	return ref, err
 }
@@ -175,7 +174,7 @@ func (daemon *Daemon) removeImageRef(ref reference.Named) (reference.Named, erro
 // daemon's event service. An "Untagged" types.ImageDelete is added to the
 // given list of records.
 func (daemon *Daemon) removeAllReferencesToImageID(imgID image.ID, records *[]types.ImageDelete) error {
-	imageRefs := daemon.tagStore.References(imgID)
+	imageRefs := daemon.referenceStore.References(imgID)
 
 	for _, imageRef := range imageRefs {
 		parsedRef, err := daemon.removeImageRef(imageRef)
@@ -325,7 +324,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(imgID image.ID) *imageDeleteC
 
 func (daemon *Daemon) checkImageDeleteSoftConflict(imgID image.ID) *imageDeleteConflict {
 	// Check if any repository tags/digest reference this image.
-	if len(daemon.tagStore.References(imgID)) > 0 {
+	if len(daemon.referenceStore.References(imgID)) > 0 {
 		return &imageDeleteConflict{
 			imgID:   imgID,
 			message: "image is referenced in one or more repositories",
@@ -355,5 +354,5 @@ func (daemon *Daemon) checkImageDeleteSoftConflict(imgID image.ID) *imageDeleteC
 // that there are no repository references to the given image and it has no
 // child images.
 func (daemon *Daemon) imageIsDangling(imgID image.ID) bool {
-	return !(len(daemon.tagStore.References(imgID)) > 0 || len(daemon.imageStore.Children(imgID)) > 0)
+	return !(len(daemon.referenceStore.References(imgID)) > 0 || len(daemon.imageStore.Children(imgID)) > 0)
 }

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -8,13 +8,13 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -90,7 +90,7 @@ func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string
 		return err
 	}
 
-	// FIXME: connect with commit code and call tagstore directly
+	// FIXME: connect with commit code and call refstore directly
 	if newRef != nil {
 		if err := daemon.TagImage(newRef, id.String()); err != nil {
 			return err

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -87,16 +87,14 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 	}
 
 	// makes sure name is not empty or `scratch`
-	if err := validateRepoName(repoInfo.LocalName.Name()); err != nil {
+	if err := validateRepoName(repoInfo.Name()); err != nil {
 		return err
 	}
 
-	endpoints, err := imagePullConfig.RegistryService.LookupPullEndpoints(repoInfo.CanonicalName)
+	endpoints, err := imagePullConfig.RegistryService.LookupPullEndpoints(repoInfo)
 	if err != nil {
 		return err
 	}
-
-	localName := registry.NormalizeLocalReference(ref)
 
 	var (
 		// use a slice to append the error strings and return a joined string to caller
@@ -112,7 +110,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 		discardNoSupportErrors bool
 	)
 	for _, endpoint := range endpoints {
-		logrus.Debugf("Trying to pull %s from %s %s", repoInfo.LocalName, endpoint.URL, endpoint.Version)
+		logrus.Debugf("Trying to pull %s from %s %s", repoInfo.Name(), endpoint.URL, endpoint.Version)
 
 		puller, err := newPuller(endpoint, repoInfo, imagePullConfig)
 		if err != nil {
@@ -148,7 +146,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 			}
 		}
 
-		imagePullConfig.EventsService.Log("pull", localName.String(), "")
+		imagePullConfig.EventsService.Log("pull", ref.String(), "")
 		return nil
 	}
 

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -6,15 +6,14 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	"github.com/docker/docker/tag"
 	"golang.org/x/net/context"
 )
 
@@ -39,8 +38,8 @@ type ImagePullConfig struct {
 	MetadataStore metadata.Store
 	// ImageStore manages images.
 	ImageStore image.Store
-	// TagStore manages tags.
-	TagStore tag.Store
+	// ReferenceStore manages tags.
+	ReferenceStore reference.Store
 	// DownloadManager manages concurrent pulls.
 	DownloadManager *xfer.LayerDownloadManager
 }

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -54,10 +54,7 @@ func (p *v2Puller) Pull(ctx context.Context, ref reference.Named) (fallback bool
 
 func (p *v2Puller) pullV2Repository(ctx context.Context, ref reference.Named) (err error) {
 	var refs []reference.Named
-	taggedName := ref
-	if _, isTagged := ref.(reference.NamedTagged); isTagged {
-		refs = []reference.Named{ref}
-	} else if _, isCanonical := ref.(reference.Canonical); isCanonical {
+	if !reference.IsNameOnly(ref) {
 		refs = []reference.Named{ref}
 	} else {
 		manSvc, err := p.repo.Manifests(ctx)
@@ -92,7 +89,7 @@ func (p *v2Puller) pullV2Repository(ctx context.Context, ref reference.Named) (e
 		layersDownloaded = layersDownloaded || pulledNew
 	}
 
-	writeStatus(taggedName.String(), p.config.ProgressOutput, layersDownloaded)
+	writeStatus(ref.String(), p.config.ProgressOutput, layersDownloaded)
 
 	return nil
 }

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/reference"
 )
 
 // TestFixManifestLayers checks that fixManifestLayers removes a duplicate
@@ -104,7 +104,7 @@ func TestFixManifestLayersBadParent(t *testing.T) {
 
 // TestValidateManifest verifies the validateManifest function
 func TestValidateManifest(t *testing.T) {
-	expectedDigest, err := reference.Parse("repo@sha256:02fee8c3220ba806531f606525eceb83f4feb654f62b207191b1c9209188dedd")
+	expectedDigest, err := reference.ParseNamed("repo@sha256:02fee8c3220ba806531f606525eceb83f4feb654f62b207191b1c9209188dedd")
 	if err != nil {
 		t.Fatal("could not parse reference")
 	}

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -104,21 +104,21 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 		return err
 	}
 
-	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(repoInfo.CanonicalName)
+	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(repoInfo)
 	if err != nil {
 		return err
 	}
 
-	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to a repository [%s]", repoInfo.CanonicalName.String())
+	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to a repository [%s]", repoInfo.FullName())
 
-	associations := imagePushConfig.ReferenceStore.ReferencesByName(repoInfo.LocalName)
+	associations := imagePushConfig.ReferenceStore.ReferencesByName(repoInfo)
 	if len(associations) == 0 {
-		return fmt.Errorf("Repository does not exist: %s", repoInfo.LocalName)
+		return fmt.Errorf("Repository does not exist: %s", repoInfo.Name())
 	}
 
 	var lastErr error
 	for _, endpoint := range endpoints {
-		logrus.Debugf("Trying to push %s to %s %s", repoInfo.CanonicalName, endpoint.URL, endpoint.Version)
+		logrus.Debugf("Trying to push %s to %s %s", repoInfo.FullName(), endpoint.URL, endpoint.Version)
 
 		pusher, err := NewPusher(ref, endpoint, repoInfo, imagePushConfig)
 		if err != nil {
@@ -143,12 +143,12 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 
 		}
 
-		imagePushConfig.EventsService.Log("push", repoInfo.LocalName.Name(), "")
+		imagePushConfig.EventsService.Log("push", repoInfo.Name(), "")
 		return nil
 	}
 
 	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", repoInfo.CanonicalName)
+		lastErr = fmt.Errorf("no endpoints found for %s", repoInfo.FullName())
 	}
 	return lastErr
 }

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
@@ -16,8 +15,8 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	"github.com/docker/docker/tag"
 	"github.com/docker/libtrust"
 	"golang.org/x/net/context"
 )
@@ -45,8 +44,8 @@ type ImagePushConfig struct {
 	LayerStore layer.Store
 	// ImageStore manages images.
 	ImageStore image.Store
-	// TagStore manages tags.
-	TagStore tag.Store
+	// ReferenceStore manages tags.
+	ReferenceStore reference.Store
 	// TrustKey is the private key for legacy signatures. This is typically
 	// an ephemeral key, since these signatures are no longer verified.
 	TrustKey libtrust.PrivateKey
@@ -112,7 +111,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 
 	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to a repository [%s]", repoInfo.CanonicalName.String())
 
-	associations := imagePushConfig.TagStore.ReferencesByName(repoInfo.LocalName)
+	associations := imagePushConfig.ReferenceStore.ReferencesByName(repoInfo.LocalName)
 	if len(associations) == 0 {
 		return fmt.Errorf("Repository does not exist: %s", repoInfo.LocalName)
 	}

--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -351,8 +351,8 @@ func (p *v1Pusher) pushImageToEndpoint(ctx context.Context, endpoint string, ima
 		}
 		if topImage, isTopImage := img.(*v1TopImage); isTopImage {
 			for _, tag := range tags[topImage.imageID] {
-				progress.Messagef(p.config.ProgressOutput, "", "Pushing tag for rev [%s] on {%s}", stringid.TruncateID(v1ID), endpoint+"repositories/"+p.repoInfo.RemoteName.Name()+"/tags/"+tag)
-				if err := p.session.PushRegistryTag(p.repoInfo.RemoteName, v1ID, tag, endpoint); err != nil {
+				progress.Messagef(p.config.ProgressOutput, "", "Pushing tag for rev [%s] on {%s}", stringid.TruncateID(v1ID), endpoint+"repositories/"+p.repoInfo.RemoteName()+"/tags/"+tag)
+				if err := p.session.PushRegistryTag(p.repoInfo, v1ID, tag, endpoint); err != nil {
 					return err
 				}
 			}
@@ -381,18 +381,18 @@ func (p *v1Pusher) pushRepository(ctx context.Context) error {
 
 	// Register all the images in a repository with the registry
 	// If an image is not in this list it will not be associated with the repository
-	repoData, err := p.session.PushImageJSONIndex(p.repoInfo.RemoteName, imageIndex, false, nil)
+	repoData, err := p.session.PushImageJSONIndex(p.repoInfo, imageIndex, false, nil)
 	if err != nil {
 		return err
 	}
-	progress.Message(p.config.ProgressOutput, "", "Pushing repository "+p.repoInfo.CanonicalName.String())
+	progress.Message(p.config.ProgressOutput, "", "Pushing repository "+p.repoInfo.FullName())
 	// push the repository to each of the endpoints only if it does not exist.
 	for _, endpoint := range repoData.Endpoints {
 		if err := p.pushImageToEndpoint(ctx, endpoint, imgList, tags, repoData); err != nil {
 			return err
 		}
 	}
-	_, err = p.session.PushImageJSONIndex(p.repoInfo.RemoteName, imageIndex, true, repoData.Endpoints)
+	_, err = p.session.PushImageJSONIndex(p.repoInfo, imageIndex, true, repoData.Endpoints)
 	return err
 }
 

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -52,8 +52,6 @@ func (p *v2Pusher) Push(ctx context.Context) (fallback bool, err error) {
 		return true, err
 	}
 
-	localName := p.repoInfo.LocalName.Name()
-
 	var associations []reference.Association
 	if _, isTagged := p.ref.(reference.NamedTagged); isTagged {
 		imageID, err := p.config.ReferenceStore.Get(p.ref)
@@ -72,10 +70,10 @@ func (p *v2Pusher) Push(ctx context.Context) (fallback bool, err error) {
 		associations = p.config.ReferenceStore.ReferencesByName(p.ref)
 	}
 	if err != nil {
-		return false, fmt.Errorf("error getting tags for %s: %s", localName, err)
+		return false, fmt.Errorf("error getting tags for %s: %s", p.repoInfo.Name(), err)
 	}
 	if len(associations) == 0 {
-		return false, fmt.Errorf("no tags to push for %s", localName)
+		return false, fmt.Errorf("no tags to push for %s", p.repoInfo.Name())
 	}
 
 	for _, association := range associations {
@@ -159,7 +157,7 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, association reference.Associat
 		return err
 	}
 
-	manifestDigest, manifestSize, err := digestFromManifest(signed, p.repo.Name())
+	manifestDigest, manifestSize, err := digestFromManifest(signed, ref)
 	if err != nil {
 		return err
 	}

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -58,16 +58,14 @@ func TestTokenPassThru(t *testing.T) {
 	}
 	n, _ := reference.ParseNamed("testremotename")
 	repoInfo := &registry.RepositoryInfo{
+		Named: n,
 		Index: &registrytypes.IndexInfo{
 			Name:     "testrepo",
 			Mirrors:  nil,
 			Secure:   false,
 			Official: false,
 		},
-		RemoteName:    n,
-		LocalName:     n,
-		CanonicalName: n,
-		Official:      false,
+		Official: false,
 	}
 	imagePullConfig := &ImagePullConfig{
 		MetaHeaders: http.Header{},

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 	"golang.org/x/net/context"

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/image/v1"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/symlink"
+	"github.com/docker/docker/reference"
 )
 
 func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer) error {
@@ -124,11 +124,11 @@ func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS) (layer.Lay
 }
 
 func (l *tarexporter) setLoadedTag(ref reference.NamedTagged, imgID image.ID, outStream io.Writer) error {
-	if prevID, err := l.ts.Get(ref); err == nil && prevID != imgID {
+	if prevID, err := l.rs.Get(ref); err == nil && prevID != imgID {
 		fmt.Fprintf(outStream, "The image %s already exists, renaming the old one with ID %s to empty string\n", ref.String(), string(prevID)) // todo: this message is wrong in case of multiple tags
 	}
 
-	if err := l.ts.AddTag(ref, imgID, true); err != nil {
+	if err := l.rs.AddTag(ref, imgID, true); err != nil {
 		return err
 	}
 	return nil

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -81,21 +81,19 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
 			addAssoc(imgID, nil)
 			continue
 		}
-		if _, ok := ref.(reference.Canonical); !ok {
-			if _, ok := ref.(reference.NamedTagged); !ok {
-				assocs := l.rs.ReferencesByName(ref)
-				for _, assoc := range assocs {
-					addAssoc(assoc.ImageID, assoc.Ref)
-				}
-				if len(assocs) == 0 {
-					imgID, err := l.is.Search(name)
-					if err != nil {
-						return nil, err
-					}
-					addAssoc(imgID, nil)
-				}
-				continue
+		if reference.IsNameOnly(ref) {
+			assocs := l.rs.ReferencesByName(ref)
+			for _, assoc := range assocs {
+				addAssoc(assoc.ImageID, assoc.Ref)
 			}
+			if len(assocs) == 0 {
+				imgID, err := l.is.Search(name)
+				if err != nil {
+					return nil, err
+				}
+				addAssoc(imgID, nil)
+			}
+			continue
 		}
 		var imgID image.ID
 		if imgID, err = l.rs.Get(ref); err != nil {

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/reference"
-	"github.com/docker/docker/registry"
 )
 
 type imageDescriptor struct {
@@ -74,7 +73,6 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
 		if err != nil {
 			return nil, err
 		}
-		ref = registry.NormalizeLocalReference(ref)
 		if ref.Name() == string(digest.Canonical) {
 			imgID, err := l.is.Search(name)
 			if err != nil {

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -10,13 +10,12 @@ import (
 	"time"
 
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/image/v1"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
-	"github.com/docker/docker/tag"
 )
 
 type imageDescriptor struct {
@@ -50,13 +49,13 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
 
 		if ref != nil {
 			var tagged reference.NamedTagged
-			if _, ok := ref.(reference.Digested); ok {
+			if _, ok := ref.(reference.Canonical); ok {
 				return
 			}
 			var ok bool
 			if tagged, ok = ref.(reference.NamedTagged); !ok {
 				var err error
-				if tagged, err = reference.WithTag(ref, tag.DefaultTag); err != nil {
+				if tagged, err = reference.WithTag(ref, reference.DefaultTag); err != nil {
 					return
 				}
 			}
@@ -84,9 +83,9 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
 			addAssoc(imgID, nil)
 			continue
 		}
-		if _, ok := ref.(reference.Digested); !ok {
+		if _, ok := ref.(reference.Canonical); !ok {
 			if _, ok := ref.(reference.NamedTagged); !ok {
-				assocs := l.ts.ReferencesByName(ref)
+				assocs := l.rs.ReferencesByName(ref)
 				for _, assoc := range assocs {
 					addAssoc(assoc.ImageID, assoc.Ref)
 				}
@@ -101,7 +100,7 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
 			}
 		}
 		var imgID image.ID
-		if imgID, err = l.ts.Get(ref); err != nil {
+		if imgID, err = l.rs.Get(ref); err != nil {
 			return nil, err
 		}
 		addAssoc(imgID, ref)

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -3,7 +3,7 @@ package tarexport
 import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/tag"
+	"github.com/docker/docker/reference"
 )
 
 const (
@@ -23,14 +23,14 @@ type manifestItem struct {
 type tarexporter struct {
 	is image.Store
 	ls layer.Store
-	ts tag.Store
+	rs reference.Store
 }
 
 // NewTarExporter returns new ImageExporter for tar packages
-func NewTarExporter(is image.Store, ls layer.Store, ts tag.Store) image.Exporter {
+func NewTarExporter(is image.Store, ls layer.Store, rs reference.Store) image.Exporter {
 	return &tarexporter{
 		is: is,
 		ls: ls,
-		ts: ts,
+		rs: rs,
 	}
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4614,7 +4614,7 @@ func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
 	_, out, err := buildImageWithOut(name, "FROM scratch\nMAINTAINER quux\n", true)
 	// if the error doesn't check for illegal tag name, or the image is built
 	// then this should fail
-	if !strings.Contains(out, "invalid reference format") || strings.Contains(out, "Sending build context to Docker daemon") {
+	if !strings.Contains(out, "Error parsing reference") || strings.Contains(out, "Sending build context to Docker daemon") {
 		c.Fatalf("failed to stop before building. Error: %s, Output: %s", err, out)
 	}
 }

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -265,7 +265,7 @@ func (s *DockerSuite) TestCreateByImageID(c *check.C) {
 		c.Fatalf("expected non-zero exit code; received %d", exit)
 	}
 
-	if expected := "invalid reference format"; !strings.Contains(out, expected) {
+	if expected := "Error parsing reference"; !strings.Contains(out, expected) {
 		c.Fatalf(`Expected %q in output; got: %s`, expected, out)
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3758,8 +3758,8 @@ func (s *DockerSuite) TestRunInvalidReference(c *check.C) {
 		c.Fatalf("expected non-zero exist code; received %d", exit)
 	}
 
-	if !strings.Contains(out, "invalid reference format") {
-		c.Fatalf(`Expected "invalid reference format" in output; got: %s`, out)
+	if !strings.Contains(out, "Error parsing reference") {
+		c.Fatalf(`Expected "Error parsing reference" in output; got: %s`, out)
 	}
 }
 

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -99,17 +99,17 @@ func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 	// test repository name begin with '-'
 	out, _, err := dockerCmdWithError("tag", "busybox:latest", "-busybox:test")
 	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "invalid reference format", check.Commentf("tag a name begin with '-' should failed"))
+	c.Assert(out, checker.Contains, "Error parsing reference", check.Commentf("tag a name begin with '-' should failed"))
 
 	// test namespace name begin with '-'
 	out, _, err = dockerCmdWithError("tag", "busybox:latest", "-test/busybox:test")
 	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "invalid reference format", check.Commentf("tag a name begin with '-' should failed"))
+	c.Assert(out, checker.Contains, "Error parsing reference", check.Commentf("tag a name begin with '-' should failed"))
 
 	// test index name begin with '-'
 	out, _, err = dockerCmdWithError("tag", "busybox:latest", "-index:5000/busybox:test")
 	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "invalid reference format", check.Commentf("tag a name begin with '-' should failed"))
+	c.Assert(out, checker.Contains, "Error parsing reference", check.Commentf("tag a name begin with '-' should failed"))
 }
 
 // ensure tagging using official names works

--- a/migrate/v1/migratev1_test.go
+++ b/migrate/v1/migratev1_test.go
@@ -13,13 +13,13 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/reference"
 )
 
-func TestMigrateTags(t *testing.T) {
+func TestMigrateRefs(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "migrate-tags")
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +29,7 @@ func TestMigrateTags(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(tmpdir, "repositories-generic"), []byte(`{"Repositories":{"busybox":{"latest":"b3ca410aa2c115c05969a7b2c8cf8a9fcf62c1340ed6a601c9ee50df337ec108","sha256:16a2a52884c2a9481ed267c2d46483eac7693b813a63132368ab098a71303f8a":"b3ca410aa2c115c05969a7b2c8cf8a9fcf62c1340ed6a601c9ee50df337ec108"},"registry":{"2":"5d165b8e4b203685301c815e95663231691d383fd5e3d3185d1ce3f8dddead3d","latest":"8d5547a9f329b1d3f93198cd661fb5117e5a96b721c5cf9a2c389e7dd4877128"}}}`), 0600)
 
 	ta := &mockTagAdder{}
-	err = migrateTags(tmpdir, "generic", ta, map[string]image.ID{
+	err = migrateRefs(tmpdir, "generic", ta, map[string]image.ID{
 		"5d165b8e4b203685301c815e95663231691d383fd5e3d3185d1ce3f8dddead3d": image.ID("sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"),
 		"b3ca410aa2c115c05969a7b2c8cf8a9fcf62c1340ed6a601c9ee50df337ec108": image.ID("sha256:fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"),
 		"abcdef3434c115c05969a7b2c8cf8a9fcf62c1340ed6a601c9ee50df337ec108": image.ID("sha256:56434342345ae68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"),
@@ -50,7 +50,7 @@ func TestMigrateTags(t *testing.T) {
 
 	// second migration is no-op
 	ioutil.WriteFile(filepath.Join(tmpdir, "repositories-generic"), []byte(`{"Repositories":{"busybox":{"latest":"b3ca410aa2c115c05969a7b2c8cf8a9fcf62c1340ed6a601c9ee50df337ec108"`), 0600)
-	err = migrateTags(tmpdir, "generic", ta, map[string]image.ID{
+	err = migrateRefs(tmpdir, "generic", ta, map[string]image.ID{
 		"b3ca410aa2c115c05969a7b2c8cf8a9fcf62c1340ed6a601c9ee50df337ec108": image.ID("sha256:fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"),
 	})
 	if err != nil {

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -1,0 +1,60 @@
+package reference
+
+import (
+	"github.com/docker/distribution/digest"
+	distreference "github.com/docker/distribution/reference"
+)
+
+// Reference is an opaque object reference identifier that may include
+// modifiers such as a hostname, name, tag, and digest.
+type Reference interface {
+	// String returns the full reference
+	String() string
+}
+
+// Named is an object with a full name
+type Named interface {
+	Reference
+	Name() string
+}
+
+// NamedTagged is an object including a name and tag.
+type NamedTagged interface {
+	Named
+	Tag() string
+}
+
+// Canonical reference is an object with a fully unique
+// name including a name with hostname and digest
+type Canonical interface {
+	Named
+	Digest() digest.Digest
+}
+
+// ParseNamed parses s and returns a syntactically valid reference implementing
+// the Named interface. The reference must have a name, otherwise an error is
+// returned.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: ParseNamed will not handle short digests.
+func ParseNamed(s string) (Named, error) {
+	// todo: docker specific validation
+	return distreference.ParseNamed(s)
+}
+
+// WithName returns a named object representing the given string. If the input
+// is invalid ErrReferenceInvalidFormat will be returned.
+func WithName(name string) (Named, error) {
+	return distreference.WithName(name)
+}
+
+// WithTag combines the name from "name" and the tag from "tag" to form a
+// reference incorporating both the name and the tag.
+func WithTag(name Named, tag string) (NamedTagged, error) {
+	return distreference.WithTag(name, tag)
+}
+
+// WithDigest combines the name from "name" and the digest from "digest" to form
+// a reference incorporating both the name and the digest.
+func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
+	return distreference.WithDigest(name, digest)
+}

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -132,6 +132,25 @@ func (r *canonicalRef) Digest() digest.Digest {
 	return r.namedRef.Named.(distreference.Canonical).Digest()
 }
 
+// WithDefaultTag adds a default tag to a reference if it only has a repo name.
+func WithDefaultTag(ref Named) Named {
+	if IsNameOnly(ref) {
+		ref, _ = WithTag(ref, DefaultTag)
+	}
+	return ref
+}
+
+// IsNameOnly returns true if reference only contains a repo name.
+func IsNameOnly(ref Named) bool {
+	if _, ok := ref.(NamedTagged); ok {
+		return false
+	}
+	if _, ok := ref.(Canonical); ok {
+		return false
+	}
+	return true
+}
+
 // splitHostname splits a repository name to hostname and remotename string.
 // If no valid hostname is found, the default hostname is used. Repository name
 // needs to be already validated before.

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -1,21 +1,37 @@
 package reference
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/docker/distribution/digest"
 	distreference "github.com/docker/distribution/reference"
+	"github.com/docker/docker/image/v1"
 )
 
-// Reference is an opaque object reference identifier that may include
-// modifiers such as a hostname, name, tag, and digest.
-type Reference interface {
-	// String returns the full reference
-	String() string
-}
+const (
+	// DefaultTag defines the default tag used when performing images related actions and no tag or digest is specified
+	DefaultTag = "latest"
+	// DefaultHostname is the default built-in hostname
+	DefaultHostname = "docker.io"
+	// LegacyDefaultHostname is automatically converted to DefaultHostname
+	LegacyDefaultHostname = "index.docker.io"
+	// DefaultRepoPrefix is the prefix used for default repositories in default host
+	DefaultRepoPrefix = "library/"
+)
 
 // Named is an object with a full name
 type Named interface {
-	Reference
+	// Name returns normalized repository name, like "ubuntu".
 	Name() string
+	// String returns full reference, like "ubuntu@sha256:abcdef..."
+	String() string
+	// FullName returns full repository name with hostname, like "docker.io/library/ubuntu"
+	FullName() string
+	// Hostname returns hostname for the reference, like "docker.io"
+	Hostname() string
+	// RemoteName returns the repository component of the full name, like "library/ubuntu"
+	RemoteName() string
 }
 
 // NamedTagged is an object including a name and tag.
@@ -35,26 +51,122 @@ type Canonical interface {
 // the Named interface. The reference must have a name, otherwise an error is
 // returned.
 // If an error was encountered it is returned, along with a nil Reference.
-// NOTE: ParseNamed will not handle short digests.
 func ParseNamed(s string) (Named, error) {
-	// todo: docker specific validation
-	return distreference.ParseNamed(s)
+	named, err := distreference.ParseNamed(s)
+	if err != nil {
+		return nil, err
+	}
+	r, err := WithName(named.Name())
+	if err != nil {
+		return nil, err
+	}
+	if canonical, isCanonical := named.(distreference.Canonical); isCanonical {
+		return WithDigest(r, canonical.Digest())
+	}
+	if tagged, isTagged := named.(distreference.NamedTagged); isTagged {
+		return WithTag(r, tagged.Tag())
+	}
+	return r, nil
 }
 
 // WithName returns a named object representing the given string. If the input
 // is invalid ErrReferenceInvalidFormat will be returned.
 func WithName(name string) (Named, error) {
-	return distreference.WithName(name)
+	name = normalize(name)
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+	r, err := distreference.WithName(name)
+	if err != nil {
+		return nil, err
+	}
+	return &namedRef{r}, nil
 }
 
 // WithTag combines the name from "name" and the tag from "tag" to form a
 // reference incorporating both the name and the tag.
 func WithTag(name Named, tag string) (NamedTagged, error) {
-	return distreference.WithTag(name, tag)
+	r, err := distreference.WithTag(name, tag)
+	if err != nil {
+		return nil, err
+	}
+	return &taggedRef{namedRef{r}}, nil
 }
 
 // WithDigest combines the name from "name" and the digest from "digest" to form
 // a reference incorporating both the name and the digest.
 func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
-	return distreference.WithDigest(name, digest)
+	r, err := distreference.WithDigest(name, digest)
+	if err != nil {
+		return nil, err
+	}
+	return &canonicalRef{namedRef{r}}, nil
+}
+
+type namedRef struct {
+	distreference.Named
+}
+type taggedRef struct {
+	namedRef
+}
+type canonicalRef struct {
+	namedRef
+}
+
+func (r *namedRef) FullName() string {
+	hostname, remoteName := splitHostname(r.Name())
+	return hostname + "/" + remoteName
+}
+func (r *namedRef) Hostname() string {
+	hostname, _ := splitHostname(r.Name())
+	return hostname
+}
+func (r *namedRef) RemoteName() string {
+	_, remoteName := splitHostname(r.Name())
+	return remoteName
+}
+func (r *taggedRef) Tag() string {
+	return r.namedRef.Named.(distreference.NamedTagged).Tag()
+}
+func (r *canonicalRef) Digest() digest.Digest {
+	return r.namedRef.Named.(distreference.Canonical).Digest()
+}
+
+// splitHostname splits a repository name to hostname and remotename string.
+// If no valid hostname is found, the default hostname is used. Repository name
+// needs to be already validated before.
+func splitHostname(name string) (hostname, remoteName string) {
+	i := strings.IndexRune(name, '/')
+	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
+		hostname, remoteName = DefaultHostname, name
+	} else {
+		hostname, remoteName = name[:i], name[i+1:]
+	}
+	if hostname == LegacyDefaultHostname {
+		hostname = DefaultHostname
+	}
+	if hostname == DefaultHostname && !strings.ContainsRune(remoteName, '/') {
+		remoteName = DefaultRepoPrefix + remoteName
+	}
+	return
+}
+
+// normalize returns a repository name in its normalized form, meaning it
+// will not contain default hostname nor library/ prefix for official images.
+func normalize(name string) string {
+	host, remoteName := splitHostname(name)
+	if host == DefaultHostname {
+		if strings.HasPrefix(remoteName, DefaultRepoPrefix) {
+			return strings.TrimPrefix(remoteName, DefaultRepoPrefix)
+		}
+		return remoteName
+	}
+	return name
+}
+
+func validateName(name string) error {
+	if err := v1.ValidateID(name); err == nil {
+		return fmt.Errorf("Invalid repository name (%s), cannot specify 64-byte hexadecimal strings", name)
+	}
+	return nil
 }

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -54,7 +54,7 @@ type Canonical interface {
 func ParseNamed(s string) (Named, error) {
 	named, err := distreference.ParseNamed(s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", s)
 	}
 	r, err := WithName(named.Name())
 	if err != nil {

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -1,0 +1,275 @@
+package reference
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/digest"
+)
+
+func TestValidateReferenceName(t *testing.T) {
+	validRepoNames := []string{
+		"docker/docker",
+		"library/debian",
+		"debian",
+		"docker.io/docker/docker",
+		"docker.io/library/debian",
+		"docker.io/debian",
+		"index.docker.io/docker/docker",
+		"index.docker.io/library/debian",
+		"index.docker.io/debian",
+		"127.0.0.1:5000/docker/docker",
+		"127.0.0.1:5000/library/debian",
+		"127.0.0.1:5000/debian",
+		"thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev",
+	}
+	invalidRepoNames := []string{
+		"https://github.com/docker/docker",
+		"docker/Docker",
+		"-docker",
+		"-docker/docker",
+		"-docker.io/docker/docker",
+		"docker///docker",
+		"docker.io/docker/Docker",
+		"docker.io/docker///docker",
+		"1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
+		"docker.io/1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
+	}
+
+	for _, name := range invalidRepoNames {
+		_, err := ParseNamed(name)
+		if err == nil {
+			t.Fatalf("Expected invalid repo name for %q", name)
+		}
+	}
+
+	for _, name := range validRepoNames {
+		_, err := ParseNamed(name)
+		if err != nil {
+			t.Fatalf("Error parsing repo name %s, got: %q", name, err)
+		}
+	}
+}
+
+func TestValidateRemoteName(t *testing.T) {
+	validRepositoryNames := []string{
+		// Sanity check.
+		"docker/docker",
+
+		// Allow 64-character non-hexadecimal names (hexadecimal names are forbidden).
+		"thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev",
+
+		// Allow embedded hyphens.
+		"docker-rules/docker",
+
+		// Allow multiple hyphens as well.
+		"docker---rules/docker",
+
+		//Username doc and image name docker being tested.
+		"doc/docker",
+
+		// single character names are now allowed.
+		"d/docker",
+		"jess/t",
+
+		// Consecutive underscores.
+		"dock__er/docker",
+	}
+	for _, repositoryName := range validRepositoryNames {
+		_, err := ParseNamed(repositoryName)
+		if err != nil {
+			t.Errorf("Repository name should be valid: %v. Error: %v", repositoryName, err)
+		}
+	}
+
+	invalidRepositoryNames := []string{
+		// Disallow capital letters.
+		"docker/Docker",
+
+		// Only allow one slash.
+		"docker///docker",
+
+		// Disallow 64-character hexadecimal.
+		"1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
+
+		// Disallow leading and trailing hyphens in namespace.
+		"-docker/docker",
+		"docker-/docker",
+		"-docker-/docker",
+
+		// Don't allow underscores everywhere (as opposed to hyphens).
+		"____/____",
+
+		"_docker/_docker",
+
+		// Disallow consecutive periods.
+		"dock..er/docker",
+		"dock_.er/docker",
+		"dock-.er/docker",
+
+		// No repository.
+		"docker/",
+
+		//namespace too long
+		"this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255/docker",
+	}
+	for _, repositoryName := range invalidRepositoryNames {
+		if _, err := ParseNamed(repositoryName); err == nil {
+			t.Errorf("Repository name should be invalid: %v", repositoryName)
+		}
+	}
+}
+
+func TestParseRepositoryInfo(t *testing.T) {
+	type tcase struct {
+		RemoteName, NormalizedName, FullName, AmbiguousName, Hostname string
+	}
+
+	tcases := []tcase{
+		{
+			RemoteName:     "fooo/bar",
+			NormalizedName: "fooo/bar",
+			FullName:       "docker.io/fooo/bar",
+			AmbiguousName:  "index.docker.io/fooo/bar",
+			Hostname:       "docker.io",
+		},
+		{
+			RemoteName:     "library/ubuntu",
+			NormalizedName: "ubuntu",
+			FullName:       "docker.io/library/ubuntu",
+			AmbiguousName:  "library/ubuntu",
+			Hostname:       "docker.io",
+		},
+		{
+			RemoteName:     "nonlibrary/ubuntu",
+			NormalizedName: "nonlibrary/ubuntu",
+			FullName:       "docker.io/nonlibrary/ubuntu",
+			AmbiguousName:  "",
+			Hostname:       "docker.io",
+		},
+		{
+			RemoteName:     "other/library",
+			NormalizedName: "other/library",
+			FullName:       "docker.io/other/library",
+			AmbiguousName:  "",
+			Hostname:       "docker.io",
+		},
+		{
+			RemoteName:     "private/moonbase",
+			NormalizedName: "127.0.0.1:8000/private/moonbase",
+			FullName:       "127.0.0.1:8000/private/moonbase",
+			AmbiguousName:  "",
+			Hostname:       "127.0.0.1:8000",
+		},
+		{
+			RemoteName:     "privatebase",
+			NormalizedName: "127.0.0.1:8000/privatebase",
+			FullName:       "127.0.0.1:8000/privatebase",
+			AmbiguousName:  "",
+			Hostname:       "127.0.0.1:8000",
+		},
+		{
+			RemoteName:     "private/moonbase",
+			NormalizedName: "example.com/private/moonbase",
+			FullName:       "example.com/private/moonbase",
+			AmbiguousName:  "",
+			Hostname:       "example.com",
+		},
+		{
+			RemoteName:     "privatebase",
+			NormalizedName: "example.com/privatebase",
+			FullName:       "example.com/privatebase",
+			AmbiguousName:  "",
+			Hostname:       "example.com",
+		},
+		{
+			RemoteName:     "private/moonbase",
+			NormalizedName: "example.com:8000/private/moonbase",
+			FullName:       "example.com:8000/private/moonbase",
+			AmbiguousName:  "",
+			Hostname:       "example.com:8000",
+		},
+		{
+			RemoteName:     "privatebasee",
+			NormalizedName: "example.com:8000/privatebasee",
+			FullName:       "example.com:8000/privatebasee",
+			AmbiguousName:  "",
+			Hostname:       "example.com:8000",
+		},
+		{
+			RemoteName:     "library/ubuntu-12.04-base",
+			NormalizedName: "ubuntu-12.04-base",
+			FullName:       "docker.io/library/ubuntu-12.04-base",
+			AmbiguousName:  "index.docker.io/library/ubuntu-12.04-base",
+			Hostname:       "docker.io",
+		},
+	}
+
+	for _, tcase := range tcases {
+		refStrings := []string{tcase.NormalizedName, tcase.FullName}
+		if tcase.AmbiguousName != "" {
+			refStrings = append(refStrings, tcase.AmbiguousName)
+		}
+
+		var refs []Named
+		for _, r := range refStrings {
+			named, err := ParseNamed(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			refs = append(refs, named)
+			named, err = WithName(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			refs = append(refs, named)
+		}
+
+		for _, r := range refs {
+			if expected, actual := tcase.NormalizedName, r.Name(); expected != actual {
+				t.Fatalf("Invalid normalized reference for %q. Expected %q, got %q", r, expected, actual)
+			}
+			if expected, actual := tcase.FullName, r.FullName(); expected != actual {
+				t.Fatalf("Invalid normalized reference for %q. Expected %q, got %q", r, expected, actual)
+			}
+			if expected, actual := tcase.Hostname, r.Hostname(); expected != actual {
+				t.Fatalf("Invalid hostname for %q. Expected %q, got %q", r, expected, actual)
+			}
+			if expected, actual := tcase.RemoteName, r.RemoteName(); expected != actual {
+				t.Fatalf("Invalid remoteName for %q. Expected %q, got %q", r, expected, actual)
+			}
+
+		}
+	}
+}
+
+func TestParseReferenceWithTagAndDigest(t *testing.T) {
+	ref, err := ParseNamed("busybox:latest@sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, isTagged := ref.(NamedTagged); isTagged {
+		t.Fatalf("Reference from %q should not support tag", ref)
+	}
+	if _, isCanonical := ref.(Canonical); !isCanonical {
+		t.Fatalf("Reference from %q should not support digest", ref)
+	}
+	if expected, actual := "busybox@sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa", ref.String(); actual != expected {
+		t.Fatalf("Invalid parsed reference for %q: expected %q, got %q", ref, expected, actual)
+	}
+}
+
+func TestInvalidReferenceComponents(t *testing.T) {
+	if _, err := WithName("-foo"); err == nil {
+		t.Fatal("Expected WithName to detect invalid name")
+	}
+	ref, err := WithName("busybox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WithTag(ref, "-foo"); err == nil {
+		t.Fatal("Expected WithName to detect invalid tag")
+	}
+	if _, err := WithDigest(ref, digest.Digest("foo")); err == nil {
+		t.Fatal("Expected WithName to detect invalid digest")
+	}
+}

--- a/reference/store.go
+++ b/reference/store.go
@@ -1,4 +1,4 @@
-package tag
+package reference
 
 import (
 	"encoding/json"
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/image"
 )
 
@@ -26,18 +25,18 @@ var (
 
 // An Association is a tuple associating a reference with an image ID.
 type Association struct {
-	Ref     reference.Named
+	Ref     Named
 	ImageID image.ID
 }
 
 // Store provides the set of methods which can operate on a tag store.
 type Store interface {
-	References(id image.ID) []reference.Named
-	ReferencesByName(ref reference.Named) []Association
-	AddTag(ref reference.Named, id image.ID, force bool) error
-	AddDigest(ref reference.Canonical, id image.ID, force bool) error
-	Delete(ref reference.Named) (bool, error)
-	Get(ref reference.Named) (image.ID, error)
+	References(id image.ID) []Named
+	ReferencesByName(ref Named) []Association
+	AddTag(ref Named, id image.ID, force bool) error
+	AddDigest(ref Canonical, id image.ID, force bool) error
+	Delete(ref Named) (bool, error)
+	Get(ref Named) (image.ID, error)
 }
 
 type store struct {
@@ -49,14 +48,14 @@ type store struct {
 	Repositories map[string]repository
 	// referencesByIDCache is a cache of references indexed by ID, to speed
 	// up References.
-	referencesByIDCache map[image.ID]map[string]reference.Named
+	referencesByIDCache map[image.ID]map[string]Named
 }
 
 // Repository maps tags to image IDs. The key is a a stringified Reference,
 // including the repository name.
 type repository map[string]image.ID
 
-type lexicalRefs []reference.Named
+type lexicalRefs []Named
 
 func (a lexicalRefs) Len() int           { return len(a) }
 func (a lexicalRefs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
@@ -68,22 +67,22 @@ func (a lexicalAssociations) Len() int           { return len(a) }
 func (a lexicalAssociations) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a lexicalAssociations) Less(i, j int) bool { return a[i].Ref.String() < a[j].Ref.String() }
 
-func defaultTagIfNameOnly(ref reference.Named) reference.Named {
+func defaultTagIfNameOnly(ref Named) Named {
 	switch ref.(type) {
-	case reference.Tagged:
+	case NamedTagged:
 		return ref
-	case reference.Digested:
+	case Canonical:
 		return ref
 	default:
 		// Should never fail
-		ref, _ = reference.WithTag(ref, DefaultTag)
+		ref, _ = WithTag(ref, DefaultTag)
 		return ref
 	}
 }
 
-// NewTagStore creates a new tag store, tied to a file path where the set of
-// tags is serialized in JSON format.
-func NewTagStore(jsonPath string) (Store, error) {
+// NewReferenceStore creates a new reference store, tied to a file path where
+// the set of references are serialized in JSON format.
+func NewReferenceStore(jsonPath string) (Store, error) {
 	abspath, err := filepath.Abs(jsonPath)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func NewTagStore(jsonPath string) (Store, error) {
 	store := &store{
 		jsonPath:            abspath,
 		Repositories:        make(map[string]repository),
-		referencesByIDCache: make(map[image.ID]map[string]reference.Named),
+		referencesByIDCache: make(map[image.ID]map[string]Named),
 	}
 	// Load the json file if it exists, otherwise create it.
 	if err := store.reload(); os.IsNotExist(err) {
@@ -105,21 +104,21 @@ func NewTagStore(jsonPath string) (Store, error) {
 	return store, nil
 }
 
-// Add adds a tag to the store. If force is set to true, existing
+// AddTag adds a tag reference to the store. If force is set to true, existing
 // references can be overwritten. This only works for tags, not digests.
-func (store *store) AddTag(ref reference.Named, id image.ID, force bool) error {
-	if _, isDigested := ref.(reference.Digested); isDigested {
+func (store *store) AddTag(ref Named, id image.ID, force bool) error {
+	if _, isCanonical := ref.(Canonical); isCanonical {
 		return errors.New("refusing to create a tag with a digest reference")
 	}
 	return store.addReference(defaultTagIfNameOnly(ref), id, force)
 }
 
-// Add adds a digest reference to the store.
-func (store *store) AddDigest(ref reference.Canonical, id image.ID, force bool) error {
+// AddDigest adds a digest reference to the store.
+func (store *store) AddDigest(ref Canonical, id image.ID, force bool) error {
 	return store.addReference(ref, id, force)
 }
 
-func (store *store) addReference(ref reference.Named, id image.ID, force bool) error {
+func (store *store) addReference(ref Named, id image.ID, force bool) error {
 	if ref.Name() == string(digest.Canonical) {
 		return errors.New("refusing to create an ambiguous tag using digest algorithm as name")
 	}
@@ -138,7 +137,7 @@ func (store *store) addReference(ref reference.Named, id image.ID, force bool) e
 
 	if exists {
 		// force only works for tags
-		if digested, isDigest := ref.(reference.Digested); isDigest {
+		if digested, isDigest := ref.(Canonical); isDigest {
 			return fmt.Errorf("Cannot overwrite digest %s", digested.Digest().String())
 		}
 
@@ -156,7 +155,7 @@ func (store *store) addReference(ref reference.Named, id image.ID, force bool) e
 
 	repository[refStr] = id
 	if store.referencesByIDCache[id] == nil {
-		store.referencesByIDCache[id] = make(map[string]reference.Named)
+		store.referencesByIDCache[id] = make(map[string]Named)
 	}
 	store.referencesByIDCache[id][refStr] = ref
 
@@ -165,7 +164,7 @@ func (store *store) addReference(ref reference.Named, id image.ID, force bool) e
 
 // Delete deletes a reference from the store. It returns true if a deletion
 // happened, or false otherwise.
-func (store *store) Delete(ref reference.Named) (bool, error) {
+func (store *store) Delete(ref Named) (bool, error) {
 	ref = defaultTagIfNameOnly(ref)
 
 	store.mu.Lock()
@@ -196,8 +195,8 @@ func (store *store) Delete(ref reference.Named) (bool, error) {
 	return false, ErrDoesNotExist
 }
 
-// Get retrieves an item from the store by reference.
-func (store *store) Get(ref reference.Named) (image.ID, error) {
+// Get retrieves an item from the store by
+func (store *store) Get(ref Named) (image.ID, error) {
 	ref = defaultTagIfNameOnly(ref)
 
 	store.mu.RLock()
@@ -218,15 +217,15 @@ func (store *store) Get(ref reference.Named) (image.ID, error) {
 
 // References returns a slice of references to the given image ID. The slice
 // will be nil if there are no references to this image ID.
-func (store *store) References(id image.ID) []reference.Named {
+func (store *store) References(id image.ID) []Named {
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
 	// Convert the internal map to an array for two reasons:
-	// 1) We must not return a mutable reference.
+	// 1) We must not return a mutable
 	// 2) It would be ugly to expose the extraneous map keys to callers.
 
-	var references []reference.Named
+	var references []Named
 	for _, ref := range store.referencesByIDCache[id] {
 		references = append(references, ref)
 	}
@@ -239,7 +238,7 @@ func (store *store) References(id image.ID) []reference.Named {
 // ReferencesByName returns the references for a given repository name.
 // If there are no references known for this repository name,
 // ReferencesByName returns nil.
-func (store *store) ReferencesByName(ref reference.Named) []Association {
+func (store *store) ReferencesByName(ref Named) []Association {
 	store.mu.RLock()
 	defer store.mu.RUnlock()
 
@@ -250,7 +249,7 @@ func (store *store) ReferencesByName(ref reference.Named) []Association {
 
 	var associations []Association
 	for refStr, refID := range repository {
-		ref, err := reference.ParseNamed(refStr)
+		ref, err := ParseNamed(refStr)
 		if err != nil {
 			// Should never happen
 			return nil
@@ -299,13 +298,13 @@ func (store *store) reload() error {
 
 	for _, repository := range store.Repositories {
 		for refStr, refID := range repository {
-			ref, err := reference.ParseNamed(refStr)
+			ref, err := ParseNamed(refStr)
 			if err != nil {
 				// Should never happen
 				continue
 			}
 			if store.referencesByIDCache[refID] == nil {
-				store.referencesByIDCache[refID] = make(map[string]reference.Named)
+				store.referencesByIDCache[refID] = make(map[string]Named)
 			}
 			store.referencesByIDCache[refID][refStr] = ref
 		}

--- a/reference/store.go
+++ b/reference/store.go
@@ -14,9 +14,6 @@ import (
 	"github.com/docker/docker/image"
 )
 
-// DefaultTag defines the default tag used when performing images related actions and no tag string is specified
-const DefaultTag = "latest"
-
 var (
 	// ErrDoesNotExist is returned if a reference is not found in the
 	// store.

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -356,7 +356,6 @@ func handlerGetDeleteTags(w http.ResponseWriter, r *http.Request) {
 		apiError(w, "Could not parse repository", 400)
 		return
 	}
-	repositoryName = NormalizeLocalName(repositoryName)
 	tags, exists := testRepositories[repositoryName.String()]
 	if !exists {
 		apiError(w, "Repository not found", 404)
@@ -380,7 +379,6 @@ func handlerGetTag(w http.ResponseWriter, r *http.Request) {
 		apiError(w, "Could not parse repository", 400)
 		return
 	}
-	repositoryName = NormalizeLocalName(repositoryName)
 	tagName := vars["tag"]
 	tags, exists := testRepositories[repositoryName.String()]
 	if !exists {
@@ -405,7 +403,6 @@ func handlerPutTag(w http.ResponseWriter, r *http.Request) {
 		apiError(w, "Could not parse repository", 400)
 		return
 	}
-	repositoryName = NormalizeLocalName(repositoryName)
 	tagName := vars["tag"]
 	tags, exists := testRepositories[repositoryName.String()]
 	if !exists {

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/distribution/reference"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/opts"
+	"github.com/docker/docker/reference"
 	"github.com/gorilla/mux"
 
 	"github.com/Sirupsen/logrus"

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -307,71 +307,24 @@ func TestPushImageLayerRegistry(t *testing.T) {
 	}
 }
 
-func TestValidateRepositoryName(t *testing.T) {
-	validRepoNames := []string{
-		"docker/docker",
-		"library/debian",
-		"debian",
-		"docker.io/docker/docker",
-		"docker.io/library/debian",
-		"docker.io/debian",
-		"index.docker.io/docker/docker",
-		"index.docker.io/library/debian",
-		"index.docker.io/debian",
-		"127.0.0.1:5000/docker/docker",
-		"127.0.0.1:5000/library/debian",
-		"127.0.0.1:5000/debian",
-		"thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev",
-	}
-	invalidRepoNames := []string{
-		"https://github.com/docker/docker",
-		"docker/Docker",
-		"-docker",
-		"-docker/docker",
-		"-docker.io/docker/docker",
-		"docker///docker",
-		"docker.io/docker/Docker",
-		"docker.io/docker///docker",
-		"1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
-		"docker.io/1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
-	}
-
-	for _, name := range invalidRepoNames {
-		named, err := reference.WithName(name)
-		if err == nil {
-			err := ValidateRepositoryName(named)
-			assertNotEqual(t, err, nil, "Expected invalid repo name: "+name)
-		}
-	}
-
-	for _, name := range validRepoNames {
-		named, err := reference.WithName(name)
-		if err != nil {
-			t.Fatalf("could not parse valid name: %s", name)
-		}
-		err = ValidateRepositoryName(named)
-		assertEqual(t, err, nil, "Expected valid repo name: "+name)
-	}
-}
-
 func TestParseRepositoryInfo(t *testing.T) {
-	withName := func(name string) reference.Named {
-		named, err := reference.WithName(name)
-		if err != nil {
-			t.Fatalf("could not parse reference %s", name)
-		}
-		return named
+	type staticRepositoryInfo struct {
+		Index         *registrytypes.IndexInfo
+		RemoteName    string
+		CanonicalName string
+		LocalName     string
+		Official      bool
 	}
 
-	expectedRepoInfos := map[string]RepositoryInfo{
+	expectedRepoInfos := map[string]staticRepositoryInfo{
 		"fooo/bar": {
 			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("fooo/bar"),
-			LocalName:     withName("fooo/bar"),
-			CanonicalName: withName("docker.io/fooo/bar"),
+			RemoteName:    "fooo/bar",
+			LocalName:     "fooo/bar",
+			CanonicalName: "docker.io/fooo/bar",
 			Official:      false,
 		},
 		"library/ubuntu": {
@@ -379,9 +332,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("library/ubuntu"),
-			LocalName:     withName("ubuntu"),
-			CanonicalName: withName("docker.io/library/ubuntu"),
+			RemoteName:    "library/ubuntu",
+			LocalName:     "ubuntu",
+			CanonicalName: "docker.io/library/ubuntu",
 			Official:      true,
 		},
 		"nonlibrary/ubuntu": {
@@ -389,9 +342,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("nonlibrary/ubuntu"),
-			LocalName:     withName("nonlibrary/ubuntu"),
-			CanonicalName: withName("docker.io/nonlibrary/ubuntu"),
+			RemoteName:    "nonlibrary/ubuntu",
+			LocalName:     "nonlibrary/ubuntu",
+			CanonicalName: "docker.io/nonlibrary/ubuntu",
 			Official:      false,
 		},
 		"ubuntu": {
@@ -399,9 +352,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("library/ubuntu"),
-			LocalName:     withName("ubuntu"),
-			CanonicalName: withName("docker.io/library/ubuntu"),
+			RemoteName:    "library/ubuntu",
+			LocalName:     "ubuntu",
+			CanonicalName: "docker.io/library/ubuntu",
 			Official:      true,
 		},
 		"other/library": {
@@ -409,9 +362,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("other/library"),
-			LocalName:     withName("other/library"),
-			CanonicalName: withName("docker.io/other/library"),
+			RemoteName:    "other/library",
+			LocalName:     "other/library",
+			CanonicalName: "docker.io/other/library",
 			Official:      false,
 		},
 		"127.0.0.1:8000/private/moonbase": {
@@ -419,9 +372,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "127.0.0.1:8000",
 				Official: false,
 			},
-			RemoteName:    withName("private/moonbase"),
-			LocalName:     withName("127.0.0.1:8000/private/moonbase"),
-			CanonicalName: withName("127.0.0.1:8000/private/moonbase"),
+			RemoteName:    "private/moonbase",
+			LocalName:     "127.0.0.1:8000/private/moonbase",
+			CanonicalName: "127.0.0.1:8000/private/moonbase",
 			Official:      false,
 		},
 		"127.0.0.1:8000/privatebase": {
@@ -429,9 +382,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "127.0.0.1:8000",
 				Official: false,
 			},
-			RemoteName:    withName("privatebase"),
-			LocalName:     withName("127.0.0.1:8000/privatebase"),
-			CanonicalName: withName("127.0.0.1:8000/privatebase"),
+			RemoteName:    "privatebase",
+			LocalName:     "127.0.0.1:8000/privatebase",
+			CanonicalName: "127.0.0.1:8000/privatebase",
 			Official:      false,
 		},
 		"localhost:8000/private/moonbase": {
@@ -439,9 +392,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "localhost:8000",
 				Official: false,
 			},
-			RemoteName:    withName("private/moonbase"),
-			LocalName:     withName("localhost:8000/private/moonbase"),
-			CanonicalName: withName("localhost:8000/private/moonbase"),
+			RemoteName:    "private/moonbase",
+			LocalName:     "localhost:8000/private/moonbase",
+			CanonicalName: "localhost:8000/private/moonbase",
 			Official:      false,
 		},
 		"localhost:8000/privatebase": {
@@ -449,9 +402,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "localhost:8000",
 				Official: false,
 			},
-			RemoteName:    withName("privatebase"),
-			LocalName:     withName("localhost:8000/privatebase"),
-			CanonicalName: withName("localhost:8000/privatebase"),
+			RemoteName:    "privatebase",
+			LocalName:     "localhost:8000/privatebase",
+			CanonicalName: "localhost:8000/privatebase",
 			Official:      false,
 		},
 		"example.com/private/moonbase": {
@@ -459,9 +412,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "example.com",
 				Official: false,
 			},
-			RemoteName:    withName("private/moonbase"),
-			LocalName:     withName("example.com/private/moonbase"),
-			CanonicalName: withName("example.com/private/moonbase"),
+			RemoteName:    "private/moonbase",
+			LocalName:     "example.com/private/moonbase",
+			CanonicalName: "example.com/private/moonbase",
 			Official:      false,
 		},
 		"example.com/privatebase": {
@@ -469,9 +422,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "example.com",
 				Official: false,
 			},
-			RemoteName:    withName("privatebase"),
-			LocalName:     withName("example.com/privatebase"),
-			CanonicalName: withName("example.com/privatebase"),
+			RemoteName:    "privatebase",
+			LocalName:     "example.com/privatebase",
+			CanonicalName: "example.com/privatebase",
 			Official:      false,
 		},
 		"example.com:8000/private/moonbase": {
@@ -479,9 +432,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "example.com:8000",
 				Official: false,
 			},
-			RemoteName:    withName("private/moonbase"),
-			LocalName:     withName("example.com:8000/private/moonbase"),
-			CanonicalName: withName("example.com:8000/private/moonbase"),
+			RemoteName:    "private/moonbase",
+			LocalName:     "example.com:8000/private/moonbase",
+			CanonicalName: "example.com:8000/private/moonbase",
 			Official:      false,
 		},
 		"example.com:8000/privatebase": {
@@ -489,9 +442,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "example.com:8000",
 				Official: false,
 			},
-			RemoteName:    withName("privatebase"),
-			LocalName:     withName("example.com:8000/privatebase"),
-			CanonicalName: withName("example.com:8000/privatebase"),
+			RemoteName:    "privatebase",
+			LocalName:     "example.com:8000/privatebase",
+			CanonicalName: "example.com:8000/privatebase",
 			Official:      false,
 		},
 		"localhost/private/moonbase": {
@@ -499,9 +452,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "localhost",
 				Official: false,
 			},
-			RemoteName:    withName("private/moonbase"),
-			LocalName:     withName("localhost/private/moonbase"),
-			CanonicalName: withName("localhost/private/moonbase"),
+			RemoteName:    "private/moonbase",
+			LocalName:     "localhost/private/moonbase",
+			CanonicalName: "localhost/private/moonbase",
 			Official:      false,
 		},
 		"localhost/privatebase": {
@@ -509,9 +462,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     "localhost",
 				Official: false,
 			},
-			RemoteName:    withName("privatebase"),
-			LocalName:     withName("localhost/privatebase"),
-			CanonicalName: withName("localhost/privatebase"),
+			RemoteName:    "privatebase",
+			LocalName:     "localhost/privatebase",
+			CanonicalName: "localhost/privatebase",
 			Official:      false,
 		},
 		IndexName + "/public/moonbase": {
@@ -519,9 +472,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("public/moonbase"),
-			LocalName:     withName("public/moonbase"),
-			CanonicalName: withName("docker.io/public/moonbase"),
+			RemoteName:    "public/moonbase",
+			LocalName:     "public/moonbase",
+			CanonicalName: "docker.io/public/moonbase",
 			Official:      false,
 		},
 		"index." + IndexName + "/public/moonbase": {
@@ -529,9 +482,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("public/moonbase"),
-			LocalName:     withName("public/moonbase"),
-			CanonicalName: withName("docker.io/public/moonbase"),
+			RemoteName:    "public/moonbase",
+			LocalName:     "public/moonbase",
+			CanonicalName: "docker.io/public/moonbase",
 			Official:      false,
 		},
 		"ubuntu-12.04-base": {
@@ -539,9 +492,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("library/ubuntu-12.04-base"),
-			LocalName:     withName("ubuntu-12.04-base"),
-			CanonicalName: withName("docker.io/library/ubuntu-12.04-base"),
+			RemoteName:    "library/ubuntu-12.04-base",
+			LocalName:     "ubuntu-12.04-base",
+			CanonicalName: "docker.io/library/ubuntu-12.04-base",
 			Official:      true,
 		},
 		IndexName + "/ubuntu-12.04-base": {
@@ -549,9 +502,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("library/ubuntu-12.04-base"),
-			LocalName:     withName("ubuntu-12.04-base"),
-			CanonicalName: withName("docker.io/library/ubuntu-12.04-base"),
+			RemoteName:    "library/ubuntu-12.04-base",
+			LocalName:     "ubuntu-12.04-base",
+			CanonicalName: "docker.io/library/ubuntu-12.04-base",
 			Official:      true,
 		},
 		"index." + IndexName + "/ubuntu-12.04-base": {
@@ -559,9 +512,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 				Name:     IndexName,
 				Official: true,
 			},
-			RemoteName:    withName("library/ubuntu-12.04-base"),
-			LocalName:     withName("ubuntu-12.04-base"),
-			CanonicalName: withName("docker.io/library/ubuntu-12.04-base"),
+			RemoteName:    "library/ubuntu-12.04-base",
+			LocalName:     "ubuntu-12.04-base",
+			CanonicalName: "docker.io/library/ubuntu-12.04-base",
 			Official:      true,
 		},
 	}
@@ -577,9 +530,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 			t.Error(err)
 		} else {
 			checkEqual(t, repoInfo.Index.Name, expectedRepoInfo.Index.Name, reposName)
-			checkEqual(t, repoInfo.RemoteName.String(), expectedRepoInfo.RemoteName.String(), reposName)
-			checkEqual(t, repoInfo.LocalName.String(), expectedRepoInfo.LocalName.String(), reposName)
-			checkEqual(t, repoInfo.CanonicalName.String(), expectedRepoInfo.CanonicalName.String(), reposName)
+			checkEqual(t, repoInfo.RemoteName(), expectedRepoInfo.RemoteName, reposName)
+			checkEqual(t, repoInfo.Name(), expectedRepoInfo.LocalName, reposName)
+			checkEqual(t, repoInfo.FullName(), expectedRepoInfo.CanonicalName, reposName)
 			checkEqual(t, repoInfo.Index.Official, expectedRepoInfo.Index.Official, reposName)
 			checkEqual(t, repoInfo.Official, expectedRepoInfo.Official, reposName)
 		}
@@ -804,82 +757,6 @@ func TestSearchRepositories(t *testing.T) {
 	assertEqual(t, results.NumResults, 1, "Expected 1 search results")
 	assertEqual(t, results.Query, "fakequery", "Expected 'fakequery' as query")
 	assertEqual(t, results.Results[0].StarCount, 42, "Expected 'fakeimage' to have 42 stars")
-}
-
-func TestValidRemoteName(t *testing.T) {
-	validRepositoryNames := []string{
-		// Sanity check.
-		"docker/docker",
-
-		// Allow 64-character non-hexadecimal names (hexadecimal names are forbidden).
-		"thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev",
-
-		// Allow embedded hyphens.
-		"docker-rules/docker",
-
-		// Allow multiple hyphens as well.
-		"docker---rules/docker",
-
-		//Username doc and image name docker being tested.
-		"doc/docker",
-
-		// single character names are now allowed.
-		"d/docker",
-		"jess/t",
-
-		// Consecutive underscores.
-		"dock__er/docker",
-	}
-	for _, repositoryName := range validRepositoryNames {
-		repositoryRef, err := reference.WithName(repositoryName)
-		if err != nil {
-			t.Errorf("Repository name should be valid: %v. Error: %v", repositoryName, err)
-		}
-		if err := validateRemoteName(repositoryRef); err != nil {
-			t.Errorf("Repository name should be valid: %v. Error: %v", repositoryName, err)
-		}
-	}
-
-	invalidRepositoryNames := []string{
-		// Disallow capital letters.
-		"docker/Docker",
-
-		// Only allow one slash.
-		"docker///docker",
-
-		// Disallow 64-character hexadecimal.
-		"1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a",
-
-		// Disallow leading and trailing hyphens in namespace.
-		"-docker/docker",
-		"docker-/docker",
-		"-docker-/docker",
-
-		// Don't allow underscores everywhere (as opposed to hyphens).
-		"____/____",
-
-		"_docker/_docker",
-
-		// Disallow consecutive periods.
-		"dock..er/docker",
-		"dock_.er/docker",
-		"dock-.er/docker",
-
-		// No repository.
-		"docker/",
-
-		//namespace too long
-		"this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255/docker",
-	}
-	for _, repositoryName := range invalidRepositoryNames {
-		repositoryRef, err := reference.ParseNamed(repositoryName)
-		if err != nil {
-			continue
-		}
-		if err := validateRemoteName(repositoryRef); err == nil {
-			t.Errorf("Repository name should be invalid: %v", repositoryName)
-		}
-	}
 }
 
 func TestTrustedLocation(t *testing.T) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/reference"
 )
 
 var (

--- a/registry/service.go
+++ b/registry/service.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/reference"
 )
 
 // Service is a registry service. It tracks configuration data such as a list

--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/pkg/tlsconfig"
+	"github.com/docker/docker/reference"
 )
 
 func (s *Service) lookupV1Endpoints(repoName reference.Named) (endpoints []APIEndpoint, err error) {

--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -11,7 +11,7 @@ import (
 func (s *Service) lookupV1Endpoints(repoName reference.Named) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
-	nameString := repoName.Name()
+	nameString := repoName.FullName()
 	if strings.HasPrefix(nameString, DefaultNamespace+"/") {
 		endpoints = append(endpoints, APIEndpoint{
 			URL:          DefaultV1Registry,

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/pkg/tlsconfig"
+	"github.com/docker/docker/reference"
 )
 
 func (s *Service) lookupV2Endpoints(repoName reference.Named) (endpoints []APIEndpoint, err error) {

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -12,7 +12,7 @@ import (
 func (s *Service) lookupV2Endpoints(repoName reference.Named) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
-	nameString := repoName.Name()
+	nameString := repoName.FullName()
 	if strings.HasPrefix(nameString, DefaultNamespace+"/") {
 		// v2 mirrors
 		for _, mirror := range s.Config.Mirrors {

--- a/registry/session.go
+++ b/registry/session.go
@@ -19,13 +19,13 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/tarsum"
+	"github.com/docker/docker/reference"
 )
 
 var (

--- a/registry/types.go
+++ b/registry/types.go
@@ -60,17 +60,9 @@ const (
 
 // RepositoryInfo describes a repository
 type RepositoryInfo struct {
+	reference.Named
 	// Index points to registry information
 	Index *registrytypes.IndexInfo
-	// RemoteName is the remote name of the repository, such as
-	// "library/ubuntu-12.04-base"
-	RemoteName reference.Named
-	// LocalName is the local name of the repository, such as
-	// "ubuntu-12.04-base"
-	LocalName reference.Named
-	// CanonicalName is the canonical name of the repository, such as
-	// "docker.io/library/ubuntu-12.04-base"
-	CanonicalName reference.Named
 	// Official indicates whether the repository is considered official.
 	// If the registry is official, and the normalized name does not
 	// contain a '/' (e.g. "foo"), then it is considered an official repo.

--- a/registry/types.go
+++ b/registry/types.go
@@ -1,8 +1,8 @@
 package registry
 
 import (
-	"github.com/docker/distribution/reference"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/reference"
 )
 
 // RepositoryData tracks the image list, list of endpoints, and list of tokens


### PR DESCRIPTION
#17924 added a reference package from `docker/distribution` that improved validation of tags and repository names a lot. There were still some cases left that needed docker specific handling for the references.

This PR adds a wrapper around `distribution/reference` that adds the docker specific functionality. This includes forbidding 64-byte hex as repo name, specific rules for detecting hostname, detection of optional default hostnames, handling references with both tag and digest and support for conversion between normalized and canonical reference forms. There is no need to remember(and forget in many places) calling validation methods for these anymore, as they all built in to parse function.

I've also cleaned up the type switches for different reference types that become easier now and made error messages more verbose(fixes #18093). After this, the need to use `RepositoryInfo` struct should be much lower as you can always turn any reference to any other form.

I recommend reviewing by commit. Most changes are in the first commit, but they are all simple replacements from moving package and easy to follow.

@aaronlehmann 
