### PR TITLE
Fix race condition in JSONFileLogger.Log

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -90,6 +90,8 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 	if err != nil {
 		return err
 	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	err = (&jsonlog.JSONLogs{
 		Log:      append(msg.Line, '\n'),
 		Stream:   msg.Source,


### PR DESCRIPTION
bytes.Buffer is not safe for concurrent use and must be guarded by a mutex.
The Log method did not lock the struct mutex before writing to the buffer.

Fixes #19021 

Signed-off-by: Ingo Gottwald in.gottwald@gmail.com
