### PR TITLE
Clarify error message when a .cert file is missing a corresponding key

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -109,7 +109,7 @@ func ReadCertsDirectory(tlsConfig *tls.Config, directory string) error {
 			keyName := certName[:len(certName)-5] + ".key"
 			logrus.Debugf("cert: %s", filepath.Join(directory, f.Name()))
 			if !hasFile(fs, keyName) {
-				return fmt.Errorf("Missing key %s for certificate %s", keyName, certName)
+				return fmt.Errorf("Missing key %s for client certificate %s. Note that CA certificates should use the extension .crt.", keyName, certName)
 			}
 			cert, err := tls.LoadX509KeyPair(filepath.Join(directory, certName), filepath.Join(directory, keyName))
 			if err != nil {
@@ -122,7 +122,7 @@ func ReadCertsDirectory(tlsConfig *tls.Config, directory string) error {
 			certName := keyName[:len(keyName)-4] + ".cert"
 			logrus.Debugf("key: %s", filepath.Join(directory, f.Name()))
 			if !hasFile(fs, certName) {
-				return fmt.Errorf("Missing certificate %s for key %s", certName, keyName)
+				return fmt.Errorf("Missing client certificate %s for key %s", certName, keyName)
 			}
 		}
 	}


### PR DESCRIPTION
The daemon uses two similar filename extensions to identify different
kinds of certificates. ".crt" files are interpreted as CA certificates,
and ".cert" files are interprted as client certificates. If a CA
certificate is accidentally given the extension ".cert", it will lead to
the following error message:

```
Missing key ca.key for certificate ca.cert
```

To make this slightly less confusing, clarify the error message with a
note that CA certificates should use the extension ".crt".

cc @dmp42 @dmcgowan 
