### PR TITLE
Add unshare image to s390x Dockerfile

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -80,7 +80,8 @@ ENV IMAGEREPO s390x
 COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	$IMAGEREPO/busybox:latest \
-	$IMAGEREPO/hello-world:frozen 
+	$IMAGEREPO/hello-world:frozen \
+	$IMAGEREPO/unshare:latest 
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]


### PR DESCRIPTION
This adds the s390x/unshare image to Dockerfile.s390x. Continuation of #18506.
ping @brahmaroutu @duglin @estesp 

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
