### PR TITLE
Better function names in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -56,7 +56,7 @@ __docker_q() {
 	docker ${host:+-H "$host"} ${config:+--config "$config"} 2>/dev/null "$@"
 }
 
-__docker_containers_all() {
+__docker_complete_containers_all() {
 	local IFS=$'\n'
 	local containers=( $(__docker_q ps -aq --no-trunc) )
 	if [ "$1" ]; then
@@ -68,35 +68,35 @@ __docker_containers_all() {
 	COMPREPLY=( $(compgen -W "${names[*]} ${containers[*]}" -- "$cur") )
 }
 
-__docker_containers_running() {
-	__docker_containers_all '.State.Running'
+__docker_complete_containers_running() {
+	__docker_complete_containers_all '.State.Running'
 }
 
-__docker_containers_stopped() {
-	__docker_containers_all 'not .State.Running'
+__docker_complete_containers_stopped() {
+	__docker_complete_containers_all 'not .State.Running'
 }
 
-__docker_containers_pauseable() {
-	__docker_containers_all 'and .State.Running (not .State.Paused)'
+__docker_complete_containers_pauseable() {
+	__docker_complete_containers_all 'and .State.Running (not .State.Paused)'
 }
 
-__docker_containers_unpauseable() {
-	__docker_containers_all '.State.Paused'
+__docker_complete_containers_unpauseable() {
+	__docker_complete_containers_all '.State.Paused'
 }
 
-__docker_container_names() {
+__docker_complete_container_names() {
 	local containers=( $(__docker_q ps -aq --no-trunc) )
 	local names=( $(__docker_q inspect --format '{{.Name}}' "${containers[@]}") )
 	names=( "${names[@]#/}" ) # trim off the leading "/" from the container names
 	COMPREPLY=( $(compgen -W "${names[*]}" -- "$cur") )
 }
 
-__docker_container_ids() {
+__docker_complete_container_ids() {
 	local containers=( $(__docker_q ps -aq) )
 	COMPREPLY=( $(compgen -W "${containers[*]}" -- "$cur") )
 }
 
-__docker_images() {
+__docker_complete_images() {
 	local images_args=""
 
 	case "$DOCKER_COMPLETION_SHOW_IMAGE_IDS" in
@@ -130,21 +130,21 @@ __docker_images() {
 	__ltrim_colon_completions "$cur"
 }
 
-__docker_image_repos() {
+__docker_complete_image_repos() {
 	local repos="$(__docker_q images | awk 'NR>1 && $1 != "<none>" { print $1 }')"
 	COMPREPLY=( $(compgen -W "$repos" -- "$cur") )
 }
 
-__docker_image_repos_and_tags() {
+__docker_complete_image_repos_and_tags() {
 	local reposAndTags="$(__docker_q images | awk 'NR>1 && $1 != "<none>" { print $1; print $1":"$2 }')"
 	COMPREPLY=( $(compgen -W "$reposAndTags" -- "$cur") )
 	__ltrim_colon_completions "$cur"
 }
 
-__docker_containers_and_images() {
-	__docker_containers_all
+__docker_complete_containers_and_images() {
+	__docker_complete_containers_all
 	local containers=( "${COMPREPLY[@]}" )
-	__docker_images
+	__docker_complete_images
 	COMPREPLY+=( "${containers[@]}" )
 }
 
@@ -157,15 +157,15 @@ __docker_networks() {
 }
 
 __docker_complete_networks() {
-	COMPREPLY=( $(compgen -W "$(__docker_complete_networks)" -- "$cur") )
+	COMPREPLY=( $(compgen -W "$(__docker_networks)" -- "$cur") )
 }
 
-__docker_containers_in_network() {
+__docker_complete_containers_in_network() {
 	local containers=$(__docker_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1")
 	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
 }
 
-__docker_volumes() {
+__docker_complete_volumes() {
 	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
 }
 
@@ -282,12 +282,12 @@ __docker_nospace() {
 	type compopt &>/dev/null && compopt -o nospace
 }
 
-__docker_resolve_hostname() {
+__docker_complete_resolved_hostname() {
 	command -v host >/dev/null 2>&1 || return
 	COMPREPLY=( $(host 2>/dev/null "${cur%:}" | awk '/has address/ {print $4}') )
 }
 
-__docker_capabilities() {
+__docker_complete_capabilities() {
 	# The list of capabilities is defined in types.go, ALL was added manually.
 	COMPREPLY=( $( compgen -W "
 		ALL
@@ -332,7 +332,7 @@ __docker_capabilities() {
 	" -- "$cur" ) )
 }
 
-__docker_log_drivers() {
+__docker_complete_log_drivers() {
 	COMPREPLY=( $( compgen -W "
 		awslogs
 		fluentd
@@ -345,7 +345,7 @@ __docker_log_drivers() {
 	" -- "$cur" ) )
 }
 
-__docker_log_driver_options() {
+__docker_complete_log_options() {
 	# see docs/reference/logging/index.md
 	local awslogs_options="awslogs-region awslogs-group awslogs-stream"
 	local fluentd_options="env fluentd-address labels tag"
@@ -444,13 +444,13 @@ __docker_complete_log_driver_options() {
 	return 1
 }
 
-__docker_log_levels() {
+__docker_complete_log_levels() {
 	COMPREPLY=( $( compgen -W "debug info warn error fatal" -- "$cur" ) )
 }
 
 # a selection of the available signals that is most likely of interest in the
 # context of docker containers.
-__docker_signals() {
+__docker_complete_signals() {
 	local signals=(
 		SIGCONT
 		SIGHUP
@@ -479,7 +479,7 @@ _docker_docker() {
 			return
 			;;
 		--log-level|-l)
-			__docker_log_levels
+			__docker_complete_log_levels
 			return
 			;;
 		$(__docker_to_extglob "$global_options_with_args") )
@@ -508,7 +508,7 @@ _docker_attach() {
 		*)
 			local counter="$(__docker_pos_first_nonflag)"
 			if [ $cword -eq $counter ]; then
-				__docker_containers_running
+				__docker_complete_containers_running
 			fi
 			;;
 	esac
@@ -553,7 +553,7 @@ _docker_build() {
 			return
 			;;
 		--tag|-t)
-			__docker_image_repos_and_tags
+			__docker_complete_image_repos_and_tags
 			return
 			;;
 		$(__docker_to_extglob "$options_with_args") )
@@ -589,13 +589,13 @@ _docker_commit() {
 			local counter=$(__docker_pos_first_nonflag '--author|-a|--change|-c|--message|-m')
 
 			if [ $cword -eq $counter ]; then
-				__docker_containers_all
+				__docker_complete_containers_all
 				return
 			fi
 			(( counter++ ))
 
 			if [ $cword -eq $counter ]; then
-				__docker_image_repos_and_tags
+				__docker_complete_image_repos_and_tags
 				return
 			fi
 			;;
@@ -619,7 +619,7 @@ _docker_cp() {
 						_filedir
 						local files=( ${COMPREPLY[@]} )
 
-						__docker_containers_all
+						__docker_complete_containers_all
 						COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
 						local containers=( ${COMPREPLY[@]} )
 
@@ -635,7 +635,7 @@ _docker_cp() {
 
 			if [ $cword -eq $counter ]; then
 				if [ -e "$prev" ]; then
-					__docker_containers_all
+					__docker_complete_containers_all
 					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
 					__docker_nospace
 				else
@@ -713,7 +713,7 @@ _docker_daemon() {
 			return
 			;;
 		--log-driver)
-			__docker_log_drivers
+			__docker_complete_log_drivers
 			return
 			;;
 		--pidfile|-p|--tlscacert|--tlscert|--tlskey)
@@ -759,11 +759,11 @@ _docker_daemon() {
 			return
 			;;
 		--log-level|-l)
-			__docker_log_levels
+			__docker_complete_log_levels
 			return
 			;;
 		--log-opt)
-			__docker_log_driver_options
+			__docker_complete_log_options
 			return
 			;;
 		$(__docker_to_extglob "$options_with_args") )
@@ -809,7 +809,7 @@ _docker_diff() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_all
+				__docker_complete_containers_all
 			fi
 			;;
 	esac
@@ -830,7 +830,7 @@ _docker_events() {
 	case "${words[$cword-2]}$prev=" in
 		*container=*)
 			cur="${cur#=}"
-			__docker_containers_all
+			__docker_complete_containers_all
 			return
 			;;
 		*event=*)
@@ -865,7 +865,7 @@ _docker_events() {
 			;;
 		*image=*)
 			cur="${cur#=}"
-			__docker_images
+			__docker_complete_images
 			return
 			;;
 	esac
@@ -889,7 +889,7 @@ _docker_exec() {
 			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i --privileged -t --tty -u --user" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_running
+			__docker_complete_containers_running
 			;;
 	esac
 }
@@ -902,7 +902,7 @@ _docker_export() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_all
+				__docker_complete_containers_all
 			fi
 			;;
 	esac
@@ -923,7 +923,7 @@ _docker_history() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_images
+				__docker_complete_images
 			fi
 			;;
 	esac
@@ -961,7 +961,7 @@ _docker_images() {
 			return
 			;;
 		*)
-			__docker_image_repos
+			__docker_complete_image_repos
 			;;
 	esac
 }
@@ -985,7 +985,7 @@ _docker_import() {
 			(( counter++ ))
 
 			if [ $cword -eq $counter ]; then
-				__docker_image_repos_and_tags
+				__docker_complete_image_repos_and_tags
 				return
 			fi
 			;;
@@ -1019,13 +1019,13 @@ _docker_inspect() {
 		*)
 			case $(__docker_value_of_option --type) in
 				'')
-					__docker_containers_and_images
+					__docker_complete_containers_and_images
 					;;
 				container)
-					__docker_containers_all
+					__docker_complete_containers_all
 					;;
 				image)
-					__docker_images
+					__docker_complete_images
 					;;
 			esac
 	esac
@@ -1034,7 +1034,7 @@ _docker_inspect() {
 _docker_kill() {
 	case "$prev" in
 		--signal|-s)
-			__docker_signals
+			__docker_complete_signals
 			return
 			;;
 	esac
@@ -1044,7 +1044,7 @@ _docker_kill() {
 			COMPREPLY=( $( compgen -W "--help --signal -s" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_running
+			__docker_complete_containers_running
 			;;
 	esac
 }
@@ -1100,7 +1100,7 @@ _docker_logs() {
 		*)
 			local counter=$(__docker_pos_first_nonflag '--tail')
 			if [ $cword -eq $counter ]; then
-				__docker_containers_all
+				__docker_complete_containers_all
 			fi
 			;;
 	esac
@@ -1116,7 +1116,7 @@ _docker_network_connect() {
 			if [ $cword -eq $counter ]; then
 				__docker_complete_networks
 			elif [ $cword -eq $(($counter + 1)) ]; then
-				__docker_containers_running
+				__docker_complete_containers_running
 			fi
 			;;
 	esac
@@ -1158,7 +1158,7 @@ _docker_network_disconnect() {
 			if [ $cword -eq $counter ]; then
 				__docker_complete_networks
 			elif [ $cword -eq $(($counter + 1)) ]; then
-				__docker_containers_in_network "$prev"
+				__docker_complete_containers_in_network "$prev"
 			fi
 			;;
 	esac
@@ -1227,7 +1227,7 @@ _docker_pause() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_pauseable
+				__docker_complete_containers_pauseable
 			fi
 			;;
 	esac
@@ -1241,7 +1241,7 @@ _docker_port() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_all
+				__docker_complete_containers_all
 			fi
 			;;
 	esac
@@ -1250,7 +1250,7 @@ _docker_port() {
 _docker_ps() {
 	case "$prev" in
 		--before|--since)
-			__docker_containers_all
+			__docker_complete_containers_all
 			;;
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "ancestor exited id label name status" -- "$cur" ) )
@@ -1265,17 +1265,17 @@ _docker_ps() {
 	case "${words[$cword-2]}$prev=" in
 		*ancestor=*)
 			cur="${cur#=}"
-			__docker_images
+			__docker_complete_images
 			return
 			;;
 		*id=*)
 			cur="${cur#=}"
-			__docker_container_ids
+			__docker_complete_container_ids
 			return
 			;;
 		*name=*)
 			cur="${cur#=}"
-			__docker_container_names
+			__docker_complete_container_names
 			return
 			;;
 		*status=*)
@@ -1302,12 +1302,12 @@ _docker_pull() {
 				for arg in "${COMP_WORDS[@]}"; do
 					case "$arg" in
 						--all-tags|-a)
-							__docker_image_repos
+							__docker_complete_image_repos
 							return
 							;;
 					esac
 				done
-				__docker_image_repos_and_tags
+				__docker_complete_image_repos_and_tags
 			fi
 			;;
 	esac
@@ -1321,7 +1321,7 @@ _docker_push() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_image_repos_and_tags
+				__docker_complete_image_repos_and_tags
 			fi
 			;;
 	esac
@@ -1335,7 +1335,7 @@ _docker_rename() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_all
+				__docker_complete_containers_all
 			fi
 			;;
 	esac
@@ -1353,7 +1353,7 @@ _docker_restart() {
 			COMPREPLY=( $( compgen -W "--help --time -t" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_all
+			__docker_complete_containers_all
 			;;
 	esac
 }
@@ -1367,12 +1367,12 @@ _docker_rm() {
 			for arg in "${COMP_WORDS[@]}"; do
 				case "$arg" in
 					--force|-f)
-						__docker_containers_all
+						__docker_complete_containers_all
 						return
 						;;
 				esac
 			done
-			__docker_containers_stopped
+			__docker_complete_containers_stopped
 			;;
 	esac
 }
@@ -1383,7 +1383,7 @@ _docker_rmi() {
 			COMPREPLY=( $( compgen -W "--force -f --help --no-prune" -- "$cur" ) )
 			;;
 		*)
-			__docker_images
+			__docker_complete_images
 			;;
 	esac
 }
@@ -1470,7 +1470,7 @@ _docker_run() {
 		--add-host)
 			case "$cur" in
 				*:)
-					__docker_resolve_hostname
+					__docker_complete_resolved_hostname
 					return
 					;;
 			esac
@@ -1480,7 +1480,7 @@ _docker_run() {
 			return
 			;;
 		--cap-add|--cap-drop)
-			__docker_capabilities
+			__docker_complete_capabilities
 			return
 			;;
 		--cidfile|--env-file|--label-file)
@@ -1512,7 +1512,7 @@ _docker_run() {
 			case "$cur" in
 				*:*)
 					cur="${cur#*:}"
-					__docker_containers_running
+					__docker_complete_containers_running
 					;;
 				*)
 					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
@@ -1528,7 +1528,7 @@ _docker_run() {
 				*:*)
 					;;
 				*)
-					__docker_containers_running
+					__docker_complete_containers_running
 					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
 					__docker_nospace
 					;;
@@ -1536,18 +1536,18 @@ _docker_run() {
 			return
 			;;
 		--log-driver)
-			__docker_log_drivers
+			__docker_complete_log_drivers
 			return
 			;;
 		--log-opt)
-			__docker_log_driver_options
+			__docker_complete_log_options
 			return
 			;;
 		--net)
 			case "$cur" in
 				container:*)
 					local cur=${cur#*:}
-					__docker_containers_all
+					__docker_complete_containers_all
 					;;
 				*)
 					COMPREPLY=( $( compgen -W "$(__docker_plugins Network) $(__docker_networks) container:" -- "$cur") )
@@ -1591,7 +1591,7 @@ _docker_run() {
 			return
 			;;
 		--volumes-from)
-			__docker_containers_all
+			__docker_complete_containers_all
 			return
 			;;
 		$(__docker_to_extglob "$options_with_args") )
@@ -1608,7 +1608,7 @@ _docker_run() {
 		*)
 			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
 			if [ $cword -eq $counter ]; then
-				__docker_images
+				__docker_complete_images
 			fi
 			;;
 	esac
@@ -1627,7 +1627,7 @@ _docker_save() {
 			COMPREPLY=( $( compgen -W "--help --output -o" -- "$cur" ) )
 			;;
 		*)
-			__docker_images
+			__docker_complete_images
 			;;
 	esac
 }
@@ -1652,7 +1652,7 @@ _docker_start() {
 			COMPREPLY=( $( compgen -W "--attach -a --help --interactive -i" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_stopped
+			__docker_complete_containers_stopped
 			;;
 	esac
 }
@@ -1663,7 +1663,7 @@ _docker_stats() {
 			COMPREPLY=( $( compgen -W "--all -a --help --no-stream" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_running
+			__docker_complete_containers_running
 			;;
 	esac
 }
@@ -1680,7 +1680,7 @@ _docker_stop() {
 			COMPREPLY=( $( compgen -W "--help --time -t" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_running
+			__docker_complete_containers_running
 			;;
 	esac
 }
@@ -1694,13 +1694,13 @@ _docker_tag() {
 			local counter=$(__docker_pos_first_nonflag)
 
 			if [ $cword -eq $counter ]; then
-				__docker_image_repos_and_tags
+				__docker_complete_image_repos_and_tags
 				return
 			fi
 			(( counter++ ))
 
 			if [ $cword -eq $counter ]; then
-				__docker_image_repos_and_tags
+				__docker_complete_image_repos_and_tags
 				return
 			fi
 			;;
@@ -1715,7 +1715,7 @@ _docker_unpause() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_unpauseable
+				__docker_complete_containers_unpauseable
 			fi
 			;;
 	esac
@@ -1729,7 +1729,7 @@ _docker_top() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_containers_running
+				__docker_complete_containers_running
 			fi
 			;;
 	esac
@@ -1773,7 +1773,7 @@ _docker_volume_inspect() {
 			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
 			;;
 		*)
-			__docker_volumes
+			__docker_complete_volumes
 			;;
 	esac
 }
@@ -1799,7 +1799,7 @@ _docker_volume_rm() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			__docker_volumes
+			__docker_complete_volumes
 			;;
 	esac
 }
@@ -1829,7 +1829,7 @@ _docker_wait() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			__docker_containers_all
+			__docker_complete_containers_all
 			;;
 	esac
 }


### PR DESCRIPTION
Most of the helper functions in bash completion directly compute the completion, e.g. `__docker_containers_all()`. They do so by modifying the global `COMPOPT` variable. They are invoked as macros, not having any return value.

Other functions work like "real" functions: The just return values without having any side effect, e.g. `__docker_networks()`.

I felt that making the distinction between these two categories more obvious in the function names would increase code readability and therefore in #18828 I introduced two function pairs `__docker_plugins()`, `__docker_complete_plugins()` and `__docker_networks()`, `__docker_complete_networks()`.

Building on this, I now renamed all functions of the first category from `__docker_XXX()` to `__docker_complete_XXX()`.
Exceptions: `__docker_log_driver_options()` became `__docker_complete_log_options()` in order to  avoid a collision, and `__docker_resolve_hostname()` became `__docker_complete_resolved_hostname()` just because it sounded better.

There's not much work going on in the completions at the moment, so this seems to be a good moment to do this kind of refactoring.

ping @jfrazelle @tianon for review
