### PR TITLE
Log events stream when TestEventStreaming fails.

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6449,7 +6449,7 @@ func (s *DockerSuite) TestBuildTagEvent(c *check.C) {
 	case ev := <-ch:
 		c.Assert(ev.Status, check.Equals, "tag")
 		c.Assert(ev.ID, check.Equals, "test:latest")
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		c.Fatal("The 'tag' event not heard from the server")
 	}
 }


### PR DESCRIPTION
Let's see if we can catch there two errors that cripple the windows builds every now and then:

```
----------------------------------------------------------------------
FAIL: docker_cli_events_test.go:216: DockerSuite.TestEventsImageImport

docker_cli_events_test.go:253:
    c.Fatal("failed to observe image import in timely fashion")
... Error: failed to observe image import in timely fashion
```

```
----------------------------------------------------------------------
FAIL: docker_cli_build_test.go:6423: DockerSuite.TestBuildTagEvent

docker_cli_build_test.go:6453:
    c.Fatal("The 'tag' event not heard from the server")
... Error: The 'tag' event not heard from the server
```

Signed-off-by: David Calavera david.calavera@gmail.com
