### PR TITLE
Fix btrfs subvolume snapshot dir perms for user namespaces

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -266,6 +266,14 @@ func (d *Driver) Create(id, parent, mountLabel string) error {
 		}
 	}
 
+	// if we have a remapped root (user namespaces enabled), change the created snapshot
+	// dir ownership to match
+	if rootUID != 0 || rootGID != 0 {
+		if err := os.Chown(path.Join(subvolumes, id), rootUID, rootGID); err != nil {
+			return err
+		}
+	}
+
 	return label.Relabel(path.Join(subvolumes, id), mountLabel, false)
 }
 


### PR DESCRIPTION
Make sure btrfs mounted subvolumes are owned properly when a remapped
root exists (user namespaces are enabled, for example)

Fixes: #19176
Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
