### PR TITLE
Update registry version in Dockerfile.ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -109,7 +109,7 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 
 # both. This allows integration-cli tests to cover push/pull with both schema1
 # and schema2 manifests.
 ENV REGISTRY_COMMIT_SCHEMA1 ec87e9b6971d831f0eff752ddb54fb64693e51cd
-ENV REGISTRY_COMMIT a7ae88da459b98b481a245e5b1750134724ac67d
+ENV REGISTRY_COMMIT cb08de17d74bef86ce6c5abe8b240e282f5750be
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/distribution.git "$GOPATH/src/github.com/docker/distribution" \


### PR DESCRIPTION
This updates the Dockerfile registry version on ppc64le to be
consistent with 63099477189ea14f3122f6aa37fa7c60d33562c7

@StefanScherer adding this to ARM Dockerfile should fix TestCrossRepositoryLayerPush, which is skipped currently

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
