### PR TITLE
Add Dame Stephanie "Steve" Shirley to names

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -423,6 +423,9 @@ var (
 		// Carol Shaw - Originally an Atari employee, Carol Shaw is said to be the first female video game designer. https://en.wikipedia.org/wiki/Carol_Shaw_(video_game_designer)
 		"shaw",
 
+		// Dame Stephanie "Steve" Shirley - Founded a software company in 1962 employing women working from home. https://en.wikipedia.org/wiki/Steve_Shirley
+		"shirley",
+
 		// William Shockley co-invented the transistor - https://en.wikipedia.org/wiki/William_Shockley
 		"shockley",
 


### PR DESCRIPTION
Born in Germany, she had to flee on the kindertransport to England in
1939. In the 1950s she worked at the Post Office Research Station at
Dollis Hill, building computers from scratch, and took evening classes
to get a degree in Mathematics.

In 1962 she set up a software company, employing almost entirely women,
working at home; the company was floated in 1996. Her team's projects
included programming Concorde's black box flight recorder. She adopted
the name "Steve" to fit in in a male domainated world.

http://www.bbc.co.uk/programmes/b05pmvl8
https://en.wikipedia.org/wiki/Steve_Shirley

Signed-off-by: Justin Cormack justin.cormack@unikernel.com
