### PR TITLE
pkg: authorization: do not register the same plugin

### DIFF
--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -17,9 +17,14 @@ type Plugin interface {
 
 // NewPlugins constructs and initialize the authorization plugins based on plugin names
 func NewPlugins(names []string) []Plugin {
-	plugins := make([]Plugin, len(names))
-	for i, name := range names {
-		plugins[i] = newAuthorizationPlugin(name)
+	plugins := []Plugin{}
+	pluginsMap := make(map[string]struct{})
+	for _, name := range names {
+		if _, ok := pluginsMap[name]; ok {
+			continue
+		}
+		pluginsMap[name] = struct{}{}
+		plugins = append(plugins, newAuthorizationPlugin(name))
 	}
 	return plugins
 }

--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// ErrNotFound plugin not found
-	ErrNotFound = errors.New("Plugin not found")
+	ErrNotFound = errors.New("plugin not found")
 	socketsPath = "/run/docker/plugins"
 	specsPaths  = []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}
 )

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -96,7 +96,6 @@ func (p *Plugin) activateWithLock() error {
 		return err
 	}
 
-	logrus.Debugf("%s's manifest: %v", p.Name, m)
 	p.Manifest = m
 
 	for _, iface := range m.Implements {


### PR DESCRIPTION
This patches avoids registering (and calling) the same plugin more than
once. Using a map indexing by name guarantees this. We shouldn't bother
about Golang internal random map loop because we actually don't care
about plugins order. If we do, I think a better approach is to think
about plugins priorities, but this is another story.
The behavior of overriding the same name in a flag is consistent with,
for instance, the `docker run -v /test -v /test` flag which register
the volume just once.
Adds integration tests.

Without this patch:

```
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.080901676+01:00" level=debug msg="Calling
GET
/v1.22/info"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.081213202+01:00" level=debug msg="AuthZ
request using plugin docker-novolume-plugin"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.081268132+01:00" level=debug
msg="docker-novolume-plugin implements: authz"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.081699788+01:00" level=debug msg="AuthZ
request using plugin docker-novolume-plugin"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.081762507+01:00" level=debug
msg="docker-novolume-plugin implements: authz"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.082092480+01:00" level=debug msg="GET
/v1.22/info"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.628691038+01:00" level=debug msg="AuthZ
response using plugin docker-novolume-plugin"
Dec 20 19:34:52 localhost.localdomain docker[9988]:
time="2015-12-20T19:34:52.629880930+01:00" level=debug msg="AuthZ
response using plugin docker-novolume-plugin"
```

With this patch:

```
Dec 20 19:37:32 localhost.localdomain docker[16620]:
time="2015-12-20T19:37:32.376523958+01:00" level=debug msg="Calling
GET
/v1.22/info"
Dec 20 19:37:32 localhost.localdomain docker[16620]:
time="2015-12-20T19:37:32.376715483+01:00" level=debug msg="AuthZ
request using plugin docker-novolume-plugin"
Dec 20 19:37:32 localhost.localdomain docker[16620]:
time="2015-12-20T19:37:32.376771230+01:00" level=debug
msg="docker-novolume-plugin implements: authz"
Dec 20 19:37:32 localhost.localdomain docker[16620]:
time="2015-12-20T19:37:32.377698897+01:00" level=debug msg="GET
/v1.22/info"
Dec 20 19:37:32 localhost.localdomain docker[16620]:
time="2015-12-20T19:37:32.951016441+01:00" level=debug msg="AuthZ
response using plugin docker-novolume-plugin"
```

Also removes a somehow duplicate debug statement (leaving only the
second one as it's a loop of plugin's manifest):

```
Dec 20 19:52:30 localhost.localdomain docker[25767]:
time="2015-12-20T19:52:30.544090518+01:00" level=debug
msg="docker-novolume-plugin's manifest: &{[authz]}"
Dec 20 19:52:30 localhost.localdomain docker[25767]:
time="2015-12-20T19:52:30.544170677+01:00" level=debug
msg="docker-novolume-plugin implements: authz"
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
