### PR TITLE
Fix docker stats show wrong memory limit when do docker update

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -601,7 +601,7 @@ func (container *Container) UpdateContainer(hostConfig *container.HostConfig) er
 	// the command so we can update configs to the real world.
 	if container.IsRunning() {
 		container.Lock()
-		updateCommand(container.Command, resources)
+		updateCommand(container.Command, *cResources)
 		container.Unlock()
 	}
 


### PR DESCRIPTION
When a container create with -m 100m and then docker update other
cgroup settings such as --cpu-quota, the memory limit show by
docker stats will become the default value but not the 100m.

Signed-off-by: Lei Jitang leijitang@huawei.com

Reproduce:
`docker run -d -ti -m 100m --name bar busybox`
`docker stats bar`

<pre><code>CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
bar                 0.00%               401.4 kB / 104.9 MB   0.38%               648 B / 648 B       0 B / 0 B
</code></pre>

As we can see the MEM LIMIT is 104.9MB just what we set on run
`docker update --cpu-quota 2000 bar`

<pre><code>CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
bar                 0.00%               421.9 kB / 4.144 GB   0.01%               648 B / 648 B       0 B / 0 B
</code></pre>

The `MEM LIMIT` become the default value.

Has discussed with @hqhq , this should be the correct fix.
