### PR TITLE
Move Unsupp Network & IP check to the new updateNetworkConfig() func

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1147,7 +1147,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *check.C) {
 
 func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedPreferredIP(c *check.C) {
 	// preferred IP is not supported on predefined networks
-	for _, mode := range []string{"none", "host", "bridge"} {
+	for _, mode := range []string{"none", "host", "bridge", "default"} {
 		checkUnsupportedNetworkAndIP(c, mode)
 	}
 
@@ -1300,4 +1300,14 @@ func (s *DockerSuite) TestUserDefinedNetworkConnectDisconnectAlias(c *check.C) {
 	// ping to net2 scoped alias "bar" must still succeed
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "bar")
 	c.Assert(err, check.IsNil)
+
+	// verify the alias option is rejected when running on predefined network
+	out, _, err := dockerCmdWithError("run", "--rm", "--name=any", "--net-alias=any", "busybox", "top")
+	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
+	c.Assert(out, checker.Contains, runconfig.ErrUnsupportedNetworkAndAlias.Error())
+
+	// verify the alias option is rejected when connecting to predefined network
+	out, _, err = dockerCmdWithError("network", "connect", "--alias=any", "bridge", "first")
+	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
+	c.Assert(out, checker.Contains, runconfig.ErrUnsupportedNetworkAndAlias.Error())
 }

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -442,7 +442,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)] = epConfig
 	}
 
-	if hostConfig.NetworkMode.IsUserDefined() && flAliases.Len() > 0 {
+	if flAliases.Len() > 0 {
 		epConfig := networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)]
 		if epConfig == nil {
 			epConfig = &networktypes.EndpointSettings{}


### PR DESCRIPTION
Fixes #19417 

This now works again as expected:

```
$ ./docker run --ip 172.17.9.9 busybox
docker: Error response from daemon: User specified IP address is supported on user defined networks only.
```

Signed-off-by: Alessandro Boch aboch@docker.com
