### PR TITLE
Fix daemon failed to start with error "layer does not exist"

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -732,7 +732,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 	d.layerStore, err = layer.NewStoreFromOptions(layer.StoreOptions{
 		StorePath:                 config.Root,
-		MetadataStorePathTemplate: filepath.Join(config.Root, "image", "%s"),
+		MetadataStorePathTemplate: filepath.Join(config.Root, "image", "%s", "layerdb"),
 		GraphDriver:               driverName,
 		GraphDriverOptions:        config.GraphOptions,
 		UIDMaps:                   uidMaps,


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The latest daemon failed to start with error

<pre><code>
WARN[0000] Running experimental build
WARN[0000] /!\ DON'T BIND ON ANY IP ADDRESS WITHOUT setting -tlsverify IF YOU DON'T KNOW WHAT YOU'RE DOING /!\
DEBU[0000] Server created for HTTP on tcp (0.0.0.0:2375)
DEBU[0000] docker group found. gid: 990
DEBU[0000] Server created for HTTP on unix (/var/run/docker.sock)
DEBU[0000] Creating actual daemon root: /var/lib/docker/0.0
DEBU[0000] Using default logging driver json-file
DEBU[0000] [graphdriver] trying provided driver "overlay"
DEBU[0000] Using graph driver overlay
DEBU[0000] Cleaning up old shm/mqueue mounts: start.
FATA[0000] Error starting daemon: layer does not exist
</code></pre>
