### PR TITLE
Don't log EPIPE errors on client download abort

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -10,11 +10,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -1047,13 +1049,28 @@ func writeDistributionProgress(cancelFunc func(), outStream io.Writer, progressC
 
 	for prog := range progressChan {
 		if err := progressOutput.WriteProgress(prog); err != nil && !operationCancelled {
-			logrus.Errorf("error writing progress to client: %v", err)
+			// don't log broken pipe errors as this is the normal case when a client aborts
+			if isBrokenPipe(err) {
+				logrus.Info("Pull session cancelled")
+			} else {
+				logrus.Errorf("error writing progress to client: %v", err)
+			}
 			cancelFunc()
 			operationCancelled = true
 			// Don't return, because we need to continue draining
 			// progressChan until it's closed to avoid a deadlock.
 		}
 	}
+}
+
+func isBrokenPipe(e error) bool {
+	if netErr, ok := e.(*net.OpError); ok {
+		e = netErr.Err
+		if sysErr, ok := netErr.Err.(*os.SyscallError); ok {
+			e = sysErr.Err
+		}
+	}
+	return e == syscall.EPIPE
 }
 
 // PullImage initiates a pull operation. image is the repository name to pull, and


### PR DESCRIPTION
Before this, when a client aborts a pull, an error is logged for the broken pipe, but this isn't really an error since the broken pipe is expected and is the normal case for client aborts.
