### PR TITLE
[WIP] POC for a query language for filtering ps output (#17569)

### DIFF
--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -28,6 +28,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		before   = cmd.String([]string{"#-before"}, "", "Only show containers created before Id or Name")
 		last     = cmd.Int([]string{"n"}, -1, "Show n last created containers (includes all states)")
 		format   = cmd.String([]string{"-format"}, "", "Pretty-print containers using a Go template")
+		query    = cmd.String([]string{"-query"}, "", "Filter output based on a query")
 		flFilter = opts.NewListOpts(nil)
 	)
 	cmd.Require(flag.Exact, 0)
@@ -54,6 +55,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		Before: *before,
 		Size:   *size,
 		Filter: psFilterArgs,
+		Query:  *query,
 	}
 
 	containers, err := cli.client.ContainerList(options)

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -38,6 +38,7 @@ func (s *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 		Since:   r.Form.Get("since"),
 		Before:  r.Form.Get("before"),
 		Filters: r.Form.Get("filters"),
+		Query:   r.Form.Get("query"),
 	}
 
 	if tmpLimit := r.Form.Get("limit"); tmpLimit != "" {

--- a/container/query.go
+++ b/container/query.go
@@ -1,0 +1,114 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+
+	"strconv"
+
+	"github.com/docker/docker/query"
+)
+
+var (
+	ContainerQueryFields = map[string][]query.Operator{
+		"running":    {query.IS},
+		"paused":     {query.IS},
+		"restarting": {query.IS},
+
+		"label.*": {query.IS, query.EQ, query.LIKE},
+
+		"id":         {query.EQ, query.LIKE},
+		"name":       {query.EQ, query.LIKE},
+		"image":      {query.EQ, query.LIKE},
+		"cmd":        {query.EQ, query.LIKE},
+		"entrypoint": {query.EQ, query.LIKE},
+
+		"exit":    {query.EQ, query.GT},
+		"created": {query.EQ, query.GT},
+		"exited":  {query.EQ, query.GT},
+	}
+)
+
+var _ query.Queryable = &Container{}
+
+func (c *Container) Is(field string, operator query.Operator, value string) bool {
+	switch {
+	case field == "running":
+		return c.Running
+	case field == "paused":
+		return c.Paused
+	case field == "restarting":
+		return c.Restarting
+	case strings.HasPrefix(field, "label."):
+		label := strings.TrimPrefix(field, "label.")
+		labelValue, found := c.Config.Labels[label]
+		if operator == query.IS {
+			return found
+		}
+		return strCompare(labelValue, operator, value)
+	case field == "id":
+		return strCompare(c.ID, operator, value)
+	case field == "name":
+		return strCompare(strings.TrimPrefix(c.Name, "/"), operator, value)
+	case field == "image":
+		//FIXME: how to retrieve image name ?
+		return strCompare(c.ImageID.String(), operator, value)
+	case field == "exit":
+		code := c.ExitCode
+		return code != -1 && intCompare(code, operator, value)
+	case field == "cmd":
+		return sliceCompare(c.Config.Cmd.Slice(), operator, value)
+	case field == "entrypoint":
+		return sliceCompare(c.Config.Entrypoint.Slice(), operator, value)
+	default:
+		panic(fmt.Sprintf("Invalid field %s", field))
+	}
+}
+
+func intCompare(value int, op query.Operator, pattern string) bool {
+	ipattern, err := strconv.Atoi(pattern)
+	if err != nil {
+		panic(fmt.Sprintf("'%s' is not a numeric", op))
+	}
+	switch op {
+	case query.EQ:
+		return value == ipattern
+	case query.GT:
+		return value > ipattern
+	default:
+		panic(fmt.Sprintf("Unsupported operator %s", op))
+	}
+}
+
+func strCompare(value string, op query.Operator, pattern string) bool {
+	switch op {
+	case query.EQ:
+		return value == pattern
+	case query.LIKE:
+		return like(value, pattern)
+	default:
+		panic(fmt.Sprintf("Unsupported operator %s", op))
+	}
+}
+
+func sliceCompare(values []string, op query.Operator, pattern string) bool {
+	for _, value := range values {
+		switch op {
+		case query.EQ:
+			if value == pattern {
+				return true
+			}
+		case query.LIKE:
+			if like(value, pattern) {
+				return true
+			}
+		default:
+			panic(fmt.Sprintf("Unsupported operator %s", op))
+		}
+	}
+	return false
+}
+
+func like(value, pattern string) bool {
+	return strings.Contains(strings.ToLower(value), strings.ToLower(pattern))
+}

