### PR TITLE
Add a validate-vendor script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,4 @@ test-unit: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit
 
 validate: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-gofmt validate-pkg validate-lint validate-test validate-toml validate-vet
+	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-gofmt validate-pkg validate-lint validate-test validate-toml validate-vet validate-vendor

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -51,6 +51,7 @@ DEFAULT_BUNDLES=(
 	validate-test
 	validate-toml
 	validate-vet
+	validate-vendor
 
 	binary
 	dynbinary

--- a/hack/make/validate-vendor
+++ b/hack/make/validate-vendor
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+source "${MAKEDIR}/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- 'hack/vendor.sh' 'hack/.vendor-helpers.sh' 'vendor/' || true) ) 
+unset IFS
+
+if [ ${#files[@]} -gt 0 ]; then
+	# We run vendor.sh to and see if we have a diff afterwards
+	./hack/vendor.sh >/dev/null
+	# Let see if the working directory is clean
+	diffs="$(git status --porcelain -- vendor 2>/dev/null)"
+	if [ "$diffs" ]; then
+		{
+			echo 'The result of ./hack/vendor.sh differs'
+			echo
+			echo "$diffs"
+			echo
+			echo 'Please vendor your package with ./hack/vendor.sh.'
+			echo
+		} >&2
+		false
+	else
+		echo 'Congratulations! All vendoring changes are done the right way.'
+	fi
+fi


### PR DESCRIPTION
Makes sure that if ./hack/vendor.sh has been updated, it has been used to update the vendor folder. 🐢

This is a complement to #19141 in order to keep the `vendor/` folder in sync with `./hack/vendor.sh`.

``` bash
# with a wrong vendor.sh
$ make validate
# […]
done
These files are not valid vendor file:
 - hack/vendor.sh

Please vendor your package with ./hack/vendor.sh.

```
- The message in case of failure <del>might</del> definitely need some _lifting_ :wink:.
- This makes a build with updates on vendoring a little longer.
- Should we run this script all the time for the build on the `master` branch or not ? 

/cc @tianon @jfrazelle :angel: 

_There is a commit to trigger the failure. I'll remove it when everything is good and validated :stuck_out_tongue_closed_eyes:._

🐸

Build failure example : https://jenkins.dockerproject.org/job/Docker-PRs/22003/console

``` bash
08:15:00 ---> Making bundle: validate-vendor (in bundles/1.10.0-dev/validate-vendor)

08:17:38 The result of ./hack/vendor.sh differs
08:17:38 
08:17:38  M vendor/src/github.com/mistifyio/go-zfs/CONTRIBUTING.md
08:17:38  M vendor/src/github.com/mistifyio/go-zfs/utils.go
08:17:38  M vendor/src/github.com/mistifyio/go-zfs/zfs.go
08:17:38  M vendor/src/github.com/mistifyio/go-zfs/zpool.go
08:17:38 
08:17:38 Please vendor your package with ./hack/vendor.sh.
08:17:38 

08:17:38 Build step 'Execute shell' marked build as failure
```

Signed-off-by: Vincent Demeester vincent@sbr.pm
