### PR TITLE
fix install script for ubuntu trusty

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -78,7 +78,7 @@ check_forked() {
 			Upstream release is '$lsb_dist' version '$dist_version'.
 			EOF
 		else
-			if [ -r /etc/debian_version ]; then
+			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ]; then
 				# We're Debian and don't even know it!
 				lsb_dist=debian
 				dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"


### PR DESCRIPTION
spun up a trusty server and installed experimental and saw this was thinking it was debian jessie, same goes for installing via the script in a container see: https://jenkins.dockerproject.org/job/Docker%20Master%20(test%20install%20script)/194/console

ping @tianon 
