### PR TITLE
Vendoring miekg/dns @ 75e6e86cc601825c5dbcd4e0c209eab180997cd7

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -43,7 +43,7 @@ fix_rewritten_imports github.com/coreos/etcd
 clone git github.com/ugorji/go 5abd4e96a45c386928ed2ca2a7ef63e2533e18ec
 clone git github.com/hashicorp/consul v0.5.2
 clone git github.com/boltdb/bolt v1.1.0
-clone git github.com/miekg/dns d27455715200c7d3e321a1e5cadb27c9ee0b0f02
+clone git github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
 clone git github.com/docker/distribution cb08de17d74bef86ce6c5abe8b240e282f5750be

--- a/vendor/src/github.com/miekg/dns/server.go
+++ b/vendor/src/github.com/miekg/dns/server.go
@@ -535,6 +535,9 @@ Redo:
 	h.ServeDNS(w, req) // Writes back to the client
 
 Exit:
+	if w.tcp == nil {
+		return
+	}
 	// TODO(miek): make this number configurable?
 	if q > maxTCPQueries { // close socket after this many queries
 		w.Close()

--- a/vendor/src/github.com/miekg/dns/udp_linux.go
+++ b/vendor/src/github.com/miekg/dns/udp_linux.go
@@ -24,6 +24,12 @@ func setUDPSocketOptions4(conn *net.UDPConn) error {
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_PKTINFO, 1); err != nil {
 		return err
 	}
+	// Calling File() above results in the connection becoming blocking, we must fix that.
+	// See https://github.com/miekg/dns/issues/279
+	err = syscall.SetNonblock(int(file.Fd()), true)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -34,6 +40,10 @@ func setUDPSocketOptions6(conn *net.UDPConn) error {
 		return err
 	}
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_RECVPKTINFO, 1); err != nil {
+		return err
+	}
+	err = syscall.SetNonblock(int(file.Fd()), true)
+	if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Fixes the issue of Shutdown() not working, resulting in hung
  goroutines
- Fixes [libnetwork #878](https://github.com/docker/libnetwork/issues/878)

Signed-off-by: Santhosh Manohar santhosh@docker.com
