### PR TITLE
bash completion for `docker {build,create,run} --shm-size`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -539,6 +539,7 @@ _docker_build() {
 		--isolation
 		--memory -m
 		--memory-swap
+		--shm-size
 		--tag -t
 		--ulimit
 	"
@@ -1484,6 +1485,7 @@ _docker_run() {
 		--publish -p
 		--restart
 		--security-opt
+		--shm-size
 		--stop-signal
 		--tmpfs
 		--ulimit


### PR DESCRIPTION
#19208 pointed me to `--shm-size` that was also missing in bash completion.

Ref #16168
