### PR TITLE
Refactor ResolveAuthConfig to remove the builder dependency on cli code

### DIFF
--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -65,7 +65,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 		return err
 	}
 
-	authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
+	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, repoInfo.Index)
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(repoInfo.Index, "pull")
 
 	if isTrusted() && !ref.HasDigest() {

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -44,7 +44,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 		return err
 	}
 	// Resolve the Auth config relevant for this server
-	authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
+	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, repoInfo.Index)
 	// If we're not using a custom registry, we know the restrictions
 	// applied to repository names and can warn the user in advance.
 	// Custom repositories can have different rules, and we must also

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -35,7 +35,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		return err
 	}
 
-	authConfig := registry.ResolveAuthConfig(cli.configFile, indexInfo)
+	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, indexInfo)
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(indexInfo, "search")
 
 	encodedAuth, err := authConfig.EncodeToBase64()

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -229,7 +229,7 @@ func (cli *DockerCli) trustedReference(ref reference.NamedTagged) (reference.Can
 	}
 
 	// Resolve the Auth config relevant for this server
-	authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
+	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, repoInfo.Index)
 
 	notaryRepo, err := cli.getNotaryRepository(repoInfo, authConfig)
 	if err != nil {

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (cli *DockerCli) encodeRegistryAuth(index *registry.IndexInfo) (string, error) {
-	authConfig := registry.ResolveAuthConfig(cli.configFile, index)
+	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, index)
 	return authConfig.EncodeToBase64()
 }
 

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -67,7 +67,7 @@ func (d Docker) Pull(name string) (*image.Image, error) {
 		}
 
 		resolvedConfig := registry.ResolveAuthConfig(
-			&cliconfig.ConfigFile{AuthConfigs: d.AuthConfigs},
+			d.AuthConfigs,
 			repoInfo.Index,
 		)
 		pullRegistryAuth = &resolvedConfig

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -221,10 +221,10 @@ func tryV2TokenAuthLogin(authConfig *cliconfig.AuthConfig, params map[string]str
 }
 
 // ResolveAuthConfig matches an auth configuration to a server address or a URL
-func ResolveAuthConfig(config *cliconfig.ConfigFile, index *IndexInfo) cliconfig.AuthConfig {
+func ResolveAuthConfig(authConfigs map[string]cliconfig.AuthConfig, index *IndexInfo) cliconfig.AuthConfig {
 	configKey := index.GetAuthConfigKey()
 	// First try the happy case
-	if c, found := config.AuthConfigs[configKey]; found || index.Official {
+	if c, found := authConfigs[configKey]; found || index.Official {
 		return c
 	}
 
@@ -243,7 +243,7 @@ func ResolveAuthConfig(config *cliconfig.ConfigFile, index *IndexInfo) cliconfig
 
 	// Maybe they have a legacy config file, we will iterate the keys converting
 	// them to the new format and testing
-	for registry, ac := range config.AuthConfigs {
+	for registry, ac := range authConfigs {
 		if configKey == convertToHostname(registry) {
 			return ac
 		}


### PR DESCRIPTION
`registry.ResolveAuthConfig()` only needs the AuthConfigs from the ConfigFile, so this changes it to accept just the AuthConfigs.

This is just a first step to removing any dependency on `cliconfig`. The full change is pretty large, so I've split this up into a smaller first step.

cc @tonistiigi, @anusha-ragunathan, @calavera 
