### PR TITLE
Fix test requirement for ARM

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -211,6 +211,7 @@ test_env() {
 	# use "env -i" to tightly control the environment variables that bleed into the tests
 	env -i \
 		DEST="$DEST" \
+		DOCKER_ENGINE_GOARCH="$DOCKER_ENGINE_GOARCH" \
 		DOCKER_GRAPHDRIVER="$DOCKER_GRAPHDRIVER" \
 		DOCKER_USERLANDPROXY="$DOCKER_USERLANDPROXY" \
 		DOCKER_HOST="$DOCKER_HOST" \

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -30,7 +30,7 @@ var (
 		"Test requires a Linux daemon",
 	}
 	NotArm = testRequirement{
-		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") == "arm" },
+		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "arm" },
 		"Test requires a daemon not running on ARM",
 	}
 	SameHostDaemon = testRequirement{


### PR DESCRIPTION
Correctly passes the DOCKER_ENGINE_GOARCH env var to the testing environment. 

Also fixes logic for skipping a test if on ARM. Currently, tests with "NotARM" are being skipped by all archs.

ping @StefanScherer I want verify DOCKER_ENGINE_GOARCH is actually "arm" and not something else. 

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
