### PR TITLE
add send, recv, and x32 so we can install i386 pkgs on amd64

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -17,7 +17,7 @@ func arches() []string {
 	var a = native.String()
 	switch a {
 	case "amd64":
-		return []string{"amd64", "x86"}
+		return []string{"amd64", "x86", "x32"}
 	case "arm64":
 		return []string{"arm64", "arm"}
 	case "mips64":
@@ -945,6 +945,11 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Args:   []*configs.Arg{},
 		},
 		{
+			Name:   "recv",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
 			Name:   "recvfrom",
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},
@@ -1116,6 +1121,11 @@ var defaultSeccompProfile = &configs.Seccomp{
 		},
 		{
 			Name:   "semtimedop",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "send",
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},
 		},


### PR DESCRIPTION
makes sure this works:

```
docker run --rm -it debian:jessie bash
# dpkg --add-architecture i386
# apt-get update && apt-get install curl:i386
# curl -sSL ifconfig.co

before patch
curl: (55) Send failure: Operation not permitted

after patch
WORKS!
```
