### PR TITLE
remove the check of ContentLength in TestApiStatsNoStreamGetCpu

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -27,7 +27,7 @@ func (s *DockerSuite) TestApiStatsNoStreamGetCpu(c *check.C) {
 
 	resp, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "")
 	c.Assert(err, checker.IsNil)
-	c.Assert(resp.ContentLength, checker.GreaterThan, int64(0), check.Commentf("should not use chunked encoding"))
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
 
 	var v *types.Stats


### PR DESCRIPTION
when the length of http body GreaterThan 2048,"Transfer-Encoding: chunked" will appear in the response header,and "Content-Length: xxx" will not appear in the response header,so resp.ContentLength will equal -1 even if sockRequestRaw has a successful return. this will reappear when the testcase run in the machine with multi-core CPU(e.g. processor       : 159).

we can also have a simple testcase for this.

```
func HelloServer(w http.ResponseWriter, req *http.Request) {
    c := make([]byte, 2049)
    for idx, _ := range c {
       c[idx] = 'a'    
    }
    fmt.Fprintf(w, string(c))
}

func main() {
    http.HandleFunc("/", HelloServer)
    http.ListenAndServe(":8080", nil)
}

# curl  -i http://x.x.x.x:8080/
HTTP/1.1 200 OK
Date: Mon, 18 Jan 2016 09:11:34 GMT
Content-Type: text/plain; charset=utf-8
Transfer-Encoding: chunked

aaaaaaaaaaaaa...
```

Signed-off-by: yangshukui yangshukui@huawei.com
