### PR TITLE
Vendor updated docker/distribution package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,7 @@ RUN set -x \
 # both. This allows integration-cli tests to cover push/pull with both schema1
 # and schema2 manifests.
 ENV REGISTRY_COMMIT_SCHEMA1 ec87e9b6971d831f0eff752ddb54fb64693e51cd
-ENV REGISTRY_COMMIT cb08de17d74bef86ce6c5abe8b240e282f5750be
+ENV REGISTRY_COMMIT 47a064d4195a9b56133891bbb13620c3ac83a827
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/distribution.git "$GOPATH/src/github.com/docker/distribution" \

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -46,7 +46,7 @@ clone git github.com/boltdb/bolt v1.1.0
 clone git github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-clone git github.com/docker/distribution cb08de17d74bef86ce6c5abe8b240e282f5750be
+clone git github.com/docker/distribution 47a064d4195a9b56133891bbb13620c3ac83a827
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile

--- a/vendor/src/github.com/docker/distribution/Dockerfile
+++ b/vendor/src/github.com/docker/distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.2
+FROM golang:1.5.3
 
 RUN apt-get update && \
     apt-get install -y librados-dev apache2-utils && \

--- a/vendor/src/github.com/docker/distribution/manifest/schema1/manifest.go
+++ b/vendor/src/github.com/docker/distribution/manifest/schema1/manifest.go
@@ -39,11 +39,11 @@ func init() {
 		desc := distribution.Descriptor{
 			Digest:    digest.FromBytes(sm.Canonical),
 			Size:      int64(len(sm.Canonical)),
-			MediaType: MediaTypeManifest,
+			MediaType: MediaTypeSignedManifest,
 		}
 		return sm, desc, err
 	}
-	err := distribution.RegisterManifestSchema(MediaTypeManifest, schema1Func)
+	err := distribution.RegisterManifestSchema(MediaTypeSignedManifest, schema1Func)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to register manifest: %s", err))
 	}
@@ -51,7 +51,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("Unable to register manifest: %s", err))
 	}
-	err = distribution.RegisterManifestSchema("application/json; charset=utf-8", schema1Func)
+	err = distribution.RegisterManifestSchema("application/json", schema1Func)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to register manifest: %s", err))
 	}
@@ -167,7 +167,7 @@ func (sm *SignedManifest) MarshalJSON() ([]byte, error) {
 
 // Payload returns the signed content of the signed manifest.
 func (sm SignedManifest) Payload() (string, []byte, error) {
-	return MediaTypeManifest, sm.all, nil
+	return MediaTypeSignedManifest, sm.all, nil
 }
 
 // Signatures returns the signatures as provided by

--- a/vendor/src/github.com/docker/distribution/manifests.go
+++ b/vendor/src/github.com/docker/distribution/manifests.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
@@ -80,7 +81,17 @@ var mappings = make(map[string]UnmarshalFunc, 0)
 
 // UnmarshalManifest looks up manifest unmarshall functions based on
 // MediaType
-func UnmarshalManifest(mediatype string, p []byte) (Manifest, Descriptor, error) {
+func UnmarshalManifest(ctHeader string, p []byte) (Manifest, Descriptor, error) {
+	// Need to look up by the actual content type, not the raw contents of
+	// the header. Strip semicolons and anything following them.
+	var mediatype string
+	semicolonIndex := strings.Index(ctHeader, ";")
+	if semicolonIndex != -1 {
+		mediatype = ctHeader[:semicolonIndex]
+	} else {
+		mediatype = ctHeader
+	}
+
 	unmarshalFunc, ok := mappings[mediatype]
 	if !ok {
 		return nil, Descriptor{}, fmt.Errorf("unsupported manifest mediatype: %s", mediatype)


### PR DESCRIPTION
Fixes #19400

Note that this introduces an incompatibility with Docker 1.10-rc1,
because the media type used for schema1 manifests has been corrected in
the upstream distribution code. Docker 1.10-rc1 won't be able to pull
old manifests from Registry 2.3-rc0 and up, but because of this vendor
update, Docker 1.10-rc2 won't have this problem.
