### PR TITLE
Limit v1 protocol fallbacks

### DIFF
--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -175,7 +175,6 @@ func (p *v1Puller) downloadImage(ctx context.Context, repoData *registry.Reposit
 		progress.Update(p.config.ProgressOutput, stringid.TruncateID(img.ID), err.Error())
 		return err
 	}
-	progress.Update(p.config.ProgressOutput, stringid.TruncateID(img.ID), "Download complete")
 	return nil
 }
 

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -59,7 +59,7 @@ type Pusher interface {
 	// Push returns an error if any, as well as a boolean that determines whether to retry Push on the next configured endpoint.
 	//
 	// TODO(tiborvass): have Push() take a reference to repository + tag, so that the pusher itself is repository-agnostic.
-	Push(ctx context.Context) (fallback bool, err error)
+	Push(ctx context.Context) error
 }
 
 const compressionBufSize = 32768
@@ -116,8 +116,21 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 		return fmt.Errorf("Repository does not exist: %s", repoInfo.Name())
 	}
 
-	var lastErr error
+	var (
+		lastErr error
+
+		// confirmedV2 is set to true if a push attempt managed to
+		// confirm that it was talking to a v2 registry. This will
+		// prevent fallback to the v1 protocol.
+		confirmedV2 bool
+	)
+
 	for _, endpoint := range endpoints {
+		if confirmedV2 && endpoint.Version == registry.APIVersion1 {
+			logrus.Debugf("Skipping v1 endpoint %s because v2 registry was detected", endpoint.URL)
+			continue
+		}
+
 		logrus.Debugf("Trying to push %s to %s %s", repoInfo.FullName(), endpoint.URL, endpoint.Version)
 
 		pusher, err := NewPusher(ref, endpoint, repoInfo, imagePushConfig)
@@ -125,22 +138,22 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 			lastErr = err
 			continue
 		}
