### PR TITLE
bash completion for container linking and aliasing

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1153,12 +1153,41 @@ _docker_logs() {
 }
 
 _docker_network_connect() {
+	local options_with_args="
+		--alias
+		--ip
+		--ip6
+		--link
+	"
+
+	local boolean_options="
+		--help
+	"
+
+	case "$prev" in
+		--link)
+			case "$cur" in
+				*:*)
+					;;
+				*)
+					__docker_complete_containers_running
+					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
+					__docker_nospace
+					;;
+			esac
+			return
+			;;
+		$(__docker_to_extglob "$options_with_args") )
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag)
+			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
 			if [ $cword -eq $counter ]; then
 				__docker_complete_networks
 			elif [ $cword -eq $(($counter + 1)) ]; then
@@ -1488,6 +1517,8 @@ _docker_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--ip
+		--ip6
 		--ipc
 		--isolation
 		--kernel-memory
@@ -1503,6 +1534,7 @@ _docker_run() {
 		--memory-reservation
 		--name
 		--net
+		--net-alias
 		--oom-score-adj
 		--pid
 		--publish -p


### PR DESCRIPTION
This updates bash completion to support the new options for linking and aliasing containers:

docker network connect --alias (#19242) --ip, --ip6 (#19001), --link (#19229)
docker run|create --ip, --ip6 (#19001), --net-alias (#19242)

ping @jfrazelle @tianon for review
Thanks @sdurrheimer for the ping.
