### PR TITLE
Add missing mountpoint shell function

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -10,26 +10,28 @@ respawn
 kill timeout 20
 
 pre-start script
+	mountpoint() {
+		! awk -v mp="$1" '$2 == mp { exit 1 }' /proc/mounts
+	}
+
 	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
 	if grep -v '^#' /etc/fstab | grep -q cgroup \
 		|| [ ! -e /proc/cgroups ] \
 		|| [ ! -d /sys/fs/cgroup ]; then
 		exit 0
 	fi
-	if ! mountpoint -q /sys/fs/cgroup; then
+	if ! mountpoint /sys/fs/cgroup; then
 		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
 	fi
-	(
-		cd /sys/fs/cgroup
-		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
-			mkdir -p $sys
-			if ! mountpoint -q $sys; then
-				if ! mount -n -t cgroup -o $sys cgroup $sys; then
-					rmdir $sys || true
-				fi
+
+	for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+		mkdir -p /sys/fs/cgroup/$sys
+		if ! mountpoint /sys/fs/cgroup/$sys; then
+			if ! mount -n -t cgroup -o $sys cgroup /sys/fs/cgroup/$sys; then
+				rmdir /sys/fs/cgroup/$sys || true
 			fi
-		done
-	)
+		fi
+	done
 end script
 
 script


### PR DESCRIPTION
I found in `/var/log/upstart/docker.log`:

```
/proc/self/fd/9: 8: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
/proc/self/fd/9: 15: /proc/self/fd/9: mountpoint: not found
Waiting for /var/run/docker.sock
Waiting for /var/run/docker.sock
ESC[34mINFOESC[0m[0000] [graphdriver] using prior storage driver "overlay" 
ESC[34mINFOESC[0m[0000] API listen on /var/run/docker.sock           
/var/run/docker.sock is up
ESC[34mINFOESC[0m[0001] Firewalld running: false                     
```

Thus I suppose it's missing for good. (spin-off #18963)
