### PR TITLE
Cleanup builder: remove container package dependency

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -52,22 +52,30 @@ func (s *router) postCommit(ctx context.Context, w http.ResponseWriter, r *http.
 	if err != nil && err != io.EOF { //Do not fail if body is empty.
 		return err
 	}
-
-	commitCfg := &dockerfile.CommitConfig{
-		Pause:   pause,
-		Repo:    r.Form.Get("repo"),
-		Tag:     r.Form.Get("tag"),
-		Author:  r.Form.Get("author"),
-		Comment: r.Form.Get("comment"),
-		Changes: r.Form["changes"],
-		Config:  c,
+	if c == nil {
+		c = &runconfig.Config{}
 	}
 
 	if !s.daemon.Exists(cname) {
 		return derr.ErrorCodeNoSuchContainer.WithArgs(cname)
 	}
 
-	imgID, err := dockerfile.Commit(cname, s.daemon, commitCfg)
+	newConfig, err := dockerfile.BuildFromConfig(c, r.Form["changes"])
+	if err != nil {
+		return err
+	}
+
+	commitCfg := &types.ContainerCommitConfig{
+		Pause:        pause,
+		Repo:         r.Form.Get("repo"),
+		Tag:          r.Form.Get("tag"),
+		Author:       r.Form.Get("author"),
+		Comment:      r.Form.Get("comment"),
+		Config:       newConfig,
+		MergeConfigs: true,
+	}
+
+	imgID, err := s.daemon.Commit(cname, commitCfg)
 	if err != nil {
 		return err
 	}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -111,7 +111,7 @@ func (fi *HashedFileInfo) SetHash(h string) {
 type Backend interface {
 	// TODO: use digest reference instead of name
 
-	// LookupImage looks up a Docker image referenced by `name`.
+	// GetImage looks up a Docker image referenced by `name`.
 	GetImage(name string) (*image.Image, error)
 	// Pull tells Docker to pull image referenced by `name`.
 	Pull(name string) (*image.Image, error)
@@ -142,12 +142,11 @@ type Backend interface {
 	// TODO: use copyBackend api
 	BuilderCopy(containerID string, destPath string, src FileInfo, decompress bool) error
 
-	// Retain retains an image avoiding it to be removed or overwritten until a corresponding Release() call.
 	// TODO: remove
-	Retain(sessionID, imgID string)
-	// Release releases a list of images that were retained for the time of a build.
-	// TODO: remove
-	Release(sessionID string, activeImages []string)
+	// Mount mounts the root filesystem for the container.
+	Mount(containerID string) error
+	// Unmount unmounts the root filesystem for the container.
+	Unmount(containerID string) error
 }
 
 // ImageCache abstracts an image cache store.

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -7,9 +7,10 @@ package builder
 import (
 	"io"
 	"os"
+	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/runconfig"
 )
@@ -106,30 +107,40 @@ func (fi *HashedFileInfo) SetHash(h string) {
 	fi.FileHash = h
 }
 
-// Docker abstracts calls to a Docker Daemon.
-type Docker interface {
+// Backend abstracts calls to a Docker Daemon.
+type Backend interface {
 	// TODO: use digest reference instead of name
 
 	// LookupImage looks up a Docker image referenced by `name`.
-	LookupImage(name string) (*image.Image, error)
+	GetImage(name string) (*image.Image, error)
 	// Pull tells Docker to pull image referenced by `name`.
 	Pull(name string) (*image.Image, error)
-
-	// Container looks up a Docker container referenced by `id`.
-	Container(id string) (*container.Container, error)
-	// Create creates a new Docker container and returns potential warnings
-	// TODO: put warnings in the error
-	Create(*runconfig.Config, *runconfig.HostConfig) (*container.Container, []string, error)
-	// Remove removes a container specified by `id`.
-	Remove(id string, cfg *types.ContainerRmConfig) error
+	// ContainerWsAttachWithLogs attaches to container.
+	ContainerWsAttachWithLogs(name string, cfg *daemon.ContainerWsAttachWithLogsConfig) error
+	// ContainerCreate creates a new Docker container and returns potential warnings
+	ContainerCreate(params *daemon.ContainerCreateConfig) (types.ContainerCreateResponse, error)
+	// ContainerRm removes a container specified by `id`.
+	ContainerRm(name string, config *types.ContainerRmConfig) error
 	// Commit creates a new Docker image from an existing Docker container.
 	Commit(string, *types.ContainerCommitConfig) (string, error)
-	// Copy copies/extracts a source FileInfo to a destination path inside a container
+	// Kill stops the container execution abruptly.
+	ContainerKill(containerID string, sig uint64) error
+	// Start starts a new container
+	ContainerStart(containerID string, hostConfig *runconfig.HostConfig) error
+	// ContainerWait stops processing until the given container is stopped.
+	ContainerWait(containerID string, timeout time.Duration) (int, error)
+
+	// ContainerUpdateCmd updates container.Path and container.Args
+	ContainerUpdateCmd(containerID string, cmd []string) error
+
+	// ContainerCopy copies/extracts a source FileInfo to a destination path inside a container
 	// specified by a container object.
 	// TODO: make an Extract method instead of passing `decompress`
 	// TODO: do not pass a FileInfo, instead refactor the archive package to export a Walk function that can be used
 	// with Context.Walk
-	Copy(c *container.Container, destPath string, src FileInfo, decompress bool) error
+	//ContainerCopy(name string, res string) (io.ReadCloser, error)
+	// TODO: use copyBackend api
+	BuilderCopy(containerID string, destPath string, src FileInfo, decompress bool) error
 
 	// Retain retains an image avoiding it to be removed or overwritten until a corresponding Release() call.
 	// TODO: remove
@@ -137,14 +148,6 @@ type Docker interface {
 	// Release releases a list of images that were retained for the time of a build.
 	// TODO: remove
 	Release(sessionID string, activeImages []string)
-	// Kill stops the container execution abruptly.
-	Kill(c *container.Container) error
-	// Mount mounts the root filesystem for the container.
-	Mount(c *container.Container) error
-	// Unmount unmounts the root filesystem for the container.
-	Unmount(c *container.Container) error
-	// Start starts a new container
-	Start(c *container.Container) error
 }
 
 // ImageCache abstracts an image cache store.

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -95,8 +95,7 @@ type Builder struct {
 	allowedBuildArgs map[string]bool // list of build-time args that are allowed for expansion/substitution and passing to commands in 'run'.
 
 	// TODO: remove once docker.Commit can receive a tag
-	id           string
-	activeImages []string
+	id string
 }
 
 // NewBuilder creates a new Dockerfile builder from an optional dockerfile and a Config.
@@ -145,11 +144,6 @@ func NewBuilder(config *Config, docker builder.Backend, context builder.Context,
 // * NOT tag the image, that is responsibility of the caller.
 //
 func (b *Builder) Build() (string, error) {
-	// TODO: remove once b.docker.Commit can take a tag parameter.
-	defer func() {
-		b.docker.Release(b.id, b.activeImages)
-	}()
-
 	// If Dockerfile was not parsed yet, extract it from the Context
 	if b.dockerfile == nil {
 		if err := b.readDockerfile(); err != nil {

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -77,7 +77,7 @@ type Builder struct {
 	Stdout io.Writer
 	Stderr io.Writer
 
-	docker  builder.Docker
+	docker  builder.Backend
 	context builder.Context
 
 	dockerfile       *parser.Node
@@ -102,7 +102,7 @@ type Builder struct {
 // NewBuilder creates a new Dockerfile builder from an optional dockerfile and a Config.
 // If dockerfile is nil, the Dockerfile specified by Config.DockerfileName,
 // will be read from the Context passed to Build().
-func NewBuilder(config *Config, docker builder.Docker, context builder.Context, dockerfile io.ReadCloser) (b *Builder, err error) {
+func NewBuilder(config *Config, docker builder.Backend, context builder.Context, dockerfile io.ReadCloser) (b *Builder, err error) {
 	if config == nil {
 		config = new(Config)
 	}

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -399,6 +399,9 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 		return err
 	}
 
+	b.docker.Mount(cID)
+	defer b.docker.Unmount(cID)
+
 	if err := b.run(cID); err != nil {
 		return err
 	}

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -29,15 +29,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
-const (
-	// DefaultPathEnv is unix style list of directories to search for
-	// executables. Each directory is separated from the next by a colon
-	// ':' character .
-	DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-
-	// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
-	DefaultSHMSize int64 = 67108864
-)
+// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
+const DefaultSHMSize int64 = 67108864
 
 // Container holds the fields specific to unixen implementations. See
 // CommonContainer for standard fields common to all containers.
@@ -66,7 +59,7 @@ func (container *Container) CreateDaemonEnvironment(linkedEnv []string) []string
 	}
 	// Setup environment
 	env := []string{
-		"PATH=" + DefaultPathEnv,
+		"PATH=" + system.DefaultPathEnv,
 		"HOSTNAME=" + fullHostname,
 		// Note: we don't set HOME here because it'll get autoset intelligently
 		// based on the value of USER inside dockerinit, but only if it isn't

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -7,10 +7,6 @@ import (
 	"github.com/docker/docker/volume"
 )
 
-// DefaultPathEnv is deliberately empty on Windows as the default path will be set by
-// the container. Docker has no context of what the default path should be.
-const DefaultPathEnv = ""
-
 // Container holds fields specific to the Windows implementation. See
 // CommonContainer for standard fields common to all containers.
 type Container struct {

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -176,6 +176,25 @@ func (d Docker) BuilderCopy(cID string, destPath string, src builder.FileInfo, d
 	return fixPermissions(srcPath, destPath, rootUID, rootGID, destExists)
 }
 
+// Mount mounts the root filesystem for the container.
+func (d Docker) Mount(cID string) error {
+	c, err := d.Daemon.GetContainer(cID)
+	if err != nil {
+		return err
+	}
+	return d.Daemon.Mount(c)
+}
+
+// Unmount unmounts the root filesystem for the container.
+func (d Docker) Unmount(cID string) error {
+	c, err := d.Daemon.GetContainer(cID)
+	if err != nil {
+		return err
+	}
+	d.Daemon.Unmount(c)
+	return nil
+}
+
 // GetCachedImage returns a reference to a cached image whose parent equals `parent`
 // and runconfig equals `cfg`. A cache miss is expected to return an empty ID and a nil error.
 func (d Docker) GetCachedImage(imgID string, cfg *runconfig.Config) (string, error) {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -50,11 +50,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		return err
 	}
 
-	if err := daemon.containerStart(container); err != nil {
-		return err
-	}
-
-	return nil
+	return daemon.containerStart(container)
 }
 
 // Start starts a container

--- a/pkg/system/path_unix.go
+++ b/pkg/system/path_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package system
+
+// DefaultPathEnv is unix style list of directories to search for
+// executables. Each directory is separated from the next by a colon
+// ':' character .
+const DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/pkg/system/path_windows.go
+++ b/pkg/system/path_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package system
+
+// DefaultPathEnv is deliberately empty on Windows as the default path will be set by
+// the container. Docker has no context of what the default path should be.
+const DefaultPathEnv = ""


### PR DESCRIPTION
This PR cleans up the builder a little: remove the dependency on the container package, and removes the daemon dependency in the commit-specific code of the builder.

Ping @anusha-ragunathan @calavera @duglin 
