### PR TITLE
Add verification to import [closes #10385]

### DIFF
--- a/api/client/import.go
+++ b/api/client/import.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/docker/api"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -59,6 +60,14 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 		}
 		defer file.Close()
 		in = file
+	}
+
+	if srcName == "-" {
+		data, err := api.VerifyTarballNotImage(in)
+		if err != nil {
+			return err
+		}
+		in = data
 	}
 
 	options := types.ImageImportOptions{

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -3,11 +3,13 @@ package daemon
 import (
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"runtime"
 	"time"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
@@ -49,6 +51,12 @@ func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string
 		}
 		progressOutput := sf.NewProgressOutput(outStream, true)
 		archive = progress.NewProgressReader(resp.Body, progressOutput, resp.ContentLength, "", "Importing")
+		data, err := api.VerifyTarballNotImage(archive)
+		archive.Close()
+		if err != nil {
+			return err
+		}
+		archive = ioutil.NopCloser(data)
 	}
 
 	defer archive.Close()


### PR DESCRIPTION
Read more here: #10385.

Before fully implementing this, I think we need to decide on how to verify that the tarball isn't an image.
Right now, just checking if the `repositories` file exists like @runcom did in https://github.com/runcom/docker/commit/e4a6a6c0d612d5da3ef275118a81571a1d9a1ad7.

/cc @unclejack @runcom -- your feedbacks?
#### Status
-  ~~implement the verifyTarball method~~
-  ~~gunzip tarball if needed~~
- write tests

Thanks.
