### PR TITLE
Carry 19305: Added `dead` to docs for docker ps -f status=...

### DIFF
--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -55,7 +55,7 @@ The currently supported filters are:
 * label (`label=<key>` or `label=<key>=<value>`)
 * name (container's name)
 * exited (int - the code of exited containers. Only useful with `--all`)
-* status (created|restarting|running|paused|exited)
+* status (created|restarting|running|paused|exited|dead)
 * ancestor (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters containers that were created from the given image or a descendant.
 * isolation (default|process|hyperv)   (Windows daemon only)
 
@@ -109,7 +109,7 @@ that have exited successfully:
 
 #### Status
 
-The `status` filter matches containers by status. You can filter using `created`, `restarting`, `running`, `paused` and `exited`. For example, to filter for `running` containers:
+The `status` filter matches containers by status. You can filter using `created`, `restarting`, `running`, `paused`, `exited` and `dead`. For example, to filter for `running` containers:
 
     $ docker ps --filter status=running
     CONTAINER ID        IMAGE                  COMMAND             CREATED             STATUS              PORTS               NAMES

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -29,7 +29,7 @@ the running containers.
    Filter output based on these conditions:
    - exited=<int> an exit code of <int>
    - label=<key> or label=<key>=<value>
-   - status=(created|restarting|running|paused|exited)
+   - status=(created|restarting|running|paused|exited|dead)
    - name=<string> a container's name
    - id=<ID> a container's ID
    - before=(<container-name>|<container-id>)


### PR DESCRIPTION
It is possible to invoke `docker ps -f status=dead`, but the
documentation for docker-ps does not mention `dead` as a valid option.
This commit fixes that.

Signed-off-by: Kareem Khazem karkhaz@karkhaz.com

Carried from #19305 thanks @karkhaz for the original PR!
