### PR TITLE
Fix network disconnect does not save the config to disk

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -711,15 +711,17 @@ func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, n li
 		return runconfig.ErrConflictHostNetwork
 	}
 
-	return disconnectFromNetwork(container, n)
-}
-
-func disconnectFromNetwork(container *container.Container, n libnetwork.Network) error {
+	if err := disconnectFromNetwork(container, n); err != nil {
+		return err
+	}
 
 	if err := container.ToDiskLocking(); err != nil {
 		return fmt.Errorf("Error saving container to disk: %v", err)
 	}
+	return nil
+}
 
+func disconnectFromNetwork(container *container.Container, n libnetwork.Network) error {
 	var (
 		ep   libnetwork.Endpoint
 		sbox libnetwork.Sandbox


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

I think this is a regression on master, the latest release 1.9.1 work correct(https://github.com/docker/docker/blob/release/v1.9/daemon/container_unix.go#L1225).
