### PR TITLE
volume: store: store.go: fix debug message

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -67,7 +67,6 @@ func (s *VolumeStore) Create(name, driverName string, opts map[string]string) (v
 		v := vc.Volume
 		return v, nil
 	}
-	logrus.Debugf("Registering new volume reference: driver %s, name %s", driverName, name)
 
 	vd, err := volumedrivers.GetDriver(driverName)
 	if err != nil {


### PR DESCRIPTION
When driver is `local` an empty string is given to the debug message.
Adds a check to set `driverName` to `local` if it's the case.

```
Dec 20 19:07:01 localhost.localdomain docker[19734]:
time="2015-12-20T19:07:01.872021857+01:00" level=debug msg="Registering
new volume reference: driver , name
c2291b964b4d7b1b51ec51d2ccfe2544f83fd23404709225a43743c5faadad55"
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
