### PR TITLE
Permit OPTIONS request against any url, fixes #19398

### DIFF
--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -20,7 +20,7 @@ func NewRouter(b Backend) router.Router {
 	}
 
 	r.routes = []router.Route{
-		local.NewOptionsRoute("/", optionsHandler),
+		local.NewOptionsRoute("/{anyroute:.*}", optionsHandler),
 		local.NewGetRoute("/_ping", pingHandler),
 		local.NewGetRoute("/events", r.getEvents),
 		local.NewGetRoute("/info", r.getInfo),


### PR DESCRIPTION
I've tested this (with https://github.com/aidanhs/Docker-Terminal) and it fixes #19398 (options requests working against any URL).
