### PR TITLE
Windows: Fix TestLinksMultipleWithSameName

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -214,6 +214,7 @@ func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksMultipleWithSameName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name=upstream-a", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name=upstream-b", "busybox", "top")
 	dockerCmd(c, "run", "--link", "upstream-a:upstream", "--link", "upstream-b:upstream", "busybox", "sh", "-c", "ping -c 1 upstream")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@cpuguy83 This test was recently introduced, but no Linux-only tag was added (links aren't supported on Windows), so it's causing Windows to Windows CI failures.
