### PR TITLE
Add support for partial load

### DIFF
--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -73,9 +73,14 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer) error {
 			if err != nil {
 				return err
 			}
-			newLayer, err := l.loadLayer(layerPath, rootFS)
+			r := rootFS
+			r.Append(diffID)
+			newLayer, err := l.ls.Get(r.ChainID())
 			if err != nil {
-				return err
+				newLayer, err = l.loadLayer(layerPath, rootFS)
+				if err != nil {
+					return err
+				}
 			}
 			defer layer.ReleaseAndLog(l.ls, newLayer)
 			if expected, actual := diffID, newLayer.DiffID(); expected != actual {


### PR DESCRIPTION
Missing layers in tar will not cause an error if 
layers are already loaded before.

Fixes #18723

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com

cc @tianon 
