### PR TITLE
Check nil Terminal to avoid panic

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -232,6 +232,9 @@ func (container *Container) ExitOnNext() {
 // Resize changes the TTY of the process running inside the container
 // to the given height and width. The container must be running.
 func (container *Container) Resize(h, w int) error {
+	if container.Command.ProcessConfig.Terminal == nil {
+		return fmt.Errorf("Container %s does not have a terminal ready", container.ID)
+	}
 	if err := container.Command.ProcessConfig.Terminal.Resize(h, w); err != nil {
 		return err
 	}


### PR DESCRIPTION
Recently I'm doing some experimental work on exec drivers, trying to implement a custom driver,  when handling `/containers/container_id/resize` API, a panic was monitored:

```
2016/01/06 18:45:28 http: panic serving @: runtime error: invalid memory address or nil pointer dereference
goroutine 41 [running]:
net/http.(*conn).serve.func1(0xc820aba000, 0x7f00be518130, 0xc820030b10)
        /usr/local/go/src/net/http/server.go:1287 +0xb5
github.com/docker/docker/container.(*Container).Resize(0xc8208e2000, 0x2c, 0x95, 0x0, 0x0)
        /go/src/github.com/docker/docker/container/container.go:235 +0x65
github.com/docker/docker/daemon.(*Daemon).ContainerResize(0xc820270900, 0xc820cc8017, 0x40, 0x2c, 0x95, 0x0, 0x0)
        /go/src/github.com/docker/docker/daemon/resize.go:17 +0x278
```

It doesn't matter because the root cause is my bad implementation of exec driver, docker's native driver will NEVER trigger this, but still I think a custom exec driver shouldn't have the capability to panic high level UX.

Add a nil pointer checker will make it more robust, I prefer an error report than panic, panic is too ugly.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
