### PR TITLE
Windows CI: Date for debugging timeouts

### DIFF
--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -8,11 +8,17 @@ bundle_test_integration_cli() {
 
 # subshell so that we can export PATH without breaking other things
 (
+	echo INFO: `date`
 	bundle .integration-daemon-start
 
+	echo INFO: `date`
 	bundle .integration-daemon-setup
 
+	echo INFO: `date`
 	bundle_test_integration_cli
 
+	echo INFO: `date`
 	bundle .integration-daemon-stop
+	
+	echo INFO: `date`
 ) 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Added a bunch of date debug output to try and identify which larger step in the overall CI process is taking longer than it should, causing occasional timeouts in Windows CI. For example https://jenkins.dockerproject.org/job/Docker%20Master%20(windows)/3604/console
