### PR TITLE
add /bin/tar to apparmor profile

### DIFF
--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -67,6 +67,7 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   /bin/kmod rCx,
   /usr/bin/xz rCx,
   /bin/ps rCx,
+  /bin/tar rCx,
   /bin/cat rCx,
   /sbin/zfs rCx,
   /sbin/apparmor_parser rCx,


### PR DESCRIPTION
when --tmpfs is use, /bin/tar is required and this PR adds that binary to the Apparmor profile.

See #18853.

Ping @thaJeztah due to https://github.com/docker/docker/issues/18853#issuecomment-166843939

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
