### PR TITLE
Add metadata function to layer store

### DIFF
--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -92,7 +92,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		}
 	}
 
-	m, err := layer.RWLayerMetadata(daemon.layerStore, c.ID)
+	m, err := daemon.layerStore.Metadata(c.ID)
 	if err != nil {
 		return derr.ErrorCodeGetLayerMetadata.WithArgs(err)
 	}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/daemon/network"
-	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/version"
 )
 
@@ -164,17 +163,7 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 
 	contJSONBase.GraphDriver.Name = container.Driver
 
-	image, err := daemon.imageStore.Get(container.ImageID)
-	if err != nil {
-		return nil, err
-	}
-	l, err := daemon.layerStore.Get(image.RootFS.ChainID())
-	if err != nil {
-		return nil, err
-	}
-	defer layer.ReleaseAndLog(daemon.layerStore, l)
-
-	graphDriverData, err := l.Metadata()
+	graphDriverData, err := daemon.layerStore.Metadata(container.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -132,6 +132,10 @@ func (ls *mockLayerStore) Changes(id string) ([]archive.Change, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (ls *mockLayerStore) Metadata(id string) (map[string]string, error) {
+	return nil, errors.New("not implemented")
+}
+
 type mockDownloadDescriptor struct {
 	currentDownloads *int32
 	id               string

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -209,8 +209,13 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 		return
 	}
 
+	imageDeviceID, err := inspectField("busybox", "GraphDriver.Data.DeviceId")
+	c.Assert(err, checker.IsNil)
+
 	deviceID, err := inspectField(out, "GraphDriver.Data.DeviceId")
 	c.Assert(err, checker.IsNil)
+
+	c.Assert(imageDeviceID, checker.Not(checker.Equals), deviceID)
 
 	_, err = strconv.Atoi(deviceID)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -151,6 +151,7 @@ type Store interface {
 	Unmount(id string) error
 	DeleteMount(id string) ([]Metadata, error)
 	Changes(id string) ([]archive.Change, error)
+	Metadata(id string) (map[string]string, error)
 }
 
 // MetadataTransaction represents functions for setting layer metadata

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -621,6 +621,17 @@ func (ls *layerStore) assembleTar(graphID string, metadata io.ReadCloser, size *
 	return pR, nil
 }
 
+// Metadata returns the low level metadata from the mount with the given name
+func (ls *layerStore) Metadata(name string) (map[string]string, error) {
+	ls.mountL.Lock()
+	m := ls.mounts[name]
+	ls.mountL.Unlock()
+	if m == nil {
+		return nil, ErrMountDoesNotExist
+	}
+	return ls.driver.GetMetadata(m.mountID)
+}
+
 type naiveDiffPathDriver struct {
 	graphdriver.Driver
 }

--- a/layer/layer_windows.go
+++ b/layer/layer_windows.go
@@ -34,24 +34,6 @@ func GetLayerPath(s Store, layer ChainID) (string, error) {
 	return path, nil
 }
 
-// RWLayerMetadata returns the graph metadata for the provided
-// mount name.
-func RWLayerMetadata(s Store, name string) (map[string]string, error) {
-	ls, ok := s.(*layerStore)
-	if !ok {
-		return nil, errors.New("unsupported layer store")
-	}
-	ls.mountL.Lock()
-	defer ls.mountL.Unlock()
-
-	ml, ok := ls.mounts[name]
-	if !ok {
-		return nil, errors.New("mount does not exist")
-	}
-
-	return ls.driver.GetMetadata(ml.mountID)
-}
-
 func (ls *layerStore) RegisterDiffID(graphID string, size int64) (Layer, error) {
 	var err error // this is used for cleanup in existingLayer case
 	diffID, err := digest.FromBytes([]byte(graphID))


### PR DESCRIPTION
Add function to get metadata from layer store for a mutable layer

Note: a refactor PR should follow this to clean up `RWLayer`. There are currently too many functions directly on layer store which are specific to `RWLayer`.

fixes #18614

ping @tonistiigi @runcom @rhvgoyal
