### PR TITLE
remove auto-creating non-existant volume host path

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -182,6 +182,9 @@ func (s *DockerSuite) TestContainerApiStartVolumeBinds(c *check.C) {
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":/tmp"},
 	}
+
+	os.Mkdir(bindPath, 0755)
+
 	status, _, err = sockRequest("POST", "/containers/"+name+"/start", config)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNoContent)

--- a/integration-cli/docker_cli_cp_utils.go
+++ b/integration-cli/docker_cli_cp_utils.go
@@ -289,15 +289,25 @@ func containerStartOutputEquals(c *check.C, containerID, contents string) (err e
 }
 
 func defaultVolumes(tmpDir string) []string {
+	var volumes []string
+
 	if SameHostDaemon.Condition() {
-		return []string{
+		volumes = []string{
 			"/vol1",
 			fmt.Sprintf("%s:/vol2", tmpDir),
 			fmt.Sprintf("%s:/vol3", filepath.Join(tmpDir, "vol3")),
 			fmt.Sprintf("%s:/vol_ro:ro", filepath.Join(tmpDir, "vol_ro")),
 		}
+	} else {
+		// Can't bind-mount volumes with separate host daemon.
+		volumes = []string{"/vol1", "/vol2", "/vol3", "/vol_ro:/vol_ro:ro"}
 	}
 
-	// Can't bind-mount volumes with separate host daemon.
-	return []string{"/vol1", "/vol2", "/vol3", "/vol_ro:/vol_ro:ro"}
+	for _, volume := range volumes {
+		dir := strings.Split(volume, ":")
+		if dir != nil {
+			os.Mkdir(dir[0], 0755)
+		}
+	}
+	return volumes
 }

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -233,6 +234,8 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 
 func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
+
+	os.Mkdir("/data", 0755)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "/data:/data:ro,z", "busybox", "cat")
 
 	vol, err := inspectFieldJSON("test", "Mounts")

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -12,6 +12,7 @@ func (s *DockerSuite) TestRmContainerWithRemovedVolume(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
+	os.Mkdir("/tmp/testing", 0755)
 	dockerCmd(c, "run", "--name", "losemyvolumes", "-v", "/tmp/testing:/test", "busybox", "true")
 
 	err := os.Remove("/tmp/testing")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -443,6 +443,8 @@ func (s *DockerSuite) TestVolumesFromGetsProperMode(c *check.C) {
 	// TODO Windows: This test cannot yet run on a Windows daemon as Windows does
 	// not support read-only bind mounts as at TP4
 	testRequires(c, DaemonIsLinux)
+
+	os.Mkdir("/test", 0755)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test:/test:ro", "busybox", "true")
 
 	// Expect this "rw" mode to be be ignored since the inherited volume is "ro"
@@ -2189,6 +2191,7 @@ func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
 		c.Fatal(err)
 	}
 
+	os.Mkdir("/foo", 0755)
 	dockerCmd(c, "run", "--name", "test", "-v", "/foo", "busybox")
 
 	if out, _, err := dockerCmdWithError("run", "--volumes-from", "test", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
@@ -2196,6 +2199,7 @@ func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
 	}
 
 	tmpDir := randomTmpDirPath("docker_test_bind_mount_copy_data", daemonPlatform)
+	os.Mkdir(tmpDir, 0755)
 	if out, _, err := dockerCmdWithError("run", "-v", tmpDir+":/foo", "dataimage", "ls", "-lh", "/foo/bar"); err == nil || !strings.Contains(out, "No such file or directory") {
 		c.Fatalf("Data was copied on bind-mount but shouldn't be:\n%q", out)
 	}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -2,12 +2,10 @@ package volume
 
 import (
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
 	derr "github.com/docker/docker/errors"
-	"github.com/docker/docker/pkg/system"
 )
 
 // DefaultDriverName is the driver name used for the driver
@@ -69,15 +67,10 @@ func (m *MountPoint) Setup() (string, error) {
 	}
 	if len(m.Source) > 0 {
 		if _, err := os.Stat(m.Source); err != nil {
-			if !os.IsNotExist(err) {
-				return "", err
+			if os.IsNotExist(err) {
+				logrus.Errorf("non-existent volume host path %s", m.Source)
 			}
-			if runtime.GOOS != "windows" { // Windows does not have deprecation issues here
-				logrus.Warnf("Auto-creating non-existent volume host path %s, this is deprecated and will be removed soon", m.Source)
-				if err := system.MkdirAll(m.Source, 0755); err != nil {
-					return "", err
-				}
-			}
+			return "", err
 		}
 		return m.Source, nil
 	}


### PR DESCRIPTION
currently, docker create non-existent volume host path automatically.
 e.g. 

```
docker run --rm -ti -v /hello:/hello ubuntu bash
```

if the /hello dir don't exist in host, docker will create it to avoid the fail of mount. 

But it is not reasonable.in fact,we can skip non-existant volume host path(https://github.com/opencontainers/runc/pull/492) and remove "MkdirAll" from Setup.

Signed-off-by: yangshukui yangshukui@huawei.com
