### PR TITLE
Proposal: Add label support to update command

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -41,7 +41,7 @@ type stateBackend interface {
 	ContainerStart(name string, hostConfig *container.HostConfig) error
 	ContainerStop(name string, seconds int) error
 	ContainerUnpause(name string) error
-	ContainerUpdate(name string, hostConfig *container.HostConfig) ([]string, error)
+	ContainerUpdate(name string, hostConfig *container.HostConfig, labels map[string]string) ([]string, error)
 	ContainerWait(name string, timeout time.Duration) (int, error)
 }
 

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -330,7 +330,7 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 	}
 
 	name := vars["name"]
-	warnings, err := s.backend.ContainerUpdate(name, hostConfig)
+	warnings, err := s.backend.ContainerUpdate(name, hostConfig, updateConfig.Labels)
 	if err != nil {
 		return err
 	}

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -564,7 +564,7 @@ func updateCommand(c *execdriver.Command, resources containertypes.Resources) {
 }
 
 // UpdateContainer updates configuration of a container.
-func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
+func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig, labels map[string]string) error {
 	container.Lock()
 
 	// update resources of container
@@ -601,9 +601,15 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		cResources.KernelMemory = resources.KernelMemory
 	}
 
-	// update HostConfig of container
+	// update HostConfig of the container
 	if hostConfig.RestartPolicy.Name != "" {
 		container.HostConfig.RestartPolicy = hostConfig.RestartPolicy
+	}
+
+	// update labels of the container
+	config := container.Config
+	if labels != nil {
+		config.Labels = labels
 	}
 	container.Unlock()
 

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -47,7 +47,7 @@ func (container *Container) TmpfsMounts() []execdriver.Mount {
 }
 
 // UpdateContainer updates configuration of a container
-func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
+func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig, labels map[string]string) error {
 	container.Lock()
 	defer container.Unlock()
 	resources := hostConfig.Resources
@@ -58,9 +58,14 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		resources.MemoryReservation != 0 || resources.KernelMemory != 0 {
 		return fmt.Errorf("Resource updating isn't supported on Windows")
 	}
-	// update HostConfig of container
+	// update HostConfig of the container
 	if hostConfig.RestartPolicy.Name != "" {
 		container.HostConfig.RestartPolicy = hostConfig.RestartPolicy
+	}
+	// update labels of the container
+	config := container.Config
+	if labels != nil {
+		config.Labels = labels
 	}
 	return nil
 }

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ContainerUpdate updates configuration of the container
-func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostConfig) ([]string, error) {
+func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostConfig, labels map[string]string) ([]string, error) {
 	var warnings []string
 
 	warnings, err := daemon.verifyContainerSettings(hostConfig, nil, true)
@@ -16,7 +16,7 @@ func (daemon *Daemon) ContainerUpdate(name string, hostConfig *container.HostCon
 		return warnings, err
 	}
 
-	if err := daemon.update(name, hostConfig); err != nil {
+	if err := daemon.update(name, hostConfig, labels); err != nil {
 		return warnings, err
 	}
 
@@ -34,7 +34,7 @@ func (daemon *Daemon) ContainerUpdateCmdOnBuild(cID string, cmd []string) error 
 	return nil
 }
 
-func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) error {
+func (daemon *Daemon) update(name string, hostConfig *container.HostConfig, labels map[string]string) error {
 	if hostConfig == nil {
 		return nil
 	}
@@ -63,7 +63,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 		return errCannotUpdate(container.ID, fmt.Errorf("Can not update kernel memory to a running container, please stop it first."))
 	}
 
-	if err := container.UpdateContainer(hostConfig); err != nil {
+	if err := container.UpdateContainer(hostConfig, labels); err != nil {
 		restoreConfig = true
 		return errCannotUpdate(container.ID, err)
 	}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 7f6071353fc48f69d2328c4ebe8f3bd0f7c75da4
+clone git github.com/docker/engine-api fc1d1e7b55a15dea971617fe54bea0668a8cf0df https://github.com/vdemeester/engine-api.git
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -289,13 +289,13 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 	}
 
 	// collect all the environment variables for the container
-	envVariables, err := readKVStrings(flEnvFile.GetAll(), flEnv.GetAll())
+	envVariables, err := ReadKVStrings(flEnvFile.GetAll(), flEnv.GetAll())
 	if err != nil {
 		return nil, nil, nil, cmd, err
 	}
 
 	// collect all the labels for the container
-	labels, err := readKVStrings(flLabelsFile.GetAll(), flLabels.GetAll())
+	labels, err := ReadKVStrings(flLabelsFile.GetAll(), flLabels.GetAll())
 	if err != nil {
 		return nil, nil, nil, cmd, err
 	}
@@ -457,8 +457,8 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 	return config, hostConfig, networkingConfig, cmd, nil
 }
 