-		if fallback, err := pusher.Push(ctx); err != nil {
+		if err := pusher.Push(ctx); err != nil {
 			// Was this push cancelled? If so, don't try to fall
 			// back.
 			select {
 			case <-ctx.Done():
-				fallback = false
 			default:
+				if fallbackErr, ok := err.(fallbackError); ok {
+					confirmedV2 = confirmedV2 || fallbackErr.confirmedV2
+					err = fallbackErr.err
+					lastErr = err
+					continue
+				}
 			}
 
-			if fallback {
-				lastErr = err
-				continue
-			}
 			logrus.Debugf("Not continuing with error: %v", err)
 			return err
-
 		}
 
 		imagePushConfig.EventsService.Log("push", repoInfo.Name(), "")

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -1,7 +1,6 @@
 package distribution
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -24,6 +23,22 @@ import (
 	"golang.org/x/net/context"
 )
 
+// fallbackError wraps an error that can possibly allow fallback to a different
+// endpoint.
+type fallbackError struct {
+	// err is the error being wrapped.
+	err error
+	// confirmedV2 is set to true if it was confirmed that the registry
+	// supports the v2 protocol. This is used to limit fallbacks to the v1
+	// protocol.
+	confirmedV2 bool
+}
+
+// Error renders the FallbackError as a string.
+func (f fallbackError) Error() string {
+	return f.err.Error()
+}
+
 type dumbCredentialStore struct {
 	auth *types.AuthConfig
 }
@@ -35,9 +50,7 @@ func (dcs dumbCredentialStore) Basic(*url.URL) (string, string) {
 // NewV2Repository returns a repository (v2 only). It creates a HTTP transport
 // providing timeout settings and authentication support, and also verifies the
 // remote API version.
-func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, metaHeaders http.Header, authConfig *types.AuthConfig, actions ...string) (distribution.Repository, error) {
-	ctx := context.Background()
-
+func NewV2Repository(ctx context.Context, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, metaHeaders http.Header, authConfig *types.AuthConfig, actions ...string) (repo distribution.Repository, foundVersion bool, err error) {
 	repoName := repoInfo.FullName()
 	// If endpoint does not support CanonicalName, use the RemoteName instead
 	if endpoint.TrimHostname {
@@ -67,32 +80,34 @@ func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEnd
 	endpointStr := strings.TrimRight(endpoint.URL, "/") + "/v2/"
 	req, err := http.NewRequest("GET", endpointStr, nil)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	resp, err := pingClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer resp.Body.Close()
 
-	versions := auth.APIVersions(resp, endpoint.VersionHeader)
-	if endpoint.VersionHeader != "" && len(endpoint.Versions) > 0 {
-		var foundVersion bool
-		for _, version := range endpoint.Versions {
-			for _, pingVersion := range versions {
-				if version == pingVersion {
-					foundVersion = true
-				}
-			}
-		}
-		if !foundVersion {
-			return nil, errors.New("endpoint does not support v2 API")
+	v2Version := auth.APIVersion{
+		Type:    "registry",
+		Version: "2.0",
+	}
+
+	versions := auth.APIVersions(resp, registry.DefaultRegistryVersionHeader)
+	for _, pingVersion := range versions {
+		if pingVersion == v2Version {
+			// The version header indicates we're definitely
+			// talking to a v2 registry. So don't allow future
+			// fallbacks to the v1 protocol.
+
+			foundVersion = true
+			break
 		}
 	}
 
 	challengeManager := auth.NewSimpleChallengeManager()
 	if err := challengeManager.AddResponse(resp); err != nil {
-		return nil, err
+		return nil, foundVersion, err
 	}
 
 	if authConfig.RegistryToken != "" {
@@ -106,7 +121,8 @@ func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEnd
 	}
 	tr := transport.NewTransport(base, modifiers...)
 
-	return client.NewRepository(ctx, repoName, endpoint.URL, tr)
+	repo, err = client.NewRepository(ctx, repoName, endpoint.URL, tr)
+	return repo, foundVersion, err
 }
 
 func digestFromManifest(m *schema1.SignedManifest, name reference.Named) (digest.Digest, int, error) {
@@ -147,7 +163,8 @@ func retryOnError(err error) error {
 		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied:
 			return xfer.DoNotRetry{Err: err}
 		}
-
+	case *client.UnexpectedHTTPResponseError:
+		return xfer.DoNotRetry{Err: err}
 	}
 	// let's be nice and fallback if the error is a completely
 	// unexpected one.

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/reference"
@@ -49,12 +48,6 @@ func TestTokenPassThru(t *testing.T) {
 		TrimHostname: false,
 		TLSConfig:    nil,
 		//VersionHeader: "verheader",
-		Versions: []auth.APIVersion{
-			{
-				Type:    "registry",
-				Version: "2",
-			},
-		},
 	}
 	n, _ := reference.ParseNamed("testremotename")
 	repoInfo := &registry.RepositoryInfo{
@@ -76,7 +69,8 @@ func TestTokenPassThru(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := puller.(*v2Puller)
-	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	ctx := context.Background()
+	p.repo, _, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +78,7 @@ func TestTokenPassThru(t *testing.T) {
 	logrus.Debug("About to pull")
 	// We expect it to fail, since we haven't mock'd the full registry exchange in our handler above
 	tag, _ := reference.WithTag(n, "tag_goes_here")
-	_ = p.pullV2Repository(context.Background(), tag)
+	_ = p.pullV2Repository(ctx, tag)
 
 	if !gotToken {
 		t.Fatal("Failed to receive registry token")

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -54,7 +53,8 @@ func (s *DockerHubPullSuite) TestPullNonExistingImage(c *check.C) {
 	} {
 		out, err := s.CmdWithError("pull", e.Alias)
 		c.Assert(err, checker.NotNil, check.Commentf("expected non-zero exit status when pulling non-existing image: %s", out))
-		c.Assert(out, checker.Contains, fmt.Sprintf("Error: image %s not found", e.Repo), check.Commentf("expected image not found error messages"))
+		// Hub returns 401 rather than 404 for nonexistent library/ repos.
+		c.Assert(out, checker.Contains, "unauthorized: access to the requested resource is not authorized", check.Commentf("expected unauthorized error message"))
 	}
 }
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/reference"
@@ -121,14 +120,12 @@ func (s *Service) ResolveIndex(name string) (*registrytypes.IndexInfo, error) {
 
 // APIEndpoint represents a remote API endpoint
 type APIEndpoint struct {
-	Mirror        bool
-	URL           string
-	Version       APIVersion
-	Official      bool
-	TrimHostname  bool
-	TLSConfig     *tls.Config
-	VersionHeader string
-	Versions      []auth.APIVersion
+	Mirror       bool
+	URL          string
+	Version      APIVersion
+	Official     bool
+	TrimHostname bool
+	TLSConfig    *tls.Config
 }
 
 // ToV1Endpoint returns a V1 API endpoint based on the APIEndpoint

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/docker/reference"
 )
@@ -52,20 +51,12 @@ func (s *Service) lookupV2Endpoints(repoName reference.Named) (endpoints []APIEn
 		return nil, err
 	}
 
-	v2Versions := []auth.APIVersion{
-		{
-			Type:    "registry",
-			Version: "2.0",
-		},
-	}
 	endpoints = []APIEndpoint{
 		{
-			URL:           "https://" + hostname,
-			Version:       APIVersion2,
-			TrimHostname:  true,
-			TLSConfig:     tlsConfig,
-			VersionHeader: DefaultRegistryVersionHeader,
-			Versions:      v2Versions,
+			URL:          "https://" + hostname,
+			Version:      APIVersion2,
+			TrimHostname: true,
+			TLSConfig:    tlsConfig,
 		},
 	}
 
@@ -75,9 +66,7 @@ func (s *Service) lookupV2Endpoints(repoName reference.Named) (endpoints []APIEn
 			Version:      APIVersion2,
 			TrimHostname: true,
 			// used to check if supposed to be secure via InsecureSkipVerify
-			TLSConfig:     tlsConfig,
-			VersionHeader: DefaultRegistryVersionHeader,
-			Versions:      v2Versions,
+			TLSConfig: tlsConfig,
 		})
 	}
 


### PR DESCRIPTION
Two commits:

```
Do not fall back to the V1 protocol when we know we are talking to a V2 registry

If we detect a Docker-Distribution-Api-Version header indicating that
the registry speaks the V2 protocol, no fallback to V1 should take
place.

The same applies if a V2 registry operation succeeds while attempting a
push or pull.
```

and:

```
Make v1 pull/push output consistent with v2

- Use layer DiffIDs for progress output in v1 push. This makes the
  output consistent with v2 pushes, which means that a fallback to v1
  won't start progress bars for a different set of IDs.

- Change wording used in v1 status updates to be consistent with v2.
```
