### PR TITLE
layer: layer_store.go: return on error

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -423,7 +423,7 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 	initID := fmt.Sprintf("%s-init", graphID)
 
 	if err := ls.driver.Create(initID, parent, mountLabel); err != nil {
-
+		return "", err
 	}
 	p, err := ls.driver.Get(initID, "")
 	if err != nil {


### PR DESCRIPTION
Is there any reason why it was missing? Should we add a comment explaining why we won't return an error if it's correct not to return? ping @tonistiigi @aaronlehmann 

Signed-off-by: Antonio Murdaca runcom@redhat.com
