### PR TITLE
Add the filename to the error message while trying to parse the config file

### DIFF
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -161,15 +161,18 @@ func Load(configDir string) (*ConfigFile, error) {
 	if _, err := os.Stat(configFile.filename); err == nil {
 		file, err := os.Open(configFile.filename)
 		if err != nil {
-			return &configFile, err
+			return &configFile, fmt.Errorf("%s - %v", configFile.filename, err)
 		}
 		defer file.Close()
 		err = configFile.LoadFromReader(file)
+		if err != nil {
+			err = fmt.Errorf("%s - %v", configFile.filename, err)
+		}
 		return &configFile, err
 	} else if !os.IsNotExist(err) {
 		// if file is there but we can't stat it for any reason other
 		// than it doesn't exist then stop
-		return &configFile, err
+		return &configFile, fmt.Errorf("%s - %v", configFile.filename, err)
 	}
 
 	// Can't find latest config file so check for the old one
@@ -179,12 +182,12 @@ func Load(configDir string) (*ConfigFile, error) {
 	}
 	file, err := os.Open(confFile)
 	if err != nil {
-		return &configFile, err
+		return &configFile, fmt.Errorf("%s - %v", confFile, err)
 	}
 	defer file.Close()
 	err = configFile.LegacyLoadFromReader(file)
 	if err != nil {
-		return &configFile, err
+		return &configFile, fmt.Errorf("%s - %v", confFile, err)
 	}
 
 	if configFile.HTTPHeaders == nil {

--- a/cliconfig/config_test.go
+++ b/cliconfig/config_test.go
@@ -138,8 +138,9 @@ email`: "Invalid Auth config file",
 		}
 
 		config, err := Load(tmpHome)
-		if err == nil || err.Error() != expectedError {
-			t.Fatalf("Should have failed, got: %q, %q", config, err)
+		// Use Contains instead of == since the file name will change each time
+		if err == nil || !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Should have failed\nConfig: %v\nGot: %v\nExpected: %v", config, err, expectedError)
 		}
 
 	}
@@ -207,7 +208,8 @@ func TestOldJsonInvalid(t *testing.T) {
 	}
 
 	config, err := Load(tmpHome)
-	if err == nil || err.Error() != "Invalid auth configuration file" {
+	// Use Contains instead of == since the file name will change each time
+	if err == nil || !strings.Contains(err.Error(), "Invalid auth configuration file") {
 		t.Fatalf("Expected an error got : %v, %v", config, err)
 	}
 }


### PR DESCRIPTION
Noticed this while looking at #18634. W/o this extra text we're not sure if
its complaining about the old or new config file.

Signed-off-by: Doug Davis dug@us.ibm.com
