### PR TITLE
api: client: build: do not fall through if git isn't installed

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6632,3 +6632,18 @@ func (s *DockerSuite) TestBuildCacheRootSource(c *check.C) {
 
 	c.Assert(out, checker.Not(checker.Contains), "Using cache")
 }
+
+// #19375
+func (s *DockerSuite) TestBuildFailsGitNotCallable(c *check.C) {
+	cmd := exec.Command(dockerBinary, "build", "github.com/docker/v1.10-migrator.git")
+	cmd.Env = append(cmd.Env, "PATH=")
+	out, _, err := runCommandWithOutput(cmd)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "unable to prepare context: unable to find 'git': ")
+
+	cmd = exec.Command(dockerBinary, "build", "https://github.com/docker/v1.10-migrator.git")
+	cmd.Env = append(cmd.Env, "PATH=")
+	out, _, err = runCommandWithOutput(cmd)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "unable to prepare context: unable to find 'git': ")
+}


### PR DESCRIPTION
Fix #19375
Couldn't mess around and rename/remove git executable from our test suite to test this behavior :/ Does anyone know how could we test this w/o git?

``` sh
[root@rawhide ~]# docker build github.com/docker/v1.10-migrator.git
unable to prepare context: unable to find 'git': exec: "git": executable file not found in $PATH

[root@rawhide ~]# docker build https://github.com/docker/v1.10-migrator.git
unable to prepare context: unable to find 'git': exec: "git": executable file not found in $PATH
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
