### PR TITLE
Don't build Darwin 32-bit binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 # Compile Go for cross compilation
 ENV DOCKER_CROSSPLATFORMS \
 	linux/386 linux/arm \
-	darwin/amd64 darwin/386 \
+	darwin/amd64 \
 	freebsd/amd64 freebsd/386 freebsd/arm \
 	windows/amd64 windows/386
 

--- a/docs/installation/binaries.md
+++ b/docs/installation/binaries.md
@@ -121,9 +121,9 @@ following URL patterns:
 
 For example:
 
-    https://get.docker.com/builds/Linux/i386/docker-1.6.0
+    https://get.docker.com/builds/Linux/i386/docker-1.9.1
 
-    https://get.docker.com/builds/Linux/x86_64/docker-1.6.0
+    https://get.docker.com/builds/Linux/x86_64/docker-1.9.1
 
 
 ### Get the Mac OS X binary
@@ -131,26 +131,20 @@ For example:
 The Mac OS X binary is only a client. You cannot use it to run the `docker`
 daemon. To download the latest version for Mac OS X, use the following URLs:
 
-    https://get.docker.com/builds/Darwin/i386/docker-latest
-    
     https://get.docker.com/builds/Darwin/x86_64/docker-latest
 
 To download a specific version for Mac OS X, use the
 following URL patterns:
 
-    https://get.docker.com/builds/Darwin/i386/docker-<version>
-    
     https://get.docker.com/builds/Darwin/x86_64/docker-<version>
 
 For example:
 
-    https://get.docker.com/builds/Darwin/i386/docker-1.6.0
-
-    https://get.docker.com/builds/Darwin/x86_64/docker-1.6.0
+    https://get.docker.com/builds/Darwin/x86_64/docker-1.9.1
 
 ### Get the Windows binary
  
-You can only download the Windows client binary for version `1.6.0` onwards.
+You can only download the Windows client binary for version `1.9.1` onwards.
 Moreover, the binary is only a client, you cannot use it to run the `docker` daemon.
 To download the latest version for Windows, use the following URLs:
 
@@ -166,9 +160,9 @@ To download a specific version for Windows, use the following URL pattern:
 
 For example:
 
-    https://get.docker.com/builds/Windows/i386/docker-1.6.0.exe
+    https://get.docker.com/builds/Windows/i386/docker-1.9.1.exe
 
-    https://get.docker.com/builds/Windows/x86_64/docker-1.6.0.exe
+    https://get.docker.com/builds/Windows/x86_64/docker-1.9.1.exe
 
 
 ## Run the Docker daemon

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -318,7 +318,6 @@ echo "We have just pushed $VERSION to $(s3_url). You can download it with the fo
 echo
 echo "Linux 64bit binary: $(s3_url)/builds/Linux/x86_64/docker-$VERSION"
 echo "Darwin/OSX 64bit client binary: $(s3_url)/builds/Darwin/x86_64/docker-$VERSION"
-echo "Darwin/OSX 32bit client binary: $(s3_url)/builds/Darwin/i386/docker-$VERSION"
 echo "Linux 64bit tgz: $(s3_url)/builds/Linux/x86_64/docker-$VERSION.tgz"
 echo "Windows 64bit client binary: $(s3_url)/builds/Windows/x86_64/docker-$VERSION.exe"
 echo "Windows 32bit client binary: $(s3_url)/builds/Windows/i386/docker-$VERSION.exe"

--- a/project/RELEASE-CHECKLIST.md
+++ b/project/RELEASE-CHECKLIST.md
@@ -255,8 +255,9 @@ way to get some useful links for sharing:
 echo "Ubuntu/Debian: curl -sSL https://test.docker.com/ | sh"
 echo "Linux 64bit binary: https://test.docker.com/builds/Linux/x86_64/docker-${VERSION#v}"
 echo "Darwin/OSX 64bit client binary: https://test.docker.com/builds/Darwin/x86_64/docker-${VERSION#v}"
-echo "Darwin/OSX 32bit client binary: https://test.docker.com/builds/Darwin/i386/docker-${VERSION#v}"
 echo "Linux 64bit tgz: https://test.docker.com/builds/Linux/x86_64/docker-${VERSION#v}.tgz"
+echo "Windows 64bit client binary: https://test.docker.com/builds/Windows/x86_64/docker-${VERSION#v}.exe"
+echo "Windows 32bit client binary: https://test.docker.com/builds/Windows/i386/docker-${VERSION#v}.exe"
 ```
 
 We recommend announcing the release candidate on:


### PR DESCRIPTION
The last 32-bit OS X computers were built in 2006, so we probably don't need these anymore. All OS X computers should now be 64-bit, although [they may trick you into thinking they're not](http://apple.stackexchange.com/questions/140651/why-does-arch-output-i386)

I've been [wondering for a while now](https://github.com/docker/docker/pull/7644#issuecomment-52850487) if there's a reason for still building 32-bit binaries, so perhaps I'm overlooking something :smile:
