### PR TITLE
Be more explicit about "+1" comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,21 +41,22 @@ and will thank you for it!
 
 Check that [our issue database](https://github.com/docker/docker/issues)
 doesn't already include that problem or suggestion before submitting an issue.
-If you find a match, add a quick "+1" or "I have this problem too." Doing this
-helps prioritize the most common problems and requests. **DO NOT DO THAT** to
-subscribe to the issue unless you have something meaningful to add to the
-conversation. The best way to subscribe the issue is by clicking Subscribe
-button in top right of the page.
+If you find a match, you can use the "subscribe" button to get notified on
+updates. Do *not* leave random "+1" or "I have this too" comments, as they
+only clutter the discussion, and don't help resolving it. However, if you
+have ways to reproduce the issue or have additional information that may help
+resolving the issue, please leave a comment.
 
-When reporting issues, please include your host OS (Ubuntu 12.04, Fedora 19,
-etc). Please include:
+When reporting issues, always include:
 
-* The output of `uname -a`.
 * The output of `docker version`.
 * The output of `docker info`.
 
-Please also include the steps required to reproduce the problem if possible and
+Also include the steps required to reproduce the problem if possible and
 applicable. This information will help us review and fix your issue faster.
+When sending lengthy log-files, consider posting them as a gist (https://gist.github.com).
+Don't forget to remove sensitive data from your logfiles before posting (you can
+replace those parts with "REDACTED").
 
 **Issue Report Template**:
 


### PR DESCRIPTION
Add some more information about not leaving random "+1" comments.

Also removed the requirements to send `uname -a`, because that information is now included in the output of `docker version`.
