### PR TITLE
Fixing a typo in apt-cacher-ng

### DIFF
--- a/docs/examples/apt-cacher-ng.md
+++ b/docs/examples/apt-cacher-ng.md
@@ -69,8 +69,8 @@ To get your Debian-based containers to use the proxy, you have following options
 a local version of a common base:
 
     FROM ubuntu
-    RUN  echo 'Acquire::http { Proxy "http://dockerhost:3142"; };' >> /etc/apt/apt.conf.d/01proxy
     RUN apt-get update && apt-get install -y vim git
+    RUN echo 'Acquire::http { Proxy "http://dockerhost:3142"; };' >> /etc/apt/apt.conf.d/01proxy
 
     # docker build -t my_ubuntu .
 


### PR DESCRIPTION
Otherwise, the example doesn't build

Signed-off-by: Vincent Demeester vincent@sbr.pm
