### PR TITLE
Update go-connections vendor to pickup addition of parser functions

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,7 +21,7 @@ clone git github.com/tchap/go-patricia v2.1.0
 clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
 clone git github.com/docker/go-units v0.2.0
-clone git github.com/docker/go-connections 96cdf8190a45946d0f19576732e2a410c6f84a31
+clone git github.com/docker/go-connections 4e42727957c146776e5de9cec8c39e4059ed9f20
 
 #get libnetwork packages
 clone git github.com/docker/libnetwork bbd6e6d8ca1e7c9b42f6f53277b0bde72847ff90

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -9,29 +9,6 @@ import (
 	"strings"
 )
 
-// PartParser parses and validates the specified string (data) using the specified template
-// e.g. ip:public:private -> 192.168.0.1:80:8000
-func PartParser(template, data string) (map[string]string, error) {
-	// ip:public:private
-	var (
-		templateParts = strings.Split(template, ":")
-		parts         = strings.Split(data, ":")
-		out           = make(map[string]string, len(templateParts))
-	)
-	if len(parts) != len(templateParts) {
-		return nil, fmt.Errorf("Invalid format to parse. %s should match template %s", data, template)
-	}
-
-	for i, t := range templateParts {
-		value := ""
-		if len(parts) > i {
-			value = parts[i]
-		}
-		out[t] = value
-	}
-	return out, nil
-}
-
 // ParseKeyValueOpt parses and validates the specified string as a key/value pair (key=value)
 func ParseKeyValueOpt(opt string) (string, string, error) {
 	parts := strings.SplitN(opt, "=", 2)
@@ -39,32 +16,6 @@ func ParseKeyValueOpt(opt string) (string, string, error) {
 		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
 	}
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
-}
-
-// ParsePortRange parses and validates the specified string as a port-range (8000-9000)
-func ParsePortRange(ports string) (uint64, uint64, error) {
-	if ports == "" {
-		return 0, 0, fmt.Errorf("Empty string specified for ports.")
-	}
-	if !strings.Contains(ports, "-") {
-		start, err := strconv.ParseUint(ports, 10, 16)
-		end := start
-		return start, end, err
-	}
-
-	parts := strings.Split(ports, "-")
-	start, err := strconv.ParseUint(parts[0], 10, 16)
-	if err != nil {
-		return 0, 0, err
-	}
-	end, err := strconv.ParseUint(parts[1], 10, 16)
-	if err != nil {
-		return 0, 0, err
-	}
-	if end < start {
-		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
-	}
-	return start, end, nil
 }
 
 // ParseUintList parses and validates the specified string as the value

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -2,7 +2,6 @@ package parsers
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -30,54 +29,6 @@ func TestParseKeyValueOpt(t *testing.T) {
 		if key != expectedKeyValue[0] || value != expectedKeyValue[1] {
 			t.Fatalf("Expected {%v: %v} got {%v: %v}", expectedKeyValue[0], expectedKeyValue[1], key, value)
 		}
-	}
-}
-
-func TestParsePortRange(t *testing.T) {
-	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
-		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
-	}
-}
-
-func TestParsePortRangeEmpty(t *testing.T) {
-	if _, _, err := ParsePortRange(""); err == nil || err.Error() != "Empty string specified for ports." {
-		t.Fatalf("Expected error 'Empty string specified for ports.', got %v", err)
-	}
-}
-
-func TestParsePortRangeWithNoRange(t *testing.T) {
-	start, end, err := ParsePortRange("8080")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if start != 8080 || end != 8080 {
-		t.Fatalf("Expected start and end to be the same and equal to 8080, but were %v and %v", start, end)
-	}
-}
-
-func TestParsePortRangeIncorrectRange(t *testing.T) {
-	if _, _, err := ParsePortRange("9000-8080"); err == nil || !strings.Contains(err.Error(), "Invalid range specified for the Port") {
-		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
-	}
-}
-
-func TestParsePortRangeIncorrectEndRange(t *testing.T) {
-	if _, _, err := ParsePortRange("8000-a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
-		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
-	}
-
-	if _, _, err := ParsePortRange("8000-30a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
-		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
-	}
-}
-
-func TestParsePortRangeIncorrectStartRange(t *testing.T) {
-	if _, _, err := ParsePortRange("a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
-		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
-	}
-
-	if _, _, err := ParsePortRange("30a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
-		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
 	}
 }
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/volume"
 	"github.com/docker/go-connections/nat"
@@ -285,7 +284,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		proto, port := nat.SplitProtoPort(e)
 		//parse the start and end port and create a sequence of ports to expose
 		//if expose a port, the start and end port are the same
-		start, end, err := parsers.ParsePortRange(port)
+		start, end, err := nat.ParsePortRange(port)
 		if err != nil {
 			return nil, nil, cmd, fmt.Errorf("Invalid range format for --expose: %s, error: %s", e, err)
 		}