--- a/query/ast.go
+++ b/query/ast.go
@@ -1,0 +1,89 @@
+package query
+
+import "fmt"
+
+/*
+Expression is a predicate which can be applied to a queryable
+*/
+type Expression interface {
+	// Match accepts or rejects a queryable depending on the expression implementation
+	Match(queryable Queryable) bool
+}
+
+type exprOr struct {
+	left, right Expression
+}
+
+func (or *exprOr) String() string {
+	return fmt.Sprintf("(%v | %v)", or.left, or.right)
+}
+
+func (or *exprOr) Match(queryable Queryable) bool {
+	if or.left.Match(queryable) {
+		return true
+	}
+	return or.right.Match(queryable)
+}
+
+type exprAnd struct {
+	left, right Expression
+}
+
+func (and *exprAnd) String() string {
+	return fmt.Sprintf("(%v & %v)", and.left, and.right)
+}
+
+func (and *exprAnd) Match(queryable Queryable) bool {
+	if !and.left.Match(queryable) {
+		return false
+	}
+	return and.right.Match(queryable)
+}
+
+type exprNot struct {
+	expression Expression
+}
+
+func (not *exprNot) String() string {
+	return fmt.Sprintf("!(%v)", not.expression)
+}
+
+func (not *exprNot) Match(queryable Queryable) bool {
+	return !not.expression.Match(queryable)
+}
+
+type exprComp struct {
+	field    string
+	operator string
+	value    string
+}
+
+func (c *exprComp) String() string {
+	return fmt.Sprintf("%s%s'%v'", c.field, c.operator, c.value)
+}
+
+func (c *exprComp) Match(queryable Queryable) bool {
+	if len(c.operator) == 0 {
+		return queryable.Is(c.field, IS, "")
+	}
+	switch c.operator {
+	case "=":
+		return queryable.Is(c.field, EQ, c.value)
+	case "!=":
+		return !queryable.Is(c.field, EQ, c.value)
+	case "~":
+		return queryable.Is(c.field, LIKE, c.value)
+	case "!~":
+		return !queryable.Is(c.field, LIKE, c.value)
+	case ">":
+		return queryable.Is(c.field, GT, c.value)
+	case ">=":
+		return queryable.Is(c.field, GT, c.value) || queryable.Is(c.field, EQ, c.value)
+	case "<":
+		return !queryable.Is(c.field, GT, c.value) && !queryable.Is(c.field, EQ, c.value)
+	case "<=":
+		return !queryable.Is(c.field, GT, c.value)
+	default:
+		panic(fmt.Sprintf("Operator %s is not implemented", c.operator))
+	}
+}

