### PR TITLE
Enable DockerTrustSuite for ARM again

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -145,7 +145,13 @@ ORIG_BUILDFLAGS=( -a -tags "autogen netgo static_build sqlite_omit_load_extensio
 # see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.
-: ${TIMEOUT:=180m}
+
+if [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
+	: ${TIMEOUT:=210m}
+else
+	: ${TIMEOUT:=120m}
+fi
+
 TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 LDFLAGS_STATIC_DOCKER="

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -128,7 +128,6 @@ type DockerTrustSuite struct {
 }
 
 func (s *DockerTrustSuite) SetUpTest(c *check.C) {
-	testRequires(c, NotArm)
 	s.reg = setupRegistry(c, false)
 	s.not = setupNotary(c)
 }


### PR DESCRIPTION
After https://github.com/docker/docker/pull/19471 has been merged I ran a test on Scaleway. And yes, the `DockerTrustSuite` now works on ARM.

The arm build should show `OK: 1145 passed, 41 skipped`
