### PR TITLE
add shiplift docker client to remote api client list

### DIFF
--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -140,7 +140,7 @@ will add the libraries here.
       <td>Albatros</td>
       <td><a class="reference external" href="https://github.com/dcylabs/albatros">https://github.com/dcylabs/albatros</a></td>
       <td>Active</td>
-    </tr>    
+    </tr>
     <tr>
       <td>JavaScript (Angular) <strong>WebUI</strong></td>
       <td>docker-cp</td>
@@ -158,7 +158,7 @@ will add the libraries here.
       <td>dockery</td>
       <td><a class="reference external" href="https://github.com/lexandro/dockery">https://github.com/lexandro/dockery</a></td>
       <td>Active</td>
-    </tr>    
+    </tr>
     <tr>
       <td>Perl</td>
       <td>Net::Docker</td>
@@ -208,6 +208,12 @@ will add the libraries here.
       <td>Active</td>
     </tr>
     <tr>
+      <td>Rust</td>
+      <td>shiplift</td>
+      <td><a class="reference external" href="https://github.com/softprops/shiplift">https://github.com/softprops/shiplift</a></td>
+      <td>Active</td>
+    </tr>
+    <tr>
       <td>Scala</td>
       <td>tugboat</td>
       <td><a class="reference external" href="https://github.com/softprops/tugboat">https://github.com/softprops/tugboat</a></td>
@@ -221,4 +227,3 @@ will add the libraries here.
     </tr>
   </tbody>
 </table>
-


### PR DESCRIPTION
I'd like to add a Rust client I've been working on to the list of remote api clients.
