### PR TITLE
Windows CI: More debugging

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -73,6 +73,16 @@ while ! docker version &> /dev/null; do
 		else
 			echo >&2 "error: daemon at $DOCKER_HOST fails to 'docker version':"
 			docker version >&2 || true
+			# Additional Windows CI debugging as this is a common error as of
+			# January 2016
+			if [ "$(go env GOOS)" = 'windows' ]; then	
+				echo >&2 "Container log below:"
+				echo >&2 "---"
+				# Important - use the docker on the CI host, not the one built locally
+				# which is currently in our path.
+				! /c/bin/docker -H=$MAIN_DOCKER_HOST logs docker-$COMMITHASH
+				echo >&2 "---"
+			fi			
 		fi
 		false
 	fi


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Adding more debugging to check the dind container log if it fails to docker version. 

I've definitely found one case where the Linux box fails to complete compilation:

```
$ docker logs docker-6508ce9 | tail -200 # github.com/docker/docker/docker
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: fork/exec /usr/bin/
gcc: cannot allocate memory
```
