### PR TITLE
Fixing TestInspectApiContainerVolumeDriver

### DIFF
--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -69,7 +69,7 @@ func (s *DockerSuite) TestInspectApiContainerVolumeDriverLegacy(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiContainerVolumeDriver(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out, _ := dockerCmd(c, "run", "-d", "--volume-driver", "local", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 


### PR DESCRIPTION
Currently the TestInspectApiContainerVolumeDriver is testing the
existence of a volume driver without specifing any volume driver.
This commit fixes that.

Signed-off-by: André Martins aanm90@gmail.com
