### PR TITLE
Windows: TestPsNotShowPortsOfStoppedContainer linux only

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -640,6 +640,7 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsNotShowPortsOfStoppedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name=foo", "-d", "-p", "5000:5000", "busybox", "top")
 	c.Assert(waitRun("foo"), checker.IsNil)
 	out, _ := dockerCmd(c, "ps")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Another recently merged CI test which won't work yet on Windows to Windows CI, which hopefully will be turned on imminently. Found while debugging a test run. 

@cpuguy83 @calavera 
