### PR TITLE
bash completion for `docker daemon --authz-plugin`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -656,6 +656,7 @@ _docker_daemon() {
 	local options_with_args="
 		$global_options_with_args
 		--api-cors-header
+		--authz-plugin
 		--bip
 		--bridge -b
 		--cluster-advertise


### PR DESCRIPTION
Ref #15365
Thanks @jfrazelle!
@thaJeztah I assume that there is no way to figure out the available plugins yet, do completion will accept any value. Maybe the installed plugins could be included in output of `docker info`?
