### PR TITLE
Move utils.ValidateContextDirectory to the one package that uses it

### DIFF
--- a/api/client/utils_unix.go
+++ b/api/client/utils_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package utils
+package client
 
 import (
 	"path/filepath"

--- a/api/client/utils_windows.go
+++ b/api/client/utils_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package utils
+package client
 
 import (
 	"path/filepath"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/stringid"
 )
 
@@ -193,54 +192,6 @@ func ReplaceOrAppendEnvValues(defaults, overrides []string) []string {
 	}
 
 	return defaults
-}
-
-// ValidateContextDirectory checks if all the contents of the directory
-// can be read and returns an error if some files can't be read
-// symlinks which point to non-existing files don't trigger an error
-func ValidateContextDirectory(srcPath string, excludes []string) error {
-	contextRoot, err := getContextRoot(srcPath)
-	if err != nil {
-		return err
-	}
-	return filepath.Walk(contextRoot, func(filePath string, f os.FileInfo, err error) error {
-		// skip this directory/file if it's not in the path, it won't get added to the context
-		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
-			return err
-		} else if skip, err := fileutils.Matches(relFilePath, excludes); err != nil {
-			return err
-		} else if skip {
-			if f.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if err != nil {
-			if os.IsPermission(err) {
-				return fmt.Errorf("can't stat '%s'", filePath)
-			}
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-
-		// skip checking if symlinks point to non-existing files, such symlinks can be useful
-		// also skip named pipes, because they hanging on open
-		if f.Mode()&(os.ModeSymlink|os.ModeNamedPipe) != 0 {
-			return nil
-		}
-
-		if !f.IsDir() {
-			currentFile, err := os.Open(filePath)
-			if err != nil && os.IsPermission(err) {
-				return fmt.Errorf("no permission to read from '%s'", filePath)
-			}
-			currentFile.Close()
-		}
-		return nil
-	})
 }
 
 // GetErrorMessage returns the human readable message associated with


### PR DESCRIPTION
This removes the `api/client` dependency on the `utils` package (technically `utils.ExperimentalBuild` is still there, but we should  be able to either drop that, or copy it, with the cli split).

cc @calavera @tiborvass @anusha-ragunathan (in case this conflicts with any of the builder work)
