### PR TITLE
Change OomKillDisable to be pointer

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -88,7 +88,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		os.Exit(125)
 	}
 
-	if hostConfig.OomKillDisable && hostConfig.Memory == 0 {
+	if hostConfig.OomKillDisable != nil && *hostConfig.OomKillDisable && hostConfig.Memory == 0 {
 		fmt.Fprintf(cli.err, "WARNING: Dangerous only disable the OOM Killer on containers but not set the '-m/--memory' option\n")
 	}
 

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -180,7 +180,7 @@ type Resources struct {
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
-	OomKillDisable       bool            // Whether to disable OOM Killer or not
+	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 }
 

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -212,7 +212,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		BlkioThrottleWriteBpsDevice:  writeBpsDevice,
 		BlkioThrottleReadIOpsDevice:  readIOpsDevice,
 		BlkioThrottleWriteIOpsDevice: writeIOpsDevice,
-		OomKillDisable:               c.HostConfig.OomKillDisable,
+		OomKillDisable:               *c.HostConfig.OomKillDisable,
 		MemorySwappiness:             -1,
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -205,6 +205,10 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 		defaultSwappiness := int64(-1)
 		hostConfig.MemorySwappiness = &defaultSwappiness
 	}
+	if hostConfig.OomKillDisable == nil {
+		defaultOomKillDisable := false
+		hostConfig.OomKillDisable = &defaultOomKillDisable
+	}
 
 	return nil
 }
@@ -265,8 +269,8 @@ func verifyContainerResources(resources *containertypes.Resources) ([]string, er
 		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 		logrus.Warnf("You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 	}
-	if resources.OomKillDisable && !sysInfo.OomKillDisable {
-		resources.OomKillDisable = false
+	if resources.OomKillDisable != nil && !sysInfo.OomKillDisable {
+		resources.OomKillDisable = nil
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -354,7 +354,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		MemorySwap:           memorySwap,
 		MemorySwappiness:     flSwappiness,
 		KernelMemory:         KernelMemory,
-		OomKillDisable:       *flOomKillDisable,
+		OomKillDisable:       flOomKillDisable,
 		CPUShares:            *flCPUShares,
 		CPUPeriod:            *flCPUPeriod,
 		CpusetCpus:           *flCpusetCpus,


### PR DESCRIPTION
It's like `MemorySwappiness`, the default value has specific
meaning (default false means enable oom kill).

We need to change it to pointer so we can update it after
container is created.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
