### PR TITLE
Update bash completion for `docker network create`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1170,7 +1170,7 @@ _docker_network_connect() {
 
 _docker_network_create() {
 	case "$prev" in
-		--aux-address|--gateway|--ip-range|--opt|-o|--subnet)
+		--aux-address|--gateway|--ip-range|--ipam-opt|--opt|-o|--subnet)
 			return
 			;;
 		--ipam-driver)
@@ -1189,7 +1189,7 @@ _docker_network_create() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--aux-address --driver -d --gateway --help --ip-range --ipam-driver --opt -o --subnet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--aux-address --driver -d --gateway --help --internal --ip-range --ipam-driver --ipam-opt --opt -o --subnet" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This adds support for `docker network create --internal` (#19276) and `docker network create --ipam-opt` (#17316)

ping @jfrazelle @tianon for review
Thanks @sdurrheimer for the ping.
