### PR TITLE
Mark device ID free only if device actually got deleted

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1801,6 +1801,7 @@ func (devices *DeviceSet) deleteTransaction(info *devInfo, syncDelete bool) erro
 		if info.Deleted {
 			devices.nrDeletedDevices--
 		}
+		devices.markDeviceIDFree(info.DeviceID)
 	} else {
 		if err := devices.markForDeferredDeletion(info); err != nil {
 			return err
@@ -1854,8 +1855,6 @@ func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
 	if err := devices.deleteTransaction(info, syncDelete); err != nil {
 		return err
 	}
-
-	devices.markDeviceIDFree(info.DeviceID)
 
 	return nil
 }


### PR DESCRIPTION
Right now if somebody has enabled deferred device deletion, then
deleteTransaction() returns success even if device could not be deleted. It
has been marked for deferred deletion. Right now we will mark device ID free
and potentially use it again when somebody tries to create new container. And
that's wrong. Device ID is not free yet. It will become free once devices
has actually been deleted by the goroutine later.

So move the location of call to markDeviceIDFree() to a place where we know
device actually got deleted and was not marked for deferred deletion.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
