### PR TITLE
fix build deb with seccomp feature in ubuntu-trusty

### DIFF
--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
@@ -5,6 +5,25 @@
 FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ENV SECCOMP_VERSION v2.2.3
+RUN buildDeps=' \
+automake \
+libtool \
+' \
+&& set -x \
+&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+&& rm -rf /var/lib/apt/lists/* \
+&& export SECCOMP_PATH=$(mktemp -d) \
+&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& ( \
+cd "$SECCOMP_PATH" \
+&& ./autogen.sh \
+&& ./configure --prefix=/usr \
+&& make \
+&& make install \
+) \
+&& rm -rf "$SECCOMP_PATH" \
+&& apt-get purge -y --auto-remove $buildDeps
 
 ENV GO_VERSION 1.5.2
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -12,4 +31,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -38,5 +38,8 @@ override_dh_install:
 	dh_install
 	dh_apparmor --profile-name=docker-engine -pdocker-engine
 
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+
 %:
 	dh $@ --with=bash-completion $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo --with=systemd)


### PR DESCRIPTION
 when I build deb for ubuntu-trusty with seccomp, " dpkg-shlibdeps: error: no dependency information found for /usr/lib/libseccomp.so.2” appears,that is the low version problem of libseccomp.in https://github.com/docker/docker/pull/18949, jfrazelle remove seccomp to fix libseccomp version problem.
I find another way to fix it,  add the following to hack/make/.build-deb/rules:

```
override_dh_shlibdeps:
       dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
```

WDYT? ping @jfrazelle 

Signed-off-by: yangshukui yangshukui@huawei.com
