### PR TITLE
Fix response hijacking with TLS enabled.

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -22,7 +22,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.1.2
-clone git github.com/docker/engine-api v0.2.1
+clone git github.com/docker/engine-api v0.2.2
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 
 #get libnetwork packages

--- a/vendor/src/github.com/docker/engine-api/client/client.go
+++ b/vendor/src/github.com/docker/engine-api/client/client.go
@@ -65,7 +65,6 @@ func NewEnvClient() (*Client, error) {
 func NewClient(host string, version string, transport *http.Transport, httpHeaders map[string]string) (*Client, error) {
 	var (
 		basePath       string
-		tlsConfig      *tls.Config
 		scheme         = "http"
 		protoAddrParts = strings.SplitN(host, "://", 2)
 		proto, addr    = protoAddrParts[0], protoAddrParts[1]
@@ -90,7 +89,7 @@ func NewClient(host string, version string, transport *http.Transport, httpHeade
 		addr:              addr,
 		basePath:          basePath,
 		scheme:            scheme,
-		tlsConfig:         tlsConfig,
+		tlsConfig:         transport.TLSClientConfig,
 		httpClient:        &http.Client{Transport: transport},
 		version:           version,
 		customHTTPHeaders: httpHeaders,

--- a/vendor/src/github.com/docker/engine-api/types/filters/parse.go
+++ b/vendor/src/github.com/docker/engine-api/types/filters/parse.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 )
 
-// Args stores filter arguments as map key:{array of values}.
-// It contains a aggregation of the list of arguments (which are in the form
+// Args stores filter arguments as map key:{map key: bool}.
+// It contains a aggregation of the map of arguments (which are in the form
 // of -f 'key=value') based on the key, and store values for the same key
-// in an slice.
+// in an map with string keys and boolean values.
 // e.g given -f 'label=label1=1' -f 'label=label2=2' -f 'image.name=ubuntu'
-// the args will be {'label': {'label1=1','label2=2'}, 'image.name', {'ubuntu'}}
+// the args will be {"image.name":{"ubuntu":true},"label":{"label1=1":true,"label2=2":true}}
 type Args struct {
 	fields map[string]map[string]bool
 }


### PR DESCRIPTION
- Vendors engine-api 0.2.2
- Fixes #19280
