### PR TITLE
pkg: version: add String method

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -37,6 +37,11 @@ func (v Version) compareTo(other Version) int {
 	return 0
 }
 
+// String returns the version string
+func (v Version) String() string {
+	return string(v)
+}
+
 // LessThan checks if a version is less than another
 func (v Version) LessThan(other Version) bool {
 	return v.compareTo(other) == -1


### PR DESCRIPTION
I'm using the pkg outside docker and I didn't like casting to `string` the var (I imported and used `api.DefaultVersion` and passed it where a `string` was expected, so instead of casting outside, I thought a `String()` method would be a better interface so who uses a `version.Version` doesn't need to know it's actually a `string` (cause maybe it will change one day and breaks))

I'll change all cast(s) to string to this new method in a follow up PR or create a beginner issue for new contributors :) 

Signed-off-by: Antonio Murdaca runcom@redhat.com
