### PR TITLE
Fix declarations of of execdriver/native.NewDriver to have the same signature for all platforms

### DIFF
--- a/daemon/execdriver/native/driver_unsupported.go
+++ b/daemon/execdriver/native/driver_unsupported.go
@@ -9,6 +9,6 @@ import (
 )
 
 // NewDriver returns a new native driver, called from NewDriver of execdriver.
-func NewDriver(root, initPath string) (execdriver.Driver, error) {
+func NewDriver(root string, options []string) (execdriver.Driver, error) {
 	return nil, fmt.Errorf("native driver not supported on non-linux")
 }

--- a/daemon/execdriver/native/driver_unsupported_nocgo.go
+++ b/daemon/execdriver/native/driver_unsupported_nocgo.go
@@ -9,6 +9,6 @@ import (
 )
 
 // NewDriver returns a new native driver, called from NewDriver of execdriver.
-func NewDriver(root, initPath string) (execdriver.Driver, error) {
+func NewDriver(root string, options []string) (execdriver.Driver, error) {
 	return nil, fmt.Errorf("native driver not supported on non-linux")
 }


### PR DESCRIPTION
This change is done so that `driver_unsupported.go` and `driver_unsupported_nocgo.go` declare the same signature for NewDriver as `driver.go`, avoding a potential compile error on unsupported platforms.
Fixes #19032 
