### PR TITLE
Add zsh completion for 'docker network create --internal'

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -303,6 +303,7 @@ __docker_network_subcommand() {
                 "($help -d --driver)"{-d=,--driver=}"[Driver to manage the Network]:driver:(null host bridge overlay)" \
                 "($help)--ipam-driver=[IP Address Management Driver]:driver:(default)" \
                 "($help)*--subnet=[Subnet in CIDR format that represents a network segment]:IP/mask: " \
+                "($help)--internal[Restricts external access to the network]" \
                 "($help)*--ip-range=[Allocate container ip from a sub-range]:IP/mask: " \
                 "($help)*--gateway=[ipv4 or ipv6 Gateway for the master subnet]:IP: " \
                 "($help)*--aux-address[Auxiliary ipv4 or ipv6 addresses used by network driver]:key=IP: " \


### PR DESCRIPTION
Ref. #19276

@albers ping new `docker network create --internal` flag

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
