### PR TITLE
Layerstore refactor rw layer

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -145,7 +145,7 @@ func (daemon *Daemon) exportContainerRw(container *container.Container) (archive
 	}
 	return ioutils.NewReadCloserWrapper(archive, func() error {
 			archive.Close()
-			return daemon.layerStore.Unmount(container.ID)
+			return container.RWLayer.Unmount()
 		}),
 		nil
 }

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -98,7 +98,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		}
 	}
 
-	m, err := daemon.layerStore.Metadata(c.ID)
+	m, err := c.RWLayer.Metadata()
 	if err != nil {
 		return derr.ErrorCodeGetLayerMetadata.WithArgs(err)
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -42,13 +42,12 @@ func (daemon *Daemon) ContainerCreate(params types.ContainerCreateConfig) (types
 }
 
 // Create creates a new container from the given configuration with a given name.
-func (daemon *Daemon) create(params types.ContainerCreateConfig) (*container.Container, error) {
+func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *container.Container, retErr error) {
 	var (
 		container *container.Container
 		img       *image.Image
 		imgID     image.ID
 		err       error
-		retErr    error
 	)
 
 	if params.Config.Image != "" {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/container"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/volume"
@@ -95,6 +96,11 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (*container.Con
 		}
 	}()
 
+	// Set RWLayer for container after mount labels have been set
+	if err := daemon.setRWLayer(container); err != nil {
+		return nil, err
+	}
+
 	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig, img); err != nil {
 		return nil, err
 	}
@@ -124,6 +130,24 @@ func (daemon *Daemon) generateSecurityOpt(ipcMode containertypes.IpcMode, pidMod
 		return label.DupSecOpt(c.ProcessLabel), nil
 	}
 	return nil, nil
+}
+
+func (daemon *Daemon) setRWLayer(container *container.Container) error {
+	var layerID layer.ChainID
+	if container.ImageID != "" {
+		img, err := daemon.imageStore.Get(container.ImageID)
+		if err != nil {
+			return err
+		}
+		layerID = img.RootFS.ChainID()
+	}
+	rwLayer, err := daemon.layerStore.CreateRWLayer(container.ID, layerID, container.MountLabel, daemon.setupInitLayer)
+	if err != nil {
+		return err
+	}
+	container.RWLayer = rwLayer
+
+	return nil
 }
 
 // VolumeCreate creates a volume with the specified name, driver, and opts

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -74,6 +74,15 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (*container.Con
 		}
 	}()
 
+	if err := daemon.setSecurityOptions(container, params.HostConfig); err != nil {
+		return nil, err
+	}
+
+	// Set RWLayer for container after mount labels have been set
+	if err := daemon.setRWLayer(container); err != nil {
+		return nil, err
+	}
+
 	if err := daemon.Register(container); err != nil {
 		return nil, err
 	}
@@ -95,11 +104,6 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (*container.Con
 			}
 		}
 	}()
-
-	// Set RWLayer for container after mount labels have been set
-	if err := daemon.setRWLayer(container); err != nil {
-		return nil, err
-	}
 
 	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig, img); err != nil {
 		return nil, err

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -130,7 +130,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 		return derr.ErrorCodeRmFS.WithArgs(container.ID, err)
 	}
 
