### PR TITLE
Free container lock during mount setup on container start

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -124,15 +124,16 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 		}
 	}
 
+	container.Unlock()
 	mounts, err := daemon.setupMounts(container)
 	if err != nil {
+		container.Lock()
 		return err
 	}
 	mounts = append(mounts, container.IpcMounts()...)
 	mounts = append(mounts, container.TmpfsMounts()...)
 
 	container.Command.Mounts = mounts
-	container.Unlock()
 
 	// don't lock waitForStart because it has potential risk of blocking
 	// which will lead to dead lock, forever.


### PR DESCRIPTION
Setting up the container mounts could potentially take a good amount of
time.  This is due to the fact that volume drivers are invoked and are
free to do quite a bit.  This change releases the container during the
setup of the mounts.

This helps https://github.com/docker/docker/issues/19328 but does not 100% fix it.  There is another section in container start that deals with networking that I'm guessing will also slow down quite a bit.  I haven't investigated that one yet.

Signed-off-by: Darren Shepherd darren@rancher.com
