### PR TITLE
Hotfix vendor libcontainer

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -57,7 +57,7 @@ clone git github.com/miekg/pkcs11 80f102b5cac759de406949c47f0928b99bd64cdf
 clone git github.com/jfrazelle/go v1.5.1-1
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
-clone git github.com/opencontainers/runc 47e3f834d73e76bc2a6a585b48d2a93325b34979 # libcontainer
+clone git github.com/opencontainers/runc f36b00aa12b3cb4e9c42506059fce4145cfbd626 # libcontainer
 clone git github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v4

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
@@ -230,11 +230,38 @@ func (m *Manager) GetPids() ([]int, error) {
 	return cgroups.GetPids(dir)
 }
 
+// pathClean makes a path safe for use with filepath.Join. This is done by not
+// only cleaning the path, but also (if the path is relative) adding a leading
+// '/' and cleaning it (then removing the leading '/'). This ensures that a
+// path resulting from prepending another path will always resolve to lexically
+// be a subdirectory of the prefixed path. This is all done lexically, so paths
+// that include symlinks won't be safe as a result of using pathClean.
+func pathClean(path string) string {
+	// Ensure that all paths are cleaned (especially problematic ones like
+	// "/../../../../../" which can cause lots of issues).
+	path = filepath.Clean(path)
+
+	// If the path isn't absolute, we need to do more processing to fix paths
+	// such as "../../../../<etc>/some/path". We also shouldn't convert absolute
+	// paths to relative ones.
+	if !filepath.IsAbs(path) {
+		path = filepath.Clean(string(os.PathSeparator) + path)
+		// This can't fail, as (by definition) all paths are relative to root.
+		path, _ = filepath.Rel(string(os.PathSeparator), path)
+	}
+
+	// Clean the path again for good measure.
+	return filepath.Clean(path)
+}
+
 func getCgroupData(c *configs.Cgroup, pid int) (*cgroupData, error) {
 	root, err := getCgroupRoot()
 	if err != nil {
 		return nil, err
 	}
+
+	// Clean the parent slice path.
+	c.Parent = pathClean(c.Parent)
 
 	return &cgroupData{
 		root:   root,

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpuset.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpuset.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -94,6 +95,10 @@ func (s *CpusetGroup) ensureParent(current, root string) error {
 	parent := filepath.Dir(current)
 	if filepath.Clean(parent) == root {
 		return nil
+	}
+	// Avoid infinite recursion.
+	if parent == current {
+		return fmt.Errorf("cpuset: cgroup parent path outside cgroup root")
 	}
 	if err := s.ensureParent(parent, root); err != nil {
 		return err


### PR DESCRIPTION
This fixes a security vulnerability in Docker, which can cause a DoS
under certain circumstances. This is from the hotfix branch, so the
vendored commit is actually opencontainers/runc@bf899fef451956be4abd63de6d6141d9f9096a02
in runc master.

This needs to be merged into `1.10`.

Signed-off-by: Aleksa Sarai asarai@suse.com

/cc @crosbymichael @calavera @tiborvass @vdemeester 
