### PR TITLE
Print the raw inspected elements when there is no template for `docker inspect`.

### DIFF
--- a/api/client/inspect/inspector.go
+++ b/api/client/inspect/inspector.go
@@ -60,6 +60,7 @@ func (i *TemplateInspector) Flush() error {
 type IndentedInspector struct {
 	outputStream io.Writer
 	elements     []interface{}
+	rawElements  [][]byte
 }
 
 // NewIndentedInspector generates a new IndentedInspector.
@@ -70,26 +71,49 @@ func NewIndentedInspector(outputStream io.Writer) Inspector {
 }
 
 // Inspect writes the raw element with an indented json format.
-func (i *IndentedInspector) Inspect(typedElement interface{}, _ []byte) error {
-	i.elements = append(i.elements, typedElement)
+func (i *IndentedInspector) Inspect(typedElement interface{}, rawElement []byte) error {
+	if rawElement != nil {
+		i.rawElements = append(i.rawElements, rawElement)
+	} else {
+		i.elements = append(i.elements, typedElement)
+	}
 	return nil
 }
 
 // Flush write the result of inspecting all elements into the output stream.
 func (i *IndentedInspector) Flush() error {
-	if len(i.elements) == 0 {
+	if len(i.elements) == 0 && len(i.rawElements) == 0 {
 		_, err := io.WriteString(i.outputStream, "[]\n")
 		return err
 	}
 
-	buffer, err := json.MarshalIndent(i.elements, "", "    ")
-	if err != nil {
-		return err
+	var buffer io.Reader
+	if len(i.rawElements) > 0 {
+		bytesBuffer := new(bytes.Buffer)
+		bytesBuffer.WriteString("[")
+		for idx, r := range i.rawElements {
+			bytesBuffer.Write(r)
+			if idx < len(i.rawElements)-1 {
+				bytesBuffer.WriteString(",")
+			}
+		}
+		bytesBuffer.WriteString("]")
+		indented := new(bytes.Buffer)
+		if err := json.Indent(indented, bytesBuffer.Bytes(), "", "    "); err != nil {
+			return err
+		}
+		buffer = indented
+	} else {
+		b, err := json.MarshalIndent(i.elements, "", "    ")
+		if err != nil {
+			return err
+		}
+		buffer = bytes.NewReader(b)
 	}
 
-	if _, err := io.Copy(i.outputStream, bytes.NewReader(buffer)); err != nil {
+	if _, err := io.Copy(i.outputStream, buffer); err != nil {
 		return err
 	}
-	_, err = io.WriteString(i.outputStream, "\n")
+	_, err := io.WriteString(i.outputStream, "\n")
 	return err
 }

--- a/api/client/inspect/inspector_test.go
+++ b/api/client/inspect/inspector_test.go
@@ -187,3 +187,34 @@ func TestIndentedInspectorEmpty(t *testing.T) {
 		t.Fatalf("Expected `%s`, got `%s`", expected, b.String())
 	}
 }
+
+func TestIndentedInspectorRawElements(t *testing.T) {
+	b := new(bytes.Buffer)
+	i := NewIndentedInspector(b)
+	if err := i.Inspect(testElement{"0.0.0.0"}, []byte(`{"Dns": "0.0.0.0", "Node": "0"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := i.Inspect(testElement{"1.1.1.1"}, []byte(`{"Dns": "1.1.1.1", "Node": "1"}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := i.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `[
+    {
+        "Dns": "0.0.0.0",
+        "Node": "0"
+    },
+    {
+        "Dns": "1.1.1.1",
+        "Node": "1"
+    }
+]
+`
+	if b.String() != expected {
+		t.Fatalf("Expected `%s`, got `%s`", expected, b.String())
+	}
+}


### PR DESCRIPTION
Otherwise we're ignoring the fields that Swarm adds to the output.

It fixes a regression with Swarm where injected elements where not properly displayed with `docker inspect`.

Signed-off-by: David Calavera david.calavera@gmail.com
