### PR TITLE
Add arm specific syscalls to default seccomp profile

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -1570,5 +1570,21 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},
 		},
+		// arm specific syscalls
+		{
+			Name:   "breakpoint",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "cacheflush",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "set_tls",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
 	},
 }


### PR DESCRIPTION
These were missing, sorry. See #19076 

I need to double check if we should allow these, but I think they are fine.
