### PR TITLE
pkg: authorization: do not lazy load

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -157,7 +157,7 @@ func versionMiddleware(handler httputils.APIFunc) httputils.APIFunc {
 //		)
 //	)
 // )
-func (s *Server) handleWithGlobalMiddlewares(handler httputils.APIFunc) httputils.APIFunc {
+func (s *Server) handleWithGlobalMiddlewares(handler httputils.APIFunc) (httputils.APIFunc, error) {
 	middlewares := []middleware{
 		versionMiddleware,
 		s.corsMiddleware,
@@ -170,7 +170,11 @@ func (s *Server) handleWithGlobalMiddlewares(handler httputils.APIFunc) httputil
 	}
 
 	if len(s.cfg.AuthZPluginNames) > 0 {
-		s.authZPlugins = authorization.NewPlugins(s.cfg.AuthZPluginNames)
+		var err error
+		s.authZPlugins, err = authorization.NewPlugins(s.cfg.AuthZPluginNames)
+		if err != nil {
+			return nil, err
+		}
 		middlewares = append(middlewares, s.authorizationMiddleware)
 	}
 
@@ -178,5 +182,5 @@ func (s *Server) handleWithGlobalMiddlewares(handler httputils.APIFunc) httputil
 	for _, m := range middlewares {
 		h = m(h)
 	}
-	return h
+	return h, nil
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -157,7 +157,10 @@ func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 		// immediate function being called should still be passed
 		// as 'args' on the function call.
 		ctx := context.Background()
-		handlerFunc := s.handleWithGlobalMiddlewares(handler)
+		handlerFunc, err := s.handleWithGlobalMiddlewares(handler)
+		if err != nil {
+			httputils.WriteError(w, err)
+		}
 
 		vars := mux.Vars(r)
 		if vars == nil {

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -27,7 +27,10 @@ func TestMiddlewares(t *testing.T) {
 		return nil
 	}
 
-	handlerFunc := srv.handleWithGlobalMiddlewares(localHandler)
+	handlerFunc, err := srv.handleWithGlobalMiddlewares(localHandler)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := handlerFunc(ctx, resp, req, map[string]string{}); err != nil {
 		t.Fatal(err)
 	}

--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -170,8 +170,8 @@ func (s *DockerAuthzSuite) TestAuthZPluginAllowRequest(c *check.C) {
 	s.ctrl.resRes.Allow = true
 
 	// Ensure command successful
-	out, err := s.d.Cmd("run", "-d", "--name", "container1", "busybox:latest", "top")
-	c.Assert(err, check.IsNil)
+	out, err := s.d.Cmd("run", "-d", "busybox:latest", "top")
+	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Extract the id of the created container
 	res := strings.Split(strings.TrimSpace(out), "\n")

--- a/pkg/authorization/authz_test.go
+++ b/pkg/authorization/authz_test.go
@@ -172,7 +172,7 @@ func createTestPlugin(t *testing.T) *authorizationPlugin {
 		t.Fatalf("Failed to create client %v", err)
 	}
 
-	return &authorizationPlugin{name: "plugin", plugin: plugin}
+	return &authorizationPlugin{plugin: plugin}
 }
 
 // AuthZPluginTestServer is a simple server that implements the authZ plugin interface

--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -36,7 +36,6 @@ func NewPlugins(names []string) ([]Plugin, error) {
 // authorizationPlugin is an internal adapter to docker plugin system
 type authorizationPlugin struct {
 	plugin *plugins.Plugin
-	name   string
 }
 
 func newAuthorizationPlugin(name string) (Plugin, error) {
@@ -44,11 +43,11 @@ func newAuthorizationPlugin(name string) (Plugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &authorizationPlugin{name: name, plugin: plugin}, nil
+	return &authorizationPlugin{plugin: plugin}, nil
 }
 
 func (a *authorizationPlugin) Name() string {
-	return a.name
+	return a.plugin.Name
 }
 
 func (a *authorizationPlugin) AuthZRequest(authReq *Request) (*Response, error) {


### PR DESCRIPTION
Since authZ plugins are daemon options I think it's preferable to
initialize them at daemon startup and return any error straight at
daemon initialization. Otherwise the daemon starts up but the cli is
unusable. This patch removes the lazy initialization of authZ plugins.
