### PR TITLE
Add DOCKER_BUILD_ARGS support for make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ binary: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
 
 build: bundles
-	docker build -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
+	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
 
 bundles:
 	mkdir bundles


### PR DESCRIPTION
We always need proxy for build, so we always use "docker build"
command instead of "make build", but now for some reasons, we need
macro defined in Makefile, so it would be helpful if we can use
"make build" without touching Dockerfile.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
