### PR TITLE
Remove `IsPaused` from backend interface.

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -44,7 +44,6 @@ type stateBackend interface {
 	ContainerUnpause(name string) error
 	ContainerWait(name string, timeout time.Duration) (int, error)
 	Exists(id string) bool
-	IsPaused(id string) bool
 }
 
 // monitorBackend includes functions to implement to provide containers monitoring functionality.

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -400,29 +400,11 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 	}
 	containerName := vars["name"]
 
-	if !s.backend.Exists(containerName) {
-		return derr.ErrorCodeNoSuchContainer.WithArgs(containerName)
-	}
-
-	if s.backend.IsPaused(containerName) {
-		return derr.ErrorCodePausedContainer.WithArgs(containerName)
-	}
-
-	inStream, outStream, err := httputils.HijackConnection(w)
-	if err != nil {
-		return err
-	}
-	defer httputils.CloseStreams(inStream, outStream)
-
-	if _, ok := r.Header["Upgrade"]; ok {
-		fmt.Fprintf(outStream, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
-	} else {
-		fmt.Fprintf(outStream, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n")
-	}
+	_, upgrade := r.Header["Upgrade"]
 
 	attachWithLogsConfig := &daemon.ContainerAttachWithLogsConfig{
-		InStream:  inStream,
-		OutStream: outStream,
+		Hijacker:  w.(http.Hijacker),
+		Upgrade:   upgrade,
 		UseStdin:  httputils.BoolValue(r, "stdin"),
 		UseStdout: httputils.BoolValue(r, "stdout"),
 		UseStderr: httputils.BoolValue(r, "stderr"),
@@ -430,11 +412,7 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 		Stream:    httputils.BoolValue(r, "stream"),
 	}
 
-	if err := s.backend.ContainerAttachWithLogs(containerName, attachWithLogsConfig); err != nil {
-		fmt.Fprintf(outStream, "Error attaching: %s\n", err)
-	}
-
-	return nil
+	return s.backend.ContainerAttachWithLogs(containerName, attachWithLogsConfig)
 }
 
 func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/errors/server.go
+++ b/errors/server.go
@@ -33,4 +33,13 @@ var (
 		Description:    "Docker's networking stack is disabled for this platform",
 		HTTPStatusCode: http.StatusNotFound,
 	})
+
+	// ErrorCodeNoHijackConnection is generated when a request tries to attach to a container
+	// but the connection to hijack is not provided.
+	ErrorCodeNoHijackConnection = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "HIJACK_CONNECTION_MISSING",
+		Message:        "error attaching to container %s, hijack connection missing",
+		Description:    "The caller didn't provide a connection to hijack",
+		HTTPStatusCode: http.StatusBadRequest,
+	})
 )


### PR DESCRIPTION
Move connection hijacking logic to the daemon.
This makes the attach endpoint in the API more flexible for other backends.

/cc @icecrime, @tiborvass

Signed-off-by: David Calavera david.calavera@gmail.com
