### PR TITLE
bash completion for connecting non-running containers to networks

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1139,7 +1139,7 @@ _docker_network_connect() {
 			if [ $cword -eq $counter ]; then
 				__docker_complete_networks
 			elif [ $cword -eq $(($counter + 1)) ]; then
-				__docker_complete_containers_running
+				__docker_complete_containers_all
 			fi
 			;;
 	esac


### PR DESCRIPTION
#18906 added support for connecting stopped containers to networks. Before that, only running containers could be connected.

This PR adjusts bash completion to the new behavior.
