### PR TITLE
Remove validate-vendor from default bundles

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -51,7 +51,6 @@ DEFAULT_BUNDLES=(
 	validate-test
 	validate-toml
 	validate-vet
-	validate-vendor
 
 	binary
 	dynbinary


### PR DESCRIPTION
Because it's triggered another way :)
See https://github.com/docker/leeroy/pull/44

<del>I added a commit to make the `validate-vendor` build trigger and fail, so **don't merge right now** :P.</del>


Signed-off-by: Vincent Demeester vincent@sbr.pm
