### PR TITLE
Move closeNotify to fix panic with newer golang

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -241,10 +241,11 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 	if closeNotifier, ok := w.(http.CloseNotifier); ok {
 		finished := make(chan struct{})
 		defer close(finished)
+		clientGone := closeNotifier.CloseNotify()
 		go func() {
 			select {
 			case <-finished:
-			case <-closeNotifier.CloseNotify():
+			case <-clientGone:
 				logrus.Infof("Client disconnected, cancelling job: build")
 				b.Cancel()
 			}


### PR DESCRIPTION
This is happening now due to improvements in net/http:
https://github.com/golang/go/commit/99fb19194c03c618c0d8faa87b91ba419ae28ee3

To test, change the go version in the Dockerfile:
-ENV GO_VERSION 1.5.3
+ENV GO_VERSION 1.6beta2

More info here: https://github.com/golang/go/issues/14001

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
