### PR TITLE
Don't retry downloads when disk is full

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/docker/distribution"
@@ -147,6 +148,10 @@ func retryOnError(err error) error {
 		}
 	case *client.UnexpectedHTTPResponseError:
 		return xfer.DoNotRetry{Err: err}
+	case error:
+		if strings.Contains(err.Error(), strings.ToLower(syscall.ENOSPC.Error())) {
+			return xfer.DoNotRetry{Err: err}
+		}
 	}
 	// let's be nice and fallback if the error is a completely
 	// unexpected one.


### PR DESCRIPTION
There was already a check that prevented protocol-level fallback in this
situation, but retries within a specific protocol will still happen.
This makes it take a long time for the pull to finally error out.

This fixes slowness in TestDaemonNoSpaceleftOnDeviceError, which used to
take a long time due to the backoff between retry attempts:

PASS: docker_cli_daemon_test.go:1868: DockerDaemonSuite.TestDaemonNoSpaceleftOnDeviceError  5.882s
