### PR TITLE
Vendor in libnetwork v0.6.0-rc2

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -21,7 +21,7 @@ import (
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/docker/utils"
 	"github.com/docker/docker/volume"
-	"github.com/docker/engine-api/types/container"
+	containertypes "github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/libnetwork"
@@ -290,7 +290,7 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network) ([]
 		}
 	}
 
-	if !container.HostConfig.NetworkMode.IsUserDefined() {
+	if !containertypes.NetworkMode(n.Name()).IsUserDefined() {
 		createOptions = append(createOptions, libnetwork.CreateOptionDisableResolution())
 	}
 
@@ -577,7 +577,7 @@ func (container *Container) IpcMounts() []execdriver.Mount {
 	return mounts
 }
 
-func updateCommand(c *execdriver.Command, resources container.Resources) {
+func updateCommand(c *execdriver.Command, resources containertypes.Resources) {
 	c.Resources.BlkioWeight = resources.BlkioWeight
 	c.Resources.CPUShares = resources.CPUShares
 	c.Resources.CPUPeriod = resources.CPUPeriod
@@ -591,7 +591,7 @@ func updateCommand(c *execdriver.Command, resources container.Resources) {
 }
 
 // UpdateContainer updates resources of a container.
-func (container *Container) UpdateContainer(hostConfig *container.HostConfig) error {
+func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 
 	resources := hostConfig.Resources

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -27,7 +27,7 @@ clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.6.0-rc1
+clone git github.com/docker/libnetwork v0.6.0-rc2
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1301,3 +1301,26 @@ func (s *DockerSuite) TestUserDefinedNetworkConnectDisconnectAlias(c *check.C) {
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "bar")
 	c.Assert(err, check.IsNil)
 }
+
+func (s *DockerSuite) TestUserDefinedNetworkConnectivity(c *check.C) {
+	testRequires(c, DaemonIsLinux, NotUserNamespace)
+	dockerCmd(c, "network", "create", "-d", "bridge", "br.net1")
+
+	dockerCmd(c, "run", "-d", "--net=br.net1", "--name=c1.net1", "busybox", "top")
+	c.Assert(waitRun("c1.net1"), check.IsNil)
+
+	dockerCmd(c, "run", "-d", "--net=br.net1", "--name=c2.net1", "busybox", "top")
+	c.Assert(waitRun("c2.net1"), check.IsNil)
+
+	// ping first container by its unqualified name
+	_, _, err := dockerCmdWithError("exec", "c2.net1", "ping", "-c", "1", "c1.net1")
+	c.Assert(err, check.IsNil)
+
+	// ping first container by its qualified name
+	_, _, err = dockerCmdWithError("exec", "c2.net1", "ping", "-c", "1", "c1.net1.br.net1")
+	c.Assert(err, check.IsNil)
+
+	// ping with first qualified name masked by an additional domain. should fail
+	_, _, err = dockerCmdWithError("exec", "c2.net1", "ping", "-c", "1", "c1.net1.br.net1.google.com")
+	c.Assert(err, check.NotNil)
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
+	"github.com/docker/libnetwork/netutils"
 	"github.com/docker/libnetwork/resolvconf"
 	"github.com/go-check/check"
 )
@@ -1258,13 +1259,13 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 		c.Fatalf("/etc/resolv.conf does not exist")
 	}
 
-	hostNamservers := resolvconf.GetNameservers(origResolvConf)
+	hostNamservers := resolvconf.GetNameservers(origResolvConf, netutils.IP)
 	hostSearch := resolvconf.GetSearchDomains(origResolvConf)
 
 	var out string
 	out, _ = dockerCmd(c, "run", "--dns=127.0.0.1", "busybox", "cat", "/etc/resolv.conf")
 
-	if actualNameservers := resolvconf.GetNameservers([]byte(out)); string(actualNameservers[0]) != "127.0.0.1" {
+	if actualNameservers := resolvconf.GetNameservers([]byte(out), netutils.IP); string(actualNameservers[0]) != "127.0.0.1" {
 		c.Fatalf("expected '127.0.0.1', but says: %q", string(actualNameservers[0]))
 	}
 
@@ -1280,7 +1281,7 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 
 	out, _ = dockerCmd(c, "run", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf")
 
-	actualNameservers := resolvconf.GetNameservers([]byte(out))
+	actualNameservers := resolvconf.GetNameservers([]byte(out), netutils.IP)
 	if len(actualNameservers) != len(hostNamservers) {
 		c.Fatalf("expected %q nameserver(s), but it has: %q", len(hostNamservers), len(actualNameservers))
 	}
@@ -1311,11 +1312,11 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 		c.Fatalf("/etc/resolv.conf does not exist")
 	}
 
-	hostNamservers = resolvconf.GetNameservers(resolvConf)
+	hostNamservers = resolvconf.GetNameservers(resolvConf, netutils.IP)
 	hostSearch = resolvconf.GetSearchDomains(resolvConf)
 
 	out, _ = dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
-	if actualNameservers = resolvconf.GetNameservers([]byte(out)); string(actualNameservers[0]) != "12.34.56.78" || len(actualNameservers) != 1 {
+	if actualNameservers = resolvconf.GetNameservers([]byte(out), netutils.IP); string(actualNameservers[0]) != "12.34.56.78" || len(actualNameservers) != 1 {
 		c.Fatalf("expected '12.34.56.78', but has: %v", actualNameservers)
 	}
 

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0-rc2 (2016-01-21)
+- Fixes docker/docker#19376
+- Fixes docker/docker#15819
+- Fixes libnetwork/#885, Not filter v6 DNS servers from resolv.conf
+- Fixes docker/docker #19448, also handles the . in service and network names correctly.
+
 ## 0.6.0-rc1 (2016-01-14)
 - Fixes docker/docker#19404
 - Fixes the ungraceful daemon restart issue in systemd with remote network plugin 

--- a/vendor/src/github.com/docker/libnetwork/netutils/utils.go
+++ b/vendor/src/github.com/docker/libnetwork/netutils/utils.go
@@ -14,6 +14,13 @@ import (
 	"github.com/docker/libnetwork/types"
 )
 
+// constants for the IP address type
+const (
+	IP = iota // IPv4 and IPv6
+	IPv4
+	IPv6
+)
+
 var (
 	// ErrNetworkOverlapsWithNameservers preformatted error
 	ErrNetworkOverlapsWithNameservers = errors.New("requested network overlaps with nameserver")


### PR DESCRIPTION
Fixes docker/docker#19376
Fixes docker/docker#15819
Fixes docker/libnetwork#885, 
Fixes docker/docker#19448
Fixes docker/docker#19403

IT for service, network name with '.'
