### PR TITLE
Windows: Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ ifeq ($(DOCKER_OSARCH), linux/ppc64le)
 else
 ifeq ($(DOCKER_OSARCH), linux/s390x)
 	DOCKERFILE := Dockerfile.s390x
+else
+ifeq ($(DOCKER_OSARCH), windows/amd64)
+	DOCKERFILE := Dockerfile.windows
+endif
 endif
 endif
 endif


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Another piece in the Windows to Windows CI puzzle. This updates the makefile to set the dockerfile name on Windows. The dockerfile itself is part of https://github.com/docker/docker/pull/18348/
