### PR TITLE
daemon: info: remove exported getter

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -142,15 +142,9 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 		pluginsInfo.Network = append(pluginsInfo.Network, nd)
 	}
 
-	pluginsInfo.Authorization = daemon.GetAuthorizationPluginsList()
+	pluginsInfo.Authorization = daemon.configStore.AuthZPlugins
 
 	return pluginsInfo
-}
-
-// GetAuthorizationPluginsList returns the list of plugins drivers
-// registered for authorization.
-func (daemon *Daemon) GetAuthorizationPluginsList() []string {
-	return daemon.configStore.AuthZPlugins
 }
 
 // The uppercase and the lowercase are available for the proxy settings.


### PR DESCRIPTION
Everywhere else `configStore` is used (`Labels` some lines above, etc etc)

Signed-off-by: Antonio Murdaca runcom@redhat.com
