### PR TITLE
Fix race condition in execCommandGC

### DIFF
--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -53,7 +53,13 @@ func NewStore() *Store {
 
 // Commands returns the exec configurations in the store.
 func (e *Store) Commands() map[string]*Config {
-	return e.commands
+	e.RLock()
+	commands := make(map[string]*Config, len(e.commands))
+	for id, config := range e.commands {
+		commands[id] = config
+	}
+	e.RUnlock()
+	return commands
 }
 
 // Add adds a new exec configuration to the store.


### PR DESCRIPTION
`daemon.execCommandGC`
The daemon object (grep execCommandGC) iterate over a map
(grep execCommands.Commands) in a goroutine.
Lock can't protect concurrency access in this case.
Exec command storage object should return a copy of commands instead.
fix #19407
Signed-off-by: Pei Su sillyousu@gmail.com
