### PR TITLE
Allow external volume drivers to host anonymous volumes again

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -105,7 +105,7 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 		}
 	}()
 
-	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig, img); err != nil {
+	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig); err != nil {
 		return nil, err
 	}
 

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -9,15 +9,13 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/container"
 	derr "github.com/docker/docker/errors"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/volume"
 	containertypes "github.com/docker/engine-api/types/container"
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
-func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig, img *image.Image) error {
+func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
 	if err := daemon.Mount(container); err != nil {
 		return err
 	}
@@ -42,17 +40,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 			return derr.ErrorCodeMountOverFile.WithArgs(path)
 		}
 
-		volumeDriver := hostConfig.VolumeDriver
-		if destination != "" && img != nil {
-			if _, ok := img.ContainerConfig.Volumes[destination]; ok {
-				// check for whether bind is not specified and then set to local
-				if _, ok := container.MountPoints[destination]; !ok {
-					volumeDriver = volume.DefaultDriverName
-				}
-			}
-		}
-
-		v, err := daemon.volumes.CreateWithRef(name, volumeDriver, container.ID, nil)
+		v, err := daemon.volumes.CreateWithRef(name, hostConfig.VolumeDriver, container.ID, nil)
 		if err != nil {
 			return err
 		}

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/volume"
 	containertypes "github.com/docker/engine-api/types/container"
 )
 
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
-func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig, img *image.Image) error {
+func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
 	for spec := range config.Volumes {
 
 		mp, err := volume.ParseMountSpec(spec, hostConfig.VolumeDriver)
@@ -31,14 +30,6 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 		}
 
 		volumeDriver := hostConfig.VolumeDriver
-		if mp.Destination != "" && img != nil {
-			if _, ok := img.ContainerConfig.Volumes[mp.Destination]; ok {
-				// check for whether bind is not specified and then set to local
-				if _, ok := container.MountPoints[mp.Destination]; !ok {
-					volumeDriver = volume.DefaultDriverName
-				}
-			}
-		}
 
 		// Create the volume in the volume driver. If it doesn't exist,
 		// a new one will be created.

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -296,33 +296,6 @@ func hostVolumePath(name string) string {
 	return fmt.Sprintf("/var/lib/docker/volumes/%s", name)
 }
 
-func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamedCheckBindLocalVolume(c *check.C) {
-	err := s.d.StartWithBusybox()
-	c.Assert(err, checker.IsNil)
-
-	expected := s.server.URL
-	dockerfile := fmt.Sprintf(`FROM busybox:latest
-	RUN mkdir /nobindthenlocalvol
-	RUN echo %s > /nobindthenlocalvol/test
-	VOLUME ["/nobindthenlocalvol"]`, expected)
-
-	img := "test-checkbindlocalvolume"
-
-	_, err = buildImageWithOutInDamon(s.d.sock(), img, dockerfile, true)
-	c.Assert(err, checker.IsNil)
-
-	out, err := s.d.Cmd("run", "--rm", "--name", "test-data-nobind", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", "test-external-volume-driver", img, "cat", "/nobindthenlocalvol/test")
-	c.Assert(err, checker.IsNil)
-
-	c.Assert(out, checker.Contains, expected)
-
-	c.Assert(s.ec.activations, checker.Equals, 1)
-	c.Assert(s.ec.creations, checker.Equals, 1)
-	c.Assert(s.ec.removals, checker.Equals, 1)
-	c.Assert(s.ec.mounts, checker.Equals, 1)
-	c.Assert(s.ec.unmounts, checker.Equals, 1)
-}
-
 // Make sure a request to use a down driver doesn't block other requests
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverLookupNotBlocked(c *check.C) {
 	specPath := "/etc/docker/plugins/down-driver.spec"


### PR DESCRIPTION
The changes for https://github.com/docker/docker/pull/15507 appear to have been made because of limitations in a 3rd party storage platform.

While I can understand the reasoning, I think this is a bad precedent to set. Unfortunately, it artificially limited all volume drivers, even those that do not have this limitation.  Generally speaking, limitations in 3rd party platforms should be best handled in the specific volume driver.

This change re-allows anonymous volumes (those built in to the IMAGE) to be proxied to volume drivers.

@cpuguy83 @thaJeztah 