--- a/query/ast_test.go
+++ b/query/ast_test.go
@@ -1,0 +1,247 @@
+package query
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/stretchr/testify/require"
+)
+
+type constAst bool
+
+func (c constAst) Match(queryable Queryable) bool {
+	return bool(c)
+}
+
+func TestOr(t *testing.T) {
+	cases := []struct{ left, right, expected bool }{
+		{false, false, false},
+		{false, true, true},
+		{true, false, true},
+		{true, true, true},
+	}
+
+	for _, cas := range cases {
+		require.Equal(t, cas.expected, (&exprOr{constAst(cas.left), constAst(cas.right)}).Match(nil))
+	}
+}
+
+func TestAnd(t *testing.T) {
+	cases := []struct{ left, right, expected bool }{
+		{false, false, false},
+		{false, true, false},
+		{true, false, false},
+		{true, true, true},
+	}
+
+	for _, cas := range cases {
+		require.Equal(t, cas.expected, (&exprAnd{constAst(cas.left), constAst(cas.right)}).Match(nil))
+	}
+}
+
+func TestNot(t *testing.T) {
+	require.Equal(t, true, (&exprNot{constAst(false)}).Match(nil))
+	require.Equal(t, false, (&exprNot{constAst(true)}).Match(nil))
+}
+
+func TestComp(t *testing.T) {
+	cases := []struct {
+		q        Queryable
+		comp     *exprComp
+		expected bool
+	}{
+		// bool
+		{
+			q:        &mockQueryable{t: t, field: "x", operator: IS, result: true},
+			comp:     &exprComp{field: "x"},
+			expected: true,
+		},
+		{
+			q:        &mockQueryable{t: t, field: "x", operator: IS, result: false},
+			comp:     &exprComp{field: "x"},
+			expected: false,
+		},
+
+		//str, =
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: EQ, value: "jawher/query", result: true},
+			comp:     &exprComp{field: "field", operator: "=", value: "jawher/query"},
+			expected: true,
+		},
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: EQ, value: "jaer/query", result: false},
+			comp:     &exprComp{field: "field", operator: "=", value: "jaer/query"},
+			expected: false,
+		},
+
+		//str, !=
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: EQ, value: "jawher/query", result: true},
+			comp:     &exprComp{field: "field", operator: "!=", value: "jawher/query"},
+			expected: false,
+		},
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: EQ, value: "jaer/query", result: false},
+			comp:     &exprComp{field: "field", operator: "!=", value: "jaer/query"},
+			expected: true,
+		},
+
+		//str, ~
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: LIKE, value: "quer", result: true},
+			comp:     &exprComp{field: "field", operator: "~", value: "quer"},
+			expected: true,
+		},
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: LIKE, value: "bateau", result: false},
+			comp:     &exprComp{field: "field", operator: "~", value: "bateau"},
+			expected: false,
+		},
+
+		//str, !~
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: LIKE, value: "quer", result: true},
+			comp:     &exprComp{field: "field", operator: "!~", value: "quer"},
+			expected: false,
+		},
+		{
+			q:        &mockQueryable{t: t, field: "field", operator: LIKE, value: "bateau", result: false},
+			comp:     &exprComp{field: "field", operator: "!~", value: "bateau"},
+			expected: true,
+		},
+
+		// >
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   true,
+			},
+			comp:     &exprComp{field: "field", operator: ">", value: "42"},
+			expected: true,
+		},
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   false,
+			},
+			comp:     &exprComp{field: "field", operator: ">", value: "42"},
+			expected: false,
+		},
+
+		// >=
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   true,
+			},
+			comp:     &exprComp{field: "field", operator: ">=", value: "42"},
+			expected: true,
+		},
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   false,
+				then:     &mockQueryable{operator: EQ, result: true},
+			},
+			comp:     &exprComp{field: "field", operator: ">=", value: "42"},
+			expected: true,
+		},
+
+		// <
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   true,
+			},
+			comp:     &exprComp{field: "field", operator: "<", value: "42"},
+			expected: false,
+		},
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   false,
+				then:     &mockQueryable{operator: EQ, result: true},
+			},
+			comp:     &exprComp{field: "field", operator: "<", value: "42"},
+			expected: false,
+		},
+
+		// <=
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   true,
+			},
+			comp:     &exprComp{field: "field", operator: "<=", value: "42"},
+			expected: false,
+		},
+		{
+			q: &mockQueryable{
+				t:        t,
+				field:    "field",
+				operator: GT,
+				value:    "42",
+				result:   false,
+			},
+			comp:     &exprComp{field: "field", operator: "<=", value: "42"},
+			expected: true,
+		},
+	}
+
+	for _, cas := range cases {
+		require.Equal(t, cas.expected, cas.comp.Match(cas.q), "comparison %v failed with %v", cas.comp, cas.q)
+	}
+}
+
+type mockQueryable struct {
+	t        *testing.T
+	field    string
+	operator Operator
+	value    string
+	result   bool
+	then     *mockQueryable
+}
+
+func (c *mockQueryable) Is(field string, operator Operator, value string) bool {
+	if field != c.field {
+		c.t.Fatalf("Unexpected field %s", field)
+	}
+	if operator != c.operator {
+		c.t.Fatalf("Unexpected operator %v", operator)
+	}
+	if value != c.value {
+		c.t.Fatalf("Unexpected value %s", value)
+	}
+	res := c.result
+
+	if c.then != nil {
+		c.operator, c.result = c.then.operator, c.then.result
+	}
+	return res
+}
+
+func (c *mockQueryable) String() string {
+	return fmt.Sprintf("%s %v %s => %v", c.field, c.operator, c.value, c.result)
+}

