### PR TITLE
Block stime in default seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -281,6 +281,12 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
+			// Time/Date is not namespaced
+			Name:   "stime",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
 			// Deny start/stop swapping to file/device
 			Name:   "swapon",
 			Action: configs.Errno,


### PR DESCRIPTION
The stime syscall is a legacy syscall on some architectures
to set the clock, should be blocked as time is not namespaced.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
