### PR TITLE
Bring discovery on par with the one in docker/swarm

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -603,6 +603,10 @@ The currently supported cluster store options are:
     private key is used as the client key for communication with the
     Key/Value store.
 
+*  `kv.path`
+
+    Specifies the path in the Key/Value store. If not configured, the default value is 'docker/nodes'.
+
 ## Access authorization
 
 Docker's access authorization can be extended by authorization plugins that your

--- a/pkg/discovery/kv/kv_test.go
+++ b/pkg/discovery/kv/kv_test.go
@@ -33,7 +33,7 @@ func (ds *DiscoverySuite) TestInitialize(c *check.C) {
 	s := d.store.(*FakeStore)
 	c.Assert(s.Endpoints, check.HasLen, 1)
 	c.Assert(s.Endpoints[0], check.Equals, "127.0.0.1")
-	c.Assert(d.path, check.Equals, discoveryPath)
+	c.Assert(d.path, check.Equals, defaultDiscoveryPath)
 
 	storeMock = &FakeStore{
 		Endpoints: []string{"127.0.0.1:1234"},
@@ -45,7 +45,7 @@ func (ds *DiscoverySuite) TestInitialize(c *check.C) {
 	s = d.store.(*FakeStore)
 	c.Assert(s.Endpoints, check.HasLen, 1)
 	c.Assert(s.Endpoints[0], check.Equals, "127.0.0.1:1234")
-	c.Assert(d.path, check.Equals, "path/"+discoveryPath)
+	c.Assert(d.path, check.Equals, "path/"+defaultDiscoveryPath)
 
 	storeMock = &FakeStore{
 		Endpoints: []string{"127.0.0.1:1234", "127.0.0.2:1234", "127.0.0.3:1234"},
@@ -60,7 +60,7 @@ func (ds *DiscoverySuite) TestInitialize(c *check.C) {
 	c.Assert(s.Endpoints[1], check.Equals, "127.0.0.2:1234")
 	c.Assert(s.Endpoints[2], check.Equals, "127.0.0.3:1234")
 
-	c.Assert(d.path, check.Equals, "path/"+discoveryPath)
+	c.Assert(d.path, check.Equals, "path/"+defaultDiscoveryPath)
 }
 
 // Extremely limited mock store so we can test initialization
@@ -224,8 +224,8 @@ func (ds *DiscoverySuite) TestWatch(c *check.C) {
 		&discovery.Entry{Host: "2.2.2.2", Port: "2222"},
 	}
 	kvs := []*store.KVPair{
-		{Key: path.Join("path", discoveryPath, "1.1.1.1"), Value: []byte("1.1.1.1:1111")},
-		{Key: path.Join("path", discoveryPath, "2.2.2.2"), Value: []byte("2.2.2.2:2222")},
+		{Key: path.Join("path", defaultDiscoveryPath, "1.1.1.1"), Value: []byte("1.1.1.1:1111")},
+		{Key: path.Join("path", defaultDiscoveryPath, "2.2.2.2"), Value: []byte("2.2.2.2:2222")},
 	}
 
 	stopCh := make(chan struct{})
@@ -245,7 +245,7 @@ func (ds *DiscoverySuite) TestWatch(c *check.C) {
 
 	// Add a new entry.
 	expected = append(expected, &discovery.Entry{Host: "3.3.3.3", Port: "3333"})
-	kvs = append(kvs, &store.KVPair{Key: path.Join("path", discoveryPath, "3.3.3.3"), Value: []byte("3.3.3.3:3333")})
+	kvs = append(kvs, &store.KVPair{Key: path.Join("path", defaultDiscoveryPath, "3.3.3.3"), Value: []byte("3.3.3.3:3333")})
 	mockCh <- kvs
 	c.Assert(<-ch, check.DeepEquals, expected)
 


### PR DESCRIPTION
A couple of fixes/patches were made in `docker/swarm/discovery` by @abronan 

Since out plan is to use the discovery from engine in swarm to avoid
duplicate code, I'm porting the changes here.

Related to https://github.com/docker/swarm/issues/1594
