### PR TITLE
Move more api types to api/types package

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
@@ -67,7 +66,7 @@ type apiClient interface {
 	NetworkInspect(networkID string) (types.NetworkResource, error)
 	NetworkList() ([]types.NetworkResource, error)
 	NetworkRemove(networkID string) error
-	RegistryLogin(auth cliconfig.AuthConfig) (types.AuthResponse, error)
+	RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error)
 	ServerVersion() (types.Version, error)
 	VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(volumeID string) (types.Volume, error)

--- a/api/client/lib/login.go
+++ b/api/client/lib/login.go
@@ -6,12 +6,11 @@ import (
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/cliconfig"
 )
 
 // RegistryLogin authenticates the docker server with a given docker registry.
 // It returns UnauthorizerError when the authentication fails.
-func (cli *Client) RegistryLogin(auth cliconfig.AuthConfig) (types.AuthResponse, error) {
+func (cli *Client) RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error) {
 	resp, err := cli.post("/auth", url.Values{}, auth, nil)
 
 	if resp != nil && resp.statusCode == http.StatusUnauthorized {

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/client/lib"
 	Cli "github.com/docker/docker/cli"
-	"github.com/docker/docker/cliconfig"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/registry"
@@ -63,7 +62,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 
 	authconfig, ok := cli.configFile.AuthConfigs[serverAddress]
 	if !ok {
-		authconfig = cliconfig.AuthConfig{}
+		authconfig = types.AuthConfig{}
 	}
 
 	if username == "" {

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/client/lib"
+	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/term"

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/registry"
@@ -78,7 +77,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 
 func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, imageID, tag string, requestPrivilege lib.RequestPrivilegeFunc) error {
 
-	encodedAuth, err := cliconfig.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -76,9 +76,9 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	return cli.imagePullPrivileged(authConfig, distributionRef.String(), "", requestPrivilege)
 }
 
-func (cli *DockerCli) imagePullPrivileged(authConfig cliconfig.AuthConfig, imageID, tag string, requestPrivilege lib.RequestPrivilegeFunc) error {
+func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, imageID, tag string, requestPrivilege lib.RequestPrivilegeFunc) error {
 
-	encodedAuth, err := authConfig.EncodeToBase64()
+	encodedAuth, err := cliconfig.EncodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -65,8 +65,8 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	return cli.imagePushPrivileged(authConfig, ref.Name(), tag, cli.out, requestPrivilege)
 }
 
-func (cli *DockerCli) imagePushPrivileged(authConfig cliconfig.AuthConfig, imageID, tag string, outputStream io.Writer, requestPrivilege lib.RequestPrivilegeFunc) error {
-	encodedAuth, err := authConfig.EncodeToBase64()
+func (cli *DockerCli) imagePushPrivileged(authConfig types.AuthConfig, imageID, tag string, outputStream io.Writer, requestPrivilege lib.RequestPrivilegeFunc) error {
+	encodedAuth, err := cliconfig.EncodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/registry"
@@ -66,7 +65,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 }
 
 func (cli *DockerCli) imagePushPrivileged(authConfig types.AuthConfig, imageID, tag string, outputStream io.Writer, requestPrivilege lib.RequestPrivilegeFunc) error {
-	encodedAuth, err := cliconfig.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
-	"github.com/docker/docker/cliconfig"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/registry"
@@ -39,7 +38,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, indexInfo)
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(indexInfo, "search")
 
-	encodedAuth, err := cliconfig.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
+	"github.com/docker/docker/cliconfig"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/registry"
@@ -38,7 +39,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, indexInfo)
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(indexInfo, "search")
 
-	encodedAuth, err := authConfig.EncodeToBase64()
+	encodedAuth, err := cliconfig.EncodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/ansiescape"
 	"github.com/docker/docker/pkg/ioutils"
@@ -81,7 +82,7 @@ func (cli *DockerCli) certificateDirectory(server string) (string, error) {
 	return filepath.Join(cliconfig.ConfigDir(), "tls", u.Host), nil
 }
 
-func trustServer(index *registry.IndexInfo) (string, error) {
+func trustServer(index *registrytypes.IndexInfo) (string, error) {
 	if s := os.Getenv("DOCKER_CONTENT_TRUST_SERVER"); s != "" {
 		urlObj, err := url.Parse(s)
 		if err != nil || urlObj.Scheme != "https" {

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -97,14 +97,14 @@ func trustServer(index *registry.IndexInfo) (string, error) {
 }
 
 type simpleCredentialStore struct {
-	auth cliconfig.AuthConfig
+	auth types.AuthConfig
 }
 
 func (scs simpleCredentialStore) Basic(u *url.URL) (string, string) {
 	return scs.auth.Username, scs.auth.Password
 }
 
-func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, authConfig cliconfig.AuthConfig) (*client.NotaryRepository, error) {
+func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, authConfig types.AuthConfig) (*client.NotaryRepository, error) {
 	server, err := trustServer(repoInfo.Index)
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func notaryError(err error) error {
 	return err
 }
 
-func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registry.Reference, authConfig cliconfig.AuthConfig, requestPrivilege lib.RequestPrivilegeFunc) error {
+func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registry.Reference, authConfig types.AuthConfig, requestPrivilege lib.RequestPrivilegeFunc) error {
 	var refs []target
 
 	notaryRepo, err := cli.getNotaryRepository(repoInfo, authConfig)
@@ -380,7 +380,7 @@ func targetStream(in io.Writer) (io.WriteCloser, <-chan []target) {
 	return ioutils.NewWriteCloserWrapper(out, w.Close), targetChan
 }
 
-func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string, authConfig cliconfig.AuthConfig, requestPrivilege lib.RequestPrivilegeFunc) error {
+func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string, authConfig types.AuthConfig, requestPrivilege lib.RequestPrivilegeFunc) error {
 	streamOut, targetChan := targetStream(cli.out)
 
 	reqError := cli.imagePushPrivileged(authConfig, repoInfo.LocalName.Name(), tag, streamOut, requestPrivilege)

--- a/api/client/trust_test.go
+++ b/api/client/trust_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 )
 
@@ -14,7 +15,7 @@ func unsetENV() {
 
 func TestENVTrustServer(t *testing.T) {
 	defer unsetENV()
-	indexInfo := &registry.IndexInfo{Name: "testserver"}
+	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
 	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "https://notary-test.com:5000"); err != nil {
 		t.Fatal("Failed to set ENV variable")
 	}
@@ -27,7 +28,7 @@ func TestENVTrustServer(t *testing.T) {
 
 func TestHTTPENVTrustServer(t *testing.T) {
 	defer unsetENV()
-	indexInfo := &registry.IndexInfo{Name: "testserver"}
+	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
 	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "http://notary-test.com:5000"); err != nil {
 		t.Fatal("Failed to set ENV variable")
 	}
@@ -38,7 +39,7 @@ func TestHTTPENVTrustServer(t *testing.T) {
 }
 
 func TestOfficialTrustServer(t *testing.T) {
-	indexInfo := &registry.IndexInfo{Name: "testserver", Official: true}
+	indexInfo := &registrytypes.IndexInfo{Name: "testserver", Official: true}
 	output, err := trustServer(indexInfo)
 	if err != nil || output != registry.NotaryServer {
 		t.Fatalf("Expected server to be %s, got %s", registry.NotaryServer, output)
@@ -46,7 +47,7 @@ func TestOfficialTrustServer(t *testing.T) {
 }
 
 func TestNonOfficialTrustServer(t *testing.T) {
-	indexInfo := &registry.IndexInfo{Name: "testserver", Official: false}
+	indexInfo := &registrytypes.IndexInfo{Name: "testserver", Official: false}
 	output, err := trustServer(indexInfo)
 	expectedStr := "https://" + indexInfo.Name
 	if err != nil || output != expectedStr {

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	gosignal "os/signal"
@@ -15,9 +17,18 @@ import (
 	"github.com/docker/docker/registry"
 )
 
+// encodeAuthToBase64 serializes the auth configuration as JSON base64 payload
+func encodeAuthToBase64(authConfig AuthConfig) (string, error) {
+	buf, err := json.Marshal(authConfig)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(buf), nil
+}
+
 func (cli *DockerCli) encodeRegistryAuth(index *registry.IndexInfo) (string, error) {
 	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, index)
-	return authConfig.EncodeToBase64()
+	return cliconfig.EncodeAuthToBase64(authConfig)
 }
 
 func (cli *DockerCli) registryAuthenticationPrivilegedFunc(index *registry.IndexInfo, cmdName string) lib.RequestPrivilegeFunc {

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon/daemonbuilder"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/archive"
@@ -91,13 +90,13 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 		message = r.Form.Get("message")
 	)
 	authEncoded := r.Header.Get("X-Registry-Auth")
-	authConfig := &cliconfig.AuthConfig{}
+	authConfig := &types.AuthConfig{}
 	if authEncoded != "" {
 		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
 		if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
 			// for a pull it is not an error if no auth was given
 			// to increase compatibility with the existing api it is defaulting to be empty
-			authConfig = &cliconfig.AuthConfig{}
+			authConfig = &types.AuthConfig{}
 		}
 	}
 
@@ -195,7 +194,7 @@ func (s *router) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	authConfig := &cliconfig.AuthConfig{}
+	authConfig := &types.AuthConfig{}
 
 	authEncoded := r.Header.Get("X-Registry-Auth")
 	if authEncoded != "" {
@@ -203,7 +202,7 @@ func (s *router) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
 		if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
 			// to increase compatibility to existing api it is defaulting to be empty
-			authConfig = &cliconfig.AuthConfig{}
+			authConfig = &types.AuthConfig{}
 		}
 	} else {
 		// the old format is supported for compatibility if there was no authConfig header
@@ -303,7 +302,7 @@ func (s *router) getImagesByName(ctx context.Context, w http.ResponseWriter, r *
 
 func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var (
-		authConfigs        = map[string]cliconfig.AuthConfig{}
+		authConfigs        = map[string]types.AuthConfig{}
 		authConfigsEncoded = r.Header.Get("X-Registry-Config")
 		buildConfig        = &dockerfile.Config{}
 	)
@@ -560,7 +559,7 @@ func (s *router) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 	var (
-		config      *cliconfig.AuthConfig
+		config      *types.AuthConfig
 		authEncoded = r.Header.Get("X-Registry-Auth")
 		headers     = map[string][]string{}
 	)
@@ -570,7 +569,7 @@ func (s *router) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *
 		if err := json.NewDecoder(authJSON).Decode(&config); err != nil {
 			// for a search it is not an error if no auth was given
 			// to increase compatibility with the existing api it is defaulting to be empty
-			config = &cliconfig.AuthConfig{}
+			config = &types.AuthConfig{}
 		}
 	}
 	for k, v := range r.Header {

--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
@@ -14,5 +13,5 @@ type Backend interface {
 	SystemVersion() types.Version
 	SubscribeToEvents(since, sinceNano int64, ef filters.Args) ([]*jsonmessage.JSONMessage, chan interface{})
 	UnsubscribeFromEvents(chan interface{})
-	AuthenticateToRegistry(authConfig *cliconfig.AuthConfig) (string, error)
+	AuthenticateToRegistry(authConfig *types.AuthConfig) (string, error)
 }

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/parsers/filters"
@@ -116,7 +115,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 }
 
 func (s *systemRouter) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	var config *cliconfig.AuthConfig
+	var config *types.AuthConfig
 	err := json.NewDecoder(r.Body).Decode(&config)
 	r.Body.Close()
 	if err != nil {

--- a/api/types/auth.go
+++ b/api/types/auth.go
@@ -1,0 +1,11 @@
+package types
+
+// AuthConfig contains authorization information for connecting to a Registry
+type AuthConfig struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth"`
+	Email         string `json:"email"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
+}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net"
 
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/pkg/ulimit"
 	"github.com/docker/docker/runconfig"
@@ -135,7 +134,7 @@ type ImageBuildOptions struct {
 	Dockerfile     string
 	Ulimits        []*ulimit.Ulimit
 	BuildArgs      []string
-	AuthConfigs    map[string]cliconfig.AuthConfig
+	AuthConfigs    map[string]types.AuthConfig
 	Context        io.Reader
 }
 

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -134,7 +134,7 @@ type ImageBuildOptions struct {
 	Dockerfile     string
 	Ulimits        []*ulimit.Ulimit
 	BuildArgs      []string
-	AuthConfigs    map[string]types.AuthConfig
+	AuthConfigs    map[string]AuthConfig
 	Context        io.Reader
 }
 

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -1,0 +1,75 @@
+package registry
+
+import (
+	"encoding/json"
+	"net"
+)
+
+// ServiceConfig stores daemon registry services configuration.
+type ServiceConfig struct {
+	InsecureRegistryCIDRs []*NetIPNet           `json:"InsecureRegistryCIDRs"`
+	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
+	Mirrors               []string
+}
+
+// NetIPNet is the net.IPNet type, which can be marshalled and
+// unmarshalled to JSON
+type NetIPNet net.IPNet
+
+// MarshalJSON returns the JSON representation of the IPNet
+func (ipnet *NetIPNet) MarshalJSON() ([]byte, error) {
+	return json.Marshal((*net.IPNet)(ipnet).String())
+}
+
+// UnmarshalJSON sets the IPNet from a byte array of JSON
+func (ipnet *NetIPNet) UnmarshalJSON(b []byte) (err error) {
+	var ipnetStr string
+	if err = json.Unmarshal(b, &ipnetStr); err == nil {
+		var cidr *net.IPNet
+		if _, cidr, err = net.ParseCIDR(ipnetStr); err == nil {
+			*ipnet = NetIPNet(*cidr)
+		}
+	}
+	return
+}
+
+// IndexInfo contains information about a registry
+//
+// RepositoryInfo Examples:
+// {
+//   "Index" : {
+//     "Name" : "docker.io",
+//     "Mirrors" : ["https://registry-2.docker.io/v1/", "https://registry-3.docker.io/v1/"],
+//     "Secure" : true,
+//     "Official" : true,
+//   },
+//   "RemoteName" : "library/debian",
+//   "LocalName" : "debian",
+//   "CanonicalName" : "docker.io/debian"
+//   "Official" : true,
+// }
+//
+// {
+//   "Index" : {
+//     "Name" : "127.0.0.1:5000",
+//     "Mirrors" : [],
+//     "Secure" : false,
+//     "Official" : false,
+//   },
+//   "RemoteName" : "user/repo",
+//   "LocalName" : "127.0.0.1:5000/user/repo",
+//   "CanonicalName" : "127.0.0.1:5000/user/repo",
+//   "Official" : false,
+// }
+type IndexInfo struct {
+	// Name is the name of the registry, such as "docker.io"
+	Name string
+	// Mirrors is a list of mirrors, expressed as URIs
+	Mirrors []string
+	// Secure is set to false if the registry is part of the list of
+	// insecure registries. Insecure registries accept HTTP and/or accept
+	// HTTPS with certificates from unknown CAs.
+	Secure bool
+	// Official indicates whether this is an official registry
+	Official bool
+}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/version"
-	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 )
 

--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -45,15 +45,6 @@ func SetConfigDir(dir string) {
 	configDir = dir
 }
 
-// EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload
-func EncodeAuthToBase64(authConfig AuthConfig) (string, error) {
-	buf, err := json.Marshal(authConfig)
-	if err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(buf), nil
-}
-
 // ConfigFile ~/.docker/config.json file info
 type ConfigFile struct {
 	AuthConfigs map[string]types.AuthConfig `json:"auths"`

--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/homedir"
 )
 
@@ -44,19 +45,9 @@ func SetConfigDir(dir string) {
 	configDir = dir
 }
 
-// AuthConfig contains authorization information for connecting to a Registry
-type AuthConfig struct {
-	Username      string `json:"username,omitempty"`
-	Password      string `json:"password,omitempty"`
-	Auth          string `json:"auth"`
-	Email         string `json:"email"`
-	ServerAddress string `json:"serveraddress,omitempty"`
-	RegistryToken string `json:"registrytoken,omitempty"`
-}
-
-// EncodeToBase64 serializes the auth configuration as JSON base64 payload
-func (a AuthConfig) EncodeToBase64() (string, error) {
-	buf, err := json.Marshal(a)
+// EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload
+func EncodeAuthToBase64(authConfig AuthConfig) (string, error) {
+	buf, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", err
 	}
@@ -65,16 +56,16 @@ func (a AuthConfig) EncodeToBase64() (string, error) {
 
 // ConfigFile ~/.docker/config.json file info
 type ConfigFile struct {
-	AuthConfigs map[string]AuthConfig `json:"auths"`
-	HTTPHeaders map[string]string     `json:"HttpHeaders,omitempty"`
-	PsFormat    string                `json:"psFormat,omitempty"`
-	filename    string                // Note: not serialized - for internal use only
+	AuthConfigs map[string]types.AuthConfig `json:"auths"`
+	HTTPHeaders map[string]string           `json:"HttpHeaders,omitempty"`
+	PsFormat    string                      `json:"psFormat,omitempty"`
+	filename    string                      // Note: not serialized - for internal use only
 }
 
 // NewConfigFile initializes an empty configuration file for the given filename 'fn'
 func NewConfigFile(fn string) *ConfigFile {
 	return &ConfigFile{
-		AuthConfigs: make(map[string]AuthConfig),
+		AuthConfigs: make(map[string]types.AuthConfig),
 		HTTPHeaders: make(map[string]string),
 		filename:    fn,
 	}
@@ -93,7 +84,7 @@ func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
 		if len(arr) < 2 {
 			return fmt.Errorf("The Auth config file is empty")
 		}
-		authConfig := AuthConfig{}
+		authConfig := types.AuthConfig{}
 		origAuth := strings.Split(arr[0], " = ")
 		if len(origAuth) != 2 {
 			return fmt.Errorf("Invalid Auth config file")
@@ -146,7 +137,7 @@ func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
 // a non-nested reader
 func LegacyLoadFromReader(configData io.Reader) (*ConfigFile, error) {
 	configFile := ConfigFile{
-		AuthConfigs: make(map[string]AuthConfig),
+		AuthConfigs: make(map[string]types.AuthConfig),
 	}
 	err := configFile.LegacyLoadFromReader(configData)
 	return &configFile, err
@@ -156,7 +147,7 @@ func LegacyLoadFromReader(configData io.Reader) (*ConfigFile, error) {
 // a reader
 func LoadFromReader(configData io.Reader) (*ConfigFile, error) {
 	configFile := ConfigFile{
-		AuthConfigs: make(map[string]AuthConfig),
+		AuthConfigs: make(map[string]types.AuthConfig),
 	}
 	err := configFile.LoadFromReader(configData)
 	return &configFile, err
@@ -171,7 +162,7 @@ func Load(configDir string) (*ConfigFile, error) {
 	}
 
 	configFile := ConfigFile{
-		AuthConfigs: make(map[string]AuthConfig),
+		AuthConfigs: make(map[string]types.AuthConfig),
 		filename:    filepath.Join(configDir, ConfigFileName),
 	}
 
@@ -215,7 +206,7 @@ func Load(configDir string) (*ConfigFile, error) {
 // the given writer
 func (configFile *ConfigFile) SaveToWriter(writer io.Writer) error {
 	// Encode sensitive data into a new/temp struct
-	tmpAuthConfigs := make(map[string]AuthConfig, len(configFile.AuthConfigs))
+	tmpAuthConfigs := make(map[string]types.AuthConfig, len(configFile.AuthConfigs))
 	for k, authConfig := range configFile.AuthConfigs {
 		authCopy := authConfig
 		// encode and save the authstring, while blanking out the original fields
@@ -261,7 +252,7 @@ func (configFile *ConfigFile) Filename() string {
 }
 
 // EncodeAuth creates a base64 encoded string to containing authorization information
-func EncodeAuth(authConfig *AuthConfig) string {
+func EncodeAuth(authConfig *types.AuthConfig) string {
 	authStr := authConfig.Username + ":" + authConfig.Password
 	msg := []byte(authStr)
 	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(msg)))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/exec"
@@ -1069,7 +1068,7 @@ func writeDistributionProgress(cancelFunc func(), outStream io.Writer, progressC
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (daemon *Daemon) PullImage(ref reference.Named, metaHeaders map[string][]string, authConfig *cliconfig.AuthConfig, outStream io.Writer) error {
+func (daemon *Daemon) PullImage(ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
 	// Include a buffer so that slow client connections don't affect
 	// transfer performance.
 	progressChan := make(chan progress.Progress, 100)
@@ -1112,7 +1111,7 @@ func (daemon *Daemon) ExportImage(names []string, outStream io.Writer) error {
 }
 
 // PushImage initiates a push operation on the repository named localName.
-func (daemon *Daemon) PushImage(ref reference.Named, metaHeaders map[string][]string, authConfig *cliconfig.AuthConfig, outStream io.Writer) error {
+func (daemon *Daemon) PushImage(ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
 	// Include a buffer so that slow client connections don't affect
 	// transfer performance.
 	progressChan := make(chan progress.Progress, 100)
@@ -1501,14 +1500,14 @@ func configureVolumes(config *Config, rootUID, rootGID int) (*store.VolumeStore,
 }
 
 // AuthenticateToRegistry checks the validity of credentials in authConfig
-func (daemon *Daemon) AuthenticateToRegistry(authConfig *cliconfig.AuthConfig) (string, error) {
+func (daemon *Daemon) AuthenticateToRegistry(authConfig *types.AuthConfig) (string, error) {
 	return daemon.RegistryService.Auth(authConfig)
 }
 
 // SearchRegistryForImages queries the registry for images matching
 // term. authConfig is used to login.
 func (daemon *Daemon) SearchRegistryForImages(term string,
-	authConfig *cliconfig.AuthConfig,
+	authConfig *types.AuthConfig,
 	headers map[string][]string) (*registry.SearchResults, error) {
 	return daemon.RegistryService.Search(term, authConfig, headers)
 }

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/image"

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -30,7 +30,7 @@ import (
 type Docker struct {
 	Daemon      *daemon.Daemon
 	OutOld      io.Writer
-	AuthConfigs map[string]cliconfig.AuthConfig
+	AuthConfigs map[string]types.AuthConfig
 	Archiver    *archive.Archiver
 }
 
@@ -58,7 +58,7 @@ func (d Docker) Pull(name string) (*image.Image, error) {
 		}
 	}
 
-	pullRegistryAuth := &cliconfig.AuthConfig{}
+	pullRegistryAuth := &types.AuthConfig{}
 	if len(d.AuthConfigs) > 0 {
 		// The request came with a full auth config file, we prefer to use that
 		repoInfo, err := d.Daemon.RegistryService.ResolveRepository(ref)

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
@@ -25,7 +24,7 @@ type ImagePullConfig struct {
 	MetaHeaders map[string][]string
 	// AuthConfig holds authentication credentials for authenticating with
 	// the registry.
-	AuthConfig *cliconfig.AuthConfig
+	AuthConfig *types.AuthConfig
 	// ProgressOutput is the interface for showing the status of the pull
 	// operation.
 	ProgressOutput progress.Output

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
@@ -29,7 +28,7 @@ type ImagePushConfig struct {
 	MetaHeaders map[string][]string
 	// AuthConfig holds authentication credentials for authenticating with
 	// the registry.
-	AuthConfig *cliconfig.AuthConfig
+	AuthConfig *types.AuthConfig
 	// ProgressOutput is the interface for showing the status of the push
 	// operation.
 	ProgressOutput progress.Output

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/registry"
 	"golang.org/x/net/context"

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -17,14 +17,13 @@ import (
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/registry"
 	"golang.org/x/net/context"
 )
 
 type dumbCredentialStore struct {
-	auth *cliconfig.AuthConfig
+	auth *types.AuthConfig
 }
 
 func (dcs dumbCredentialStore) Basic(*url.URL) (string, string) {
@@ -34,7 +33,7 @@ func (dcs dumbCredentialStore) Basic(*url.URL) (string, string) {
 // NewV2Repository returns a repository (v2 only). It creates a HTTP transport
 // providing timeout settings and authentication support, and also verifies the
 // remote API version.
-func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, metaHeaders http.Header, authConfig *cliconfig.AuthConfig, actions ...string) (distribution.Repository, error) {
+func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, metaHeaders http.Header, authConfig *types.AuthConfig, actions ...string) (distribution.Repository, error) {
 	ctx := context.Background()
 
 	repoName := repoInfo.CanonicalName

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 	"golang.org/x/net/context"
@@ -56,7 +58,7 @@ func TestTokenPassThru(t *testing.T) {
 	}
 	n, _ := reference.ParseNamed("testremotename")
 	repoInfo := &registry.RepositoryInfo{
-		Index: &registry.IndexInfo{
+		Index: &registrytypes.IndexInfo{
 			Name:     "testrepo",
 			Mirrors:  nil,
 			Secure:   false,

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -10,14 +10,13 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 	"golang.org/x/net/context"
 )
 
 func TestTokenPassThru(t *testing.T) {
-	authConfig := &cliconfig.AuthConfig{
+	authConfig := &types.AuthConfig{
 		RegistryToken: "mysecrettoken",
 	}
 	gotToken := false

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Login tries to register/login to the registry server.
-func Login(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint) (string, error) {
+func Login(authConfig *types.AuthConfig, registryEndpoint *Endpoint) (string, error) {
 	// Separates the v2 registry login logic from the v1 logic.
 	if registryEndpoint.Version == APIVersion2 {
 		return loginV2(authConfig, registryEndpoint, "" /* scope */)
@@ -21,7 +21,7 @@ func Login(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint) (string
 }
 
 // loginV1 tries to register/login to the v1 registry server.
-func loginV1(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint) (string, error) {
+func loginV1(authConfig *types.AuthConfig, registryEndpoint *Endpoint) (string, error) {
 	var (
 		status         string
 		respBody       []byte
@@ -136,7 +136,7 @@ func loginV1(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint) (stri
 // now, users should create their account through other means like directly from a web page
 // served by the v2 registry service provider. Whether this will be supported in the future
 // is to be determined.
-func loginV2(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint, scope string) (string, error) {
+func loginV2(authConfig *types.AuthConfig, registryEndpoint *Endpoint, scope string) (string, error) {
 	logrus.Debugf("attempting v2 login to registry endpoint %s", registryEndpoint)
 	var (
 		err       error
@@ -173,7 +173,7 @@ func loginV2(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint, scope
 	return "", fmt.Errorf("no successful auth challenge for %s - errors: %s", registryEndpoint, allErrors)
 }
 
-func tryV2BasicAuthLogin(authConfig *cliconfig.AuthConfig, params map[string]string, registryEndpoint *Endpoint) error {
+func tryV2BasicAuthLogin(authConfig *types.AuthConfig, params map[string]string, registryEndpoint *Endpoint) error {
 	req, err := http.NewRequest("GET", registryEndpoint.Path(""), nil)
 	if err != nil {
 		return err
@@ -194,7 +194,7 @@ func tryV2BasicAuthLogin(authConfig *cliconfig.AuthConfig, params map[string]str
 	return nil
 }
 
-func tryV2TokenAuthLogin(authConfig *cliconfig.AuthConfig, params map[string]string, registryEndpoint *Endpoint) error {
+func tryV2TokenAuthLogin(authConfig *types.AuthConfig, params map[string]string, registryEndpoint *Endpoint) error {
 	token, err := getToken(authConfig.Username, authConfig.Password, params, registryEndpoint)
 	if err != nil {
 		return err
@@ -221,7 +221,7 @@ func tryV2TokenAuthLogin(authConfig *cliconfig.AuthConfig, params map[string]str
 }
 
 // ResolveAuthConfig matches an auth configuration to a server address or a URL
-func ResolveAuthConfig(authConfigs map[string]cliconfig.AuthConfig, index *IndexInfo) cliconfig.AuthConfig {
+func ResolveAuthConfig(authConfigs map[string]types.AuthConfig, index *IndexInfo) types.AuthConfig {
 	configKey := index.GetAuthConfigKey()
 	// First try the happy case
 	if c, found := authConfigs[configKey]; found || index.Official {
@@ -250,5 +250,5 @@ func ResolveAuthConfig(authConfigs map[string]cliconfig.AuthConfig, index *Index
 	}
 
 	// When all else fails, return an empty auth config
-	return cliconfig.AuthConfig{}
+	return types.AuthConfig{}
 }

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
 // Login tries to register/login to the registry server.
@@ -221,8 +222,8 @@ func tryV2TokenAuthLogin(authConfig *types.AuthConfig, params map[string]string,
 }
 
 // ResolveAuthConfig matches an auth configuration to a server address or a URL
-func ResolveAuthConfig(authConfigs map[string]types.AuthConfig, index *IndexInfo) types.AuthConfig {
-	configKey := index.GetAuthConfigKey()
+func ResolveAuthConfig(authConfigs map[string]types.AuthConfig, index *registrytypes.IndexInfo) types.AuthConfig {
+	configKey := GetAuthConfigKey(index)
 	// First try the happy case
 	if c, found := authConfigs[configKey]; found || index.Official {
 		return c

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/cliconfig"
 )
 
@@ -26,8 +28,8 @@ func TestEncodeAuth(t *testing.T) {
 	}
 }
 
-func buildAuthConfigs() map[string]cliconfig.AuthConfig {
-	authConfigs := map[string]cliconfig.AuthConfig{}
+func buildAuthConfigs() map[string]types.AuthConfig {
+	authConfigs := map[string]types.AuthConfig{}
 
 	for _, registry := range []string{"testIndex", IndexServer} {
 		authConfigs[registry] = types.AuthConfig{
@@ -61,10 +63,10 @@ func TestResolveAuthConfigIndexServer(t *testing.T) {
 	authConfigs := buildAuthConfigs()
 	indexConfig := authConfigs[IndexServer]
 
-	officialIndex := &IndexInfo{
+	officialIndex := &registrytypes.IndexInfo{
 		Official: true,
 	}
-	privateIndex := &IndexInfo{
+	privateIndex := &registrytypes.IndexInfo{
 		Official: false,
 	}
 
@@ -127,7 +129,7 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 		if !ok || configured.Email == "" {
 			t.Fail()
 		}
-		index := &IndexInfo{
+		index := &registrytypes.IndexInfo{
 			Name: configKey,
 		}
 		for _, registry := range registries {

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestEncodeAuth(t *testing.T) {
-	newAuthConfig := &cliconfig.AuthConfig{Username: "ken", Password: "test", Email: "test@example.com"}
+	newAuthConfig := &types.AuthConfig{Username: "ken", Password: "test", Email: "test@example.com"}
 	authStr := cliconfig.EncodeAuth(newAuthConfig)
-	decAuthConfig := &cliconfig.AuthConfig{}
+	decAuthConfig := &types.AuthConfig{}
 	var err error
 	decAuthConfig.Username, decAuthConfig.Password, err = cliconfig.DecodeAuth(authStr)
 	if err != nil {
@@ -30,7 +30,7 @@ func buildAuthConfigs() map[string]cliconfig.AuthConfig {
 	authConfigs := map[string]cliconfig.AuthConfig{}
 
 	for _, registry := range []string{"testIndex", IndexServer} {
-		authConfigs[registry] = cliconfig.AuthConfig{
+		authConfigs[registry] = types.AuthConfig{
 			Username: "docker-user",
 			Password: "docker-pass",
 			Email:    "docker@docker.io",
@@ -78,24 +78,24 @@ func TestResolveAuthConfigIndexServer(t *testing.T) {
 func TestResolveAuthConfigFullURL(t *testing.T) {
 	authConfigs := buildAuthConfigs()
 
-	registryAuth := cliconfig.AuthConfig{
+	registryAuth := types.AuthConfig{
 		Username: "foo-user",
 		Password: "foo-pass",
 		Email:    "foo@example.com",
 	}
-	localAuth := cliconfig.AuthConfig{
+	localAuth := types.AuthConfig{
 		Username: "bar-user",
 		Password: "bar-pass",
 		Email:    "bar@example.com",
 	}
-	officialAuth := cliconfig.AuthConfig{
+	officialAuth := types.AuthConfig{
 		Username: "baz-user",
 		Password: "baz-pass",
 		Email:    "baz@example.com",
 	}
 	authConfigs[IndexServer] = officialAuth
 
-	expectedAuths := map[string]cliconfig.AuthConfig{
+	expectedAuths := map[string]types.AuthConfig{
 		"registry.example.com": registryAuth,
 		"localhost:8000":       localAuth,
 		"registry.com":         localAuth,

--- a/registry/config.go
+++ b/registry/config.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -9,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/reference"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/image/v1"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -60,32 +60,8 @@ func (options *Options) InstallFlags(cmd *flag.FlagSet, usageFn func(string) str
 	cmd.BoolVar(&V2Only, []string{"-disable-legacy-registry"}, false, "Do not contact legacy registries")
 }
 
-type netIPNet net.IPNet
-
-func (ipnet *netIPNet) MarshalJSON() ([]byte, error) {
-	return json.Marshal((*net.IPNet)(ipnet).String())
-}
-
-func (ipnet *netIPNet) UnmarshalJSON(b []byte) (err error) {
-	var ipnetStr string
-	if err = json.Unmarshal(b, &ipnetStr); err == nil {
-		var cidr *net.IPNet
-		if _, cidr, err = net.ParseCIDR(ipnetStr); err == nil {
-			*ipnet = netIPNet(*cidr)
-		}
-	}
-	return
-}
-
-// ServiceConfig stores daemon registry services configuration.
-type ServiceConfig struct {
-	InsecureRegistryCIDRs []*netIPNet           `json:"InsecureRegistryCIDRs"`
-	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
-	Mirrors               []string
-}
-
 // NewServiceConfig returns a new instance of ServiceConfig
-func NewServiceConfig(options *Options) *ServiceConfig {
+func NewServiceConfig(options *Options) *registrytypes.ServiceConfig {
 	if options == nil {
 		options = &Options{
 			Mirrors:            opts.NewListOpts(nil),
@@ -100,9 +76,9 @@ func NewServiceConfig(options *Options) *ServiceConfig {
 	// daemon flags on boot2docker?
 	options.InsecureRegistries.Set("127.0.0.0/8")
 
-	config := &ServiceConfig{
-		InsecureRegistryCIDRs: make([]*netIPNet, 0),
-		IndexConfigs:          make(map[string]*IndexInfo, 0),
+	config := &registrytypes.ServiceConfig{
+		InsecureRegistryCIDRs: make([]*registrytypes.NetIPNet, 0),
+		IndexConfigs:          make(map[string]*registrytypes.IndexInfo, 0),
 		// Hack: Bypass setting the mirrors to IndexConfigs since they are going away
 		// and Mirrors are only for the official registry anyways.
 		Mirrors: options.Mirrors.GetAll(),
@@ -113,10 +89,10 @@ func NewServiceConfig(options *Options) *ServiceConfig {
 		_, ipnet, err := net.ParseCIDR(r)
 		if err == nil {
 			// Valid CIDR.
-			config.InsecureRegistryCIDRs = append(config.InsecureRegistryCIDRs, (*netIPNet)(ipnet))
+			config.InsecureRegistryCIDRs = append(config.InsecureRegistryCIDRs, (*registrytypes.NetIPNet)(ipnet))
 		} else {
 			// Assume `host:port` if not CIDR.
-			config.IndexConfigs[r] = &IndexInfo{
+			config.IndexConfigs[r] = &registrytypes.IndexInfo{
 				Name:     r,
 				Mirrors:  make([]string, 0),
 				Secure:   false,
@@ -126,7 +102,7 @@ func NewServiceConfig(options *Options) *ServiceConfig {
 	}
 
 	// Configure public registry.
-	config.IndexConfigs[IndexName] = &IndexInfo{
+	config.IndexConfigs[IndexName] = &registrytypes.IndexInfo{
 		Name:     IndexName,
 		Mirrors:  config.Mirrors,
 		Secure:   true,
@@ -147,9 +123,9 @@ func NewServiceConfig(options *Options) *ServiceConfig {
 // or an IP address. If it is a domain name, then it will be resolved in order to check if the IP is contained
 // in a subnet. If the resolving is not successful, isSecureIndex will only try to match hostname to any element
 // of insecureRegistries.
-func (config *ServiceConfig) isSecureIndex(indexName string) bool {
+func isSecureIndex(config *registrytypes.ServiceConfig, indexName string) bool {
 	// Check for configured index, first.  This is needed in case isSecureIndex
-	// is called from anything besides NewIndexInfo, in order to honor per-index configurations.
+	// is called from anything besides newIndexInfo, in order to honor per-index configurations.
 	if index, ok := config.IndexConfigs[indexName]; ok {
 		return index.Secure
 	}
@@ -258,8 +234,8 @@ func loadRepositoryName(reposName reference.Named) (string, reference.Named, err
 	return indexName, remoteName, nil
 }
 
-// NewIndexInfo returns IndexInfo configuration from indexName
-func (config *ServiceConfig) NewIndexInfo(indexName string) (*IndexInfo, error) {
+// newIndexInfo returns IndexInfo configuration from indexName
+func newIndexInfo(config *registrytypes.ServiceConfig, indexName string) (*registrytypes.IndexInfo, error) {
 	var err error
 	indexName, err = ValidateIndexName(indexName)
 	if err != nil {
@@ -272,18 +248,18 @@ func (config *ServiceConfig) NewIndexInfo(indexName string) (*IndexInfo, error) 
 	}
 
 	// Construct a non-configured index info.
-	index := &IndexInfo{
+	index := &registrytypes.IndexInfo{
 		Name:     indexName,
 		Mirrors:  make([]string, 0),
 		Official: false,
 	}
-	index.Secure = config.isSecureIndex(indexName)
+	index.Secure = isSecureIndex(config, indexName)
 	return index, nil
 }
 
 // GetAuthConfigKey special-cases using the full index address of the official
 // index as the AuthConfig key, and uses the (host)name[:port] for private indexes.
-func (index *IndexInfo) GetAuthConfigKey() string {
+func GetAuthConfigKey(index *registrytypes.IndexInfo) string {
 	if index.Official {
 		return IndexServer
 	}
@@ -306,8 +282,8 @@ func splitReposName(reposName reference.Named) (indexName string, remoteName ref
 	return
 }
 
-// NewRepositoryInfo validates and breaks down a repository name into a RepositoryInfo
-func (config *ServiceConfig) NewRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
+// newRepositoryInfo validates and breaks down a repository name into a RepositoryInfo
+func newRepositoryInfo(config *registrytypes.ServiceConfig, reposName reference.Named) (*RepositoryInfo, error) {
 	if err := validateNoSchema(reposName.Name()); err != nil {
 		return nil, err
 	}
@@ -323,7 +299,7 @@ func (config *ServiceConfig) NewRepositoryInfo(reposName reference.Named) (*Repo
 		return nil, err
 	}
 
-	repoInfo.Index, err = config.NewIndexInfo(indexName)
+	repoInfo.Index, err = newIndexInfo(config, indexName)
 	if err != nil {
 		return nil, err
 	}
@@ -364,14 +340,14 @@ func (config *ServiceConfig) NewRepositoryInfo(reposName reference.Named) (*Repo
 // ParseRepositoryInfo performs the breakdown of a repository name into a RepositoryInfo, but
 // lacks registry configuration.
 func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
-	return emptyServiceConfig.NewRepositoryInfo(reposName)
+	return newRepositoryInfo(emptyServiceConfig, reposName)
 }
 
 // ParseSearchIndexInfo will use repository name to get back an indexInfo.
-func ParseSearchIndexInfo(reposName string) (*IndexInfo, error) {
+func ParseSearchIndexInfo(reposName string) (*registrytypes.IndexInfo, error) {
 	indexName, _ := splitReposSearchTerm(reposName)
 
-	indexInfo, err := emptyServiceConfig.NewIndexInfo(indexName)
+	indexInfo, err := newIndexInfo(emptyServiceConfig, indexName)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client/transport"
+	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
 // for mocking in unit tests
@@ -44,12 +45,12 @@ func scanForAPIVersion(address string) (string, APIVersion) {
 
 // NewEndpoint parses the given address to return a registry endpoint.  v can be used to
 // specify a specific endpoint version
-func NewEndpoint(index *IndexInfo, metaHeaders http.Header, v APIVersion) (*Endpoint, error) {
+func NewEndpoint(index *registrytypes.IndexInfo, metaHeaders http.Header, v APIVersion) (*Endpoint, error) {
 	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}
-	endpoint, err := newEndpoint(index.GetAuthConfigKey(), tlsConfig, metaHeaders)
+	endpoint, err := newEndpoint(GetAuthConfigKey(index), tlsConfig, metaHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/opts"
 	"github.com/gorilla/mux"
 
@@ -150,22 +151,22 @@ func makeHTTPSURL(req string) string {
 	return testHTTPSServer.URL + req
 }
 
-func makeIndex(req string) *IndexInfo {
-	index := &IndexInfo{
+func makeIndex(req string) *registrytypes.IndexInfo {
+	index := &registrytypes.IndexInfo{
 		Name: makeURL(req),
 	}
 	return index
 }
 
-func makeHTTPSIndex(req string) *IndexInfo {
-	index := &IndexInfo{
+func makeHTTPSIndex(req string) *registrytypes.IndexInfo {
+	index := &registrytypes.IndexInfo{
 		Name: makeHTTPSURL(req),
 	}
 	return index
 }
 
-func makePublicIndex() *IndexInfo {
-	index := &IndexInfo{
+func makePublicIndex() *registrytypes.IndexInfo {
+	index := &registrytypes.IndexInfo{
 		Name:     IndexServer,
 		Secure:   true,
 		Official: true,
@@ -173,7 +174,7 @@ func makePublicIndex() *IndexInfo {
 	return index
 }
 
-func makeServiceConfig(mirrors []string, insecureRegistries []string) *ServiceConfig {
+func makeServiceConfig(mirrors []string, insecureRegistries []string) *registrytypes.ServiceConfig {
 	options := &Options{
 		Mirrors:            opts.NewListOpts(nil),
 		InsecureRegistries: opts.NewListOpts(nil),

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
 var (
@@ -49,7 +51,7 @@ func spawnTestRegistrySession(t *testing.T) *Session {
 }
 
 func TestPingRegistryEndpoint(t *testing.T) {
-	testPing := func(index *IndexInfo, expectedStandalone bool, assertMessage string) {
+	testPing := func(index *registrytypes.IndexInfo, expectedStandalone bool, assertMessage string) {
 		ep, err := NewEndpoint(index, nil, APIVersionUnknown)
 		if err != nil {
 			t.Fatal(err)
@@ -69,7 +71,7 @@ func TestPingRegistryEndpoint(t *testing.T) {
 
 func TestEndpoint(t *testing.T) {
 	// Simple wrapper to fail test if err != nil
-	expandEndpoint := func(index *IndexInfo) *Endpoint {
+	expandEndpoint := func(index *registrytypes.IndexInfo) *Endpoint {
 		endpoint, err := NewEndpoint(index, nil, APIVersionUnknown)
 		if err != nil {
 			t.Fatal(err)
@@ -77,7 +79,7 @@ func TestEndpoint(t *testing.T) {
 		return endpoint
 	}
 
-	assertInsecureIndex := func(index *IndexInfo) {
+	assertInsecureIndex := func(index *registrytypes.IndexInfo) {
 		index.Secure = true
 		_, err := NewEndpoint(index, nil, APIVersionUnknown)
 		assertNotEqual(t, err, nil, index.Name+": Expected error for insecure index")
@@ -85,7 +87,7 @@ func TestEndpoint(t *testing.T) {
 		index.Secure = false
 	}
 
-	assertSecureIndex := func(index *IndexInfo) {
+	assertSecureIndex := func(index *registrytypes.IndexInfo) {
 		index.Secure = true
 		_, err := NewEndpoint(index, nil, APIVersionUnknown)
 		assertNotEqual(t, err, nil, index.Name+": Expected cert error for secure index")
@@ -93,7 +95,7 @@ func TestEndpoint(t *testing.T) {
 		index.Secure = false
 	}
 
-	index := &IndexInfo{}
+	index := &registrytypes.IndexInfo{}
 	index.Name = makeURL("/v1/")
 	endpoint := expandEndpoint(index)
 	assertEqual(t, endpoint.String(), index.Name, "Expected endpoint to be "+index.Name)
@@ -363,7 +365,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 
 	expectedRepoInfos := map[string]RepositoryInfo{
 		"fooo/bar": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -373,7 +375,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"library/ubuntu": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -383,7 +385,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		"nonlibrary/ubuntu": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -393,7 +395,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"ubuntu": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -403,7 +405,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		"other/library": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -413,7 +415,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"127.0.0.1:8000/private/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "127.0.0.1:8000",
 				Official: false,
 			},
@@ -423,7 +425,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"127.0.0.1:8000/privatebase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "127.0.0.1:8000",
 				Official: false,
 			},
@@ -433,7 +435,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost:8000/private/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "localhost:8000",
 				Official: false,
 			},
@@ -443,7 +445,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost:8000/privatebase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "localhost:8000",
 				Official: false,
 			},
@@ -453,7 +455,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com/private/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "example.com",
 				Official: false,
 			},
@@ -463,7 +465,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com/privatebase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "example.com",
 				Official: false,
 			},
@@ -473,7 +475,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com:8000/private/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "example.com:8000",
 				Official: false,
 			},
@@ -483,7 +485,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"example.com:8000/privatebase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "example.com:8000",
 				Official: false,
 			},
@@ -493,7 +495,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost/private/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "localhost",
 				Official: false,
 			},
@@ -503,7 +505,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"localhost/privatebase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     "localhost",
 				Official: false,
 			},
@@ -513,7 +515,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		IndexName + "/public/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -523,7 +525,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"index." + IndexName + "/public/moonbase": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -533,7 +535,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      false,
 		},
 		"ubuntu-12.04-base": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -543,7 +545,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		IndexName + "/ubuntu-12.04-base": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -553,7 +555,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Official:      true,
 		},
 		"index." + IndexName + "/ubuntu-12.04-base": {
-			Index: &IndexInfo{
+			Index: &registrytypes.IndexInfo{
 				Name:     IndexName,
 				Official: true,
 			},
@@ -585,9 +587,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 }
 
 func TestNewIndexInfo(t *testing.T) {
-	testIndexInfo := func(config *ServiceConfig, expectedIndexInfos map[string]*IndexInfo) {
+	testIndexInfo := func(config *registrytypes.ServiceConfig, expectedIndexInfos map[string]*registrytypes.IndexInfo) {
 		for indexName, expectedIndexInfo := range expectedIndexInfos {
-			index, err := config.NewIndexInfo(indexName)
+			index, err := newIndexInfo(config, indexName)
 			if err != nil {
 				t.Fatal(err)
 			} else {
@@ -601,7 +603,7 @@ func TestNewIndexInfo(t *testing.T) {
 
 	config := NewServiceConfig(nil)
 	noMirrors := []string{}
-	expectedIndexInfos := map[string]*IndexInfo{
+	expectedIndexInfos := map[string]*registrytypes.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
 			Official: true,
@@ -632,7 +634,7 @@ func TestNewIndexInfo(t *testing.T) {
 	publicMirrors := []string{"http://mirror1.local", "http://mirror2.local"}
 	config = makeServiceConfig(publicMirrors, []string{"example.com"})
 
-	expectedIndexInfos = map[string]*IndexInfo{
+	expectedIndexInfos = map[string]*registrytypes.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
 			Official: true,
@@ -679,7 +681,7 @@ func TestNewIndexInfo(t *testing.T) {
 	testIndexInfo(config, expectedIndexInfos)
 
 	config = makeServiceConfig(nil, []string{"42.42.0.0/16"})
-	expectedIndexInfos = map[string]*IndexInfo{
+	expectedIndexInfos = map[string]*registrytypes.IndexInfo{
 		"example.com": {
 			Name:     "example.com",
 			Official: false,
@@ -981,7 +983,7 @@ func TestIsSecureIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		config := makeServiceConfig(nil, tt.insecureRegistries)
-		if sec := config.isSecureIndex(tt.addr); sec != tt.expected {
+		if sec := isSecureIndex(config, tt.addr); sec != tt.expected {
 			t.Errorf("isSecureIndex failed for %q %v, expected %v got %v", tt.addr, tt.insecureRegistries, tt.expected, sec)
 		}
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/docker/cliconfig"
 )
 
 var (
@@ -23,7 +22,7 @@ const (
 )
 
 func spawnTestRegistrySession(t *testing.T) *Session {
-	authConfig := &cliconfig.AuthConfig{}
+	authConfig := &types.AuthConfig{}
 	endpoint, err := NewEndpoint(makeIndex("/v1/"), nil, APIVersionUnknown)
 	if err != nil {
 		t.Fatal(err)

--- a/registry/service.go
+++ b/registry/service.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
 // Service is a registry service. It tracks configuration data such as a list
 // of mirrors.
 type Service struct {
-	Config *ServiceConfig
+	Config *registrytypes.ServiceConfig
 }
 
 // NewService returns a new instance of Service ready to be
@@ -78,7 +80,7 @@ func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[
 
 	indexName, remoteName := splitReposSearchTerm(term)
 
-	index, err := s.Config.NewIndexInfo(indexName)
+	index, err := newIndexInfo(s.Config, indexName)
 	if err != nil {
 		return nil, err
 	}
@@ -109,12 +111,12 @@ func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[
 // ResolveRepository splits a repository name into its components
 // and configuration of the associated registry.
 func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, error) {
-	return s.Config.NewRepositoryInfo(name)
+	return newRepositoryInfo(s.Config, name)
 }
 
 // ResolveIndex takes indexName and returns index info
-func (s *Service) ResolveIndex(name string) (*IndexInfo, error) {
-	return s.Config.NewIndexInfo(name)
+func (s *Service) ResolveIndex(name string) (*registrytypes.IndexInfo, error) {
+	return newIndexInfo(s.Config, name)
 }
 
 // APIEndpoint represents a remote API endpoint
@@ -136,7 +138,7 @@ func (e APIEndpoint) ToV1Endpoint(metaHeaders http.Header) (*Endpoint, error) {
 
 // TLSConfig constructs a client TLS configuration based on server defaults
 func (s *Service) TLSConfig(hostname string) (*tls.Config, error) {
-	return newTLSConfig(hostname, s.Config.isSecureIndex(hostname))
+	return newTLSConfig(hostname, isSecureIndex(s.Config, hostname))
 }
 
 func (s *Service) tlsConfigForMirror(mirror string) (*tls.Config, error) {

--- a/registry/service.go
+++ b/registry/service.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
-	"github.com/docker/docker/cliconfig"
 )
 
 // Service is a registry service. It tracks configuration data such as a list
@@ -28,7 +27,7 @@ func NewService(options *Options) *Service {
 // Auth contacts the public registry with the provided credentials,
 // and returns OK if authentication was successful.
 // It can be used to verify the validity of a client's credentials.
-func (s *Service) Auth(authConfig *cliconfig.AuthConfig) (string, error) {
+func (s *Service) Auth(authConfig *types.AuthConfig) (string, error) {
 	addr := authConfig.ServerAddress
 	if addr == "" {
 		// Use the official registry address if not specified.
@@ -72,7 +71,7 @@ func splitReposSearchTerm(reposName string) (string, string) {
 
 // Search queries the public registry for images matching the specified
 // search terms, and returns the results.
-func (s *Service) Search(term string, authConfig *cliconfig.AuthConfig, headers map[string][]string) (*SearchResults, error) {
+func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[string][]string) (*SearchResults, error) {
 	if err := validateNoSchema(term); err != nil {
 		return nil, err
 	}

--- a/registry/session.go
+++ b/registry/session.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"
@@ -39,13 +38,13 @@ type Session struct {
 	indexEndpoint *Endpoint
 	client        *http.Client
 	// TODO(tiborvass): remove authConfig
-	authConfig *cliconfig.AuthConfig
+	authConfig *types.AuthConfig
 	id         string
 }
 
 type authTransport struct {
 	http.RoundTripper
-	*cliconfig.AuthConfig
+	*types.AuthConfig
 
 	alwaysSetBasicAuth bool
 	token              []string
@@ -67,7 +66,7 @@ type authTransport struct {
 // If the server sends a token without the client having requested it, it is ignored.
 //
 // This RoundTripper also has a CancelRequest method important for correct timeout handling.
-func AuthTransport(base http.RoundTripper, authConfig *cliconfig.AuthConfig, alwaysSetBasicAuth bool) http.RoundTripper {
+func AuthTransport(base http.RoundTripper, authConfig *types.AuthConfig, alwaysSetBasicAuth bool) http.RoundTripper {
 	if base == nil {
 		base = http.DefaultTransport
 	}
@@ -162,7 +161,7 @@ func (tr *authTransport) CancelRequest(req *http.Request) {
 
 // NewSession creates a new session
 // TODO(tiborvass): remove authConfig param once registry client v2 is vendored
-func NewSession(client *http.Client, authConfig *cliconfig.AuthConfig, endpoint *Endpoint) (r *Session, err error) {
+func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *Endpoint) (r *Session, err error) {
 	r = &Session{
 		authConfig:    authConfig,
 		client:        client,
@@ -743,12 +742,12 @@ func (r *Session) SearchRepositories(term string) (*SearchResults, error) {
 
 // GetAuthConfig returns the authentication settings for a session
 // TODO(tiborvass): remove this once registry client v2 is vendored
-func (r *Session) GetAuthConfig(withPasswd bool) *cliconfig.AuthConfig {
+func (r *Session) GetAuthConfig(withPasswd bool) *types.AuthConfig {
 	password := ""
 	if withPasswd {
 		password = r.authConfig.Password
 	}
-	return &cliconfig.AuthConfig{
+	return &types.AuthConfig{
 		Username: r.authConfig.Username,
 		Password: password,
 		Email:    r.authConfig.Email,

--- a/registry/session.go
+++ b/registry/session.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"

--- a/registry/types.go
+++ b/registry/types.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"github.com/docker/distribution/reference"
+	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
 // SearchResult describes a search result returned from a registry
@@ -83,51 +84,10 @@ const (
 	APIVersion2
 )
 
-// IndexInfo contains information about a registry
-//
-// RepositoryInfo Examples:
-// {
-//   "Index" : {
-//     "Name" : "docker.io",
-//     "Mirrors" : ["https://registry-2.docker.io/v1/", "https://registry-3.docker.io/v1/"],
-//     "Secure" : true,
-//     "Official" : true,
-//   },
-//   "RemoteName" : "library/debian",
-//   "LocalName" : "debian",
-//   "CanonicalName" : "docker.io/debian"
-//   "Official" : true,
-// }
-//
-// {
-//   "Index" : {
-//     "Name" : "127.0.0.1:5000",
-//     "Mirrors" : [],
-//     "Secure" : false,
-//     "Official" : false,
-//   },
-//   "RemoteName" : "user/repo",
-//   "LocalName" : "127.0.0.1:5000/user/repo",
-//   "CanonicalName" : "127.0.0.1:5000/user/repo",
-//   "Official" : false,
-// }
-type IndexInfo struct {
-	// Name is the name of the registry, such as "docker.io"
-	Name string
-	// Mirrors is a list of mirrors, expressed as URIs
-	Mirrors []string
-	// Secure is set to false if the registry is part of the list of
-	// insecure registries. Insecure registries accept HTTP and/or accept
-	// HTTPS with certificates from unknown CAs.
-	Secure bool
-	// Official indicates whether this is an official registry
-	Official bool
-}
-
 // RepositoryInfo describes a repository
 type RepositoryInfo struct {
 	// Index points to registry information
-	Index *IndexInfo
+	Index *registrytypes.IndexInfo
 	// RemoteName is the remote name of the repository, such as
 	// "library/ubuntu-12.04-base"
 	RemoteName reference.Named


### PR DESCRIPTION
Moves `AuthConfig` to `api/types` and removes the build and api/types dependency on `cliconfig`.

Moves a few registry types to `api/types/registry` which removes the api/types dependency on `registry`.

I had to do this together because after moving `AuthConfig` there was a circular import.

Some methods were turned into package level functions as a result of the types being moved.

cc @calavera 
