### PR TITLE
api: client: info: add newline after warning

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -33,7 +33,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 			// print a warning if devicemapper is using a loopback file
 			if pair[0] == "Data loop file" {
-				fmt.Fprintf(cli.err, " WARNING: Usage of loopback devices is strongly discouraged for production use. Either use `--storage-opt dm.thinpooldev` or use `--storage-opt dm.no_warn_on_loop_devices=true` to suppress this warning.")
+				fmt.Fprintln(cli.err, " WARNING: Usage of loopback devices is strongly discouraged for production use. Either use `--storage-opt dm.thinpooldev` or use `--storage-opt dm.no_warn_on_loop_devices=true` to suppress this warning.")
 			}
 		}
 
@@ -88,34 +88,34 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	// Only output these warnings if the server does not support these features
 	if info.OSType != "windows" {
 		if !info.MemoryLimit {
-			fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")
+			fmt.Fprintln(cli.err, "WARNING: No memory limit support")
 		}
 		if !info.SwapLimit {
-			fmt.Fprintf(cli.err, "WARNING: No swap limit support\n")
+			fmt.Fprintln(cli.err, "WARNING: No swap limit support")
 		}
 		if !info.OomKillDisable {
-			fmt.Fprintf(cli.err, "WARNING: No oom kill disable support\n")
+			fmt.Fprintln(cli.err, "WARNING: No oom kill disable support")
 		}
 		if !info.CPUCfsQuota {
-			fmt.Fprintf(cli.err, "WARNING: No cpu cfs quota support\n")
+			fmt.Fprintln(cli.err, "WARNING: No cpu cfs quota support")
 		}
 		if !info.CPUCfsPeriod {
-			fmt.Fprintf(cli.err, "WARNING: No cpu cfs period support\n")
+			fmt.Fprintln(cli.err, "WARNING: No cpu cfs period support")
 		}
 		if !info.CPUShares {
-			fmt.Fprintf(cli.err, "WARNING: No cpu shares support\n")
+			fmt.Fprintln(cli.err, "WARNING: No cpu shares support")
 		}
 		if !info.CPUSet {
-			fmt.Fprintf(cli.err, "WARNING: No cpuset support\n")
+			fmt.Fprintln(cli.err, "WARNING: No cpuset support")
 		}
 		if !info.IPv4Forwarding {
-			fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled\n")
+			fmt.Fprintln(cli.err, "WARNING: IPv4 forwarding is disabled")
 		}
 		if !info.BridgeNfIptables {
-			fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-iptables is disabled\n")
+			fmt.Fprintln(cli.err, "WARNING: bridge-nf-call-iptables is disabled")
 		}
 		if !info.BridgeNfIP6tables {
-			fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-ip6tables is disabled\n")
+			fmt.Fprintln(cli.err, "WARNING: bridge-nf-call-ip6tables is disabled")
 		}
 	}
 


### PR DESCRIPTION
Somehow I totally missed it, probably after fixing the first space and force pushing again..

Signed-off-by: Antonio Murdaca runcom@redhat.com
