### PR TITLE
Block additional ptrace related syscalls in default seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -112,6 +112,13 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
+			// Restrict process inspection capabilities
+			// Already blocked by dropping CAP_PTRACE
+			Name:   "kcmp",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
 			// Sister syscall of kexec_load that does the same thing,
 			// slightly different arguments
 			Name:   "kexec_file_load",
@@ -206,6 +213,20 @@ var defaultSeccompProfile = &configs.Seccomp{
 		{
 			// Deny pivot_root
 			Name:   "pivot_root",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
+			// Restrict process inspection capabilities
+			// Already blocked by dropping CAP_PTRACE
+			Name:   "process_vm_readv",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
+			// Restrict process modification capabilities
+			// Already blocked by dropping CAP_PTRACE
+			Name:   "process_vm_writev",
 			Action: configs.Errno,
 			Args:   []*configs.Arg{},
 		},


### PR DESCRIPTION
Block kcmp, procees_vm_readv, process_vm_writev.
All these require CAP_PTRACE, and are only used for ptrace related
actions, so are not useful as we block ptrace.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
