### PR TITLE
Better debug message for post form data

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -38,7 +38,12 @@ func debugRequestMiddleware(handler httputils.APIFunc) httputils.APIFunc {
 						if _, exists := postForm["password"]; exists {
 							postForm["password"] = "*****"
 						}
-						logrus.Debugf("form data: %q", postForm)
+						formStr, errMarshal := json.Marshal(postForm)
+						if errMarshal == nil {
+							logrus.Debugf("form data: %s", string(formStr))
+						} else {
+							logrus.Debugf("form data: %q", postForm)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Print json format instead of default `%q` format.

Debug error message is always good, better format is better. :smile: 

Original debug info:

```
DEBU[1082] POST /v1.22/containers/create?name=test
DEBU[1082] form data: map["Domainname":"" "AttachStderr":%!q(bool=false) "Tty":%!q(bool=true) "OnBuild":<nil> "Entrypoint":<nil> "AttachStdin":%!q(bool=false) "AttachStdout":%!q(bool=false) "Image":"ubuntu" "Volumes":map[] "Labels":map[] "StopSignal":"SIGTERM" "User":"" "OpenStdin":%!q(bool=true) "Env":[] "Cmd":["bash"] "Hostname":"" "StdinOnce":%!q(bool=false) "WorkingDir":"" "HostConfig":map["ShmSize":<nil> "Isolation":"" "CpuShares":%!q(float64=0) "BlkioDeviceReadBps":<nil> "VolumeDriver":"" "VolumesFrom":<nil> "CapAdd":<nil> "OomKillDisable":%!q(bool=false) "BlkioWeight":%!q(float64=0) "Devices":[] "MemorySwap":%!q(float64=0) "Ulimits":<nil> "PortBindings":map[] "Dns":[] "UTSMode":"" "ConsoleSize":[%!q(float64=0) %!q(float64=0)] "CpusetMems":"" "DnsSearch":[] "ExtraHosts":<nil> "GroupAdd":<nil> "ReadonlyRootfs":%!q(bool=false) "LogConfig":map["Type":"" "Config":map[]] "CapDrop":<nil> "CgroupParent":"" "Memory":%!q(float64=0) "Binds":<nil> "RestartPolicy":map["Name":"no" "MaximumRetryCount":%!q(float64=0)] "PidMode":"" "BlkioWeightDevice":<nil> "CpuPeriod":%!q(float64=0) "CpusetCpus":"" "MemoryReservation":%!q(float64=0) "DnsOptions":[] "OomScoreAdj":%!q(float64=0) "Privileged":%!q(bool=false) "SecurityOpt":<nil> "MemorySwappiness":%!q(float64=-1) "NetworkMode":"default" "Links":<nil> "KernelMemory":%!q(float64=0) "CpuQuota":%!q(float64=0) "ContainerIDFile":"" "IpcMode":"" "PublishAllPorts":%!q(bool=false) "BlkioDeviceWriteBps":<nil>]]
```

Json format of this error message:

```
DEBU[0003] form data: {"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["bash"],"Domainname":"","Entrypoint":null,"Env":[],"HostConfig":{"Binds":null,"BlkioDeviceReadBps":null,"BlkioDeviceWriteBps":null,"BlkioWeight":0,"BlkioWeightDevice":null,"CapAdd":null,"CapDrop":null,"CgroupParent":"","ConsoleSize":[0,0],"ContainerIDFile":"","CpuPeriod":0,"CpuQuota":0,"CpuShares":0,"CpusetCpus":"","CpusetMems":"","Devices":[],"Dns":[],"DnsOptions":[],"DnsSearch":[],"ExtraHosts":null,"GroupAdd":null,"IpcMode":"","Isolation":"","KernelMemory":0,"Links":null,"LogConfig":{"Config":{},"Type":""},"Memory":0,"MemoryReservation":0,"MemorySwap":0,"MemorySwappiness":-1,"NetworkMode":"default","OomKillDisable":false,"OomScoreAdj":0,"PidMode":"","PortBindings":{},"Privileged":false,"PublishAllPorts":false,"ReadonlyRootfs":false,"RestartPolicy":{"MaximumRetryCount":0,"Name":"no"},"SecurityOpt":null,"ShmSize":null,"UTSMode":"","Ulimits":null,"VolumeDriver":"","VolumesFrom":null},"Hostname":"","Image":"ubuntu","Labels":{},"OnBuild":null,"OpenStdin":true,"StdinOnce":false,"StopSignal":"SIGTERM","Tty":true,"User":"","Volumes":{},"WorkingDir":""}
```

Extra benefit is that we can use python tool to format json message. e.g.

```
# echo xxxxx | python -mjson.tool
{
    "AttachStderr": false,
    "AttachStdin": false,
    "AttachStdout": false,
    "Cmd": [
        "bash"
    ],
    "Domainname": "",
    "Entrypoint": null,
    "Env": [],
    "HostConfig": {
        "Binds": null,
        "BlkioDeviceReadBps": null,
        "BlkioDeviceWriteBps": null,
        "BlkioWeight": 0,
        "BlkioWeightDevice": null,
        "CapAdd": null,
        "CapDrop": null,
        "CgroupParent": "",
        "ConsoleSize": [
            0,
            0
        ],
        "ContainerIDFile": "",
        "CpuPeriod": 0,
        "CpuQuota": 0,
        "CpuShares": 0,
        "CpusetCpus": "",
        "CpusetMems": "",
        "Devices": [],
        "Dns": [],
        "DnsOptions": [],
        "DnsSearch": [],
        "ExtraHosts": null,
        "GroupAdd": null,
        "IpcMode": "",
        "Isolation": "",
        "KernelMemory": 0,
        "Links": null,
        "LogConfig": {
            "Config": {},
            "Type": ""
        },
        "Memory": 0,
        "MemoryReservation": 0,
        "MemorySwap": 0,
        "MemorySwappiness": -1,
        "NetworkMode": "default",
        "OomKillDisable": false,
        "OomScoreAdj": 0,
        "PidMode": "",
        "PortBindings": {},
        "Privileged": false,
        "PublishAllPorts": false,
        "ReadonlyRootfs": false,
        "RestartPolicy": {
            "MaximumRetryCount": 0,
            "Name": "no"
        },
        "SecurityOpt": null,
        "ShmSize": null,
        "UTSMode": "",
        "Ulimits": null,
        "VolumeDriver": "",
        "VolumesFrom": null
    },
    "Hostname": "",
    "Image": "ubuntu",
    "Labels": {},
    "OnBuild": null,
    "OpenStdin": true,
    "StdinOnce": false,
    "StopSignal": "SIGTERM",
    "Tty": true,
    "User": "",
    "Volumes": {},
    "WorkingDir": ""
}
```

Signed-off-by: Zhang Wei zhangwei555@huawei.com
