### PR TITLE
Fix comment about swap limit of docker update

### DIFF
--- a/api/client/update.go
+++ b/api/client/update.go
@@ -23,7 +23,7 @@ func (cli *DockerCli) CmdUpdate(args ...string) error {
 	flCPUShares := cmd.Int64([]string{"#c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 	flMemoryString := cmd.String([]string{"m", "-memory"}, "", "Memory limit")
 	flMemoryReservation := cmd.String([]string{"-memory-reservation"}, "", "Memory soft limit")
-	flMemorySwap := cmd.String([]string{"-memory-swap"}, "", "Total memory (memory + swap), '-1' to disable swap")
+	flMemorySwap := cmd.String([]string{"-memory-swap"}, "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
 	flKernelMemory := cmd.String([]string{"-kernel-memory"}, "", "Kernel memory limit")
 
 	cmd.Require(flag.Min, 1)

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -303,7 +303,7 @@ Json Parameters:
       for the container.
 -   **User** - A string value specifying the user inside the container.
 -   **Memory** - Memory limit in bytes.
--   **MemorySwap** - Total memory limit (memory + swap); set `-1` to disable swap
+-   **MemorySwap** - Total memory limit (memory + swap); set `-1` to enable unlimited swap.
       You must use this with `memory` and make the swap value larger than `memory`.
 -   **MemoryReservation** - Memory soft limit in bytes.
 -   **KernelMemory** - Kernel memory limit in bytes.
@@ -1595,7 +1595,7 @@ Query Parameters:
 -   **rm** - Remove intermediate containers after a successful build (default behavior).
 -   **forcerm** - Always remove intermediate containers (includes `rm`).
 -   **memory** - Set memory limit for build.
--   **memswap** - Total memory (memory + swap), `-1` to disable swap.
+-   **memswap** - Total memory (memory + swap), `-1` to enable unlimited swap.
 -   **cpushares** - CPU shares (relative weight).
 -   **cpusetcpus** - CPUs in which to allow execution (e.g., `0-3`, `0,1`).
 -   **cpuperiod** - The length of a CPU period in microseconds.

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -23,7 +23,7 @@ parent = "smn_cli"
       --cpuset-mems=""           Memory nodes (MEMs) in which to allow execution (0-3, 0,1)
       -m, --memory=""            Memory limit
       --memory-reservation=""    Memory soft limit
-      --memory-swap=""           Total memory (memory + swap), '-1' to disable swap
+      --memory-swap=""           A positive integer equal to memory plus swap. Specify -1 to enable unlimited swap
       --kernel-memory=""         Kernel memory limit: container must be stopped
 
 The `docker update` command dynamically updates container resources.  Use this


### PR DESCRIPTION
The description "set `-1` to disable swap" is wrong, `build`,
`create` and `run` already fixed, we need to fix `update` as well.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
