### PR TITLE
Ensure volume ready before setting up mountpoint

### DIFF
--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -20,6 +20,14 @@ import (
 func (daemon *Daemon) setupMounts(container *container.Container) ([]execdriver.Mount, error) {
 	var mounts []execdriver.Mount
 	for _, m := range container.MountPoints {
+		// In some cases this can be nil, like if the daemon restarted and the driver was not available
+		if m.Volume == nil && m.Driver != "" {
+			v, err := daemon.volumes.GetWithRef(m.Name, m.Driver, container.ID)
+			if err != nil {
+				return nil, err
+			}
+			m.Volume = v
+		}
 		path, err := m.Setup()
 		if err != nil {
 			return nil, err

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -67,6 +67,7 @@ func (m *MountPoint) Setup() (string, error) {
 	if m.Volume != nil {
 		return m.Volume.Mount()
 	}
+
 	if len(m.Source) > 0 {
 		if _, err := os.Stat(m.Source); err != nil {
 			if !os.IsNotExist(err) {


### PR DESCRIPTION
Before this change, on daemon restart, if the volume driver is not
ready, the mountpoint's volume is not set, this was causing Docker to
treat the mountpoint like a bind-mount and even created a host dir.
This could not be resolved until the daemon is restarted again, and
hopefully the volume driver was ready.

This is particularly problematic if the volume driver is running in a
container.
