### PR TITLE
Use bufio.Reader in io.Copy source for overlay.copyRegular

### DIFF
--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -4,12 +4,12 @@ package overlay
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"syscall"
 	"time"
 
+	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/system"
 )
 
@@ -32,7 +32,7 @@ func copyRegular(srcPath, dstPath string, mode os.FileMode) error {
 	}
 	defer dstFile.Close()
 
-	_, err = io.Copy(dstFile, srcFile)
+	_, err = pools.Copy(dstFile, srcFile)
 
 	return err
 }


### PR DESCRIPTION
It allows avoiding allocation of 32K buffer each time because of WriteTo method.
ping @unclejack 
