### PR TITLE
Display `internal` flag on `network inspect`

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -164,6 +164,7 @@ func buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {
 	r.Options = nw.Info().DriverOptions()
 	r.Containers = make(map[string]types.EndpointResource)
 	buildIpamResources(r, nw)
+	r.Internal = nw.Info().Internal()
 
 	epl := nw.Endpoints()
 	for _, e := range epl {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -105,6 +105,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.23](docker_remote_api_v1.23.md) documentation
 
 * `GET /containers/json` returns the state of the container, one of `created`, `restarting`, `running`, `paused`, `exited` or `dead`.
+* `GET /networks/(name)` now returns an `Internal` field showing whether the network is internal or not.
 
 
 ### v1.22 API changes

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -2963,6 +2963,7 @@ Content-Type: application/json
         "foo": "bar"
     }
   },
+  "Internal": false,
   "Containers": {
     "19a4d5d687db25203351ed79d478946f861258f018fe384f229f2efa4b23513c": {
       "Name": "test",

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -50,6 +50,7 @@ $ sudo docker network inspect bridge
                 }
             ]
         },
+        "Internal": false,
         "Containers": {
             "bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727": {
                 "Name": "container2",

--- a/man/docker-network-inspect.1.md
+++ b/man/docker-network-inspect.1.md
@@ -45,6 +45,7 @@ $ sudo docker network inspect bridge
                 }
             ]
         },
+        "Internal": false,
         "Containers": {
             "bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727": {
                 "Name": "container2",


### PR DESCRIPTION
Also adds internal network tests for bridge network
Depends on https://github.com/docker/engine-api/pull/47

Signed-off-by: ramichen ramichen@tencent.com