--- a/vendor/src/github.com/docker/go-connections/nat/nat.go
+++ b/vendor/src/github.com/docker/go-connections/nat/nat.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-
-	"github.com/docker/docker/pkg/parsers"
 )
 
 const (
@@ -37,7 +35,7 @@ func NewPort(proto, port string) (Port, error) {
 	// Check for parsing issues on "port" now so we can avoid having
 	// to check it later on.
 
-	portStartInt, portEndInt, err := ParsePortRange(port)
+	portStartInt, portEndInt, err := ParsePortRangeToInt(port)
 	if err != nil {
 		return "", err
 	}
@@ -60,12 +58,12 @@ func ParsePort(rawPort string) (int, error) {
 	return int(port), nil
 }
 
-// ParsePortRange parses the port range string and returns start/end ints
-func ParsePortRange(rawPort string) (int, int, error) {
+// ParsePortRangeToInt parses the port range string and returns start/end ints
+func ParsePortRangeToInt(rawPort string) (int, int, error) {
 	if len(rawPort) == 0 {
 		return 0, 0, nil
 	}
-	start, end, err := parsers.ParsePortRange(rawPort)
+	start, end, err := ParsePortRange(rawPort)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -99,7 +97,7 @@ func (p Port) Int() int {
 
 // Range returns the start/end port numbers of a Port range as ints
 func (p Port) Range() (int, int, error) {
-	return ParsePortRange(p.Port())
+	return ParsePortRangeToInt(p.Port())
 }
 
 // SplitProtoPort splits a port in the format of proto/port
@@ -148,7 +146,7 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 			rawPort = fmt.Sprintf(":%s", rawPort)
 		}
 
-		parts, err := parsers.PartParser(portSpecTemplate, rawPort)
+		parts, err := PartParser(portSpecTemplate, rawPort)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -166,14 +164,14 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 			return nil, nil, fmt.Errorf("No port specified: %s<empty>", rawPort)
 		}
 
-		startPort, endPort, err := parsers.ParsePortRange(containerPort)
+		startPort, endPort, err := ParsePortRange(containerPort)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Invalid containerPort: %s", containerPort)
 		}
 
 		var startHostPort, endHostPort uint64 = 0, 0
 		if len(hostPort) > 0 {
-			startHostPort, endHostPort, err = parsers.ParsePortRange(hostPort)
+			startHostPort, endHostPort, err = ParsePortRange(hostPort)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Invalid hostPort: %s", hostPort)
 			}

--- a/vendor/src/github.com/docker/go-connections/nat/nat_test.go
+++ b/vendor/src/github.com/docker/go-connections/nat/nat_test.go
@@ -41,7 +41,7 @@ func TestParsePort(t *testing.T) {
 	}
 }
 
-func TestParsePortRange(t *testing.T) {
+func TestParsePortRangeToInt(t *testing.T) {
 	var (
 		begin int
 		end   int
@@ -63,7 +63,7 @@ func TestParsePortRange(t *testing.T) {
 	}
 
 	for _, r := range validRanges {
-		begin, end, err = ParsePortRange(r.Range)
+		begin, end, err = ParsePortRangeToInt(r.Range)
 
 		if err != nil || begin != r.Begin {
 			t.Fatalf("Parsing port range '%s' did not succeed. Expected begin %d, got %d", r.Range, r.Begin, begin)
@@ -83,7 +83,7 @@ func TestParsePortRange(t *testing.T) {
 	}
 
 	for _, r := range invalidRanges {
-		begin, end, err = ParsePortRange(r)
+		begin, end, err = ParsePortRangeToInt(r)
 
 		if err == nil || begin != 0 || end != 0 {
 			t.Fatalf("Parsing port range '%s' succeeded", r)

--- a/vendor/src/github.com/docker/go-connections/nat/parse.go
+++ b/vendor/src/github.com/docker/go-connections/nat/parse.go
@@ -1,0 +1,56 @@
+package nat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PartParser parses and validates the specified string (data) using the specified template
+// e.g. ip:public:private -> 192.168.0.1:80:8000
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse. %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+// ParsePortRange parses and validates the specified string as a port-range (8000-9000)
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}

--- a/vendor/src/github.com/docker/go-connections/nat/parse_test.go
+++ b/vendor/src/github.com/docker/go-connections/nat/parse_test.go
@@ -1,0 +1,54 @@
+package nat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePortRange(t *testing.T) {
+	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
+		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
+	}
+}
+
+func TestParsePortRangeEmpty(t *testing.T) {
+	if _, _, err := ParsePortRange(""); err == nil || err.Error() != "Empty string specified for ports." {
+		t.Fatalf("Expected error 'Empty string specified for ports.', got %v", err)
+	}
+}
+
+func TestParsePortRangeWithNoRange(t *testing.T) {
+	start, end, err := ParsePortRange("8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start != 8080 || end != 8080 {
+		t.Fatalf("Expected start and end to be the same and equal to 8080, but were %v and %v", start, end)
+	}
+}
+
+func TestParsePortRangeIncorrectRange(t *testing.T) {
+	if _, _, err := ParsePortRange("9000-8080"); err == nil || !strings.Contains(err.Error(), "Invalid range specified for the Port") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectEndRange(t *testing.T) {
+	if _, _, err := ParsePortRange("8000-a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("8000-30a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectStartRange(t *testing.T) {
+	if _, _, err := ParsePortRange("a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("30a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}

--- a/vendor/src/github.com/docker/go-connections/nat/sort.go
+++ b/vendor/src/github.com/docker/go-connections/nat/sort.go
@@ -3,8 +3,6 @@ package nat
 import (
 	"sort"
 	"strings"
-
-	"github.com/docker/docker/pkg/parsers"
 )
 
 type portSorter struct {
@@ -90,7 +88,7 @@ func SortPortMap(ports []Port, bindings PortMap) {
 }
 
 func toInt(s string) uint64 {
-	i, _, err := parsers.ParsePortRange(s)
+	i, _, err := ParsePortRange(s)
 	if err != nil {
 		i = 0
 	}


### PR DESCRIPTION
Removes some parser functions that were moved into the `go-connections` package.
