### PR TITLE
Handle error for dockerCmdInDir

### DIFF
--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -21,7 +21,10 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	`, map[string]string{})
 	c.Assert(err, checker.IsNil)
 
-	dockerCmdInDir(c, ctx.Dir, "build", "--no-cache", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpuset-mems=0", "--cpu-shares=100", "--cpu-quota=8000", "--ulimit", "nofile=42", "-t", name, ".")
+	_, _, err = dockerCmdInDir(c, ctx.Dir, "build", "--no-cache", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpuset-mems=0", "--cpu-shares=100", "--cpu-quota=8000", "--ulimit", "nofile=42", "-t", name, ".")
+	if err != nil {
+		c.Fatal(err)
+	}
 
 	out, _ := dockerCmd(c, "ps", "-lq")
 	cID := strings.TrimSpace(out)


### PR DESCRIPTION
Only two of these are not handled, the one in `TestBuildForceRm`
is intended to not be handled, while the other one in
`TestBuildResourceConstraintsAreUsed` causes problem.

In test case `TestBuildResourceConstraintsAreUsed`, somehow we
are not able to access network to get base image, but the error
message is:

```
Error: failed to inspect container : Unable to read inspect data: json: cannot unmarshal array into Go value of type types.ContainerJSON
```

Totally confusion.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
