### PR TITLE
Added "trap" into docker "while" loop examples

### DIFF
--- a/docs/articles/puppet.md
+++ b/docs/articles/puppet.md
@@ -72,18 +72,18 @@ managed by Docker.
 
     docker::run { 'helloworld':
       image   => 'ubuntu',
-      command => '/bin/sh -c "while true; do echo hello world; sleep 1; done"',
+      command => '/bin/sh -c "trap \'exit 0\' INT TERM; while true; do echo hello world; sleep 1; done"',
     }
 
 This is equivalent to running the following command, but under upstart:
 
-    $ docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"
+    $ docker run -d ubuntu /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo hello world; sleep 1; done"
 
 Run also contains a number of optional parameters:
 
     docker::run { 'helloworld':
       image        => 'ubuntu',
-      command      => '/bin/sh -c "while true; do echo hello world; sleep 1; done"',
+      command      => '/bin/sh -c "trap \'exit 0\' INT TERM; while true; do echo hello world; sleep 1; done"',
       ports        => ['4444', '4555'],
       volumes      => ['/var/lib/couchdb', '/var/log'],
       volumes_from => '6446ea52fbc9',

--- a/docs/userguide/basics.md
+++ b/docs/userguide/basics.md
@@ -127,7 +127,7 @@ TCP and a Unix socket
 ## Starting a long-running worker process
 
     # Start a very useful long-running process
-    $ JOB=$(docker run -d ubuntu /bin/sh -c "while true; do echo Hello world; sleep 1; done")
+    $ JOB=$(docker run -d ubuntu /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello world; sleep 1; done")
 
     # Collect the output of the job so far
     $ docker logs $JOB
@@ -143,7 +143,7 @@ TCP and a Unix socket
 ## Controlling containers
 
     # Start a new container
-    $ JOB=$(docker run -d ubuntu /bin/sh -c "while true; do echo Hello world; sleep 1; done")
+    $ JOB=$(docker run -d ubuntu /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello world; sleep 1; done")
 
     # Stop the container
     $ docker stop $JOB

--- a/docs/userguide/dockerizing.md
+++ b/docs/userguide/dockerizing.md
@@ -108,7 +108,7 @@ like most of the applications we're probably going to run with Docker.
 
 Again we can do this with the `docker run` command:
 
-    $ docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"
+    $ docker run -d ubuntu /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo hello world; sleep 1; done"
     1e5535038e285177d5214659a068137486f96ee5c2e85a4ac52dc83f2ebe4147
 
 Wait, what? Where's our "hello world" output? Let's look at what we've run here.
@@ -120,7 +120,7 @@ We also specified the same image: `ubuntu`.
 
 Finally, we specified a command to run:
 
-    /bin/sh -c "while true; do echo hello world; sleep 1; done"
+    /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo hello world; sleep 1; done"
 
 This is the (hello) world's silliest daemon: a shell script that echoes
 `hello world` forever.


### PR DESCRIPTION
When you don't use `trap`, `bash`/sh`doesn't catch TERM signal which`docker stop`sends.
This causes`docker stop`timeout and then`docker kill`.

Steps to reproduce:
- run `docker run -ti --name busybox --rm busybox /bin/sh -c "while true; do echo hello world; sleep 1; done"`
- in another window run `docker stop busybox`. after 10 seconds container will be killed by "kill -9" with the `137` exit code.

When you use `trap`, `sh` will exit gracefully.

relates to https://github.com/coreos/docs/pull/727
