### PR TITLE
Make `docker load` to output json when the response content type is json.

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -53,7 +53,7 @@ type apiClient interface {
 	ImageImport(options types.ImageImportOptions) (io.ReadCloser, error)
 	ImageInspectWithRaw(imageID string, getSize bool) (types.ImageInspect, []byte, error)
 	ImageList(options types.ImageListOptions) ([]types.Image, error)
-	ImageLoad(input io.Reader) (io.ReadCloser, error)
+	ImageLoad(input io.Reader) (types.ImageLoadResponse, error)
 	ImagePull(options types.ImagePullOptions, privilegeFunc lib.RequestPrivilegeFunc) (io.ReadCloser, error)
 	ImagePush(options types.ImagePushOptions, privilegeFunc lib.RequestPrivilegeFunc) (io.ReadCloser, error)
 	ImageRemove(options types.ImageRemoveOptions) ([]types.ImageDelete, error)

--- a/api/client/lib/image_load.go
+++ b/api/client/lib/image_load.go
@@ -3,15 +3,20 @@ package lib
 import (
 	"io"
 	"net/url"
+
+	"github.com/docker/docker/api/types"
 )
 
 // ImageLoad loads an image in the docker host from the client host.
 // It's up to the caller to close the io.ReadCloser returned by
 // this function.
-func (cli *Client) ImageLoad(input io.Reader) (io.ReadCloser, error) {
+func (cli *Client) ImageLoad(input io.Reader) (types.ImageLoadResponse, error) {
 	resp, err := cli.postRaw("/images/load", url.Values{}, input, nil)
 	if err != nil {
-		return nil, err
+		return types.ImageLoadResponse{}, err
 	}
-	return resp.body, nil
+	return types.ImageLoadResponse{
+		Body: resp.body,
+		JSON: resp.header.Get("Content-Type") == "application/json",
+	}, nil
 }

--- a/api/client/load.go
+++ b/api/client/load.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	Cli "github.com/docker/docker/cli"
+	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
@@ -29,12 +30,16 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 		input = file
 	}
 
-	responseBody, err := cli.client.ImageLoad(input)
+	response, err := cli.client.ImageLoad(input)
 	if err != nil {
 		return err
 	}
-	defer responseBody.Close()
+	defer response.Body.Close()
 
-	_, err = io.Copy(cli.out, responseBody)
+	if response.JSON {
+		return jsonmessage.DisplayJSONMessagesStream(response.Body, cli.out, cli.outFd, cli.isTerminalOut)
+	}
+
+	_, err = io.Copy(cli.out, response.Body)
 	return err
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -179,6 +179,12 @@ type ImageListOptions struct {
 	Filters   filters.Args
 }
 
+// ImageLoadResponse returns information to the client about a load process.
+type ImageLoadResponse struct {
+	Body io.ReadCloser
+	JSON bool
+}
+
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {
 	ImageID string


### PR DESCRIPTION
Swarm hijacks the response from `docker load` and returns JSON rather than plain text like the Engine does.
This makes the API library to return information to figure that out.

/cc @vieux

Signed-off-by: David Calavera david.calavera@gmail.com
