### PR TITLE
Windows: Fix docker build not to sigsegv the daemon

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -396,7 +396,7 @@ func containsWildcards(name string) bool {
 func (b *Builder) processImageFrom(img builder.Image) error {
 	b.image = img.ID()
 
-	if img.Config != nil {
+	if img.Config() != nil {
 		b.runConfig = img.Config()
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Looks like someone introduced a bug which causes docker build against a Windows daemon to SIGSEGV over the Christmas break. 
