### PR TITLE
Handle authorization errors in the middle of a stream response.

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/distribution"
-	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
@@ -364,12 +363,6 @@ func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registr
 }
 
 func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string, authConfig types.AuthConfig, requestPrivilege apiclient.RequestPrivilegeFunc) error {
-	responseBody, err := cli.imagePushPrivileged(authConfig, repoInfo.Name(), tag, requestPrivilege)
-	if err != nil {
-		return err
-	}
-
-	defer responseBody.Close()
 
 	targets := []target{}
 	handleTarget := func(aux *json.RawMessage) {
@@ -384,7 +377,7 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string,
 		}
 	}
 
-	err = jsonmessage.DisplayJSONMessagesStream(responseBody, cli.out, cli.outFd, cli.isTerminalOut, handleTarget)
+	err := cli.imagePushPrivileged(authConfig, repoInfo.Name(), tag, requestPrivilege, handleTarget)
 	if err != nil {
 		return err
 	}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	gosignal "os/signal"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -137,4 +138,12 @@ func (cli *DockerCli) getTtySize() (int, int) {
 		}
 	}
 	return int(ws.Height), int(ws.Width)
+}
+
+func isUnauthorizedErr(err error) bool {
+	loError := strings.ToLower(err.Error())
+	return strings.Contains(loError, "authentication is required") ||
+		strings.Contains(loError, "status 401") ||
+		strings.Contains(loError, "unauthorized") ||
+		strings.Contains(loError, "status code 401")
 }


### PR DESCRIPTION
Preserving the behavior we have in 1.9.1. Although we're strill trying to explain when that can happen:

https://github.com/docker/docker/blob/v1.9.1/api/client/utils.go#L150-L159

/cc @aaronlehmann, @tonistiigi

Signed-off-by: David Calavera david.calavera@gmail.com
