### PR TITLE
Allow to set the volume name on creation as the first argument.

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -106,20 +106,25 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 //
 // Usage: docker volume create [OPTIONS]
 func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
-	cmd := Cli.Subcmd("volume create", nil, "Create a volume", true)
+	cmd := Cli.Subcmd("volume create", []string{"NAME"}, "Create a volume", true)
 	flDriver := cmd.String([]string{"d", "-driver"}, "local", "Specify volume driver name")
 	flName := cmd.String([]string{"-name"}, "", "Specify volume name")
 
 	flDriverOpts := opts.NewMapOpts(nil, nil)
 	cmd.Var(flDriverOpts, []string{"o", "-opt"}, "Set driver specific options")
 
-	cmd.Require(flag.Exact, 0)
+	cmd.Require(flag.Max, 1)
 	cmd.ParseFlags(args, true)
+
+	name := cmd.Arg(0)
+	if *flName != "" {
+		name = *flName
+	}
 
 	volReq := types.VolumeCreateRequest{
 		Driver:     *flDriver,
 		DriverOpts: flDriverOpts.GetAll(),
-		Name:       *flName,
+		Name:       name,
 	}
 
 	vol, err := cli.client.VolumeCreate(volReq)

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -12,16 +12,16 @@ parent = "smn_cli"
 
     Usage: docker volume create [OPTIONS]
 
-    Create a volume
+    Create a volume [NAME]
 
       -d, --driver=local    Specify volume driver name
       --help                Print usage
-      --name=               Specify volume name
+      --name=               Specify volume name, overrides the command's first argument
       -o, --opt=map[]       Set driver specific options
 
 Creates a new volume that containers can consume and store data in. If a name is not specified, Docker generates a random name. You create a volume and then configure the container to use it, for example:
 
-    $ docker volume create --name hello
+    $ docker volume create hello
     hello
 
     $ docker run -d -v hello:/world busybox ls /world

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -19,6 +19,10 @@ func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
 	out, _ := dockerCmd(c, "volume", "create", "--name=test")
 	name := strings.TrimSpace(out)
 	c.Assert(name, check.Equals, "test")
+
+	out, _ = dockerCmd(c, "volume", "create", "volume-test")
+	name = strings.TrimSpace(out)
+	c.Assert(name, check.Equals, "volume-test")
 }
 
 func (s *DockerSuite) TestVolumeCliCreateOptionConflict(c *check.C) {


### PR DESCRIPTION
`docker volume create` requires a flag to set the volume name. This is
specially confusing compared with `docker network create` that uses the
first argument in the command to set the name.

This change allows people to set the volume name with the first
argument, copying what `docker network create` does. It preserves the
`--name` flag and uses it over the argument if it's set. That way we
don't break current workflows.

Signed-off-by: David Calavera david.calavera@gmail.com
