### PR TITLE
Rename `-dirty` to `-unsupported`

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -11,7 +11,7 @@ set -e
 # - The VERSION file, at the root of the repository, should exist, and
 #   will be used as Docker binary version and package version.
 # - The hash of the git commit will also be included in the Docker binary,
-#   with the suffix -dirty if the repository isn't clean.
+#   with the suffix -unsupported if the repository isn't clean.
 # - The script is intended to be run inside the docker container specified
 #   in the Dockerfile at the root of the source. In other words:
 #   DO NOT CALL THIS SCRIPT DIRECTLY.
@@ -68,7 +68,7 @@ VERSION=$(< ./VERSION)
 if command -v git &> /dev/null && git rev-parse &> /dev/null; then
 	GITCOMMIT=$(git rev-parse --short HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-		GITCOMMIT="$GITCOMMIT-dirty"
+		GITCOMMIT="$GITCOMMIT-unsupported"
 	fi
 	! BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
 	if [ -z $BUILDTIME ]; then

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -26,7 +26,7 @@ set -e
 
 	DOCKER_GITCOMMIT=$(git rev-parse --short HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-		DOCKER_GITCOMMIT="$DOCKER_GITCOMMIT-dirty"
+		DOCKER_GITCOMMIT="$DOCKER_GITCOMMIT-unsupported"
 	fi
 
 	# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better


### PR DESCRIPTION
:snowflake: :snowman: :christmas_tree: :santa: :christmas_tree: :snowman: :snowflake: 

Nightly and unofficial builds of Docker bear the suffix `-dirty` in the
version string. Change this suffix to `-unsupported` to make it explicit
that no support will be provided on such versions, and that it is for
example unnecessary to file an issue for it.

:snowflake: :snowman: :christmas_tree: :santa: :christmas_tree: :snowman: :snowflake: 

Signed-off-by: Arnaud Porterie arnaud.porterie@docker.com
