### PR TITLE
Windows CI: Setup for testing against Windows

### DIFF
--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -30,7 +30,7 @@ fi
 if ! docker inspect "${images[@]}" &> /dev/null; then
 	hardCodedDir='/docker-frozen-images'
 	if [ -d "$hardCodedDir" ]; then
-		# Do not use a subshell for the following command. Windows CI
+		# Do not use a subshell for the following command. Windows to Linux CI
 		# runs bash 3.x so will not trap an error in a subshell.
 		# http://stackoverflow.com/questions/22630363/how-does-set-e-work-with-subshells
 		set -x; tar -cC "$hardCodedDir" . | docker load; set +x
@@ -55,7 +55,7 @@ if ! docker inspect "${images[@]}" &> /dev/null; then
 				}
 			}
 		' "${DOCKERFILE:=Dockerfile}" | sh -x
-		# Do not use a subshell for the following command. Windows CI
+		# Do not use a subshell for the following command. Windows to Linux CI
 		# runs bash 3.x so will not trap an error in a subshell.
 		# http://stackoverflow.com/questions/22630363/how-does-set-e-work-with-subshells
 		set -x; tar -cC "$dir" . | docker load; set +x

--- a/hack/make/.ensure-frozen-images-windows
+++ b/hack/make/.ensure-frozen-images-windows
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# This scripts sets up the required images for Windows to Windows CI
+
+# Tag windowsservercore as latest
+set +e
+! BUILD=$(docker images | grep windowsservercore | grep -v latest | awk '{print $2}')
+if [ -z $BUILD ]; then
+	echo "ERROR: Could not find windowsservercore images"
+	exit 1
+fi
+
+! LATESTCOUNT=$(docker images | grep windowsservercore | grep -v $BUILD | wc -l)
+if [ $LATESTCOUNT -ne 1 ]; then
+	set -e
+	docker tag windowsservercore:$BUILD windowsservercore:latest
+	echo "INFO: Tagged windowsservercore:$BUILD with latest"
+fi
+
+# Busybox (requires windowsservercore)
+if [ -z "$(docker images | grep busybox)" ]; then
+	echo "INFO: Building busybox"
+	docker build -t busybox https://raw.githubusercontent.com/jhowardmsft/busybox/master/Dockerfile
+fi

--- a/hack/make/.integration-daemon-setup
+++ b/hack/make/.integration-daemon-setup
@@ -2,7 +2,12 @@
 set -e
 
 bundle .detect-daemon-osarch
-bundle .ensure-emptyfs
-bundle .ensure-frozen-images
-bundle .ensure-httpserver
-bundle .ensure-syscall-test
+if [ $DOCKER_ENGINE_GOOS != "windows" ]; then
+	bundle .ensure-emptyfs
+	bundle .ensure-frozen-images
+	bundle .ensure-httpserver
+	bundle .ensure-syscall-test
+else
+	# Note this is Windows to Windows CI, not Windows to Linux CI
+	bundle .ensure-frozen-images-windows
+fi


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @mikedougherty @icecrime You guys ready for this? :smile:  Running locally, with this PR plus #19193 and #19195 cherry-picked, I got a successful run using a Jenkins build script (although locally, not invoked from my test Jenkins server) against TP4.

