### PR TITLE
Enable incremental builds

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -140,8 +140,17 @@ LDFLAGS_STATIC=''
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.
-ORIG_BUILDFLAGS=( -a -tags "autogen netgo static_build sqlite_omit_load_extension $DOCKER_BUILDTAGS" -installsuffix netgo )
+ORIG_BUILDFLAGS=( -tags "autogen netgo static_build sqlite_omit_load_extension $DOCKER_BUILDTAGS" -installsuffix netgo )
 # see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
+
+# When $DOCKER_INCREMENTAL_BINARY is set in the environment, enable incremental
+# builds by installing dependent packages to the GOPATH.
+REBUILD_FLAG="-a"
+if [ "$DOCKER_INCREMENTAL_BINARY" ]; then
+	REBUILD_FLAG="-i"
+fi
+ORIG_BUILDFLAGS+=( $REBUILD_FLAG )
+
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.
 : ${TIMEOUT:=120m}


### PR DESCRIPTION
Remove the `-a` build flag and introduce `-i` in order to reuse previously compiled dependencies. This is more about opening a discussion, because I don't understand why we wouldn't be doing this.

From the [Go documentation](https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies):

> The -i flag installs the packages that are dependencies of the target.

This is the difference it makes for me:

```
# First compilation
root@d6d1ae70e97e:/go/src/github.com/docker/docker# time hack/make.sh binary

bundles/1.10.0-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.10.0-dev/binary)
Building: bundles/1.10.0-dev/binary/docker-1.10.0-dev
Created binary: bundles/1.10.0-dev/binary/docker-1.10.0-dev


real    0m52.216s
user    1m52.800s
sys     0m5.400s
```

```
# Second compilation
root@d6d1ae70e97e:/go/src/github.com/docker/docker# time hack/make.sh binary

bundles/1.10.0-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.10.0-dev/binary)
Building: bundles/1.10.0-dev/binary/docker-1.10.0-dev
Created binary: bundles/1.10.0-dev/binary/docker-1.10.0-dev


real    0m10.145s
user    0m18.968s
sys     0m1.144s
```

As far as I can tell, updating a source file does trigger a rebuild of the impacted dependency as expected.

One thing we might want to do if we decide to proceed with the merge is to ensure that the release script starts by cleaning previously compiled dependencies (or adds a `-a`).

Ping @tianon @jfrazelle!
