### PR TITLE
disable install of docker-engine for 1.10, try to get ready for 1.11

### DIFF
--- a/hack/make/.build-deb/docker-engine.install
+++ b/hack/make/.build-deb/docker-engine.install
@@ -10,4 +10,3 @@ contrib/init/systemd/docker.socket lib/systemd/system/
 contrib/mk* usr/share/docker-engine/contrib/
 contrib/nuke-graph-directory.sh usr/share/docker-engine/contrib/
 contrib/syntax/nano/Dockerfile.nanorc usr/share/nano/
-contrib/apparmor/docker-engine etc/apparmor.d/

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -59,8 +59,6 @@ set -e
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
 		fi
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			RUN GOPATH=/go go build -o aagen contrib/apparmor/*.go \
-				&& ./aagen contrib/apparmor/docker-engine
 			RUN ln -sfv hack/make/.build-deb debian
 			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
 			RUN dpkg-buildpackage -uc -us


### PR DESCRIPTION
removes the install of the docker-engine profile, i think we should do this for 1.10 because it should have been complain only and not enforced, but since that is not working i think we should wait til i can study TFM and get this working as intended :) ping @cpuguy83 related to #19415

relates to https://github.com/docker/docker/issues/18948

This fixes Docker not working correctly on Ubuntu 14.04 and lower
