### PR TITLE
fix a spelling error of 'dnsmasq'

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -393,7 +393,7 @@ NetworkManager (this might slow your network).
 
         $ sudo nano /etc/NetworkManager/NetworkManager.conf
 
-2. Comment out the `dns=dsnmasq` line:
+2. Comment out the `dns=dnsmasq` line:
 
         dns=dnsmasq
 


### PR DESCRIPTION
I think there is a spelling error of 'dnsmasq', so I changed it.
Please have a look.Thanks.

Signed-off-by: Wenyu You 21551128@zju.edu.cn
