### PR TITLE
Print an info message when detaching a container started with --rm

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/signal"
+	"github.com/docker/docker/pkg/stringid"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/libnetwork/resolvconf/dns"
@@ -260,6 +261,16 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 
 	// Attached mode
 	if *flAutoRemove {
+		// Warn user if they detached us
+		js, err := cli.client.ContainerInspect(createResponse.ID)
+		if err != nil {
+			return runStartContainerErr(err)
+		}
+		if js.State.Running == true || js.State.Paused == true {
+			fmt.Fprintf(cli.out, "Detached from %s, awaiting its termination in order to uphold \"--rm\".\n",
+				stringid.TruncateID(createResponse.ID))
+		}
+
 		// Autoremove: wait for the container to finish, retrieve
 		// the exit code and remove the container
 		if status, err = cli.client.ContainerWait(createResponse.ID); err != nil {


### PR DESCRIPTION
This patch aims to avoid confusion for users that detach a container (^P^Q) that was started with `--rm -ti`.

After the container is detached, the users are left with what they consider an "unresponsive" prompt but is actually the cli waiting for the container to exit in order to delete the container.

Closes #17516

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
