### PR TITLE
Fix systemd cgroups implementation

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -78,7 +78,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))
 	cmd.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", usageFn("Set CORS headers in the remote API"))
-	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "/docker", usageFn("Set parent cgroup for all containers"))
+	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))
 
 	config.attachExperimentalFlags(cmd, usageFn)
 }


### PR DESCRIPTION
The cgroup parent was getting set to /docker by default which doesn't work
for the systemd cgroup implementation. It isn't necessary to set the default
as we set the correct value in the template code.

Signed-off-by: Mrunal Patel mrunalp@gmail.com
