### PR TITLE
Improve & cleanup documentation comments

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -173,11 +173,15 @@ func (b *Builder) Cancel() {
 	})
 }
 
-// BuildFromConfig will do build directly from parameter 'changes', which comes
-// from Dockerfile entries, it will:
-// - call parse.Parse() to get AST root from Dockerfile entries
-// - do build by calling builder.dispatch() to call all entries' handling routines
-// TODO: remove?
+// BuildFromConfig will do build directly from parameter 'changes',
+// which is treated like it is coming from a Dockerfile. It will:
+// - Call parse.Parse() to get an AST root for the concatenated Dockerfile entries.
+// - Do build by calling builder.dispatch() to call all entries' handling routines
+//
+// BuildFromConfig is used by the /commit endpoint, with the changes
+// coming from the query parameter of the same name.
+//
+// TODO: Remove?
 func BuildFromConfig(config *container.Config, changes []string) (*container.Config, error) {
 	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")))
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1013,8 +1013,8 @@ func (daemon *Daemon) changes(container *container.Container) ([]archive.Change,
 	return container.RWLayer.Changes()
 }
 
-// TagImage creates a tag in the repository reponame, pointing to the image named
-// imageName.
+// TagImage creates a tag in the repository and with the name specified by newTag,
+// pointing to the image named imageName (alternatively, imageName can also be an image ID).
 func (daemon *Daemon) TagImage(newTag reference.Named, imageName string) error {
 	imageID, err := daemon.GetImageID(imageName)
 	if err != nil {


### PR DESCRIPTION
This PR contains multiple small improvements to wording and formatting of the documentation comments.

If desired, I can squash the commits into one, although I think that the commits are fine as-is.
