### PR TITLE
Windows CI: No integration daemon stop

### DIFF
--- a/hack/make/.integration-daemon-stop
+++ b/hack/make/.integration-daemon-stop
@@ -1,21 +1,27 @@
 #!/bin/bash
 
-trap - EXIT # reset EXIT trap applied in .integration-daemon-start
+if [ ! "$(go env GOOS)" = 'windows' ]; then
+	trap - EXIT # reset EXIT trap applied in .integration-daemon-start
 
-for pidFile in $(find "$DEST" -name docker.pid); do
-	pid=$(set -x; cat "$pidFile")
-	( set -x; kill "$pid" )
-	if ! wait "$pid"; then
-		echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
-	fi
-done
+	for pidFile in $(find "$DEST" -name docker.pid); do
+		pid=$(set -x; cat "$pidFile")
+		( set -x; kill "$pid" )
+		if ! wait "$pid"; then
+			echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
+		fi
+	done
 
-if [ -z "$DOCKER_TEST_HOST" ]; then
-	# Stop apparmor if it is enabled
-	if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
-		(
-			set -x
-			/etc/init.d/apparmor stop
-		)
+	if [ -z "$DOCKER_TEST_HOST" ]; then
+		# Stop apparmor if it is enabled
+		if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
+			(
+				set -x
+				/etc/init.d/apparmor stop
+			)
+		fi
 	fi
+else
+	# Note this script is not actionable on Windows to Linux CI. Instead the 
+	# DIND daemon under test is torn down by the Jenkins tear-down script
+	echo "INFO: Not stopping daemon on Windows CI"
 fi


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @mikedougherty The integration daemon stop script is meaningless on Windows CI. The daemon under test is torn down through the Jenkins tear down (and setup) scripts. Rather than modify the multiple places where the .integration-daemon-stop bundle is made, putting a condition around the entire contents and a comment.
