### PR TITLE
Fixed migrate defect, allow migrate the empty directory

### DIFF
--- a/migrate/v1/migratev1.go
+++ b/migrate/v1/migratev1.go
@@ -238,12 +238,14 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 
 		containerJSON, err := ioutil.ReadFile(filepath.Join(containersDir, id, configFileNameLegacy))
 		if err != nil {
-			return err
+			logrus.Errorf("Migrate Container Error: %v",err)
+			continue
 		}
 
 		var c map[string]*json.RawMessage
 		if err := json.Unmarshal(containerJSON, &c); err != nil {
-			return err
+			logrus.Errorf("Migrate Container Error: %v",err)
+			continue
 		}
 
 		imageStrJSON, ok := c["Image"]
@@ -253,7 +255,8 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 
 		var image string
 		if err := json.Unmarshal([]byte(*imageStrJSON), &image); err != nil {
-			return err
+			logrus.Errorf("Migrate Container Error: %v",err)
+			continue
 		}
 		imageID, ok := imageMappings[image]
 		if !ok {

--- a/migrate/v1/migratev1.go
+++ b/migrate/v1/migratev1.go
@@ -238,13 +238,13 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 
 		containerJSON, err := ioutil.ReadFile(filepath.Join(containersDir, id, configFileNameLegacy))
 		if err != nil {
-			logrus.Errorf("Migrate Container Error: %v",err)
+			logrus.Errorf("migrate container error: %v", err)
 			continue
 		}
 
 		var c map[string]*json.RawMessage
 		if err := json.Unmarshal(containerJSON, &c); err != nil {
-			logrus.Errorf("Migrate Container Error: %v",err)
+			logrus.Errorf("migrate container error: %v", err)
 			continue
 		}
 
@@ -255,9 +255,10 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 
 		var image string
 		if err := json.Unmarshal([]byte(*imageStrJSON), &image); err != nil {
-			logrus.Errorf("Migrate Container Error: %v",err)
+			logrus.Errorf("migrate container error: %v", err)
 			continue
 		}
+
 		imageID, ok := imageMappings[image]
 		if !ok {
 			logrus.Errorf("image not migrated %v", imageID) // non-fatal error


### PR DESCRIPTION
If there is an empty directory exists in the $DOCKER_ROOT/containers ,
that will cause migrate fail. Then docker daemon will initialize failed.
This commit allow skips the empty directory.

Signed-off-by: Andy Zhang andy.zhangtao@hotmail.com
