### PR TITLE
Add note in dockerfile about go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,9 @@ RUN cd /usr/local/lvm2 \
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install Go
+# IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
+#            will need updating, to avoid errors. Ping #docker-maintainers on IRC 
+#            with a heads-up.
 ENV GO_VERSION 1.5.3
 RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Putting a note in the Dockerfile to (hopefully) ensure that Windows to Linux CI gets updated correctly when the version of Go is updated.
