### PR TITLE
Expose plugin retry option for clients

### DIFF
--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -19,7 +19,7 @@ type pluginClient interface {
 }
 
 func lookupPlugin(name, home string, opts []string) (Driver, error) {
-	pl, err := plugins.Get(name, "GraphDriver")
+	pl, err := plugins.Get(name, "GraphDriver", true)
 	if err != nil {
 		return nil, fmt.Errorf("Error looking up graphdriver plugin %s: %v", name, err)
 	}

--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -74,7 +74,7 @@ func (a *authorizationPlugin) initPlugin() error {
 	// Lazy loading of plugins
 	if a.plugin == nil {
 		var err error
-		a.plugin, err = plugins.Get(a.name, AuthZApiImplements)
+		a.plugin, err = plugins.Get(a.name, AuthZApiImplements, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -16,7 +16,7 @@
 // In order to use a plugins, you can use the ``Get`` with the name of the
 // plugin and the subsystem it implements.
 //
-//	plugin, err := plugins.Get("example", "VolumeDriver")
+//	plugin, err := plugins.Get("example", "VolumeDriver", true)
 //	if err != nil {
 //		return fmt.Errorf("Error looking up volume plugin example: %v", err)
 //	}
@@ -159,19 +159,19 @@ func loadWithRetry(name string, retry bool) (*Plugin, error) {
 	}
 }
 
-func get(name string) (*Plugin, error) {
+func get(name string, retry bool) (*Plugin, error) {
 	storage.Lock()
 	pl, ok := storage.plugins[name]
 	storage.Unlock()
 	if ok {
 		return pl, pl.activate()
 	}
-	return load(name)
+	return loadWithRetry(name, retry)
 }
 
 // Get returns the plugin given the specified name and requested implementation.
-func Get(name, imp string) (*Plugin, error) {
-	pl, err := get(name)
+func Get(name, imp string, retry bool) (*Plugin, error) {
+	pl, err := get(name, retry)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/libnetwork/controller.go
+++ b/vendor/src/github.com/docker/libnetwork/controller.go
@@ -674,7 +674,7 @@ func SandboxKeyWalker(out *Sandbox, key string) SandboxWalker {
 func (c *controller) loadDriver(networkType string) (*driverData, error) {
 	// Plugins pkg performs lazy loading of plugins that acts as remote drivers.
 	// As per the design, this Get call will result in remote driver discovery if there is a corresponding plugin available.
-	_, err := plugins.Get(networkType, driverapi.NetworkPluginEndpointType)
+	_, err := plugins.Get(networkType, driverapi.NetworkPluginEndpointType, true)
 	if err != nil {
 		if err == plugins.ErrNotFound {
 			return nil, types.NotFoundErrorf(err.Error())
@@ -691,7 +691,7 @@ func (c *controller) loadDriver(networkType string) (*driverData, error) {
 }
 
 func (c *controller) loadIpamDriver(name string) (*ipamData, error) {
-	if _, err := plugins.Get(name, ipamapi.PluginEndpointType); err != nil {
+	if _, err := plugins.Get(name, ipamapi.PluginEndpointType, true); err != nil {
 		if err == plugins.ErrNotFound {
 			return nil, types.NotFoundErrorf(err.Error())
 		}

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -89,7 +89,7 @@ func Lookup(name string) (volume.Driver, error) {
 	if ok {
 		return ext, nil
 	}
-	pl, err := plugins.Get(name, extName)
+	pl, err := plugins.Get(name, extName, true)
 	if err != nil {
 		return nil, fmt.Errorf("Error looking up volume plugin %s: %v", name, err)
 	}


### PR DESCRIPTION
There are cases as in https://github.com/docker/libnetwork/issues/813, the clients (libnetwork in this case) would have to force cleanup states without having to retry for plugin availability.
#15921 added the retry functionality by default to plugin manager. But did not expose this to the clients.

Clients can make use of GetAll (as a hack to get workaround this problem). But having this exposed to
the clients makes it cleaner.

@calavera @cpuguy83 wdyt ?

Signed-off-by: Madhu Venugopal madhu@docker.com
