### PR TITLE
Not having a changelog is bad RPM etiquette.

### DIFF
--- a/hack/make/.build-rpm/docker-engine-selinux.spec
+++ b/hack/make/.build-rpm/docker-engine-selinux.spec
@@ -101,3 +101,6 @@ fi
 %attr(0644,root,root) %{_datadir}/selinux/devel/include/%{moduletype}/*.if
 
 %changelog
+* Tue Dec 1 2015 Jessica Frazelle <acidburn@docker.com> 1.9.1-1
+- add licence to rpm
+- add selinux-policy and docker-engine-selinux rpm


### PR DESCRIPTION
This RPM changes infrequently, so hardcoding the changelog is probably acceptable. I just grabbed the git history and combined it for the initial 1.9.1-1 release.

Signed-off-by: Avi Miller avi.miller@oracle.com
