### PR TITLE
Allow access to 'systemd' cgroup for daemon uid

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -46,7 +46,7 @@ fi
 
 check_init() {
 	 # see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it directly)
-	 if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then        
+	 if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then
                 log_failure_msg "$DOCKER_DESC is managed via upstart, try using service $BASE $1"
                 exit 1
          fi
@@ -99,6 +99,10 @@ case "$1" in
 		else
 			ulimit -p 1048576
 		fi
+
+		# allow access on non-systemd systems
+		mkdir -p /sys/fs/cgroup/systemd/user
+		echo $$ > /sys/fs/cgroup/systemd/user/cgroup.procs
 
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -39,6 +39,11 @@ script
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
+
+	# allow access on non-systemd systems
+	mkdir -p /sys/fs/cgroup/systemd/user
+	echo $$ > /sys/fs/cgroup/systemd/user/cgroup.procs
+
 	exec "$DOCKER" daemon $DOCKER_OPTS
 end script
 


### PR DESCRIPTION
...even on non-systemd systems
The fix for missing mountpoint shell function has been moved to #18973

Fixes #18922

Cc @tianon @jfrazelle 

Please note that I have not modified the RedHat one; I can say that I only tested the upstart script as this version of Ubuntu uses that and bypasses the sysvinit script.
