### PR TITLE
Vendoring libnetwork v0.5.5

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -26,7 +26,7 @@ clone git github.com/docker/engine-api v0.2.2
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.5.4
+clone git github.com/docker/libnetwork v0.5.5
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/.gitignore
+++ b/vendor/src/github.com/docker/libnetwork/.gitignore
@@ -8,6 +8,8 @@ bin/
 integration-tmp/
 _obj
 _test
+.vagrant
+
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.5 (2016-01-14)
+- Allow network-scoped alias to be resolved for anonymous endpoint
+- Self repair corrupted IP database that could happen in 1.9.0 & 1.9.1
+- Skip IPTables cleanup if --iptables=false is set. Fixes docker/docker#19063
+
 ## 0.5.4 (2016-01-12)
 - Removed the isNodeAlive protection when user forces an endpoint delete
 

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -135,7 +135,7 @@ func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
 	if err := iptables.FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}
-	removeIPChains()
+
 	d := newDriver()
 	if err := d.configure(config); err != nil {
 		return err
@@ -378,6 +378,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 	}
 
 	if config.EnableIPTables {
+		removeIPChains()
 		natChain, filterChain, isolationChain, err = setupIPChains(config)
 		if err != nil {
 			return err

--- a/vendor/src/github.com/docker/libnetwork/network.go
+++ b/vendor/src/github.com/docker/libnetwork/network.go
@@ -822,20 +822,20 @@ func (n *network) EndpointByID(id string) (Endpoint, error) {
 }
 
 func (n *network) updateSvcRecord(ep *endpoint, localEps []*endpoint, isAdd bool) {
-	if ep.isAnonymous() {
-		return
-	}
-
 	epName := ep.Name()
 	if iface := ep.Iface(); iface.Address() != nil {
 		myAliases := ep.MyAliases()
 		if isAdd {
-			n.addSvcRecords(epName, iface.Address().IP, true)
+			if !ep.isAnonymous() {
+				n.addSvcRecords(epName, iface.Address().IP, true)
+			}
 			for _, alias := range myAliases {
 				n.addSvcRecords(alias, iface.Address().IP, false)
 			}
 		} else {
-			n.deleteSvcRecords(epName, iface.Address().IP, true)
+			if !ep.isAnonymous() {
+				n.deleteSvcRecords(epName, iface.Address().IP, true)
+			}
 			for _, alias := range myAliases {
 				n.deleteSvcRecords(alias, iface.Address().IP, false)
 			}


### PR DESCRIPTION
- Allow network-scoped alias to be resolved for anonymous endpoint
- Auto-Repair corrupted IP database that could happen in 1.9.0 & 1.9.1
- Skip IPTables cleanup if --iptables=false is set. 

Fixes #18113 
Fixes #19063 

Signed-off-by: Alessandro Boch aboch@docker.com
