### PR TITLE
Unwrap URL errors on retry

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -145,6 +145,8 @@ func retryOnError(err error) error {
 		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied:
 			return xfer.DoNotRetry{Err: err}
 		}
+	case *url.Error:
+		return retryOnError(v.Err)
 	case *client.UnexpectedHTTPResponseError:
 		return xfer.DoNotRetry{Err: err}
 	}


### PR DESCRIPTION
When authorization errors are returned by the token process the error will be wrapped in `url.Error`.
In order to check the underlying error for retry this error message should be unwrapped.
Unwrapping this error allows failure to push due to an unauthorized response to keep from retrying, possibly resulting in later 429 responses.

Ping @aaronlehmann 
Ping @mattmoor (google container registry is not setting unauthorized code on error, this change would allow such errors to keep from hitting the new retry logic)
