### PR TITLE
Move registry.SearchResult types to api/types/registry

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/docker/docker/api/client/lib"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/parsers/filters"
-	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 )
 

--- a/api/client/lib/image_search.go
+++ b/api/client/lib/image_search.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/registry"
+	"github.com/docker/docker/api/types/registry"
 )
 
 // ImageSearch makes the docker host to search by a term in a remote registry.

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringutils"
@@ -83,7 +84,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 }
 
 // SearchResultsByStars sorts search results in descending order by number of stars.
-type searchResultsByStars []registry.SearchResult
+type searchResultsByStars []registrytypes.SearchResult
 
 func (r searchResultsByStars) Len() int           { return len(r) }
 func (r searchResultsByStars) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -73,3 +73,29 @@ type IndexInfo struct {
 	// Official indicates whether this is an official registry
 	Official bool
 }
+
+// SearchResult describes a search result returned from a registry
+type SearchResult struct {
+	// StarCount indicates the number of stars this repository has
+	StarCount int `json:"star_count"`
+	// IsOfficial indicates whether the result is an official repository or not
+	IsOfficial bool `json:"is_official"`
+	// Name is the name of the repository
+	Name string `json:"name"`
+	// IsOfficial indicates whether the result is trusted
+	IsTrusted bool `json:"is_trusted"`
+	// IsAutomated indicates whether the result is automated
+	IsAutomated bool `json:"is_automated"`
+	// Description is a textual description of the repository
+	Description string `json:"description"`
+}
+
+// SearchResults lists a collection search results returned from a registry
+type SearchResults struct {
+	// Query contains the query string that generated the search results
+	Query string `json:"query"`
+	// NumResults indicates the number of results the query returned
+	NumResults int `json:"num_results"`
+	// Results is a slice containing the actual results for the search
+	Results []SearchResult `json:"results"`
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/exec"
@@ -1508,7 +1509,7 @@ func (daemon *Daemon) AuthenticateToRegistry(authConfig *types.AuthConfig) (stri
 // term. authConfig is used to login.
 func (daemon *Daemon) SearchRegistryForImages(term string,
 	authConfig *types.AuthConfig,
-	headers map[string][]string) (*registry.SearchResults, error) {
+	headers map[string][]string) (*registrytypes.SearchResults, error) {
 	return daemon.RegistryService.Search(term, authConfig, headers)
 }
 

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -460,10 +460,10 @@ func handlerAuth(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerSearch(w http.ResponseWriter, r *http.Request) {
-	result := &SearchResults{
+	result := &registrytypes.SearchResults{
 		Query:      "fakequery",
 		NumResults: 1,
-		Results:    []SearchResult{{Name: "fakeimage", StarCount: 42}},
+		Results:    []registrytypes.SearchResult{{Name: "fakeimage", StarCount: 42}},
 	}
 	writeResponse(w, result, 200)
 }

--- a/registry/service.go
+++ b/registry/service.go
@@ -73,7 +73,7 @@ func splitReposSearchTerm(reposName string) (string, string) {
 
 // Search queries the public registry for images matching the specified
 // search terms, and returns the results.
-func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[string][]string) (*SearchResults, error) {
+func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	if err := validateNoSchema(term); err != nil {
 		return nil, err
 	}

--- a/registry/session.go
+++ b/registry/session.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"
@@ -718,7 +719,7 @@ func shouldRedirect(response *http.Response) bool {
 }
 
 // SearchRepositories performs a search against the remote repository
-func (r *Session) SearchRepositories(term string) (*SearchResults, error) {
+func (r *Session) SearchRepositories(term string) (*registrytypes.SearchResults, error) {
 	logrus.Debugf("Index server: %s", r.indexEndpoint)
 	u := r.indexEndpoint.VersionString(1) + "search?q=" + url.QueryEscape(term)
 
@@ -736,7 +737,7 @@ func (r *Session) SearchRepositories(term string) (*SearchResults, error) {
 	if res.StatusCode != 200 {
 		return nil, httputils.NewHTTPRequestError(fmt.Sprintf("Unexpected status code %d", res.StatusCode), res)
 	}
-	result := new(SearchResults)
+	result := new(registrytypes.SearchResults)
 	return result, json.NewDecoder(res.Body).Decode(result)
 }
 

--- a/registry/types.go
+++ b/registry/types.go
@@ -5,32 +5,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
-// SearchResult describes a search result returned from a registry
-type SearchResult struct {
-	// StarCount indicates the number of stars this repository has
-	StarCount int `json:"star_count"`
-	// IsOfficial indicates whether the result is an official repository or not
-	IsOfficial bool `json:"is_official"`
-	// Name is the name of the repository
-	Name string `json:"name"`
-	// IsOfficial indicates whether the result is trusted
-	IsTrusted bool `json:"is_trusted"`
-	// IsAutomated indicates whether the result is automated
-	IsAutomated bool `json:"is_automated"`
-	// Description is a textual description of the repository
-	Description string `json:"description"`
-}
-
-// SearchResults lists a collection search results returned from a registry
-type SearchResults struct {
-	// Query contains the query string that generated the search results
-	Query string `json:"query"`
-	// NumResults indicates the number of results the query returned
-	NumResults int `json:"num_results"`
-	// Results is a slice containing the actual results for the search
-	Results []SearchResult `json:"results"`
-}
-
 // RepositoryData tracks the image list, list of endpoints, and list of tokens
 // for a repository
 type RepositoryData struct {


### PR DESCRIPTION
This is the last of the registry types used by both client and daemon. While these types aren't actually part of the interface definition they are used by both sides, so hopefully it's alright to put them into `api/types/registry`.

cc @calavera 
