### PR TITLE
Windows: In container build check

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -29,11 +29,22 @@ export MAKEDIR="$SCRIPTDIR/make"
 
 # We're a nice, sexy, little shell script, and people might try to run us;
 # but really, they shouldn't. We want to be in a container!
-if [ "$PWD" != "/go/src/$DOCKER_PKG" ] || [ -z "$DOCKER_CROSSPLATFORMS" ]; then
+inContainer="AssumeSoInitially"
+if [ "$(go env GOHOSTOS)" = 'windows' ]; then
+	if [ -n "$FROM_DOCKERFILE" ]; then
+		unset inContainer
+	fi
+else
+	if [ "$PWD" != "/go/src/$DOCKER_PKG" ] || [ -z "$DOCKER_CROSSPLATFORMS" ]; then
+		unset inContainer
+	fi
+fi
+
+if [ -n "$inContainer" ]; then
 	{
-		echo "# WARNING! I don't seem to be running in the Docker container."
+		echo "# WARNING! I don't seem to be running in a Docker container."
 		echo "# The result of this command might be an incorrect build, and will not be"
-		echo "#   officially supported."
+		echo "# officially supported."
 		echo "#"
 		echo "# Try this instead: make all"
 		echo "#"


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Part of the overall Windows to Windows CI work. This updates the check in hack/make.sh so that it is aware of whether it's running inside a container in Windows and doesn't emit the build warning. The simplest way to do this is to check an environment variable which is set in the dockerfile (not yet merged) for Windows. [See https://gist.github.com/jhowardmsft/b9413e30ece1d4cf8465]

I also corrected the text which has been bugging me forever!

@jfrazelle @mikedougherty 
