### PR TITLE
Support new events in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -862,7 +862,7 @@ _docker_diff() {
 _docker_events() {
 	case "$prev" in
 		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "container event image" -- "$cur" ) )
+			COMPREPLY=( $( compgen -S = -W "container event image label network type volume" -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -881,16 +881,19 @@ _docker_events() {
 			COMPREPLY=( $( compgen -W "
 				attach
 				commit
+				connect
 				copy
 				create
 				delete
 				destroy
 				die
+				disconnect
 				exec_create
 				exec_start
 				export
 				import
 				kill
+				mount
 				oom
 				pause
 				pull
@@ -902,14 +905,31 @@ _docker_events() {
 				stop
 				tag
 				top
+				unmount
 				unpause
 				untag
+				update
 			" -- "${cur#=}" ) )
 			return
 			;;
 		*image=*)
 			cur="${cur#=}"
 			__docker_complete_images
+			return
+			;;
+		*network=*)
+			## BUG: this also triggers after -f type=network
+			cur="${cur#=}"
+			__docker_complete_networks
+			return
+			;;
+		*type=*)
+			COMPREPLY=( $( compgen -W "container image network volume" -- "${cur#=}" ) )
+			return
+			;;
+		*volume=*)
+			cur="${cur#=}"
+			__docker_complete_volumes
 			return
 			;;
 	esac

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -220,6 +220,32 @@ __docker_pos_first_nonflag() {
 	echo $counter
 }
 
+# If we are currently completing the value of a map option (key=value)
+# which matches the extglob given as an argument, returns key.
+# This function is needed for key-specific completions.
+# TODO use this in all "${words[$cword-2]}$prev=" occurrences
+__docker_map_key_of_current_option() {
+	local glob="$1"
+
+	local key glob_pos
+	if [ "$cur" = "=" ] ; then        # key= case
+		key="$prev"
+		glob_pos=$((cword - 2))
+	elif [[ $cur == *=* ]] ; then     # key=value case (OSX)
+		key=${cur%=*}
+		glob_pos=$((cword - 1))
+	elif [ "$prev" = "=" ] ; then
+		key=${words[$cword - 2]}  # key=value case
+		glob_pos=$((cword - 3))
+	else
+		return
+	fi
+
+	[ "${words[$glob_pos]}" = "=" ] && ((glob_pos--))  # --option=key=value syntax
+
+	[[ ${words[$glob_pos]} == @($glob) ]] && echo "$key"
+}
+
 # Returns the value of the first option matching option_glob.
 # Valid values for option_glob are option names like '--log-level' and
 # globs like '--log-level|-l'
@@ -860,24 +886,14 @@ _docker_diff() {
 }
 
 _docker_events() {
-	case "$prev" in
-		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "container event image label network type volume" -- "$cur" ) )
-			__docker_nospace
-			return
-			;;
-		--since|--until)
-			return
-			;;
-	esac
-
-	case "${words[$cword-2]}$prev=" in
-		*container=*)
-			cur="${cur#=}"
+	local filter=$(__docker_map_key_of_current_option '-f|--filter')
+	case "$filter" in
+		container)
+			cur="${cur##*=}"
 			__docker_complete_containers_all
 			return
 			;;
-		*event=*)
+		event)
 			COMPREPLY=( $( compgen -W "
 				attach
 				commit
@@ -909,27 +925,37 @@ _docker_events() {
 				unpause
 				untag
 				update
-			" -- "${cur#=}" ) )
+			" -- "${cur##*=}" ) )
 			return
 			;;
-		*image=*)
-			cur="${cur#=}"
+		image)
+			cur="${cur##*=}"
 			__docker_complete_images
 			return
 			;;
-		*network=*)
-			## BUG: this also triggers after -f type=network
-			cur="${cur#=}"
+		network)
+			cur="${cur##*=}"
 			__docker_complete_networks
 			return
 			;;
-		*type=*)
-			COMPREPLY=( $( compgen -W "container image network volume" -- "${cur#=}" ) )
+		type)
+			COMPREPLY=( $( compgen -W "container image network volume" -- "${cur##*=}" ) )
 			return
 			;;
-		*volume=*)
-			cur="${cur#=}"
+		volume)
+			cur="${cur##*=}"
 			__docker_complete_volumes
+			return
+			;;
+	esac
+
+	case "$prev" in
+		--filter|-f)
+			COMPREPLY=( $( compgen -S = -W "container event image label network type volume" -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+		--since|--until)
 			return
 			;;
 	esac


### PR DESCRIPTION
#18888 added new events and new filters to `docker events`.

This PR aligns bash completion with these changes.

The completion of `docker events -f type=network` uncovered a problem with the current approach to key specific subcompletions of map option values. This PR introduces a new approach for this but only applies it to `docker events --filter` so that the PR can be more easily cherry-picked into 1.10.
I will create a follow-up PR for other occurences of this idiom.

This change was tested against the [albers/bash-completion-mac](https://hub.docker.com/r/albers/bash-completion-mac/) image in order to avoid problems with Mac OSX. On Macs, completing e.g. `docker events -f t` adds a trailing white space after `type` because the `nospace` option is not availabe on bash 3.2. The user will have to backspace once and then can continue to use completion.

ping @jfrazelle @tianon for review
