### PR TITLE
Re-vendoring notary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-1
+ENV NOTARY_VERSION docker-v1.10-2
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -47,7 +47,7 @@ clone git github.com/docker/distribution 568bf038af6d65b376165d02886b1c7fcaef1f6
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile
-clone git github.com/docker/notary docker-v1.10-1
+clone git github.com/docker/notary docker-v1.10-2
 
 clone git google.golang.org/grpc 174192fc93efcb188fc8f46ca447f0da606b6885 https://github.com/grpc/grpc-go.git
 clone git github.com/miekg/pkcs11 80f102b5cac759de406949c47f0928b99bd64cdf

--- a/vendor/src/github.com/docker/notary/client/client.go
+++ b/vendor/src/github.com/docker/notary/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,8 +13,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
-
 	"github.com/docker/notary/certs"
 	"github.com/docker/notary/client/changelist"
 	"github.com/docker/notary/cryptoservice"
@@ -324,7 +323,7 @@ func (r *NotaryRepository) AddDelegation(name string, threshold int,
 	logrus.Debugf(`Adding delegation "%s" with threshold %d, and %d keys\n`,
 		name, threshold, len(delegationKeys))
 
-	tdJSON, err := json.MarshalCanonical(&changelist.TufDelegation{
+	tdJSON, err := json.Marshal(&changelist.TufDelegation{
 		NewThreshold: threshold,
 		AddKeys:      data.KeyList(delegationKeys),
 		AddPaths:     paths,
@@ -386,7 +385,7 @@ func (r *NotaryRepository) AddTarget(target *Target, roles ...string) error {
 	logrus.Debugf("Adding target \"%s\" with sha256 \"%x\" and size %d bytes.\n", target.Name, target.Hashes["sha256"], target.Length)
 
 	meta := data.FileMeta{Length: target.Length, Hashes: target.Hashes}
-	metaJSON, err := json.MarshalCanonical(meta)
+	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}
@@ -690,7 +689,7 @@ func (r *NotaryRepository) saveMetadata(ignoreSnapshot bool) error {
 		if err != nil {
 			return err
 		}
-		targetsJSON, err := json.MarshalCanonical(signedTargets)
+		targetsJSON, err := json.Marshal(signedTargets)
 		if err != nil {
 			return err
 		}
@@ -838,7 +837,7 @@ func (r *NotaryRepository) rootFileKeyChange(role, action string, key data.Publi
 		RoleName: role,
 		Keys:     kl,
 	}
-	metaJSON, err := json.MarshalCanonical(meta)
+	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}

--- a/vendor/src/github.com/docker/notary/client/helpers.go
+++ b/vendor/src/github.com/docker/notary/client/helpers.go
@@ -1,14 +1,13 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
-
 	"github.com/docker/notary/client/changelist"
 	tuf "github.com/docker/notary/tuf"
 	"github.com/docker/notary/tuf/data"
@@ -262,5 +261,5 @@ func serializeCanonicalRole(tufRepo *tuf.Repo, role string) (out []byte, err err
 		return
 	}
 
-	return json.MarshalCanonical(s)
+	return json.Marshal(s)
 }

--- a/vendor/src/github.com/docker/notary/tuf/data/snapshot.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/snapshot.go
@@ -27,12 +27,12 @@ type Snapshot struct {
 // and targets objects
 func NewSnapshot(root *Signed, targets *Signed) (*SignedSnapshot, error) {
 	logrus.Debug("generating new snapshot...")
-	targetsJSON, err := json.MarshalCanonical(targets)
+	targetsJSON, err := json.Marshal(targets)
 	if err != nil {
 		logrus.Debug("Error Marshalling Targets")
 		return nil, err
 	}
-	rootJSON, err := json.MarshalCanonical(root)
+	rootJSON, err := json.Marshal(root)
 	if err != nil {
 		logrus.Debug("Error Marshalling Root")
 		return nil, err

--- a/vendor/src/github.com/docker/notary/tuf/data/timestamp.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/timestamp.go
@@ -24,7 +24,7 @@ type Timestamp struct {
 
 // NewTimestamp initializes a timestamp with an existing snapshot
 func NewTimestamp(snapshot *Signed) (*SignedTimestamp, error) {
-	snapshotJSON, err := json.MarshalCanonical(snapshot)
+	snapshotJSON, err := json.Marshal(snapshot)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/notary/tuf/tuf.go
+++ b/vendor/src/github.com/docker/notary/tuf/tuf.go
@@ -5,14 +5,13 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/jfrazelle/go/canonical/json"
-
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/keys"
 	"github.com/docker/notary/tuf/signed"
@@ -607,7 +606,7 @@ func (tr *Repo) RemoveTargets(role string, targets ...string) error {
 
 // UpdateSnapshot updates the FileMeta for the given role based on the Signed object
 func (tr *Repo) UpdateSnapshot(role string, s *data.Signed) error {
-	jsonData, err := json.MarshalCanonical(s)
+	jsonData, err := json.Marshal(s)
 	if err != nil {
 		return err
 	}
@@ -622,7 +621,7 @@ func (tr *Repo) UpdateSnapshot(role string, s *data.Signed) error {
 
 // UpdateTimestamp updates the snapshot meta in the timestamp based on the Signed object
 func (tr *Repo) UpdateTimestamp(s *data.Signed) error {
-	jsonData, err := json.MarshalCanonical(s)
+	jsonData, err := json.Marshal(s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@tonistiigi kindly found an issue where we couldn't pull with a different docker version.  

Re-vendoring notary in order to deal with a canonical JSON serialization issue.

Many apologies - we have now tested a docker client build of this branch with a [docker version test script](https://github.com/docker/notary/blob/master/misc/dockertest.py).
