### PR TITLE
Add DOCKER_BUILD_ARGS env to pass build-arg for building deb and rpm

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -44,7 +44,7 @@ set -e
 
 		image="dockercore/builder-deb:$version"
 		if ! docker inspect "$image" &> /dev/null; then
-			( set -x && docker build -t "$image" "$dir" )
+			( set -x && docker build ${DOCKER_BUILD_ARGS} -t "$image" "$dir" )
 		fi
 
 		mkdir -p "$DEST/$version"

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -67,7 +67,7 @@ set -e
 
 		image="dockercore/builder-rpm:$version"
 		if ! docker inspect "$image" &> /dev/null; then
-			( set -x && docker build -t "$image" "$dir" )
+			( set -x && docker build ${DOCKER_BUILD_ARGS} -t "$image" "$dir" )
 		fi
 
 		mkdir -p "$DEST/$version"


### PR DESCRIPTION
During building the deb or rpm, sometimes we have to
edit the Dockerfile to add some env such as http_proxy,
and we want to reuse the container for building, but
if the container already has the image, it will not build
the image again, so the chenges of Dockerfile doesn't affect.
This patch is to build the image all the time.

ping @jfrazelle 

Signed-off-by: Lei Jitang leijitang@huawei.com
