### PR TITLE
example cannot work, pip needs --requirement

### DIFF
--- a/docs/articles/dockerfile_best-practices.md
+++ b/docs/articles/dockerfile_best-practices.md
@@ -312,7 +312,7 @@ specifically required files change.
 For example:
 
     COPY requirements.txt /tmp/
-    RUN pip install /tmp/requirements.txt
+    RUN pip install --requirement /tmp/requirements.txt
     COPY . /tmp/
 
 Results in fewer cache invalidations for the `RUN` step, than if you put the


### PR DESCRIPTION
The example is not explicit, but the requirements.txt file is most likely a list of requirements (i.e. list of packages to be installed) and not a python package itself. As such it needs the "--requirement" or "-r" option.

Signed-off-by: Anthon van der Neut anthon@mnt.org
