### PR TITLE
pkg/version.Version: use the new String() method

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -104,7 +104,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, clientFlags *cli.ClientF
 		}
 		customHeaders["User-Agent"] = "Docker-Client/" + dockerversion.Version + " (" + runtime.GOOS + ")"
 
-		verStr := string(api.DefaultVersion)
+		verStr := api.DefaultVersion.String()
 		if tmpStr := os.Getenv("DOCKER_API_VERSION"); tmpStr != "" {
 			verStr = tmpStr
 		}

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -49,7 +49,7 @@ func (s *DockerSuite) TestApiVersionStatusCode(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiClientVersionNewerThanServer(c *check.C) {
-	v := strings.Split(string(api.DefaultVersion), ".")
+	v := strings.Split(api.DefaultVersion.String(), ".")
 	vMinInt, err := strconv.Atoi(v[1])
 	c.Assert(err, checker.IsNil)
 	vMinInt++
@@ -63,7 +63,7 @@ func (s *DockerSuite) TestApiClientVersionNewerThanServer(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiClientVersionOldNotSupported(c *check.C) {
-	v := strings.Split(string(api.MinVersion), ".")
+	v := strings.Split(api.MinVersion.String(), ".")
 	vMinInt, err := strconv.Atoi(v[1])
 	c.Assert(err, checker.IsNil)
 	vMinInt--


### PR DESCRIPTION
Resolves #18750

Signed-off-by: Aditi Rajagopal arajagopal@us.ibm.com
