### PR TITLE
Fix loading with containerized plugins

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -159,7 +159,6 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 func (daemon *Daemon) lazyInitializeVolume(containerID string, m *volume.MountPoint) error {
 	if len(m.Driver) > 0 && m.Volume == nil {
 		v, err := daemon.volumes.GetWithRef(m.Name, m.Driver, containerID)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
During daemon startup, all containers are registered before any are
started.
During container registration it was calling out to initialize volumes.
If the volume uses a plugin that is running in a container, this will
cause the restart of that container to fail since the plugin is not yet
running.
This also slowed down daemon startup since volume initialization was
happening sequentially, which can be slow (and is flat out slow since
initialization would fail but take 8 seconds for each volume to do it).

This fix holds off on volume initialization until after containers are
restarted and does the initialization in parallel.

The containers that are restarted will have thier volumes initialized
because they are being started. If any of these containers are using a
plugin they will just keep retrying to reach the plugin (up to the
timeout, which is 8seconds) until the container with the plugin is up
and running.
