### PR TITLE
Add note to volume docs that data is not copied to mounted volumes

### DIFF
--- a/docs/userguide/dockervolumes.md
+++ b/docs/userguide/dockervolumes.md
@@ -29,7 +29,8 @@ containers that bypasses the [*Union File System*](../reference/glossary.md#unio
 
 - Volumes are initialized when a container is created. If the container's
   base image contains data at the specified mount point, that existing data is
-  copied into the new volume upon volume initialization.
+  copied into the new volume upon volume initialization. (Note that this does
+  not apply when [mounting a host directory](#mount-a-host-directory-as-a-data-volume).)
 - Data volumes can be shared and reused among containers.
 - Changes to a data volume are made directly.
 - Changes to a data volume will not be included when you update an image.


### PR DESCRIPTION
In the [volume docs](https://docs.docker.com/engine/userguide/dockervolumes/), it says under /Data volumes/: “If the container’s base image contains data at the specified mount point, that existing data is copied into the new volume upon volume initialization.”

This does not apply when host directories are mounted as volumes, as is also explained further down on the page.

This patch adds a note about this to the docs to prevent confusion.

fixes https://github.com/docker/docker/issues/13984
