### PR TITLE
pkg: authorization: add Err to tweak response status code

### DIFF
--- a/docs/extend/authorization.md
+++ b/docs/extend/authorization.md
@@ -146,13 +146,13 @@ should implement the following two methods:
 **Request**:
 
 ```json
-{    
-    "User":              "The user identification"
-    "UserAuthNMethod":   "The authentication method used"
-    "RequestMethod":     "The HTTP method"
-    "RequestUri":        "The HTTP request URI"
-    "RequestBody":       "Byte array containing the raw HTTP request body"
-    "RequestHeader":     "Byte array containing the raw HTTP request header as a map[string][]string "
+{
+    "User":              "The user identification",
+    "UserAuthNMethod":   "The authentication method used",
+    "RequestMethod":     "The HTTP method",
+    "RequestUri":        "The HTTP request URI",
+    "RequestBody":       "Byte array containing the raw HTTP request body",
+    "RequestHeader":     "Byte array containing the raw HTTP request header as a map[string][]string ",
     "RequestStatusCode": "Request status code"
 }
 ```
@@ -160,27 +160,27 @@ should implement the following two methods:
 **Response**:
 
 ```json
-{    
-    "Allow" : "Determined whether the user is allowed or not"
-    "Msg":    "The authorization message"
+{
+    "Allow": "Determined whether the user is allowed or not",
+    "Msg":   "The authorization message",
+    "Err":   "The error message if things go wrong"
 }
 ```
-
 #### /AuthzPlugin.AuthZRes
 
 **Request**:
 
 ```json
 {
-    "User":              "The user identification"
-    "UserAuthNMethod":   "The authentication method used"
-    "RequestMethod":     "The HTTP method"
-    "RequestUri":        "The HTTP request URI"
-    "RequestBody":       "Byte array containing the raw HTTP request body"
-    "RequestHeader":     "Byte array containing the raw HTTP request header as a map[string][]string"
-    "RequestStatusCode": "Request status code"
-    "ResponseBody":      "Byte array containing the raw HTTP response body"
-    "ResponseHeader":    "Byte array containing the raw HTTP response header as a map[string][]string"
+    "User":              "The user identification",
+    "UserAuthNMethod":   "The authentication method used",
+    "RequestMethod":     "The HTTP method",
+    "RequestUri":        "The HTTP request URI",
+    "RequestBody":       "Byte array containing the raw HTTP request body",
+    "RequestHeader":     "Byte array containing the raw HTTP request header as a map[string][]string",
+    "RequestStatusCode": "Request status code",
+    "ResponseBody":      "Byte array containing the raw HTTP response body",
+    "ResponseHeader":    "Byte array containing the raw HTTP response header as a map[string][]string",
     "ResponseStatusCode":"Response status code"
 }
 ```
@@ -189,11 +189,12 @@ should implement the following two methods:
 
 ```json
 {
-   "Allow" :               "Determined whether the user is allowed or not"
-   "Msg":                  "The authorization message"
-   "ModifiedBody":         "Byte array containing a modified body of the raw HTTP body (or nil if no changes required)"
-   "ModifiedHeader":       "Byte array containing a modified header of the HTTP response (or nil if no changes required)"
-   "ModifiedStatusCode":   "int containing the modified version of the status code (or 0 if not change is required)"
+   "Allow":              "Determined whether the user is allowed or not",
+   "Msg":                "The authorization message",
+   "Err":                "The error message if things go wrong",
+   "ModifiedBody":       "Byte array containing a modified body of the raw HTTP body (or nil if no changes required)",
+   "ModifiedHeader":     "Byte array containing a modified header of the HTTP response (or nil if no changes required)",
+   "ModifiedStatusCode": "int containing the modified version of the status code (or 0 if not change is required)"
 }
 ```
 
@@ -222,7 +223,8 @@ Request body           | []byte            | Raw request body
 Name    | Type   | Description
 --------|--------|----------------------------------------------------------------------------------
 Allow   | bool   | Boolean value indicating whether the request is allowed or denied
-Message | string | Authorization message (will be returned to the client in case the access is denied)
+Msg     | string | Authorization message (will be returned to the client in case the access is denied)
+Err     | string | Error message (will be returned to the client in case the plugin encounter an error)
 
 ### Response authorization
 
@@ -249,4 +251,5 @@ Response body           | []byte            | Raw docker daemon response body
 Name    | Type   | Description
 --------|--------|----------------------------------------------------------------------------------
 Allow   | bool   | Boolean value indicating whether the response is allowed or denied
-Message | string | Authorization message (will be returned to the client in case the access is denied)
+Msg     | string | Authorization message (will be returned to the client in case the access is denied)
+Err     | string | Error message (will be returned to the client in case the plugin encounter an error)

--- a/pkg/authorization/api.go
+++ b/pkg/authorization/api.go
@@ -43,10 +43,12 @@ type Request struct {
 
 // Response represents authZ plugin response
 type Response struct {
-
 	// Allow indicating whether the user is allowed or not
 	Allow bool `json:"Allow"`
 
 	// Msg stores the authorization message
 	Msg string `json:"Msg,omitempty"`
+
+	// Err stores a message in case there's an error
+	Err string `json:"Err,omitempty"`
 }

--- a/pkg/authorization/authz.go
+++ b/pkg/authorization/authz.go
@@ -84,6 +84,10 @@ func (a *Ctx) AuthZRequest(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 
+		if authRes.Err != "" {
+			return fmt.Errorf(authRes.Err)
+		}
+
 		if !authRes.Allow {
 			return fmt.Errorf(authRes.Msg)
 		}
@@ -105,6 +109,10 @@ func (a *Ctx) AuthZResponse(rm ResponseModifier, r *http.Request) error {
 		authRes, err := plugin.AuthZResponse(a.authReq)
 		if err != nil {
 			return err
+		}
+
+		if authRes.Err != "" {
+			return fmt.Errorf(authRes.Err)
 		}
 
 		if !authRes.Allow {


### PR DESCRIPTION
This will allow plugin implementations to reply easily with a 500 status code if `Response.Err` isn't an empty string and there was an error (which doesn't imply not authorized, but just something went wrong)
I'm actually hardcoding `Err` in my Response proxy type and using it at https://github.com/runcom/dkauthz/blob/master/api.go#L122 but I think it would be generally useful here as well

ping @liron-l @nalind 

Signed-off-by: Antonio Murdaca runcom@redhat.com
