### PR TITLE
Block clock_adjtime in default seccomp config

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -30,6 +30,12 @@ var defaultSeccompProfile = &configs.Seccomp{
 		},
 		{
 			// Time/Date is not namespaced
+			Name:   "clock_adjtime",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
+			// Time/Date is not namespaced
 			Name:   "clock_settime",
 			Action: configs.Errno,
 			Args:   []*configs.Arg{},


### PR DESCRIPTION
clock_adjtime is the new posix style version of adjtime allowing
a specific clock to be specified. Time is not namespaced, so do
not allow.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
