### PR TITLE
Add i386 specific modify_ldt syscall to default seccomp filter

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -1564,5 +1564,11 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},
 		},
+		// i386 specific syscalls
+		{
+			Name:   "modify_ldt",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
 	},
 }


### PR DESCRIPTION
This syscall is used by Go on i386 binaries, although not by libc.

Should fix #19201 