--- a/query/doc.go
+++ b/query/doc.go
@@ -1,0 +1,103 @@
+/*
+Package query provides the means the filter a collection of arbitrary data structures according to user provided query.
+
+Here's an example for a query over docker containers:
+
+  matcher, err := query.Parse("!running & (exit!=0 | name~junk", ...)
+  if matcher.Match(container) {
+    :
+    :
+  }
+
+The queries supported by this library are parsed from a string represetnation according to the following rules:
+
+Boolean fields
+
+The simplest form a query is a simple boolean field:
+
+  running
+
+String fields
+
+Fields of type string are supported and can be used with the following operators:
+
+- "=" : Exact equality
+  name=library/container
+
+- "!=" : Not equal to:
+  name!=value
+
+- "~" : Like, i.e. the field value must contain the provided value:
+  name~value
+
+- "!~" : Not like:
+  name!~value
+
+String slice fields
+
+bateau/query also supports multi-valued fields.
+The same operators as for string fields (=, !=, ~, !~) are available for multi-valued fields.
+
+
+- "=" : Matches if any value of the slice is exactly equal to the provided value
+  cmd=/bin/sh
+
+- "!=" : Fails if any value of the slice is exactly equal to the provided value
+  cmd!=/bin/sh
+
+- "~" : Matches if any value of the slice contains the provided value
+  cmd~sh
+
+- "!~" : Fails if any value of the slice contains the provided value
+  cmd!~sh
+
+Negation
+
+A condition can be negated using the "!" operator, e.g.:
+
+  !running
+
+or
+
+  !name=server
+
+And
+
+Two or more conditions can be combined using the boolean and operator "&"
+
+  running & name=server
+
+or
+
+  running & image=mongo & cmd~sh
+
+Or
+
+Two or more conditions can be combined using the boolean or operator "|"
+
+  running | name=server
+
+or
+
+  running | image=mongo | cmd~sh
+
+Parenthesis
+
+To control the evaluation precedence, conditions can be wrapped between "(" and ")":
+
+  running & !(name=server | image~mongo)
+
+
+Grammar
+
+The query langauge is described below using the EBNF notation:
+
+  expr     -> or
+  or       -> and ('|' and)*
+  and      -> atom ('&' atom)*
+  atom     -> cond | '(' expr ')' | '!' atom
+  cond     -> LITERAL (OPERATOR LITERAL)?
+  LITERAL  -> "[^|&!=~]+"
+  OPERATOR -> '=' | '!=' | '~' | '!~' | '<' | '<=' | '>' | '>='
+*/
+package query

