### PR TITLE
Avoid outputting last progress item twice

### DIFF
--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -41,15 +41,6 @@ func TestTransfer(t *testing.T) {
 				if p.Current != 0 {
 					t.Fatalf("got unexpected progress value: %d (expected 0)", p.Current)
 				}
-			} else if p.Current == 10 {
-				// Special case: last progress output may be
-				// repeated because the transfer finishing
-				// causes the latest progress output to be
-				// written to the channel (in case the watcher
-				// missed it).
-				if p.Current != 9 && p.Current != 10 {
-					t.Fatalf("got unexpected progress value: %d (expected %d)", p.Current, val+1)
-				}
 			} else if p.Current != val+1 {
 				t.Fatalf("got unexpected progress value: %d (expected %d)", p.Current, val+1)
 			}


### PR DESCRIPTION
A watcher would output the current progress item when it was detached, in case it missed that item earlier, which would leave the user seeing some intermediate step of the operation. This commit changes it to only output it on detach if it didn't already output the same item.

This fixes a duplicate `Pull complete` message seen when the output isn't a TTY. See discussion at https://github.com/docker/docker/pull/18210#issuecomment-163788056 and https://github.com/docker/docker/pull/17428#discussion_r47672500.
