### PR TITLE
Deny finit_module in default seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -72,6 +72,12 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
+			// Deny manipulation and functions on kernel modules.
+			Name:   "finit_module",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
 			// Deny retrieval of exported kernel and module symbols
 			Name:   "get_kernel_syms",
 			Action: configs.Errno,


### PR DESCRIPTION
This is a new version of init_module that takes a file descriptor
rather than a file name.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