```
INFO: Started at Fri, Jan 8, 2016 2:30:42 PM.
INFO: Script version 8-Jan-2016 HH:MM PST
INFO: The control daemon replied to a ping. Good!
INFO: Repository was found
INFO: Commit hash is a8e9479
INFO: Location for testing is /c/CI/CI-a8e9479
INFO: No PID file found from a previous docker run. Good!
INFO: Killing any spurious leftover daemons just in case
SUCCESS: The process with PID 7848 (child process of PID 7072) has been terminated.
INFO: Cleaning environment...
INFO: Redirecting USERPROFILE and LOCALAPPDATA
INFO: Validating installed GOLang version go1.5.2 is correct...
INFO: Deleting pre-existing containers and images...
INFO: Docker version of control daemon

Client:
 Version:      1.10.0-dev
 API version:  1.22
 Go version:   go1.5.2
 Git commit:   3a8d694
 Built:        Fri Jan  8 17:45:43 UTC 2016
 OS/Arch:      windows/amd64

Server:
 Version:      1.10.0-dev
 API version:  1.22
 Go version:   go1.5.2
 Git commit:   3a8d694
 Built:        Fri Jan  8 17:45:43 UTC 2016
 OS/Arch:      windows/amd64

INFO: Docker info of control daemon

Containers: 4
Images: 4
Server Version: 1.10.0-dev
Storage Driver: windowsfilter
 Windows:
Execution Driver:
 Name: Windows 1854
 Build: 1.10.0-dev 3a8d694
 Default Isolation: process
Logging Driver: json-file
Plugins:
 Volume: local
 Network:
Kernel Version: 10.0 10586 (10586.17.amd64fre.th2_release.151121-2308)
Operating System: Windows Server 2016 Technical Preview 4 Standard
OSType: windows
Architecture: x86_64
CPUs: 8
Total Memory: 2.53 GiB
Name: WIN-T2JD5DLNQNI
ID: 6JOS:Y2PK:SJSH:OBFW:7K62:OIDE:WCVF:FA3H:GXKR:QVT5:4WZN:BU4L
Debug mode (server): true
 File Descriptors: -1
 Goroutines: 28
 System Time: 2016-01-08T14:30:56.4640257-08:00
 EventsListeners: 0
 Init SHA1:
 Init Path: e:\go\src\github.com\docker\docker\docker\docker.exe
 Docker Root Dir: C:\ProgramData\docker

INFO: Building test docker.exe binary...

++ hack/make.sh binary
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

bundles/1.10.0-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.10.0-dev/binary)
Building: bundles/1.10.0-dev/binary/docker-1.10.0-dev.exe
Created binary: bundles/1.10.0-dev/binary/docker-1.10.0-dev.exe

++ ec=0
++ set +x
INFO: Starting a daemon under test...
INFO: Daemon under test started
INFO: The daemon under test replied to a ping. Good!
INFO: Docker version and info of the daemon under test

---------------------------------------------------------------------------
Client:
 Version:      1.10.0-dev
 API version:  1.22
 Go version:   go1.5.2
 Git commit:   a8e9479
 Built:        Fri Jan  8 14:30:56 2016
 OS/Arch:      windows/amd64

Server:
 Version:      1.10.0-dev
 API version:  1.22
 Go version:   go1.5.2
 Git commit:   a8e9479
 Built:        Fri Jan  8 14:30:56 2016
 OS/Arch:      windows/amd64
---------------------------------------------------------------------------
Containers: 0
Images: 2
Server Version: 1.10.0-dev
Storage Driver: windowsfilter
 Windows:
Execution Driver:
 Name: Windows 1854
 Build: 1.10.0-dev a8e9479
 Default Isolation: process
Logging Driver: json-file
Plugins:
 Volume: local
 Network:
Kernel Version: 10.0 10586 (10586.17.amd64fre.th2_release.151121-2308)
Operating System: Windows Server 2016 Technical Preview 4 Standard
OSType: windows
Architecture: x86_64
CPUs: 8
Total Memory: 2.851 GiB
Name: WIN-T2JD5DLNQNI
ID: 6JOS:Y2PK:SJSH:OBFW:7K62:OIDE:WCVF:FA3H:GXKR:QVT5:4WZN:BU4L
Debug mode (server): true
 File Descriptors: -1
 Goroutines: 23
 System Time: 2016-01-08T14:31:56.254745-08:00
 EventsListeners: 0
 Init SHA1:
 Init Path: C:\CI\CI-a8e9479\docker-a8e9479.exe
 Docker Root Dir: C:/CI/CI-a8e9479/daemon/graph
---------------------------------------------------------------------------


INFO: Running Integration tests...
++ hack/make.sh test-integration-cli
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

bundles/1.10.0-dev already exists. Removing.

---> Making bundle: test-integration-cli (in bundles/1.10.0-dev/test-integration-cli)
---> Making bundle: .integration-daemon-start (in bundles/1.10.0-dev/test-integration-cli)
INFO: Waiting for daemon to start...

---> Making bundle: .integration-daemon-setup (in bundles/1.10.0-dev/test-integration-cli)
---> Making bundle: .ensure-frozen-images-windows (in bundles/1.10.0-dev/test-integration-cli)
INFO: Tagged windowsservercore:10.0.10586.0 with latest
INFO: Building a busybox image
Downloading build context from remote url: https://raw.githubusercontent.com/jhowardmsft/busybox/master/Dockerfile    552 B
Sending build context to Docker daemon  2.56 kB
Step 1 : FROM windowsservercore
 ---> efc12fd2d2ec
Step 2 : ADD http://frippery.org/files/busybox/busybox.exe /

 ---> 70fe5b1d929d
Removing intermediate container 8eb9ba217e27
Step 3 : ENTRYPOINT /busybox.exe
 ---> Running in 284cc4eece1f
 ---> 990843841a09
Removing intermediate container 284cc4eece1f
Successfully built 990843841a09
SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
+ go test -test.timeout=120m -check.v github.com/docker/docker/integration-cli
INFO: Testing against a local daemon
PASS: docker_api_test.go:51: DockerSuite.TestApiClientVersionNewerThanServer    0.002s
PASS: docker_api_test.go:65: DockerSuite.TestApiClientVersionOldNotSupported    0.001s
SKIP: docker_api_network_test.go:222: DockerSuite.TestApiCreateDeletePredefinedNetworks (Test requires a Linux daemon)
PASS: docker_api_create_test.go:11: DockerSuite.TestApiCreateWithNotExistImage  0.004s
PASS: docker_api_test.go:79: DockerSuite.TestApiDockerApiVersion        0.050s
PASS: docker_api_test.go:24: DockerSuite.TestApiGetEnabledCors  0.001s
SKIP: docker_api_images_test.go:74: DockerSuite.TestApiImagesDelete (Test requires a Linux daemon)
SKIP: docker_api_images_test.go:14: DockerSuite.TestApiImagesFilter (Test requires a Linux daemon)
SKIP: docker_api_images_test.go:97: DockerSuite.TestApiImagesHistory (Test requires a Linux daemon)
SKIP: docker_api_images_test.go:51: DockerSuite.TestApiImagesSaveAndLoad (Test requires a Linux daemon)
PASS: docker_api_images_test.go:119: DockerSuite.TestApiImagesSearchJSONContentType     0.970s
SKIP: docker_api_network_test.go:122: DockerSuite.TestApiNetworkConnectDisconnect (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:43: DockerSuite.TestApiNetworkCreateCheckDuplicate (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:27: DockerSuite.TestApiNetworkCreateDelete (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:66: DockerSuite.TestApiNetworkFilter (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:18: DockerSuite.TestApiNetworkGetDefaults (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:72: DockerSuite.TestApiNetworkInspect (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:163: DockerSuite.TestApiNetworkIpamMultipleBridgeNetworks (Test requires a Linux daemon)
PASS: docker_api_test.go:18: DockerSuite.TestApiOptionsRoute    0.001s
SKIP: docker_api_stats_test.go:224: DockerSuite.TestApiStatsContainerNotFound (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:82: DockerSuite.TestApiStatsNetworkStats (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:128: DockerSuite.TestApiStatsNetworkStatsVersioning (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:21: DockerSuite.TestApiStatsNoStreamGetCpu (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:46: DockerSuite.TestApiStatsStoppedContainerInGoroutines (Test requires a Linux daemon)
PASS: docker_api_test.go:36: DockerSuite.TestApiVersionStatusCode       0.000s
SKIP: docker_cli_run_test.go:3244: DockerSuite.TestAppArmorDeniesChmodProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:3222: DockerSuite.TestAppArmorDeniesPtrace (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:3234: DockerSuite.TestAppArmorTraceSelf (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:124: DockerSuite.TestAttachDisconnect (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:18: DockerSuite.TestAttachMultipleAndRestart (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:155: DockerSuite.TestAttachPausedContainer (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:89: DockerSuite.TestAttachTtyWithoutStdin (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1573: DockerSuite.TestBuildAddBadLinks (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1660: DockerSuite.TestBuildAddBadLinksVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4142: DockerSuite.TestBuildAddBrokenTar (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2740: DockerSuite.TestBuildAddCurrentDirWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2798: DockerSuite.TestBuildAddCurrentDirWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1267: DockerSuite.TestBuildAddDirContentToExistingDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1243: DockerSuite.TestBuildAddDirContentToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1321: DockerSuite.TestBuildAddEtcToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3158: DockerSuite.TestBuildAddFileNotFound (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:970: DockerSuite.TestBuildAddFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2953: DockerSuite.TestBuildAddLocalAndRemoteFilesWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3038: DockerSuite.TestBuildAddLocalAndRemoteFilesWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2618: DockerSuite.TestBuildAddLocalFileWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2678: DockerSuite.TestBuildAddLocalFileWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:838: DockerSuite.TestBuildAddMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:882: DockerSuite.TestBuildAddMultipleFilesToFileWild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1042: DockerSuite.TestBuildAddMultipleFilesToFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2649: DockerSuite.TestBuildAddMultipleLocalFileWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4194: DockerSuite.TestBuildAddNonTar (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1340: DockerSuite.TestBuildAddPreservesFilesSpecialBits (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2891: DockerSuite.TestBuildAddRemoteFileMTime (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2826: DockerSuite.TestBuildAddRemoteFileWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2858: DockerSuite.TestBuildAddRemoteFileWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4061: DockerSuite.TestBuildAddScript (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:767: DockerSuite.TestBuildAddSingleFileToExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1217: DockerSuite.TestBuildAddSingleFileToNonExistingDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:714: DockerSuite.TestBuildAddSingleFileToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:740: DockerSuite.TestBuildAddSingleFileToWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4084: DockerSuite.TestBuildAddTar (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4215: DockerSuite.TestBuildAddTarXz (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4270: DockerSuite.TestBuildAddTarXzGz (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3313: DockerSuite.TestBuildAddToSymlinkDest (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1293: DockerSuite.TestBuildAddWholeDirToRoot (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:181: DockerSuite.TestBuildApiBuildGitWithF (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:45: DockerSuite.TestBuildApiDockerFileRemote (Test requires a Linux daemon)
PASS: docker_api_build_test.go:12: DockerSuite.TestBuildApiDockerfilePath       0.000s
PASS: docker_api_build_test.go:227: DockerSuite.TestBuildApiDockerfileSymlink   0.004s
SKIP: docker_api_build_test.go:204: DockerSuite.TestBuildApiDoubleDockerfile (Test requires posix utilities or functionality to run.)
SKIP: docker_api_build_test.go:161: DockerSuite.TestBuildApiLowerDockerfile (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:71: DockerSuite.TestBuildApiRemoteTarballContext (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:105: DockerSuite.TestBuildApiRemoteTarballContextWithCustomDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5726: DockerSuite.TestBuildBadCmdFlag (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5890: DockerSuite.TestBuildBuildTimeArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6257: DockerSuite.TestBuildBuildTimeArgBuiltinArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5942: DockerSuite.TestBuildBuildTimeArgCacheHit (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5969: DockerSuite.TestBuildBuildTimeArgCacheMissExtraArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6001: DockerSuite.TestBuildBuildTimeArgCacheMissSameArgDiffVal (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6282: DockerSuite.TestBuildBuildTimeArgDefaultOverride (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6394: DockerSuite.TestBuildBuildTimeArgDefintionWithNoEnvInjection (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6374: DockerSuite.TestBuildBuildTimeArgEmptyValVariants (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6091: DockerSuite.TestBuildBuildTimeArgExpansion (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6201: DockerSuite.TestBuildBuildTimeArgExpansionOverride (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5916: DockerSuite.TestBuildBuildTimeArgHistory (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6310: DockerSuite.TestBuildBuildTimeArgMultiArgsSameLine (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6033: DockerSuite.TestBuildBuildTimeArgOverrideArgDefinedBeforeEnv (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6062: DockerSuite.TestBuildBuildTimeArgOverrideEnvDefinedBeforeArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6348: DockerSuite.TestBuildBuildTimeArgQuotedValVariants (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6327: DockerSuite.TestBuildBuildTimeArgUnconsumedArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6231: DockerSuite.TestBuildBuildTimeArgUntrustedDefinedAfterUse (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:596: DockerSuite.TestBuildCacheAdd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6468: DockerSuite.TestBuildCacheBrokenSymlink (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6592: DockerSuite.TestBuildCacheRootSource (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4998: DockerSuite.TestBuildChownSingleFile (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:4450: DockerSuite.TestBuildCleanupCmdOnEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4483: DockerSuite.TestBuildClearCmd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2231: DockerSuite.TestBuildCmd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4603: DockerSuite.TestBuildCmdJSONNoShDashC (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4546: DockerSuite.TestBuildCmdShDashC (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4566: DockerSuite.TestBuildCmdSpaces (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3836: DockerSuite.TestBuildCommentsShebangs (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2577: DockerSuite.TestBuildConditionalCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5657: DockerSuite.TestBuildContainerWithCgroupParent (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2179: DockerSuite.TestBuildContextCleanup (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2205: DockerSuite.TestBuildContextCleanupFailedBuild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3015: DockerSuite.TestBuildContextTarGzip (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3019: DockerSuite.TestBuildContextTarNoCompression (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:793: DockerSuite.TestBuildCopyAddMultipleFiles (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2709: DockerSuite.TestBuildCopyDirButNotFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1491: DockerSuite.TestBuildCopyDirContentToExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1467: DockerSuite.TestBuildCopyDirContentToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1562: DockerSuite.TestBuildCopyDisallowRemote (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1544: DockerSuite.TestBuildCopyEtcToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1006: DockerSuite.TestBuildCopyFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:926: DockerSuite.TestBuildCopyMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1064: DockerSuite.TestBuildCopyMultipleFilesToFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1416: DockerSuite.TestBuildCopySingleFileToExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1442: DockerSuite.TestBuildCopySingleFileToNonExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1363: DockerSuite.TestBuildCopySingleFileToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1389: DockerSuite.TestBuildCopySingleFileToWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1517: DockerSuite.TestBuildCopyWholeDirToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1086: DockerSuite.TestBuildCopyWildcard (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1183: DockerSuite.TestBuildCopyWildcardCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1158: DockerSuite.TestBuildCopyWildcardInName (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1137: DockerSuite.TestBuildCopyWildcardNoFind (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5383: DockerSuite.TestBuildDockerfileOutsideContext (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:3382: DockerSuite.TestBuildDockerignore (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3428: DockerSuite.TestBuildDockerignoreCleanPaths (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3450: DockerSuite.TestBuildDockerignoreExceptions (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3584: DockerSuite.TestBuildDockerignoreTouchDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3673: DockerSuite.TestBuildDockerignoringBadExclusion (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3503: DockerSuite.TestBuildDockerignoringDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3563: DockerSuite.TestBuildDockerignoringDockerignore (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3532: DockerSuite.TestBuildDockerignoringRenamedDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3637: DockerSuite.TestBuildDockerignoringWholeDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3725: DockerSuite.TestBuildDockerignoringWildDirs (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3698: DockerSuite.TestBuildDockerignoringWildTopDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5603: DockerSuite.TestBuildDotDotFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3820: DockerSuite.TestBuildEOLInLine (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4503: DockerSuite.TestBuildEmptyCmd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2410: DockerSuite.TestBuildEmptyEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2368: DockerSuite.TestBuildEmptyEntrypointInheritance (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5592: DockerSuite.TestBuildEmptyScratch (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5642: DockerSuite.TestBuildEmptyStringVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:45: DockerSuite.TestBuildEmptyWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2432: DockerSuite.TestBuildEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4634: DockerSuite.TestBuildEntrypointInheritance (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4661: DockerSuite.TestBuildEntrypointInheritanceInspect (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3102: DockerSuite.TestBuildEntrypointRunCleanup (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2124: DockerSuite.TestBuildEnv (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:422: DockerSuite.TestBuildEnvEscapes (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:445: DockerSuite.TestBuildEnvOverwrite (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3918: DockerSuite.TestBuildEnvUsage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3956: DockerSuite.TestBuildEnvUsage2 (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:198: DockerSuite.TestBuildEnvironmentReplacementAddCopy (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:233: DockerSuite.TestBuildEnvironmentReplacementEnv (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:144: DockerSuite.TestBuildEnvironmentReplacementExpose (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:90: DockerSuite.TestBuildEnvironmentReplacementUser (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:114: DockerSuite.TestBuildEnvironmentReplacementVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:181: DockerSuite.TestBuildEnvironmentReplacementWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4623: DockerSuite.TestBuildErrorInvalidInstruction (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3334: DockerSuite.TestBuildEscapeWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4710: DockerSuite.TestBuildExoticShellInterpolation (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2251: DockerSuite.TestBuildExpose (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2271: DockerSuite.TestBuildExposeMorePorts (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2326: DockerSuite.TestBuildExposeOrder (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2348: DockerSuite.TestBuildExposeUpperCaseProto (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3217: DockerSuite.TestBuildFails (Test requires a Linux daemon)
PASS: docker_cli_build_test.go:3233: DockerSuite.TestBuildFailsDockerfileEmpty  0.044s
SKIP: docker_cli_build_test.go:6531: DockerSuite.TestBuildFollowSymlinkToDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6498: DockerSuite.TestBuildFollowSymlinkToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3136: DockerSuite.TestBuildForbiddenContextPath (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1839: DockerSuite.TestBuildForceRm (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4330: DockerSuite.TestBuildFromGIT (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4358: DockerSuite.TestBuildFromGITWithContext (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4387: DockerSuite.TestBuildFromGITwithF (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5246: DockerSuite.TestBuildFromMixedcaseDockerfile (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:5362: DockerSuite.TestBuildFromOfficialNames (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4409: DockerSuite.TestBuildFromRemoteTarball (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5331: DockerSuite.TestBuildFromStdinWithF (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5296: DockerSuite.TestBuildFromURLWithF (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:301: DockerSuite.TestBuildHandleEscapes (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:15: DockerSuite.TestBuildHistory (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3177: DockerSuite.TestBuildInheritance (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4535: DockerSuite.TestBuildInvalidTag (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:860: DockerSuite.TestBuildJSONAddMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:904: DockerSuite.TestBuildJSONAddMultipleFilesToFileWild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:948: DockerSuite.TestBuildJSONCopyMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:27: DockerSuite.TestBuildJSONEmptyRun (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4798: DockerSuite.TestBuildLabels (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4819: DockerSuite.TestBuildLabelsCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:631: DockerSuite.TestBuildLastModified (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3804: DockerSuite.TestBuildLineBreak (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1992: DockerSuite.TestBuildMaintainer (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5550: DockerSuite.TestBuildMissingArgs (Test requires a Linux daemon)
PASS: docker_cli_build_test.go:6449: DockerSuite.TestBuildMultipleTags  2.562s
SKIP: docker_cli_build_test.go:3023: DockerSuite.TestBuildNoContext (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5688: DockerSuite.TestBuildNoDupOutput (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6411: DockerSuite.TestBuildNoNamedVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4930: DockerSuite.TestBuildNotVerboseFailure (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4956: DockerSuite.TestBuildNotVerboseFailureRemote (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4868: DockerSuite.TestBuildNotVerboseSuccess (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5851: DockerSuite.TestBuildNullStringInAddCopyVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3245: DockerSuite.TestBuildOnBuild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:538: DockerSuite.TestBuildOnBuildCmdEntrypointJSON (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:568: DockerSuite.TestBuildOnBuildEntrypointJSON (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3264: DockerSuite.TestBuildOnBuildForbiddenChained (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:515: DockerSuite.TestBuildOnBuildForbiddenChainedInSourceImage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3280: DockerSuite.TestBuildOnBuildForbiddenFrom (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:492: DockerSuite.TestBuildOnBuildForbiddenFromInSourceImage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3296: DockerSuite.TestBuildOnBuildForbiddenMaintainer (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:469: DockerSuite.TestBuildOnBuildForbiddenMaintainerInSourceImage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2454: DockerSuite.TestBuildOnBuildLimitedInheritence (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:389: DockerSuite.TestBuildOnBuildLowercase (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4518: DockerSuite.TestBuildOnBuildOutput (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2146: DockerSuite.TestBuildPATH (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5743: DockerSuite.TestBuildRUNErrMsg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5620: DockerSuite.TestBuildRUNoneJSON (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2083: DockerSuite.TestBuildRelativeCopy (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2034: DockerSuite.TestBuildRelativeWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5141: DockerSuite.TestBuildRenamedDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1865: DockerSuite.TestBuildRm (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4696: DockerSuite.TestBuildRunShEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:65: DockerSuite.TestBuildShCmdJSONEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:697: DockerSuite.TestBuildSixtySteps (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5441: DockerSuite.TestBuildSpaces (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5512: DockerSuite.TestBuildSpacesWithQuotes (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5709: DockerSuite.TestBuildStartsFromOne (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4972: DockerSuite.TestBuildStderr (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5874: DockerSuite.TestBuildStopSignal (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6568: DockerSuite.TestBuildSymlinkBasename (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5027: DockerSuite.TestBuildSymlinkBreakout (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6423: DockerSuite.TestBuildTagEvent (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2012: DockerSuite.TestBuildUser (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3855: DockerSuite.TestBuildUsersAndGroups (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4761: DockerSuite.TestBuildVerboseOut (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3360: DockerSuite.TestBuildVerifyIntString (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4739: DockerSuite.TestBuildVerifySingleQuoteFails (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5534: DockerSuite.TestBuildVolumeFileExistsinContainer (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5109: DockerSuite.TestBuildVolumesRetainContents (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2523: DockerSuite.TestBuildWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1713: DockerSuite.TestBuildWithInaccessibleFilesInContext (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4779: DockerSuite.TestBuildWithTabs (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5271: DockerSuite.TestBuildWithTwoDockerfiles (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:3074: DockerSuite.TestBuildWithVolumeOwnership (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1945: DockerSuite.TestBuildWithVolumes (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2549: DockerSuite.TestBuildWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2060: DockerSuite.TestBuildWorkdirWithEnvVariables (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5079: DockerSuite.TestBuildXZHost (Test requires a Linux daemon)
SKIP: docker_cli_proxy_test.go:12: DockerSuite.TestCliProxyDisableProxyUnixSock (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3737: DockerSuite.TestCmdCannotBeInvoked   3.606s
SKIP: docker_cli_commit_test.go:10: DockerSuite.TestCommitAfterContainerIsDone (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:110: DockerSuite.TestCommitChange (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:70: DockerSuite.TestCommitHardlink (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:151: DockerSuite.TestCommitMergeConfigRun (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:58: DockerSuite.TestCommitNewFile (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:41: DockerSuite.TestCommitPausedContainer (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:90: DockerSuite.TestCommitTTY (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:100: DockerSuite.TestCommitWithHostBindMount (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:25: DockerSuite.TestCommitWithoutPause (Test requires a Linux daemon)
PASS: docker_cli_config_test.go:64: DockerSuite.TestConfigDir   0.244s
SKIP: docker_cli_config_test.go:18: DockerSuite.TestConfigHttpHeader (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_netmode_test.go:52: DockerSuite.TestConflictContainerNetworkAndLinks (Test requires a Linux daemon)
SKIP: docker_cli_netmode_test.go:62: DockerSuite.TestConflictNetworkModeAndOptions (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:551: DockerSuite.TestContainerApiBadPort (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:491: DockerSuite.TestContainerApiCommit (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:515: DockerSuite.TestContainerApiCommitWithLabelInConfig (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:967: DockerSuite.TestContainerApiCopy (Test requires a Linux daemon)
PASS: docker_api_containers_test.go:1027: DockerSuite.TestContainerApiCopyContainerNotFound     0.002s
SKIP: docker_api_containers_test.go:997: DockerSuite.TestContainerApiCopyResourcePathEmpty (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1012: DockerSuite.TestContainerApiCopyResourcePathNotFound (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:575: DockerSuite.TestContainerApiCreate (Test requires a Linux daemon)
PASS: docker_api_containers_test.go:596: DockerSuite.TestContainerApiCreateEmptyConfig  0.000s
SKIP: docker_api_containers_test.go:655: DockerSuite.TestContainerApiCreateNetworkMode (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:684: DockerSuite.TestContainerApiCreateWithCpuSharesCpuset (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:631: DockerSuite.TestContainerApiCreateWithDomainName (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:607: DockerSuite.TestContainerApiCreateWithHostName (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1037: DockerSuite.TestContainerApiDelete (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1095: DockerSuite.TestContainerApiDeleteConflict (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1058: DockerSuite.TestContainerApiDeleteForce (Test requires a Linux daemon)
PASS: docker_api_containers_test.go:1051: DockerSuite.TestContainerApiDeleteNotExist    0.001s
SKIP: docker_api_containers_test.go:1070: DockerSuite.TestContainerApiDeleteRemoveLinks (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1107: DockerSuite.TestContainerApiDeleteRemoveVolume (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:26: DockerSuite.TestContainerApiGetAll (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:144: DockerSuite.TestContainerApiGetChanges (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:121: DockerSuite.TestContainerApiGetExport (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:51: DockerSuite.TestContainerApiGetJSONNoFieldsOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:748: DockerSuite.TestContainerApiInvalidPortSyntax (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:874: DockerSuite.TestContainerApiKill (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:440: DockerSuite.TestContainerApiPause (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:772: DockerSuite.TestContainerApiPostCreateNull (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:859: DockerSuite.TestContainerApiRename (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:888: DockerSuite.TestContainerApiRestart (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:899: DockerSuite.TestContainerApiRestartNotimeoutParam (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:912: DockerSuite.TestContainerApiStart (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:195: DockerSuite.TestContainerApiStartDupVolumeBinds (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:169: DockerSuite.TestContainerApiStartVolumeBinds (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:219: DockerSuite.TestContainerApiStartVolumesFrom (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:936: DockerSuite.TestContainerApiStop (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:466: DockerSuite.TestContainerApiTop (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:716: DockerSuite.TestContainerApiVerifyHeader (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:952: DockerSuite.TestContainerApiWait (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2329: DockerSuite.TestContainerNetworkMode (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:89: DockerSuite.TestContainerPsOmitFields (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3584: DockerSuite.TestContainerRestartInMultipleNetworks (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:130: DockerSuite.TestContainerRestartSuccess (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:112: DockerSuite.TestContainerRestartwithGoodContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3616: DockerSuite.TestContainerWithConflictingHostNetworks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3647: DockerSuite.TestContainerWithConflictingNoneNetwork (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3630: DockerSuite.TestContainerWithConflictingSharedNetwork (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1128: DockerSuite.TestContainersApiChunkedEncoding (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1298: DockerSuite.TestContainersApiCreateNoHostConfig118 (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1342: DockerSuite.TestContainersApiGetContainersJSONEmpty (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3520: DockerSuite.TestContainersInMultipleNetworks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3512: DockerSuite.TestContainersInUserDefinedNetwork (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3539: DockerSuite.TestContainersNetworkIsolation (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:582: DockerSuite.TestCopyAndRestart (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:603: DockerSuite.TestCopyCreatedContainer (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:129: DockerSuite.TestCpAbsolutePath (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:173: DockerSuite.TestCpAbsoluteSymlink (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:209: DockerSuite.TestCpFromCaseA (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:229: DockerSuite.TestCpFromCaseB (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:247: DockerSuite.TestCpFromCaseC (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:272: DockerSuite.TestCpFromCaseD (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:312: DockerSuite.TestCpFromCaseE (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:341: DockerSuite.TestCpFromCaseF (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:364: DockerSuite.TestCpFromCaseG (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:403: DockerSuite.TestCpFromCaseH (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:433: DockerSuite.TestCpFromCaseI (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:457: DockerSuite.TestCpFromCaseJ (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:85: DockerSuite.TestCpFromErrDstNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:56: DockerSuite.TestCpFromErrDstParentNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:41: DockerSuite.TestCpFromErrSrcNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:26: DockerSuite.TestCpFromErrSrcNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:114: DockerSuite.TestCpFromSymlinkDestination (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:211: DockerSuite.TestCpFromSymlinkToDirectory (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:37: DockerSuite.TestCpGarbagePath (Test requires a Linux daemon)
PASS: docker_cli_cp_test.go:28: DockerSuite.TestCpLocalOnly     0.043s
SKIP: docker_cli_cp_test.go:563: DockerSuite.TestCpNameHasColon (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:80: DockerSuite.TestCpRelativePath (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:408: DockerSuite.TestCpSpecialFiles (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:339: DockerSuite.TestCpSymlinkComponent (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:616: DockerSuite.TestCpSymlinkFromConToHostFollowSymlink (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:229: DockerSuite.TestCpToCaseA (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:251: DockerSuite.TestCpToCaseB (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:273: DockerSuite.TestCpToCaseC (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:300: DockerSuite.TestCpToCaseD (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:346: DockerSuite.TestCpToCaseE (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:382: DockerSuite.TestCpToCaseF (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:405: DockerSuite.TestCpToCaseG (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:451: DockerSuite.TestCpToCaseH (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:488: DockerSuite.TestCpToCaseI (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:512: DockerSuite.TestCpToCaseJ (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:521: DockerSuite.TestCpToDot (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:92: DockerSuite.TestCpToErrDstNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:63: DockerSuite.TestCpToErrDstParentNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:555: DockerSuite.TestCpToErrReadOnlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:582: DockerSuite.TestCpToErrReadOnlyVolume (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:43: DockerSuite.TestCpToErrSrcNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:25: DockerSuite.TestCpToErrSrcNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:543: DockerSuite.TestCpToStdout (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:128: DockerSuite.TestCpToSymlinkDestination (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:259: DockerSuite.TestCpToSymlinkToDirectory (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:383: DockerSuite.TestCpUnprivilegedUser (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:452: DockerSuite.TestCpVolumePath (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:22: DockerSuite.TestCreateArgs (Test requires a Linux daemon)
PASS: docker_cli_create_test.go:247: DockerSuite.TestCreateByImageID    4.892s
SKIP: docker_cli_create_test.go:143: DockerSuite.TestCreateEchoStdout (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:60: DockerSuite.TestCreateHostConfig (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:212: DockerSuite.TestCreateHostnameWithNumber (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:189: DockerSuite.TestCreateLabelFromImage (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:174: DockerSuite.TestCreateLabels (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:237: DockerSuite.TestCreateModeIpcContainer (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:219: DockerSuite.TestCreateRM (Test requires a Linux daemon)
PASS: docker_cli_create_test.go:409: DockerSuite.TestCreateStopSignal   0.466s
SKIP: docker_cli_create_test.go:155: DockerSuite.TestCreateVolumesCreated (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:83: DockerSuite.TestCreateWithPortRange (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:821: DockerSuite.TestCreateWithTooLowMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:113: DockerSuite.TestCreateWithiLargePortRange (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2898: DockerSuite.TestDevicePermissions (Test requires a Linux daemon)
PASS: docker_cli_diff_test.go:83: DockerSuite.TestDiffEmptyArgClientError       0.038s
SKIP: docker_cli_diff_test.go:30: DockerSuite.TestDiffEnsureDockerinitFilesAreIgnored (Test requires a Linux daemon)
SKIP: docker_cli_diff_test.go:50: DockerSuite.TestDiffEnsureOnlyKmsgAndPtmx (Test requires a Linux daemon)
SKIP: docker_cli_diff_test.go:11: DockerSuite.TestDiffFilenameShownInOutput (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3761: DockerSuite.TestDockerFails  0.051s
PASS: docker_api_events_test.go:38: DockerSuite.TestEventsApiBackwardsCompatible        2.575s
PASS: docker_api_events_test.go:17: DockerSuite.TestEventsApiEmptyOutput        0.001s
SKIP: docker_cli_events_test.go:438: DockerSuite.TestEventsAttach (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:374: DockerSuite.TestEventsCommit (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:123: DockerSuite.TestEventsContainerEvents (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:144: DockerSuite.TestEventsContainerEventsSinceUnixEpoch (Test requires a Linux daemon)
PASS: docker_cli_events_test.go:68: DockerSuite.TestEventsContainerFailStartDie 3.184s
SKIP: docker_cli_events_test.go:389: DockerSuite.TestEventsCopy (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:497: DockerSuite.TestEventsDefaultEmpty (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:334: DockerSuite.TestEventsFilterContainer (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:577: DockerSuite.TestEventsFilterImageInContainerAction (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:301: DockerSuite.TestEventsFilterImageLabels (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:244: DockerSuite.TestEventsFilterImageName (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:274: DockerSuite.TestEventsFilterLabels (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:523: DockerSuite.TestEventsFilterType (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:226: DockerSuite.TestEventsFilters (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:204: DockerSuite.TestEventsImageImport (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:185: DockerSuite.TestEventsImagePull (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:165: DockerSuite.TestEventsImageTag (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:96: DockerSuite.TestEventsLimit (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:470: DockerSuite.TestEventsRename (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:419: DockerSuite.TestEventsResize (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:19: DockerSuite.TestEventsTimestampFormats (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:481: DockerSuite.TestEventsTop (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:47: DockerSuite.TestEventsUntag (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:22: DockerSuite.TestExec (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:65: DockerSuite.TestExecAPIStart (Test requires a Linux daemon)
PASS: docker_api_exec_test.go:98: DockerSuite.TestExecAPIStartBackwardsCompatible       2.239s
SKIP: docker_cli_exec_test.go:68: DockerSuite.TestExecAfterContainerRestart (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:51: DockerSuite.TestExecApiCreateContainerPaused (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:17: DockerSuite.TestExecApiCreateNoCmd (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:30: DockerSuite.TestExecApiCreateNoValidContentType (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:234: DockerSuite.TestExecCgroup (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:105: DockerSuite.TestExecEnv (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:117: DockerSuite.TestExecExitStatus (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:32: DockerSuite.TestExecInteractive (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:509: DockerSuite.TestExecOnReadonlyContainer (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:197: DockerSuite.TestExecParseError (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:127: DockerSuite.TestExecPausedContainer (Test requires a Linux daemon)
SKIP: docker_api_exec_resize_test.go:16: DockerSuite.TestExecResizeApiHeightWidthNoInt (Test requires a Linux daemon)
SKIP: docker_api_exec_resize_test.go:28: DockerSuite.TestExecResizeImmediatelyAfterExecStart (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:517: DockerSuite.TestExecStartFails (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:208: DockerSuite.TestExecStopNotHanging (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:143: DockerSuite.TestExecTtyCloseStdin (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:163: DockerSuite.TestExecTtyWithoutStdin (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:493: DockerSuite.TestExecWithImageUser (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:460: DockerSuite.TestExecWithPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:449: DockerSuite.TestExecWithUser (Test requires a Linux daemon)
SKIP: docker_cli_export_import_test.go:13: DockerSuite.TestExportContainerAndImportImage (Test requires a Linux daemon)
SKIP: docker_cli_export_import_test.go:31: DockerSuite.TestExportContainerWithOutputAndImportImage (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:250: DockerSuite.TestGetContainerStats (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:365: DockerSuite.TestGetContainerStatsNoStream (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:288: DockerSuite.TestGetContainerStatsRmRunning (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:328: DockerSuite.TestGetContainerStatsStream (Test requires a Linux daemon)
SKIP: docker_api_attach_test.go:16: DockerSuite.TestGetContainersAttachWebsocket (Test requires a Linux daemon)
PASS: docker_api_attach_test.go:77: DockerSuite.TestGetContainersWsAttachContainerNotFound      0.001s
SKIP: docker_api_containers_test.go:400: DockerSuite.TestGetStoppedContainerStats (Test requires a Linux daemon)
PASS: docker_api_version_test.go:13: DockerSuite.TestGetVersion 0.001s
SKIP: docker_cli_help_test.go:240: DockerSuite.TestHelpExitCodesHelpOutput (Test requires a Linux daemon)
SKIP: docker_cli_help_test.go:15: DockerSuite.TestHelpTextVerify (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:61: DockerSuite.TestHistoryExistentImage (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:91: DockerSuite.TestHistoryHumanOptionFalse (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:110: DockerSuite.TestHistoryHumanOptionTrue (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:71: DockerSuite.TestHistoryImageWithComment (Test requires a Linux daemon)
PASS: docker_cli_history_test.go:66: DockerSuite.TestHistoryNonExistentImage    0.047s
SKIP: docker_cli_images_test.go:163: DockerSuite.TestImagesEnsureDanglingImageOnlyListedOnce (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:18: DockerSuite.TestImagesEnsureImageIsListed (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:45: DockerSuite.TestImagesEnsureImageWithBadTagIsNotListed      0.044s
SKIP: docker_cli_images_test.go:24: DockerSuite.TestImagesEnsureImageWithTagIsListed (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:211: DockerSuite.TestImagesEnsureImagesFromScratchShown (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:187: DockerSuite.TestImagesEnsureOnlyHeadsImagesShown (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:74: DockerSuite.TestImagesErrorWithInvalidFilterNameTest        0.042s
SKIP: docker_cli_images_test.go:80: DockerSuite.TestImagesFilterLabelMatch (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:112: DockerSuite.TestImagesFilterLabelWithCommit        9.539s
PASS: docker_cli_images_test.go:227: DockerSuite.TestImagesFilterNameWithPort   0.214s
SKIP: docker_cli_images_test.go:124: DockerSuite.TestImagesFilterSpaceTrimCase (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:240: DockerSuite.TestImagesFormat       0.118s
SKIP: docker_cli_images_test.go:258: DockerSuite.TestImagesFormatDefaultFormat (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:50: DockerSuite.TestImagesOrderedByCreationDate (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:181: DockerSuite.TestImagesWithIncorrectFilter  0.046s
SKIP: docker_cli_import_test.go:33: DockerSuite.TestImportBadURL (Test requires a Linux daemon)
SKIP: docker_cli_import_test.go:15: DockerSuite.TestImportDisplay (Test requires a Linux daemon)
SKIP: docker_cli_import_test.go:40: DockerSuite.TestImportFile (Test requires a Linux daemon)
PASS: docker_cli_import_test.go:94: DockerSuite.TestImportFileNonExistentFile   0.036s
SKIP: docker_cli_import_test.go:62: DockerSuite.TestImportFileWithMessage (Test requires a Linux daemon)
PASS: docker_api_info_test.go:10: DockerSuite.TestInfoApi       0.002s
SKIP: docker_cli_info_test.go:80: DockerSuite.TestInfoDiscoveryAdvertiseInterfaceName (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:45: DockerSuite.TestInfoDiscoveryBackend (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:63: DockerSuite.TestInfoDiscoveryInvalidAdvertise (Test requires a Linux daemon)
PASS: docker_cli_info_test.go:13: DockerSuite.TestInfoEnsureSucceeds    0.045s
SKIP: docker_api_inspect_test.go:137: DockerSuite.TestInspectApiBridgeNetworkSettings120 (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:153: DockerSuite.TestInspectApiBridgeNetworkSettings121 (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:15: DockerSuite.TestInspectApiContainerResponse (Test requires a Linux daemon)
PASS: docker_api_inspect_test.go:71: DockerSuite.TestInspectApiContainerVolumeDriver    2.378s
SKIP: docker_api_inspect_test.go:49: DockerSuite.TestInspectApiContainerVolumeDriverLegacy (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:114: DockerSuite.TestInspectApiEmptyFieldsInConfigPre121 (Test requires a Linux daemon)
PASS: docker_api_inspect_test.go:95: DockerSuite.TestInspectApiImageResponse    0.064s
SKIP: docker_cli_inspect_test.go:234: DockerSuite.TestInspectBindMountPoint (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:357: DockerSuite.TestInspectByPrefix   0.148s
SKIP: docker_cli_inspect_test.go:154: DockerSuite.TestInspectContainerFilterInt (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:202: DockerSuite.TestInspectContainerGraphDriver (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:47: DockerSuite.TestInspectDefault (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:286: DockerSuite.TestInspectExecID (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:382: DockerSuite.TestInspectHistory (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:23: DockerSuite.TestInspectImage (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:137: DockerSuite.TestInspectImageFilterInt (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:177: DockerSuite.TestInspectImageGraphDriver (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:38: DockerSuite.TestInspectInt64 (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:349: DockerSuite.TestInspectJSONFields 2.501s
SKIP: docker_cli_inspect_test.go:285: DockerSuite.TestInspectLogConfigNoType (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:300: DockerSuite.TestInspectNoSizeFlagContainer        2.592s
PASS: docker_cli_inspect_test.go:312: DockerSuite.TestInspectSizeFlagContainer  2.480s
PASS: docker_cli_inspect_test.go:323: DockerSuite.TestInspectSizeFlagImage      2.593s
SKIP: docker_cli_inspect_test.go:60: DockerSuite.TestInspectStatus (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:371: DockerSuite.TestInspectStopWhenNotFound   5.120s
PASS: docker_cli_inspect_test.go:335: DockerSuite.TestInspectTempateError       2.567s
SKIP: docker_cli_inspect_test.go:259: DockerSuite.TestInspectTimesAsRFC3339Nano (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:87: DockerSuite.TestInspectTypeFlagContainer (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:112: DockerSuite.TestInspectTypeFlagWithImage (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:124: DockerSuite.TestInspectTypeFlagWithInvalidValue (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:99: DockerSuite.TestInspectTypeFlagWithNoContainer (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:12: DockerSuite.TestKillContainer (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:36: DockerSuite.TestKillDifferentUserContainer (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:89: DockerSuite.TestKillStoppedContainerAPIPre120 (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:63: DockerSuite.TestKillWithInvalidSignal (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:50: DockerSuite.TestKillWithSignal (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:25: DockerSuite.TestKillofStoppedContainer (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:181: DockerSuite.TestLinkShortDefinition (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:172: DockerSuite.TestLinksEnvs (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:209: DockerSuite.TestLinksEtcHostsRegularFile (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:111: DockerSuite.TestLinksHostsFilesInject (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:63: DockerSuite.TestLinksInspectLinksStarted (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:83: DockerSuite.TestLinksInspectLinksStopped (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:22: DockerSuite.TestLinksInvalidContainerTarget (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:198: DockerSuite.TestLinksNetworkHostContainer (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:103: DockerSuite.TestLinksNotStartedParentNotFail (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:32: DockerSuite.TestLinksPingLinkedContainers (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:50: DockerSuite.TestLinksPingLinkedContainersAfterRename (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:349: DockerSuite.TestLinksPingLinkedContainersOnRename (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:13: DockerSuite.TestLinksPingUnlinkedContainers (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:132: DockerSuite.TestLinksUpdateOnRestart (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:299: DockerSuite.TestLoadZeroSizeLayer (Test requires a Linux daemon)
PASS: docker_cli_login_test.go:11: DockerSuite.TestLoginWithoutTTY      0.058s
PASS: docker_api_logs_test.go:87: DockerSuite.TestLogsAPIContainerNotFound      0.001s
SKIP: docker_api_logs_test.go:71: DockerSuite.TestLogsApiFollowEmptyOutput (Test requires a Linux daemon)
SKIP: docker_api_logs_test.go:55: DockerSuite.TestLogsApiNoStdoutNorStderr (Test requires a Linux daemon)
SKIP: docker_api_logs_test.go:15: DockerSuite.TestLogsApiWithStdout (Test requires a Linux daemon)
PASS: docker_cli_logs_test.go:349: DockerSuite.TestLogsCLIContainerNotFound     0.055s
SKIP: docker_cli_logs_test.go:33: DockerSuite.TestLogsContainerBiggerThanPage (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:47: DockerSuite.TestLogsContainerMuchBiggerThanPage (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:19: DockerSuite.TestLogsContainerSmallerThanPage (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:307: DockerSuite.TestLogsFollowGoroutinesNoOutput (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:255: DockerSuite.TestLogsFollowGoroutinesWithStdout (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:223: DockerSuite.TestLogsFollowSlowStdoutConsumer (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:145: DockerSuite.TestLogsFollowStopped (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:86: DockerSuite.TestLogsSeparateStderr (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:169: DockerSuite.TestLogsSince (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:205: DockerSuite.TestLogsSinceFutureFollow (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:103: DockerSuite.TestLogsStderrInStdout (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:118: DockerSuite.TestLogsTail (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:60: DockerSuite.TestLogsTimestamps (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2840: DockerSuite.TestMountIntoProc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2849: DockerSuite.TestMountIntoSys (Test requires a Linux daemon)
SKIP: docker_cli_netmode_test.go:24: DockerSuite.TestNetHostname (Test requires a Linux daemon)
SKIP: docker_cli_nat_test.go:68: DockerSuite.TestNetworkLocalhostTCPNat (Test requires a Linux daemon)
SKIP: docker_cli_nat_test.go:85: DockerSuite.TestNetworkLoopbackNat (Test requires a Linux daemon)
SKIP: docker_cli_nat_test.go:52: DockerSuite.TestNetworkNat (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3566: DockerSuite.TestNetworkRmWithActiveContainers (Test requires a Linux daemon)
SKIP: docker_cli_pause_test.go:11: DockerSuite.TestPause (Test requires a Linux daemon)
PASS: docker_cli_pause_test.go:62: DockerSuite.TestPauseFailsOnWindows  2.292s
SKIP: docker_cli_pause_test.go:33: DockerSuite.TestPauseMultipleContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2612: DockerSuite.TestPermissionsPtsReadonlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:275: DockerSuite.TestPortExposeHostBinding (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:253: DockerSuite.TestPortHostBinding (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:14: DockerSuite.TestPortList (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:421: DockerSuite.TestPostContainerBindNormalVolume (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1163: DockerSuite.TestPostContainerStop (Test requires a Linux daemon)
SKIP: docker_api_attach_test.go:85: DockerSuite.TestPostContainersAttach (Test requires a Linux daemon)
PASS: docker_api_attach_test.go:69: DockerSuite.TestPostContainersAttachContainerNotFound       0.001s
SKIP: docker_api_containers_test.go:1500: DockerSuite.TestPostContainersCreateMemorySwappinessHostConfigOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1407: DockerSuite.TestPostContainersCreateShmSizeHostConfigOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1394: DockerSuite.TestPostContainersCreateShmSizeNegative (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1438: DockerSuite.TestPostContainersCreateShmSizeOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1524: DockerSuite.TestPostContainersCreateWithOomScoreAdjInvalidRange (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1469: DockerSuite.TestPostContainersCreateWithShmSize (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1225: DockerSuite.TestPostContainersCreateWithStringOrSliceCapAddDrop (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1202: DockerSuite.TestPostContainersCreateWithStringOrSliceCmd (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1178: DockerSuite.TestPostContainersCreateWithStringOrSliceEntrypoint (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1351: DockerSuite.TestPostContainersCreateWithWrongCpusetValues (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1263: DockerSuite.TestPostContainersStartWithLinksInHostConfig (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1280: DockerSuite.TestPostContainersStartWithLinksInHostConfigIdLinked (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1247: DockerSuite.TestPostContainersStartWithoutLinksInHostConfig (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:568: DockerSuite.TestPsDefaultFormatAndQuiet (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:556: DockerSuite.TestPsFormatHeaders (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:528: DockerSuite.TestPsFormatMultiNames (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:478: DockerSuite.TestPsGroupPortRange (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:588: DockerSuite.TestPsImageIDAfterUpdate (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:460: DockerSuite.TestPsLinkedWithNoTrunc (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:19: DockerSuite.TestPsListContainersBase (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:248: DockerSuite.TestPsListContainersFilterAncestorImage (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:497: DockerSuite.TestPsListContainersFilterCreated (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:381: DockerSuite.TestPsListContainersFilterExited (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:208: DockerSuite.TestPsListContainersFilterID (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:344: DockerSuite.TestPsListContainersFilterLabel (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:224: DockerSuite.TestPsListContainersFilterName (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:170: DockerSuite.TestPsListContainersFilterStatus (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:129: DockerSuite.TestPsListContainersSize (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:419: DockerSuite.TestPsRightTagName (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:489: DockerSuite.TestPsWithSize (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3206: DockerSuite.TestPtraceContainerProcsFromHost (Test requires a Linux daemon)
PASS: docker_cli_push_test.go:28: DockerSuite.TestPushUnprefixedRepo    0.798s
SKIP: docker_api_containers_test.go:1311: DockerSuite.TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:62: DockerSuite.TestRenameCheckNames (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:78: DockerSuite.TestRenameInvalidName (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:28: DockerSuite.TestRenameRunningContainer (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:41: DockerSuite.TestRenameRunningContainerAndReuse (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:11: DockerSuite.TestRenameStoppedContainer (Test requires a Linux daemon)
SKIP: docker_api_resize_test.go:22: DockerSuite.TestResizeApiHeightWidthNoInt (Test requires a Linux daemon)
SKIP: docker_api_resize_test.go:11: DockerSuite.TestResizeApiResponse (Test requires a Linux daemon)
SKIP: docker_api_resize_test.go:33: DockerSuite.TestResizeApiResponseWhenContainerNotStarted (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:83: DockerSuite.TestRestartPolicyAlways (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:73: DockerSuite.TestRestartPolicyNO (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:99: DockerSuite.TestRestartPolicyOnFailure (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:29: DockerSuite.TestRestartRunningContainer (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:13: DockerSuite.TestRestartStoppedContainer (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:50: DockerSuite.TestRestartWithVolumes (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:46: DockerSuite.TestRmContainerOrphaning (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:11: DockerSuite.TestRmContainerWithRemovedVolume (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:23: DockerSuite.TestRmContainerWithVolume (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:38: DockerSuite.TestRmForceRemoveRunningContainer (Test requires a Linux daemon)
PASS: docker_cli_rm_test.go:73: DockerSuite.TestRmInvalidContainer      0.050s
SKIP: docker_cli_rm_test.go:30: DockerSuite.TestRmRunningContainer (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:222: DockerSuite.TestRmiBlank (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:240: DockerSuite.TestRmiContainerImageNotFound (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:166: DockerSuite.TestRmiForceWithExistingContainers (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:197: DockerSuite.TestRmiForceWithMultipleRepositories (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:137: DockerSuite.TestRmiImageIDForceWithRunningContainersAndMultipleTags (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:102: DockerSuite.TestRmiImgIDForce (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:64: DockerSuite.TestRmiImgIDMultipleTag (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:314: DockerSuite.TestRmiParentImageFail (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:35: DockerSuite.TestRmiTag (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:153: DockerSuite.TestRmiTagWithExistingContainers (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:267: DockerSuite.TestRmiUntagHistoryLayer (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:13: DockerSuite.TestRmiWithContainerFails (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:182: DockerSuite.TestRmiWithMultipleRepositories (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:326: DockerSuite.TestRmiWithParentInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1435: DockerSuite.TestRunAddHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:997: DockerSuite.TestRunAddingOptionalDevices (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1015: DockerSuite.TestRunAddingOptionalDevicesInvalidMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1006: DockerSuite.TestRunAddingOptionalDevicesNoSrc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1956: DockerSuite.TestRunAllocatePortInReservedRange (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1056: DockerSuite.TestRunAllowBindMountingRoot     3.919s
SKIP: docker_cli_run_test.go:2178: DockerSuite.TestRunAllowPortRangeThroughExpose (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2541: DockerSuite.TestRunAllowPortRangeThroughPublish (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:388: DockerSuite.TestRunApplyVolumesFromBeforeVolumes      6.887s
PASS: docker_cli_run_test.go:1447: DockerSuite.TestRunAttachStdErrOnlyTTYMode   3.437s
PASS: docker_cli_run_test.go:1463: DockerSuite.TestRunAttachStdOutAndErrTTYMode 3.107s
PASS: docker_cli_run_test.go:1455: DockerSuite.TestRunAttachStdOutOnlyTTYMode   3.747s
PASS: docker_cli_run_test.go:1472: DockerSuite.TestRunAttachWithDetach  0.058s
PASS: docker_cli_run_test.go:1772: DockerSuite.TestRunBindMounts        3.208s
SKIP: docker_cli_run_test.go:878: DockerSuite.TestRunCapAddALLCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:888: DockerSuite.TestRunCapAddALLDropNetAdminCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2911: DockerSuite.TestRunCapAddCHOWN (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:868: DockerSuite.TestRunCapAddCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:859: DockerSuite.TestRunCapAddInvalid (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3257: DockerSuite.TestRunCapAddSYSTIME (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:849: DockerSuite.TestRunCapDropALLAddMknodCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:837: DockerSuite.TestRunCapDropALLCannotMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:811: DockerSuite.TestRunCapDropCannotMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:824: DockerSuite.TestRunCapDropCannotMknodLowerCase (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:802: DockerSuite.TestRunCapDropInvalid (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1852: DockerSuite.TestRunCidFileCheckIDLength      2.722s
PASS: docker_cli_run_test.go:1824: DockerSuite.TestRunCidFileCleanupIfEmpty     0.056s
PASS: docker_cli_run_test.go:1568: DockerSuite.TestRunCleanupCmdOnEntrypoint    8.385s
SKIP: docker_cli_run_test.go:3388: DockerSuite.TestRunContainerNetModeWithDnsMacHosts (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3412: DockerSuite.TestRunContainerNetModeWithExposePort (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:747: DockerSuite.TestRunContainerNetwork   3.740s
SKIP: docker_cli_run_test.go:3379: DockerSuite.TestRunContainerNetworkModeToSelf (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3363: DockerSuite.TestRunContainerWithCgroupMountRO (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3304: DockerSuite.TestRunContainerWithCgroupParent (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3334: DockerSuite.TestRunContainerWithCgroupParentAbsPath (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2652: DockerSuite.TestRunContainerWithReadonlyEtcHostsAndLinkedContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2603: DockerSuite.TestRunContainerWithReadonlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2676: DockerSuite.TestRunContainerWithReadonlyRootfsWithAddHostFlag (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2665: DockerSuite.TestRunContainerWithReadonlyRootfsWithDnsFlag (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2720: DockerSuite.TestRunContainerWithRmFlagCannotStartContainer   3.801s
PASS: docker_cli_run_test.go:2703: DockerSuite.TestRunContainerWithRmFlagExitCodeNotEqualToZero 3.410s
PASS: docker_cli_run_test.go:2599: DockerSuite.TestRunContainerWithWritableRootfs       3.829s
SKIP: docker_cli_run_test.go:1548: DockerSuite.TestRunCopyVolumeContent (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1525: DockerSuite.TestRunCopyVolumeUidGid (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3265: DockerSuite.TestRunCreateContainerFailedCleanUp (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:427: DockerSuite.TestRunCreateVolume       3.416s
SKIP: docker_cli_run_test.go:2054: DockerSuite.TestRunCreateVolumeEtc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:437: DockerSuite.TestRunCreateVolumeWithSymlink (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:243: DockerSuite.TestRunCreateVolumesInSymlinkDir  22.405s
SKIP: docker_cli_run_test.go:1915: DockerSuite.TestRunDeallocatePortOnMissingIptablesRule (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:110: DockerSuite.TestRunDetachedContainerIDPrinting        3.640s
SKIP: docker_cli_run_test.go:966: DockerSuite.TestRunDeviceNumbers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1065: DockerSuite.TestRunDisallowBindMountingRootToRoot    0.052s
SKIP: docker_cli_run_test.go:1079: DockerSuite.TestRunDnsDefaultOptions (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1113: DockerSuite.TestRunDnsOptions (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1147: DockerSuite.TestRunDnsOptionsBasedOnHostResolvConf (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1137: DockerSuite.TestRunDnsRepeatOptions (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:38: DockerSuite.TestRunEchoNamedContainer  3.271s
PASS: docker_cli_run_test.go:30: DockerSuite.TestRunEchoStdout  3.337s
PASS: docker_cli_run_test.go:1754: DockerSuite.TestRunEntrypoint        3.435s
SKIP: docker_cli_run_test.go:638: DockerSuite.TestRunEnvironment (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:677: DockerSuite.TestRunEnvironmentErase (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:712: DockerSuite.TestRunEnvironmentOverride (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:364: DockerSuite.TestRunExecDir (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:508: DockerSuite.TestRunExitCode   3.268s
PASS: docker_cli_run_test.go:75: DockerSuite.TestRunExitCodeOne 3.123s
PASS: docker_cli_run_test.go:70: DockerSuite.TestRunExitCodeZero        3.160s
PASS: docker_cli_run_test.go:1607: DockerSuite.TestRunExitOnStdinClose  3.364s
PASS: docker_cli_run_test.go:2203: DockerSuite.TestRunExposePort        0.043s
SKIP: docker_cli_run_test.go:773: DockerSuite.TestRunFullHostnameSet (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:900: DockerSuite.TestRunGroupAdd (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3782: DockerSuite.TestRunInitLayerPathOwnership (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1892: DockerSuite.TestRunInspectMacAddress (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3770: DockerSuite.TestRunInvalidReference  0.042s
SKIP: docker_cli_run_test.go:47: DockerSuite.TestRunLeakyFileDescriptors (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3433: DockerSuite.TestRunLinkToContainerNetMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:186: DockerSuite.TestRunLinksContainerWithContainerId (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:170: DockerSuite.TestRunLinksContainerWithContainerName (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:59: DockerSuite.TestRunLookupGoogleDns     4.680s
SKIP: docker_cli_run_test.go:3443: DockerSuite.TestRunLoopbackOnlyExistsWhenNetworkingDisabled (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3469: DockerSuite.TestRunLoopbackWhenNetworkDisabled       3.579s
SKIP: docker_cli_run_test.go:1024: DockerSuite.TestRunModeHostname (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2258: DockerSuite.TestRunModeIpcContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2290: DockerSuite.TestRunModeIpcContainerNotExists (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2299: DockerSuite.TestRunModeIpcContainerNotRunning (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2236: DockerSuite.TestRunModeIpcHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3477: DockerSuite.TestRunModeNetContainerHostname (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2351: DockerSuite.TestRunModePidHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2373: DockerSuite.TestRunModeUTSHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1977: DockerSuite.TestRunMountOrdering (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2312: DockerSuite.TestRunMountShmMqueueFromHost (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:397: DockerSuite.TestRunMultipleVolumesFrom        9.749s
SKIP: docker_cli_exec_test.go:411: DockerSuite.TestRunMutableNetworkFiles (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3276: DockerSuite.TestRunNamedVolume (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3942: DockerSuite.TestRunNamedVolumeCopyImageData (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3929: DockerSuite.TestRunNamedVolumesMountedAsShared (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2523: DockerSuite.TestRunNetContainerWhichHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2492: DockerSuite.TestRunNetHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:756: DockerSuite.TestRunNetHostNotAllowedWithLinks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2514: DockerSuite.TestRunNetHostTwiceSameName (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2980: DockerSuite.TestRunNetworkFilesBindMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2999: DockerSuite.TestRunNetworkFilesBindMountRO (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3016: DockerSuite.TestRunNetworkFilesBindMountROFilesystem (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3490: DockerSuite.TestRunNetworkNotInitializedNoneMode (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:357: DockerSuite.TestRunNoDupVolumes       0.492s
PASS: docker_cli_run_test.go:2099: DockerSuite.TestRunNoOutputFromPullInStdout  1.114s
PASS: docker_cli_run_test.go:3713: DockerSuite.TestRunNonExecutableCmd  3.725s
PASS: docker_cli_run_test.go:3724: DockerSuite.TestRunNonExistingCmd    3.303s
PASS: docker_cli_run_test.go:3752: DockerSuite.TestRunNonExistingImage  1.517s
PASS: docker_cli_run_test.go:2474: DockerSuite.TestRunNonLocalMacAddress        3.507s
SKIP: docker_cli_run_test.go:1230: DockerSuite.TestRunNonRootUserResolvName (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2737: DockerSuite.TestRunPidHostWithChildIsKillable (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2413: DockerSuite.TestRunPortFromDockerRangeInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1937: DockerSuite.TestRunPortInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:782: DockerSuite.TestRunPrivilegedCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:911: DockerSuite.TestRunPrivilegedCanMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:950: DockerSuite.TestRunProcNotWritableInNonPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:958: DockerSuite.TestRunProcWritableInPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2886: DockerSuite.TestRunPublishPort (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2817: DockerSuite.TestRunReadFilteredProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:2796: DockerSuite.TestRunReadProcLatency (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2781: DockerSuite.TestRunReadProcTimer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1255: DockerSuite.TestRunResolvconfUpdate (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2574: DockerSuite.TestRunRestartMaxRetries 11.454s
SKIP: docker_cli_run_test.go:2025: DockerSuite.TestRunReuseBindVolumeThatIsSymlink (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1045: DockerSuite.TestRunRootWorkdir       3.187s
PASS: docker_cli_run_test.go:2565: DockerSuite.TestRunSetDefaultRestartPolicy   2.545s
PASS: docker_cli_run_test.go:1876: DockerSuite.TestRunSetMacAddress     3.989s
SKIP: docker_cli_run_test.go:2153: DockerSuite.TestRunSlowStdoutConsumer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1482: DockerSuite.TestRunState (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3670: DockerSuite.TestRunStdinBlockedAfterContainerExit    3.549s
SKIP: docker_cli_run_test.go:86: DockerSuite.TestRunStdinPipe (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:934: DockerSuite.TestRunSysNotWritableInNonPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:942: DockerSuite.TestRunSysWritableInPrivilegedContainers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2395: DockerSuite.TestRunTLSverify 0.142s
SKIP: docker_cli_run_test.go:982: DockerSuite.TestRunThatCharacterDevicesActLikeCharacterDevices (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2445: DockerSuite.TestRunTtyWithPipe       0.045s
SKIP: docker_cli_run_test.go:604: DockerSuite.TestRunTwoConcurrentContainers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2211: DockerSuite.TestRunUnknownCommand    3.445s
SKIP: docker_cli_run_test.go:792: DockerSuite.TestRunUnprivilegedCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:921: DockerSuite.TestRunUnprivilegedCannotMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:991: DockerSuite.TestRunUnprivilegedWithChroot (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2856: DockerSuite.TestRunUnshareProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:545: DockerSuite.TestRunUserByID (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:555: DockerSuite.TestRunUserByIDBig (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:568: DockerSuite.TestRunUserByIDNegative (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:581: DockerSuite.TestRunUserByIDZero (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:535: DockerSuite.TestRunUserByName (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:524: DockerSuite.TestRunUserDefaults       3.538s
SKIP: docker_cli_run_test.go:594: DockerSuite.TestRunUserNotFound (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:408: DockerSuite.TestRunVerifyContainerID  2.631s
PASS: docker_cli_run_test.go:2112: DockerSuite.TestRunVolumesCleanPaths 6.178s
PASS: docker_cli_run_test.go:313: DockerSuite.TestRunVolumesFromInReadWriteMode 10.102s
SKIP: docker_cli_run_test.go:289: DockerSuite.TestRunVolumesFromInReadonlyModeFails (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2687: DockerSuite.TestRunVolumesFromRestartAfterRemoved    8.688s
PASS: docker_cli_run_test.go:473: DockerSuite.TestRunVolumesFromSymlinkPath     29.595s
SKIP: docker_cli_run_test.go:280: DockerSuite.TestRunVolumesMountedAsReadonly (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3832: DockerSuite.TestRunVolumesMountedAsShared (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3870: DockerSuite.TestRunVolumesMountedAsSlave (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1739: DockerSuite.TestRunWithBadDevice (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:203: DockerSuite.TestRunWithDaemonFlags    3.625s
PASS: docker_cli_run_test.go:1907: DockerSuite.TestRunWithInvalidMacAddress     0.048s
SKIP: docker_cli_run_test.go:3804: DockerSuite.TestRunWithOomScoreAdj (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3815: DockerSuite.TestRunWithOomScoreAdjInvalidRange (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2760: DockerSuite.TestRunWithTooSmallMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3293: DockerSuite.TestRunWithUlimits (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:213: DockerSuite.TestRunWithVolumesFromExited      7.719s
PASS: docker_cli_run_test.go:151: DockerSuite.TestRunWithoutNetworking  3.742s
PASS: docker_cli_run_test.go:1593: DockerSuite.TestRunWorkdirExistsAndIsFile    3.842s
SKIP: docker_cli_run_test.go:125: DockerSuite.TestRunWorkingDirectory (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2953: DockerSuite.TestRunWriteFilteredProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:1708: DockerSuite.TestRunWriteHostnameFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1666: DockerSuite.TestRunWriteHostsFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1724: DockerSuite.TestRunWriteResolvFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2772: DockerSuite.TestRunWriteToProcAsound (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3690: DockerSuite.TestRunWrongCpusetCpusFlagValue (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3701: DockerSuite.TestRunWrongCpusetMemsFlagValue (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:149: DockerSuite.TestSaveAndLoadRepoFlags (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:91: DockerSuite.TestSaveCheckTimes (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:240: DockerSuite.TestSaveDirectoryPermissions (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:110: DockerSuite.TestSaveImageId (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:170: DockerSuite.TestSaveMultipleNames (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:188: DockerSuite.TestSaveRepoWithMultipleImages (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:76: DockerSuite.TestSaveSingleTag (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:22: DockerSuite.TestSaveXzAndLoadRepoStdout (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:49: DockerSuite.TestSaveXzGzAndLoadRepoStdout (Test requires a Linux daemon)
PASS: docker_cli_search_test.go:28: DockerSuite.TestSearchCmdOptions    3.215s
SKIP: docker_cli_search_test.go:11: DockerSuite.TestSearchOnCentralRegistry (Test requires a Linux daemon)
SKIP: docker_cli_search_test.go:51: DockerSuite.TestSearchOnCentralRegistryWithDash (Test requires a Linux daemon)
PASS: docker_cli_search_test.go:18: DockerSuite.TestSearchStarsOptionWithWrongParameter 0.083s
SKIP: docker_cli_start_test.go:42: DockerSuite.TestStartAttachCorrectExitCode (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:151: DockerSuite.TestStartAttachMultipleContainers (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:13: DockerSuite.TestStartAttachReturnsOnError (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:58: DockerSuite.TestStartAttachSilent (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:113: DockerSuite.TestStartMultipleContainers (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:98: DockerSuite.TestStartPausedContainer (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:71: DockerSuite.TestStartRecordError (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1377: DockerSuite.TestStartWithNilDNS (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:840: DockerSuite.TestStartWithTooLowMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:94: DockerSuite.TestStatsAllNewContainersAdded (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:77: DockerSuite.TestStatsAllNoStream (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:54: DockerSuite.TestStatsAllRunningNoStream (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:42: DockerSuite.TestStatsContainerNotFound (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:14: DockerSuite.TestStatsNoStream (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:83: DockerSuite.TestTagExistedNameWithForce (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:73: DockerSuite.TestTagExistedNameWithoutForce (Test requires a Linux daemon)
PASS: docker_cli_tag_test.go:42: DockerSuite.TestTagInvalidPrefixedRepo 0.499s
SKIP: docker_cli_tag_test.go:173: DockerSuite.TestTagInvalidRepoName (Test requires a Linux daemon)
PASS: docker_cli_tag_test.go:32: DockerSuite.TestTagInvalidUnprefixedRepo       0.347s
SKIP: docker_cli_tag_test.go:155: DockerSuite.TestTagMatchesDigest (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:117: DockerSuite.TestTagOfficialNames (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:187: DockerSuite.TestTagTruncationAmbiguity (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:24: DockerSuite.TestTagUnprefixedRepoByID (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:14: DockerSuite.TestTagUnprefixedRepoByName (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:54: DockerSuite.TestTagValidPrefixedRepo (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:93: DockerSuite.TestTagWithPrefixHyphen (Test requires a Linux daemon)
SKIP: docker_cli_top_test.go:10: DockerSuite.TestTopMultipleArgs (Test requires a Linux daemon)
SKIP: docker_cli_top_test.go:19: DockerSuite.TestTopNonPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_top_test.go:32: DockerSuite.TestTopPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3503: DockerSuite.TestTwoContainersInNetHost (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:180: DockerSuite.TestUnpublishedPortsInPsOutput (Test requires a Linux daemon)
PASS: docker_cli_version_test.go:11: DockerSuite.TestVersionEnsureSucceeds      0.049s
SKIP: docker_cli_version_test.go:36: DockerSuite.TestVersionPlatform_l (Test requires a Linux daemon)
PASS: docker_cli_version_test.go:30: DockerSuite.TestVersionPlatform_w  0.051s
PASS: docker_cli_volume_test.go:11: DockerSuite.TestVolumeCliCreate     15.148s
PASS: docker_cli_volume_test.go:22: DockerSuite.TestVolumeCliCreateOptionConflict       0.214s
PASS: docker_cli_volume_test.go:33: DockerSuite.TestVolumeCliInspect    0.216s
PASS: docker_cli_volume_test.go:50: DockerSuite.TestVolumeCliInspectMulti       0.212s
PASS: docker_cli_volume_test.go:182: DockerSuite.TestVolumeCliInspectTmplError  0.104s
PASS: docker_cli_volume_test.go:66: DockerSuite.TestVolumeCliLs 3.508s
PASS: docker_cli_volume_test.go:86: DockerSuite.TestVolumeCliLsFilterDangling   4.218s
PASS: docker_cli_volume_test.go:164: DockerSuite.TestVolumeCliNoArgs    0.145s
PASS: docker_cli_volume_test.go:122: DockerSuite.TestVolumeCliRm        11.779s
PASS: docker_cli_run_test.go:2922: DockerSuite.TestVolumeFromMixedRWOptions     7.249s
PASS: docker_api_volumes_test.go:30: DockerSuite.TestVolumesApiCreate   0.003s
PASS: docker_api_volumes_test.go:72: DockerSuite.TestVolumesApiInspect  0.003s
PASS: docker_api_volumes_test.go:13: DockerSuite.TestVolumesApiList     2.471s
PASS: docker_api_volumes_test.go:45: DockerSuite.TestVolumesApiRemove   3.712s
SKIP: docker_cli_run_test.go:337: DockerSuite.TestVolumesFromGetsProperMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2075: DockerSuite.TestVolumesNoCopyData (Test requires a Linux daemon)
SKIP: docker_cli_wait_test.go:67: DockerSuite.TestWaitBlockedExitRandom (Test requires a Linux daemon)
SKIP: docker_cli_wait_test.go:27: DockerSuite.TestWaitBlockedExitZero (Test requires a Linux daemon)
PASS: docker_cli_wait_test.go:55: DockerSuite.TestWaitNonBlockedExitRandom      3.622s
PASS: docker_cli_wait_test.go:14: DockerSuite.TestWaitNonBlockedExitZero        3.502s
SKIP: docker_cli_by_digest_test.go:160: DockerRegistrySuite.TestBuildByDigest
SKIP: docker_cli_pull_local_test.go:93: DockerRegistrySuite.TestConcurrentFailingPull
SKIP: docker_cli_pull_local_test.go:117: DockerRegistrySuite.TestConcurrentPullMultipleTags
SKIP: docker_cli_pull_local_test.go:44: DockerRegistrySuite.TestConcurrentPullWholeRepo
SKIP: docker_cli_by_digest_test.go:103: DockerRegistrySuite.TestCreateByDigest
SKIP: docker_cli_by_digest_test.go:358: DockerRegistrySuite.TestDeleteImageByIDOnlyPulledByDigest
SKIP: docker_cli_events_test.go:505: DockerRegistrySuite.TestEventsImageFilterPush
SKIP: docker_cli_by_digest_test.go:303: DockerRegistrySuite.TestInspectImageWithDigests
SKIP: docker_cli_by_digest_test.go:222: DockerRegistrySuite.TestListImagesWithDigests
SKIP: docker_cli_by_digest_test.go:209: DockerRegistrySuite.TestListImagesWithoutDigests
SKIP: docker_cli_by_digest_test.go:322: DockerRegistrySuite.TestPsListContainersFilterAncestorImageByDigest
SKIP: docker_cli_by_digest_test.go:76: DockerRegistrySuite.TestPullByDigest
SKIP: docker_cli_by_digest_test.go:94: DockerRegistrySuite.TestPullByDigestNoFallback
SKIP: docker_cli_by_digest_test.go:59: DockerRegistrySuite.TestPullByTagDisplaysDigest
SKIP: docker_cli_by_digest_test.go:416: DockerRegistrySuite.TestPullFailsWithAlteredLayer
SKIP: docker_cli_by_digest_test.go:375: DockerRegistrySuite.TestPullFailsWithAlteredManifest
SKIP: docker_cli_pull_local_test.go:236: DockerRegistrySuite.TestPullFallbackOn404
SKIP: docker_cli_pull_local_test.go:166: DockerRegistrySuite.TestPullIDStability
SKIP: docker_cli_pull_local_test.go:16: DockerRegistrySuite.TestPullImageWithAliases
SKIP: docker_cli_push_test.go:42: DockerRegistrySuite.TestPushBadTag
SKIP: docker_cli_push_test.go:19: DockerRegistrySuite.TestPushBusyboxImage
SKIP: docker_cli_push_test.go:88: DockerRegistrySuite.TestPushEmptyLayer
SKIP: docker_cli_push_test.go:51: DockerRegistrySuite.TestPushMultipleTags
SKIP: docker_cli_push_test.go:33: DockerRegistrySuite.TestPushUntagged
SKIP: docker_cli_by_digest_test.go:136: DockerRegistrySuite.TestRemoveImageByDigest
SKIP: docker_cli_by_digest_test.go:117: DockerRegistrySuite.TestRunByDigest
SKIP: docker_cli_by_digest_test.go:188: DockerRegistrySuite.TestTagByDigest
SKIP: docker_cli_v2_only_test.go:71: DockerRegistrySuite.TestV1
SKIP: docker_cli_v2_only_test.go:38: DockerRegistrySuite.TestV2Only
SKIP: docker_cli_proxy_test.go:26: DockerDaemonSuite.TestCliProxyProxyTCPSock
SKIP: docker_cli_exec_test.go:81: DockerDaemonSuite.TestExecAfterDaemonRestart
SKIP: docker_cli_build_test.go:5813: DockerTrustSuite.TestBuildContextDirIsSymlink
SKIP: docker_cli_create_test.go:332: DockerTrustSuite.TestCreateWhenCertExpired
SKIP: docker_cli_pull_trusted_test.go:64: DockerTrustSuite.TestPullWhenCertExpired
SKIP: docker_cli_run_test.go:3095: DockerTrustSuite.TestRunWhenCertExpired
SKIP: docker_cli_build_test.go:5761: DockerTrustSuite.TestTrustedBuild
SKIP: docker_cli_build_test.go:5792: DockerTrustSuite.TestTrustedBuildUntrustedTag
SKIP: docker_cli_create_test.go:282: DockerTrustSuite.TestTrustedCreate
SKIP: docker_cli_create_test.go:359: DockerTrustSuite.TestTrustedCreateFromBadTrustServer
SKIP: docker_cli_create_test.go:319: DockerTrustSuite.TestTrustedIsolatedCreate
SKIP: docker_cli_pull_trusted_test.go:34: DockerTrustSuite.TestTrustedIsolatedPull
SKIP: docker_cli_pull_trusted_test.go:176: DockerTrustSuite.TestTrustedOfflinePull
SKIP: docker_cli_pull_trusted_test.go:13: DockerTrustSuite.TestTrustedPull
SKIP: docker_cli_pull_trusted_test.go:92: DockerTrustSuite.TestTrustedPullFromBadTrustServer
SKIP: docker_cli_pull_trusted_test.go:146: DockerTrustSuite.TestTrustedPullWithExpiredSnapshot
SKIP: docker_cli_push_test.go:110: DockerTrustSuite.TestTrustedPush
SKIP: docker_cli_push_test.go:150: DockerTrustSuite.TestTrustedPushWithDeprecatedEnvPasswords
SKIP: docker_cli_push_test.go:129: DockerTrustSuite.TestTrustedPushWithEnvPasswords
SKIP: docker_cli_push_test.go:206: DockerTrustSuite.TestTrustedPushWithExistingSignedTag
SKIP: docker_cli_push_test.go:186: DockerTrustSuite.TestTrustedPushWithExistingTag
SKIP: docker_cli_push_test.go:278: DockerTrustSuite.TestTrustedPushWithExpiredSnapshot
SKIP: docker_cli_push_test.go:304: DockerTrustSuite.TestTrustedPushWithExpiredTimestamp
SKIP: docker_cli_push_test.go:162: DockerTrustSuite.TestTrustedPushWithFailingServer
SKIP: docker_cli_push_test.go:258: DockerTrustSuite.TestTrustedPushWithIncorrectDeprecatedPassphraseForNonRoot
SKIP: docker_cli_push_test.go:236: DockerTrustSuite.TestTrustedPushWithIncorrectPassphraseForNonRoot
SKIP: docker_cli_push_test.go:330: DockerTrustSuite.TestTrustedPushWithReleasesDelegation
SKIP: docker_cli_push_test.go:174: DockerTrustSuite.TestTrustedPushWithoutServerAndUntrusted
SKIP: docker_cli_run_test.go:3041: DockerTrustSuite.TestTrustedRun
SKIP: docker_cli_run_test.go:3133: DockerTrustSuite.TestTrustedRunFromBadTrustServer
SKIP: docker_cli_create_test.go:303: DockerTrustSuite.TestUntrustedCreate
SKIP: docker_cli_pull_trusted_test.go:48: DockerTrustSuite.TestUntrustedPull
SKIP: docker_cli_run_test.go:3073: DockerTrustSuite.TestUntrustedRun
OK: 131 passed, 807 skipped
PASS
coverage: 23.7% of statements
ok      github.com/docker/docker/integration-cli        468.525s
---> Making bundle: .integration-daemon-stop (in bundles/1.10.0-dev/test-integration-cli)
INFO: Not stopping daemon on Windows CI

++ ec=0
++ set +x
INFO: Completed successfully at Fri, Jan  8, 2016  2:40:09 PM.

```
