### PR TITLE
add new impact/distribution label

### DIFF
--- a/project/REVIEWING.md
+++ b/project/REVIEWING.md
@@ -43,8 +43,9 @@ help in reviewing the PR, or because of the potential impact of the PR on their 
  * `impact/api`
  * `impact/changelog`
  * `impact/cli`
- * `impact/dockerfile`
  * `impact/deprecation`
+ * `impact/distribution`
+ * `impact/dockerfile`
 
 # Workflow
 


### PR DESCRIPTION
Adds the new label to the documentation. The impact/distribution label is intended for changes that affect the image-format or interaction with the registry (distribution).