-	metadata, err := daemon.layerStore.DeleteMount(container.ID)
+	metadata, err := daemon.layerStore.ReleaseRWLayer(container.RWLayer)
 	layer.LogReleaseMetadata(metadata)
 	if err != nil && err != layer.ErrMountDoesNotExist {
 		return derr.ErrorCodeRmDriverFS.WithArgs(daemon.driver, container.ID, err)

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -163,7 +163,7 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 
 	contJSONBase.GraphDriver.Name = container.Driver
 
-	graphDriverData, err := daemon.layerStore.Metadata(container.ID)
+	graphDriverData, err := container.RWLayer.Metadata()
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -31,6 +31,9 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 		// creating a container, not during start.
 		if hostConfig != nil {
 			logrus.Warn("DEPRECATED: Setting host configuration options when the container starts is deprecated and will be removed in Docker 1.12")
+			if err := daemon.setSecurityOptions(container, hostConfig); err != nil {
+				return err
+			}
 			if err := daemon.setHostConfig(container, hostConfig); err != nil {
 				return err
 			}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/progress"
 	"golang.org/x/net/context"
 )
@@ -115,25 +114,18 @@ func (ls *mockLayerStore) Get(chainID layer.ChainID) (layer.Layer, error) {
 func (ls *mockLayerStore) Release(l layer.Layer) ([]layer.Metadata, error) {
 	return []layer.Metadata{}, nil
 }
-
-func (ls *mockLayerStore) Mount(id string, parent layer.ChainID, label string, init layer.MountInit) (layer.RWLayer, error) {
+func (ls *mockLayerStore) CreateRWLayer(string, layer.ChainID, string, layer.MountInit) (layer.RWLayer, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ls *mockLayerStore) Unmount(id string) error {
-	return errors.New("not implemented")
+func (ls *mockLayerStore) GetRWLayer(string) (layer.RWLayer, error) {
+	return nil, errors.New("not implemented")
+
 }
 
-func (ls *mockLayerStore) DeleteMount(id string) ([]layer.Metadata, error) {
+func (ls *mockLayerStore) ReleaseRWLayer(layer.RWLayer) ([]layer.Metadata, error) {
 	return nil, errors.New("not implemented")
-}
 
-func (ls *mockLayerStore) Changes(id string) ([]archive.Change, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (ls *mockLayerStore) Metadata(id string) (map[string]string, error) {
-	return nil, errors.New("not implemented")
 }
 
 type mockDownloadDescriptor struct {

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -31,6 +31,11 @@ var (
 	// attempted on a mount layer which does not exist.
 	ErrMountDoesNotExist = errors.New("mount does not exist")
 
+	// ErrMountNameConflict is used when a mount is attempted
+	// to be created but there is already a mount with the name
+	// used for creation.
+	ErrMountNameConflict = errors.New("mount already exists with name")
+
 	// ErrActiveMount is used when an operation on a
 	// mount is attempted but the layer is still
 	// mounted and the operation cannot be performed.
@@ -103,18 +108,33 @@ type Layer interface {
 type RWLayer interface {
 	TarStreamer
 
-	// Path returns the filesystem path to the writable
-	// layer.
-	Path() (string, error)
+	// Name of mounted layer
+	Name() string
 
 	// Parent returns the layer which the writable
 	// layer was created from.
 	Parent() Layer
 
+	// Mount mounts the RWLayer and returns the filesystem path
+	// the to the writable layer.
+	Mount(mountLabel string) (string, error)
+
+	// Unmount unmounts the RWLayer. This should be called
+	// for every mount. If there are multiple mount calls
+	// this operation will only decrement the internal mount counter.
+	Unmount() error
+
 	// Size represents the size of the writable layer
 	// as calculated by the total size of the files
 	// changed in the mutable layer.
 	Size() (int64, error)
+
+	// Changes returns the set of changes for the mutable layer
+	// from the base layer.
+	Changes() ([]archive.Change, error)
+
+	// Metadata returns the low level metadata for the mutable layer
+	Metadata() (map[string]string, error)
 }
 
 // Metadata holds information about a
@@ -147,11 +167,9 @@ type Store interface {
 	Get(ChainID) (Layer, error)
 	Release(Layer) ([]Metadata, error)
 
-	Mount(id string, parent ChainID, label string, init MountInit) (RWLayer, error)
-	Unmount(id string) error
-	DeleteMount(id string) ([]Metadata, error)
-	Changes(id string) ([]archive.Change, error)
-	Metadata(id string) (map[string]string, error)
+	CreateRWLayer(id string, parent ChainID, mountLabel string, initFunc MountInit) (RWLayer, error)
+	GetRWLayer(id string) (RWLayer, error)
+	ReleaseRWLayer(RWLayer) ([]Metadata, error)
 }
 
 // MetadataTransaction represents functions for setting layer metadata

--- a/layer/layer_unix.go
+++ b/layer/layer_unix.go
@@ -1,0 +1,9 @@
+// +build linux freebsd darwin
+
+package layer
+
+import "github.com/docker/docker/pkg/stringid"
+
+func (ls *layerStore) mountID(name string) string {
+	return stringid.GenerateRandomID()
+}

--- a/layer/layer_windows.go
+++ b/layer/layer_windows.go
@@ -89,3 +89,8 @@ func (ls *layerStore) RegisterDiffID(graphID string, size int64) (Layer, error) 
 
 	return layer.getReference(), nil
 }
+
+func (ls *layerStore) mountID(name string) string {
+	// windows has issues if container ID doesn't match mount ID
+	return name
+}

--- a/layer/mount_test.go
+++ b/layer/mount_test.go
@@ -27,12 +27,12 @@ func TestMountInit(t *testing.T) {
 		return initfile.ApplyFile(root)
 	}
 
-	m, err := ls.Mount("fun-mount", layer.ChainID(), "", mountInit)
+	m, err := ls.CreateRWLayer("fun-mount", layer.ChainID(), "", mountInit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	path, err := m.Path()
+	path, err := m.Mount("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,12 +80,12 @@ func TestMountSize(t *testing.T) {
 		return newTestFile("file-init", contentInit, 0777).ApplyFile(root)
 	}
 
-	m, err := ls.Mount("mount-size", layer.ChainID(), "", mountInit)
+	m, err := ls.CreateRWLayer("mount-size", layer.ChainID(), "", mountInit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	path, err := m.Path()
+	path, err := m.Mount("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,12 +125,12 @@ func TestMountChanges(t *testing.T) {
 		return initfile.ApplyFile(root)
 	}
 
-	m, err := ls.Mount("mount-changes", layer.ChainID(), "", mountInit)
+	m, err := ls.CreateRWLayer("mount-changes", layer.ChainID(), "", mountInit)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	path, err := m.Path()
+	path, err := m.Mount("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestMountChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err := ls.Changes("mount-changes")
+	changes, err := m.Changes()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -1,15 +1,20 @@
 package layer
 
-import "io"
+import (
+	"io"
+	"sync"
+
+	"github.com/docker/docker/pkg/archive"
+)
 
 type mountedLayer struct {
-	name          string
-	mountID       string
-	initID        string
-	parent        *roLayer
-	path          string
-	layerStore    *layerStore
-	activityCount int
+	name       string
+	mountID    string
+	initID     string
+	parent     *roLayer
+	layerStore *layerStore
+
+	references map[RWLayer]*referencedRWLayer
 }
 
 func (ml *mountedLayer) cacheParent() string {
@@ -30,11 +35,8 @@ func (ml *mountedLayer) TarStream() (io.ReadCloser, error) {
 	return archiver, nil
 }
 
-func (ml *mountedLayer) Path() (string, error) {
-	if ml.path == "" {
-		return "", ErrNotMounted
-	}
-	return ml.path, nil
+func (ml *mountedLayer) Name() string {
+	return ml.name
 }
 
 func (ml *mountedLayer) Parent() Layer {
@@ -47,6 +49,96 @@ func (ml *mountedLayer) Parent() Layer {
 	return nil
 }
 
+func (ml *mountedLayer) Mount(mountLabel string) (string, error) {
+	return ml.layerStore.driver.Get(ml.mountID, mountLabel)
+}
+
+func (ml *mountedLayer) Unmount() error {
+	return ml.layerStore.driver.Put(ml.mountID)
+}
+
 func (ml *mountedLayer) Size() (int64, error) {
 	return ml.layerStore.driver.DiffSize(ml.mountID, ml.cacheParent())
+}
+
+func (ml *mountedLayer) Changes() ([]archive.Change, error) {
+	return ml.layerStore.driver.Changes(ml.mountID, ml.cacheParent())
+}
+
+func (ml *mountedLayer) Metadata() (map[string]string, error) {
+	return ml.layerStore.driver.GetMetadata(ml.mountID)
+}
+
+func (ml *mountedLayer) getReference() RWLayer {
+	ref := &referencedRWLayer{
+		mountedLayer: ml,
+	}
+	ml.references[ref] = ref
+
+	return ref
+}
+
+func (ml *mountedLayer) hasReferences() bool {
+	return len(ml.references) > 0
+}
+
+func (ml *mountedLayer) deleteReference(ref RWLayer) error {
+	rl, ok := ml.references[ref]
+	if !ok {
+		return ErrLayerNotRetained
+	}
+
+	if err := rl.release(); err != nil {
+		return err
+	}
+	delete(ml.references, ref)
+
+	return nil
+}
+
+type referencedRWLayer struct {
+	*mountedLayer
+
+	activityL     sync.Mutex
+	activityCount int
+}
+
+func (rl *referencedRWLayer) release() error {
+	rl.activityL.Lock()
+	defer rl.activityL.Unlock()
+
+	if rl.activityCount > 0 {
+		return ErrActiveMount
+	}
+
+	rl.activityCount = -1
+
+	return nil
+}
+
+func (rl *referencedRWLayer) Mount(mountLabel string) (string, error) {
+	rl.activityL.Lock()
+	defer rl.activityL.Unlock()
+
+	if rl.activityCount == -1 {
+		return "", ErrLayerNotRetained
+	}
+
+	rl.activityCount++
+	return rl.mountedLayer.Mount(mountLabel)
+}
+
+func (rl *referencedRWLayer) Unmount() error {
+	rl.activityL.Lock()
+	defer rl.activityL.Unlock()
+
+	if rl.activityCount == 0 {
+		return ErrNotMounted
+	}
+	if rl.activityCount == -1 {
+		return ErrLayerNotRetained
+	}
+	rl.activityCount--
+
+	return rl.mountedLayer.Unmount()
 }

--- a/migrate/v1/migratev1.go
+++ b/migrate/v1/migratev1.go
@@ -24,8 +24,7 @@ type graphIDRegistrar interface {
 }
 
 type graphIDMounter interface {
-	MountByGraphID(string, string, layer.ChainID) (layer.RWLayer, error)
-	Unmount(string) error
+	CreateRWLayerByGraphID(string, string, layer.ChainID) error
 }
 
 const (
@@ -172,13 +171,7 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 			return err
 		}
 
-		_, err = ls.MountByGraphID(id, id, img.RootFS.ChainID())
-		if err != nil {
-			return err
-		}
-
-		err = ls.Unmount(id)
-		if err != nil {
+		if err := ls.CreateRWLayerByGraphID(id, id, img.RootFS.ChainID()); err != nil {
 			return err
 		}
 

--- a/migrate/v1/migratev1_test.go
+++ b/migrate/v1/migratev1_test.go
@@ -338,10 +338,9 @@ type mockMounter struct {
 	count  int
 }
 
-func (r *mockMounter) MountByGraphID(name string, graphID string, parent layer.ChainID) (layer.RWLayer, error) {
+func (r *mockMounter) CreateRWLayerByGraphID(name string, graphID string, parent layer.ChainID) error {
 	r.mounts = append(r.mounts, mountInfo{name, graphID, string(parent)})
-	r.count++
-	return nil, nil
+	return nil
 }
 func (r *mockMounter) Unmount(string) error {
 	r.count--


### PR DESCRIPTION
Updates the layer interface to have a RW layer with a more complete interface. RW layer objects are now more powerful and individually reference counted. This change allows for separating the creation of the RW layer from when it is mounted. Container will now always have a reference to the RW layerr.

Fixes race between creating a writable layer and registering a container.

Fixes #18753 

Additional refactoring should be done the container create process. Currently ordering is ambiguous and there are still periods of time between a container being visible, fully setup, and saved to disk that make the process prone to races.

ping @tonistiigi @LK4D4 
