### PR TITLE
Make .ensure-syscall-test to use build-arg

### DIFF
--- a/hack/make/.ensure-syscall-test
+++ b/hack/make/.ensure-syscall-test
@@ -4,5 +4,5 @@ set -e
 # Build a C binary for cloning a userns for seccomp tests
 # and compile it for target daemon
 if [ "$DOCKER_ENGINE_GOOS" = "linux" ]; then
-	docker build -qt syscall-test contrib/syscall-test > /dev/null
+	docker build ${DOCKER_BUILD_ARGS} -qt syscall-test contrib/syscall-test > /dev/null
 fi


### PR DESCRIPTION
.ensure-syscall-test need to build an image, we have
to add http_proxy and https_proxy to make it work.
Inseted of adding http_proxy and https_proxy env to the Dockerfile,
adding a DOCKER_BUILD_ARGS env to pass the build-arg is much more
elegant.

Signed-off-by: Lei Jitang leijitang@huawei.com
This PR is similar to #18933 
ping @jfrazelle 
