### PR TITLE
Add authorization plugins to docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/ioutils"
@@ -43,15 +44,17 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	fmt.Fprintf(cli.out, "Plugins: \n")
 	fmt.Fprintf(cli.out, " Volume:")
-	for _, driver := range info.Plugins.Volume {
-		fmt.Fprintf(cli.out, " %s", driver)
-	}
+	fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Volume, " "))
 	fmt.Fprintf(cli.out, "\n")
 	fmt.Fprintf(cli.out, " Network:")
-	for _, driver := range info.Plugins.Network {
-		fmt.Fprintf(cli.out, " %s", driver)
-	}
+	fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Network, " "))
 	fmt.Fprintf(cli.out, "\n")
+
+	if len(info.Plugins.Authorization) != 0 {
+		fmt.Fprintf(cli.out, " Authorization:")
+		fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Authorization, " "))
+		fmt.Fprintf(cli.out, "\n")
+	}
 
 	ioutils.FprintfIfNotEmpty(cli.out, "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -243,6 +243,8 @@ type PluginsInfo struct {
 	Volume []string
 	// List of Network plugins registered
 	Network []string
+	// List of Authorization plugins registered
+	Authorization []string
 }
 
 // ExecStartCheck is a temp struct used by execStart

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -142,7 +142,15 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 		pluginsInfo.Network = append(pluginsInfo.Network, nd)
 	}
 
+	pluginsInfo.Authorization = daemon.GetAuthorizationPluginsList()
+
 	return pluginsInfo
+}
+
+// GetAuthorizationPluginsList returns the list of plugins drivers
+// registered for authorization.
+func (daemon *Daemon) GetAuthorizationPluginsList() []string {
+	return daemon.configStore.AuthZPlugins
 }
 
 // The uppercase and the lowercase are available for the proxy settings.


### PR DESCRIPTION
Add Authorization plugins to Plugins part of the docker info endpoint / cli. 🐮
- [x] Deciding on if we print something if there is no plugin registered (`Authorization:`) or not ?
- [ ] Add integration test to validate it's there and populated. Maybe add some for other ones (volumes & co), but probably in another PR.

Closes #18829.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
