### PR TITLE
Move client version to the docker cli.

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -68,7 +68,7 @@ type apiClient interface {
 	NetworkList() ([]types.NetworkResource, error)
 	NetworkRemove(networkID string) error
 	RegistryLogin(auth cliconfig.AuthConfig) (types.AuthResponse, error)
-	SystemVersion() (types.VersionResponse, error)
+	ServerVersion() (types.Version, error)
 	VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(volumeID string) (types.Volume, error)
 	VolumeList(filter filters.Args) (types.VolumesListResponse, error)

--- a/api/client/lib/version.go
+++ b/api/client/lib/version.go
@@ -2,37 +2,19 @@ package lib
 
 import (
 	"encoding/json"
-	"runtime"
 
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/dockerversion"
-	"github.com/docker/docker/utils"
 )
 
-// SystemVersion returns information of the docker client and server host.
-func (cli *Client) SystemVersion() (types.VersionResponse, error) {
-	client := &types.Version{
-		Version:      dockerversion.Version,
-		APIVersion:   api.Version,
-		GoVersion:    runtime.Version(),
-		GitCommit:    dockerversion.GitCommit,
-		BuildTime:    dockerversion.BuildTime,
-		Os:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
-		Experimental: utils.ExperimentalBuild(),
-	}
-
+// ServerVersion returns information of the docker client and server host.
+func (cli *Client) ServerVersion() (types.Version, error) {
 	resp, err := cli.get("/version", nil, nil)
 	if err != nil {
-		return types.VersionResponse{Client: client}, err
+		return types.Version{}, err
 	}
 	defer ensureReaderClosed(resp)
 
 	var server types.Version
 	err = json.NewDecoder(resp.body).Decode(&server)
-	if err != nil {
-		return types.VersionResponse{Client: client}, err
-	}
-	return types.VersionResponse{Client: client, Server: &server}, nil
+	return server, err
 }

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -1,11 +1,16 @@
 package client
 
 import (
+	"runtime"
 	"text/template"
 	"time"
 
+	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
+	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/utils"
 )
 
 var versionTemplate = `Client:
@@ -49,7 +54,23 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 			Status: "Template parsing error: " + err.Error()}
 	}
 
-	vd, err := cli.client.SystemVersion()
+	vd := types.VersionResponse{
+		Client: &types.Version{
+			Version:      dockerversion.Version,
+			APIVersion:   api.Version,
+			GoVersion:    runtime.Version(),
+			GitCommit:    dockerversion.GitCommit,
+			BuildTime:    dockerversion.BuildTime,
+			Os:           runtime.GOOS,
+			Arch:         runtime.GOARCH,
+			Experimental: utils.ExperimentalBuild(),
+		},
+	}
+
+	serverVersion, err := cli.client.ServerVersion()
+	if err == nil {
+		vd.Server = &serverVersion
+	}
 
 	// first we need to make BuildTime more human friendly
 	t, errTime := time.Parse(time.RFC3339Nano, vd.Client.BuildTime)


### PR DESCRIPTION
This removes the dockerversion dependency from the client library.

/cc @dnephin

Signed-off-by: David Calavera david.calavera@gmail.com
