### PR TITLE
Windows: Update dockerfile for Windows to Windows CI

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,57 +1,93 @@
-# This file describes the standard way to build Docker, using docker on TP4
+# This file describes the standard way to build Docker, using a docker container on Windows 
+# Server 2016
 #
 # Usage:
 #
-# # Assemble the full dev environment. This is slow the first time.
+# # Assemble the full dev environment. This is slow the first time. Run this from
+# # a directory containing the sources you are validating. For example from 
+# # c:\go\src\github.com\docker\docker
+#
 # docker build -t docker -f Dockerfile.windows .
 #
-# # Mount your source in an interactive container for quick testing:
-# docker run -it -v ${pwd}\bundles:c:/go/src/github.com/docker/docker/bundles docker cmd
 #
+# # Build docker in a container. Run the following from a Windows cmd command prommpt,
+# # replacing c:\built with the directory you want the binaries to be placed on the
+# # host system.
+#
+# docker run --rm -v "c:\built:c:\target" docker sh -c 'cd /c/go/src/github.com/docker/docker; hack/make.sh binary; ec=$?; if [ $ec -eq 0 ]; then robocopy /c/go/src/github.com/docker/docker/bundles/$(cat VERSION)/binary /c/target/binary; fi; exit $ec'
+#
+# Important notes:
+# ---------------
+#
+# Multiple commands in a single powershell RUN command are deliberately not done. This is
+# because PS doesn't have a concept quite like set -e in bash. It would be possible to use 
+# try-catch script blocks, but that would make this file unreadable. The problem is that
+# if there are two commands eg "RUN powershell -command fail; succeed", as far as docker
+# would be concerned, the return code from the overall RUN is succeed. This doesn't apply to
+# RUN which uses cmd as the command interpreter such as "RUN fail; succeed".
+#
+# 'sleep 5' is a deliberate workaround for a current problem on containers in Windows 
+# Server 2016. It ensures that the network is up and available for when the command is
+# network related. This bug is being tracked internally at Microsoft and exists in TP4.
+# Generally sleep 1 or 2 is probably enough, but making it 5 to make the build file
+# as bullet proof as possible. This isn't a big deal as this only runs the first time.
+#
+# The cygwin posix utilities from GIT aren't usable interactively as at January 2016. This
+# is because they require a console window which isn't present in a container in Windows.
+# See the example at the top of this file. Do NOT use -it in that docker run!!! 
+#
+# Don't try to use a volume for passing the source through. The cygwin posix utilities will
+# balk at reparse points. Again, see the example at the top of this file on how use a volume
+# to get the built binary out of the container.
 
 FROM windowsservercore
 
-ENV GO_VERSION=1.5.3 \
+# Environment variable notes:
+#  - GOLANG_VERSION should be updated to be consistent with the Linux dockerfile.
+#  - FROM_DOCKERFILE is used for detection of building within a container.
+ENV GOLANG_VERSION=1.5.3 \
     GIT_VERSION=2.7.0 \
-    RSRC_COMMIT=e48dbf1b7fc464a9e85fcec450dddf80816b76e0 \
+    RSRC_COMMIT=ba14da1f827188454a4591717fff29999010887f \
     GOPATH=C:/go;C:/go/src/github.com/docker/docker/vendor \
     FROM_DOCKERFILE=1
 
+# Make sure we're in temp for the downloads
 WORKDIR c:/windows/temp
 
-RUN powershell -command \
-    sleep 2 ; \
-    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+# Download everything else we need to install
+# We want a 64-bit make.exe, not 16 or 32-bit. This was hard to find, so documenting the links
+#  - http://sourceforge.net/p/mingw-w64/wiki2/Make/ -->
+#  - http://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/ -->
+#  - http://sourceforge.net/projects/mingw-w64/files/External binary packages %28Win64 hosted%29/make/
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile make.zip http://downloads.sourceforge.net/project/mingw-w64/External%20binary%20packages%20%28Win64%20hosted%29/make/make-3.82.90-20111115.zip
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile gcc.zip http://downloads.sourceforge.net/project/tdm-gcc/TDM-GCC%205%20series/5.1.0-tdm64-1/gcc-5.1.0-tdm64-1-core.zip 
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile runtime.zip http://downloads.sourceforge.net/project/tdm-gcc/MinGW-w64%20runtime/GCC%205%20series/mingw64runtime-v4-git20150618-gcc5-tdm64-1.zip
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile binutils.zip http://downloads.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-2.25-tdm64-1.zip
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile 7zsetup.exe http://www.7-zip.org/a/7z1514-x64.exe 
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile lzma.7z http://www.7-zip.org/a/lzma1514.7z
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile gitsetup.exe https://github.com/git-for-windows/git/releases/download/v%GIT_VERSION%.windows.1/Git-%GIT_VERSION%-64-bit.exe
+RUN powershell -command sleep 5; Invoke-WebRequest -UserAgent 'DockerCI' -outfile go.msi https://storage.googleapis.com/golang/go%GOLANG_VERSION%.windows-amd64.msi
 
-RUN powershell -command \
-    sleep 2 ; \
-    choco install curl -y -v ; \
-    choco install git -y -v --version=%GIT_VERSION% -params '"/GitAndUnixToolsOnPath"'
+# Path
+RUN setx /M Path "c:\git\cmd;c:\git\bin;c:\git\usr\bin;%Path%;c:\gcc\bin;c:\7zip"
 
-RUN setx /M Path "c:\ProgramData\chocolatey\bin;c:\Program Files\Git\usr\bin;%Path%;c:\gcc\bin"
+# Install and expand the bits we downloaded. 
+# Note: The git, 7z and go.msi installers execute asynchronously. 
+RUN powershell -command start-process .\gitsetup.exe -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /CLOSEAPPLICATIONS /DIR=c:\git' -Wait
+RUN powershell -command start-process .\7zsetup -ArgumentList '/S /D=c:/7zip' -Wait
+RUN powershell -command start-process .\go.msi -ArgumentList '/quiet' -Wait
+RUN powershell -command Expand-Archive gcc.zip \gcc -Force 
+RUN powershell -command Expand-Archive runtime.zip \gcc -Force 
+RUN powershell -command Expand-Archive binutils.zip \gcc -Force
+RUN powershell -command 7z e lzma.7z bin/lzma.exe
+RUN powershell -command 7z x make.zip  make-3.82.90-20111115/bin_amd64/make.exe 
+RUN powershell -command mv make-3.82.90-20111115/bin_amd64/make.exe /gcc/bin/ 
 
-RUN powershell -command \
-    sleep 2; \
-    curl.exe -L -k -o go.msi https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.msi; \
-    curl.exe -L -k -o gcc.zip http://downloads.sourceforge.net/project/tdm-gcc/TDM-GCC%205%20series/5.1.0-tdm64-1/gcc-5.1.0-tdm64-1-core.zip ; \
-    curl.exe -L -k -o runtime.zip http://downloads.sourceforge.net/project/tdm-gcc/MinGW-w64%20runtime/GCC%205%20series/mingw64runtime-v4-git20150618-gcc5-tdm64-1.zip ; \
-    curl.exe -L -k -o binutils.zip http://downloads.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-2.25-tdm64-1.zip
+# RSRC for manifest and icon	
+RUN powershell -command sleep 5 ; git clone https://github.com/akavel/rsrc.git c:\go\src\github.com\akavel\rsrc 
+RUN cd c:/go/src/github.com/akavel/rsrc && git checkout -q %RSRC_COMMIT% && go install -v
 
-RUN powershell -command \
-    .\go.msi /quiet ; \
-    Expand-Archive gcc.zip \gcc -Force ; \
-    Expand-Archive runtime.zip \gcc -Force ; \
-    Expand-Archive binutils.zip \gcc -Force
-
-RUN del go.msi gcc.zip runtime.zip binutils.zip
-
-RUN powershell -Command \
-    sleep 2 ; \
-    git clone https://github.com/akavel/rsrc.git c:\go\src\github.com\akavel\rsrc ; \
-    cd \go\src\github.com\akavel\rsrc ; \
-    git checkout -q $env:RSRC_COMMIT ; \
-    go install -v
-
-WORKDIR c:/go/src/github.com/docker/docker
-
+# Prepare for building
+WORKDIR c:/
 COPY . /go/src/github.com/docker/docker
+


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@mikedougherty @jfrazelle @icecrime @thaJeztah @powersplay

A significant update to Dockerfile.windows to bring it up to date (eg version of rsrc) and make it far more reliable. This has been verified on internal builds of 'TP5', and completes a full Jenkins run. Biggest step forward is now building docker in docker, hence no need for the CI servers have compilers or rsrc installed, and fully utilizing the bash scripts in `hack` for building and testing. 

Note this needs to be merged before we can bring Windows to Windows CI online if we are going to build docker in docker, which is by far the preferred option. Otherwise, I can fall back to an alternate Jenkins scripts which does a local build instead.

Output from a full CI run against a very recent 'TP5' build of Windows using this dockerfile is below to demonstrate it works :smile:! (Even though one of the tests failed - flakey test!!!)

