### PR TITLE
Add seccomp include file for building 

### DIFF
--- a/contrib/builder/deb/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/debian-jessie/Dockerfile
@@ -22,6 +22,7 @@ cd "$SECCOMP_PATH" \
 && ./configure --prefix=/usr \
 && make \
 && install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& install -c include/seccomp.h /usr/include/seccomp.h \
 && chmod 644 /usr/lib/libseccomp.a \
 && ranlib /usr/lib/libseccomp.a \
 && ldconfig -n /usr/lib \

--- a/contrib/builder/deb/generate.sh
+++ b/contrib/builder/deb/generate.sh
@@ -126,6 +126,7 @@ for version in "${versions[@]}"; do
 				&& ./configure --prefix=/usr \
 				&& make \
 				&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+				&& install -c include/seccomp.h /usr/include/seccomp.h \
 				&& chmod 644 /usr/lib/libseccomp.a \
 				&& ranlib /usr/lib/libseccomp.a \
 				&& ldconfig -n /usr/lib \

--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
@@ -22,6 +22,7 @@ cd "$SECCOMP_PATH" \
 && ./configure --prefix=/usr \
 && make \
 && install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& install -c include/seccomp.h /usr/include/seccomp.h \
 && chmod 644 /usr/lib/libseccomp.a \
 && ranlib /usr/lib/libseccomp.a \
 && ldconfig -n /usr/lib \

--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -23,6 +23,7 @@ cd "$SECCOMP_PATH" \
 && ./configure --prefix=/usr \
 && make \
 && install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& install -c include/seccomp.h /usr/include/seccomp.h \
 && chmod 644 /usr/lib/libseccomp.a \
 && ranlib /usr/lib/libseccomp.a \
 && ldconfig -n /usr/lib \

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -22,6 +22,7 @@ cd "$SECCOMP_PATH" \
 && ./configure --prefix=/usr \
 && make \
 && install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& install -c include/seccomp.h /usr/include/seccomp.h \
 && chmod 644 /usr/lib/libseccomp.a \
 && ranlib /usr/lib/libseccomp.a \
 && ldconfig -n /usr/lib \

--- a/contrib/builder/rpm/fedora-23/Dockerfile
+++ b/contrib/builder/rpm/fedora-23/Dockerfile
@@ -22,6 +22,7 @@ cd "$SECCOMP_PATH" \
 && ./configure --prefix=/usr \
 && make \
 && install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& install -c include/seccomp.h /usr/include/seccomp.h \
 && chmod 644 /usr/lib/libseccomp.a \
 && ranlib /usr/lib/libseccomp.a \
 && ldconfig -n /usr/lib \

--- a/contrib/builder/rpm/generate.sh
+++ b/contrib/builder/rpm/generate.sh
@@ -128,6 +128,7 @@ for version in "${versions[@]}"; do
 				&& ./configure --prefix=/usr \
 				&& make \
 				&& install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+				&& install -c include/seccomp.h /usr/include/seccomp.h \
 				&& chmod 644 /usr/lib/libseccomp.a \
 				&& ranlib /usr/lib/libseccomp.a \
 				&& ldconfig -n /usr/lib \

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -22,6 +22,7 @@ cd "$SECCOMP_PATH" \
 && ./configure --prefix=/usr \
 && make \
 && install -c src/.libs/libseccomp.a /usr/lib/libseccomp.a \
+&& install -c include/seccomp.h /usr/include/seccomp.h \
 && chmod 644 /usr/lib/libseccomp.a \
 && ranlib /usr/lib/libseccomp.a \
 && ldconfig -n /usr/lib \


### PR DESCRIPTION
Signed-off-by: yangshukui yangshukui@huawei.com
when build deb/rpm, we install libseccomp.a only and miss seccomp.h. it maybe lead to fail of docker binary' s seccomp feature.
eg .

```
docker run --rm -it --security-opt seccomp:/root/test/seccomp/profile.json ubuntu ls /
conditional filtering requires libseccomp version >= 2.2.1
```
