### PR TITLE
Display total consumption for stats

### DIFF
--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -17,6 +17,7 @@ parent = "smn_cli"
       -a, --all          Show all containers (default shows just running)
       --help             Print usage
       --no-stream        Disable streaming stats and only pull the first result
+      --totals           Show total consumption of resources
 
 The `docker stats` command returns a live data stream for running containers. To limit data to one or more specific containers, specify a list of container names or ids separated by a space. You can specify a stopped container but stopped containers do not return any data.
 
@@ -24,13 +25,14 @@ If you want more detailed information about a container's resource usage, use th
 
 ## Examples
 
-Running `docker stats` on all running containers
+Running `docker stats` on all running containers, and display totals in the last line:
 
-    $ docker stats
+    $ docker stats --totals
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    1285939c1fd3        0.07%               796 kB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 kB
+    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 kB / 648 B    12.4 MB / 0 B
+    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 kB / 648 B    27.7 MB / 0 B
+    Totals              0.17%               8.125 MB / 3.7 GB     0.21%               4.908 kB / 1.944 kB 43.7 MB / 512 kB
 
 Running `docker stats` on multiple containers by name and id.
 

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -134,3 +134,19 @@ func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {
 		// ignore, done
 	}
 }
+
+func (s *DockerSuite) TestStatsTotalsNoStream(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	out, _ := runSleepingContainer(c)
+	id1 := strings.TrimSpace(out)
+	c.Assert(waitRun(id1), checker.IsNil, check.Commentf("run container %s failed", id1))
+
+	out, _ = runSleepingContainer(c)
+	id2 := strings.TrimSpace(out)
+	c.Assert(waitRun(id2), checker.IsNil, check.Commentf("run container %s failed", id2))
+
+	out, _ = dockerCmd(c, "stats", "--no-stream", "--totals")
+	c.Assert(out, checker.Contains, id1[:12], check.Commentf("out: %s", out))
+	c.Assert(out, checker.Contains, id2[:12], check.Commentf("out: %s", out))
+	c.Assert(out, checker.Contains, "Totals", check.Commentf("out: %s", out))
+}

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -9,6 +9,7 @@ docker-stats - Display a live stream of one or more containers' resource usage s
 [**-a**|**--all**]
 [**--help**]
 [**--no-stream**]
+[**--totals**]
 [CONTAINER...]
 
 # DESCRIPTION
@@ -25,15 +26,19 @@ Display a live stream of one or more containers' resource usage statistics
 **--no-stream**=*true*|*false*
   Disable streaming stats and only pull the first result, default setting is false.
 
+**--totals**=*true*|*false*
+  Show total consumption of resources.
+
 # EXAMPLES
 
-Running `docker stats` on all running containers
+Running `docker stats` on all running containers, and display totals in the last line:
 
-    $ docker stats
+    $ docker stats --totals
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    1285939c1fd3        0.07%               796 kB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 kB
+    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 kB / 648 B    12.4 MB / 0 B
+    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 kB / 648 B    27.7 MB / 0 B
+    Totals              0.17%               8.125 MB / 3.7 GB     0.21%               4.908 kB / 1.944 kB 43.7 MB / 512 kB
 
 Running `docker stats` on multiple containers by name and id.
 


### PR DESCRIPTION
Fixes #18733 

Display total resource consumption of all containers in `stats` result.

Add flag `-t` to enable or disable total's display, default is 'true'. I'm thinking how about make total's display a predefined behavior and remove flag(which means display total value always)?

`docker stats` result with this change:

```
$ docker stats --no-stream
CONTAINER           CPU %               MEM USAGE / LIMIT   MEM %               NET I/O             BLOCK I/O
101fb7f50a5c        0.00%               104.8 MB / 3.7 GB   2.83%               4.812 kB / 648 B    79.97 MB / 8.192 kB
344851d0e3f4        0.00%               3.043 MB / 3.7 GB   0.08%               12.1 kB / 648 B     2.728 MB / 0 B
------------
Totals              0.00%               107.8 MB / 0 B      2.91%               16.91 kB / 1.296 kB   82.7 MB / 8.192 kB
```

I'm not sure how to calculate total memory limit, so just leave it to zero which means it has no representative meanings.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
