### PR TITLE
Fixes layer MediaTypes in manifests created from a cross-repository push

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -311,6 +311,8 @@ func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.
 	case distribution.ErrBlobMounted:
 		progress.Updatef(progressOutput, pd.ID(), "Mounted from %s", err.From.Name())
 
+		err.Descriptor.MediaType = schema2.MediaTypeLayer
+
 		pd.pushState.Lock()
 		pd.pushState.confirmedV2 = true
 		pd.pushState.remoteLayers[diffID] = err.Descriptor


### PR DESCRIPTION
While testing cross-repository pushing on staging, I discovered that the manifest generated from a cross-repository push differs from that of a standard push or one where the layers already exist. This change overrides the mediatype returned from checking the blob stat on the registry, just like what happens [when checking for layers which already exist.](https://github.com/docker/docker/blob/63099477189ea14f3122f6aa37fa7c60d33562c7/distribution/push_v2.go#L408)

``` bash
bbland@Lark master¹] docker push registry-1-stage.docker.io/brianbland/test1
The push refers to a repository [registry-1-stage.docker.io/brianbland/test1]
5f70bf18a086: Pushed 
dfd83ed44976: Pushed 
217e6c75dcfc: Pushed 
c0b5f9221fac: Pushed 
latest: digest: sha256:b829109a30b2f6b9901042cd5bbe6bb7f83d9fabcf746f8ef8b650a0ad54a35b size: 1129
bbland@Lark master¹] docker tag registry-1-stage.docker.io/brianbland/test1 registry-1-stage.docker.io/brianbland/test2 
bbland@Lark master¹] docker push registry-1-stage.docker.io/brianbland/test2
The push refers to a repository [registry-1-stage.docker.io/brianbland/test2]
5f70bf18a086: Mounted from brianbland/test1 
dfd83ed44976: Mounted from brianbland/test1 
217e6c75dcfc: Mounted from brianbland/test1 
c0b5f9221fac: Mounted from brianbland/test1 
latest: digest: sha256:6dacab110ec7e0f1d0c14b5a5d2f44ff13529124d18df420da8de7d58e178644 size: 1029
```

Inspecting the manifests revealed that the only difference was the mediaType fields for each layer.
Original:

``` json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/octet-stream",
      "size": 2946,
      "digest": "sha256:1c9b046c28502c1d1267a7cfda7d89d29c9469d66e886cd79b34b9d03ed4d29d"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 65674854,
         "digest": "sha256:d89e1bee20d9cb344674e213b581f14fbd8e70274ecf9d10c514bab78a307845"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 71476,
         "digest": "sha256:9e0bc8a71bde464f710bc2b593a1fc21521517671e918687892303151331fa56"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 682,
         "digest": "sha256:27aa681c95e5165caf287dcfe896532df4ae8b10e099500f2f8f71acf4002a89"
      },
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 32,
         "digest": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
      }
   ]
}
```

X-Repo:

``` json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/octet-stream",
      "size": 2946,
      "digest": "sha256:1c9b046c28502c1d1267a7cfda7d89d29c9469d66e886cd79b34b9d03ed4d29d"
   },
   "layers": [
      {
         "mediaType": "application/octet-stream",
         "size": 65674854,
         "digest": "sha256:d89e1bee20d9cb344674e213b581f14fbd8e70274ecf9d10c514bab78a307845"
      },
      {
         "mediaType": "application/octet-stream",
         "size": 71476,
         "digest": "sha256:9e0bc8a71bde464f710bc2b593a1fc21521517671e918687892303151331fa56"
      },
      {
         "mediaType": "application/octet-stream",
         "size": 682,
         "digest": "sha256:27aa681c95e5165caf287dcfe896532df4ae8b10e099500f2f8f71acf4002a89"
      },
      {
         "mediaType": "application/octet-stream",
         "size": 32,
         "digest": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
      }
   ]
}
```
