### PR TITLE
Fix DockerTrustSuite SetUpTest

### DIFF
--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -106,7 +106,7 @@ func newTestNotary(c *check.C) (*testNotary, error) {
 	}
 
 	// Wait for notary to be ready to serve requests.
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 20; i++ {
 		if err = testNotary.Ping(); err == nil {
 			break
 		}


### PR DESCRIPTION
This hopefully makes DockerTrustSuite.SetUpTest less flaky.

Increased the number of attempts to check if Notary is available before giving up.

fixes https://github.com/docker/docker/issues/19393 (fingers crossed)
