### PR TITLE
 daemon option (--storage-opt dm.basesize) for increasing the base device size on daemon restart

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -213,10 +213,22 @@ options for `zfs` start with `zfs`.
 *  `dm.basesize`
 
     Specifies the size to use when creating the base device, which limits the
-    size of images and containers. The default value is 100G. Note, thin devices
-    are inherently "sparse", so a 100G device which is mostly empty doesn't use
-    100 GB of space on the pool. However, the filesystem will use more space for
+    size of images and containers. The default value is 10G. Note, thin devices
+    are inherently "sparse", so a 10G device which is mostly empty doesn't use
+    10 GB of space on the pool. However, the filesystem will use more space for
     the empty case the larger the device is.
+
+    The base device size can be increased at daemon restart which will allow
+    all future images and containers (based on those new images) to be of the 
+    new base device size.
+
+    Example use: 
+
+        $ docker daemon --storage-opt dm.basesize=50G
+
+    This will increase the base device size to 50G. The Docker daemon will throw an 
+    error if existing base device size is larger than 50G. A user can use 
+    this option to expand the base device size however shrinking is not permitted.
 
     This value affects the system-wide "base" empty filesystem
     that may already be initialized and inherited by pulled images. Typically,

--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -249,11 +249,11 @@ You can use the `lsblk` command to see the device files created above and the `p
     NAME                       MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
     xvda                       202:0    0    8G  0 disk
     └─xvda1                    202:1    0    8G  0 part /
-    xvdf                       202:80   0  100G  0 disk
+    xvdf                       202:80   0   10G  0 disk
     ├─vg--docker-data          253:0    0   90G  0 lvm
-    │ └─docker-202:1-1032-pool 253:2    0  100G  0 dm
+    │ └─docker-202:1-1032-pool 253:2    0   10G  0 dm
     └─vg--docker-metadata      253:1    0    4G  0 lvm
-      └─docker-202:1-1032-pool 253:2    0  100G  0 dm
+      └─docker-202:1-1032-pool 253:2    0   10G  0 dm
 
 The diagram below shows the image from prior examples updated with the detail from the `lsblk` command above.
 

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -271,11 +271,21 @@ Example use: `docker daemon --storage-opt dm.thinpooldev=/dev/mapper/thin-pool`
 #### dm.basesize
 
 Specifies the size to use when creating the base device, which limits
-the size of images and containers. The default value is 100G. Note,
-thin devices are inherently "sparse", so a 100G device which is mostly
-empty doesn't use 100 GB of space on the pool. However, the filesystem
+the size of images and containers. The default value is 10G. Note,
+thin devices are inherently "sparse", so a 10G device which is mostly
+empty doesn't use 10 GB of space on the pool. However, the filesystem
 will use more space for base images the larger the device
 is.
+
+The base device size can be increased at daemon restart which will allow
+all future images and containers (based on those new images) to be of the 
+new base device size.
+
+Example use: `docker daemon --storage-opt dm.basesize=50G` 
+
+This will increase the base device size to 50G. The Docker daemon will throw an 
+error if existing base device size is larger than 50G. A user can use 
+this option to expand the base device size however shrinking is not permitted.
 
 This value affects the system-wide "base" empty filesystem that may already
 be initialized and inherited by pulled images. Typically, a change to this


### PR DESCRIPTION
Signed-off-by: Shishir Mahajan shishir.mahajan@redhat.com

Fixes #18314
