### PR TITLE
remove `--format` from bash completion for `docker network rm`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1195,7 +1195,13 @@ _docker_network_ls() {
 }
 
 _docker_network_rm() {
-	_docker_network_inspect
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_networks
+	esac
 }
 
 _docker_network() {


### PR DESCRIPTION
Due to delegation of completions, `docker network rm` falsely supported a `--format` option. This PR removes this option.