--- a/query/lexer.go
+++ b/query/lexer.go
@@ -1,0 +1,196 @@
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"unicode/utf8"
+)
+
+type tokenClass string
+
+const (
+	tkLparen  tokenClass = "("
+	tkRparen             = ")"
+	tkLiteral            = "LITERAL"
+	tkAnd                = "&"
+	tkOr                 = "|"
+	tkCompOp             = "comp"
+	tkNot                = "!"
+	tkEOF                = "$"
+)
+
+type token struct {
+	class tokenClass
+	value string
+	pos   int
+}
+
+type lexer struct {
+	input string
+	start int
+	pos   int
+	width int
+}
+
+func newLexer(input string) *lexer {
+	return &lexer{
+		input: input,
+		pos:   0,
+		width: 0,
+	}
+}
+
+func (lx *lexer) next() token {
+	for {
+		for lx.peek() == ' ' {
+			lx.pop()
+		}
+		lx.drop()
+
+		r := lx.pop()
+		switch {
+		case r == eof:
+			return lx.emit(tkEOF)
+		case r == '(':
+			return lx.emit(tkLparen)
+		case r == ')':
+			return lx.emit(tkRparen)
+		case r == '&':
+			return lx.emit(tkAnd)
+		case r == '|':
+			return lx.emit(tkOr)
+		case r == '~':
+			return lx.emit(tkCompOp)
+		case r == '=':
+			return lx.emit(tkCompOp)
+		case r == '!':
+			switch lx.peek() {
+			case '~':
+				lx.pop()
+				return lx.emit(tkCompOp)
+			case '=':
+				lx.pop()
+				return lx.emit(tkCompOp)
+			default:
+				return lx.emit(tkNot)
+			}
+		case r == '>':
+			switch lx.peek() {
+			case '=':
+				lx.pop()
+				return lx.emit(tkCompOp)
+			default:
+				return lx.emit(tkCompOp)
+			}
+		case r == '<':
+			switch lx.peek() {
+			case '=':
+				lx.pop()
+				return lx.emit(tkCompOp)
+			default:
+				return lx.emit(tkCompOp)
+			}
+		case r == '"':
+			return lx.lexString()
+		default:
+			for notIn(lx.peek(), notOkInLiteral) {
+				lx.pop()
+			}
+			return lx.emit(tkLiteral)
+		}
+	}
+}
+
+func (lx *lexer) lexString() token {
+	lx.drop() // get rid of the opening quotes "
+	var buffer bytes.Buffer
+	for {
+		r := lx.pop()
+		switch r {
+		case eof:
+			panic("unclosed string")
+		case '\\':
+			if lx.peek() == '"' {
+				buffer.WriteRune(lx.pop())
+			} else {
+				buffer.WriteRune('\\')
+			}
+		case '"':
+			return lx.emitV(tkLiteral, buffer.String())
+		default:
+			buffer.WriteRune(r)
+		}
+	}
+
+}
+
+func notIn(needle rune, haystack []rune) bool {
+	for _, r := range haystack {
+		if needle == r {
+			return false
+		}
+	}
+	return true
+}
+
+var (
+	notOkInLiteral = []rune{eof, ' ', '(', ')', '~', '=', '!', '&', '|', '<', '>'}
+)
+
+const eof = -1
+
+func (l *lexer) pop() rune {
+	r, w := l.nextRune()
+	l.width = w
+	l.pos += w
+	return r
+}
+
+func (l *lexer) peek() rune {
+	r, _ := l.nextRune()
+	return r
+}
+
+func (l *lexer) nextRune() (rune, int) {
+	if l.pos >= len(l.input) {
+		return eof, 0
+	}
+	return utf8.DecodeRuneInString(l.input[l.pos:])
+}
+
+func (l *lexer) push() {
+	l.pos -= l.width
+	l.width = 0
+}
+
+func (l *lexer) drop() {
+	l.start = l.pos
+}
+
+func (l *lexer) matched() string {
+	return l.input[l.start:l.pos]
+}
+
+func (l *lexer) errorf(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
+func (l *lexer) emit(class tokenClass) token {
+	res := token{
+		class: class,
+		value: l.input[l.start:l.pos],
+		pos:   l.start,
+	}
+	l.start = l.pos
+	return res
+}
+
+func (l *lexer) emitV(class tokenClass, v string) token {
+	res := token{
+		class: class,
+		value: v,
+		pos:   l.start,
+	}
+	l.start = l.pos
+	return res
+}

--- a/query/lexer_test.go
+++ b/query/lexer_test.go
@@ -1,0 +1,131 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLexerSingleTokens(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected token
+	}{
+		{"a", token{class: tkLiteral, value: "a", pos: 0}},
+		{"a.b", token{class: tkLiteral, value: "a.b", pos: 0}},
+		{"a/b", token{class: tkLiteral, value: "a/b", pos: 0}},
+		{`"a b"`, token{class: tkLiteral, value: "a b", pos: 1}},
+		{`"a\"b"`, token{class: tkLiteral, value: `a"b`, pos: 1}},
+
+		{"=", token{class: tkCompOp, value: "=", pos: 0}},
+		{"~", token{class: tkCompOp, value: "~", pos: 0}},
+		{"!=", token{class: tkCompOp, value: "!=", pos: 0}},
+		{"!~", token{class: tkCompOp, value: "!~", pos: 0}},
+		{">", token{class: tkCompOp, value: ">", pos: 0}},
+		{">=", token{class: tkCompOp, value: ">=", pos: 0}},
+		{"<", token{class: tkCompOp, value: "<", pos: 0}},
+		{"<=", token{class: tkCompOp, value: "<=", pos: 0}},
+
+		{"(", token{class: tkLparen, value: "(", pos: 0}},
+		{")", token{class: tkRparen, value: ")", pos: 0}},
+
+		{"!", token{class: tkNot, value: "!", pos: 0}},
+		{"|", token{class: tkOr, value: "|", pos: 0}},
+		{"&", token{class: tkAnd, value: "&", pos: 0}},
+
+		{"", token{class: tkEOF, value: "", pos: 0}},
+	}
+
+	for _, cas := range cases {
+		lx := newLexer(cas.input)
+		require.Equal(t, cas.expected, lx.next())
+	}
+}
+
+func TestLexerMultiTokens(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected []token
+	}{
+		{"lit1 lit2", []token{
+			{class: tkLiteral, value: "lit1", pos: 0},
+			{class: tkLiteral, value: "lit2", pos: 5},
+			{class: tkEOF, value: "", pos: 9},
+		}},
+		{"lit1/lit2=", []token{
+			{class: tkLiteral, value: "lit1/lit2", pos: 0},
+			{class: tkCompOp, value: "=", pos: 9},
+			{class: tkEOF, value: "", pos: 10},
+		}},
+		{"!lit1/lit2", []token{
+			{class: tkNot, value: "!", pos: 0},
+			{class: tkLiteral, value: "lit1/lit2", pos: 1},
+			{class: tkEOF, value: "", pos: 10},
+		}},
+		{`!"!"!=!`, []token{
+			{class: tkNot, value: "!", pos: 0},
+			{class: tkLiteral, value: "!", pos: 2},
+			{class: tkCompOp, value: "!=", pos: 4},
+			{class: tkNot, value: "!", pos: 6},
+			{class: tkEOF, value: "", pos: 7},
+		}},
+		{"=>=> =", []token{
+			{class: tkCompOp, value: "=", pos: 0},
+			{class: tkCompOp, value: ">=", pos: 1},
+			{class: tkCompOp, value: ">", pos: 3},
+			{class: tkCompOp, value: "=", pos: 5},
+			{class: tkEOF, value: "", pos: 6},
+		}},
+	}
+
+	for _, cas := range cases {
+		lx := newLexer(cas.input)
+		for _, expected := range cas.expected {
+			require.Equal(t, expected, lx.next())
+		}
+
+		next := lx.next()
+		require.True(t, next.class == tkEOF, "Lexer returned more tokens than expected: %v", next)
+	}
+}
+func TestLexer(t *testing.T) {
+	lx := newLexer(`image=jawher/image:3.0.2 & (exit=0 | exit!=1) & !( name~angry | name !~panini | label="arch=arm\"11\"")  `)
+	expected := []token{
+		{class: tkLiteral, value: "image", pos: 0},
+		{class: tkCompOp, value: "=", pos: 5},
+		{class: tkLiteral, value: "jawher/image:3.0.2", pos: 6},
+		{class: tkAnd, value: "&", pos: 25},
+		{class: tkLparen, value: "(", pos: 27},
+		{class: tkLiteral, value: "exit", pos: 28},
+		{class: tkCompOp, value: "=", pos: 32},
+		{class: tkLiteral, value: "0", pos: 33},
+		{class: tkOr, value: "|", pos: 35},
+		{class: tkLiteral, value: "exit", pos: 37},
+		{class: tkCompOp, value: "!=", pos: 41},
+		{class: tkLiteral, value: "1", pos: 43},
+		{class: tkRparen, value: ")", pos: 44},
+		{class: tkAnd, value: "&", pos: 46},
+		{class: tkNot, value: "!", pos: 48},
+		{class: tkLparen, value: "(", pos: 49},
+		{class: tkLiteral, value: "name", pos: 51},
+		{class: tkCompOp, value: "~", pos: 55},
+		{class: tkLiteral, value: "angry", pos: 56},
+		{class: tkOr, value: "|", pos: 62},
+		{class: tkLiteral, value: "name", pos: 64},
+		{class: tkCompOp, value: "!~", pos: 69},
+		{class: tkLiteral, value: "panini", pos: 71},
+		{class: tkOr, value: "|", pos: 78},
+		{class: tkLiteral, value: "label", pos: 80},
+		{class: tkCompOp, value: "=", pos: 85},
+		{class: tkLiteral, value: `arch=arm"11"`, pos: 87},
+		{class: tkRparen, value: ")", pos: 102},
+		{class: tkEOF, value: "", pos: 105},
+	}
+
+	for _, exTk := range expected {
+		tk := lx.next()
+		require.Equal(t, exTk, tk)
+	}
+
+	require.Equal(t, token{class: tkEOF, value: "", pos: 105}, lx.next(), "was expecting EOF")
+}

