### PR TITLE
added documentation for groupadd for remote api

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -188,6 +188,7 @@ Create a container
              "ReadonlyRootfs": false,
              "Dns": ["8.8.8.8"],
              "DnsSearch": [""],
+             "GroupAdd": ["newgroup"],
              "ExtraHosts": null,
              "VolumesFrom": ["parent", "other:ro"],
              "CapAdd": ["NET_ADMIN"],
@@ -272,6 +273,7 @@ Json Parameters:
           Specified as a boolean value.
     -   **Dns** - A list of DNS servers for the container to use.
     -   **DnsSearch** - A list of DNS search domains
+    -   **GroupAdd** - A list of additional groups that the container process will run as
     -   **ExtraHosts** - A list of hostnames/IP mappings to add to the
         container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
     -   **VolumesFrom** - A list of volumes to inherit from another container.

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -196,6 +196,7 @@ Create a container
              "Dns": ["8.8.8.8"],
              "DnsOptions": [""],
              "DnsSearch": [""],
+             "GroupAdd": ["newgroup"],
              "ExtraHosts": null,
              "VolumesFrom": ["parent", "other:ro"],
              "CapAdd": ["NET_ADMIN"],
@@ -287,6 +288,7 @@ Json Parameters:
     -   **Dns** - A list of DNS servers for the container to use.
     -   **DnsOptions** - A list of DNS options
     -   **DnsSearch** - A list of DNS search domains
+    -   **GroupAdd** - A list of additional groups that the container process will run as
     -   **ExtraHosts** - A list of hostnames/IP mappings to add to the
         container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
     -   **VolumesFrom** - A list of volumes to inherit from another container.

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -261,6 +261,7 @@ Create a container
              "Dns": ["8.8.8.8"],
              "DnsOptions": [""],
              "DnsSearch": [""],
+             "GroupAdd": ["newgroup"],
              "ExtraHosts": null,
              "VolumesFrom": ["parent", "other:ro"],
              "CapAdd": ["NET_ADMIN"],
@@ -361,6 +362,7 @@ Json Parameters:
     -   **Dns** - A list of DNS servers for the container to use.
     -   **DnsOptions** - A list of DNS options
     -   **DnsSearch** - A list of DNS search domains
+    -   **GroupAdd** - A list of additional groups that the container process will run as
     -   **ExtraHosts** - A list of hostnames/IP mappings to add to the
         container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
     -   **VolumesFrom** - A list of volumes to inherit from another container.


### PR DESCRIPTION
I had noticed that GroupAdd was added in version 1.20 of the remote api but isn't listed in subsequent documentation.
