### PR TITLE
move api config structs from daemon to api/types

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/version"
@@ -51,17 +50,17 @@ type stateBackend interface {
 type monitorBackend interface {
 	ContainerChanges(name string) ([]archive.Change, error)
 	ContainerInspect(name string, size bool, version version.Version) (interface{}, error)
-	ContainerLogs(name string, config *daemon.ContainerLogsConfig) error
-	ContainerStats(name string, config *daemon.ContainerStatsConfig) error
+	ContainerLogs(name string, config *types.ContainerLogsConfig) error
+	ContainerStats(name string, config *types.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error)
 
-	Containers(config *daemon.ContainersConfig) ([]*types.Container, error)
+	Containers(config *types.ContainersConfig) ([]*types.Container, error)
 }
 
 // attachBackend includes function to implement to provide container attaching functionality.
 type attachBackend interface {
-	ContainerAttachWithLogs(name string, c *daemon.ContainerAttachWithLogsConfig) error
-	ContainerWsAttachWithLogs(name string, c *daemon.ContainerWsAttachWithLogsConfig) error
+	ContainerAttachWithLogs(name string, c *types.ContainerAttachWithLogsConfig) error
+	ContainerWsAttachWithLogs(name string, c *types.ContainerWsAttachWithLogsConfig) error
 }
 
 // Backend is all the methods that need to be implemented to provide container specific functionality.

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	timetypes "github.com/docker/docker/api/types/time"
-	"github.com/docker/docker/daemon"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
@@ -31,7 +30,7 @@ func (s *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 		return err
 	}
 
-	config := &daemon.ContainersConfig{
+	config := &types.ContainersConfig{
 		All:     httputils.BoolValue(r, "all"),
 		Size:    httputils.BoolValue(r, "size"),
 		Since:   r.Form.Get("since"),
@@ -76,7 +75,7 @@ func (s *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 		closeNotifier = notifier.CloseNotify()
 	}
 
-	config := &daemon.ContainerStatsConfig{
+	config := &types.ContainerStatsConfig{
 		Stream:    stream,
 		OutStream: out,
 		Stop:      closeNotifier,
@@ -132,7 +131,7 @@ func (s *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
 
-	logsConfig := &daemon.ContainerLogsConfig{
+	logsConfig := &types.ContainerLogsConfig{
 		Follow:     httputils.BoolValue(r, "follow"),
 		Timestamps: httputils.BoolValue(r, "timestamps"),
 		Since:      since,
@@ -438,7 +437,7 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 		}
 	}
 
-	attachWithLogsConfig := &daemon.ContainerAttachWithLogsConfig{
+	attachWithLogsConfig := &types.ContainerAttachWithLogsConfig{
 		Hijacker:   w.(http.Hijacker),
 		Upgrade:    upgrade,
 		UseStdin:   httputils.BoolValue(r, "stdin"),
@@ -475,7 +474,7 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 	h := websocket.Handler(func(ws *websocket.Conn) {
 		defer ws.Close()
 
-		wsAttachWithLogsConfig := &daemon.ContainerWsAttachWithLogsConfig{
+		wsAttachWithLogsConfig := &types.ContainerWsAttachWithLogsConfig{
 			InStream:   ws,
 			OutStream:  ws,
 			ErrStream:  ws,

--- a/api/types/configs.go
+++ b/api/types/configs.go
@@ -1,6 +1,13 @@
 package types
 
-import "github.com/docker/docker/api/types/container"
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/version"
+)
 
 // configs holds structs used for internal communication between the
 // frontend (such as an http server) and the backend (such as the
@@ -47,4 +54,69 @@ type ExecConfig struct {
 	Detach       bool     // Execute in detach mode
 	DetachKeys   string   // Escape keys for detach
 	Cmd          []string // Execution commands and args
+}
+
+// ContainerWsAttachWithLogsConfig attach with websockets, since all
+// stream data is delegated to the websocket to handle there.
+type ContainerWsAttachWithLogsConfig struct {
+	InStream             io.ReadCloser
+	OutStream, ErrStream io.Writer
+	Logs, Stream         bool
+	DetachKeys           []byte
+}
+
+// ContainerAttachWithLogsConfig holds the streams to use when
+// connecting to a container to view logs.
+type ContainerAttachWithLogsConfig struct {
+	Hijacker   http.Hijacker
+	Upgrade    bool
+	UseStdin   bool
+	UseStdout  bool
+	UseStderr  bool
+	Logs       bool
+	Stream     bool
+	DetachKeys []byte
+}
+
+// ContainerLogsConfig holds configs for logging operations. Exists
+// for users of the daemon to to pass it a logging configuration.
+type ContainerLogsConfig struct {
+	// if true stream log output
+	Follow bool
+	// if true include timestamps for each line of log output
+	Timestamps bool
+	// return that many lines of log output from the end
+	Tail string
+	// filter logs by returning on those entries after this time
+	Since time.Time
+	// whether or not to show stdout and stderr as well as log entries.
+	UseStdout, UseStderr bool
+	OutStream            io.Writer
+	Stop                 <-chan bool
+}
+
+// ContainerStatsConfig holds information for configuring the runtime
+// behavior of a daemon.ContainerStats() call.
+type ContainerStatsConfig struct {
+	Stream    bool
+	OutStream io.Writer
+	Stop      <-chan bool
+	Version   version.Version
+}
+
+// ContainersConfig is the filtering specified by the user to iterate
+// over containers.
+type ContainersConfig struct {
+	// if true show all containers, otherwise only running containers.
+	All bool
+	// show all containers created after this container id
+	Since string
+	// show all containers created before this container id
+	Before string
+	// number of containers to return at most
+	Limit int
+	// if true include the sizes of the containers
+	Size bool
+	// return only containers that match filters
+	Filters string
 }

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -3,30 +3,18 @@ package daemon
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/logger"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-// ContainerAttachWithLogsConfig holds the streams to use when connecting to a container to view logs.
-type ContainerAttachWithLogsConfig struct {
-	Hijacker   http.Hijacker
-	Upgrade    bool
-	UseStdin   bool
-	UseStdout  bool
-	UseStderr  bool
-	Logs       bool
-	Stream     bool
-	DetachKeys []byte
-}
-
 // ContainerAttachWithLogs attaches to logs according to the config passed in. See ContainerAttachWithLogsConfig.
-func (daemon *Daemon) ContainerAttachWithLogs(prefixOrName string, c *ContainerAttachWithLogsConfig) error {
+func (daemon *Daemon) ContainerAttachWithLogs(prefixOrName string, c *types.ContainerAttachWithLogsConfig) error {
 	if c.Hijacker == nil {
 		return derr.ErrorCodeNoHijackConnection.WithArgs(prefixOrName)
 	}
@@ -82,17 +70,8 @@ func (daemon *Daemon) ContainerAttachWithLogs(prefixOrName string, c *ContainerA
 	return nil
 }
 
-// ContainerWsAttachWithLogsConfig attach with websockets, since all
-// stream data is delegated to the websocket to handle there.
-type ContainerWsAttachWithLogsConfig struct {
-	InStream             io.ReadCloser
-	OutStream, ErrStream io.Writer
-	Logs, Stream         bool
-	DetachKeys           []byte
-}
-
 // ContainerWsAttachWithLogs websocket connection
-func (daemon *Daemon) ContainerWsAttachWithLogs(prefixOrName string, c *ContainerWsAttachWithLogsConfig) error {
+func (daemon *Daemon) ContainerWsAttachWithLogs(prefixOrName string, c *types.ContainerWsAttachWithLogsConfig) error {
 	container, err := daemon.GetContainer(prefixOrName)
 	if err != nil {
 		return err

--- a/daemon/daemonbuilder/builder.go
+++ b/daemon/daemonbuilder/builder.go
@@ -86,7 +86,7 @@ func (d Docker) ContainerUpdateCmd(cID string, cmd []string) error {
 
 // ContainerAttach attaches streams to the container cID. If stream is true, it streams the output.
 func (d Docker) ContainerAttach(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool) error {
-	return d.Daemon.ContainerWsAttachWithLogs(cID, &daemon.ContainerWsAttachWithLogsConfig{
+	return d.Daemon.ContainerWsAttachWithLogs(cID, &types.ContainerWsAttachWithLogsConfig{
 		InStream:  stdin,
 		OutStream: stdout,
 		ErrStream: stderr,

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -39,22 +39,6 @@ func (daemon *Daemon) List() []*container.Container {
 	return daemon.containers.List()
 }
 
-// ContainersConfig is the filtering specified by the user to iterate over containers.
-type ContainersConfig struct {
-	// if true show all containers, otherwise only running containers.
-	All bool
-	// show all containers created after this container id
-	Since string
-	// show all containers created before this container id
-	Before string
-	// number of containers to return at most
-	Limit int
-	// if true include the sizes of the containers
-	Size bool
-	// return only containers that match filters
-	Filters string
-}
-
 // listContext is the daemon generated filtering to iterate over containers.
 // This is created based on the user specification.
 type listContext struct {
@@ -77,16 +61,16 @@ type listContext struct {
 	// this is used for --filter=since= and --since=, the latter is deprecated.
 	sinceFilter *container.Container
 	// ContainersConfig is the filters set by the user
-	*ContainersConfig
+	*types.ContainersConfig
 }
 
 // Containers returns the list of containers to show given the user's filtering.
-func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, error) {
+func (daemon *Daemon) Containers(config *types.ContainersConfig) ([]*types.Container, error) {
 	return daemon.reduceContainers(config, daemon.transformContainer)
 }
 
 // reduceContainer parses the user filtering and generates the list of containers to return based on a reducer.
-func (daemon *Daemon) reduceContainers(config *ContainersConfig, reducer containerReducer) ([]*types.Container, error) {
+func (daemon *Daemon) reduceContainers(config *types.ContainersConfig, reducer containerReducer) ([]*types.Container, error) {
 	containers := []*types.Container{}
 
 	ctx, err := daemon.foldFilter(config)
@@ -129,7 +113,7 @@ func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *lis
 }
 
 // foldFilter generates the container filter based in the user's filtering options.
-func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error) {
+func (daemon *Daemon) foldFilter(config *types.ContainersConfig) (*listContext, error) {
 	psFilters, err := filters.FromParam(config.Filters)
 	if err != nil {
 		return nil, err

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -3,9 +3,9 @@ package daemon
 import (
 	"io"
 	"strconv"
-	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/jsonfilelog"
@@ -13,26 +13,9 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-// ContainerLogsConfig holds configs for logging operations. Exists
-// for users of the daemon to to pass it a logging configuration.
-type ContainerLogsConfig struct {
-	// if true stream log output
-	Follow bool
-	// if true include timestamps for each line of log output
-	Timestamps bool
-	// return that many lines of log output from the end
-	Tail string
-	// filter logs by returning on those entries after this time
-	Since time.Time
-	// whether or not to show stdout and stderr as well as log entries.
-	UseStdout, UseStderr bool
-	OutStream            io.Writer
-	Stop                 <-chan bool
-}
-
 // ContainerLogs hooks up a container's stdout and stderr streams
 // configured with the given struct.
-func (daemon *Daemon) ContainerLogs(containerName string, config *ContainerLogsConfig) error {
+func (daemon *Daemon) ContainerLogs(containerName string, config *types.ContainerLogsConfig) error {
 	container, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return derr.ErrorCodeNoSuchContainer.WithArgs(containerName)

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -2,26 +2,15 @@ package daemon
 
 import (
 	"encoding/json"
-	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/daemon/execdriver"
-	"github.com/docker/docker/pkg/version"
 )
-
-// ContainerStatsConfig holds information for configuring the runtime
-// behavior of a daemon.ContainerStats() call.
-type ContainerStatsConfig struct {
-	Stream    bool
-	OutStream io.Writer
-	Stop      <-chan bool
-	Version   version.Version
-}
 
 // ContainerStats writes information about the container to the stream
 // given in the config object.
-func (daemon *Daemon) ContainerStats(prefixOrName string, config *ContainerStatsConfig) error {
+func (daemon *Daemon) ContainerStats(prefixOrName string, config *types.ContainerStatsConfig) error {
 	container, err := daemon.GetContainer(prefixOrName)
 	if err != nil {
 		return err


### PR DESCRIPTION
- ContainerLogsConfig
- ContainerStatsConfig
- ContainersConfig
- ContainerAttachWithLogsConfig
- ContainerWsAttachWithLogsConfig

Signed-off-by: Morgan Bauer mbauer@us.ibm.com

No more dependency on daemon in a couple of places.

Might confict a little bit with #18943 on the merge.

@calavera @duglin 
