### PR TITLE
Don't error out on plugin err with json

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -134,11 +134,10 @@ func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool)
 				Err string
 			}
 			remoteErr := responseErr{}
-			if err := json.Unmarshal(b, &remoteErr); err != nil {
-				return nil, fmt.Errorf("%s: %s", serviceMethod, err)
-			}
-			if remoteErr.Err != "" {
-				return nil, fmt.Errorf("%s: %s", serviceMethod, remoteErr.Err)
+			if err := json.Unmarshal(b, &remoteErr); err == nil {
+				if remoteErr.Err != "" {
+					return nil, fmt.Errorf("%s: %s", serviceMethod, remoteErr.Err)
+				}
 			}
 			// old way...
 			return nil, fmt.Errorf("%s: %s", serviceMethod, string(b))


### PR DESCRIPTION
We don't want to error out when there is a json unmarshal error since
the `old way` will cause this to error.

I'm also a little suspect of this new handling now that I've messed with it.
HTTP statuses other than `200` should only be used for protocol level issues, which don't really need to encode a json message since it can just write a string to the body.
