### PR TITLE
Disable coloring in Docker logs

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -700,6 +700,7 @@ _docker_daemon() {
 		--ip-masq=false
 		--iptables=false
 		--ipv6
+		--raw-logs=true
 		--selinux-enabled
 		--userland-proxy=false
 	"

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -39,7 +39,7 @@ script
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
-	exec "$DOCKER" daemon $DOCKER_OPTS
+	exec "$DOCKER" daemon $DOCKER_OPTS --raw-logs
 end script
 
 # Don't emit "started" event until docker.sock is ready.

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -59,6 +59,7 @@ type CommonConfig struct {
 	LogConfig            LogConfig           `json:"log-config,omitempty"`
 	Mtu                  int                 `json:"mtu,omitempty"`
 	Pidfile              string              `json:"pidfile,omitempty"`
+	RawLogs              bool                `json:"raw-logs"`
 	Root                 string              `json:"graph,omitempty"`
 	TrustKeyPath         string              `json:"-"`
 
@@ -100,6 +101,7 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, usageFn("--restart on the daemon has been deprecated in favor of --restart policies on docker run"))
 	cmd.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", usageFn("Storage driver to use"))
 	cmd.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, usageFn("Set the containers network MTU"))
+	cmd.BoolVar(&config.RawLogs, []string{"-raw-logs"}, false, usageFn("Forces daemon to output logs with full timestamps and without ANSI coloring"))
 	// FIXME: why the inconsistency between "hosts" and "sockets"?
 	cmd.Var(opts.NewListOptsRef(&config.DNS, opts.ValidateIPAddress), []string{"#dns", "-dns"}, usageFn("DNS server to use"))
 	cmd.Var(opts.NewNamedListOptsRef("dns-opts", &config.DNSOptions, nil), []string{"-dns-opt"}, usageFn("DNS options to use"))

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -168,7 +168,10 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 		logrus.Warn("Running experimental build")
 	}
 
-	logrus.SetFormatter(&logrus.TextFormatter{TimestampFormat: jsonlog.RFC3339NanoFixed})
+	logrus.SetFormatter(&logrus.TextFormatter{
+		TimestampFormat: jsonlog.RFC3339NanoFixed,
+		DisableColors:   cli.Config.RawLogs,
+	})
 
 	if err := setDefaultUmask(); err != nil {
 		logrus.Fatalf("Failed to set umask: %v", err)

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -54,6 +54,7 @@ weight = -1
       --mtu=0                                Set the containers network MTU
       --disable-legacy-registry              Do not contact legacy registries
       -p, --pidfile="/var/run/docker.pid"    Path to use for daemon PID file
+      --raw-logs                             Output logs with timestamps and no coloring
       --registry-mirror=[]                   Preferred Docker registry mirror
       -s, --storage-driver=""                Storage driver to use
       --selinux-enabled                      Enable selinux support

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -44,6 +44,7 @@ docker-daemon - Enable daemon mode
 [**--log-opt**[=*map[]*]]
 [**--mtu**[=*0*]]
 [**-p**|**--pidfile**[=*/var/run/docker.pid*]]
+[**--raw-logs**[=*false*]]
 [**--registry-mirror**[=*[]*]]
 [**-s**|**--storage-driver**[=*STORAGE-DRIVER*]]
 [**--selinux-enabled**]
@@ -196,6 +197,9 @@ unix://[/path/to/socket] to use.
 
 **-p**, **--pidfile**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
+
+**--raw-logs**=*false*
+  When set to `true`, this the daemon will always output logs in full timestamp format without ANSI coloring. When set to `false` (the default), the daemon will try to output condensed, colorized logs when it detects that it is running inside a terminal.
 
 **--registry-mirror**=*<scheme>://<host>*
   Prepend a registry mirror to be used for image pulls. May be specified multiple times.


### PR DESCRIPTION
Addresses https://github.com/docker/docker/issues/14358 and other color related issues by cutting the proverbial Gordian knot. Since the _default_ behavior in upstart is to put the Docker daemon behind a pty (crazy, right?), most people's logs are going to have garbage terminal characters stuck in them unless coloring is removed by default. Docker doesn't really need colored output at all, and I doubt too many people would bother turning it back on if it was put behind a flag, but let me know if we _realllly_ need a flag here. I'd prefer to avoid more complication in the daemon.

Signed-off-by: Vincent Woo me@vincentwoo.com
