### PR TITLE
Rename detachKeys queryparam to detach-keys

### DIFF
--- a/api/client/lib/container_attach.go
+++ b/api/client/lib/container_attach.go
@@ -25,7 +25,7 @@ func (cli *Client) ContainerAttach(options types.ContainerAttachOptions) (types.
 		query.Set("stderr", "1")
 	}
 	if options.DetachKeys != "" {
-		query.Set("detachKeys", options.DetachKeys)
+		query.Set("detach-keys", options.DetachKeys)
 	}
 
 	headers := map[string][]string{"Content-Type": {"text/plain"}}

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -430,7 +430,7 @@ func (s *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 	_, upgrade := r.Header["Upgrade"]
 
 	keys := []byte{}
-	detachKeys := r.FormValue("detachKeys")
+	detachKeys := r.FormValue("detach-keys")
 	if detachKeys != "" {
 		keys, err = term.ToBytes(detachKeys)
 		if err != nil {
@@ -464,7 +464,7 @@ func (s *containerRouter) wsContainersAttach(ctx context.Context, w http.Respons
 
 	var keys []byte
 	var err error
-	detachKeys := r.FormValue("detachKeys")
+	detachKeys := r.FormValue("detach-keys")
 	if detachKeys != "" {
 		keys, err = term.ToBytes(detachKeys)
 		if err != nil {

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -862,9 +862,10 @@ This endpoint returns a live stream of a container's resource usage statistics.
                "total_usage" : 36488948,
                "usage_in_kernelmode" : 20000000
             },
-            "system_cpu_usage" : 20091722000000000,
+            "system_cpu_usage" : 20091722000000000,
             "throttling_data" : {}
-         }      }
+         }
+      }
 
 Query Parameters:
 
@@ -923,7 +924,7 @@ Start the container `id`
 
 Query Parameters:
 
--   **detacheys** – Override the key sequence for detaching a
+-   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 
@@ -1138,7 +1139,7 @@ Attach to the container `id`
 
 Query Parameters:
 
--   **detacheys** – Override the key sequence for detaching a
+-   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
@@ -1221,7 +1222,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 Query Parameters:
 
--   **detacheys** – Override the key sequence for detaching a
+-   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
@@ -2501,7 +2502,7 @@ Json Parameters:
 -   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
 -   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
 -   **AttachStderr** - Boolean value, attaches to `stderr` of the `exec` command.
--   **Detacheys** – Override the key sequence for detaching a
+-   **DetachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 -   **Tty** - Boolean value to allocate a pseudo-TTY.
@@ -2969,11 +2970,6 @@ Status Codes:
 
 `POST /networks/create`
 
-Create a network
-
-**Example request**:
-
-```
 Create a network
 
 **Example request**:

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -924,7 +924,7 @@ Start the container `id`
 
 Query Parameters:
 
--   **detachKeys** – Override the key sequence for detaching a
+-   **detach-keys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 
@@ -1139,7 +1139,7 @@ Attach to the container `id`
 
 Query Parameters:
 
--   **detachKeys** – Override the key sequence for detaching a
+-   **detach-keys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
@@ -1222,7 +1222,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 Query Parameters:
 
--   **detachKeys** – Override the key sequence for detaching a
+-   **detach-keys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.


### PR DESCRIPTION
Per https://github.com/docker/docker/pull/19090#issue-124990149, but it's just something I like more so feel free to close

(is based on top of that PR, so I'll rebase if that's merged)
