### PR TITLE
Add lock for container update

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -545,6 +545,8 @@ func (container *Container) StopSignal() int {
 // See https://github.com/docker/docker/pull/17779
 // for a more detailed explanation on why we don't want that.
 func (container *Container) InitDNSHostConfig() {
+	container.Lock()
+	defer container.Unlock()
 	if container.HostConfig.DNS == nil {
 		container.HostConfig.DNS = make([]string, 0)
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -30,12 +30,6 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		// creating a container, not during start.
 		if hostConfig != nil {
 			logrus.Warn("DEPRECATED: Setting host configuration options when the container starts is deprecated and will be removed in Docker 1.12")
-			container.Lock()
-			if err := parseSecurityOpt(container, hostConfig); err != nil {
-				container.Unlock()
-				return err
-			}
-			container.Unlock()
 			if err := daemon.adaptContainerSettings(hostConfig, false); err != nil {
 				return err
 			}


### PR DESCRIPTION
Container needs to be locked when updating the fields, and
this PR also remove the redundant `parseSecurityOpt` since
it'll be done in `setHostConfig`.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
