### PR TITLE
Remove duplication checking for the existence of endpoint to speed up container starting

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -758,22 +758,13 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 		container.NetworkSettings.Networks[n.Name()] = endpointConfig
 	}
 
-	ep, err := container.GetEndpointInNetwork(n)
-	if err == nil {
-		return fmt.Errorf("Conflict. A container with name %q is already connected to network %s.", strings.TrimPrefix(container.Name, "/"), idOrName)
-	}
-
-	if _, ok := err.(libnetwork.ErrNoSuchEndpoint); !ok {
-		return err
-	}
-
 	createOptions, err := container.BuildCreateEndpointOptions(n)
 	if err != nil {
 		return err
 	}
 
 	endpointName := strings.TrimPrefix(container.Name, "/")
-	ep, err = n.CreateEndpoint(endpointName, createOptions...)
+	ep, err := n.CreateEndpoint(endpointName, createOptions...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`CreateEndpoint` will check if the endpoint exist or not(https://github.com/docker/libnetwork/blob/master/network.go#L674)
, so there is no need to check before call `CreatEndpoint` in `connectToNetwork` since
checking the existence of the endpoint could take much time especially
if we use external K-V store, this would slow down the starting of container.

Signed-off-by: Lei Jitang leijitang@huawei.com
