### PR TITLE
List engine-api in the client libraries reference.

### DIFF
--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -57,6 +57,12 @@ will add the libraries here.
     </tr>
     <tr>
       <td>Go</td>
+      <td>engine-api</td>
+      <td><a class="reference external" href="https://github.com/docker/engine-api">https://github.com/docker/engine-api</a></td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td>Go</td>
       <td>go-dockerclient</td>
       <td><a class="reference external" href="https://github.com/fsouza/go-dockerclient">https://github.com/fsouza/go-dockerclient</a></td>
       <td>Active</td>


### PR DESCRIPTION
Add https://github.com/docker/engine-api to the list of client libraries. :tada:

Signed-off-by: David Calavera david.calavera@gmail.com
