### PR TITLE
don't try to create devices in a user namespace

### DIFF
--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -105,6 +105,10 @@ func copyDir(srcDir, dstDir string, flags copyFlags) error {
 		case os.ModeNamedPipe:
 			fallthrough
 		case os.ModeSocket:
+			if system.RunningInUserNS() {
+				// cannot create a device if running in user namespace
+				return nil
+			}
 			if err := syscall.Mkfifo(dstPath, stat.Mode); err != nil {
 				return err
 			}

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -80,6 +80,10 @@ func minor(device uint64) uint64 {
 // handleTarTypeBlockCharFifo is an OS-specific helper function used by
 // createTarFile to handle the following types of header: Block; Char; Fifo
 func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
+	if system.RunningInUserNS() {
+		// cannot create a device if running in user namespace
+		return nil
+	}
 	mode := uint32(hdr.Mode & 07777)
 	switch hdr.Typeflag {
 	case tar.TypeBlock:

--- a/pkg/system/userns.go
+++ b/pkg/system/userns.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package system
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// RunningInUserNS detects whether we are currently running in a user
+// namespace.  Copied from github.com/lxc/lxd/shared/util.go
+func RunningInUserNS() bool {
+	file, err := os.Open("/proc/self/uid_map")
+	if err != nil {
+		/*
+		 * This kernel-provided file only exists if user namespaces are
+		 * supported
+		 */
+		return false
+	}
+	defer file.Close()
+
+	buf := bufio.NewReader(file)
+	l, _, err := buf.ReadLine()
+	if err != nil {
+		return false
+	}
+
+	line := string(l)
+	var a, b, c int64
+	fmt.Sscanf(line, "%d %d %d", &a, &b, &c)
+	/*
+	 * We assume we are in the initial user namespace if we have a full
+	 * range - 4294967295 uids starting at uid 0.
+	 */
+	if a == 0 && b == 0 && c == 4294967295 {
+		return false
+	}
+	return true
+}

--- a/pkg/system/userns_unsupported.go
+++ b/pkg/system/userns_unsupported.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package system
+
+// RunningInUserNS - User namespaces are only supported in linux
+func RunningInUserNS() bool {
+	return false
+}


### PR DESCRIPTION
If docker is being run inside a user namespace, it won't be able
to create devices.  Since libcontainer will try to bind mount the
devices anyway this is fine - ignore it.

Signed-off-by: Serge Hallyn serge.hallyn@ubuntu.com
