### PR TITLE
remove seccomp from seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -255,12 +255,6 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
-			// meta, deny seccomp
-			Name:   "seccomp",
-			Action: configs.Errno,
-			Args:   []*configs.Arg{},
-		},
-		{
 			// Terrifying syscalls that modify kernel memory and NUMA settings.
 			// They're gated by CAP_SYS_NICE,
 			// which we do not retain by default in containers.


### PR DESCRIPTION
This can be allowed because it should only restrict more per the seccomp docs, and multiple apps use it today.
re conversation here: https://github.com/docker/docker/pull/18780#discussion_r48546597
