### PR TITLE
Fix Pipe In Docs

### DIFF
--- a/docs/userguide/networking/dockernetworks.md
+++ b/docs/userguide/networking/dockernetworks.md
@@ -433,7 +433,7 @@ Docker Engine for use with `overlay` network. There are two options to set:
         <td>Describes the location of the KV service.</td>
     </tr>
     <tr>
-        <td><pre>--cluster-advertise=HOST_IP|HOST_IFACE:PORT</pre></td>
+        <td><pre>--cluster-advertise=HOST_IP&#124;HOST_IFACE:PORT</pre></td>
         <td>The IP address or interface of the HOST used for clustering.</td>
     </tr>
     </tbody>


### PR DESCRIPTION
In the networking docs, there is a cell in a table which has a `|` in it. When this is changed into HTML, it is interpreted as a table marker so it messes up that row:

![Screenshot of messed up table](https://www.dropbox.com/s/wcsx9t9cixb1qzj/Screen%20Shot%202015-12-21%20at%2012.35.44%20AM.png?dl=1).

Replacing it with the HTML code for the pipe bar [should help](https://github.com/gitlabhq/gitlabhq/issues/1238#issuecomment-10022918)
