### PR TITLE
Set TasksMax in addition to LimitNPROC in systemd service files

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,6 +11,7 @@ MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
+TasksMax=1048576
 TimeoutStartSec=0
 
 [Install]

--- a/docs/articles/systemd.md
+++ b/docs/articles/systemd.md
@@ -88,6 +88,7 @@ In this example, we'll assume that your `docker.service` file looks something li
     ExecStart=/usr/bin/docker daemon -H fd://
     LimitNOFILE=1048576
     LimitNPROC=1048576
+    TasksMax=1048576
 
     [Install]
     Also=docker.socket


### PR DESCRIPTION
systemd sets an additional limit on processes and threads that defaults to 512 when run under Linux >= 4.3 (see [here](http://unix.stackexchange.com/a/255603/59955)). The problem has been described in #9868 and #19124.

This patch sets the `TasksMax` in the example systemd service files provided with docker.
