### PR TITLE
Choose default-cgroup parent by cgroup driver

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -78,7 +78,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))
 	cmd.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", usageFn("Set CORS headers in the remote API"))
-	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "/docker", usageFn("Set parent cgroup for all containers"))
+	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))
 
 	config.attachExperimentalFlags(cmd, usageFn)
 }

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-units"
@@ -241,6 +242,20 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 	}
 	uidMap, gidMap := daemon.GetUIDGIDMaps()
 
+	defaultCgroupParent := "/docker"
+	if daemon.configStore.CgroupParent != "" {
+		defaultCgroupParent = daemon.configStore.CgroupParent
+	} else {
+		for _, option := range daemon.configStore.ExecOptions {
+			key, val, err := parsers.ParseKeyValueOpt(option)
+			if err != nil || !strings.EqualFold(key, "native.cgroupdriver") {
+				continue
+			}
+			if val == "systemd" {
+				defaultCgroupParent = "system.slice"
+			}
+		}
+	}
 	c.Command = &execdriver.Command{
 		CommonCommand: execdriver.CommonCommand{
 			ID:            c.ID,
@@ -258,7 +273,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		AutoCreatedDevices: autoCreatedDevices,
 		CapAdd:             c.HostConfig.CapAdd.Slice(),
 		CapDrop:            c.HostConfig.CapDrop.Slice(),
-		CgroupParent:       daemon.configStore.CgroupParent,
+		CgroupParent:       defaultCgroupParent,
 		GIDMapping:         gidMap,
 		GroupAdd:           c.HostConfig.GroupAdd,
 		Ipc:                ipc,

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -146,14 +146,11 @@ func InitContainer(c *Command) *configs.Config {
 	// This can be overridden later by driver during mount setup based
 	// on volume options
 	SetRootPropagation(container, mount.RPRIVATE)
+	container.Cgroups.Parent = c.CgroupParent
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
 
-	// Default parent cgroup is "docker". Override if required.
-	if c.CgroupParent != "" {
-		container.Cgroups.Parent = c.CgroupParent
-	}
 	return container
 }
 

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/execdriver"
-	"github.com/docker/docker/daemon/execdriver/native/template"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/reexec"
@@ -90,7 +89,6 @@ func NewDriver(root string, options []string) (*Driver, error) {
 			case "systemd":
 				if systemd.UseSystemd() {
 					cgm = libcontainer.SystemdCgroups
-					template.SystemdCgroups = true
 				} else {
 					// warn them that they chose the wrong driver
 					logrus.Warn("You cannot use systemd as native.cgroupdriver, using cgroupfs instead")

--- a/daemon/execdriver/native/template/default_template_linux.go
+++ b/daemon/execdriver/native/template/default_template_linux.go
@@ -9,9 +9,6 @@ import (
 
 const defaultMountFlags = syscall.MS_NOEXEC | syscall.MS_NOSUID | syscall.MS_NODEV
 
-// SystemdCgroups indicates whether systemd cgroup implemenation is in use or not
-var SystemdCgroups = false
-
 // New returns the docker default configuration for libcontainer
 func New() *configs.Config {
 	container := &configs.Config{
@@ -40,7 +37,7 @@ func New() *configs.Config {
 			{Type: "NEWUSER"},
 		}),
 		Cgroups: &configs.Cgroup{
-			Parent: "/docker",
+			ScopePrefix: "docker", // systemd only
 			Resources: &configs.Resources{
 				AllowAllDevices:  false,
 				MemorySwappiness: -1,
@@ -97,11 +94,6 @@ func New() *configs.Config {
 
 	if apparmor.IsEnabled() {
 		container.AppArmorProfile = "docker-default"
-	}
-
-	if SystemdCgroups {
-		container.Cgroups.Parent = "system.slice"
-		container.Cgroups.ScopePrefix = "docker"
 	}
 
 	return container

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -17,10 +17,10 @@ weight = -1
 
     Options:
       --api-cors-header=""                   Set CORS headers in the remote API
-      --authz-plugin=[]                     Set authorization plugins to load
+      --authz-plugin=[]                      Set authorization plugins to load
       -b, --bridge=""                        Attach containers to a network bridge
       --bip=""                               Specify network bridge IP
-      --cgroup-parent=/docker                Set parent cgroup for all containers
+      --cgroup-parent=                       Set parent cgroup for all containers
       -D, --debug                            Enable debug mode
       --default-gateway=""                   Container default gateway IPv4 address
       --default-gateway-v6=""                Container default gateway IPv6 address
@@ -647,7 +647,8 @@ set like this:
 # Default cgroup parent
 
 The `--cgroup-parent` option allows you to set the default cgroup parent
-to use for containers. If this option is not set, it defaults to `/docker`.
+to use for containers. If this option is not set, it defaults to `/docker` for
+fs cgroup driver and `system.slice` for systemd cgroup driver.
 
 If the cgroup has a leading forward slash (`/`), the cgroup is created
 under the root cgroup, otherwise the cgroup is created under the daemon

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -10,7 +10,7 @@ docker-daemon - Enable daemon mode
 [**--authz-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
-[**--cgroup-parent**[=*/docker*]]
+[**--cgroup-parent**[=*[]*]]
 [**--cluster-store**[=*[]*]]
 [**--cluster-advertise**[=*[]*]]
 [**--cluster-store-opt**[=*map[]*]]
@@ -82,7 +82,7 @@ format.
   Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
 
 **--cgroup-parent**=""
-  Set parent cgroup for all containers. Default is "/docker".
+  Set parent cgroup for all containers. Default is "/docker" for fs cgroup driver and "system.slice" for systemd cgroup driver.
 
 **--cluster-store**=""
   URL of the distributed storage backend


### PR DESCRIPTION
It's "/docker" for cgroupfs and "system.slice" for systemd.

Fix #19140 
