### PR TITLE
Don't error out when link name in use.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -601,6 +601,10 @@ func (daemon *Daemon) parents(c *container.Container) map[string]*container.Cont
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.nameIndex.Reserve(fullName, child.ID); err != nil {
+		if err == registrar.ErrNameReserved {
+			logrus.Warnf("error registering link for %s, to %s, as alias %s, ignoring: %v", parent.ID, child.ID, alias, err)
+			return nil
+		}
 		return err
 	}
 	daemon.linkIndex.link(parent, child, fullName)

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -212,3 +212,9 @@ func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
 	// /etc/hosts should be a regular file
 	c.Assert(out, checker.Matches, "^-.+\n")
 }
+
+func (s *DockerSuite) TestLinksMultipleWithSameName(c *check.C) {
+	dockerCmd(c, "run", "-d", "--name=upstream-a", "busybox", "top")
+	dockerCmd(c, "run", "-d", "--name=upstream-b", "busybox", "top")
+	dockerCmd(c, "run", "--link", "upstream-a:upstream", "--link", "upstream-b:upstream", "busybox", "sh", "-c", "ping -c 1 upstream")
+}


### PR DESCRIPTION
This preserves old behavior from sqlite links/names.

ping @tiborvass @aanand
Fixes #19444 
