### PR TITLE
Remove build time arg from history

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -410,6 +410,21 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 	// have the build-time env vars in it (if any) so that future cache look-ups
 	// properly match it.
 	b.runConfig.Env = env
+
+	// remove build time arg form saveCmd
+	if len(cmdBuildEnv) > 0 {
+		var tmpSaveCmd []string
+		tmpSaveCmd = saveCmd.Slice()
+		tmpEnv := append([]string{fmt.Sprintf("|%d", len(cmdBuildEnv))}, cmdBuildEnv...)
+		for _, env := range tmpEnv {
+			for i, e := range tmpSaveCmd {
+				if env == e {
+					tmpSaveCmd = append(tmpSaveCmd[:i], tmpSaveCmd[i+1:]...)
+				}
+			}
+		}
+		saveCmd = stringutils.NewStrSlice(tmpSaveCmd...)
+	}
 	b.runConfig.Cmd = saveCmd
 	return b.commit(cID, cmd, "run")
 }


### PR DESCRIPTION
When use --build-arg during build, the build-arg will be shown in
docker history of the image. It's dangerous because we alway use
http_proxy or https_proxy build args which contain the proxy accout
and password. For example:

<pre><code>
$ cat Dockerfile
FROM busybox

RUN echo "Hello world"

$ docker build --build-arg http_proxy=http://accout:passwd@server:port .
Sending build context to Docker daemon 2.048 kB
Step 1 : FROM busybox
 ---> d9551b4026f0
Step 2 : RUN echo "Hello world"
 ---> Running in 604a95da2760
Hello world
 ---> 892cbca9cf9a
Removing intermediate container 604a95da2760
Successfully built 892cbca9cf9a

$ docker history 892cbca9cf9a
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
892cbca9cf9a        7 seconds ago       |1 http_proxy=http://accout:passwd@server:por   0 B
d9551b4026f0        7 days ago          /bin/sh -c #(nop) CMD ["sh"]                    0 B
<missing>           7 days ago          /bin/sh -c #(nop) ADD file:c295b0748bf05d4527   1.113 MB

</code></pre>

 I think we should remove the build time arg from the
history.
ping @tiborvass  @mapuri

Signed-off-by: Lei Jitang leijitang@huawei.com