```

C:\Go\src\github.com\docker\docker>sh /e/docker/ci/scripts/doit.sh
INFO: Started at Wed Jan 20 19:09:21 PST 2016.
INFO: Script version 20-Jan-2016 14:38 PST
INFO: Running bash version 4.3.42(5)-release
INFO: Root for testing is /c/go
INFO: Workspace for sources is /c/go/src/github.com/docker/docker
INFO: GOPATH set to /c/go:/c/go/src/github.com/docker/docker/vendor
INFO: The control daemon replied to a ping. Good!
INFO: Repository was found
INFO: Commit hash is 52a1836
INFO: End of cleanup
INFO: Location for testing is /c/CI/CI-52a1836
INFO: Validating installed GOLang version go1.5.3 is correct...
INFO: Validating GOLang consistency in Dockerfile.windows...
INFO: Docker version of control daemon

Client:
 Version:      1.10.0-dev
 API version:  1.23
 Go version:   go1.5.2
 Git commit:   7657e23
 Built:        Wed Jan 20 02:42:44 UTC 2016
 OS/Arch:      windows/amd64

Server:
 Version:      1.10.0-dev
 API version:  1.23
 Go version:   go1.5.2
 Git commit:   7657e23
 Built:        Wed Jan 20 02:42:44 UTC 2016
 OS/Arch:      windows/amd64

INFO: Docker info of control daemon

Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 1
Server Version: 1.10.0-dev
Storage Driver: windowsfilter
 Windows:
Execution Driver:
 Name: Windows 1854
 Build: 1.10.0-dev 7657e23
 Default Isolation: process
Logging Driver: json-file
Plugins:
 Volume: local
 Network:
Kernel Version: 10.0 11102 (11102.1004.amd64fre.rs1_onecore_container_hyp.160118-1800)
Operating System: Windows Server 2016 Technical Preview 4 Standard
OSType: windows
Architecture: x86_64
CPUs: 8
Total Memory: 4.36 GiB
Name: WIN-H8I65ROOE40
ID: D2AT:YE63:GIYL:C7HG:UKQA:SLWN:5BBU:KBGX:BB2K:7KZV:V6S4:KVLD
Debug mode (server): true
 File Descriptors: -1
 Goroutines: 29
 System Time: 2016-01-20T19:09:22.6565371-08:00
 EventsListeners: 0
 Init SHA1:
 Init Path: e:\go\src\github.com\docker\docker\docker\docker.exe
 Docker Root Dir: C:\ProgramData\docker

INFO: Running initial test suite on sources...
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

bundles/1.10.0-dev already exists. Removing.

---> Making bundle: validate-dco (in bundles/1.10.0-dev/validate-dco)
Congratulations!  All commits are properly signed with the DCO!

---> Making bundle: validate-gofmt (in bundles/1.10.0-dev/validate-gofmt)
Congratulations!  All Go source files are properly formatted.

---> Making bundle: validate-pkg (in bundles/1.10.0-dev/validate-pkg)
Congratulations! "./pkg/..." is safely isolated from internal code.

---> Making bundle: validate-lint (in bundles/1.10.0-dev/validate-lint)
Congratulations!  All Go source files have been linted.

---> Making bundle: validate-toml (in bundles/1.10.0-dev/validate-toml)
Congratulations!  All toml source files changed here have valid syntax.

---> Making bundle: validate-vet (in bundles/1.10.0-dev/validate-vet)
Congratulations!  All Go source files have been vetted.

---> Making bundle: validate-vendor (in bundles/1.10.0-dev/validate-vendor)

INFO: Building the image from Dockerfile.windows...
+ docker build -t docker -f Dockerfile.windows .
Sending build context to Docker daemon 171.5 MB
Step 1 : FROM windowsservercore
 ---> 76a47dab27ad
Step 2 : ENV GOLANG_VERSION 1.5.3 GIT_VERSION 2.7.0 RSRC_COMMIT ba14da1f827188454a4591717fff29999010887f GOPATH C:/go;C:/go/src/github.com/docker/docker/vendor FROM_DOCKERFILE 1
 ---> Running in 94faf9c97eec
 ---> d9abfbc72ace
Removing intermediate container 94faf9c97eec
Step 3 : WORKDIR c:/windows/temp
 ---> Running in 001c1143fb26
 ---> 89ad49d87e7a
Removing intermediate container 001c1143fb26
Step 4 : RUN powershell -command sleep 5 ; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 ---> Running in 20938b696571

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        1/20/2016   7:09 PM                chocInstall
Downloading https://packages.chocolatey.org/chocolatey.0.9.9.11.nupkg to C:\Windows\TEMP\chocolatey\chocInstall\chocolatey.zip
Download 7Zip commandline tool
Downloading https://chocolatey.org/7za.exe to C:\Windows\TEMP\chocolatey\chocInstall\7za.exe
Extracting C:\Windows\TEMP\chocolatey\chocInstall\chocolatey.zip to C:\Windows\TEMP\chocolatey\chocInstall...

7-Zip (A) 9.20  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18

Processing archive: C:\Windows\TEMP\chocolatey\chocInstall\chocolatey.zip

Extracting  _rels\.rels
Extracting  chocolatey.nuspec
Extracting  tools\chocolateyInstall.ps1
Extracting  tools\chocolateysetup.psm1
Extracting  tools\init.ps1
Extracting  tools\chocolateyInstall\choco.exe
Extracting  tools\chocolateyInstall\choco.exe.ignore
Extracting  tools\chocolateyInstall\LICENSE.txt
Extracting  tools\chocolateyInstall\helpers\chocolateyInstaller.psm1
Extracting  tools\chocolateyInstall\helpers\chocolateyScriptRunner.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-BinRoot.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-CheckSumValid.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-ChocolateyUnzip.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-ChocolateyWebFile.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-EnvironmentVariable.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-EnvironmentVariableNames.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-FtpFile.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-ProcessorBits.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-UACEnabled.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-VirusCheckValid.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-WebFile.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Get-WebHeaders.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-BinFile.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyDesktopLink.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyEnvironmentVariable.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyExplorerMenuItem.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyFileAssociation.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyInstallPackage.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyPackage.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyPath.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyPinnedTaskBarItem.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyPowershellCommand.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyShortcut.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyVsixPackage.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Install-ChocolateyZipPackage.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Set-EnvironmentVariable.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Start-ChocolateyProcessAsAdmin.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Test-ProcessAdminRights.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Uninstall-BinFile.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Uninstall-ChocolateyPackage.ps1
Extracting  tools\chocolateyInstall\helpers\functions\UnInstall-ChocolateyZipPackage.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Update-SessionEnvironment.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Write-ChocolateyFailure.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Write-ChocolateySuccess.ps1
Extracting  tools\chocolateyInstall\helpers\functions\Write-FileUpdateLog.ps1
Extracting  tools\chocolateyInstall\redirects\choco.exe
Extracting  tools\chocolateyInstall\redirects\choco.exe.ignore
Extracting  tools\chocolateyInstall\redirects\chocolatey.exe
Extracting  tools\chocolateyInstall\redirects\chocolatey.exe.ignore
Extracting  tools\chocolateyInstall\redirects\cinst.exe
Extracting  tools\chocolateyInstall\redirects\cinst.exe.ignore
Extracting  tools\chocolateyInstall\redirects\clist.exe
Extracting  tools\chocolateyInstall\redirects\clist.exe.ignore
Extracting  tools\chocolateyInstall\redirects\cpack.exe
Extracting  tools\chocolateyInstall\redirects\cpack.exe.ignore
Extracting  tools\chocolateyInstall\redirects\cpush.exe
Extracting  tools\chocolateyInstall\redirects\cpush.exe.ignore
Extracting  tools\chocolateyInstall\redirects\cuninst.exe
Extracting  tools\chocolateyInstall\redirects\cuninst.exe.ignore
Extracting  tools\chocolateyInstall\redirects\cup.exe
Extracting  tools\chocolateyInstall\redirects\cup.exe.ignore
Extracting  tools\chocolateyInstall\redirects\cver.exe
Extracting  tools\chocolateyInstall\redirects\cver.exe.ignore
Extracting  tools\chocolateyInstall\redirects\RefreshEnv.cmd
Extracting  tools\chocolateyInstall\tools\7za.exe
Extracting  tools\chocolateyInstall\tools\7za.exe.ignore
Extracting  tools\chocolateyInstall\tools\7za.exe.manifest
Extracting  tools\chocolateyInstall\tools\7zip.license.txt
Extracting  tools\chocolateyInstall\tools\checksum.exe
Extracting  tools\chocolateyInstall\tools\checksum.exe.ignore
Extracting  tools\chocolateyInstall\tools\checksum.license.txt
Extracting  tools\chocolateyInstall\tools\shimgen.exe
Extracting  tools\chocolateyInstall\tools\shimgen.exe.ignore
Extracting  tools\chocolateyInstall\tools\shimgen.license.txt
Extracting  package\services\metadata\core-properties\d830953f078f45f99a2e4d814d1b7974.psmdcp
Extracting  [Content_Types].xml

Everything is Ok

Files: 76
Size:       4893948
Compressed: 1806765
Installing chocolatey on this machine
Creating ChocolateyInstall as an environment variable (targeting 'Machine')
  Setting ChocolateyInstall to 'C:\ProgramData\chocolatey'
WARNING: It's very likely you will need to close and reopen your shell
  before you can use choco.
Adding Modify permission for current user to 'C:\ProgramData\chocolatey'
We are setting up the Chocolatey package repository.
The packages themselves go to 'C:\ProgramData\chocolatey\lib'
  (i.e. C:\ProgramData\chocolatey\lib\yourPackageName).
A shim file for the command line goes to 'C:\ProgramData\chocolatey\bin'
  and points to an executable in 'C:\ProgramData\chocolatey\lib\yourPackageName'.

Creating Chocolatey folders if they do not already exist.

WARNING: You can safely ignore errors related to missing log files when
  upgrading from a version of Chocolatey less than 0.9.9.
  'Batch file could not be found' is also safe to ignore.
  'The system cannot find the file specified' - also safe.
chocolatey.nupkg file not installed in lib.
 Attempting to locate it from bootstrapper.
PATH environment variable does not have C:\ProgramData\chocolatey\bin in it. Adding...
Chocolatey (choco.exe) is now ready.
You can call choco from anywhere, command line or powershell by typing choco.
Run choco /? for a list of functions.
You may need to shut down and restart powershell and/or consoles
 first prior to using choco.
Ensuring chocolatey commands are on the path
Ensuring chocolatey.nupkg is in the lib folder


 ---> 5c3bd76774ac
Removing intermediate container 20938b696571
Step 5 : RUN powershell -command sleep 5; choco install curl -y -v
 ---> Running in 489630be5f0d
Installing the following packages:
curl
By installing you accept licenses for the packages.

curl v7.28.1
 ShimGen has successfully created a shim for curl.exe
 The install of curl was successful.

Chocolatey installed 1/1 package(s). 0 package(s) failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
 ---> afdad21dc77b
Removing intermediate container 489630be5f0d
Step 6 : RUN powershell -command sleep 5; choco install git -y -v --version=%GIT_VERSION% -params '"/GitAndUnixToolsOnPath"'
 ---> Running in 547e18325b7f
Installing the following packages:
git
By installing you accept licenses for the packages.

git.install v2.7.0
 VERBOSE: Exporting function 'Get-BinRoot'.
 VERBOSE: Exporting function 'Get-ChecksumValid'.
 VERBOSE: Exporting function 'Get-ChocolateyUnzip'.
 VERBOSE: Exporting function 'Get-ChocolateyWebFile'.
 VERBOSE: Exporting function 'Get-EnvironmentVariable'.
 VERBOSE: Exporting function 'Get-EnvironmentVariableNames'.
 VERBOSE: Exporting function 'Get-FtpFile'.
 VERBOSE: Exporting function 'Get-ProcessorBits'.
 VERBOSE: Exporting function 'Get-UACEnabled'.
 VERBOSE: Exporting function 'Get-VirusCheckValid'.
 VERBOSE: Exporting function 'Get-WebFile'.
 VERBOSE: Exporting function 'Get-WebHeaders'.
 VERBOSE: Exporting function 'Install-BinFile'.
 VERBOSE: Exporting function 'Install-ChocolateyDesktopLink'.
 VERBOSE: Exporting function 'Install-ChocolateyEnvironmentVariable'.
 VERBOSE: Exporting function 'Install-ChocolateyExplorerMenuItem'.
 VERBOSE: Exporting function 'Install-ChocolateyFileAssociation'.
 VERBOSE: Exporting function 'Install-ChocolateyInstallPackage'.
 VERBOSE: Exporting function 'Install-ChocolateyPackage'.
 VERBOSE: Exporting function 'Install-ChocolateyPath'.
 VERBOSE: Exporting function 'Install-ChocolateyPinnedTaskBarItem'.
 VERBOSE: Exporting function 'Install-ChocolateyPowershellCommand'.
 VERBOSE: Exporting function 'Install-ChocolateyShortcut'.
 VERBOSE: Exporting function 'Install-ChocolateyVsixPackage'.
 VERBOSE: Exporting function 'Install-Vsix'.
 VERBOSE: Exporting function 'Install-ChocolateyZipPackage'.
 VERBOSE: Exporting function 'Set-EnvironmentVariable'.
 VERBOSE: Exporting function 'Start-ChocolateyProcessAsAdmin'.
 VERBOSE: Exporting function 'Test-ProcessAdminRights'.
 VERBOSE: Exporting function 'Uninstall-BinFile'.
 VERBOSE: Exporting function 'Uninstall-ChocolateyPackage'.
 VERBOSE: Exporting function 'UnInstall-ChocolateyZipPackage'.
 VERBOSE: Exporting function 'Update-SessionEnvironment'.
 VERBOSE: Exporting function 'Write-ChocolateyFailure'.
 VERBOSE: Exporting function 'Write-ChocolateySuccess'.
 VERBOSE: Exporting function 'Write-FileUpdateLog'.
 VERBOSE: Exporting alias 'Generate-BinFile'.
 VERBOSE: Exporting alias 'Add-BinFile'.
 VERBOSE: Exporting alias 'Remove-BinFile'.
 You want Git and Unix Tools on the command line
 Downloading git.install 64 bit
   from 'https://github.com/git-for-windows/git/releases/download/v2.7.0.windows.1/Git-2.7.0-64-bit.exe'
 Installing git.install...
 git.install has been installed.
 WARNING: Git installed - You may need to close and reopen your shell for PATH
 changes to take effect.
 The install of git.install was successful.

git v2.7.0
 The install of git was successful.

Chocolatey installed 2/2 package(s). 0 package(s) failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
 ---> 10f963940d84
Removing intermediate container 547e18325b7f
Step 7 : RUN setx /M Path "c:\ProgramData\chocolatey\bin;c:\Program Files\Git\usr\bin;%Path%;c:\gcc\bin;c:\7zip"
 ---> Running in dcf4f06bc74f

SUCCESS: Specified value was saved.
 ---> 75f9d17fa03c
Removing intermediate container dcf4f06bc74f
Step 8 : RUN powershell -command sleep 5; curl.exe -L -k -o make.zip http://downloads.sourceforge.net/project/mingw-w64/External%20binary%20packages%20%28Win64%20hosted%29/make/make-3.82.90-20111115.zip
 ---> Running in 8286f3414188
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   459    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2523k  100 2523k    0     0   134k      0  0:00:18  0:00:18 --:--:--  166k
 ---> 8a433f38878d
Removing intermediate container 8286f3414188
Step 9 : RUN powershell -command sleep 5; curl.exe -L -k -o gcc.zip http://downloads.sourceforge.net/project/tdm-gcc/TDM-GCC%205%20series/5.1.0-tdm64-1/gcc-5.1.0-tdm64-1-core.zip
 ---> Running in 6644ac39f10a
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   399    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 23.8M  100 23.8M    0     0   189k      0  0:02:09  0:02:09 --:--:--  183k
 ---> 6aec438c18a0
Removing intermediate container 6644ac39f10a
Step 10 : RUN powershell -command sleep 5; curl.exe -L -k -o runtime.zip http://downloads.sourceforge.net/project/tdm-gcc/MinGW-w64%20runtime/GCC%205%20series/mingw64runtime-v4-git20150618-gcc5-tdm64-1.zip
 ---> Running in 4c4b3f0b3606
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   443    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 15.0M  100 15.0M    0     0   164k      0  0:01:33  0:01:33 --:--:--  148k
 ---> 8df00176532b
Removing intermediate container 4c4b3f0b3606
Step 11 : RUN powershell -command sleep 5; curl.exe -L -k -o binutils.zip http://downloads.sourceforge.net/project/tdm-gcc/GNU%20binutils/binutils-2.25-tdm64-1.zip
 ---> Running in fd12969bdc75
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   363    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 13.4M  100 13.4M    0     0   338k      0  0:00:40  0:00:40 --:--:-- 1825k
 ---> da9e26d67212
Removing intermediate container fd12969bdc75
Step 12 : RUN powershell -command sleep 5; curl.exe -L -k -o 7zsetup.exe http://www.7-zip.org/a/7z1514-x64.exe
 ---> Running in 0125620b7739
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1339k  100 1339k    0     0   824k      0  0:00:01  0:00:01 --:--:--  996k
 ---> 0767d3cbc945
Removing intermediate container 0125620b7739
Step 13 : RUN powershell -command sleep 5; curl.exe -L -k -o lzma.7z http://www.7-zip.org/a/lzma1514.7z
 ---> Running in 0528e3bc1dbf
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   169  100   169    0     0    492      0 --:--:-- --:--:-- --:--:--  1083
100  946k  100  946k    0     0   420k      0  0:00:02  0:00:02 --:--:--  928k
 ---> c0ec9a61909b
Removing intermediate container 0528e3bc1dbf
Step 14 : RUN powershell -command sleep 5; curl.exe -L -k -o go.msi https://storage.googleapis.com/golang/go%GOLANG_VERSION%.windows-amd64.msi
 ---> Running in c8d7b3598e73
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 67.4M  100 67.4M    0     0  47.9M      0  0:00:01  0:00:01 --:--:-- 49.0M
 ---> d28c0edb93ee
Removing intermediate container c8d7b3598e73
Step 15 : RUN powershell -command .\7zsetup /S /D="c:/7zip" ; sleep 5
 ---> Running in e91bc9f2b8ce
 ---> f30938cec56e
Removing intermediate container e91bc9f2b8ce
Step 16 : RUN powershell -command .\go.msi /quiet ; wait-process msiexec
 ---> Running in ec7d31f75cce
Removing intermediate container ec7d31f75cce
Step 17 : RUN powershell -command Expand-Archive gcc.zip \gcc -Force
 ---> Running in 533ff6fd579e
Removing intermediate container 533ff6fd579e
Step 18 : RUN powershell -command Expand-Archive runtime.zip \gcc -Force
 ---> Running in 60c31c335a7a
 ---> d3ee9e91cf52
Removing intermediate container 60c31c335a7a
Step 19 : RUN powershell -command Expand-Archive binutils.zip \gcc -Force
 ---> Running in d7e466a478f4
 ---> d9a33f22f069
Removing intermediate container d7e466a478f4
Step 20 : RUN powershell -command 7z e lzma.7z bin/lzma.exe
 ---> Running in b4997025e266

7-Zip [64] 15.14 : Copyright (c) 1999-2015 Igor Pavlov : 2015-12-31

Scanning the drive for archives:
1 file, 969380 bytes (947 KiB)

Extracting archive: lzma.7z
--
Path = lzma.7z
Type = 7z
Physical Size = 969380
Headers Size = 10907
Method = LZMA:3m BCJ2
Solid = +
Blocks = 3

Everything is Ok

Files: 6
Size:       775168
Compressed: 969380
 ---> de668a5c702f
Removing intermediate container b4997025e266
Step 21 : RUN powershell -command 7z x make.zip  make-3.82.90-20111115/bin_amd64/make.exe
 ---> Running in f406602f3597

7-Zip [64] 15.14 : Copyright (c) 1999-2015 Igor Pavlov : 2015-12-31

Scanning the drive for archives:
1 file, 2584446 bytes (2524 KiB)

Extracting archive: make.zip
--
Path = make.zip
Type = zip
Physical Size = 2584446

Everything is Ok

Size:       193024
Compressed: 2584446
 ---> 0889aab74f73
Removing intermediate container f406602f3597
Step 22 : RUN powershell -command mv make-3.82.90-20111115/bin_amd64/make.exe /gcc/bin/
 ---> Running in 7ae7fc98d246
 ---> 5503b331032a
Removing intermediate container 7ae7fc98d246
Step 23 : RUN powershell -command sleep 5 ; git clone https://github.com/akavel/rsrc.git c:\go\src\github.com\akavel\rsrc
 ---> Running in 70a8458a4972
Cloning into 'c:\go\src\github.com\akavel\rsrc'...
 ---> 0acea0f4598c
Removing intermediate container 70a8458a4972
Step 24 : RUN cd c:/go/src/github.com/akavel/rsrc && git checkout -q %RSRC_COMMIT% && go install -v
 ---> Running in 59dd86c507a8
github.com/akavel/rsrc/binutil
github.com/akavel/rsrc/ico
github.com/akavel/rsrc/coff
github.com/akavel/rsrc
 ---> 04276770ee04
Removing intermediate container 59dd86c507a8
Step 25 : WORKDIR c:/
 ---> Running in 9221d37cd889
 ---> 2d9394a4ab2a
Removing intermediate container 9221d37cd889
Step 26 : COPY . /go/src/github.com/docker/docker
 ---> e6d93f5e6402
Removing intermediate container 0d4f6819237e
Successfully built e6d93f5e6402
+ ec=0
+ set +x
INFO: Building the test binary...
+ docker run --rm -v 'c:\CI\CI-52a1836:c:\target' docker sh -c 'cd /c/go/src/github.com/docker/docker; \
                                                hack/make.sh binary; \
                                                ec=$?; \
                                                if [ $ec -eq 0 ]; then \
                                                        robocopy /c/go/src/github.com/docker/docker/bundles/$(cat VERSION)/binary /c/target/binary; \
                                                fi; \
                                                exit $ec'
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

---> Making bundle: binary (in bundles/1.10.0-dev/binary)
Building: bundles/1.10.0-dev/binary/docker-1.10.0-dev.exe
Created binary: bundles/1.10.0-dev/binary/docker-1.10.0-dev.exe


-------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : Wednesday, January 20, 2016 7:27:39 PM
   Source : C:\go\src\github.com\docker\docker\bundles\1.10.0-dev\binary\
     Dest : C:\target\binary\

  Options : *.* /DCOPY:DA /COPY:DAT /R:1000000 /W:30
                           4    C:\go\src\github.com\docker\docker\bundles\1.10.0-dev\binary\
100%  --    New File  ----------  27.3 m--------docker-1.10.0-dev.exe---------
100%        New File                  56        docker-1.10.0-dev.exe.md5
100%        New File              27.3 m        docker.exe0.0-dev.exe.sha256

------------------------------------------------------------------------------

               Total    Copied   Skipped  Mismatch    FAILED    Extras
    Dirs :         1         0         1         0         0         0
   Files :         4         4         0         0         0         0
   Bytes :   54.69 m   54.69 m         0         0         0         0
   Times :   0:00:00   0:00:00                       0:00:00   0:00:00


   Speed :           1246800652 Bytes/sec.
   Speed :            71342.505 MegaBytes/min.
   Ended : Wednesday, January 20, 2016 7:27:39 PM

+ ec=0
+ set +x
INFO: Linking the built binary to /c/CI/CI-52a1836/docker-52a1836...
INFO: Starting a daemon under test...
INFO: Daemon under test started
INFO: Waiting for daemon under test to start...
INFO: Daemon under test started and replied!
INFO: Docker version of the daemon under test

Client:
 Version:      1.10.0-dev
 API version:  1.23
 Go version:   go1.5.3
 Git commit:   52a1836
 Built:        Wed Jan 20 19:26:32 2016
 OS/Arch:      windows/amd64

Server:
 Version:      1.10.0-dev
 API version:  1.23
 Go version:   go1.5.3
 Git commit:   52a1836
 Built:        Wed Jan 20 19:26:32 2016
 OS/Arch:      windows/amd64

INFO: Docker info of the daemon under test

Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 1
Server Version: 1.10.0-dev
Storage Driver: windowsfilter
 Windows:
Execution Driver:
 Name: Windows 1854
 Build: 1.10.0-dev 52a1836
 Default Isolation: process
Logging Driver: json-file
Plugins:
 Volume: local
 Network:
Kernel Version: 10.0 11102 (11102.1004.amd64fre.rs1_onecore_container_hyp.160118-1800)
Operating System: Windows Server 2016 Technical Preview 4 Standard
OSType: windows
Architecture: x86_64
CPUs: 8
Total Memory: 5.353 GiB
Name: WIN-H8I65ROOE40
ID: D2AT:YE63:GIYL:C7HG:UKQA:SLWN:5BBU:KBGX:BB2K:7KZV:V6S4:KVLD
Debug mode (server): true
 File Descriptors: -1
 Goroutines: 23
 System Time: 2016-01-20T19:27:41.1409406-08:00
 EventsListeners: 0
 Init SHA1:
 Init Path: C:\CI\CI-52a1836\binary\docker-52a1836.exe
 Docker Root Dir: C:/CI/CI-52a1836/daemon/graph

INFO: Running integration tests...
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

bundles/1.10.0-dev already exists. Removing.

---> Making bundle: test-integration-cli (in bundles/1.10.0-dev/test-integration-cli)
---> Making bundle: .integration-daemon-start (in bundles/1.10.0-dev/test-integration-cli)
INFO: Waiting for daemon to start...

---> Making bundle: .integration-daemon-setup (in bundles/1.10.0-dev/test-integration-cli)
---> Making bundle: .detect-daemon-osarch (in bundles/1.10.0-dev/test-integration-cli)
---> Making bundle: .ensure-frozen-images-windows (in bundles/1.10.0-dev/test-integration-cli)
INFO: Tagged windowsservercore:10.0.11102.1004 with latest
INFO: Building busybox
Downloading build context from remote url: https://raw.githubusercontent.com/jhowardmsft/busybox/master/Dockerfile    552 B
Sending build context to Docker daemon  2.56 kB
Step 1 : FROM windowsservercore
 ---> 76a47dab27ad
Step 2 : ADD http://frippery.org/files/busybox/busybox.exe /

 ---> fbb5c73d15ab
Removing intermediate container 7057acc59d6f
Step 3 : ENTRYPOINT /busybox.exe
 ---> Running in 6883f15f6334
 ---> 056c79445a25
Removing intermediate container 6883f15f6334
Successfully built 056c79445a25
+ go test -test.timeout=180m -check.v github.com/docker/docker/integration-cli
INFO: Testing against a local daemon
PASS: docker_api_test.go:51: DockerSuite.TestApiClientVersionNewerThanServer    0.002s
PASS: docker_api_test.go:65: DockerSuite.TestApiClientVersionOldNotSupported    0.003s
SKIP: docker_api_network_test.go:222: DockerSuite.TestApiCreateDeletePredefinedNetworks (Test requires a Linux daemon)
PASS: docker_api_create_test.go:11: DockerSuite.TestApiCreateWithNotExistImage  0.002s
PASS: docker_api_test.go:79: DockerSuite.TestApiDockerApiVersion        0.045s
PASS: docker_api_test.go:24: DockerSuite.TestApiGetEnabledCors  0.001s
SKIP: docker_api_images_test.go:74: DockerSuite.TestApiImagesDelete (Test requires a Linux daemon)
SKIP: docker_api_images_test.go:14: DockerSuite.TestApiImagesFilter (Test requires a Linux daemon)
SKIP: docker_api_images_test.go:97: DockerSuite.TestApiImagesHistory (Test requires a Linux daemon)
SKIP: docker_api_images_test.go:51: DockerSuite.TestApiImagesSaveAndLoad (Test requires a Linux daemon)
PASS: docker_api_images_test.go:119: DockerSuite.TestApiImagesSearchJSONContentType     1.073s
SKIP: docker_api_network_test.go:122: DockerSuite.TestApiNetworkConnectDisconnect (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:43: DockerSuite.TestApiNetworkCreateCheckDuplicate (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:27: DockerSuite.TestApiNetworkCreateDelete (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:66: DockerSuite.TestApiNetworkFilter (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:18: DockerSuite.TestApiNetworkGetDefaults (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:72: DockerSuite.TestApiNetworkInspect (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:163: DockerSuite.TestApiNetworkIpamMultipleBridgeNetworks (Test requires a Linux daemon)
PASS: docker_api_test.go:18: DockerSuite.TestApiOptionsRoute    0.001s
SKIP: docker_api_stats_test.go:224: DockerSuite.TestApiStatsContainerNotFound (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:82: DockerSuite.TestApiStatsNetworkStats (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:128: DockerSuite.TestApiStatsNetworkStatsVersioning (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:21: DockerSuite.TestApiStatsNoStreamGetCpu (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:46: DockerSuite.TestApiStatsStoppedContainerInGoroutines (Test requires a Linux daemon)
PASS: docker_api_test.go:36: DockerSuite.TestApiVersionStatusCode       0.000s
SKIP: docker_cli_run_test.go:3349: DockerSuite.TestAppArmorDeniesChmodProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:3327: DockerSuite.TestAppArmorDeniesPtrace (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:3339: DockerSuite.TestAppArmorTraceSelf (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:124: DockerSuite.TestAttachDisconnect (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:18: DockerSuite.TestAttachMultipleAndRestart (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:155: DockerSuite.TestAttachPausedContainer (Test requires a Linux daemon)
SKIP: docker_cli_attach_test.go:89: DockerSuite.TestAttachTtyWithoutStdin (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1573: DockerSuite.TestBuildAddBadLinks (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1660: DockerSuite.TestBuildAddBadLinksVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4142: DockerSuite.TestBuildAddBrokenTar (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2740: DockerSuite.TestBuildAddCurrentDirWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2798: DockerSuite.TestBuildAddCurrentDirWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1267: DockerSuite.TestBuildAddDirContentToExistingDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1243: DockerSuite.TestBuildAddDirContentToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1321: DockerSuite.TestBuildAddEtcToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3158: DockerSuite.TestBuildAddFileNotFound (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:970: DockerSuite.TestBuildAddFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2953: DockerSuite.TestBuildAddLocalAndRemoteFilesWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3038: DockerSuite.TestBuildAddLocalAndRemoteFilesWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2618: DockerSuite.TestBuildAddLocalFileWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2678: DockerSuite.TestBuildAddLocalFileWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:838: DockerSuite.TestBuildAddMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:882: DockerSuite.TestBuildAddMultipleFilesToFileWild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1042: DockerSuite.TestBuildAddMultipleFilesToFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2649: DockerSuite.TestBuildAddMultipleLocalFileWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4194: DockerSuite.TestBuildAddNonTar (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1340: DockerSuite.TestBuildAddPreservesFilesSpecialBits (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2891: DockerSuite.TestBuildAddRemoteFileMTime (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2826: DockerSuite.TestBuildAddRemoteFileWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2858: DockerSuite.TestBuildAddRemoteFileWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4061: DockerSuite.TestBuildAddScript (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:767: DockerSuite.TestBuildAddSingleFileToExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1217: DockerSuite.TestBuildAddSingleFileToNonExistingDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:714: DockerSuite.TestBuildAddSingleFileToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:740: DockerSuite.TestBuildAddSingleFileToWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4084: DockerSuite.TestBuildAddTar (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4215: DockerSuite.TestBuildAddTarXz (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4270: DockerSuite.TestBuildAddTarXzGz (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3313: DockerSuite.TestBuildAddToSymlinkDest (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1293: DockerSuite.TestBuildAddWholeDirToRoot (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:181: DockerSuite.TestBuildApiBuildGitWithF (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:45: DockerSuite.TestBuildApiDockerFileRemote (Test requires a Linux daemon)
PASS: docker_api_build_test.go:12: DockerSuite.TestBuildApiDockerfilePath       0.002s
PASS: docker_api_build_test.go:227: DockerSuite.TestBuildApiDockerfileSymlink   0.004s
SKIP: docker_api_build_test.go:204: DockerSuite.TestBuildApiDoubleDockerfile (Test requires posix utilities or functionality to run.)
SKIP: docker_api_build_test.go:161: DockerSuite.TestBuildApiLowerDockerfile (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:71: DockerSuite.TestBuildApiRemoteTarballContext (Test requires a Linux daemon)
SKIP: docker_api_build_test.go:105: DockerSuite.TestBuildApiRemoteTarballContextWithCustomDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5744: DockerSuite.TestBuildBadCmdFlag (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5908: DockerSuite.TestBuildBuildTimeArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6275: DockerSuite.TestBuildBuildTimeArgBuiltinArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5960: DockerSuite.TestBuildBuildTimeArgCacheHit (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5987: DockerSuite.TestBuildBuildTimeArgCacheMissExtraArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6019: DockerSuite.TestBuildBuildTimeArgCacheMissSameArgDiffVal (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6300: DockerSuite.TestBuildBuildTimeArgDefaultOverride (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6412: DockerSuite.TestBuildBuildTimeArgDefintionWithNoEnvInjection (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6392: DockerSuite.TestBuildBuildTimeArgEmptyValVariants (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6109: DockerSuite.TestBuildBuildTimeArgExpansion (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6219: DockerSuite.TestBuildBuildTimeArgExpansionOverride (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5934: DockerSuite.TestBuildBuildTimeArgHistory (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6328: DockerSuite.TestBuildBuildTimeArgMultiArgsSameLine (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6051: DockerSuite.TestBuildBuildTimeArgOverrideArgDefinedBeforeEnv (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6080: DockerSuite.TestBuildBuildTimeArgOverrideEnvDefinedBeforeArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6366: DockerSuite.TestBuildBuildTimeArgQuotedValVariants (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6345: DockerSuite.TestBuildBuildTimeArgUnconsumedArg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6249: DockerSuite.TestBuildBuildTimeArgUntrustedDefinedAfterUse (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:596: DockerSuite.TestBuildCacheAdd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6486: DockerSuite.TestBuildCacheBrokenSymlink (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6610: DockerSuite.TestBuildCacheRootSource (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5016: DockerSuite.TestBuildChownSingleFile (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:4450: DockerSuite.TestBuildCleanupCmdOnEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4483: DockerSuite.TestBuildClearCmd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2231: DockerSuite.TestBuildCmd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4603: DockerSuite.TestBuildCmdJSONNoShDashC (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4546: DockerSuite.TestBuildCmdShDashC (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4566: DockerSuite.TestBuildCmdSpaces (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3836: DockerSuite.TestBuildCommentsShebangs (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2577: DockerSuite.TestBuildConditionalCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5675: DockerSuite.TestBuildContainerWithCgroupParent (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2179: DockerSuite.TestBuildContextCleanup (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2205: DockerSuite.TestBuildContextCleanupFailedBuild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3015: DockerSuite.TestBuildContextTarGzip (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3019: DockerSuite.TestBuildContextTarNoCompression (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:793: DockerSuite.TestBuildCopyAddMultipleFiles (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2709: DockerSuite.TestBuildCopyDirButNotFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1491: DockerSuite.TestBuildCopyDirContentToExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1467: DockerSuite.TestBuildCopyDirContentToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1562: DockerSuite.TestBuildCopyDisallowRemote (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1544: DockerSuite.TestBuildCopyEtcToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1006: DockerSuite.TestBuildCopyFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:926: DockerSuite.TestBuildCopyMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1064: DockerSuite.TestBuildCopyMultipleFilesToFileWithWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1416: DockerSuite.TestBuildCopySingleFileToExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1442: DockerSuite.TestBuildCopySingleFileToNonExistDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1363: DockerSuite.TestBuildCopySingleFileToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1389: DockerSuite.TestBuildCopySingleFileToWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1517: DockerSuite.TestBuildCopyWholeDirToRoot (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1086: DockerSuite.TestBuildCopyWildcard (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1183: DockerSuite.TestBuildCopyWildcardCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1158: DockerSuite.TestBuildCopyWildcardInName (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1137: DockerSuite.TestBuildCopyWildcardNoFind (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5401: DockerSuite.TestBuildDockerfileOutsideContext (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:3382: DockerSuite.TestBuildDockerignore (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3428: DockerSuite.TestBuildDockerignoreCleanPaths (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3450: DockerSuite.TestBuildDockerignoreExceptions (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3584: DockerSuite.TestBuildDockerignoreTouchDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3673: DockerSuite.TestBuildDockerignoringBadExclusion (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3503: DockerSuite.TestBuildDockerignoringDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3563: DockerSuite.TestBuildDockerignoringDockerignore (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3532: DockerSuite.TestBuildDockerignoringRenamedDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3637: DockerSuite.TestBuildDockerignoringWholeDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3725: DockerSuite.TestBuildDockerignoringWildDirs (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3698: DockerSuite.TestBuildDockerignoringWildTopDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5621: DockerSuite.TestBuildDotDotFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3820: DockerSuite.TestBuildEOLInLine (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4503: DockerSuite.TestBuildEmptyCmd (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2410: DockerSuite.TestBuildEmptyEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2368: DockerSuite.TestBuildEmptyEntrypointInheritance (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5610: DockerSuite.TestBuildEmptyScratch (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5660: DockerSuite.TestBuildEmptyStringVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:45: DockerSuite.TestBuildEmptyWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2432: DockerSuite.TestBuildEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4634: DockerSuite.TestBuildEntrypointInheritance (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4661: DockerSuite.TestBuildEntrypointInheritanceInspect (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3102: DockerSuite.TestBuildEntrypointRunCleanup (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2124: DockerSuite.TestBuildEnv (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:422: DockerSuite.TestBuildEnvEscapes (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:445: DockerSuite.TestBuildEnvOverwrite (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3918: DockerSuite.TestBuildEnvUsage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3956: DockerSuite.TestBuildEnvUsage2 (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:198: DockerSuite.TestBuildEnvironmentReplacementAddCopy (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:233: DockerSuite.TestBuildEnvironmentReplacementEnv (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:144: DockerSuite.TestBuildEnvironmentReplacementExpose (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:90: DockerSuite.TestBuildEnvironmentReplacementUser (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:114: DockerSuite.TestBuildEnvironmentReplacementVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:181: DockerSuite.TestBuildEnvironmentReplacementWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4623: DockerSuite.TestBuildErrorInvalidInstruction (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3334: DockerSuite.TestBuildEscapeWhitespace (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4710: DockerSuite.TestBuildExoticShellInterpolation (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2251: DockerSuite.TestBuildExpose (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2271: DockerSuite.TestBuildExposeMorePorts (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2326: DockerSuite.TestBuildExposeOrder (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2348: DockerSuite.TestBuildExposeUpperCaseProto (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3217: DockerSuite.TestBuildFails (Test requires a Linux daemon)
PASS: docker_cli_build_test.go:3233: DockerSuite.TestBuildFailsDockerfileEmpty  0.065s
PASS: docker_cli_build_test.go:6637: DockerSuite.TestBuildFailsGitNotCallable   0.091s
SKIP: docker_cli_build_test.go:6549: DockerSuite.TestBuildFollowSymlinkToDir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6516: DockerSuite.TestBuildFollowSymlinkToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3136: DockerSuite.TestBuildForbiddenContextPath (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1839: DockerSuite.TestBuildForceRm (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4330: DockerSuite.TestBuildFromGIT (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4358: DockerSuite.TestBuildFromGITWithContext (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4387: DockerSuite.TestBuildFromGITwithF (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5264: DockerSuite.TestBuildFromMixedcaseDockerfile (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:5380: DockerSuite.TestBuildFromOfficialNames (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4409: DockerSuite.TestBuildFromRemoteTarball (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5349: DockerSuite.TestBuildFromStdinWithF (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5314: DockerSuite.TestBuildFromURLWithF (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:301: DockerSuite.TestBuildHandleEscapes (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:15: DockerSuite.TestBuildHistory (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3177: DockerSuite.TestBuildInheritance (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4535: DockerSuite.TestBuildInvalidTag (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:860: DockerSuite.TestBuildJSONAddMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:904: DockerSuite.TestBuildJSONAddMultipleFilesToFileWild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:948: DockerSuite.TestBuildJSONCopyMultipleFilesToFile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:27: DockerSuite.TestBuildJSONEmptyRun (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4798: DockerSuite.TestBuildLabels (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4819: DockerSuite.TestBuildLabelsCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:631: DockerSuite.TestBuildLastModified (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3804: DockerSuite.TestBuildLineBreak (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1992: DockerSuite.TestBuildMaintainer (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5568: DockerSuite.TestBuildMissingArgs (Test requires a Linux daemon)
PASS: docker_cli_build_test.go:6467: DockerSuite.TestBuildMultipleTags  2.357s
SKIP: docker_cli_build_test.go:3023: DockerSuite.TestBuildNoContext (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5706: DockerSuite.TestBuildNoDupOutput (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6429: DockerSuite.TestBuildNoNamedVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4948: DockerSuite.TestBuildNotVerboseFailure (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4974: DockerSuite.TestBuildNotVerboseFailureRemote (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4868: DockerSuite.TestBuildNotVerboseSuccess (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5869: DockerSuite.TestBuildNullStringInAddCopyVolume (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3245: DockerSuite.TestBuildOnBuild (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:538: DockerSuite.TestBuildOnBuildCmdEntrypointJSON (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:568: DockerSuite.TestBuildOnBuildEntrypointJSON (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3264: DockerSuite.TestBuildOnBuildForbiddenChained (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:515: DockerSuite.TestBuildOnBuildForbiddenChainedInSourceImage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3280: DockerSuite.TestBuildOnBuildForbiddenFrom (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:492: DockerSuite.TestBuildOnBuildForbiddenFromInSourceImage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3296: DockerSuite.TestBuildOnBuildForbiddenMaintainer (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:469: DockerSuite.TestBuildOnBuildForbiddenMaintainerInSourceImage (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2454: DockerSuite.TestBuildOnBuildLimitedInheritence (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:389: DockerSuite.TestBuildOnBuildLowercase (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4518: DockerSuite.TestBuildOnBuildOutput (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2146: DockerSuite.TestBuildPATH (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5761: DockerSuite.TestBuildRUNErrMsg (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5638: DockerSuite.TestBuildRUNoneJSON (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2083: DockerSuite.TestBuildRelativeCopy (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2034: DockerSuite.TestBuildRelativeWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5159: DockerSuite.TestBuildRenamedDockerfile (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1865: DockerSuite.TestBuildRm (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4696: DockerSuite.TestBuildRunShEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:65: DockerSuite.TestBuildShCmdJSONEntrypoint (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:697: DockerSuite.TestBuildSixtySteps (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5459: DockerSuite.TestBuildSpaces (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5530: DockerSuite.TestBuildSpacesWithQuotes (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5727: DockerSuite.TestBuildStartsFromOne (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4990: DockerSuite.TestBuildStderr (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5892: DockerSuite.TestBuildStopSignal (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6586: DockerSuite.TestBuildSymlinkBasename (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5045: DockerSuite.TestBuildSymlinkBreakout (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:6441: DockerSuite.TestBuildTagEvent (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2012: DockerSuite.TestBuildUser (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3855: DockerSuite.TestBuildUsersAndGroups (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4761: DockerSuite.TestBuildVerboseOut (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:3360: DockerSuite.TestBuildVerifyIntString (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4739: DockerSuite.TestBuildVerifySingleQuoteFails (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5552: DockerSuite.TestBuildVolumeFileExistsinContainer (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5127: DockerSuite.TestBuildVolumesRetainContents (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2523: DockerSuite.TestBuildWithCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1713: DockerSuite.TestBuildWithInaccessibleFilesInContext (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:4779: DockerSuite.TestBuildWithTabs (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5289: DockerSuite.TestBuildWithTwoDockerfiles (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_build_test.go:3074: DockerSuite.TestBuildWithVolumeOwnership (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:1945: DockerSuite.TestBuildWithVolumes (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2549: DockerSuite.TestBuildWithoutCache (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:2060: DockerSuite.TestBuildWorkdirWithEnvVariables (Test requires a Linux daemon)
SKIP: docker_cli_build_test.go:5097: DockerSuite.TestBuildXZHost (Test requires a Linux daemon)
SKIP: docker_cli_proxy_test.go:12: DockerSuite.TestCliProxyDisableProxyUnixSock (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3842: DockerSuite.TestCmdCannotBeInvoked   3.426s
SKIP: docker_cli_commit_test.go:10: DockerSuite.TestCommitAfterContainerIsDone (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:110: DockerSuite.TestCommitChange (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:70: DockerSuite.TestCommitHardlink (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:151: DockerSuite.TestCommitMergeConfigRun (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:58: DockerSuite.TestCommitNewFile (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:41: DockerSuite.TestCommitPausedContainer (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:90: DockerSuite.TestCommitTTY (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:100: DockerSuite.TestCommitWithHostBindMount (Test requires a Linux daemon)
SKIP: docker_cli_commit_test.go:25: DockerSuite.TestCommitWithoutPause (Test requires a Linux daemon)
PASS: docker_cli_config_test.go:64: DockerSuite.TestConfigDir   0.339s
SKIP: docker_cli_config_test.go:18: DockerSuite.TestConfigHttpHeader (Test requires posix utilities or functionality to run.)
SKIP: docker_cli_netmode_test.go:52: DockerSuite.TestConflictContainerNetworkAndLinks (Test requires a Linux daemon)
SKIP: docker_cli_netmode_test.go:62: DockerSuite.TestConflictNetworkModeAndOptions (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:551: DockerSuite.TestContainerApiBadPort (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:491: DockerSuite.TestContainerApiCommit (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:515: DockerSuite.TestContainerApiCommitWithLabelInConfig (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:971: DockerSuite.TestContainerApiCopy (Test requires a Linux daemon)
PASS: docker_api_containers_test.go:1031: DockerSuite.TestContainerApiCopyContainerNotFound     0.001s
SKIP: docker_api_containers_test.go:1001: DockerSuite.TestContainerApiCopyResourcePathEmpty (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1016: DockerSuite.TestContainerApiCopyResourcePathNotFound (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:575: DockerSuite.TestContainerApiCreate (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:655: DockerSuite.TestContainerApiCreateBridgeNetworkMode (Test requires a Linux daemon)
PASS: docker_api_containers_test.go:596: DockerSuite.TestContainerApiCreateEmptyConfig  0.000s
SKIP: docker_api_containers_test.go:660: DockerSuite.TestContainerApiCreateOtherNetworkModes (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:688: DockerSuite.TestContainerApiCreateWithCpuSharesCpuset (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:631: DockerSuite.TestContainerApiCreateWithDomainName (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:607: DockerSuite.TestContainerApiCreateWithHostName (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1041: DockerSuite.TestContainerApiDelete (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1099: DockerSuite.TestContainerApiDeleteConflict (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1062: DockerSuite.TestContainerApiDeleteForce (Test requires a Linux daemon)
PASS: docker_api_containers_test.go:1055: DockerSuite.TestContainerApiDeleteNotExist    0.001s
SKIP: docker_api_containers_test.go:1074: DockerSuite.TestContainerApiDeleteRemoveLinks (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1111: DockerSuite.TestContainerApiDeleteRemoveVolume (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:26: DockerSuite.TestContainerApiGetAll (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:144: DockerSuite.TestContainerApiGetChanges (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:121: DockerSuite.TestContainerApiGetExport (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:51: DockerSuite.TestContainerApiGetJSONNoFieldsOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:752: DockerSuite.TestContainerApiInvalidPortSyntax (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:878: DockerSuite.TestContainerApiKill (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:440: DockerSuite.TestContainerApiPause (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:776: DockerSuite.TestContainerApiPostCreateNull (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:863: DockerSuite.TestContainerApiRename (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:892: DockerSuite.TestContainerApiRestart (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:903: DockerSuite.TestContainerApiRestartNotimeoutParam (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:916: DockerSuite.TestContainerApiStart (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:195: DockerSuite.TestContainerApiStartDupVolumeBinds (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:169: DockerSuite.TestContainerApiStartVolumeBinds (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:219: DockerSuite.TestContainerApiStartVolumesFrom (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:940: DockerSuite.TestContainerApiStop (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:466: DockerSuite.TestContainerApiTop (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:720: DockerSuite.TestContainerApiVerifyHeader (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:956: DockerSuite.TestContainerApiWait (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2434: DockerSuite.TestContainerNetworkMode (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:89: DockerSuite.TestContainerPsOmitFields (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3689: DockerSuite.TestContainerRestartInMultipleNetworks (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:130: DockerSuite.TestContainerRestartSuccess (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:112: DockerSuite.TestContainerRestartwithGoodContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3721: DockerSuite.TestContainerWithConflictingHostNetworks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3752: DockerSuite.TestContainerWithConflictingNoneNetwork (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3735: DockerSuite.TestContainerWithConflictingSharedNetwork (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1132: DockerSuite.TestContainersApiChunkedEncoding (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1302: DockerSuite.TestContainersApiCreateNoHostConfig118 (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1346: DockerSuite.TestContainersApiGetContainersJSONEmpty (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3625: DockerSuite.TestContainersInMultipleNetworks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3617: DockerSuite.TestContainersInUserDefinedNetwork (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3644: DockerSuite.TestContainersNetworkIsolation (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:582: DockerSuite.TestCopyAndRestart (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:603: DockerSuite.TestCopyCreatedContainer (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:129: DockerSuite.TestCpAbsolutePath (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:173: DockerSuite.TestCpAbsoluteSymlink (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:209: DockerSuite.TestCpFromCaseA (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:229: DockerSuite.TestCpFromCaseB (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:247: DockerSuite.TestCpFromCaseC (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:272: DockerSuite.TestCpFromCaseD (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:312: DockerSuite.TestCpFromCaseE (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:341: DockerSuite.TestCpFromCaseF (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:364: DockerSuite.TestCpFromCaseG (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:403: DockerSuite.TestCpFromCaseH (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:433: DockerSuite.TestCpFromCaseI (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:457: DockerSuite.TestCpFromCaseJ (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:85: DockerSuite.TestCpFromErrDstNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:56: DockerSuite.TestCpFromErrDstParentNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:41: DockerSuite.TestCpFromErrSrcNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:26: DockerSuite.TestCpFromErrSrcNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_from_container_test.go:114: DockerSuite.TestCpFromSymlinkDestination (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:211: DockerSuite.TestCpFromSymlinkToDirectory (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:37: DockerSuite.TestCpGarbagePath (Test requires a Linux daemon)
PASS: docker_cli_cp_test.go:28: DockerSuite.TestCpLocalOnly     0.043s
SKIP: docker_cli_cp_test.go:563: DockerSuite.TestCpNameHasColon (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:80: DockerSuite.TestCpRelativePath (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:408: DockerSuite.TestCpSpecialFiles (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:339: DockerSuite.TestCpSymlinkComponent (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:616: DockerSuite.TestCpSymlinkFromConToHostFollowSymlink (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:229: DockerSuite.TestCpToCaseA (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:251: DockerSuite.TestCpToCaseB (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:273: DockerSuite.TestCpToCaseC (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:300: DockerSuite.TestCpToCaseD (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:346: DockerSuite.TestCpToCaseE (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:382: DockerSuite.TestCpToCaseF (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:405: DockerSuite.TestCpToCaseG (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:451: DockerSuite.TestCpToCaseH (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:488: DockerSuite.TestCpToCaseI (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:512: DockerSuite.TestCpToCaseJ (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:521: DockerSuite.TestCpToDot (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:92: DockerSuite.TestCpToErrDstNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:63: DockerSuite.TestCpToErrDstParentNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:555: DockerSuite.TestCpToErrReadOnlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:582: DockerSuite.TestCpToErrReadOnlyVolume (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:43: DockerSuite.TestCpToErrSrcNotDir (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:25: DockerSuite.TestCpToErrSrcNotExists (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:543: DockerSuite.TestCpToStdout (Test requires a Linux daemon)
SKIP: docker_cli_cp_to_container_test.go:128: DockerSuite.TestCpToSymlinkDestination (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:259: DockerSuite.TestCpToSymlinkToDirectory (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:383: DockerSuite.TestCpUnprivilegedUser (Test requires a Linux daemon)
SKIP: docker_cli_cp_test.go:452: DockerSuite.TestCpVolumePath (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:22: DockerSuite.TestCreateArgs (Test requires a Linux daemon)
PASS: docker_cli_create_test.go:247: DockerSuite.TestCreateByImageID    5.164s
SKIP: docker_cli_create_test.go:143: DockerSuite.TestCreateEchoStdout (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:60: DockerSuite.TestCreateHostConfig (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:212: DockerSuite.TestCreateHostnameWithNumber (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:189: DockerSuite.TestCreateLabelFromImage (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:174: DockerSuite.TestCreateLabels (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:237: DockerSuite.TestCreateModeIpcContainer (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:219: DockerSuite.TestCreateRM (Test requires a Linux daemon)
PASS: docker_cli_create_test.go:409: DockerSuite.TestCreateStopSignal   0.491s
SKIP: docker_cli_create_test.go:155: DockerSuite.TestCreateVolumesCreated (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:83: DockerSuite.TestCreateWithPortRange (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:825: DockerSuite.TestCreateWithTooLowMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:419: DockerSuite.TestCreateWithWorkdir (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:113: DockerSuite.TestCreateWithiLargePortRange (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3003: DockerSuite.TestDevicePermissions (Test requires a Linux daemon)
PASS: docker_cli_diff_test.go:83: DockerSuite.TestDiffEmptyArgClientError       0.057s
SKIP: docker_cli_diff_test.go:30: DockerSuite.TestDiffEnsureDockerinitFilesAreIgnored (Test requires a Linux daemon)
SKIP: docker_cli_diff_test.go:50: DockerSuite.TestDiffEnsureOnlyKmsgAndPtmx (Test requires a Linux daemon)
SKIP: docker_cli_diff_test.go:11: DockerSuite.TestDiffFilenameShownInOutput (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3866: DockerSuite.TestDockerFails  0.045s
PASS: docker_api_events_test.go:38: DockerSuite.TestEventsApiBackwardsCompatible        2.241s
PASS: docker_api_events_test.go:17: DockerSuite.TestEventsApiEmptyOutput        0.001s
SKIP: docker_cli_events_test.go:438: DockerSuite.TestEventsAttach (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:374: DockerSuite.TestEventsCommit (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:123: DockerSuite.TestEventsContainerEvents (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:144: DockerSuite.TestEventsContainerEventsSinceUnixEpoch (Test requires a Linux daemon)
PASS: docker_cli_events_test.go:68: DockerSuite.TestEventsContainerFailStartDie 3.286s
SKIP: docker_cli_events_test.go:389: DockerSuite.TestEventsCopy (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:497: DockerSuite.TestEventsDefaultEmpty (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:334: DockerSuite.TestEventsFilterContainer (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:577: DockerSuite.TestEventsFilterImageInContainerAction (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:301: DockerSuite.TestEventsFilterImageLabels (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:244: DockerSuite.TestEventsFilterImageName (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:274: DockerSuite.TestEventsFilterLabels (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:523: DockerSuite.TestEventsFilterType (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:226: DockerSuite.TestEventsFilters (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:204: DockerSuite.TestEventsImageImport (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:185: DockerSuite.TestEventsImagePull (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:165: DockerSuite.TestEventsImageTag (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:96: DockerSuite.TestEventsLimit (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:470: DockerSuite.TestEventsRename (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:419: DockerSuite.TestEventsResize (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:19: DockerSuite.TestEventsTimestampFormats (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:481: DockerSuite.TestEventsTop (Test requires a Linux daemon)
SKIP: docker_cli_events_test.go:47: DockerSuite.TestEventsUntag (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:22: DockerSuite.TestExec (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:66: DockerSuite.TestExecAPIStart (Test requires a Linux daemon)
PASS: docker_api_exec_test.go:89: DockerSuite.TestExecAPIStartBackwardsCompatible       2.189s
PASS: docker_api_exec_test.go:103: DockerSuite.TestExecAPIStartMultipleTimesError       2.498s
SKIP: docker_cli_exec_test.go:68: DockerSuite.TestExecAfterContainerRestart (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:52: DockerSuite.TestExecApiCreateContainerPaused (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:18: DockerSuite.TestExecApiCreateNoCmd (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:31: DockerSuite.TestExecApiCreateNoValidContentType (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:234: DockerSuite.TestExecCgroup (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:105: DockerSuite.TestExecEnv (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:117: DockerSuite.TestExecExitStatus (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:32: DockerSuite.TestExecInteractive (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:509: DockerSuite.TestExecOnReadonlyContainer (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:197: DockerSuite.TestExecParseError (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:127: DockerSuite.TestExecPausedContainer (Test requires a Linux daemon)
SKIP: docker_api_exec_resize_test.go:16: DockerSuite.TestExecResizeApiHeightWidthNoInt (Test requires a Linux daemon)
SKIP: docker_api_exec_resize_test.go:28: DockerSuite.TestExecResizeImmediatelyAfterExecStart (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:517: DockerSuite.TestExecStartFails (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:208: DockerSuite.TestExecStopNotHanging (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:143: DockerSuite.TestExecTtyCloseStdin (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:163: DockerSuite.TestExecTtyWithoutStdin (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:493: DockerSuite.TestExecWithImageUser (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:460: DockerSuite.TestExecWithPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:449: DockerSuite.TestExecWithUser (Test requires a Linux daemon)
SKIP: docker_cli_export_import_test.go:13: DockerSuite.TestExportContainerAndImportImage (Test requires a Linux daemon)
SKIP: docker_cli_export_import_test.go:31: DockerSuite.TestExportContainerWithOutputAndImportImage (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:250: DockerSuite.TestGetContainerStats (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:365: DockerSuite.TestGetContainerStatsNoStream (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:288: DockerSuite.TestGetContainerStatsRmRunning (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:328: DockerSuite.TestGetContainerStatsStream (Test requires a Linux daemon)
SKIP: docker_api_attach_test.go:16: DockerSuite.TestGetContainersAttachWebsocket (Test requires a Linux daemon)
PASS: docker_api_attach_test.go:77: DockerSuite.TestGetContainersWsAttachContainerNotFound      0.001s
SKIP: docker_api_containers_test.go:400: DockerSuite.TestGetStoppedContainerStats (Test requires a Linux daemon)
PASS: docker_api_version_test.go:13: DockerSuite.TestGetVersion 0.001s
SKIP: docker_cli_help_test.go:240: DockerSuite.TestHelpExitCodesHelpOutput (Test requires a Linux daemon)
SKIP: docker_cli_help_test.go:15: DockerSuite.TestHelpTextVerify (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:61: DockerSuite.TestHistoryExistentImage (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:91: DockerSuite.TestHistoryHumanOptionFalse (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:110: DockerSuite.TestHistoryHumanOptionTrue (Test requires a Linux daemon)
SKIP: docker_cli_history_test.go:71: DockerSuite.TestHistoryImageWithComment (Test requires a Linux daemon)
PASS: docker_cli_history_test.go:66: DockerSuite.TestHistoryNonExistentImage    0.055s
SKIP: docker_cli_images_test.go:163: DockerSuite.TestImagesEnsureDanglingImageOnlyListedOnce (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:18: DockerSuite.TestImagesEnsureImageIsListed (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:45: DockerSuite.TestImagesEnsureImageWithBadTagIsNotListed      0.087s
SKIP: docker_cli_images_test.go:24: DockerSuite.TestImagesEnsureImageWithTagIsListed (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:220: DockerSuite.TestImagesEnsureImagesFromScratchShown (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:196: DockerSuite.TestImagesEnsureOnlyHeadsImagesShown (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:74: DockerSuite.TestImagesErrorWithInvalidFilterNameTest        0.051s
SKIP: docker_cli_images_test.go:80: DockerSuite.TestImagesFilterLabelMatch (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:112: DockerSuite.TestImagesFilterLabelWithCommit        8.852s
PASS: docker_cli_images_test.go:236: DockerSuite.TestImagesFilterNameWithPort   0.203s
SKIP: docker_cli_images_test.go:124: DockerSuite.TestImagesFilterSpaceTrimCase (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:249: DockerSuite.TestImagesFormat       0.145s
SKIP: docker_cli_images_test.go:267: DockerSuite.TestImagesFormatDefaultFormat (Test requires a Linux daemon)
SKIP: docker_cli_images_test.go:50: DockerSuite.TestImagesOrderedByCreationDate (Test requires a Linux daemon)
PASS: docker_cli_images_test.go:190: DockerSuite.TestImagesWithIncorrectFilter  0.050s
SKIP: docker_cli_import_test.go:33: DockerSuite.TestImportBadURL (Test requires a Linux daemon)
SKIP: docker_cli_import_test.go:15: DockerSuite.TestImportDisplay (Test requires a Linux daemon)
SKIP: docker_cli_import_test.go:40: DockerSuite.TestImportFile (Test requires a Linux daemon)
PASS: docker_cli_import_test.go:94: DockerSuite.TestImportFileNonExistentFile   0.047s
SKIP: docker_cli_import_test.go:62: DockerSuite.TestImportFileWithMessage (Test requires a Linux daemon)
PASS: docker_api_info_test.go:10: DockerSuite.TestInfoApi       0.005s
SKIP: docker_cli_info_test.go:84: DockerSuite.TestInfoDiscoveryAdvertiseInterfaceName (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:49: DockerSuite.TestInfoDiscoveryBackend (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:67: DockerSuite.TestInfoDiscoveryInvalidAdvertise (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:120: DockerSuite.TestInfoDisplaysPausedContainers (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:109: DockerSuite.TestInfoDisplaysRunningContainers (Test requires a Linux daemon)
SKIP: docker_cli_info_test.go:135: DockerSuite.TestInfoDisplaysStoppedContainers (Test requires a Linux daemon)
PASS: docker_cli_info_test.go:14: DockerSuite.TestInfoEnsureSucceeds    0.056s
SKIP: docker_api_inspect_test.go:137: DockerSuite.TestInspectApiBridgeNetworkSettings120 (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:153: DockerSuite.TestInspectApiBridgeNetworkSettings121 (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:15: DockerSuite.TestInspectApiContainerResponse (Test requires a Linux daemon)
PASS: docker_api_inspect_test.go:71: DockerSuite.TestInspectApiContainerVolumeDriver    2.092s
SKIP: docker_api_inspect_test.go:49: DockerSuite.TestInspectApiContainerVolumeDriverLegacy (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:114: DockerSuite.TestInspectApiEmptyFieldsInConfigPre121 (Test requires a Linux daemon)
PASS: docker_api_inspect_test.go:95: DockerSuite.TestInspectApiImageResponse    0.068s
SKIP: docker_cli_inspect_test.go:234: DockerSuite.TestInspectBindMountPoint (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:357: DockerSuite.TestInspectByPrefix   0.195s
SKIP: docker_cli_inspect_test.go:154: DockerSuite.TestInspectContainerFilterInt (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:202: DockerSuite.TestInspectContainerGraphDriver (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:406: DockerSuite.TestInspectContainerNetworkCustom (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:392: DockerSuite.TestInspectContainerNetworkDefault (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:47: DockerSuite.TestInspectDefault (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:286: DockerSuite.TestInspectExecID (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:382: DockerSuite.TestInspectHistory (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:23: DockerSuite.TestInspectImage (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:137: DockerSuite.TestInspectImageFilterInt (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:177: DockerSuite.TestInspectImageGraphDriver (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:38: DockerSuite.TestInspectInt64 (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:349: DockerSuite.TestInspectJSONFields 2.301s
SKIP: docker_cli_inspect_test.go:285: DockerSuite.TestInspectLogConfigNoType (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:300: DockerSuite.TestInspectNoSizeFlagContainer        2.253s
PASS: docker_cli_inspect_test.go:312: DockerSuite.TestInspectSizeFlagContainer  2.134s
PASS: docker_cli_inspect_test.go:323: DockerSuite.TestInspectSizeFlagImage      2.481s
SKIP: docker_cli_inspect_test.go:60: DockerSuite.TestInspectStatus (Test requires a Linux daemon)
PASS: docker_cli_inspect_test.go:371: DockerSuite.TestInspectStopWhenNotFound   5.167s
PASS: docker_cli_inspect_test.go:335: DockerSuite.TestInspectTempateError       2.572s
SKIP: docker_cli_inspect_test.go:259: DockerSuite.TestInspectTimesAsRFC3339Nano (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:87: DockerSuite.TestInspectTypeFlagContainer (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:112: DockerSuite.TestInspectTypeFlagWithImage (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:124: DockerSuite.TestInspectTypeFlagWithInvalidValue (Test requires a Linux daemon)
SKIP: docker_cli_inspect_test.go:99: DockerSuite.TestInspectTypeFlagWithNoContainer (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:12: DockerSuite.TestKillContainer (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:36: DockerSuite.TestKillDifferentUserContainer (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:89: DockerSuite.TestKillStoppedContainerAPIPre120 (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:63: DockerSuite.TestKillWithInvalidSignal (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:50: DockerSuite.TestKillWithSignal (Test requires a Linux daemon)
SKIP: docker_cli_kill_test.go:25: DockerSuite.TestKillofStoppedContainer (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:181: DockerSuite.TestLinkShortDefinition (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:172: DockerSuite.TestLinksEnvs (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:209: DockerSuite.TestLinksEtcHostsRegularFile (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:111: DockerSuite.TestLinksHostsFilesInject (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:63: DockerSuite.TestLinksInspectLinksStarted (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:83: DockerSuite.TestLinksInspectLinksStopped (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:22: DockerSuite.TestLinksInvalidContainerTarget (Test requires a Linux daemon)

----------------------------------------------------------------------
FAIL: docker_cli_links_test.go:216: DockerSuite.TestLinksMultipleWithSameName

docker_cli_links_test.go:219:
    dockerCmd(c, "run", "--link", "upstream-a:upstream", "--link", "upstream-b:upstream", "busybox", "sh", "-c", "ping -c 1 upstream")
c:/go/src/github.com/docker/docker/pkg/integration/dockerCmd_utils.go:35:
    c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), out, err))
... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc082454020)} ("exit status 1")
... "run --link upstream-a:upstream --link upstream-b:upstream busybox sh -c ping -c 1 upstream" failed with errors: Bad value for option -c.
, exit status 1


----------------------------------------------------------------------
SKIP: docker_cli_links_test.go:198: DockerSuite.TestLinksNetworkHostContainer (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:103: DockerSuite.TestLinksNotStartedParentNotFail (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:32: DockerSuite.TestLinksPingLinkedContainers (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:50: DockerSuite.TestLinksPingLinkedContainersAfterRename (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:349: DockerSuite.TestLinksPingLinkedContainersOnRename (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:13: DockerSuite.TestLinksPingUnlinkedContainers (Test requires a Linux daemon)
SKIP: docker_cli_links_test.go:132: DockerSuite.TestLinksUpdateOnRestart (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:299: DockerSuite.TestLoadZeroSizeLayer (Test requires a Linux daemon)
PASS: docker_cli_login_test.go:11: DockerSuite.TestLoginWithoutTTY      0.057s
PASS: docker_api_logs_test.go:87: DockerSuite.TestLogsAPIContainerNotFound      0.000s
SKIP: docker_api_logs_test.go:71: DockerSuite.TestLogsApiFollowEmptyOutput (Test requires a Linux daemon)
SKIP: docker_api_logs_test.go:55: DockerSuite.TestLogsApiNoStdoutNorStderr (Test requires a Linux daemon)
SKIP: docker_api_logs_test.go:15: DockerSuite.TestLogsApiWithStdout (Test requires a Linux daemon)
PASS: docker_cli_logs_test.go:349: DockerSuite.TestLogsCLIContainerNotFound     0.057s
SKIP: docker_cli_logs_test.go:33: DockerSuite.TestLogsContainerBiggerThanPage (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:47: DockerSuite.TestLogsContainerMuchBiggerThanPage (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:19: DockerSuite.TestLogsContainerSmallerThanPage (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:307: DockerSuite.TestLogsFollowGoroutinesNoOutput (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:255: DockerSuite.TestLogsFollowGoroutinesWithStdout (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:223: DockerSuite.TestLogsFollowSlowStdoutConsumer (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:145: DockerSuite.TestLogsFollowStopped (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:86: DockerSuite.TestLogsSeparateStderr (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:169: DockerSuite.TestLogsSince (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:205: DockerSuite.TestLogsSinceFutureFollow (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:103: DockerSuite.TestLogsStderrInStdout (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:118: DockerSuite.TestLogsTail (Test requires a Linux daemon)
SKIP: docker_cli_logs_test.go:60: DockerSuite.TestLogsTimestamps (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2945: DockerSuite.TestMountIntoProc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2954: DockerSuite.TestMountIntoSys (Test requires a Linux daemon)
SKIP: docker_cli_netmode_test.go:24: DockerSuite.TestNetHostname (Test requires a Linux daemon)
SKIP: docker_cli_nat_test.go:68: DockerSuite.TestNetworkLocalhostTCPNat (Test requires a Linux daemon)
SKIP: docker_cli_nat_test.go:85: DockerSuite.TestNetworkLoopbackNat (Test requires a Linux daemon)
SKIP: docker_cli_nat_test.go:52: DockerSuite.TestNetworkNat (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3671: DockerSuite.TestNetworkRmWithActiveContainers (Test requires a Linux daemon)
SKIP: docker_cli_pause_test.go:11: DockerSuite.TestPause (Test requires a Linux daemon)
PASS: docker_cli_pause_test.go:62: DockerSuite.TestPauseFailsOnWindows  2.294s
SKIP: docker_cli_pause_test.go:33: DockerSuite.TestPauseMultipleContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2717: DockerSuite.TestPermissionsPtsReadonlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:275: DockerSuite.TestPortExposeHostBinding (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:253: DockerSuite.TestPortHostBinding (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:14: DockerSuite.TestPortList (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:421: DockerSuite.TestPostContainerBindNormalVolume (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1167: DockerSuite.TestPostContainerStop (Test requires a Linux daemon)
SKIP: docker_api_attach_test.go:85: DockerSuite.TestPostContainersAttach (Test requires a Linux daemon)
PASS: docker_api_attach_test.go:69: DockerSuite.TestPostContainersAttachContainerNotFound       0.002s
SKIP: docker_api_containers_test.go:1504: DockerSuite.TestPostContainersCreateMemorySwappinessHostConfigOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1411: DockerSuite.TestPostContainersCreateShmSizeHostConfigOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1398: DockerSuite.TestPostContainersCreateShmSizeNegative (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1442: DockerSuite.TestPostContainersCreateShmSizeOmitted (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1528: DockerSuite.TestPostContainersCreateWithOomScoreAdjInvalidRange (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1473: DockerSuite.TestPostContainersCreateWithShmSize (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1229: DockerSuite.TestPostContainersCreateWithStringOrSliceCapAddDrop (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1206: DockerSuite.TestPostContainersCreateWithStringOrSliceCmd (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1182: DockerSuite.TestPostContainersCreateWithStringOrSliceEntrypoint (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1355: DockerSuite.TestPostContainersCreateWithWrongCpusetValues (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1267: DockerSuite.TestPostContainersStartWithLinksInHostConfig (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1284: DockerSuite.TestPostContainersStartWithLinksInHostConfigIdLinked (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1251: DockerSuite.TestPostContainersStartWithoutLinksInHostConfig (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:568: DockerSuite.TestPsDefaultFormatAndQuiet (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:556: DockerSuite.TestPsFormatHeaders (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:528: DockerSuite.TestPsFormatMultiNames (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:478: DockerSuite.TestPsGroupPortRange (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:588: DockerSuite.TestPsImageIDAfterUpdate (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:460: DockerSuite.TestPsLinkedWithNoTrunc (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:19: DockerSuite.TestPsListContainersBase (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:248: DockerSuite.TestPsListContainersFilterAncestorImage (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:497: DockerSuite.TestPsListContainersFilterCreated (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:381: DockerSuite.TestPsListContainersFilterExited (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:208: DockerSuite.TestPsListContainersFilterID (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:344: DockerSuite.TestPsListContainersFilterLabel (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:224: DockerSuite.TestPsListContainersFilterName (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:170: DockerSuite.TestPsListContainersFilterStatus (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:129: DockerSuite.TestPsListContainersSize (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:419: DockerSuite.TestPsRightTagName (Test requires a Linux daemon)
SKIP: docker_cli_ps_test.go:489: DockerSuite.TestPsWithSize (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3311: DockerSuite.TestPtraceContainerProcsFromHost (Test requires a Linux daemon)
PASS: docker_cli_push_test.go:36: DockerSuite.TestPushUnprefixedRepo    0.836s
SKIP: docker_api_containers_test.go:1315: DockerSuite.TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:62: DockerSuite.TestRenameCheckNames (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:78: DockerSuite.TestRenameInvalidName (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:28: DockerSuite.TestRenameRunningContainer (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:41: DockerSuite.TestRenameRunningContainerAndReuse (Test requires a Linux daemon)
SKIP: docker_cli_rename_test.go:11: DockerSuite.TestRenameStoppedContainer (Test requires a Linux daemon)
SKIP: docker_api_resize_test.go:22: DockerSuite.TestResizeApiHeightWidthNoInt (Test requires a Linux daemon)
SKIP: docker_api_resize_test.go:11: DockerSuite.TestResizeApiResponse (Test requires a Linux daemon)
SKIP: docker_api_resize_test.go:33: DockerSuite.TestResizeApiResponseWhenContainerNotStarted (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:83: DockerSuite.TestRestartPolicyAlways (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:73: DockerSuite.TestRestartPolicyNO (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:99: DockerSuite.TestRestartPolicyOnFailure (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:29: DockerSuite.TestRestartRunningContainer (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:13: DockerSuite.TestRestartStoppedContainer (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:50: DockerSuite.TestRestartWithVolumes (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:46: DockerSuite.TestRmContainerOrphaning (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:11: DockerSuite.TestRmContainerWithRemovedVolume (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:23: DockerSuite.TestRmContainerWithVolume (Test requires a Linux daemon)
SKIP: docker_cli_rm_test.go:38: DockerSuite.TestRmForceRemoveRunningContainer (Test requires a Linux daemon)
PASS: docker_cli_rm_test.go:73: DockerSuite.TestRmInvalidContainer      0.049s
SKIP: docker_cli_rm_test.go:30: DockerSuite.TestRmRunningContainer (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:222: DockerSuite.TestRmiBlank (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:342: DockerSuite.TestRmiByIDHardConflict (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:240: DockerSuite.TestRmiContainerImageNotFound (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:166: DockerSuite.TestRmiForceWithExistingContainers (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:197: DockerSuite.TestRmiForceWithMultipleRepositories (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:137: DockerSuite.TestRmiImageIDForceWithRunningContainersAndMultipleTags (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:102: DockerSuite.TestRmiImgIDForce (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:64: DockerSuite.TestRmiImgIDMultipleTag (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:314: DockerSuite.TestRmiParentImageFail (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:35: DockerSuite.TestRmiTag (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:153: DockerSuite.TestRmiTagWithExistingContainers (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:267: DockerSuite.TestRmiUntagHistoryLayer (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:13: DockerSuite.TestRmiWithContainerFails (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:182: DockerSuite.TestRmiWithMultipleRepositories (Test requires a Linux daemon)
SKIP: docker_cli_rmi_test.go:326: DockerSuite.TestRmiWithParentInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1540: DockerSuite.TestRunAddHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1102: DockerSuite.TestRunAddingOptionalDevices (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1120: DockerSuite.TestRunAddingOptionalDevicesInvalidMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1111: DockerSuite.TestRunAddingOptionalDevicesNoSrc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2061: DockerSuite.TestRunAllocatePortInReservedRange (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1161: DockerSuite.TestRunAllowBindMountingRoot     3.605s
SKIP: docker_cli_run_test.go:2283: DockerSuite.TestRunAllowPortRangeThroughExpose (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2646: DockerSuite.TestRunAllowPortRangeThroughPublish (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:493: DockerSuite.TestRunApplyVolumesFromBeforeVolumes      6.556s
PASS: docker_cli_run_test.go:1552: DockerSuite.TestRunAttachStdErrOnlyTTYMode   3.503s
PASS: docker_cli_run_test.go:1568: DockerSuite.TestRunAttachStdOutAndErrTTYMode 3.103s
PASS: docker_cli_run_test.go:1560: DockerSuite.TestRunAttachStdOutOnlyTTYMode   3.354s
PASS: docker_cli_run_test.go:1577: DockerSuite.TestRunAttachWithDetach  0.044s
PASS: docker_cli_run_test.go:1877: DockerSuite.TestRunBindMounts        3.312s
SKIP: docker_cli_run_test.go:983: DockerSuite.TestRunCapAddALLCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:993: DockerSuite.TestRunCapAddALLDropNetAdminCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3016: DockerSuite.TestRunCapAddCHOWN (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:973: DockerSuite.TestRunCapAddCanDownInterface (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:964: DockerSuite.TestRunCapAddInvalid (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3362: DockerSuite.TestRunCapAddSYSTIME (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:954: DockerSuite.TestRunCapDropALLAddMknodCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:942: DockerSuite.TestRunCapDropALLCannotMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:916: DockerSuite.TestRunCapDropCannotMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:929: DockerSuite.TestRunCapDropCannotMknodLowerCase (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:907: DockerSuite.TestRunCapDropInvalid (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1957: DockerSuite.TestRunCidFileCheckIDLength      2.260s
PASS: docker_cli_run_test.go:1929: DockerSuite.TestRunCidFileCleanupIfEmpty     0.051s
PASS: docker_cli_run_test.go:1673: DockerSuite.TestRunCleanupCmdOnEntrypoint    7.840s
SKIP: docker_cli_run_test.go:3493: DockerSuite.TestRunContainerNetModeWithDnsMacHosts (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3517: DockerSuite.TestRunContainerNetModeWithExposePort (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:852: DockerSuite.TestRunContainerNetwork   3.525s
SKIP: docker_cli_run_test.go:3484: DockerSuite.TestRunContainerNetworkModeToSelf (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3468: DockerSuite.TestRunContainerWithCgroupMountRO (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3409: DockerSuite.TestRunContainerWithCgroupParent (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3439: DockerSuite.TestRunContainerWithCgroupParentAbsPath (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2757: DockerSuite.TestRunContainerWithReadonlyEtcHostsAndLinkedContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2708: DockerSuite.TestRunContainerWithReadonlyRootfs (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2781: DockerSuite.TestRunContainerWithReadonlyRootfsWithAddHostFlag (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2770: DockerSuite.TestRunContainerWithReadonlyRootfsWithDnsFlag (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2825: DockerSuite.TestRunContainerWithRmFlagCannotStartContainer   3.358s
PASS: docker_cli_run_test.go:2808: DockerSuite.TestRunContainerWithRmFlagExitCodeNotEqualToZero 3.182s
PASS: docker_cli_run_test.go:2704: DockerSuite.TestRunContainerWithWritableRootfs       3.293s
SKIP: docker_cli_run_test.go:1653: DockerSuite.TestRunCopyVolumeContent (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1630: DockerSuite.TestRunCopyVolumeUidGid (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3370: DockerSuite.TestRunCreateContainerFailedCleanUp (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:532: DockerSuite.TestRunCreateVolume       3.067s
SKIP: docker_cli_run_test.go:2159: DockerSuite.TestRunCreateVolumeEtc (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:542: DockerSuite.TestRunCreateVolumeWithSymlink (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:348: DockerSuite.TestRunCreateVolumesInSymlinkDir  21.125s
SKIP: docker_cli_run_test.go:2020: DockerSuite.TestRunDeallocatePortOnMissingIptablesRule (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:110: DockerSuite.TestRunDetachedContainerIDPrinting        3.423s
SKIP: docker_cli_run_test.go:1071: DockerSuite.TestRunDeviceNumbers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1170: DockerSuite.TestRunDisallowBindMountingRootToRoot    0.060s
SKIP: docker_cli_run_test.go:1184: DockerSuite.TestRunDnsDefaultOptions (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1218: DockerSuite.TestRunDnsOptions (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1252: DockerSuite.TestRunDnsOptionsBasedOnHostResolvConf (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1242: DockerSuite.TestRunDnsRepeatOptions (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:38: DockerSuite.TestRunEchoNamedContainer  3.233s
PASS: docker_cli_run_test.go:30: DockerSuite.TestRunEchoStdout  3.159s
PASS: docker_cli_run_test.go:1859: DockerSuite.TestRunEntrypoint        3.066s
SKIP: docker_cli_run_test.go:743: DockerSuite.TestRunEnvironment (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:782: DockerSuite.TestRunEnvironmentErase (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:817: DockerSuite.TestRunEnvironmentOverride (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:364: DockerSuite.TestRunExecDir (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:613: DockerSuite.TestRunExitCode   3.457s
PASS: docker_cli_run_test.go:75: DockerSuite.TestRunExitCodeOne 3.124s
PASS: docker_cli_run_test.go:70: DockerSuite.TestRunExitCodeZero        3.273s
PASS: docker_cli_run_test.go:1712: DockerSuite.TestRunExitOnStdinClose  3.371s
PASS: docker_cli_run_test.go:2308: DockerSuite.TestRunExposePort        0.061s
SKIP: docker_cli_run_test.go:878: DockerSuite.TestRunFullHostnameSet (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1005: DockerSuite.TestRunGroupAdd (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3887: DockerSuite.TestRunInitLayerPathOwnership (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1997: DockerSuite.TestRunInspectMacAddress (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3875: DockerSuite.TestRunInvalidReference  0.051s
SKIP: docker_cli_run_test.go:47: DockerSuite.TestRunLeakyFileDescriptors (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3538: DockerSuite.TestRunLinkToContainerNetMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:186: DockerSuite.TestRunLinksContainerWithContainerId (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:170: DockerSuite.TestRunLinksContainerWithContainerName (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:59: DockerSuite.TestRunLookupGoogleDns     4.162s
SKIP: docker_cli_run_test.go:3548: DockerSuite.TestRunLoopbackOnlyExistsWhenNetworkingDisabled (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3574: DockerSuite.TestRunLoopbackWhenNetworkDisabled       2.865s
SKIP: docker_cli_run_test.go:1129: DockerSuite.TestRunModeHostname (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2363: DockerSuite.TestRunModeIpcContainer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2395: DockerSuite.TestRunModeIpcContainerNotExists (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2404: DockerSuite.TestRunModeIpcContainerNotRunning (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2341: DockerSuite.TestRunModeIpcHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3582: DockerSuite.TestRunModeNetContainerHostname (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2456: DockerSuite.TestRunModePidHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2478: DockerSuite.TestRunModeUTSHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2082: DockerSuite.TestRunMountOrdering (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2417: DockerSuite.TestRunMountShmMqueueFromHost (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:502: DockerSuite.TestRunMultipleVolumesFrom        9.986s
SKIP: docker_cli_exec_test.go:411: DockerSuite.TestRunMutableNetworkFiles (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3381: DockerSuite.TestRunNamedVolume (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:4047: DockerSuite.TestRunNamedVolumeCopyImageData (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:4034: DockerSuite.TestRunNamedVolumesMountedAsShared (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2628: DockerSuite.TestRunNetContainerWhichHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2597: DockerSuite.TestRunNetHost (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:861: DockerSuite.TestRunNetHostNotAllowedWithLinks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2619: DockerSuite.TestRunNetHostTwiceSameName (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3085: DockerSuite.TestRunNetworkFilesBindMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3104: DockerSuite.TestRunNetworkFilesBindMountRO (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3121: DockerSuite.TestRunNetworkFilesBindMountROFilesystem (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3595: DockerSuite.TestRunNetworkNotInitializedNoneMode (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:462: DockerSuite.TestRunNoDupVolumes       0.420s
PASS: docker_cli_run_test.go:2204: DockerSuite.TestRunNoOutputFromPullInStdout  1.351s
PASS: docker_cli_run_test.go:3818: DockerSuite.TestRunNonExecutableCmd  3.281s
PASS: docker_cli_run_test.go:3829: DockerSuite.TestRunNonExistingCmd    3.225s
PASS: docker_cli_run_test.go:3857: DockerSuite.TestRunNonExistingImage  1.445s
PASS: docker_cli_run_test.go:2579: DockerSuite.TestRunNonLocalMacAddress        3.613s
SKIP: docker_cli_run_test.go:1335: DockerSuite.TestRunNonRootUserResolvName (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2842: DockerSuite.TestRunPidHostWithChildIsKillable (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2518: DockerSuite.TestRunPortFromDockerRangeInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2042: DockerSuite.TestRunPortInUse (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:887: DockerSuite.TestRunPrivilegedCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1016: DockerSuite.TestRunPrivilegedCanMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1055: DockerSuite.TestRunProcNotWritableInNonPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1063: DockerSuite.TestRunProcWritableInPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2991: DockerSuite.TestRunPublishPort (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2922: DockerSuite.TestRunReadFilteredProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:2901: DockerSuite.TestRunReadProcLatency (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2886: DockerSuite.TestRunReadProcTimer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1360: DockerSuite.TestRunResolvconfUpdate (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2679: DockerSuite.TestRunRestartMaxRetries 10.850s
SKIP: docker_cli_run_test.go:2130: DockerSuite.TestRunReuseBindVolumeThatIsSymlink (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:1150: DockerSuite.TestRunRootWorkdir       3.075s
PASS: docker_cli_run_test.go:2670: DockerSuite.TestRunSetDefaultRestartPolicy   2.225s
PASS: docker_cli_run_test.go:1981: DockerSuite.TestRunSetMacAddress     3.483s
SKIP: docker_cli_run_test.go:2258: DockerSuite.TestRunSlowStdoutConsumer (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1587: DockerSuite.TestRunState (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:3775: DockerSuite.TestRunStdinBlockedAfterContainerExit    3.154s
SKIP: docker_cli_run_test.go:86: DockerSuite.TestRunStdinPipe (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1039: DockerSuite.TestRunSysNotWritableInNonPrivilegedContainers (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1047: DockerSuite.TestRunSysWritableInPrivilegedContainers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2500: DockerSuite.TestRunTLSverify 0.144s
SKIP: docker_cli_run_test.go:1087: DockerSuite.TestRunThatCharacterDevicesActLikeCharacterDevices (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2550: DockerSuite.TestRunTtyWithPipe       0.045s
SKIP: docker_cli_run_test.go:709: DockerSuite.TestRunTwoConcurrentContainers (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2316: DockerSuite.TestRunUnknownCommand    3.240s
SKIP: docker_cli_run_test.go:897: DockerSuite.TestRunUnprivilegedCanMknod (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1026: DockerSuite.TestRunUnprivilegedCannotMount (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1096: DockerSuite.TestRunUnprivilegedWithChroot (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2961: DockerSuite.TestRunUnshareProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:650: DockerSuite.TestRunUserByID (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:660: DockerSuite.TestRunUserByIDBig (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:673: DockerSuite.TestRunUserByIDNegative (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:686: DockerSuite.TestRunUserByIDZero (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:640: DockerSuite.TestRunUserByName (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:629: DockerSuite.TestRunUserDefaults       3.338s
SKIP: docker_cli_run_test.go:699: DockerSuite.TestRunUserNotFound (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:513: DockerSuite.TestRunVerifyContainerID  2.341s
PASS: docker_cli_run_test.go:2217: DockerSuite.TestRunVolumesCleanPaths 5.793s
PASS: docker_cli_run_test.go:418: DockerSuite.TestRunVolumesFromInReadWriteMode 10.211s
SKIP: docker_cli_run_test.go:394: DockerSuite.TestRunVolumesFromInReadonlyModeFails (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:2792: DockerSuite.TestRunVolumesFromRestartAfterRemoved    7.843s
PASS: docker_cli_run_test.go:578: DockerSuite.TestRunVolumesFromSymlinkPath     29.108s
SKIP: docker_cli_run_test.go:385: DockerSuite.TestRunVolumesMountedAsReadonly (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3937: DockerSuite.TestRunVolumesMountedAsShared (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3975: DockerSuite.TestRunVolumesMountedAsSlave (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1844: DockerSuite.TestRunWithBadDevice (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:308: DockerSuite.TestRunWithDaemonFlags    3.304s
PASS: docker_cli_run_test.go:2012: DockerSuite.TestRunWithInvalidMacAddress     0.052s
SKIP: docker_cli_run_test.go:3909: DockerSuite.TestRunWithOomScoreAdj (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3920: DockerSuite.TestRunWithOomScoreAdjInvalidRange (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2865: DockerSuite.TestRunWithTooSmallMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3398: DockerSuite.TestRunWithUlimits (Test requires a Linux daemon)
PASS: docker_cli_run_test.go:318: DockerSuite.TestRunWithVolumesFromExited      7.026s
PASS: docker_cli_run_test.go:151: DockerSuite.TestRunWithoutNetworking  2.930s
PASS: docker_cli_run_test.go:1698: DockerSuite.TestRunWorkdirExistsAndIsFile    3.277s
SKIP: docker_cli_run_test.go:125: DockerSuite.TestRunWorkingDirectory (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3058: DockerSuite.TestRunWriteFilteredProc (Test requires apparmor is enabled.)
SKIP: docker_cli_run_test.go:1813: DockerSuite.TestRunWriteHostnameFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1771: DockerSuite.TestRunWriteHostsFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:1829: DockerSuite.TestRunWriteResolvFileAndNotCommit (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2877: DockerSuite.TestRunWriteToProcAsound (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3795: DockerSuite.TestRunWrongCpusetCpusFlagValue (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3806: DockerSuite.TestRunWrongCpusetMemsFlagValue (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:149: DockerSuite.TestSaveAndLoadRepoFlags (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:91: DockerSuite.TestSaveCheckTimes (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:240: DockerSuite.TestSaveDirectoryPermissions (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:110: DockerSuite.TestSaveImageId (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:170: DockerSuite.TestSaveMultipleNames (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:188: DockerSuite.TestSaveRepoWithMultipleImages (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:76: DockerSuite.TestSaveSingleTag (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:22: DockerSuite.TestSaveXzAndLoadRepoStdout (Test requires a Linux daemon)
SKIP: docker_cli_save_load_test.go:49: DockerSuite.TestSaveXzGzAndLoadRepoStdout (Test requires a Linux daemon)
PASS: docker_cli_search_test.go:28: DockerSuite.TestSearchCmdOptions    2.900s
SKIP: docker_cli_search_test.go:11: DockerSuite.TestSearchOnCentralRegistry (Test requires a Linux daemon)
SKIP: docker_cli_search_test.go:51: DockerSuite.TestSearchOnCentralRegistryWithDash (Test requires a Linux daemon)
PASS: docker_cli_search_test.go:18: DockerSuite.TestSearchStarsOptionWithWrongParameter 0.114s
SKIP: docker_cli_start_test.go:42: DockerSuite.TestStartAttachCorrectExitCode (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:151: DockerSuite.TestStartAttachMultipleContainers (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:13: DockerSuite.TestStartAttachReturnsOnError (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:58: DockerSuite.TestStartAttachSilent (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:113: DockerSuite.TestStartMultipleContainers (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:98: DockerSuite.TestStartPausedContainer (Test requires a Linux daemon)
SKIP: docker_cli_start_test.go:71: DockerSuite.TestStartRecordError (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:1381: DockerSuite.TestStartWithNilDNS (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:844: DockerSuite.TestStartWithTooLowMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:94: DockerSuite.TestStatsAllNewContainersAdded (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:77: DockerSuite.TestStatsAllNoStream (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:54: DockerSuite.TestStatsAllRunningNoStream (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:42: DockerSuite.TestStatsContainerNotFound (Test requires a Linux daemon)
SKIP: docker_cli_stats_test.go:14: DockerSuite.TestStatsNoStream (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:83: DockerSuite.TestTagExistedNameWithForce (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:73: DockerSuite.TestTagExistedNameWithoutForce (Test requires a Linux daemon)
PASS: docker_cli_tag_test.go:42: DockerSuite.TestTagInvalidPrefixedRepo 0.625s
SKIP: docker_cli_tag_test.go:173: DockerSuite.TestTagInvalidRepoName (Test requires a Linux daemon)
PASS: docker_cli_tag_test.go:32: DockerSuite.TestTagInvalidUnprefixedRepo       0.378s
SKIP: docker_cli_tag_test.go:155: DockerSuite.TestTagMatchesDigest (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:117: DockerSuite.TestTagOfficialNames (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:187: DockerSuite.TestTagTruncationAmbiguity (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:24: DockerSuite.TestTagUnprefixedRepoByID (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:14: DockerSuite.TestTagUnprefixedRepoByName (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:54: DockerSuite.TestTagValidPrefixedRepo (Test requires a Linux daemon)
SKIP: docker_cli_tag_test.go:93: DockerSuite.TestTagWithPrefixHyphen (Test requires a Linux daemon)
SKIP: docker_cli_top_test.go:10: DockerSuite.TestTopMultipleArgs (Test requires a Linux daemon)
SKIP: docker_cli_top_test.go:19: DockerSuite.TestTopNonPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_top_test.go:32: DockerSuite.TestTopPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:3608: DockerSuite.TestTwoContainersInNetHost (Test requires a Linux daemon)
SKIP: docker_cli_port_test.go:180: DockerSuite.TestUnpublishedPortsInPsOutput (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:276: DockerSuite.TestUserDefinedNetworkAlias (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:202: DockerSuite.TestUserDefinedNetworkLinks (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:238: DockerSuite.TestUserDefinedNetworkLinksWithRestart (Test requires a Linux daemon)
SKIP: docker_cli_restart_test.go:157: DockerSuite.TestUserDefinedNetworkWithRestartPolicy (Test requires a Linux daemon)
PASS: docker_cli_version_test.go:11: DockerSuite.TestVersionEnsureSucceeds      0.056s
SKIP: docker_cli_version_test.go:36: DockerSuite.TestVersionPlatform_l (Test requires a Linux daemon)
PASS: docker_cli_version_test.go:30: DockerSuite.TestVersionPlatform_w  0.051s
PASS: docker_cli_volume_test.go:11: DockerSuite.TestVolumeCliCreate     15.165s
PASS: docker_cli_volume_test.go:22: DockerSuite.TestVolumeCliCreateOptionConflict       0.190s
PASS: docker_cli_volume_test.go:33: DockerSuite.TestVolumeCliInspect    0.246s
PASS: docker_cli_volume_test.go:50: DockerSuite.TestVolumeCliInspectMulti       0.214s
PASS: docker_cli_volume_test.go:206: DockerSuite.TestVolumeCliInspectTmplError  0.111s
PASS: docker_cli_volume_test.go:66: DockerSuite.TestVolumeCliLs 3.415s
PASS: docker_cli_volume_test.go:134: DockerSuite.TestVolumeCliLsErrorWithInvalidFilterName      0.056s
PASS: docker_cli_volume_test.go:86: DockerSuite.TestVolumeCliLsFilterDangling   4.326s
PASS: docker_cli_volume_test.go:140: DockerSuite.TestVolumeCliLsWithIncorrectFilterValue        0.063s
PASS: docker_cli_volume_test.go:188: DockerSuite.TestVolumeCliNoArgs    0.138s
PASS: docker_cli_volume_test.go:146: DockerSuite.TestVolumeCliRm        10.166s
PASS: docker_cli_run_test.go:3027: DockerSuite.TestVolumeFromMixedRWOptions     6.477s
PASS: docker_api_volumes_test.go:30: DockerSuite.TestVolumesApiCreate   0.001s
PASS: docker_api_volumes_test.go:72: DockerSuite.TestVolumesApiInspect  0.002s
PASS: docker_api_volumes_test.go:13: DockerSuite.TestVolumesApiList     2.439s
PASS: docker_api_volumes_test.go:45: DockerSuite.TestVolumesApiRemove   3.109s
SKIP: docker_cli_run_test.go:442: DockerSuite.TestVolumesFromGetsProperMode (Test requires a Linux daemon)
SKIP: docker_cli_run_test.go:2180: DockerSuite.TestVolumesNoCopyData (Test requires a Linux daemon)
SKIP: docker_cli_wait_test.go:67: DockerSuite.TestWaitBlockedExitRandom (Test requires a Linux daemon)
SKIP: docker_cli_wait_test.go:27: DockerSuite.TestWaitBlockedExitZero (Test requires a Linux daemon)
PASS: docker_cli_wait_test.go:55: DockerSuite.TestWaitNonBlockedExitRandom      3.256s
PASS: docker_cli_wait_test.go:14: DockerSuite.TestWaitNonBlockedExitZero        3.245s
SKIP: docker_cli_by_digest_test.go:185: DockerRegistrySuite.TestBuildByDigest
SKIP: docker_cli_pull_local_test.go:198: DockerRegistrySuite.TestConcurrentPullMultipleTags
SKIP: docker_cli_by_digest_test.go:128: DockerRegistrySuite.TestCreateByDigest
SKIP: docker_cli_push_test.go:150: DockerRegistrySuite.TestCrossRepositoryLayerPush
SKIP: docker_cli_by_digest_test.go:383: DockerRegistrySuite.TestDeleteImageByIDOnlyPulledByDigest
SKIP: docker_cli_by_digest_test.go:398: DockerRegistrySuite.TestDeleteImageWithDigestAndTag
SKIP: docker_cli_events_test.go:505: DockerRegistrySuite.TestEventsImageFilterPush
SKIP: docker_cli_by_digest_test.go:328: DockerRegistrySuite.TestInspectImageWithDigests
SKIP: docker_cli_by_digest_test.go:247: DockerRegistrySuite.TestListImagesWithDigests
SKIP: docker_cli_by_digest_test.go:234: DockerRegistrySuite.TestListImagesWithoutDigests
SKIP: docker_cli_by_digest_test.go:347: DockerRegistrySuite.TestPsListContainersFilterAncestorImageByDigest
SKIP: docker_cli_by_digest_test.go:103: DockerRegistrySuite.TestPullByDigest
SKIP: docker_cli_by_digest_test.go:120: DockerRegistrySuite.TestPullByDigestNoFallback
SKIP: docker_cli_by_digest_test.go:77: DockerRegistrySuite.TestPullByTagDisplaysDigest
SKIP: docker_cli_by_digest_test.go:512: DockerRegistrySuite.TestPullFailsWithAlteredLayer
SKIP: docker_cli_by_digest_test.go:430: DockerRegistrySuite.TestPullFailsWithAlteredManifest
SKIP: docker_cli_pull_local_test.go:274: DockerRegistrySuite.TestPullIDStability
SKIP: docker_cli_pull_local_test.go:53: DockerRegistrySuite.TestPullImageWithAliases
SKIP: docker_cli_pull_local_test.go:282: DockerRegistrySuite.TestPullManifestList
SKIP: docker_cli_push_test.go:67: DockerRegistrySuite.TestPushBadTag
SKIP: docker_cli_push_test.go:27: DockerRegistrySuite.TestPushBusyboxImage
SKIP: docker_cli_push_test.go:142: DockerRegistrySuite.TestPushEmptyLayer
SKIP: docker_cli_push_test.go:112: DockerRegistrySuite.TestPushMultipleTags
SKIP: docker_cli_push_test.go:50: DockerRegistrySuite.TestPushUntagged
SKIP: docker_cli_by_digest_test.go:161: DockerRegistrySuite.TestRemoveImageByDigest
SKIP: docker_cli_by_digest_test.go:142: DockerRegistrySuite.TestRunByDigest
SKIP: docker_cli_by_digest_test.go:213: DockerRegistrySuite.TestTagByDigest
SKIP: docker_cli_v2_only_test.go:71: DockerRegistrySuite.TestV1
SKIP: docker_cli_v2_only_test.go:38: DockerRegistrySuite.TestV2Only
SKIP: docker_cli_pull_local_test.go:202: DockerSchema1RegistrySuite.TestConcurrentPullMultipleTags
SKIP: docker_cli_push_test.go:177: DockerSchema1RegistrySuite.TestCrossRepositoryLayerPushNotSupported
SKIP: docker_cli_by_digest_test.go:107: DockerSchema1RegistrySuite.TestPullByDigest
SKIP: docker_cli_by_digest_test.go:124: DockerSchema1RegistrySuite.TestPullByDigestNoFallback
SKIP: docker_cli_by_digest_test.go:81: DockerSchema1RegistrySuite.TestPullByTagDisplaysDigest
SKIP: docker_cli_by_digest_test.go:555: DockerSchema1RegistrySuite.TestPullFailsWithAlteredLayer
SKIP: docker_cli_by_digest_test.go:470: DockerSchema1RegistrySuite.TestPullFailsWithAlteredManifest
SKIP: docker_cli_pull_local_test.go:278: DockerSchema1RegistrySuite.TestPullIDStability
SKIP: docker_cli_pull_local_test.go:57: DockerSchema1RegistrySuite.TestPullImageWithAliases
SKIP: docker_cli_push_test.go:71: DockerSchema1RegistrySuite.TestPushBadTag
SKIP: docker_cli_push_test.go:31: DockerSchema1RegistrySuite.TestPushBusyboxImage
SKIP: docker_cli_push_test.go:146: DockerSchema1RegistrySuite.TestPushEmptyLayer
SKIP: docker_cli_push_test.go:116: DockerSchema1RegistrySuite.TestPushMultipleTags
SKIP: docker_cli_push_test.go:54: DockerSchema1RegistrySuite.TestPushUntagged
SKIP: docker_cli_proxy_test.go:26: DockerDaemonSuite.TestCliProxyProxyTCPSock
SKIP: docker_cli_exec_test.go:81: DockerDaemonSuite.TestExecAfterDaemonRestart
SKIP: docker_cli_build_test.go:5831: DockerTrustSuite.TestBuildContextDirIsSymlink
SKIP: docker_cli_create_test.go:332: DockerTrustSuite.TestCreateWhenCertExpired
SKIP: docker_cli_pull_trusted_test.go:65: DockerTrustSuite.TestPullWhenCertExpired
SKIP: docker_cli_run_test.go:3200: DockerTrustSuite.TestRunWhenCertExpired
SKIP: docker_cli_build_test.go:5779: DockerTrustSuite.TestTrustedBuild
SKIP: docker_cli_build_test.go:5810: DockerTrustSuite.TestTrustedBuildUntrustedTag
SKIP: docker_cli_create_test.go:282: DockerTrustSuite.TestTrustedCreate
SKIP: docker_cli_create_test.go:359: DockerTrustSuite.TestTrustedCreateFromBadTrustServer
SKIP: docker_cli_create_test.go:319: DockerTrustSuite.TestTrustedIsolatedCreate
SKIP: docker_cli_pull_trusted_test.go:35: DockerTrustSuite.TestTrustedIsolatedPull
SKIP: docker_cli_pull_trusted_test.go:177: DockerTrustSuite.TestTrustedOfflinePull
SKIP: docker_cli_pull_trusted_test.go:14: DockerTrustSuite.TestTrustedPull
SKIP: docker_cli_pull_trusted_test.go:205: DockerTrustSuite.TestTrustedPullDelete
SKIP: docker_cli_pull_trusted_test.go:93: DockerTrustSuite.TestTrustedPullFromBadTrustServer
SKIP: docker_cli_pull_trusted_test.go:147: DockerTrustSuite.TestTrustedPullWithExpiredSnapshot
SKIP: docker_cli_push_test.go:203: DockerTrustSuite.TestTrustedPush
SKIP: docker_cli_push_test.go:243: DockerTrustSuite.TestTrustedPushWithDeprecatedEnvPasswords
SKIP: docker_cli_push_test.go:222: DockerTrustSuite.TestTrustedPushWithEnvPasswords
SKIP: docker_cli_push_test.go:299: DockerTrustSuite.TestTrustedPushWithExistingSignedTag
SKIP: docker_cli_push_test.go:279: DockerTrustSuite.TestTrustedPushWithExistingTag
SKIP: docker_cli_push_test.go:371: DockerTrustSuite.TestTrustedPushWithExpiredSnapshot
SKIP: docker_cli_push_test.go:397: DockerTrustSuite.TestTrustedPushWithExpiredTimestamp
SKIP: docker_cli_push_test.go:255: DockerTrustSuite.TestTrustedPushWithFailingServer
SKIP: docker_cli_push_test.go:351: DockerTrustSuite.TestTrustedPushWithIncorrectDeprecatedPassphraseForNonRoot
SKIP: docker_cli_push_test.go:329: DockerTrustSuite.TestTrustedPushWithIncorrectPassphraseForNonRoot
SKIP: docker_cli_push_test.go:423: DockerTrustSuite.TestTrustedPushWithReleasesDelegation
SKIP: docker_cli_push_test.go:267: DockerTrustSuite.TestTrustedPushWithoutServerAndUntrusted
SKIP: docker_cli_run_test.go:3146: DockerTrustSuite.TestTrustedRun
SKIP: docker_cli_run_test.go:3238: DockerTrustSuite.TestTrustedRunFromBadTrustServer
SKIP: docker_cli_create_test.go:303: DockerTrustSuite.TestUntrustedCreate
SKIP: docker_cli_pull_trusted_test.go:49: DockerTrustSuite.TestUntrustedPull
SKIP: docker_cli_run_test.go:3178: DockerTrustSuite.TestUntrustedRun
OOPS: 135 passed, 834 skipped, 1 FAILED
--- FAIL: Test (567.26s)
FAIL
coverage: 23.7% of statements
exit status 1
FAIL    github.com/docker/docker/integration-cli        567.444s
ERROR: Tests failed.
INFO: Removing containers and images...
INFO: Removing 1 images
Untagged: busybox:latest
Deleted: sha256:056c79445a251aa90fde5119a1dbaa40a3fad78c280b4a16302dc53de995a6ad
Deleted: sha256:453c757d219523da07c596fc29807d0fd0947632c96477b0c1ad22e3eb53e9ba
Deleted: sha256:fbb5c73d15ab9f6ce69cfaaafd2ac00920ce4efea2beaf6b6425596d49f20760
Deleted: sha256:1c2f850295e1c7034a01a08906c8579dde2deadc75b12d001147baa4038296fc
INFO: Stopping daemon under test
SUCCESS: The process with PID 7300 (child process of PID 7596) has been terminated.
ERROR: Failed with exitcode 1 at Wed Jan 20 19:37:57 PST 2016.
INFO: Tidying up at end of run
INFO: Cleaning /c/CI/CI-bdcc3eb
INFO: Nuking /c/CI/CI-bdcc3eb
INFO: End of cleanup
INFO: Ended at Wed Jan 20 19:37:57 PST 2016.

C:\Go\src\github.com\docker\docker>
```
