### PR TITLE
Add gccgo target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ deb: build
 docs:
 	$(MAKE) -C docs docs
 
+gccgo: build
+	$(DOCKER_RUN_DOCKER) hack/make.sh gccgo
+
 rpm: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary build-rpm
 


### PR DESCRIPTION
This adds gccgo as a target in the Makefile. 

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
