### PR TITLE
Refactor sysinfo usage

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -218,9 +218,8 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 	return nil
 }
 
-func verifyContainerResources(resources *containertypes.Resources) ([]string, error) {
+func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysinfo.SysInfo) ([]string, error) {
 	warnings := []string{}
-	sysInfo := sysinfo.New(true)
 
 	// memory subsystem checks and adjustments
 	if resources.Memory != 0 && resources.Memory < linuxMinMemory {
@@ -372,7 +371,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		return warnings, err
 	}
 
-	w, err := verifyContainerResources(&hostConfig.Resources)
+	w, err := verifyContainerResources(&hostConfig.Resources, sysInfo)
 	if err != nil {
 		return warnings, err
 	}

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -1,6 +1,7 @@
 package sysinfo
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -16,18 +17,37 @@ const (
 	SeccompModeFilter = uintptr(2)
 )
 
+func findCgroupMountpoints() (map[string]string, error) {
+	cgMounts, err := cgroups.GetCgroupMounts()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse cgroup information: %v", err)
+	}
+	mps := make(map[string]string)
+	for _, m := range cgMounts {
+		for _, ss := range m.Subsystems {
+			mps[ss] = m.Mountpoint
+		}
+	}
+	return mps, nil
+}
+
 // New returns a new SysInfo, using the filesystem to detect which features
 // the kernel supports. If `quiet` is `false` warnings are printed in logs
 // whenever an error occurs or misconfigurations are present.
 func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
-	sysInfo.cgroupMemInfo = checkCgroupMem(quiet)
-	sysInfo.cgroupCPUInfo = checkCgroupCPU(quiet)
-	sysInfo.cgroupBlkioInfo = checkCgroupBlkioInfo(quiet)
-	sysInfo.cgroupCpusetInfo = checkCgroupCpusetInfo(quiet)
+	cgMounts, err := findCgroupMountpoints()
+	if err != nil {
+		logrus.Warnf("Failed to parse cgroup information: %v", err)
+	} else {
+		sysInfo.cgroupMemInfo = checkCgroupMem(cgMounts, quiet)
+		sysInfo.cgroupCPUInfo = checkCgroupCPU(cgMounts, quiet)
+		sysInfo.cgroupBlkioInfo = checkCgroupBlkioInfo(cgMounts, quiet)
+		sysInfo.cgroupCpusetInfo = checkCgroupCpusetInfo(cgMounts, quiet)
+	}
 
-	_, err := cgroups.FindCgroupMountpoint("devices")
-	sysInfo.CgroupDevicesEnabled = err == nil
+	_, ok := cgMounts["devices"]
+	sysInfo.CgroupDevicesEnabled = ok
 
 	sysInfo.IPv4ForwardingDisabled = !readProcBool("/proc/sys/net/ipv4/ip_forward")
 	sysInfo.BridgeNfCallIptablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-iptables")
@@ -50,11 +70,11 @@ func New(quiet bool) *SysInfo {
 }
 
 // checkCgroupMem reads the memory information from the memory cgroup mount point.
-func checkCgroupMem(quiet bool) cgroupMemInfo {
-	mountPoint, err := cgroups.FindCgroupMountpoint("memory")
-	if err != nil {
+func checkCgroupMem(cgMounts map[string]string, quiet bool) cgroupMemInfo {
+	mountPoint, ok := cgMounts["memory"]
+	if !ok {
 		if !quiet {
-			logrus.Warnf("Your kernel does not support cgroup memory limit: %v", err)
+			logrus.Warnf("Your kernel does not support cgroup memory limit")
 		}
 		return cgroupMemInfo{}
 	}
@@ -91,11 +111,11 @@ func checkCgroupMem(quiet bool) cgroupMemInfo {
 }
 
 // checkCgroupCPU reads the cpu information from the cpu cgroup mount point.
-func checkCgroupCPU(quiet bool) cgroupCPUInfo {
-	mountPoint, err := cgroups.FindCgroupMountpoint("cpu")
-	if err != nil {
+func checkCgroupCPU(cgMounts map[string]string, quiet bool) cgroupCPUInfo {
+	mountPoint, ok := cgMounts["cpu"]
+	if !ok {
 		if !quiet {
-			logrus.Warn(err)
+			logrus.Warnf("Unable to find cpu cgroup in mounts")
 		}
 		return cgroupCPUInfo{}
 	}
@@ -122,11 +142,11 @@ func checkCgroupCPU(quiet bool) cgroupCPUInfo {
 }
 
 // checkCgroupBlkioInfo reads the blkio information from the blkio cgroup mount point.
-func checkCgroupBlkioInfo(quiet bool) cgroupBlkioInfo {
-	mountPoint, err := cgroups.FindCgroupMountpoint("blkio")
-	if err != nil {
+func checkCgroupBlkioInfo(cgMounts map[string]string, quiet bool) cgroupBlkioInfo {
+	mountPoint, ok := cgMounts["blkio"]
+	if !ok {
 		if !quiet {
-			logrus.Warn(err)
+			logrus.Warnf("Unable to find blkio cgroup in mounts")
 		}
 		return cgroupBlkioInfo{}
 	}
@@ -170,11 +190,11 @@ func checkCgroupBlkioInfo(quiet bool) cgroupBlkioInfo {
 }
 
 // checkCgroupCpusetInfo reads the cpuset information from the cpuset cgroup mount point.
-func checkCgroupCpusetInfo(quiet bool) cgroupCpusetInfo {
-	mountPoint, err := cgroups.FindCgroupMountpoint("cpuset")
-	if err != nil {
+func checkCgroupCpusetInfo(cgMounts map[string]string, quiet bool) cgroupCpusetInfo {
+	mountPoint, ok := cgMounts["cpuset"]
+	if !ok {
 		if !quiet {
-			logrus.Warn(err)
+			logrus.Warnf("Unable to find cpuset cgroup in mounts")
 		}
 		return cgroupCpusetInfo{}
 	}


### PR DESCRIPTION
Two things:
- Reuse `*sysinfo.SysInfo` object
- Reuse parsed cgroups info between checks
