### PR TITLE
Remove version package from API types.

### DIFF
--- a/api/client/version.go
+++ b/api/client/version.go
@@ -9,7 +9,6 @@ import (
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
-	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/utils"
 )
 
@@ -57,7 +56,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	vd := types.VersionResponse{
 		Client: &types.Version{
 			Version:      dockerversion.Version,
-			APIVersion:   version.Version(cli.client.ClientVersion()),
+			APIVersion:   cli.client.ClientVersion(),
 			GoVersion:    runtime.Version(),
 			GitCommit:    dockerversion.GitCommit,
 			BuildTime:    dockerversion.BuildTime,

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -37,7 +37,7 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 
 func (s *systemRouter) getVersion(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	info := s.backend.SystemVersion()
-	info.APIVersion = api.DefaultVersion
+	info.APIVersion = api.DefaultVersion.String()
 
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/pkg/version"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -178,7 +177,7 @@ type ContainerProcessList struct {
 // GET "/version"
 type Version struct {
 	Version       string
-	APIVersion    version.Version `json:"ApiVersion"`
+	APIVersion    string `json:"ApiVersion"`
 	GitCommit     string
 	GoVersion     string
 	Os            string


### PR DESCRIPTION
It's an internal type that only extends string.

Signed-off-by: David Calavera david.calavera@gmail.com
