### PR TITLE
Add -f flag to cURL install instructions

### DIFF
--- a/docs/examples/running_riak_service.Dockerfile
+++ b/docs/examples/running_riak_service.Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Hector Castro hector@basho.com
 # Install Riak repository before we do apt-get update, so that update happens
 # in a single step
 RUN apt-get install -q -y curl && \
-    curl -sSL https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash
+    curl -fsSL https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash
 
 # Install and setup project dependencies
 RUN apt-get update && \

--- a/docs/examples/running_riak_service.md
+++ b/docs/examples/running_riak_service.md
@@ -37,7 +37,7 @@ script and we download the setup script and run it.
     # Install Riak repository before we do apt-get update, so that update happens
     # in a single step
     RUN apt-get install -q -y curl && \
-        curl -sSL https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash
+        curl -fsSL https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash
 
 Then we install and setup a few dependencies:
 

--- a/docs/installation/centos.md
+++ b/docs/installation/centos.md
@@ -109,7 +109,7 @@ package manager.
 
 3. Run the Docker installation script.
 
-		$ curl -sSL https://get.docker.com/ | sh
+		$ curl -fsSL https://get.docker.com/ | sh
 
 	This script adds the `docker.repo` repository and installs Docker.
 

--- a/docs/installation/fedora.md
+++ b/docs/installation/fedora.md
@@ -104,7 +104,7 @@ There are two ways to install Docker Engine.  You can install with the `dnf` pac
 
 3. Run the Docker installation script.
 
-		$ curl -sSL https://get.docker.com/ | sh
+		$ curl -fsSL https://get.docker.com/ | sh
 
 	This script adds the `docker.repo` repository and installs Docker.
 

--- a/docs/installation/rhel.md
+++ b/docs/installation/rhel.md
@@ -104,7 +104,7 @@ You use the same installation procedure for all versions of CentOS.
 
 3. Run the Docker installation script.
 
-		$ curl -sSL https://get.docker.com/ | sh
+		$ curl -fsSL https://get.docker.com/ | sh
 
 4. Start the Docker daemon.
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -7,12 +7,12 @@ set -e
 #   'wget -qO- https://get.docker.com/ | sh'
 #
 # For test builds (ie. release candidates):
-#   'curl -sSL https://test.docker.com/ | sh'
+#   'curl -fsSL https://test.docker.com/ | sh'
 # or:
 #   'wget -qO- https://test.docker.com/ | sh'
 #
 # For experimental builds:
-#   'curl -sSL https://experimental.docker.com/ | sh'
+#   'curl -fsSL https://experimental.docker.com/ | sh'
 # or:
 #   'wget -qO- https://experimental.docker.com/ | sh'
 #


### PR DESCRIPTION
Per @tianon's comment here: https://github.com/docker/docker/pull/15409#issuecomment-169171846

From the -f description:

```
(HTTP) Fail silently (no output at all) on server errors. This is mostly done
to better enable scripts etc to better deal with failed attempts. In normal
cases when an HTTP server fails to deliver a document, it returns an HTML
document stating so (which often also describes why and more). This flag will
prevent curl from outputting that and return error 22.
```

**however**

We may want to check if combining `-f` and `-S` gives the right result, given that `-S` does;

```
-S, --show-error
      When used with -s it makes curl show an error message if it fails.
```
