### PR TITLE
Fix flaky testTestStatsAllNewContainersAdded

### DIFF
--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -118,6 +118,7 @@ func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {
 	}()
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	c.Assert(waitRun(strings.TrimSpace(out)), check.IsNil)
 	id <- strings.TrimSpace(out)[:12]
 
 	select {


### PR DESCRIPTION
Wait the new created container for running and then check if it
is in the docker stats to avoid flaky test.

Signed-off-by: Lei Jitang leijitang@huawei.com

see https://jenkins.dockerproject.org/job/Windows-PRs/19944/console
https://jenkins.dockerproject.org/job/Windows-PRs/19942/console

<pre><code>04:44:05 ----------------------------------------------------------------------
04:44:05 FAIL: docker_cli_stats_test.go:94: DockerSuite.TestStatsAllNewContainersAdded
04:44:05 
04:44:05 docker_cli_stats_test.go:125:
04:44:05     c.Fatal("failed to observe new container created added to stats")
04:44:05 ... Error: failed to observe new container created added to stats
04:44:05 
04:44:09 
04:44:09 ----------------------------------------------------------------------</code></pre>
