### PR TITLE
integration-cli: fix wrong formats

### DIFF
--- a/integration-cli/registry_mock.go
+++ b/integration-cli/registry_mock.go
@@ -36,7 +36,7 @@ func newTestRegistry(c *check.C) (*testRegistry, error) {
 		for re, function := range testReg.handlers {
 			matched, err = regexp.MatchString(re, url)
 			if err != nil {
-				c.Fatalf("Error with handler regexp")
+				c.Fatal("Error with handler regexp")
 				return
 			}
 			if matched {
@@ -46,7 +46,7 @@ func newTestRegistry(c *check.C) (*testRegistry, error) {
 		}
 
 		if !matched {
-			c.Fatal("Unable to match", url, "with regexp")
+			c.Fatalf("Unable to match %s with regexp", url)
 		}
 	}))
 


### PR DESCRIPTION
```
Error: Unable to match/v1/repositories/127.0.0.1/imageswith regexp
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
