### PR TITLE
Fix missing comment in docker inspect

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1170,12 +1170,17 @@ func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
 		}
 	}
 
+	comment := img.Comment
+	if len(comment) == 0 && len(img.History) > 0 {
+		comment = img.History[len(img.History)-1].Comment
+	}
+
 	imageInspect := &types.ImageInspect{
 		ID:              img.ID().String(),
 		RepoTags:        repoTags,
 		RepoDigests:     repoDigests,
 		Parent:          img.Parent.String(),
-		Comment:         img.Comment,
+		Comment:         comment,
 		Created:         img.Created.Format(time.RFC3339Nano),
 		Container:       img.Container,
 		ContainerConfig: &img.ContainerConfig,

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -372,3 +372,12 @@ func (s *DockerSuite) TestInspectStopWhenNotFound(c *check.C) {
 	c.Assert(out, checker.Not(checker.Contains), "not-shown")
 	c.Assert(out, checker.Contains, "Error: No such container: missing")
 }
+
+func (s *DockerSuite) TestInspectHistory(c *check.C) {
+	dockerCmd(c, "run", "--name=testcont", "-d", "busybox", "top")
+	dockerCmd(c, "commit", "-m", "test comment", "testcont", "testimg")
+	out, _, err := dockerCmdWithError("inspect", "--format='{{.Comment}}'", "testimg")
+
+	c.Assert(err, check.IsNil)
+	c.Assert(out, checker.Contains, "test comment")
+}


### PR DESCRIPTION
Rather than writing the comment twice into the image config just read it directly out of history array for the inspect output.

Fixes #18571

cc @dqminh

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
