### PR TITLE
Vendor engine-api 0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 57512760c83fbe41302891aa51e34a86f4db74de
+ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -148,7 +148,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 57512760c83fbe41302891aa51e34a86f4db74de
+ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -61,7 +61,7 @@ RUN set -x \
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 139850f3f3b17357bab5ba3edfb745fb14043764
+ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -126,7 +126,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 57512760c83fbe41302891aa51e34a86f4db74de
+ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -126,7 +126,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 57512760c83fbe41302891aa51e34a86f4db74de
+ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/api/client/network.go
+++ b/api/client/network.go
@@ -135,7 +135,7 @@ func (cli *DockerCli) CmdNetworkDisconnect(args ...string) error {
 		return err
 	}
 
-	return cli.client.NetworkDisconnect(cmd.Arg(0), cmd.Arg(1))
+	return cli.client.NetworkDisconnect(cmd.Arg(0), cmd.Arg(1), false)
 }
 
 // CmdNetworkLs lists all the networks managed by docker daemon

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -90,7 +90,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		os.Exit(125)
 	}
 
-	if hostConfig.OomKillDisable && hostConfig.Memory == 0 {
+	if hostConfig.OomKillDisable != nil && *hostConfig.OomKillDisable && hostConfig.Memory == 0 {
 		fmt.Fprintf(cli.err, "WARNING: Dangerous only disable the OOM Killer on containers but not set the '-m/--memory' option\n")
 	}
 

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -209,7 +209,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		BlkioThrottleWriteBpsDevice:  writeBpsDevice,
 		BlkioThrottleReadIOpsDevice:  readIOpsDevice,
 		BlkioThrottleWriteIOpsDevice: writeIOpsDevice,
-		OomKillDisable:               c.HostConfig.OomKillDisable,
+		OomKillDisable:               *c.HostConfig.OomKillDisable,
 		MemorySwappiness:             -1,
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -210,6 +210,10 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 		defaultSwappiness := int64(-1)
 		hostConfig.MemorySwappiness = &defaultSwappiness
 	}
+	if hostConfig.OomKillDisable == nil {
+		defaultOomKillDisable := false
+		hostConfig.OomKillDisable = &defaultOomKillDisable
+	}
 
 	return nil
 }
