### PR TITLE
Fix downstream client API build errors on Solaris

### DIFF
--- a/pkg/system/stat_solaris.go
+++ b/pkg/system/stat_solaris.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows,!freebsd,!solaris
+// +build solaris
 
 package system
 
@@ -13,5 +13,5 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtimespec}, nil
+		mtim: s.Mtim}, nil
 }

--- a/volume/volume_unix.go
+++ b/volume/volume_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd darwin
+// +build linux freebsd darwin solaris
 
 package volume
 


### PR DESCRIPTION
The client API at `fsouza/go-dockerclient` has dependencies on packages in the `docker/docker` repository which currently do not build on Solaris. In particular, `stat_unsupported.go` makes use of the `Mtimespec` field of the `syscall.Stat_t` struct, which is not present on Solaris (it is named `Mtim` instead), and a number of Unix-specific packages do not list Solaris in their compile targets.

This commit adds enough support to be able to build `fsouza/go-dockerclient` on SmartOS using Go 1.5.1, without affecting other platforms.
