### PR TITLE
Fix post config verification without flags.

### DIFF
--- a/docker/common.go
+++ b/docker/common.go
@@ -55,16 +55,7 @@ func init() {
 func postParseCommon() {
 	cmd := commonFlags.FlagSet
 
-	if commonFlags.LogLevel != "" {
-		lvl, err := logrus.ParseLevel(commonFlags.LogLevel)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to parse logging level: %s\n", commonFlags.LogLevel)
-			os.Exit(1)
-		}
-		logrus.SetLevel(lvl)
-	} else {
-		logrus.SetLevel(logrus.InfoLevel)
-	}
+	setDaemonLogLevel(commonFlags.LogLevel)
 
 	// Regardless of whether the user sets it to true or false, if they
 	// specify --tlsverify at all then we need to turn on tls
@@ -91,5 +82,18 @@ func postParseCommon() {
 				tlsOptions.KeyFile = ""
 			}
 		}
+	}
+}
+
+func setDaemonLogLevel(logLevel string) {
+	if logLevel != "" {
+		lvl, err := logrus.ParseLevel(logLevel)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to parse logging level: %s\n", logLevel)
+			os.Exit(1)
+		}
+		logrus.SetLevel(lvl)
+	} else {
+		logrus.SetLevel(logrus.InfoLevel)
 	}
 }

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -360,5 +360,14 @@ func loadDaemonCliConfig(config *daemon.Config, daemonFlags *flag.FlagSet, commo
 		}
 	}
 
+	// Regardless of whether the user sets it to true or false, if they
+	// specify TLSVerify at all then we need to turn on TLS
+	if config.IsValueSet("tls-verify") {
+		config.TLS = true
+	}
+
+	// ensure that the log level is the one set after merging configurations
+	setDaemonLogLevel(config.LogLevel)
+
 	return config, nil
 }


### PR DESCRIPTION
- Set the daemon log level to what's set in the configuration.
- Enable TLS when TLSVerify is enabled.

Fixes #19408

Signed-off-by: David Calavera david.calavera@gmail.com
