### PR TITLE
Sync the docker network create api docs with the error code

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -2763,13 +2763,13 @@ Content-Type: application/json
 Status Codes:
 
 - **201** - no error
-- **404** - driver not found
+- **404** - plugin not found
 - **500** - server error
 
 JSON Parameters:
 
 - **Name** - The new network's name. this is a mandatory field
-- **Driver** - Name of the network driver to use. Defaults to `bridge` driver
+- **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
 - **IPAM** - Optional custom IP scheme for the network
 - **Options** - Network specific options to be used by the drivers
 - **CheckDuplicate** - Requests daemon to check for networks with same name

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2893,13 +2893,13 @@ Content-Type: application/json
 Status Codes:
 
 - **201** - no error
-- **404** - driver not found
+- **404** - plugin not found
 - **500** - server error
 
 JSON Parameters:
 
 - **Name** - The new network's name. this is a mandatory field
-- **Driver** - Name of the network driver to use. Defaults to `bridge` driver
+- **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
 - **IPAM** - Optional custom IP scheme for the network
 - **Options** - Network specific options to be used by the drivers
 - **CheckDuplicate** - Requests daemon to check for networks with same name


### PR DESCRIPTION
```
$ curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d '{"Name":"testapi", "Driver":"weave"}' --unix-socket /var/run/docker.sock http:/networks/create   HTTP/1.1
HTTP/1.1 404 Not Found
Content-Type: text/plain; charset=utf-8
Server: Docker/1.9.1 (linux)
Date: Thu, 17 Dec 2015 09:36:45 GMT
Content-Length: 17

Plugin not found
```

error code is here :  https://github.com/docker/docker/blob/master/pkg/plugins/discovery.go#L16

Signed-off-by: Wen Cheng Ma wenchma@cn.ibm.com
