### PR TITLE
Create the working directory on container creation

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -22,6 +22,10 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 	}
 	defer daemon.Unmount(container)
 
+	if err := container.SetupWorkingDirectory(); err != nil {
+		return err
+	}
+
 	for spec := range config.Volumes {
 		name := stringid.GenerateNonCryptoID()
 		destination := filepath.Clean(spec)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6152,8 +6152,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansion(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if res != wdVal {
-		c.Fatalf("Config.WorkingDir value mismatch. Expected: %s, got: %s", wdVal, res)
+	if res != filepath.Clean(wdVal) {
+		c.Fatalf("Config.WorkingDir value mismatch. Expected: %s, got: %s", filepath.Clean(wdVal), res)
 	}
 
 	err = inspectFieldAndMarshall(imgName, "Config.Env", &resArr)

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -415,3 +415,11 @@ func (s *DockerSuite) TestCreateStopSignal(c *check.C) {
 	c.Assert(res, checker.Contains, "9")
 
 }
+
+func (s *DockerSuite) TestCreateWithWorkdir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	name := "foo"
+	dir := "/home/foo/bar"
+	dockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
+	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), "/tmp")
+}


### PR DESCRIPTION
If create a container with -w to specify the working directory and
the directory does not exist in the container rootfs, the directory
will be created until the container start. It makes `docker export` of
a created container and a running container inconsistent. We always
use `docker export` to export the container rootfs for `runc`, it will cause
error if setup `cwd` in `config.json` and the `cwd` is the same with what
we specified in `docker create` with `-w`.

Signed-off-by: Lei Jitang leijitang@huawei.com
