### PR TITLE
Windows: Remove linkmode internal hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,10 +234,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Build/install the tool for embedding resources in Windows binaries
-ENV RSRC_VERSION v2
+ENV RSRC_COMMIT ba14da1f827188454a4591717fff29999010887f
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone --depth 1 -b "$RSRC_VERSION" https://github.com/akavel/rsrc.git "$GOPATH/src/github.com/akavel/rsrc" \
+	&& git clone https://github.com/akavel/rsrc.git "$GOPATH/src/github.com/akavel/rsrc" \
+	&& (cd "$GOPATH/src/github.com/akavel/rsrc" && git checkout -q "$RSRC_COMMIT") \
 	&& go build -v -o /usr/local/bin/rsrc github.com/akavel/rsrc \
 	&& rm -rf "$GOPATH"
 

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -55,5 +55,12 @@ if [ "$(go env GOOS)" = 'windows' ]; then
 	rsrc \
 		-manifest hack/make/.resources-windows/docker.exe.manifest \
 		-ico      hack/make/.resources-windows/docker.ico \
-		-o        autogen/winresources/rsrc.syso > /dev/null
+		-arch     "amd64" \
+		-o        autogen/winresources/rsrc_amd64.syso > /dev/null
+
+	rsrc \
+		-manifest hack/make/.resources-windows/docker.exe.manifest \
+		-ico      hack/make/.resources-windows/docker.ico \
+		-arch     "386" \
+		-o        autogen/winresources/rsrc_386.syso > /dev/null
 fi

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -14,15 +14,8 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 		windows/amd64)
 			export CC=x86_64-w64-mingw32-gcc
 			export CGO_ENABLED=1
-			export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC_DOCKER -linkmode internal -extld=${CC}"
 			;;
 	esac
-fi
-
-if [ "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" == "windows/amd64" ] && [ "$(go env GOOS)" == "windows" ]; then
-	# native compilation of Windows on Windows with golang 1.5+ needs linkmode internal
-	# https://github.com/golang/go/issues/13070
-	export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC_DOCKER -linkmode=internal"
 fi
 
 if [ "$(go env GOOS)" == "linux" ] ; then


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle 

@akavel has fixed rsrc to support building .syso files which are multi-architecture. Hence there's no need for the hack to force linkmode internal anymore following the upgrade to golang 1.5.x. This change now builds both architectures of the Windows resource binary using a golang build tag so that the right resource gets picked up by the linker.

Verified locally that both 32 and 64-bit cross-build binaries work as expected.
