### PR TITLE
Fix Windows client authentication

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -27,7 +27,7 @@ const (
 	DefaultRegistryVersionHeader = "Docker-Distribution-Api-Version"
 
 	// IndexServer is the v1 registry server used for user auth + account creation
-	IndexServer = DefaultV1Registry + "/v1/"
+	IndexServer = "https://index.docker.io/v1/"
 	// IndexName is the name of the index
 	IndexName = "docker.io"
 


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/18019

The Windows daemon hits a (temporary) specific registry instance when
interacting with the Hub infrastructure. It should however be using the
same authentication endpoint than the Linux client.

Note to reviewers: I have a doubt regarding [this line](https://github.com/docker/docker/blob/1393c450cd8b4b7143a069ac062fd2adc6e02ca0/registry/session.go#L177). Is it ok that the value of `IndexServer` will be changed there for the Windows daemon?

Ping @jhowardmsft @mbentley!
