### PR TITLE
.gitignore: do not ignore *.rej

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.exe
 *.exe~
 *.orig
-*.rej
 *.test
 .*.swp
 .DS_Store


### PR DESCRIPTION
I'm usually applying patches with --reject and it's an hassle finding rejs with *.rej in .gitignore :/ ppl who don't apply patches won't be affected by this and ppl who do will usually rm processed *.rej files (linux .gitignore ignores *.orig(s) but doesn't ignore *.rej(s) for instance) 

Signed-off-by: Antonio Murdaca runcom@redhat.com
