### PR TITLE
Remove duplicated OomKilldisable

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -209,7 +209,6 @@ type HostConfig struct {
 	IpcMode         IpcMode            // IPC namespace to use for the container
 	Links           []string           // List of links (in the name:alias form)
 	OomScoreAdj     int                // Container preference for OOM-killing
-	OomKillDisable  bool               // Whether to disable OOM Killer or not
 	PidMode         PidMode            // PID namespace to use for the container
 	Privileged      bool               // Is the container in privileged mode
 	PublishAllPorts bool               // Should docker publish all exposed port for the container


### PR DESCRIPTION
It's in Resources, but wrongly added back to HostConfig in
https://github.com/docker/docker/pull/18762

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
