### PR TITLE
Update link to Oracle Linux

### DIFF
--- a/docs/installation/oracle.md
+++ b/docs/installation/oracle.md
@@ -16,7 +16,7 @@ Support subscription to install Docker on Oracle Linux.
 This page instructs you to install using Docker-managed release packages and
 installation mechanisms. Using these packages ensures you get the latest release
 of Docker. If you wish to install using Oracle-managed packages, consult your
-[Oracle Linux documentation](https://linux.oracle.com).
+[Oracle Linux documentation](https://oracle.com/linux).
 
 
 ## Prerequisites


### PR DESCRIPTION
The https://linux.oracle.com/ url results in too many redirects, which may result in our link-checker to think the link is broken.

Replacing the link, per discussion in
https://github.com/docker/docker/pull/18534#issuecomment-164202592

/cc @Djelibeybi 
