### PR TITLE
use a locally available frozen image

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1889,7 +1889,9 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceleftOnDeviceError(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// pull a repository large enough to fill the mount point
-	out, err := s.d.Cmd("pull", "registry:2")
+	// use a frozen image, because it's already locally available
+	imageName := fmt.Sprintf("%v/dockercli/debian:jessie", privateRegistryURL)
+	out, err := s.d.Cmd("pull", imageName)
 	c.Assert(out, check.Not(check.Equals), 1, check.Commentf("no space left on device"))
 }
 


### PR DESCRIPTION
- avoid a remote pull from the docker hub

Signed-off-by: Morgan Bauer mbauer@us.ibm.com

my hacky attempt at solving DockerDaemonSuite.TestDaemonNoSpaceleftOnDeviceError from #19425

I think I know what I am doing, but I'd really like someone else to check, and make sure I'm not doing something very very dumb.

this takes the test from wildly variable 4-200+seconds down to consistently subsecond runs.
