### PR TITLE
Verify that the configuration keys in the file are valid.

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -56,7 +56,6 @@ type CommonConfig struct {
 	GraphDriver          string              `json:"storage-driver,omitempty"`
 	GraphOptions         []string            `json:"storage-opts,omitempty"`
 	Labels               []string            `json:"labels,omitempty"`
-	LogConfig            LogConfig           `json:"log-config,omitempty"`
 	Mtu                  int                 `json:"mtu,omitempty"`
 	Pidfile              string              `json:"pidfile,omitempty"`
 	Root                 string              `json:"graph,omitempty"`
@@ -76,12 +75,16 @@ type CommonConfig struct {
 	// reachable by other hosts.
 	ClusterAdvertise string `json:"cluster-advertise,omitempty"`
 
-	Debug      bool             `json:"debug,omitempty"`
-	Hosts      []string         `json:"hosts,omitempty"`
-	LogLevel   string           `json:"log-level,omitempty"`
-	TLS        bool             `json:"tls,omitempty"`
-	TLSVerify  bool             `json:"tlsverify,omitempty"`
-	TLSOptions CommonTLSOptions `json:"tls-opts,omitempty"`
+	Debug     bool     `json:"debug,omitempty"`
+	Hosts     []string `json:"hosts,omitempty"`
+	LogLevel  string   `json:"log-level,omitempty"`
+	TLS       bool     `json:"tls,omitempty"`
+	TLSVerify bool     `json:"tlsverify,omitempty"`
+
+	// Embedded structs that allow config
+	// deserialization without the full struct.
+	CommonTLSOptions
+	LogConfig
 
 	reloadLock sync.Mutex
 	valuesSet  map[string]interface{}
@@ -227,7 +230,8 @@ func findConfigurationConflicts(config map[string]interface{}, flags *flag.FlagS
 		}
 	}
 
-	// 2. Discard keys that might have a given name, like `labels`.
+	// 2. Discard values that implement NamedOption.
+	// Their configuration name differs from their flag name, like `labels` and `label`.
 	unknownNamedConflicts := func(f *flag.Flag) {
 		if namedOption, ok := f.Value.(opts.NamedOption); ok {
 			if _, valid := unknownKeys[namedOption.Name()]; valid {

--- a/docker/common.go
+++ b/docker/common.go
@@ -18,6 +18,7 @@ const (
 	defaultCaFile       = "ca.pem"
 	defaultKeyFile      = "key.pem"
 	defaultCertFile     = "cert.pem"
+	tlsVerifyKey        = "tlsverify"
 )
 
 var (
@@ -60,7 +61,7 @@ func postParseCommon() {
 	// Regardless of whether the user sets it to true or false, if they
 	// specify --tlsverify at all then we need to turn on tls
 	// TLSVerify can be true even if not set due to DOCKER_TLS_VERIFY env var, so we need to check that here as well
-	if cmd.IsSet("-tlsverify") || commonFlags.TLSVerify {
+	if cmd.IsSet("-"+tlsVerifyKey) || commonFlags.TLSVerify {
 		commonFlags.TLS = true
 	}
 

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -362,7 +362,7 @@ func loadDaemonCliConfig(config *daemon.Config, daemonFlags *flag.FlagSet, commo
 
 	// Regardless of whether the user sets it to true or false, if they
 	// specify TLSVerify at all then we need to turn on TLS
-	if config.IsValueSet("tls-verify") {
+	if config.IsValueSet(tlsVerifyKey) {
 		config.TLS = true
 	}
 

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -204,9 +204,9 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 	defaultHost := opts.DefaultHost
 	if cli.Config.TLS {
 		tlsOptions := tlsconfig.Options{
-			CAFile:   cli.Config.TLSOptions.CAFile,
-			CertFile: cli.Config.TLSOptions.CertFile,
-			KeyFile:  cli.Config.TLSOptions.KeyFile,
+			CAFile:   cli.Config.CommonTLSOptions.CAFile,
+			CertFile: cli.Config.CommonTLSOptions.CertFile,
+			KeyFile:  cli.Config.CommonTLSOptions.KeyFile,
 		}
 
 		if cli.Config.TLSVerify {
@@ -338,12 +338,12 @@ func loadDaemonCliConfig(config *daemon.Config, daemonFlags *flag.FlagSet, commo
 	config.LogLevel = commonConfig.LogLevel
 	config.TLS = commonConfig.TLS
 	config.TLSVerify = commonConfig.TLSVerify
-	config.TLSOptions = daemon.CommonTLSOptions{}
+	config.CommonTLSOptions = daemon.CommonTLSOptions{}
 
 	if commonConfig.TLSOptions != nil {
-		config.TLSOptions.CAFile = commonConfig.TLSOptions.CAFile
-		config.TLSOptions.CertFile = commonConfig.TLSOptions.CertFile
-		config.TLSOptions.KeyFile = commonConfig.TLSOptions.KeyFile
+		config.CommonTLSOptions.CAFile = commonConfig.TLSOptions.CAFile
+		config.CommonTLSOptions.CertFile = commonConfig.TLSOptions.CertFile
+		config.CommonTLSOptions.KeyFile = commonConfig.TLSOptions.KeyFile
 	}
 
 	if configFile != "" {

--- a/docker/daemon_test.go
+++ b/docker/daemon_test.go
@@ -105,10 +105,11 @@ func TestLoadDaemonCliConfigWithTLSVerify(t *testing.T) {
 	}
 
 	configFile := f.Name()
-	f.Write([]byte(`{"tls-verify": true}`))
+	f.Write([]byte(`{"tlsverify": true}`))
 	f.Close()
 
 	flags := mflag.NewFlagSet("test", mflag.ContinueOnError)
+	flags.Bool([]string{"-tlsverify"}, false, "")
 	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
 	if err != nil {
 		t.Fatal(err)
@@ -136,10 +137,11 @@ func TestLoadDaemonCliConfigWithExplicitTLSVerifyFalse(t *testing.T) {
 	}
 
 	configFile := f.Name()
-	f.Write([]byte(`{"tls-verify": false}`))
+	f.Write([]byte(`{"tlsverify": false}`))
 	f.Close()
 
 	flags := mflag.NewFlagSet("test", mflag.ContinueOnError)
+	flags.Bool([]string{"-tlsverify"}, false, "")
 	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
 	if err != nil {
 		t.Fatal(err)
@@ -198,6 +200,7 @@ func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
 	f.Close()
 
 	flags := mflag.NewFlagSet("test", mflag.ContinueOnError)
+	flags.String([]string{"-log-level"}, "", "")
 	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
 	if err != nil {
 		t.Fatal(err)
@@ -211,5 +214,32 @@ func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {
 
 	if logrus.GetLevel() != logrus.WarnLevel {
 		t.Fatalf("expected warn log level, got %v", logrus.GetLevel())
+	}
+}
+
+func TestLoadDaemonCliConfigWithTLSOptions(t *testing.T) {
+	c := &daemon.Config{}
+	common := &cli.CommonFlags{}
+
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+	f.Write([]byte(`{"tls-opts": {"tlscacert": "/etc/certs/ca.pem"}}`))
+	f.Close()
+
+	flags := mflag.NewFlagSet("test", mflag.ContinueOnError)
+	flags.String([]string{"-tlscacert"}, "", "")
+	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadedConfig == nil {
+		t.Fatalf("expected configuration %v, got nil", c)
+	}
+	if loadedConfig.TLSOptions.CAFile != "/etc/certs/ca.pem" {
+		t.Fatalf("expected CA file path /etc/certs/ca.pem, got %v", loadedConfig.TLSOptions.CAFile)
 	}
 }

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -852,7 +852,7 @@ This is a full example of the allowed configuration options in the file:
 	"hosts": [],
 	"log-level": "",
 	"tls": true,
-	"tls-verify": true,
+	"tlsverify": true,
 	"tls-opts": {
 		"tlscacert": "",
 		"tlscert": "",

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -838,10 +838,8 @@ This is a full example of the allowed configuration options in the file:
 	"storage-driver": "",
 	"storage-opts": "",
 	"labels": [],
-	"log-config": {
-		"log-driver": "",
-		"log-opts": []
-	},
+	"log-driver": "",
+	"log-opts": [],
 	"mtu": 0,
 	"pidfile": "",
 	"graph": "",
@@ -853,11 +851,9 @@ This is a full example of the allowed configuration options in the file:
 	"log-level": "",
 	"tls": true,
 	"tlsverify": true,
-	"tls-opts": {
-		"tlscacert": "",
-		"tlscert": "",
-		"tlskey": ""
-	},
+	"tlscacert": "",
+	"tlscert": "",
+	"tlskey": "",
 	"api-cors-headers": "",
 	"selinux-enabled": false,
 	"userns-remap": "",

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -1223,11 +1223,27 @@ func (v mergeVal) IsBoolFlag() bool {
 	return false
 }
 
+// Name returns the name of a mergeVal.
+// If the original value had a name, return the original name,
+// otherwise, return the key asinged to this mergeVal.
+func (v mergeVal) Name() string {
+	type namedValue interface {
+		Name() string
+	}
+	if nVal, ok := v.Value.(namedValue); ok {
+		return nVal.Name()
+	}
+	return v.key
+}
+
 // Merge is an helper function that merges n FlagSets into a single dest FlagSet
 // In case of name collision between the flagsets it will apply
 // the destination FlagSet's errorHandling behavior.
 func Merge(dest *FlagSet, flagsets ...*FlagSet) error {
 	for _, fset := range flagsets {
+		if fset.formal == nil {
+			continue
+		}
 		for k, f := range fset.formal {
 			if _, ok := dest.formal[k]; ok {
 				var err error
@@ -1249,6 +1265,9 @@ func Merge(dest *FlagSet, flagsets ...*FlagSet) error {
 			}
 			newF := *f
 			newF.Value = mergeVal{f.Value, k, fset}
+			if dest.formal == nil {
+				dest.formal = make(map[string]*Flag)
+			}
 			dest.formal[k] = &newF
 		}
 	}

--- a/pkg/mflag/flag_test.go
+++ b/pkg/mflag/flag_test.go
@@ -514,3 +514,14 @@ func TestSortFlags(t *testing.T) {
 		t.Fatalf("NFlag (%d) != fs.NFlag() (%d) of elements visited", nflag, fs.NFlag())
 	}
 }
+
+func TestMergeFlags(t *testing.T) {
+	base := NewFlagSet("base", ContinueOnError)
+	base.String([]string{"f"}, "", "")
+
+	fs := NewFlagSet("test", ContinueOnError)
+	Merge(fs, base)
+	if len(fs.formal) != 1 {
+		t.Fatalf("FlagCount (%d) != number (1) of elements merged", len(fs.formal))
+	}
+}


### PR DESCRIPTION
Return an error if any of the keys don't match valid flags.
Flatten configuration file by embedding TLSOptions and LogConfig.

Fixes #19515 

/cc @cpuguy83

Signed-off-by: David Calavera david.calavera@gmail.com
