### PR TITLE
integration-cli: log error when starting registry

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	remoteRepoName  = "dockercli/busybox-by-dgst"
-	repoName        = fmt.Sprintf("%v/%s", privateRegistryURL, remoteRepoName)
+	repoName        = fmt.Sprintf("%s/%s", privateRegistryURL, remoteRepoName)
 	pushDigestRegex = regexp.MustCompile("[\\S]+: digest: ([\\S]+) size: [0-9]+")
 	digestRegex     = regexp.MustCompile("Digest: ([\\S]+)")
 )

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1567,7 +1567,7 @@ func setupRegistry(c *check.C) *testRegistryV2 {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	c.Assert(err, check.IsNil, check.Commentf("Timeout waiting for test registry to become available"))
+	c.Assert(err, check.IsNil, check.Commentf("Timeout waiting for test registry to become available: %v", err))
 	return reg
 }
 

--- a/integration-cli/registry.go
+++ b/integration-cli/registry.go
@@ -61,7 +61,7 @@ func (t *testRegistryV2) Ping() error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("registry ping replied with an unexpected status code %d", resp.StatusCode)
 	}
 	return nil

--- a/integration-cli/registry_mock.go
+++ b/integration-cli/registry_mock.go
@@ -37,7 +37,6 @@ func newTestRegistry(c *check.C) (*testRegistry, error) {
 			matched, err = regexp.MatchString(re, url)
 			if err != nil {
 				c.Fatal("Error with handler regexp")
-				return
 			}
 			if matched {
 				function(w, r)


### PR DESCRIPTION
I had troubles figuring out why a test registry was always failing (before realizing a 401), the log I added states clearly why so I thought it was helpful to everyone
Also do not hardcode http status code..

Signed-off-by: Antonio Murdaca runcom@redhat.com