-// reads a file of line terminated key=value pairs and override that with override parameter
-func readKVStrings(files []string, override []string) ([]string, error) {
+// ReadKVStrings reads a file of line terminated key=value pairs and override that with override parameter
+func ReadKVStrings(files []string, override []string) ([]string, error) {
 	envVariables := []string{}
 	for _, ef := range files {
 		parsedVars, err := ParseEnvFile(ef)

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -223,9 +223,9 @@ type Resources struct {
 // UpdateConfig holds the mutable attributes of a Container.
 // Those attributes can be updated at runtime.
 type UpdateConfig struct {
-	// Contains container's resources (cgroups, ulimits)
-	Resources
-	RestartPolicy RestartPolicy
+	Resources                       // Contains container's resources (cgroups, ulimits)
+	RestartPolicy RestartPolicy     // Restart policies
+	Labels        map[string]string // List of labels set to this container
 }
 
 // HostConfig the non-portable Config structure of a container.


### PR DESCRIPTION
Now that we have the `update` command that allow us to update resources of already created containers (see #15078), the second use case we saw and hear about were about **labels**. 🐠

This adds **support for labels on the `update` command**. It's not mergeable for now as a PR is needed in `engine-api` if we agree on the API changes. 
### Current design and _ideas_ 🐟

Support `--label` and `--label-file` as the `run` command. The API (changes) are thus kept pretty simple.

``` bash
$ docker inspect --format="{{json .Config.Labels}}" d61
{}
$ docker update --labell=foo=bar --label=bar=foo d61
d61
$ docker inspect --format="{{json .Config.Labels}}" d61
{"bar":"foo","foo":"bar"}
$ docker update --label=foo=bar d61
d61
$ docker inspect --format="{{json .Config.Labels}}" d61
{"foo":"bar"}
```

On the daemon side, the labels updated are on `Config`, this means the **updated labels** will be commited when `docker commit` is called – which I'm not sure we want.
- [x] Decides if we should update `Config` (simple, obvious) or `HostConfig` (trickier and way more changes – on ps filters and such for example).
- [ ] Write some integration tests
- [ ] Update completion scripts
- [ ] Update documentation

---

For _archive_ :
### Discussions 🐚

There is three part to discuss on this proposal : the `cli` side, the `api` side and the _behind the scene_ side.
#### CLI
- Do we support `label-file` as we do on `run` ? (it might be too quick to think of that but…) — I think we should not (at first), if there is a need for it, we can add it later.
- Do we allow to add/remove labels or just overriding them _all at once_ ? (I'm definitely for the 1st)
- If we do allow add/remove labels, there is a few options and questions :
  - Could be `--add-label=foo=bar` and `--remove-label=foo`.
  - Or could be `--update-label=+foo=bar`, `--update-label=-foo`.
  - Do we still allow to set labels _all at once_ (so you could either add, remove or completely set the labels) ?
  - What about removing a label that is not set (`--remove-label=idontexists`), should it fail or just put a warning (or even nothing at all) ?
#### API

The current `update` implementation sends the `HostConfig` struct as body ; Labels are _currently_ in `Config` struct (see "Behind the Scene").

<del>- Would we send `Config` and `HostConfig` like it's done with this naive implementation (using `configWrapper` from the `create` command) ?</del>

<del>- Or should we just send the map of `Labels` ? That would mean we should only send the `Resources` instead of `HostConfig` too (might need to be done in another PR, see issue #18957).</del>

<del>- Do we want to *merge* the labels client-side or server-side ? This will have impact on what we are sending — it's going to be a little complicated to use `Config` to send labels if we want to do the merge server-side.</del>


<del>I would definitely vote for merging labels server-side and not using `HostConfig` or `Config` struct on the client side, but more specific sturct (otherwise we are opening the pandora box big time).</del>

#### Behind the Scene 🐙

This is probably where we need to discuss the most. The `update` command currently only updates `Resources` that are on `HostConfig`. The idea behind it is, `update` is currently only allowed to update stuff that are in `Resources` (meaning only `cgroups` right now).

For `Labels` it's a little different and maybe a little bit trickier : `Labels` are in the `Config` struct, which is something we were thinking as _immutable_ when we discuss #15078.
- Should we move `Labels` to `HostConfig` ? It feels a little weird, because `Config` "should hold only portable information about the container" and `HostConfig` "should hold the non-portable Config structure of a container" — so it makes sence to have `Labels` in `Config` ; they are portable.
- Should we copy `Labels` to `HostConfig` at start/creation and update those ones ? It also feels a little bit weird, we would have two `Labels` on `inspect`, and they could differ… plus, does it make sence to keep the labels that were set at creation ? If they comes from the images, then they are still there and _immutable_ there so it's somehow possible to track back which one were there at start.
- Should we update `Config.Labels` like currently done on this PR or should we have some `MutableConfig` sturct to hold stuff we can change ? (and then, should `Resources` be in this `MutableConfig` sturct or not ?)

I'm mostly thinking out loud but it should _bring water to your mill_ (not sure if it's a valid sentence in english but _meh_ :stuck_out_tongue_closed_eyes:).

Waiting for your inputs now :wink:.

🐸

/cc @icecrime @ehazlett @thaJeztah @runcom @tiborvass @unclejack 

Signed-off-by: Vincent Demeester vincent@sbr.pm
