### PR TITLE
Allow use of robust list syscalls in default seccomp policy

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -86,12 +86,6 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
-			// Deny getting the list of robust futexes
-			Name:   "get_robust_list",
-			Action: configs.Errno,
-			Args:   []*configs.Arg{},
-		},
-		{
 			// Deny manipulation and functions on kernel modules.
 			Name:   "init_module",
 			Action: configs.Errno,
@@ -264,12 +258,6 @@ var defaultSeccompProfile = &configs.Seccomp{
 		{
 			// deny associating a thread with a namespace
 			Name:   "setns",
-			Action: configs.Errno,
-			Args:   []*configs.Arg{},
-		},
-		{
-			// Deny setting the list of robust futexes
-			Name:   "set_robust_list",
 			Action: configs.Errno,
 			Args:   []*configs.Arg{},
 		},


### PR DESCRIPTION
The set_robust_list syscall sets the list of futexes which are
cleaned up on thread exit, and are needed to avoid mutexes
being held forever on thread exit.

See for example in Musl libc mutex handling:
http://git.musl-libc.org/cgit/musl/tree/src/thread/pthread_mutex_trylock.c#n22

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
