### PR TITLE
Use sync.Pool for io.Copy buffers

### DIFF
--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -4,12 +4,12 @@ package overlay
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"syscall"
 	"time"
 
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/system"
 )
 
@@ -32,7 +32,7 @@ func copyRegular(srcPath, dstPath string, mode os.FileMode) error {
 	}
 	defer dstFile.Close()
 
-	_, err = io.Copy(dstFile, srcFile)
+	_, err = ioutils.Copy(dstFile, srcFile)
 
 	return err
 }

--- a/pkg/ioutils/copy.go
+++ b/pkg/ioutils/copy.go
@@ -1,0 +1,21 @@
+package ioutils
+
+import (
+	"io"
+	"sync"
+)
+
+const bufSize = 32 * 1024
+
+var bufPool = &sync.Pool{
+	New: func() interface{} { return make([]byte, bufSize) },
+}
+
+// Copy calls io.CopyBuffer with buffer from sync.Pool.
+// Buffer size is 32K.
+func Copy(dst io.Writer, src io.Reader) (written int64, err error) {
+	buf := bufPool.Get().([]byte)
+	written, err = io.CopyBuffer(dst, src, buf)
+	bufPool.Put(buf)
+	return
+}


### PR DESCRIPTION
Small ioutils.Copy function uses buffers from sync.Pool instead of allocating them on each io.Copy. The size of buffer chosen as a default size in io.Copy.
I used it only in overlay copy function because it was major memory eater.
