### PR TITLE
Block bpf syscall from default seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -29,6 +29,13 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
+			// Deny loading potentially persistent bpf programs into kernel
+			// already gated by CAP_SYS_ADMIN
+			Name:   "bpf",
+			Action: configs.Errno,
+			Args:   []*configs.Arg{},
+		},
+		{
 			// Time/Date is not namespaced
 			Name:   "clock_settime",
 			Action: configs.Errno,


### PR DESCRIPTION
The bpf syscall can load code into the kernel which may
persist beyond container lifecycle. Requires CAP_SYS_ADMIN
already.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
