### PR TITLE
Update docker network api doc

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -2797,8 +2797,9 @@ Content-Type: application/json
 
 Status Codes:
 
-- **201** - no error
+- **200** - no error
 - **404** - network or container is not found
+- **500** - Internal Server Error
 
 JSON Parameters:
 
@@ -2827,8 +2828,9 @@ Content-Type: application/json
 
 Status Codes:
 
-- **201** - no error
+- **200** - no error
 - **404** - network or container not found
+- **500** - Internal Server Error
 
 JSON Parameters:
 
@@ -2846,11 +2848,11 @@ Instruct the driver to remove the network (`id`).
 
 **Example response**:
 
-    HTTP/1.1 204 No Content
+    HTTP/1.1 200 OK
 
 Status Codes
 
--   **204** - no error
+-   **200** - no error
 -   **404** - no such network
 -   **500** - server error
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2995,8 +2995,9 @@ Content-Type: application/json
 
 Status Codes:
 
-- **201** - no error
+- **200** - no error
 - **404** - network or container is not found
+- **500** - Internal Server Error
 
 JSON Parameters:
 
@@ -3025,8 +3026,9 @@ Content-Type: application/json
 
 Status Codes:
 
-- **201** - no error
+- **200** - no error
 - **404** - network or container not found
+- **500** - Internal Server Error
 
 JSON Parameters:
 
@@ -3044,11 +3046,11 @@ Instruct the driver to remove the network (`id`).
 
 **Example response**:
 
-    HTTP/1.1 204 No Content
+    HTTP/1.1 200 OK
 
 Status Codes
 
--   **204** - no error
+-   **200** - no error
 -   **404** - no such network
 -   **500** - server error
 


### PR DESCRIPTION
Test results:
1) for connect:

```
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Server: Docker/1.9.1 (linux)
Date: Mon, 04 Jan 2016 09:56:31 GMT
Content-Length: 50

container already connected to network testnework
```

2) for disconnect:

```
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Server: Docker/1.9.1 (linux)
Date: Mon, 04 Jan 2016 09:45:24 GMT
Content-Length: 107

container e86cf50fde54217bfd72429fec5e7f7e3cfa2246cb30e842088ad3c1fdcf7f61 is not connected to the network
```

3) for remove:

```
HTTP/1.1 200 OK
Server: Docker/1.9.1 (linux)
Date: Mon, 04 Jan 2016 09:59:11 GMT
Content-Length: 0
Content-Type: text/plain; charset=utf-8
```

Signed-off-by: Wen Cheng Ma wenchma@cn.ibm.com
