### PR TITLE
Fix syntax error in init script

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -56,7 +56,7 @@ start() {
         prestart
         printf "Starting $prog:\t"
         echo "\n$(date)\n" >> $logfile
-        "$unshare" -m -- $exec daemon $other_args &>> $logfile &
+        "$unshare" -m -- $exec daemon $other_args >> $logfile 2>&1 &
         pid=$!
         touch $lockfile
         # wait up to 10 seconds for the pidfile to exist.  see


### PR DESCRIPTION
The method of output redirection being modified.
