### PR TITLE
updated fedora yum to dnf package manager

### DIFF
--- a/docs/installation/fedora.md
+++ b/docs/installation/fedora.md
@@ -34,15 +34,15 @@ reported kernel bugs may have already been fixed on the latest kernel packages
 
 ## Install
 
-There are two ways to install Docker Engine.  You can install with the `yum` package manager. Or you can use `curl` with the  `get.docker.com` site. This second method runs an installation script which also installs via the `yum` package manager.
+There are two ways to install Docker Engine.  You can install with the `dnf` package manager. Or you can use `curl` with the  `get.docker.com` site. This second method runs an installation script which also installs via the `dnf` package manager.
 
-### Install with yum
+### Install with DNF
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing yum packages are up-to-date.
+2. Make sure your existing dnf packages are up-to-date.
 
-		$ sudo yum update
+		$ sudo dnf update
 
 3. Add the yum repo yourself.
 
@@ -57,7 +57,7 @@ There are two ways to install Docker Engine.  You can install with the `yum` pac
 
 4. Install the Docker package.
 
-        $ sudo yum install docker-engine
+        $ sudo dnf install docker-engine
 
 5. Start the Docker daemon.
 
@@ -98,9 +98,9 @@ There are two ways to install Docker Engine.  You can install with the `yum` pac
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing yum packages are up-to-date.
+2. Make sure your existing dnf packages are up-to-date.
 
-		$ sudo yum update
+		$ sudo dnf update
 
 3. Run the Docker installation script.
 
@@ -177,16 +177,16 @@ This configuration allows IP forwarding from the container as expected.
 
 ## Uninstall
 
-You can uninstall the Docker software with `yum`.
+You can uninstall the Docker software with `dnf`.
 
 1. List the package you have installed.
 
-		$ yum list installed | grep docker yum list installed | grep docker
+		$ dnf list installed | grep docker dnf list installed | grep docker
 		docker-engine.x86_64     1.7.1-0.1.fc21 @/docker-engine-1.7.1-0.1.fc21.el7.x86_64
 
 2. Remove the package.
 
-		$ sudo yum -y remove docker-engine.x86_64
+		$ sudo dnf -y remove docker-engine.x86_64
 
 	This command does not remove images, containers, volumes, or user-created
 	configuration files on your host.


### PR DESCRIPTION
Fedora has a new package manager (dnf instead of yum). "The DNF package and its dependencies are in f18 repositories now, in a testable state."; see [fedora wiki on dnf](https://fedoraproject.org/wiki/Features/DNF). A more complete overview of dnf is available at [readthedocs](http://dnf.readthedocs.org/en/latest/index.html). 

This pull request is a proposal to upgrade the Fedora documentation to reflect the new package manager.
