### PR TITLE
CONTRIBUTING: add guidelines regarding email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,12 @@ guidelines for the community as a whole:
   to an email you are potentially sending to a large number of people. Please
   consider this before you update. Also remember that nobody likes spam.
 
+* Don't send email to the maintainers: There's no need to send email to the
+  maintainers to ask them to investigate an issue or to take a look at a
+  pull request. Instead of sending an email, GitHub mentions should be
+  used to ping maintainers to review a pull request, a proposal or an
+  issue.
+
 ### Guideline violations — 3 strikes method
 
 The point of this section is not to find opportunities to punish people, but we


### PR DESCRIPTION
This PR adds guidelines around reaching the maintainers. Emails shouldn't be sent to maintainers. GitHub mentions should be used instead.

There has been a recent case when most (if not all) maintainers were sent email to review something on GitHub. Other emails have also been sent asking for support and help with particular issues.

Given the size of the community and the number of users, sending email directly to the maintainers shouldn't be encouraged because that would easily overwhelm the maintainers.
