### PR TITLE
Block original umount syscall in default seccomp filter

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -300,6 +300,12 @@ var defaultSeccompProfile = &configs.Seccomp{
 		},
 		{
 			// Deny umount
+			Name:   "umount",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
+			// Deny umount
 			Name:   "umount2",
 			Action: configs.Errno,
 			Args:   []*configs.Arg{},


### PR DESCRIPTION
The original umount syscall without flags argument needs to
be blocked too.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
