### PR TITLE
Make daemonbuilder.Docker leaner.

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -77,9 +77,8 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	cmd.ParseFlags(args, true)
 
 	var (
-		context  io.ReadCloser
-		isRemote bool
-		err      error
+		context io.ReadCloser
+		err     error
 	)
 
 	_, err = exec.LookPath("git")
@@ -215,18 +214,12 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		}
 	}
 
-	var remoteContext string
-	if isRemote {
-		remoteContext = cmd.Arg(0)
-	}
-
 	options := types.ImageBuildOptions{
 		Context:        body,
 		Memory:         memory,
 		MemorySwap:     memorySwap,
 		Tags:           flTags.GetAll(),
 		SuppressOutput: *suppressOutput,
-		RemoteContext:  remoteContext,
 		NoCache:        *noCache,
 		Remove:         *rm,
 		ForceRemove:    *forceRm,

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -101,7 +101,7 @@ type Backend interface {
 	// GetImage looks up a Docker image referenced by `name`.
 	GetImage(name string) (Image, error)
 	// Pull tells Docker to pull image referenced by `name`.
-	Pull(name string) (Image, error)
+	Pull(name string, authConfigs map[string]types.AuthConfig, output io.Writer) (Image, error)
 	// ContainerAttach attaches to container.
 	ContainerAttach(cID string, stdin io.ReadCloser, stdout, stderr io.Writer, stream bool) error
 	// ContainerCreate creates a new Docker container and returns potential warnings

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -67,7 +67,8 @@ type Builder struct {
 	allowedBuildArgs map[string]bool // list of build-time args that are allowed for expansion/substitution and passing to commands in 'run'.
 
 	// TODO: remove once docker.Commit can receive a tag
-	id string
+	id     string
+	Output io.Writer
 }
 
 // NewBuilder creates a new Dockerfile builder from an optional dockerfile and a Config.

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -212,7 +212,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 			// TODO: shouldn't we error out if error is different from "not found" ?
 		}
 		if image == nil {
-			image, err = b.docker.Pull(name)
+			image, err = b.docker.Pull(name, b.options.AuthConfigs, b.Output)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently builder.Backend is implemented by daemonbuilder.Docker{} for
the daemon. This registration happens in the API/server code. However,
this is too implementation specific. Ideally we should be able to specify
that docker daemon (or any other) is implementing the Backend and abstract
the implementation details. So we should remove package daemonbuilder
dependency in build_routes.go

With this change, daemonbuilder.Docker is nothing more than the daemon.
A follow on change will remove the daemonbuilder package and move relevant
methods under daemon, so that API only knows about the backend.

Also cleanup code in api/client/build.go. docker cli always performs build
context tar download for remoteURLs and sends an empty remoteContext. So
remove relevant dead code.

Signed-off-by: Anusha Ragunathan anusha@docker.com
