### PR TITLE
Do not fail if not support OomKillDisable

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -275,8 +275,9 @@ func verifyContainerResources(resources *containertypes.Resources) ([]string, er
 		logrus.Warnf("You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 	}
 	if resources.OomKillDisable != nil && !sysInfo.OomKillDisable {
+		warnings = append(warnings, "Your kernel does not support OomKillDisable, OomKillDisable discarded.")
+		logrus.Warnf("Your kernel does not support OomKillDisable, OomKillDisable discarded.")
 		resources.OomKillDisable = nil
-		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
 
 	// cpu subsystem checks and adjustments


### PR DESCRIPTION
Fixes: #19278

The issue seems existed since we add support for OomKillDisable,
OomKillDisable support should not be hard request, we just
discard it if not support and move on.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
