### PR TITLE
Force API versioning in the client library.

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cliconfig"
@@ -102,7 +103,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, clientFlags *cli.ClientF
 		}
 		customHeaders["User-Agent"] = "Docker-Client/" + dockerversion.Version + " (" + runtime.GOOS + ")"
 
-		client, err := lib.NewClient(host, clientFlags.Common.TLSOptions, customHeaders)
+		client, err := lib.NewClient(host, string(api.Version), clientFlags.Common.TLSOptions, customHeaders)
 		if err != nil {
 			return err
 		}

--- a/api/client/lib/client_test.go
+++ b/api/client/lib/client_test.go
@@ -1,0 +1,36 @@
+package lib
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestGetAPIPath(t *testing.T) {
+	cases := []struct {
+		v string
+		p string
+		q url.Values
+		e string
+	}{
+		{"", "/containers/json", nil, "/containers/json"},
+		{"", "/containers/json", url.Values{}, "/containers/json"},
+		{"", "/containers/json", url.Values{"s": []string{"c"}}, "/containers/json?s=c"},
+		{"1.22", "/containers/json", nil, "/v1.22/containers/json"},
+		{"1.22", "/containers/json", url.Values{}, "/v1.22/containers/json"},
+		{"1.22", "/containers/json", url.Values{"s": []string{"c"}}, "/v1.22/containers/json?s=c"},
+		{"v1.22", "/containers/json", nil, "/v1.22/containers/json"},
+		{"v1.22", "/containers/json", url.Values{}, "/v1.22/containers/json"},
+		{"v1.22", "/containers/json", url.Values{"s": []string{"c"}}, "/v1.22/containers/json?s=c"},
+	}
+
+	for _, cs := range cases {
+		c, err := NewClient("unix:///var/run/docker.sock", cs.v, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		g := c.getAPIPath(cs.p, cs.q)
+		if g != cs.e {
+			t.Fatalf("Expected %s, got %s", cs.e, g)
+		}
+	}
+}


### PR DESCRIPTION
Remove dependencies on docker's version packages.
Allow empty version as a fallback to latest version.

/cc @dnephin, @tiborvass

Signed-off-by: David Calavera david.calavera@gmail.com
