### PR TITLE
docs: extend: plugins_volume.md: Err default to empty string

### DIFF
--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -65,7 +65,7 @@ Opts is a map of driver specific options passed through from the user request.
 **Response**:
 ```
 {
-    "Err": null
+    "Err": ""
 }
 ```
 
@@ -85,7 +85,7 @@ Delete the specified volume from disk. This request is issued when a user invoke
 **Response**:
 ```
 {
-    "Err": null
+    "Err": ""
 }
 ```
 
@@ -109,7 +109,7 @@ at the first mount request and deprovision at the last corresponding unmount req
 ```
 {
     "Mountpoint": "/path/to/directory/on/host",
-    "Err": null
+    "Err": ""
 }
 ```
 
@@ -131,7 +131,7 @@ Docker needs reminding of the path to the volume on the host.
 ```
 {
     "Mountpoint": "/path/to/directory/on/host",
-    "Err": null
+    "Err": ""
 }
 ```
 
@@ -154,7 +154,7 @@ this point.
 **Response**:
 ```
 {
-    "Err": null
+    "Err": ""
 }
 ```
 


### PR DESCRIPTION
nit picking, cause `Err` is an empty string not a `null` when empty

Signed-off-by: Antonio Murdaca runcom@redhat.com
