### PR TITLE
Record PID of exec'd process.

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -267,6 +267,10 @@ func (d *Daemon) containerExec(container *container.Container, ec *exec.Config) 
 
 	callback := func(processConfig *execdriver.ProcessConfig, pid int, chOOM <-chan struct{}) error {
 		if processConfig.Tty {
+			ec.Lock()
+			ec.PID = pid
+			ec.Unlock()
+
 			// The callback is called after the process Start()
 			// so we are in the parent process. In TTY mode, stdin/out/err is the PtySlave
 			// which we close here.

--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -26,6 +26,7 @@ type Config struct {
 	CanRemove     bool
 	ContainerID   string
 	DetachKeys    []byte
+	PID           int
 
 	// waitStart will be closed immediately after the exec is really started.
 	waitStart chan struct{}

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2321,7 +2321,7 @@ Docker networks report the following events:
     [
 	    {
 		"action": "pull",
-		"type": "image", 
+		"type": "image",
 		"actor": {
 			"id": "busybox:latest",
 			"attributes": {}
@@ -2630,6 +2630,7 @@ Return low-level information about the `exec` command `id`.
       "OpenStdin" : false,
       "OpenStderr" : false,
       "OpenStdout" : false,
+      "PID": 1934,
       "Container" : {
         "State" : {
           "Status" : "running",
@@ -2921,7 +2922,7 @@ Content-Type: application/json
 
 Query Parameters:
 
-- **filters** - JSON encoded network list filter. The filter value is one of: 
+- **filters** - JSON encoded network list filter. The filter value is one of:
   -   `name=<network-name>` Matches all or part of a network name.
   -   `id=<network-id>` Matches all or part of a network id.
   -   `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -70,6 +70,10 @@ func (s *DockerSuite) TestExecAPIStart(c *check.C) {
 	id := createExec(c, "test")
 	startExec(c, id, http.StatusOK)
 
+	var execJSON struct{ PID int }
+	inspectExec(c, id, &execJSON)
+	c.Assert(execJSON.PID, checker.Not(checker.Equals), 0)
+
 	id = createExec(c, "test")
 	dockerCmd(c, "stop", "test")
 


### PR DESCRIPTION
Fixes #18635 

Example:

```
root@7b9cc5889e76:/go/src/github.com/docker/docker# echo -e "GET /exec/7cef454771d3771e5b10dea5644934611baf0d9d1d3a6d64039f72abcedd8f66/json HTTP/1.0\r\n" | nc -U /var/run/docker.sock
HTTP/1.0 200 OK
Content-Type: application/json
Server: Docker/1.10.0-dev (linux)
Date: Tue, 05 Jan 2016 17:20:13 GMT
Content-Length: 377

{
    "CanRemove": false,
    "ContainerID": "ae0218d93d8b2a2003630e22ab2b464d5284897063b7212fb621b12e5c9e5366",
    "DetachKeys": "",
    "ExitCode": 0,
    "ID": "7cef454771d3771e5b10dea5644934611baf0d9d1d3a6d64039f72abcedd8f66",
    "OpenStderr": true,
    "OpenStdin": true,
    "OpenStdout": true,
    "PID": 1934,
    "ProcessConfig": {
        "arguments": [],
        "entrypoint": "/bin/sh",
        "privileged": false,
        "tty": true,
        "user": ""
    },
    "Running": true
}
root@7b9cc5889e76:/go/src/github.com/docker/docker# ps auxf
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root      1940  0.0  0.1  18168  3368 ?        Ss   17:18   0:00 bash
root      1980  0.0  0.1  15568  2096 ?        R+   17:20   0:00  \_ ps auxf
root      1891  0.0  0.1  18168  3376 ?        Ss   17:16   0:00 bash
root      1924  0.0  1.3 291188 28388 ?        Sl+  17:17   0:00  \_ docker exec -ti ae0218d93d8b /bin/sh
root         1  0.0  0.1  18168  3364 pts/1    Ss   16:45   0:00 /bin/bash
root      1846  0.3  1.9 532364 40644 pts/1    Sl+  17:16   0:00 docker daemon -D
root      1915  0.0  0.0   1520     4 pts/0    Ss+  17:17   0:00  \_ /bin/sh
root      1934  0.0  0.0   1520     4 pts/1    Ss+  17:17   0:00  \_ /bin/sh
```
