### PR TITLE
Bump plugin API version

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	versionMimetype = "application/vnd.docker.plugins.v1.1+json"
+	versionMimetype = "application/vnd.docker.plugins.v1.2+json"
 	defaultTimeOut  = 30
 )
 


### PR DESCRIPTION
This should have been updated with the changes to volume drivers (#16534).
