### PR TITLE
pkg: plugins: remove dead code

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -18,23 +18,15 @@ var (
 	specsPaths  = []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}
 )
 
-// Registry defines behavior of a registry of plugins.
-type Registry interface {
-	// Plugins lists all plugins.
-	Plugins() ([]*Plugin, error)
-	// Plugin returns the plugin registered with the given name (or returns an error).
-	Plugin(name string) (*Plugin, error)
-}
+// localRegistry defines a registry that is local (using unix socket).
+type localRegistry struct{}
 
-// LocalRegistry defines a registry that is local (using unix socket).
-type LocalRegistry struct{}
-
-func newLocalRegistry() LocalRegistry {
-	return LocalRegistry{}
+func newLocalRegistry() localRegistry {
+	return localRegistry{}
 }
 
 // Plugin returns the plugin registered with the given name (or returns an error).
-func (l *LocalRegistry) Plugin(name string) (*Plugin, error) {
+func (l *localRegistry) Plugin(name string) (*Plugin, error) {
 	socketpaths := pluginPaths(socketsPath, name, ".sock")
 
 	for _, p := range socketpaths {


### PR DESCRIPTION
`Registry` interface was not implemented and `LocalRegistry` is an internal type. I don't know if this will break someone (probably?)

I could implement the rest of the interface instead to not remove the interface but I see no reason for the interface now (i cannot think use cases where this inteface is helpful, but maybe i'm wrong).. @calavera @cpuguy83 WDYT?

Signed-off-by: Antonio Murdaca runcom@redhat.com
