### PR TITLE
Add tag support to journald logging driver, closes #19556

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/journal"
 	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/daemon/logger/loggerutils"
 )
 
 const name = "journald"
@@ -48,10 +49,17 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		name = name[1:]
 	}
 
+	// parse log tag
+	tag, err := loggerutils.ParseLogTag(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
 	vars := map[string]string{
 		"CONTAINER_ID":      ctx.ContainerID[:12],
 		"CONTAINER_ID_FULL": ctx.ContainerID,
 		"CONTAINER_NAME":    name,
+		"CONTAINER_TAG":     tag,
 	}
 	extraAttrs := ctx.ExtraAttributes(strings.ToTitle)
 	for k, v := range extraAttrs {
@@ -67,6 +75,7 @@ func validateLogOpt(cfg map[string]string) error {
 		switch key {
 		case "labels":
 		case "env":
+		case "tag":
 		default:
 			return fmt.Errorf("unknown log opt '%s' for journald log driver", key)
 		}

--- a/docs/admin/logging/journald.md
+++ b/docs/admin/logging/journald.md
@@ -24,6 +24,7 @@ driver stores the following metadata in the journal with each message:
 | `CONTAINER_ID`      | The container ID truncated to 12 characters. |
 | `CONTAINER_ID_FULL` | The full 64-character container ID. |
 | `CONTAINER_NAME`    | The container name at the time it was started. If you use `docker rename` to rename a container, the new name is not reflected in the journal entries. |
+| `CONTAINER_TAG`     | The container tag ([log tag option documentation](log_tags.md)). |
 
 ## Usage
 
@@ -41,6 +42,11 @@ You can set the logging driver for a specific container by using the
 
 Users can use the `--log-opt NAME=VALUE` flag to specify additional
 journald logging driver options.
+
+### tag
+
+Specify template to set `CONTAINER_TAG` value in journald logs. Refer to
+[log tag option documentation](log_tags.md) for customizing the log tag format.
 
 ### labels and env
 

--- a/docs/admin/logging/log_tags.md
+++ b/docs/admin/logging/log_tags.md
@@ -3,7 +3,7 @@
 aliases = ["/engine/reference/logging/log_tags/"]
 title = "Log tags for logging driver"
 description = "Describes how to format tags for."
-keywords = ["docker, logging, driver, syslog, Fluentd, gelf"]
+keywords = ["docker, logging, driver, syslog, Fluentd, gelf, journald"]
 [menu.main]
 parent = "smn_logging"
 weight = 1


### PR DESCRIPTION
Tested manually on debian jessie, it worked :whale: 
