### PR TITLE
Use constant instead of "scratch"

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -584,7 +584,7 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(reference.Name
 		line := scanner.Text()
 
 		matches := dockerfileFromLinePattern.FindStringSubmatch(line)
-		if matches != nil && matches[1] != "scratch" {
+		if matches != nil && matches[1] != api.NoBaseImageSpecifier {
 			// Replace the line with a resolved "FROM repo@digest"
 			ref, err := reference.ParseNamed(matches[1])
 			if err != nil {

--- a/api/common.go
+++ b/api/common.go
@@ -25,6 +25,10 @@ const (
 
 	// DefaultDockerfileName is the Default filename with Docker commands, read by docker build
 	DefaultDockerfileName string = "Dockerfile"
+
+	// NoBaseImageSpecifier is the symbol used by the FROM
+	// command to specify that no base image is to be used.
+	NoBaseImageSpecifier string = "scratch"
 )
 
 // byPortInfo is a temporary type used to sort types.Port by its fields

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
@@ -25,12 +26,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
-)
-
-const (
-	// NoBaseImageSpecifier is the symbol used by the FROM
-	// command to specify that no base image is to be used.
-	NoBaseImageSpecifier string = "scratch"
 )
 
 // dispatch with no layer / parsing. This is effectively not a command.
@@ -199,7 +194,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 	name := args[0]
 
 	// Windows cannot support a container with no base image.
-	if name == NoBaseImageSpecifier {
+	if name == api.NoBaseImageSpecifier {
 		if runtime.GOOS == "windows" {
 			return fmt.Errorf("Windows does not support FROM scratch")
 		}

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/distribution/metadata"
@@ -191,8 +192,8 @@ func validateRepoName(name string) error {
 	if name == "" {
 		return fmt.Errorf("Repository name can't be empty")
 	}
-	if name == "scratch" {
-		return fmt.Errorf("'scratch' is a reserved name")
+	if name == api.NoBaseImageSpecifier {
+		return fmt.Errorf("'%s' is a reserved name", api.NoBaseImageSpecifier)
 	}
 	return nil
 }


### PR DESCRIPTION
Move NoBaseImageSpecifier to a common spot and then use it instead of
"scratch" in a couple of places.

Signed-off-by: Doug Davis dug@us.ibm.com
