### PR TITLE
update Dockerfile.arm to reflect latest changes in main Dockerfile

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -39,18 +39,22 @@ RUN apt-get update && apt-get install -y \
 	dpkg-sig \
 	git \
 	iptables \
+	jq \
 	libapparmor-dev \
 	libcap-dev \
+	libltdl-dev \
 	libsqlite3-dev \
 	libsystemd-journal-dev \
+	libtool \
 	mercurial \
-	parallel \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \
 	s3cmd=1.1.0* \
+	xfsprogs \
+	tar \
 	--no-install-recommends
 
 # Get lvm2 source for compiling statically
@@ -96,6 +100,23 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 
 	&& (cd /go/src/github.com/golang/lint && git checkout -q $GO_LINT_COMMIT) \
 	&& go install -v github.com/golang/lint/golint
 
+# install seccomp
+# this can be changed to the ubuntu package libseccomp-dev if dockerinit is removed,
+# we need libseccomp.a (which the package does not provide) for dockerinit
+ENV SECCOMP_VERSION v2.2.3
+RUN set -x \
+	&& export SECCOMP_PATH=$(mktemp -d) \
+	&& git clone https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+	&& ( \
+		cd "$SECCOMP_PATH" \
+		&& git checkout "$SECCOMP_VERSION" \
+		&& ./autogen.sh \
+		&& ./configure --prefix=/usr \
+		&& make \
+		&& make install \
+	) \
+	&& rm -rf "$SECCOMP_PATH"
+
 # Install registry
 ENV REGISTRY_COMMIT ec87e9b6971d831f0eff752ddb54fb64693e51cd
 RUN set -x \
@@ -140,7 +161,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc
@@ -149,18 +170,18 @@ RUN ln -sfv $PWD/.bashrc ~/.bashrc
 RUN ln -sv $PWD/contrib/completion/bash/docker /etc/bash_completion.d/docker
 
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
-COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/
-RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
-  hypriot/armhf-busybox@ea0800bb83571c585c5652b53668e76b29c7c0eef719892f9d0a48607984f9e1 \
-  hypriot/armhf-hello-world@508c59a4f8b23c77bbcf43296c3f580873dc7eecb1f0d680cea3067e221fd4c2 \
-  hypriot/armhf-unshare@3f1db65f8bbabc743fd739cf7145a56c35b2a0979ae3174e9d79b7fa4b00fca1
+COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
+RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
+  hypriot/armhf-busybox:latest@sha256:b0fc94dac9793ce3c35607b15012b4c7deca300963a7cc38ab440189ec81e2e7 \
+  hypriot/armhf-hello-world:latest@sha256:b618ec0cc3acf683e8d77ad6c5ec81546cddde2036eda9a78f628effdeca74cd \
+  hypriot/armhf-unshare:latest@sha256:8fede091760d2fb8b2d14cedffdd681c4575b02b1abeeb18dd79b754c62327db
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
-	&& git clone -b v1.2 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
+ 	&& git clone -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \
 	&& rm -rf "$GOPATH"

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,6 @@
 
 # get OS/Arch of docker engine
 DOCKER_ENGINE_OSARCH = $(shell docker version | grep 'OS/Arch' | tail -1 | cut -d':' -f2 | tr -d '[[:space:]]')
-DOCKER_ENGINE_GOOS = $(word 1, $(subst /, ,$(DOCKER_ENGINE_OSARCH)))
-DOCKER_ENGINE_GOARCH = $(word 2, $(subst /, ,$(DOCKER_ENGINE_OSARCH)))
-export DOCKER_ENGINE_OSARCH
-export DOCKER_ENGINE_GOOS
-export DOCKER_ENGINE_GOARCH
 # default for linux/amd64 and others
 DOCKER_FILE = Dockerfile
 # switch to different Dockerfile for linux/arm
@@ -22,9 +17,6 @@ DOCKER_ENVS := \
 	-e BUILDFLAGS \
 	-e DOCKER_CLIENTONLY \
 	-e DOCKER_DEBUG \
-	-e DOCKER_ENGINE_GOARCH \
-	-e DOCKER_ENGINE_GOOS \
-	-e DOCKER_ENGINE_OSARCH \
 	-e DOCKER_EXPERIMENTAL \
 	-e DOCKER_FILE \
 	-e DOCKER_GRAPHDRIVER \

--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -5,9 +5,9 @@ set -e
 case "$DOCKER_ENGINE_OSARCH" in
 	linux/arm)
 		images=(
-			hypriot/armhf-busybox@ea0800bb83571c585c5652b53668e76b29c7c0eef719892f9d0a48607984f9e1
-			hypriot/armhf-hello-world@508c59a4f8b23c77bbcf43296c3f580873dc7eecb1f0d680cea3067e221fd4c2
-			hypriot/armhf-unshare@3f1db65f8bbabc743fd739cf7145a56c35b2a0979ae3174e9d79b7fa4b00fca1
+			hypriot/armhf-busybox:latest
+			hypriot/armhf-hello-world:latest
+			hypriot/armhf-unshare:latest
 		)
 		;;
 	linux/ppc64le)

--- a/hack/make/.integration-daemon-setup
+++ b/hack/make/.integration-daemon-setup
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Retrieve OS/ARCH of docker daemon, eg. linux/amd64
+export DOCKER_ENGINE_OSARCH=$(docker version | grep 'OS/Arch' | tail -1 | cut -d':' -f2 | tr -d '[[:space:]]')
+# Retrieve OS of docker daemon, eg. linux
+export DOCKER_ENGINE_GOOS=$(echo $DOCKER_ENGINE_OSARCH | cut -d'/' -f1)
+# Retrieve ARCH of docker daemon, eg. amd64
+export DOCKER_ENGINE_GOARCH=$(echo $DOCKER_ENGINE_OSARCH | cut -d'/' -f2)
+
 bundle .ensure-emptyfs
 bundle .ensure-frozen-images
 bundle .ensure-httpserver


### PR DESCRIPTION
Following the latest changes to the main Dockerfile I updated the Dockerfile.arm accordingly.

The changes were:
- [update go-md2man](https://github.com/docker/docker/commit/6842c906c44fefeb3ca78aae550e64341e040391)
- [add tar package to support tmpfs mount support](https://github.com/docker/docker/commit/b3e527dfd242ad30c0297c8b257862116cf2c50e)
- [add xfsprogs for devmapper](https://github.com/docker/docker/commit/2b766a455cc01f3fd51be886c9e61c0b6a5fdeb1)
- [add initial seccomp support](https://github.com/docker/docker/pull/17989)
- [remove parallel os package](https://github.com/docker/docker/pull/18417)

[Upgrading to go version 1.5.2](https://github.com/docker/docker/commit/2b766a455cc01f3fd51be886c9e61c0b6a5fdeb1) DID NOT work out well. I got [lots of errors](https://gist.github.com/Govinda-Fichtner/78da2b9bf1ba20809a96). 

/cc @jfrazelle This PR will help to overcome the latest problems in PR #18176. 
