### PR TITLE
Block vm86 syscalls in default seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -316,5 +316,17 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Action: configs.Errno,
 			Args:   []*configs.Arg{},
 		},
+		{
+			// In kernel x86 real mode virtual machine
+			Name:   "vm86",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
+			// In kernel x86 real mode virtual machine
+			Name:   "vm86old",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
 	},
 }


### PR DESCRIPTION
These provide an in kernel virtual machine for x86 real mode on x86
used by one very early DOS emulator. Not required for any normal use.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
