### PR TITLE
Remove unecessary chown on mqueue device path

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -888,9 +888,6 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 		if err := syscall.Mount("mqueue", mqueuePath, "mqueue", uintptr(syscall.MS_NOEXEC|syscall.MS_NOSUID|syscall.MS_NODEV), ""); err != nil {
 			return fmt.Errorf("mounting mqueue mqueue : %s", err)
 		}
-		if err := os.Chown(mqueuePath, rootUID, rootGID); err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
This was causing the host /dev/mqueue to be remapped to the daemon's
user namespace range root user and group. Given the perms are open on
the mqueue path, there is no need to chown this path at all.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
