### PR TITLE
WiP Support for specifying .dockerignore file with --ignore-file

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -65,9 +65,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	flBuildArg := opts.NewListOpts(opts.ValidateEnv)
 	cmd.Var(&flBuildArg, []string{"-build-arg"}, "Set build-time variables")
 	isolation := cmd.String([]string{"-isolation"}, "", "Container isolation level")
-	ignoreFile := cmd.String([]string{"-ignore-file"}, ignoreFileDefault, "List of rules to exclude matching files from context (relative path in the context)")
+	ignoreFile := cmd.String([]string{"-ignore-file"}, ignoreFileDefault, "List of rules for excluding files from context")
 	flIgnore := opts.NewListOpts(func(val string) (string, error) { return val, nil })
-	cmd.Var(&flIgnore, []string{"-ignore"}, "Excludes matching files from context")
+	cmd.Var(&flIgnore, []string{"-ignore"}, "Rule for excluding files from context")
 
 	ulimits := make(map[string]*units.Ulimit)
 	flUlimits := runconfigopts.NewUlimitOpt(&ulimits)

--- a/api/client/lib/image_build.go
+++ b/api/client/lib/image_build.go
@@ -86,6 +86,9 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	query.Set("cgroupparent", options.CgroupParent)
 	query.Set("shmsize", strconv.FormatInt(options.ShmSize, 10))
 	query.Set("dockerfile", options.Dockerfile)
+	for _, v := range options.IgnoreRules {
+		query.Add("ignorerule", v)
+	}
 
 	ulimitsJSON, err := json.Marshal(options.Ulimits)
 	if err != nil {

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -83,6 +83,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	}
 
 	options.Dockerfile = r.FormValue("dockerfile")
+	options.IgnoreRules = r.Form["ignorerule"]
 	options.SuppressOutput = httputils.BoolValue(r, "q")
 	options.NoCache = httputils.BoolValue(r, "nocache")
 	options.ForceRemove = httputils.BoolValue(r, "forcerm")

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -142,6 +142,7 @@ type ImageBuildOptions struct {
 	BuildArgs      map[string]string
 	AuthConfigs    map[string]AuthConfig
 	Context        io.Reader
+	IgnoreRules    []string
 }
 
 // ImageBuildResponse holds information

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -629,7 +629,7 @@ func (b *Builder) readDockerfile() error {
 	// Note that this assumes the Dockerfile has been read into memory and
 	// is now safe to be removed.
 	if dockerIgnore, ok := b.context.(builder.DockerIgnoreContext); ok {
-		dockerIgnore.Process([]string{b.options.Dockerfile})
+		dockerIgnore.Process([]string{b.options.Dockerfile}, b.options.IgnoreRules)
 	}
 	return nil
 }


### PR DESCRIPTION
Client: Parsed `.dockerignore` is passed in build options field `IgnoreRules []string`.
Server: If field `IgnoreRules` is empty contents of `.dockerignore` are used (old behaviour) preserving backwards compatibility with older clients.

NOTE: I was not able to build docker locally using `make`.

```
rm: cannot remove 'autogen/winresources': Directory not empty
```
