### PR TITLE
Remove the need for runconfig.Parse() in the builder

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -9,7 +9,6 @@ package dockerfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,10 +17,10 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
 	derr "github.com/docker/docker/errors"
-	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
@@ -315,13 +314,9 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 		}
 	}
 
-	runCmd := flag.NewFlagSet("run", flag.ContinueOnError)
-	runCmd.SetOutput(ioutil.Discard)
-	runCmd.Usage = nil
-
-	config, _, _, err := runconfig.Parse(runCmd, append([]string{b.image}, args...))
-	if err != nil {
-		return err
+	config := &container.Config{
+		Cmd:   strslice.New(args...),
+		Image: b.image,
 	}
 
 	// stash the cmd


### PR DESCRIPTION
`runconfig.Parse()` is being used by the builder, but for a huge 350+ line function, it's doing almost nothing in this case.  The only args passed to the call are command and image. I believe this version which just constructs a `container.Config` directly is equivalent.

This change allows us to move `runconfig.Parse()` to the client, which is the last remaining place it is used, instead of trying to share it with the daemon as well. I think we might be able to drop the other two calls into `runconfig` as well, but I'm leaving those for another PR.

cc @calavera, @anusha-ragunathan, @tiborvass
