### PR TITLE
Fix race on cleaning endpoint data

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	networktypes "github.com/docker/engine-api/types/network"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -351,7 +352,30 @@ func (daemon *Daemon) transformContainer(container *container.Container, ctx *li
 	newC.Created = container.Created.Unix()
 	newC.Status = container.State.String()
 	newC.HostConfig.NetworkMode = string(container.HostConfig.NetworkMode)
-	newC.NetworkSettings = &types.SummaryNetworkSettings{container.NetworkSettings.Networks}
+	// copy networks to avoid races
+	networks := make(map[string]*networktypes.EndpointSettings)
+	for name, network := range container.NetworkSettings.Networks {
+		if network == nil {
+			continue
+		}
+		networks[name] = &networktypes.EndpointSettings{
+			EndpointID:          network.EndpointID,
+			Gateway:             network.Gateway,
+			IPAddress:           network.IPAddress,
+			IPPrefixLen:         network.IPPrefixLen,
+			IPv6Gateway:         network.IPv6Gateway,
+			GlobalIPv6Address:   network.GlobalIPv6Address,
+			GlobalIPv6PrefixLen: network.GlobalIPv6PrefixLen,
+			MacAddress:          network.MacAddress,
+		}
+		if network.IPAMConfig != nil {
+			networks[name].IPAMConfig = &networktypes.EndpointIPAMConfig{
+				IPv4Address: network.IPAMConfig.IPv4Address,
+				IPv6Address: network.IPAMConfig.IPv6Address,
+			}
+		}
+	}
+	newC.NetworkSettings = &types.SummaryNetworkSettings{Networks: networks}
 
 	newC.Ports = []types.Port{}
 	for port, bindings := range container.NetworkSettings.Ports {


### PR DESCRIPTION
Race is with any endpoint data reading, for example /containers api.
