### PR TITLE
Windows: Fix security warning regression

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -265,8 +265,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		}
 	}
 
-	// Windows: show error message about modified file permissions.
-	if response.OSType == "windows" {
+	// Windows: show error message about modified file permissions if the
+	// daemon isn't running Windows.
+	if response.OSType != "windows" && runtime.GOOS == "windows" {
 		fmt.Fprintln(cli.err, `SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.`)
 	}
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4920,8 +4920,26 @@ func (s *DockerSuite) TestBuildNotVerboseSuccess(c *check.C) {
 		if outRegexp.Find([]byte(stdout)) == nil {
 			c.Fatalf("Test %s expected stdout to match the [%v] regexp, but it is [%v]", te.Name, outRegexp, stdout)
 		}
-		if stderr != "" {
-			c.Fatalf("Test %s expected stderr to be empty, but it is [%#v]", te.Name, stderr)
+		if runtime.GOOS == "windows" {
+			// stderr contains a security warning on Windows if the daemon isn't Windows
+			lines := strings.Split(stderr, "\n")
+			warningCount := 0
+			for _, v := range lines {
+				warningText := "SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host."
+				if strings.Contains(v, warningText) {
+					warningCount++
+				}
+				if v != "" && !strings.Contains(v, warningText) {
+					c.Fatalf("Stderr contains unexpected output line: %q", v)
+				}
+			}
+			if warningCount != 1 && daemonPlatform != "windows" {
+				c.Fatalf("Test %s didn't get security warning running from Windows to non-Windows", te.Name)
+			}
+		} else {
+			if stderr != "" {
+				c.Fatalf("Test %s expected stderr to be empty, but it is [%#v]", te.Name, stderr)
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Guessing this was regressed in the builder refactor over the Christmas break. The security warning message is only supposed to happen if the target daemon is not Windows, and the client is running on Windows, not if the daemon is running Windows.