--- a/query/parser.go
+++ b/query/parser.go
@@ -1,0 +1,173 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+type parser struct {
+	lexer   *lexer
+	matched token
+	next    token
+
+	fields map[string][]Operator
+}
+
+// ParseError is returned if a query cannot be successfuly parsed
+type ParseError struct {
+	// The original query
+	Input string
+	// The position where the parsing fails
+	Pos int
+	// The error message
+	Message string
+}
+
+func (e ParseError) Error() string {
+	return fmt.Sprintf("Parse error: %s\n%s\n%s^", e.Message, e.Input, strings.Repeat(" ", e.Pos))
+}
+
+/*
+Parse accepts an input string and the list and types of valid fields and returns either a matcher expression if the query
+is valid, or else an error
+*/
+func Parse(input string, fields map[string][]Operator) (Expression, error) {
+	lexer := newLexer(input)
+	return (&parser{
+		lexer:  lexer,
+		next:   lexer.next(),
+		fields: fields,
+	}).parse()
+}
+
+func (p *parser) parse() (ast Expression, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			ast = nil
+			err = ParseError{
+				Input:   p.lexer.input,
+				Pos:     p.matched.pos,
+				Message: fmt.Sprintf("%v", r),
+			}
+		}
+	}()
+	ast = p.or()
+	if !p.found(tkEOF) {
+		p.advance()
+		panic("Unexpected input")
+	}
+	return
+}
+
+func (p *parser) or() Expression {
+	left := p.and()
+	for p.found(tkOr) {
+		right := p.and()
+		left = &exprOr{left, right}
+	}
+	return left
+}
+
+func (p *parser) and() Expression {
+	left := p.atom()
+	for p.found(tkAnd) {
+		right := p.atom()
+		left = &exprAnd{left, right}
+	}
+	return left
+}
+
+func (p *parser) atom() Expression {
+	switch {
+	case p.found(tkNot):
+		return &exprNot{p.atom()}
+	case p.found(tkLparen):
+		res := p.or()
+		if !p.found(tkRparen) {
+			p.advance()
+			panic("was expecting a closing parenthesis")
+		}
+		return res
+	case p.found(tkLiteral):
+		field := p.matched.value
+		operators, found := p.fieldOperators(field)
+		if !found {
+			panic(fmt.Sprintf("Unknown field %s", field))
+		}
+		if !p.found(tkCompOp) {
+			if !hasOperator(operators, IS) {
+				panic(fmt.Sprintf("field %s cannot be used without an operator", field))
+			}
+			return &exprComp{field: field}
+		}
+
+		operator := p.matched.value
+		if !hasOperator(operators, operatorMapping[operator]) {
+			panic(fmt.Sprintf("field %s doesn not support operator %s", field, operator))
+		}
+		if !p.found(tkLiteral) {
+			p.advance()
+			panic("was expecting a comparison value")
+		}
+		value := p.matched.value
+		return &exprComp{field: field, operator: operator, value: value}
+	case p.found(tkEOF):
+		panic("Unexpected end of query")
+	default:
+		panic("unexpected input")
+	}
+}
+
+func (p *parser) fieldOperators(field string) ([]Operator, bool) {
+	operators, found := p.fields[field]
+	if found {
+		return operators, true
+	}
+	for k, v := range p.fields {
+		if strings.HasSuffix(k, ".*") && strings.HasPrefix(field, strings.TrimSuffix(k, ".*")) {
+			return v, true
+		}
+	}
+
+	return nil, false
+}
+
+var operatorMapping = map[string]Operator{
+	"=":  EQ,
+	"!=": EQ,
+	"~":  LIKE,
+	"!~": LIKE,
+	">":  GT,
+	">=": GT,
+	"<":  GT,
+	"<=": GT,
+}
+
+func hasOperator(operators []Operator, op Operator) bool {
+	for _, o := range operators {
+		if o == op {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) expect(class tokenClass) {
+	if !p.found(class) {
+		panic(fmt.Sprintf("was expecting %v", class))
+	}
+}
+
+func (p *parser) found(class tokenClass) bool {
+	if p.next.class == class {
+		p.matched = p.next
+		p.next = p.lexer.next()
+		return true
+	}
+	return false
+}
+
+func (p *parser) advance() {
+	p.matched = p.next
+	p.next = p.lexer.next()
+}

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -1,0 +1,64 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	fields = map[string][]Operator{
+		"running": {IS},
+		"name":    {EQ, LIKE},
+		"exit":    {EQ, GT},
+	}
+)
+
+func TestSimpleParse(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected Expression
+	}{
+		{
+			input:    "running",
+			expected: &exprComp{field: "running"},
+		}, {
+			input:    "name~x",
+			expected: &exprComp{field: "name", operator: "~", value: "x"},
+		}, {
+			input:    "name=x",
+			expected: &exprComp{field: "name", operator: "=", value: "x"},
+		},
+	}
+
+	for _, cas := range testCases {
+		ast, err := Parse(cas.input, fields)
+
+		require.NoError(t, err)
+		require.Equal(t, cas.expected, ast)
+	}
+}
+
+func TestComplexParse(t *testing.T) {
+	expected := &exprOr{
+		left: &exprComp{field: "name", operator: "=", value: "jawher/image"},
+		right: &exprAnd{
+			left: &exprOr{
+				left:  &exprComp{field: "running"},
+				right: &exprComp{field: "exit", operator: "!=", value: "1"},
+			},
+			right: &exprNot{
+				&exprOr{
+					left:  &exprComp{field: "name", operator: "~", value: "angry"},
+					right: &exprComp{field: "name", operator: "!~", value: "panini"},
+				},
+			},
+		},
+	}
+
+	ast, err := Parse("name=jawher/image | (running | exit!=1) & !( name~angry | name !~panini )  ",
+		fields)
+
+	require.NoError(t, err)
+	require.Equal(t, expected, ast)
+}

