### PR TITLE
Update registry version in Dockerfile.armhf

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -132,7 +132,7 @@ RUN set -x \
 # both. This allows integration-cli tests to cover push/pull with both schema1
 # and schema2 manifests.
 ENV REGISTRY_COMMIT_SCHEMA1 ec87e9b6971d831f0eff752ddb54fb64693e51cd
-ENV REGISTRY_COMMIT a7ae88da459b98b481a245e5b1750134724ac67d
+ENV REGISTRY_COMMIT cb08de17d74bef86ce6c5abe8b240e282f5750be
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/distribution.git "$GOPATH/src/github.com/docker/distribution" \

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -149,7 +149,6 @@ func (s *DockerSchema1RegistrySuite) TestPushEmptyLayer(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *check.C) {
-	testRequires(c, NotArm)
 	sourceRepoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	// tag the image to upload it to the private registry
 	dockerCmd(c, "tag", "busybox", sourceRepoName)


### PR DESCRIPTION
Similar to https://github.com/docker/docker/pull/19516 this updates the registry version and re-enables the TestCrossRepositoryLayerPush which then works on ARM:

```
PASS: docker_cli_push_test.go:150: DockerRegistrySuite.TestCrossRepositoryLayerPush 5.799s
```
