### PR TITLE
Better warning message on OOM kill disable without mem limit

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -91,7 +91,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	}
 
 	if hostConfig.OomKillDisable != nil && *hostConfig.OomKillDisable && hostConfig.Memory == 0 {
-		fmt.Fprintf(cli.err, "WARNING: Dangerous only disable the OOM Killer on containers but not set the '-m/--memory' option\n")
+		fmt.Fprintf(cli.err, "WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.\n")
 	}
 
 	if len(hostConfig.DNS) > 0 {


### PR DESCRIPTION
Modify the warning to be more readable/understandable.

If we end up keeping this warning (see discussion around this https://github.com/docker/docker/pull/19281#issuecomment-171390780) this is hopefully a more understandable version of the message.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
