### PR TITLE
Rename Dockerfile.arm to Dockerfile.armhf to more clearly reflect the specific subversion of ARM it targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,10 +223,10 @@ RUN set -x \
 # Build/install the tool for embedding resources in Windows binaries
 ENV RSRC_COMMIT e48dbf1b7fc464a9e85fcec450dddf80816b76e0
 RUN set -x \
-    && git clone https://github.com/akavel/rsrc.git /go/src/github.com/akavel/rsrc \
-    && cd /go/src/github.com/akavel/rsrc \
-    && git checkout -q $RSRC_COMMIT \
-    && go install -v
+	&& git clone https://github.com/akavel/rsrc.git /go/src/github.com/akavel/rsrc \
+	&& cd /go/src/github.com/akavel/rsrc \
+	&& git checkout -q $RSRC_COMMIT \
+	&& go install -v
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,9 +1,9 @@
-# This file describes the standard way to build Docker on ARM, using docker
+# This file describes the standard way to build Docker on ARMv7, using docker
 #
 # Usage:
 #
 # # Assemble the full dev environment. This is slow the first time.
-# docker build -t docker -f Dockerfile.arm .
+# docker build -t docker -f Dockerfile.armhf .
 #
 # # Mount your source in an interactive container for quick testing:
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
@@ -70,22 +70,21 @@ RUN cd /usr/local/lvm2 \
 
 # Install Go
 ENV GO_VERSION 1.4.3
-RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
-	&& mkdir -p /go/bin
+# TODO update GO_TOOLS_COMMIT below when this updates to 1.5+
+RUN curl -fsSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
-# (set an explicit GOARM of 5 for maximum compatibility)
-ENV GOARM 5
-RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 
-# Compile Go for cross compilation
-ENV DOCKER_CROSSPLATFORMS " "
+# we're building for armhf, which is ARMv7, so let's be explicit about that
+ENV GOARM 7
+
+RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 
 # This has been commented out and kept as reference because we don't support compiling with older Go anymore.
 # ENV GOFMT_VERSION 1.3.3
 # RUN curl -sSL https://storage.googleapis.com/golang/go${GOFMT_VERSION}.$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C /go/bin -xz --strip-components=2 go/bin/gofmt
 
-# Update this sha when we upgrade to go 1.5.0
+# TODO update this sha when we upgrade to Go 1.5+
 ENV GO_TOOLS_COMMIT 069d2f3bcb68257b627205f0486d6cc69a231ff9
 # Grab Go's cover tool for dead-simple code coverage testing
 # Grab Go's vet tool for examining go code to find suspicious constructs
@@ -172,15 +171,15 @@ RUN ln -sv $PWD/contrib/completion/bash/docker /etc/bash_completion.d/docker
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
-  hypriot/armhf-busybox:latest@sha256:b0fc94dac9793ce3c35607b15012b4c7deca300963a7cc38ab440189ec81e2e7 \
-  hypriot/armhf-hello-world:latest@sha256:b618ec0cc3acf683e8d77ad6c5ec81546cddde2036eda9a78f628effdeca74cd \
-  hypriot/armhf-unshare:latest@sha256:8fede091760d2fb8b2d14cedffdd681c4575b02b1abeeb18dd79b754c62327db
+	hypriot/armhf-busybox:latest@sha256:b0fc94dac9793ce3c35607b15012b4c7deca300963a7cc38ab440189ec81e2e7 \
+	hypriot/armhf-hello-world:latest@sha256:b618ec0cc3acf683e8d77ad6c5ec81546cddde2036eda9a78f628effdeca74cd \
+	hypriot/armhf-unshare:latest@sha256:8fede091760d2fb8b2d14cedffdd681c4575b02b1abeeb18dd79b754c62327db
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
- 	&& git clone -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \
@@ -198,10 +197,10 @@ RUN set -x \
 # Build/install the tool for embedding resources in Windows binaries
 ENV RSRC_COMMIT e48dbf1b7fc464a9e85fcec450dddf80816b76e0
 RUN set -x \
-    && git clone https://github.com/akavel/rsrc.git /go/src/github.com/akavel/rsrc \
-    && cd /go/src/github.com/akavel/rsrc \
-    && git checkout -q $RSRC_COMMIT \
-    && go install -v
+	&& git clone https://github.com/akavel/rsrc.git /go/src/github.com/akavel/rsrc \
+	&& cd /go/src/github.com/akavel/rsrc \
+	&& git checkout -q $RSRC_COMMIT \
+	&& go install -v
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_ENGINE_OSARCH = $(shell docker version | grep 'OS/Arch' | tail -1 | cut -
 DOCKER_FILE = Dockerfile
 # switch to different Dockerfile for linux/arm
 ifeq ($(DOCKER_ENGINE_OSARCH),linux/arm)
-  DOCKER_FILE = Dockerfile.arm
+	DOCKER_FILE = Dockerfile.armhf
 endif
 export DOCKER_FILE
 


### PR DESCRIPTION
This will be even more important when we look to add arm64 (which is where ARM actually gets interesting in the server space, IMO).

cc @jfrazelle