@@ -270,8 +274,8 @@ func verifyContainerResources(resources *containertypes.Resources) ([]string, er
 		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 		logrus.Warnf("You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 	}
-	if resources.OomKillDisable && !sysInfo.OomKillDisable {
-		resources.OomKillDisable = false
+	if resources.OomKillDisable != nil && !sysInfo.OomKillDisable {
+		resources.OomKillDisable = nil
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
 

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -22,7 +22,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.1.2
-clone git github.com/docker/engine-api v0.1.3
+clone git github.com/docker/engine-api v0.2.1
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 
 #get libnetwork packages

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -327,7 +327,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		MemorySwap:           memorySwap,
 		MemorySwappiness:     flSwappiness,
 		KernelMemory:         KernelMemory,
-		OomKillDisable:       *flOomKillDisable,
+		OomKillDisable:       flOomKillDisable,
 		CPUShares:            *flCPUShares,
 		CPUPeriod:            *flCPUPeriod,
 		CpusetCpus:           *flCpusetCpus,

--- a/vendor/src/github.com/docker/engine-api/client/container_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_create.go
@@ -33,13 +33,13 @@ func (cli *Client) ContainerCreate(config *container.Config, hostConfig *contain
 
 	serverResp, err := cli.post("/containers/create", query, body, nil)
 	if err != nil {
-		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), config.Image) {
+		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 			return response, imageNotFoundError{config.Image}
 		}
 		return response, err
 	}
 
-	if serverResp.statusCode == 404 && strings.Contains(err.Error(), config.Image) {
+	if serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 		return response, imageNotFoundError{config.Image}
 	}
 

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -60,7 +60,7 @@ type APIClient interface {
 	Info() (types.Info, error)
 	NetworkConnect(networkID, containerID string, config *network.EndpointSettings) error
 	NetworkCreate(options types.NetworkCreate) (types.NetworkCreateResponse, error)
-	NetworkDisconnect(networkID, containerID string) error
+	NetworkDisconnect(networkID, containerID string, force bool) error
 	NetworkInspect(networkID string) (types.NetworkResource, error)
 	NetworkList(options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(networkID string) error

--- a/vendor/src/github.com/docker/engine-api/client/network.go
+++ b/vendor/src/github.com/docker/engine-api/client/network.go
@@ -42,9 +42,9 @@ func (cli *Client) NetworkConnect(networkID, containerID string, config *network
 }
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
-func (cli *Client) NetworkDisconnect(networkID, containerID string) error {
-	nc := types.NetworkConnect{Container: containerID}
-	resp, err := cli.post("/networks/"+networkID+"/disconnect", nil, nc, nil)
+func (cli *Client) NetworkDisconnect(networkID, containerID string, force bool) error {
+	nd := types.NetworkDisconnect{Container: containerID, Force: force}
+	resp, err := cli.post("/networks/"+networkID+"/disconnect", nil, nd, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -154,28 +154,19 @@ type ImageBuildResponse struct {
 
 // ImageCreateOptions holds information to create images.
 type ImageCreateOptions struct {
-	// Parent is the image to create this image from
-	Parent string
-	// Tag is the name to tag this image
-	Tag string
-	// RegistryAuth is the base64 encoded credentials for this server
-	RegistryAuth string
+	Parent       string // Parent is the name of the image to pull
+	Tag          string // Tag is the name to tag this image with
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
 }
 
 // ImageImportOptions holds information to import images from the client host.
 type ImageImportOptions struct {
-	// Source is the data to send to the server to create this image from
-	Source io.Reader
-	// Source is the name of the source to import this image from
-	SourceName string
-	// RepositoryName is the name of the repository to import this image
-	RepositoryName string
-	// Message is the message to tag the image with
-	Message string
-	// Tag is the name to tag this image
-	Tag string
-	// Changes are the raw changes to apply to the image
-	Changes []string
+	Source         io.Reader // Source is the data to send to the server to create this image from (mutually exclusive with SourceName)
+	SourceName     string    // SourceName is the name of the image to pull (mutually exclusive with Source)
+	RepositoryName string    // RepositoryName is the name of the repository to import this image into
+	Message        string    // Message is the message to tag the image with
+	Tag            string    // Tag is the name to tag this image with
+	Changes        []string  // Changes are the raw changes to apply to this image
 }
 
 // ImageListOptions holds parameters to filter the list of images with.
@@ -193,10 +184,9 @@ type ImageLoadResponse struct {
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {
-	ImageID string
-	Tag     string
-	// RegistryAuth is the base64 encoded credentials for this server
-	RegistryAuth string
+	ImageID      string // ImageID is the name of the image to pull
+	Tag          string // Tag is the name of the tag to be pulled
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
 }
 
 //ImagePushOptions holds information to push images.

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -180,7 +180,7 @@ type Resources struct {
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
-	OomKillDisable       bool            // Whether to disable OOM Killer or not
+	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 }
@@ -222,7 +222,6 @@ type HostConfig struct {
 	PublishAllPorts bool               // Should docker publish all exposed port for the container
 	ReadonlyRootfs  bool               // Is the container root filesystem in read-only
 	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
-	StorageOpt      []string           // Graph storage options per container
 	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode            // UTS namespace to use for the container
 	ShmSize         int64              // Total shm memory usage

--- a/vendor/src/github.com/docker/engine-api/types/network/network.go
+++ b/vendor/src/github.com/docker/engine-api/types/network/network.go
@@ -8,8 +8,9 @@ type Address struct {
 
 // IPAM represents IP Address Management
 type IPAM struct {
-	Driver string
-	Config []IPAMConfig
+	Driver  string
+	Options map[string]string //Per network IPAM driver options
+	Config  []IPAMConfig
 }
 
 // IPAMConfig represents IPAM configurations
@@ -30,7 +31,10 @@ type EndpointIPAMConfig struct {
 type EndpointSettings struct {
 	// Configurations
 	IPAMConfig *EndpointIPAMConfig
+	Links      []string
+	Aliases    []string
 	// Operational data
+	NetworkID           string
 	EndpointID          string
 	Gateway             string
 	IPAddress           string

--- a/vendor/src/github.com/docker/engine-api/types/seccomp.go
+++ b/vendor/src/github.com/docker/engine-api/types/seccomp.go
@@ -1,0 +1,68 @@
+package types
+
+// Seccomp represents the config for a seccomp profile for syscall restriction.
+type Seccomp struct {
+	DefaultAction Action     `json:"defaultAction"`
+	Architectures []Arch     `json:"architectures"`
+	Syscalls      []*Syscall `json:"syscalls"`
+}
+
+// Arch used for additional architectures
+type Arch string
+
+// Additional architectures permitted to be used for system calls
+// By default only the native architecture of the kernel is permitted
+const (
+	ArchX86         Arch = "SCMP_ARCH_X86"
+	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
+	ArchX32         Arch = "SCMP_ARCH_X32"
+	ArchARM         Arch = "SCMP_ARCH_ARM"
+	ArchAARCH64     Arch = "SCMP_ARCH_AARCH64"
+	ArchMIPS        Arch = "SCMP_ARCH_MIPS"
+	ArchMIPS64      Arch = "SCMP_ARCH_MIPS64"
+	ArchMIPS64N32   Arch = "SCMP_ARCH_MIPS64N32"
+	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
+	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
+	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+)
+
+// Action taken upon Seccomp rule match
+type Action string
+
+// Define actions for Seccomp rules
+const (
+	ActKill  Action = "SCMP_ACT_KILL"
+	ActTrap  Action = "SCMP_ACT_TRAP"
+	ActErrno Action = "SCMP_ACT_ERRNO"
+	ActTrace Action = "SCMP_ACT_TRACE"
+	ActAllow Action = "SCMP_ACT_ALLOW"
+)
+
+// Operator used to match syscall arguments in Seccomp
+type Operator string
+
+// Define operators for syscall arguments in Seccomp
+const (
+	OpNotEqual     Operator = "SCMP_CMP_NE"
+	OpLessThan     Operator = "SCMP_CMP_LT"
+	OpLessEqual    Operator = "SCMP_CMP_LE"
+	OpEqualTo      Operator = "SCMP_CMP_EQ"
+	OpGreaterEqual Operator = "SCMP_CMP_GE"
+	OpGreaterThan  Operator = "SCMP_CMP_GT"
+	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
+)
+
+// Arg used for matching specific syscall arguments in Seccomp
+type Arg struct {
+	Index    uint     `json:"index"`
+	Value    uint64   `json:"value"`
+	ValueTwo uint64   `json:"valueTwo"`
+	Op       Operator `json:"op"`
+}
+
+// Syscall is used to match a syscall in Seccomp
+type Syscall struct {
+	Name   string `json:"name"`
+	Action Action `json:"action"`
+	Args   []*Arg `json:"args"`
+}

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -192,6 +192,9 @@ type Version struct {
 type Info struct {
 	ID                 string
 	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
 	Images             int
 	Driver             string
 	DriverStatus       [][2]string
@@ -404,6 +407,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool
 	Driver         string
 	IPAM           network.IPAM
+	Internal       bool
 	Options        map[string]string
 }
 
@@ -416,10 +420,11 @@ type NetworkCreateResponse struct {
 // NetworkConnect represents the data to be used to connect a container to the network
 type NetworkConnect struct {
 	Container      string
-	EndpointConfig *network.EndpointSettings `json:"endpoint_config"`
+	EndpointConfig *network.EndpointSettings `json:",omitempty"`
 }
 
 // NetworkDisconnect represents the data to be used to disconnect a container from the network
 type NetworkDisconnect struct {
 	Container string
+	Force     bool
 }


### PR DESCRIPTION
Vendor engine-api 0.2.1.You can read the full changelog in https://github.com/docker/engine-api/commit/a234637b37aa55700ad5650be7936a6128a196fc.

It also carries #19014.
