### PR TITLE
Windows: Fix test regression from 19155

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6170,8 +6170,8 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansion(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if res != filepath.Clean(wdVal) {
-		c.Fatalf("Config.WorkingDir value mismatch. Expected: %s, got: %s", filepath.Clean(wdVal), res)
+	if res != filepath.ToSlash(filepath.Clean(wdVal)) {
+		c.Fatalf("Config.WorkingDir value mismatch. Expected: %s, got: %s", filepath.ToSlash(filepath.Clean(wdVal)), res)
 	}
 
 	err = inspectFieldAndMarshall(imgName, "Config.Env", &resArr)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This fixes a test regression merged in #19155 which is now causing failures across Windows CI jobs. Verified Windows to Linux locally, but not Linux to Linux (think its OK- lets see what those CI runs in Jenkins say).

@calavera @coolljt0725 
