### PR TITLE
bugfix: prevent creating network 'default'

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -277,6 +277,24 @@ func (s *DockerNetworkSuite) TestDockerNetworkLsDefault(c *check.C) {
 	}
 }
 
+func (s *DockerNetworkSuite) TestDockerNetworkCreatePredefined(c *check.C) {
+	predefined := []string{"bridge", "host", "none", "default"}
+	for _, net := range predefined {
+		// predefined networks can't be created again
+		out, _, err := dockerCmdWithError("network", "create", net)
+		c.Assert(err, checker.NotNil, check.Commentf("%v", out))
+	}
+}
+
+func (s *DockerNetworkSuite) TestDockerNetworkRmPredefined(c *check.C) {
+	predefined := []string{"bridge", "host", "none", "default"}
+	for _, net := range predefined {
+		// predefined networks can't be removed
+		out, _, err := dockerCmdWithError("network", "rm", net)
+		c.Assert(err, checker.NotNil, check.Commentf("%v", out))
+	}
+}
+
 func (s *DockerNetworkSuite) TestDockerNetworkLsFilter(c *check.C) {
 	out, _ := dockerCmd(c, "network", "create", "dev")
 	defer func() {

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -19,7 +19,7 @@ func DefaultDaemonNetworkMode() container.NetworkMode {
 // IsPreDefinedNetwork indicates if a network is predefined by the daemon
 func IsPreDefinedNetwork(network string) bool {
 	n := container.NetworkMode(network)
-	return n.IsBridge() || n.IsHost() || n.IsNone()
+	return n.IsBridge() || n.IsHost() || n.IsNone() || n.IsDefault()
 }
 
 // ValidateNetMode ensures that the various combinations of requested


### PR DESCRIPTION
- Fixes #19422

Default is predefined network and is reserved, so we should stop user
from creating network with name `default`

Signed-off-by: Zhang Wei zhangwei555@huawei.com
