### PR TITLE
Update notary and re-enable on arm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_COMMIT 8e8122eb5528f621afcd4e2854c47302f17392f7
+ENV NOTARY_COMMIT f211b1826dde5fc8c117ccff9bb04ae458a8e3d0
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -127,16 +127,14 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-# commented Notary temporary as we are waiting for an update of jose2go: https://github.com/docker/notary/issues/239
-#
-# ENV NOTARY_COMMIT 8e8122eb5528f621afcd4e2854c47302f17392f7
-# RUN set -x \
-# 	&& export GOPATH="$(mktemp -d)" \
-# 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
-# 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_COMMIT") \
-# 	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
-# 		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
-# 	&& rm -rf "$GOPATH"
+ENV NOTARY_COMMIT f211b1826dde5fc8c117ccff9bb04ae458a8e3d0
+RUN set -x \
+	&& export GOPATH="$(mktemp -d)" \
+	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
+	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_COMMIT") \
+	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
+		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
+	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT 139850f3f3b17357bab5ba3edfb745fb14043764

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -53,7 +53,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_COMMIT 8e8122eb5528f621afcd4e2854c47302f17392f7
+ENV NOTARY_COMMIT f211b1826dde5fc8c117ccff9bb04ae458a8e3d0
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -52,7 +52,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_COMMIT 8e8122eb5528f621afcd4e2854c47302f17392f7
+ENV NOTARY_COMMIT f211b1826dde5fc8c117ccff9bb04ae458a8e3d0
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \


### PR DESCRIPTION
See discussion in #19076

Notary now builds on arm, so re-enable build and make all
releases use the same version.

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
