### PR TITLE
Compute plugin list in bash completion for `docker daemon --authz-plugin`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -706,6 +706,10 @@ _docker_daemon() {
 	"
 
 	case "$prev" in
+		--authz-plugin)
+			__docker_complete_plugins Authorization
+			return
+			;;
 		--cluster-store)
 			COMPREPLY=( $( compgen -W "consul etcd zk" -S "://" -- "$cur" ) )
 			__docker_nospace


### PR DESCRIPTION
#18836 added the available Authorization plugins to the output of `docker info`.

This PR makes this information available in bash completion for `docker daemon --authz-plugin` instead of allowing any string.

Ref https://github.com/docker/docker/pull/18649#issuecomment-164573830
