### PR TITLE
Dockerfile,contrib,hack: remove buildpack-deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,6 +211,7 @@ RUN ln -sv $PWD/contrib/completion/bash/docker /etc/bash_completion.d/docker
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image-v2.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
+        alpine:latest@sha256:14f89d0e62577f42622f994da6b1b47159d95516d24ba050952e517b915a41f8 \
 	buildpack-deps:jessie@sha256:25785f89240fbcdd8a74bdaf30dd5599a9523882c6dfc567f2e9ef7cf6f79db6 \
 	busybox:latest@sha256:e4f93f6ed15a0cdd342f5aae387886fba0ab98af0a102da6276eaf24d6e6ade0 \
 	debian:jessie@sha256:f968f10b4b523737e253a97eac59b0d1420b5c19b69928d35801a6373ffe330e \

--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -4,6 +4,7 @@ set -e
 # image list should match what's in the Dockerfile (minus the explicit images IDs)
 images=(
 	buildpack-deps:jessie
+        alpine:latest
 	busybox:latest
 	debian:jessie
 	hello-world:latest

--- a/hack/make/.ensure-syscall-test
+++ b/hack/make/.ensure-syscall-test
@@ -4,5 +4,20 @@ set -e
 # Build a C binary for cloning a userns for seccomp tests
 # and compile it for target daemon
 if [ "$DOCKER_ENGINE_GOOS" = "linux" ]; then
-	docker build ${DOCKER_BUILD_ARGS} -qt syscall-test contrib/syscall-test > /dev/null
+	if [ "$DOCKER_ENGINE_OSARCH" = "$DOCKER_CLIENT_OSARCH" ]; then
+		tmpdir=$(mktemp -d)
+		gcc -g -Wall -static contrib/syscall-test/userns.c -o "${tmpdir}/userns-test"
+		gcc -g -Wall -static contrib/syscall-test/ns.c -o "${tmpdir}/ns-test"
+		gcc -g -Wall -static contrib/syscall-test/acct.c -o "${tmpdir}/acct-test"
+
+		dockerfile="${tmpdir}/Dockerfile"
+		cat <<-EOF > "$dockerfile"
+		FROM alpine
+		COPY . /usr/bin/
+		EOF
+		docker build --force-rm ${DOCKER_BUILD_ARGS} -qt syscall-test "${tmpdir}" > /dev/null
+		rm -rf "${tmpdir}"
+	else
+		docker build ${DOCKER_BUILD_ARGS} -qt syscall-test contrib/syscall-test > /dev/null
+	fi
 fi


### PR DESCRIPTION
This PR removes buildpack-deps from all Dockerfiles and from all the files where it was used. This helps us save time:
- we don't have to download a frozen image (1-4 minutes, depending on network connection speed) when building the main Dockerfile (e.g. `make test`, `make build`, `make binary`, `make release`)
- we don't have to waste ~5 minutes when doing a build to build the syscall-test image (see https://github.com/docker/docker/issues/19425#issuecomment-173110360 and https://github.com/docker/docker/issues/19425#issuecomment-173220891)

Helps with #19425
