### PR TITLE
Fix the restore data example

### DIFF
--- a/docs/userguide/dockervolumes.md
+++ b/docs/userguide/dockervolumes.md
@@ -263,7 +263,7 @@ elsewhere. Create a new container.
 
 Then un-tar the backup file in the new container's data volume.
 
-    $ docker run --rm --volumes-from dbstore2 -v $(pwd):/backup ubuntu bash -c "cd /dbdata && tar xvf /backup/backup.tar"
+    $ docker run --rm --volumes-from dbstore2 -v $(pwd):/backup ubuntu bash -c "cd /dbdata && tar xvf /backup/backup.tar --strip 1"
 
 You can use the techniques above to automate backup, migration and
 restore testing using your preferred tools.


### PR DESCRIPTION
Fixes: #18872

For backup, restore case, we usually restore in same directory, so
when we untar it, we not need go to /dbdata directory, wich could
result in /dbdata/dbdata, this fix make it untar directly. The directory
/dbdata would be same as old container /dbdata.

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
