### PR TITLE
Fix --storage-driver example

### DIFF
--- a/docs/articles/systemd.md
+++ b/docs/articles/systemd.md
@@ -98,7 +98,7 @@ directory:
 
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --graph /mnt/docker-data --storage-driver btrfs
+    ExecStart=/usr/bin/docker daemon -H fd:// --graph /mnt/docker-data --storage-driver=overlay
 
 You can also set other environment variables in this file, for example, the
 `HTTP_PROXY` environment variables described below.

--- a/docs/articles/systemd.md
+++ b/docs/articles/systemd.md
@@ -98,7 +98,7 @@ directory:
 
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --graph /mnt/docker-data --storage-driver=overlay
+    ExecStart=/usr/bin/docker daemon -H fd:// --graph="/mnt/docker-data" --storage-driver=overlay
 
 You can also set other environment variables in this file, for example, the
 `HTTP_PROXY` environment variables described below.


### PR DESCRIPTION
Missing = at the end of the --storage-driver example means that it doesn't work. Also switched from btrfs to overlay as overlay has been recommended by Docker team since March 2015. Fixes #18898 

Signed-off-by: Chris Swan chris.swan@iee.org
