### PR TITLE
Windows CI: Deal with failing tests for TP4

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1311,7 +1311,7 @@ func (s *DockerSuite) TestContainersApiCreateNoHostConfig118(c *check.C) {
 func (s *DockerSuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs(c *check.C) {
 	// Requires local volume mount bind.
 	// --read-only + userns has remount issues
-	testRequires(c, SameHostDaemon, NotUserNamespace)
+	testRequires(c, SameHostDaemon, NotUserNamespace, DaemonIsLinux)
 
 	testVol := getTestDir(c, "test-put-container-archive-err-symlink-in-volume-to-read-only-rootfs-")
 	defer os.RemoveAll(testVol)
@@ -1392,6 +1392,7 @@ func (s *DockerSuite) TestStartWithNilDNS(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersCreateShmSizeNegative(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image":      "busybox",
 		"HostConfig": map[string]interface{}{"ShmSize": -1},
@@ -1404,6 +1405,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeNegative(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersCreateShmSizeHostConfigOmitted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var defaultSHMSize int64 = 67108864
 	config := map[string]interface{}{
 		"Image": "busybox",
@@ -1434,6 +1436,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeHostConfigOmitted(c *check.
 }
 
 func (s *DockerSuite) TestPostContainersCreateShmSizeOmitted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image":      "busybox",
 		"HostConfig": map[string]interface{}{},
@@ -1464,6 +1467,7 @@ func (s *DockerSuite) TestPostContainersCreateShmSizeOmitted(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersCreateWithShmSize(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image":      "busybox",
 		"Cmd":        "mount",
@@ -1494,6 +1498,7 @@ func (s *DockerSuite) TestPostContainersCreateWithShmSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersCreateMemorySwappinessHostConfigOmitted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image": "busybox",
 	}

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -63,6 +63,7 @@ func (s *DockerSuite) TestExecApiCreateContainerPaused(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecAPIStart(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Uses pause/unpause but bits may be salvagable to Windows to Windows CI
 	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
 
 	startExec := func(id string, code int) {

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -47,6 +47,7 @@ func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiContainerVolumeDriverLegacy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -111,6 +112,7 @@ func (s *DockerSuite) TestInspectApiImageResponse(c *check.C) {
 
 // #17131, #17139, #17173
 func (s *DockerSuite) TestInspectApiEmptyFieldsInConfigPre121(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -133,6 +135,7 @@ func (s *DockerSuite) TestInspectApiEmptyFieldsInConfigPre121(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiBridgeNetworkSettings120(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	containerID := strings.TrimSpace(out)
 	waitRun(containerID)
@@ -148,6 +151,7 @@ func (s *DockerSuite) TestInspectApiBridgeNetworkSettings120(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiBridgeNetworkSettings121(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	containerID := strings.TrimSpace(out)
 	waitRun(containerID)

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -153,6 +153,7 @@ func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachPausedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Containers cannot be paused on Windows
 	defer unpauseAllContainers()
 	dockerCmd(c, "run", "-d", "--name=test", "busybox", "top")
 	dockerCmd(c, "pause", "test")

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -561,7 +561,7 @@ func (s *DockerSuite) TestCpToStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /te:s:t")
 

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -43,7 +43,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 // TestInfoDiscoveryBackend verifies that a daemon run with `--cluster-advertise` and
 // `--cluster-store` properly show the backend's endpoint in info output.
 func (s *DockerSuite) TestInfoDiscoveryBackend(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	d := NewDaemon(c)
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
@@ -61,7 +61,7 @@ func (s *DockerSuite) TestInfoDiscoveryBackend(c *check.C) {
 // TestInfoDiscoveryInvalidAdvertise verifies that a daemon run with
 // an invalid `--cluster-advertise` configuration
 func (s *DockerSuite) TestInfoDiscoveryInvalidAdvertise(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	d := NewDaemon(c)
 	discoveryBackend := "consul://consuladdr:consulport/some/path"
@@ -78,7 +78,7 @@ func (s *DockerSuite) TestInfoDiscoveryInvalidAdvertise(c *check.C) {
 // TestInfoDiscoveryAdvertiseInterfaceName verifies that a daemon run with `--cluster-advertise`
 // configured with interface name properly show the advertise ip-address in info output.
 func (s *DockerSuite) TestInfoDiscoveryAdvertiseInterfaceName(c *check.C) {
-	testRequires(c, SameHostDaemon, Network)
+	testRequires(c, SameHostDaemon, Network, DaemonIsLinux)
 
 	d := NewDaemon(c)
 	discoveryBackend := "consul://consuladdr:consulport/some/path"

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -380,6 +380,7 @@ func (s *DockerSuite) TestInspectStopWhenNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectHistory(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name=testcont", "-d", "busybox", "top")
 	dockerCmd(c, "commit", "-m", "test comment", "testcont", "testimg")
 	out, _, err := dockerCmdWithError("inspect", "--format='{{.Comment}}'", "testimg")

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -58,3 +58,10 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 		c.Assert(actions[len(actions)-1], checker.Equals, "unpause")
 	}
 }
+
+func (s *DockerSuite) TestPauseFailsOnWindows(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	dockerCmd(c, "run", "-d", "--name=test", "busybox", "sleep 3")
+	out, _, _ := dockerCmdWithError("pause", "test")
+	c.Assert(out, checker.Contains, "Windows: Containers cannot be paused")
+}

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -89,6 +89,7 @@ func (s *DockerSuite) TestSaveSingleTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestSaveCheckTimes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := "busybox:latest"
 	out, _ := dockerCmd(c, "inspect", repoName)
 	data := []struct {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This deals with a bunch of tests which fail when running Windows to Windows CI. The majority of tests are simply disabled, using the similar pattern to what has been done to the majority of tests. In time, we'll modify and bring more and more online where applicable.

I did though add a pause failure test for Windows as that was an easy one :)
