### PR TITLE
Prune digest references when deleting by tag

### DIFF
--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -19,8 +19,9 @@ parent = "smn_cli"
       --no-prune           Do not delete untagged parents
 
 You can remove an image using its short or long ID, its tag, or its digest. If
-an image has one or more tag or digest reference, you must remove all of them
-before the image is removed.
+an image has one or more tag referencing it, you must remove all of them before
+the image is removed. Digest references are removed automatically when an image
+is removed by tag.
 
     $ docker images
     REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -370,6 +370,35 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 	dockerCmd(c, "rmi", imageID)
 }
 
+func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndTag(c *check.C) {
+	pushDigest, err := setupImage(c)
+	c.Assert(err, checker.IsNil, check.Commentf("error setting up image"))
+
+	// pull from the registry using the <name>@<digest> reference
+	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
+	dockerCmd(c, "pull", imageReference)
+
+	imageID, err := inspectField(imageReference, "Id")
+	c.Assert(err, checker.IsNil, check.Commentf("error inspecting image id"))
+
+	repoTag := repoName + ":sometag"
+	repoTag2 := repoName + ":othertag"
+	dockerCmd(c, "tag", imageReference, repoTag)
+	dockerCmd(c, "tag", imageReference, repoTag2)
+
+	dockerCmd(c, "rmi", repoTag2)
+
+	// rmi should have deleted only repoTag2, because there's another tag
+	_, err = inspectField(repoTag, "Id")
+	c.Assert(err, checker.IsNil, check.Commentf("repoTag should not have been removed"))
+
+	dockerCmd(c, "rmi", repoTag)
+
+	// rmi should have deleted the tag, the digest reference, and the image itself
+	_, err = inspectField(imageID, "Id")
+	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
+}
+
 // TestPullFailsWithAlteredManifest tests that a `docker pull` fails when
 // we have modified a manifest blob and its digest cannot be verified.
 func (s *DockerRegistrySuite) TestPullFailsWithAlteredManifest(c *check.C) {


### PR DESCRIPTION
When pulling an image with content trust enabled, two references are
created: a digest reference and a tag reference. Deleting by tag
wouldn't actually remove the image, because the digest reference keeps
it alive.

This change modifies the rmi logic so that digest references don't keep
an image alive. If the last tag referencing a given image is deleted,
any digest references to it will be removed as well, so the image can
actually get deleted. This fixes the usability problem with deletions
when content trust is in use, so something like "docker pull busybox;
docker rmi busybox" will work as expected.

cc @diogomonica @dmcgowan @icecrime @tonistiigi @ncdc
