### PR TITLE
Fix error messages

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -224,7 +224,7 @@ func (s *containerRouter) postContainersKill(ctx context.Context, w http.Respons
 		// to keep backwards compatibility.
 		version := httputils.VersionFromContext(ctx)
 		if version.GreaterThanOrEqualTo("1.20") || !isStopped {
-			return fmt.Errorf("Cannot kill container %s: %v", name, err)
+			return fmt.Errorf("Cannot kill container %s: %v", name, utils.GetErrorMessage(err))
 		}
 	}
 
@@ -462,7 +462,7 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 		}
 
 		if err := s.backend.ContainerWsAttachWithLogs(containerName, wsAttachWithLogsConfig); err != nil {
-			logrus.Errorf("Error attaching websocket: %s", err)
+			logrus.Errorf("Error attaching websocket: %s", utils.GetErrorMessage(err))
 		}
 	})
 	ws := websocket.Server{Handler: h, Handshake: nil}

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/docker/utils"
 	"golang.org/x/net/context"
 )
 
@@ -45,7 +46,7 @@ func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 	// Register an instance of Exec in container.
 	id, err := s.backend.ContainerExecCreate(execConfig)
 	if err != nil {
-		logrus.Errorf("Error setting up exec command in container %s: %s", name, err)
+		logrus.Errorf("Error setting up exec command in container %s: %s", name, utils.GetErrorMessage(err))
 		return err
 	}
 
@@ -112,7 +113,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		if execStartCheck.Detach {
 			return err
 		}
-		logrus.Errorf("Error running exec in container: %v\n", err)
+		logrus.Errorf("Error running exec in container: %v\n", utils.GetErrorMessage(err))
 	}
 	return nil
 }


### PR DESCRIPTION
`docker kill 123` will show something like:
`Error response from daemon: Cannot kill container 123: nosuchcontainer: No such container: 123`
Notice the `nosuchcontainer` text, that should not be there as that's an internal ID that means nothing to the end user.
This PR fixes this by using `util.GetErrorMessage()` to extract just the message.

While in that dir I found a couple of other spots that could use the same call, just to be safe.

Signed-off-by: Doug Davis dug@us.ibm.com