--- a/query/query.go
+++ b/query/query.go
@@ -1,0 +1,20 @@
+package query
+
+type Operator string
+
+const (
+	IS   Operator = ""
+	EQ            = "="
+	LIKE          = "~"
+	GT            = ">"
+)
+
+/*
+Queryable is the abstraction used by this library to work on arbitrary data structures.
+Implementing this interface's methods for a user type makes it compatible with the Expression
+predicates
+*/
+type Queryable interface {
+	// Returns true if the provided field is set
+	Is(field string, operator Operator, value string) bool
+}

--- a/vendor/src/github.com/docker/engine-api/client/container_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_list.go
@@ -29,6 +29,10 @@ func (cli *Client) ContainerList(options types.ContainerListOptions) ([]types.Co
 		query.Set("before", options.Before)
 	}
 
+	if options.Query != "" {
+		query.Set("query", options.Query)
+	}
+
 	if options.Size {
 		query.Set("size", "1")
 	}

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -50,6 +50,7 @@ type ContainerListOptions struct {
 	Before string
 	Limit  int
 	Filter filters.Args
+	Query  string
 }
 
 // ContainerLogsOptions holds parameters to filter logs with.


### PR DESCRIPTION
Feature proposal: #17569
Please head to the linked issue for more details on the query language syntax and for a preliminary discussion on this proposal.
### This is just a quick and dirty POC

