### PR TITLE
docs: update configuring docker for systemd

### DIFF
--- a/docs/articles/configuring.md
+++ b/docs/articles/configuring.md
@@ -85,6 +85,10 @@ You can start/stop/restart the `docker` daemon using
 
 ### Configuring Docker
 
+The instructions below depict configuring Docker on a system that uses `upstart`
+as the process manager. As of Ubuntu 15.04, Ubuntu uses `systemd` as its process
+manager. For Ubuntu 15.04 and higher, refer to [control and configure Docker with systemd](systemd.md).
+
 You configure the `docker` daemon in the `/etc/default/docker` file on your
 system. You do this by specifying values in a `DOCKER_OPTS` variable.
 


### PR DESCRIPTION
Ubuntu 15.04 and above uses systemd. Add a note to point users to the right instructions.

closes https://github.com/docker/docker/issues/16770
