### PR TITLE
Remove hello-world:latest tag before integration

### DIFF
--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -97,5 +97,6 @@ case "$DOCKER_ENGINE_OSARCH" in
 		;;
 	*)
 		docker tag hello-world:latest hello-world:frozen
+		docker rmi hello-world:latest
 		;;
 esac


### PR DESCRIPTION
This is to make sure we are in the same state on linux/arm, linux/… and
other architecture. 🐙

Maybe we want the other way around (meaning having `hello-world:latest` everywhere), but I'm wondering :stuck_out_tongue_closed_eyes:.

/cc @jfrazelle @tianon 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