with the sole goal of having a working example to build the discussion on.
## Modifications
- Add a new top-level package in docker named `query`. This package parses a given query from a string to an AST. The AST can be used to filter containers, images, volumes, networks and any other list of items according to the query. The only requirement is for the item type to implement an interface (`query.Queryable`)
- Make `containers/Container` implement `query.Queryable`
- Add a `--query` flag to `docker ps`
- Modify `engine-api/client/type/ContainerListOptions` to add a `Query` field (in a true quick and dirty fashion, I modified the concerned files in the vendor directory, but a proper PR to the engine-api project will be created if this proposal is accepted)
- Modify `daemon/list.go` to use the provided query instead of psFilters if it is present. The current implementation is, again, a quick and dirty one, and is incomplete, i.e. doesn't handle all psFilters fields among other things.
## Query language

More details in [bateau's project page](https://github.com/jawher/bateau)
### Boolean fields

```
running
```
### Valued fields

e.g. string, []string, int, duration, size, etc.
Syntax: `field operator value`
Where operator is one of:
- `=` for strict equality, `!=` for strict inequality
- `~` for string contains (LIKE), `!~` for the negated version
- `>`, `>=`, `<` and `<=` for numeric comparisons

examples:

```
exit=1
```

```
name=server_1
```

```
name~"server"
```

```
created > 2h
```
### Negation

Any clause can be negated using the `!` operator.
Examples:

```
!running
```

```
!(exit=1) // though this is equivalent to exit!=1
```
### Anding, Oring

2 or more clauses can be combined using anding `&` or bring `|`:

```
running & created > 2d // running containers created more than 2 days ago
```

```
size>300MB & (created > 2M | docker_version~1.5 | docker_version~1.6) 
```

```
!label.arch | label.arch=x86 // containers without an "arch" label or with one set to "x86"
```
## Open questions

Do you think this proposal has a chance of being accepted ? If the answer is yes, I'm willing to rework this PR to handle:
- at least the current supported filters, if not more fields
- generalise it to work on images, volumes and networks (am I forgetting any other item list in docker ?)
### The query syntax:

I reused the code I wrote for [bateau](https://github.com/jawher/bateau).

What is the preferred syntax between:

```
!label.arch | label.arch=x86
size>300MB & (created > 2M | docker_version~1.5 | docker_version~1.6) 
```

and

```
not label.arch and label.arch=x86
size>300MB and (created > 2M and docker_version~1.5 or docker_version~1.6) 
```
### The query parsing complexity

One of the points raised by @duglin in the original issue (#17569) was the cost of adding and maintaining the parsing code.

The current implementation is comprised of a lexer (200 LOC) and a recursive descent parser (~180 LOC).
I also have a [working prototype with a lexer-less parser](https://gist.github.com/jawher/56ed7ec4ab8ea7e9d5e7) (~240LOC), which I believe will be easier to extend with new operators for example than trying to do so with the current lexer.

Also, the syntax as such should not need to be modified frequently, if at all.
A more frequent task would be to add more fields to filter on.
This task can be be accomplished without touching the parsing logic: see `container/query.go` for how the list of fields of a containers are defined.
### Interaction with the current ps filtering mechanism

The `-f`, `--since` and `--before` filters are a subset of the query language of this proposal.

If this proposal is accepted, one possibility would be to deprecate these 3 flags, and make them exclusive with `--query`:

```
Usage:
docker ps ([-f] [--since] [--before]) | --query)
```
### Implementation details

What do you think about how `query.Queryable`  is directly implemented by the concerned types (Container for example) ?
The other possibility would be to created adapter types which would implement the iface in the `daemon` package, e.g. `containerQueryable`, etc.
