### PR TITLE
Do not perform build context switch when content trust is not enabled.

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -121,15 +121,6 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		contextDir = tempDir
 	}
 
-	// Resolve the FROM lines in the Dockerfile to trusted digest references
-	// using Notary. On a successful build, we must tag the resolved digests
-	// to the original name specified in the Dockerfile.
-	newDockerfile, resolvedTags, err := rewriteDockerfileFrom(filepath.Join(contextDir, relDockerfile), cli.trustedReference)
-	if err != nil {
-		return fmt.Errorf("unable to process Dockerfile: %v", err)
-	}
-	defer newDockerfile.Close()
-
 	// And canonicalize dockerfile name to a platform-independent one
 	relDockerfile, err = archive.CanonicalTarNameForPath(relDockerfile)
 	if err != nil {
@@ -176,9 +167,22 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		return err
 	}
 
-	// Wrap the tar archive to replace the Dockerfile entry with the rewritten
-	// Dockerfile which uses trusted pulls.
-	context = replaceDockerfileTarWrapper(context, newDockerfile, relDockerfile)
+	var resolvedTags []*resolvedTag
+	if isTrusted() {
+		// Resolve the FROM lines in the Dockerfile to trusted digest references
+		// using Notary. On a successful build, we must tag the resolved digests
+		// to the original name specified in the Dockerfile.
+		var newDockerfile *trustedDockerfile
+		newDockerfile, resolvedTags, err = rewriteDockerfileFrom(filepath.Join(contextDir, relDockerfile), cli.trustedReference)
+		if err != nil {
+			return fmt.Errorf("unable to process Dockerfile: %v", err)
+		}
+		defer newDockerfile.Close()
+
+		// Wrap the tar archive to replace the Dockerfile entry with the rewritten
+		// Dockerfile which uses trusted pulls.
+		context = replaceDockerfileTarWrapper(context, newDockerfile, relDockerfile)
+	}
 
 	// Setup an upload progress bar
 	progressOutput := streamformatter.NewStreamFormatter().NewProgressOutput(progBuff, true)
@@ -266,11 +270,14 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	if *suppressOutput {
 		fmt.Fprintf(cli.out, "%s", buildBuff)
 	}
-	// Since the build was successful, now we must tag any of the resolved
-	// images from the above Dockerfile rewrite.
-	for _, resolved := range resolvedTags {
-		if err := cli.tagTrusted(resolved.digestRef, resolved.tagRef); err != nil {
-			return err
+
+	if isTrusted() {
+		// Since the build was successful, now we must tag any of the resolved
+		// images from the above Dockerfile rewrite.
+		for _, resolved := range resolvedTags {
+			if err := cli.tagTrusted(resolved.digestRef, resolved.tagRef); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR does not fix #15785 but it mitigates its impact for 1.10.
There is a great discussion going on on that issue about better ways to do the dockerfile context switch that we should consider.

Given that we're slightly time constrained, I think we should at least try to mitigate the issue as much as possible.
We don't need that context switch when TRUST is not enabled, therefore we should not do it.

Signed-off-by: David Calavera david.calavera@gmail.com
