### PR TITLE
Update Instructions for Docker Remote API access

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -66,7 +66,7 @@ without protocol. Throughout this structure, double quotes are required.
 If you are using `docker-machine`, the Docker daemon is on a virtual host that uses an encrypted TCP socket. This means, for Docker Machine users, you need to add extra parameters to `curl` or `wget` when making test API requests, for example:
 
 ```
-curl --insecure --cert ~/.docker/cert.pem --key ~/.docker/key.pem https://YOUR_VM_IP:2376/images/json
+curl --insecure --cert %USERPROFILE%\.docker\machine\machines\<name_of_your_machine>\cert.pem --key %USERPROFILE%\.docker\machine\machines\<name_of_your_machine>\key.pem https://YOUR_VM_IP:2376/images/json
 
 wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem --private-key=$DOCKER_CERT_PATH/key.pem https://your_vm_ip:2376/images/json -O - -q
 ```


### PR DESCRIPTION
Update the location of cert.pem and key.pem to use within the ~/.docker folder
Resolves: #18778

Signed-off-by: Aditi Rajagopal arajagopal@us.ibm.com
