### PR TITLE
[1.10-rc1] Remove locks on docker ps/inspect

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -32,9 +32,6 @@ func (daemon *Daemon) containerInspectCurrent(name string, size bool) (*types.Co
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
-
 	base, err := daemon.getInspectData(container, size)
 	if err != nil {
 		return nil, err

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -112,9 +112,6 @@ func (daemon *Daemon) reduceContainers(config *ContainersConfig, reducer contain
 
 // reducePsContainer is the basic representation for a container as expected by the ps command.
 func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *listContext, reducer containerReducer) (*types.Container, error) {
-	container.Lock()
-	defer container.Unlock()
-
 	// filter containers to return
 	action := includeContainerInList(container, ctx)
 	switch action {


### PR DESCRIPTION
What could possibly go wrong?  But seriously, what could?  By removing the locks all we run the chance of getting partially modified data but I'm not so sure why that would be a big deal.

https://github.com/docker/docker/issues/19328
