### PR TITLE
bash completion for `docker daemon --cgroup-parent`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -678,6 +678,7 @@ _docker_daemon() {
 		--authz-plugin
 		--bip
 		--bridge -b
+		--cgroup-parent
 		--cluster-advertise
 		--cluster-store
 		--cluster-store-opt


### PR DESCRIPTION
This adds bash completion for `docker daemon --cgroup-parent`, which was introduced in #19062.

/cc @sdurrheimer for zsh completion
