### PR TITLE
Add a specific config struct for the update command (#18957)

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -332,9 +333,15 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 		return err
 	}
 
-	_, hostConfig, _, err := runconfig.DecodeContainerConfig(r.Body)
-	if err != nil {
+	var updateConfig container.UpdateConfig
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&updateConfig); err != nil {
 		return err
+	}
+
+	hostConfig := &container.HostConfig{
+		Resources: updateConfig.Resources,
 	}
 
 	name := vars["name"]

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -95,6 +95,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.22](docker_remote_api_v1.22.md) documentation
 
+* `POST /container/(name)/update` updates the resources of a container.
 * `GET /containers/json` supports filter `isolation` on Windows.
 * `GET /containers/json` now returns the list of networks of containers.
 * `GET /info` Now returns `Architecture` and `OSType` fields, providing information
@@ -120,7 +121,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /volumes` lists volumes from all volume drivers.
 * `POST /volumes/create` to create a volume.
 * `GET /volumes/(name)` get low-level information about a volume.
-* `DELETE /volumes/(name)`remove a volume with the specified name.
+* `DELETE /volumes/(name)` remove a volume with the specified name.
 * `VolumeDriver` was moved from `config` to `HostConfig` to make the configuration portable.
 * `GET /images/(name)/json` now returns information about an image's `RepoTags` and `RepoDigests`.
 * The `config` option now accepts the field `StopSignal`, which specifies the signal to use to kill a container.

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1023,7 +1023,7 @@ Update resource configs of one or more containers.
        Content-Type: application/json
 
        {
-           "HostConfig": {
+           "UpdateConfig": {
                "Resources": {
                    "BlkioWeight": 300,
                    "CpuShares": 512,


### PR DESCRIPTION
This is a proposal for #18957, to reduce what we send to the `update` endpoint. This also make it clear what is mutable in the container, and untie it from `Config`/`HostConfig`. It is still easy to add more attributes

This allows use to control more what is or is not mutable in a container and remove the use of the internal HostConfig struct to be used 🐳.
- [X] `UpdateConfig` might not be a good name, maybe `MutableConfig` or something ?
- [X] The implementation is _naive_ right now, it's there for discussion :wink:.

Related PR for api changes : docker/engine-api#11. Waiting for it to be merged to vendor it and rebase this one :stuck_out_tongue_closed_eyes:.

Closes #18957.

Signed-off-by: Vincent Demeester vincent@sbr.pm
