### PR TITLE
check the output, not the errcode

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1890,7 +1890,8 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceleftOnDeviceError(c *check.C) {
 
 	// pull a repository large enough to fill the mount point
 	out, err := s.d.Cmd("pull", "registry:2")
-	c.Assert(out, check.Not(check.Equals), 1, check.Commentf("no space left on device"))
+
+	c.Assert(strings.Contains(out, "no space left on device"), check.Equals, true)
 }
 
 // Test daemon restart with container links + auto restart


### PR DESCRIPTION
- errcode of 1 can be returned for cases other than the 'no space left' case

Signed-off-by: Morgan Bauer mbauer@us.ibm.com

for @duglin https://github.com/docker/docker/pull/19484#discussion_r50270648

@aaronlehmann as a check, please.
