### PR TITLE
Add more robust error handling on layer store creation

### DIFF
--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
@@ -154,7 +155,7 @@ func (fms *fileMetadataStore) GetParent(layer ChainID) (ChainID, error) {
 		return "", err
 	}
 
-	dgst, err := digest.ParseDigest(string(content))
+	dgst, err := digest.ParseDigest(strings.TrimSpace(string(content)))
 	if err != nil {
 		return "", err
 	}
@@ -168,7 +169,7 @@ func (fms *fileMetadataStore) GetDiffID(layer ChainID) (DiffID, error) {
 		return "", err
 	}
 
-	dgst, err := digest.ParseDigest(string(content))
+	dgst, err := digest.ParseDigest(strings.TrimSpace(string(content)))
 	if err != nil {
 		return "", err
 	}
@@ -177,16 +178,17 @@ func (fms *fileMetadataStore) GetDiffID(layer ChainID) (DiffID, error) {
 }
 
 func (fms *fileMetadataStore) GetCacheID(layer ChainID) (string, error) {
-	content, err := ioutil.ReadFile(fms.getLayerFilename(layer, "cache-id"))
+	contentBytes, err := ioutil.ReadFile(fms.getLayerFilename(layer, "cache-id"))
 	if err != nil {
 		return "", err
 	}
+	content := strings.TrimSpace(string(contentBytes))
 
-	if !stringIDRegexp.MatchString(string(content)) {
+	if !stringIDRegexp.MatchString(content) {
 		return "", errors.New("invalid cache id value")
 	}
 
-	return string(content), nil
+	return content, nil
 }
 
 func (fms *fileMetadataStore) TarSplitReader(layer ChainID) (io.ReadCloser, error) {
@@ -227,32 +229,34 @@ func (fms *fileMetadataStore) SetMountParent(mount string, parent ChainID) error
 }
 
 func (fms *fileMetadataStore) GetMountID(mount string) (string, error) {
-	content, err := ioutil.ReadFile(fms.getMountFilename(mount, "mount-id"))
+	contentBytes, err := ioutil.ReadFile(fms.getMountFilename(mount, "mount-id"))
 	if err != nil {
 		return "", err
 	}
+	content := strings.TrimSpace(string(contentBytes))
 
-	if !stringIDRegexp.MatchString(string(content)) {
+	if !stringIDRegexp.MatchString(content) {
 		return "", errors.New("invalid mount id value")
 	}
 
-	return string(content), nil
+	return content, nil
 }
 
 func (fms *fileMetadataStore) GetInitID(mount string) (string, error) {
-	content, err := ioutil.ReadFile(fms.getMountFilename(mount, "init-id"))
+	contentBytes, err := ioutil.ReadFile(fms.getMountFilename(mount, "init-id"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil
 		}
 		return "", err
 	}
+	content := strings.TrimSpace(string(contentBytes))
 
-	if !stringIDRegexp.MatchString(string(content)) {
+	if !stringIDRegexp.MatchString(content) {
 		return "", errors.New("invalid init id value")
 	}
 
-	return string(content), nil
+	return content, nil
 }
 
 func (fms *fileMetadataStore) GetMountParent(mount string) (ChainID, error) {
@@ -264,7 +268,7 @@ func (fms *fileMetadataStore) GetMountParent(mount string) (ChainID, error) {
 		return "", err
 	}
 
-	dgst, err := digest.ParseDigest(string(content))
+	dgst, err := digest.ParseDigest(strings.TrimSpace(string(content)))
 	if err != nil {
 		return "", err
 	}

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -86,6 +86,7 @@ func NewStoreFromGraphDriver(store MetadataStore, driver graphdriver.Driver) (St
 		l, err := ls.loadLayer(id)
 		if err != nil {
 			logrus.Debugf("Failed to load layer %s: %s", id, err)
+			continue
 		}
 		if l.parent != nil {
 			l.parent.referenceCount++
@@ -109,22 +110,22 @@ func (ls *layerStore) loadLayer(layer ChainID) (*roLayer, error) {
 
 	diff, err := ls.store.GetDiffID(layer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get diff id for %s: %s", layer, err)
 	}
 
 	size, err := ls.store.GetSize(layer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get size for %s: %s", layer, err)
 	}
 
 	cacheID, err := ls.store.GetCacheID(layer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get cache id for %s: %s", layer, err)
 	}
 
 	parent, err := ls.store.GetParent(layer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get parent for %s: %s", layer, err)
 	}
 
 	cl = &roLayer{


### PR DESCRIPTION
Add continue when layer fails on store creation, fixes panic attempting to deference to get parent.
Trim whitespace from layerstore files to keep trailing space from failing a layer load.

Add error strings when a layer load fails to indicate which file and layer the failure was caused by. This will allow easier diagnosis when the layer store fails to load.

Fixes #19449
