### PR TITLE
PS and Inspect without container lock.

### DIFF
--- a/container/memory_store.go
+++ b/container/memory_store.go
@@ -1,67 +1,88 @@
 package container
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/docker/docker/pkg/locker"
+)
 
 // memoryStore implements a Store in memory.
+// It uses two locks to keep concurrent
+// accesss control to the containers.
+// - globalLock controls all accesses to the
+// map store. This lock MUST always be acquired
+// first in order to avoid deadlocks.
+// - namedLock controls accesses to specific
+// container IDs. This prevents accessing
+// references that could have been garbage
+// collected, like inspecting a container that
+// was removed concurrently.
 type memoryStore struct {
-	s map[string]*Container
-	sync.Mutex
+	s          map[string]*Container
+	globalLock sync.Mutex
+	namedLock  *locker.Locker
 }
 
 // NewMemoryStore initializes a new memory store.
 func NewMemoryStore() Store {
 	return &memoryStore{
-		s: make(map[string]*Container),
+		s:         make(map[string]*Container),
+		namedLock: locker.New(),
 	}
 }
 
 // Add appends a new container to the memory store.
 // It overrides the id if it existed before.
 func (c *memoryStore) Add(id string, cont *Container) {
-	c.Lock()
+	c.globalLock.Lock()
 	c.s[id] = cont
-	c.Unlock()
+	c.globalLock.Unlock()
 }
 
 // Get returns a container from the store by id.
 func (c *memoryStore) Get(id string) *Container {
-	c.Lock()
+	c.globalLock.Lock()
+	c.namedLock.Lock(id)
 	res := c.s[id]
-	c.Unlock()
+	c.namedLock.Unlock(id)
+	c.globalLock.Unlock()
 	return res
 }
 
 // Delete removes a container from the store by id.
 func (c *memoryStore) Delete(id string) {
-	c.Lock()
+	c.globalLock.Lock()
+	c.namedLock.Lock(id)
 	delete(c.s, id)
-	c.Unlock()
+	c.namedLock.Unlock(id)
+	c.globalLock.Unlock()
 }
 
 // List returns a sorted list of containers from the store.
 // The containers are ordered by creation date.
 func (c *memoryStore) List() []*Container {
 	containers := new(History)
-	c.Lock()
+	c.globalLock.Lock()
 	for _, cont := range c.s {
 		containers.Add(cont)
 	}
-	c.Unlock()
+	c.globalLock.Unlock()
 	containers.sort()
 	return *containers
 }
 
 // Size returns the number of containers in the store.
 func (c *memoryStore) Size() int {
-	c.Lock()
-	defer c.Unlock()
-	return len(c.s)
+	c.globalLock.Lock()
+	l := len(c.s)
+	c.globalLock.Unlock()
+	return l
 }
 
 // First returns the first container found in the store by a given filter.
 func (c *memoryStore) First(filter StoreFilter) *Container {
-	c.Lock()
-	defer c.Unlock()
+	c.globalLock.Lock()
+	defer c.globalLock.Unlock()
 	for _, cont := range c.s {
 		if filter(cont) {
 			return cont
@@ -73,19 +94,60 @@ func (c *memoryStore) First(filter StoreFilter) *Container {
 // ApplyAll calls the reducer function with every container in the store.
 // This operation is asyncronous in the memory store.
 func (c *memoryStore) ApplyAll(apply StoreReducer) {
-	c.Lock()
-	defer c.Unlock()
+	c.globalLock.Lock()
+	defer c.globalLock.Unlock()
 
 	wg := new(sync.WaitGroup)
 	for _, cont := range c.s {
 		wg.Add(1)
+		c.namedLock.Lock(cont.ID)
 		go func(container *Container) {
+			defer func() {
+				c.namedLock.Unlock(container.ID)
+				wg.Done()
+			}()
 			apply(container)
-			wg.Done()
 		}(cont)
 	}
 
 	wg.Wait()
+}
+
+// ReduceAll filters a list of containers and calls the reducer function with each one of them.
+func (c *memoryStore) ReduceAll(filter StoreFilter, apply StoreReducer) error {
+	var containers []*Container
+	c.globalLock.Lock()
+	for _, cont := range c.s {
+		if filter(cont) {
+			containers = append(containers, cont)
+		}
+	}
+	c.globalLock.Unlock()
+
+	for _, cont := range containers {
+		c.namedLock.Lock(cont.ID)
+		if err := apply(cont); err != nil {
+			c.namedLock.Unlock(cont.ID)
+			return err
+		}
+		c.namedLock.Unlock(cont.ID)
+	}
+	return nil
+}
+
+// ReduceOne gets a controller and calls the reducer function with it.
+func (c *memoryStore) ReduceOne(id string, apply StoreReducer) error {
+	c.namedLock.Lock(id)
+	c.globalLock.Lock()
+	defer func() {
+		c.globalLock.Unlock()
+		c.namedLock.Unlock(id)
+	}()
+	cont := c.s[id]
+	if cont == nil {
+		return nil
+	}
+	return apply(cont)
 }
 
 var _ Store = &memoryStore{}

--- a/container/memory_store_test.go
+++ b/container/memory_store_test.go
@@ -90,10 +90,11 @@ func TestApplyAllContainer(t *testing.T) {
 	s.Add("id", NewBaseContainer("id", "root"))
 	s.Add("id2", NewBaseContainer("id2", "root"))
 
-	s.ApplyAll(func(cont *Container) {
+	s.ApplyAll(func(cont *Container) error {
 		if cont.ID == "id2" {
 			cont.ID = "newID"
 		}
+		return nil
 	})
 
 	cont := s.Get("id2")

--- a/container/store.go
+++ b/container/store.go
@@ -6,7 +6,7 @@ type StoreFilter func(*Container) bool
 
 // StoreReducer defines a function to
 // manipulate containers in the store
-type StoreReducer func(*Container)
+type StoreReducer func(*Container) error
 
 // Store defines an interface that
 // any container store must implement.
@@ -25,4 +25,8 @@ type Store interface {
 	First(StoreFilter) *Container
 	// ApplyAll calls the reducer function with every container in the store.
 	ApplyAll(StoreReducer)
+	// ReduceAll filters a list of containers and calls the reducer function with each one of them.
+	ReduceAll(StoreFilter, StoreReducer) error
+	// ReduceOne gets a controller and calls the reducer function with it.
+	ReduceOne(string, StoreReducer) error
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -856,16 +856,17 @@ func (daemon *Daemon) Shutdown() error {
 	daemon.shutdown = true
 	if daemon.containers != nil {
 		logrus.Debug("starting clean shutdown of all containers...")
-		daemon.containers.ApplyAll(func(c *container.Container) {
+		daemon.containers.ApplyAll(func(c *container.Container) error {
 			if !c.IsRunning() {
-				return
+				return nil
 			}
 			logrus.Debugf("stopping %s", c.ID)
 			if err := daemon.shutdownContainer(c); err != nil {
 				logrus.Errorf("Stop container error: %v", err)
-				return
+				return err
 			}
 			logrus.Debugf("container stopped %s", c.ID)
+			return nil
 		})
 	}
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -57,7 +57,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	sysInfo := sysinfo.New(true)
 
 	var cRunning, cPaused, cStopped int32
-	daemon.containers.ApplyAll(func(c *container.Container) {
+	daemon.containers.ApplyAll(func(c *container.Container) error {
 		switch c.StateString() {
 		case "paused":
 			atomic.AddInt32(&cPaused, 1)
@@ -66,6 +66,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		default:
 			atomic.AddInt32(&cStopped, 1)
 		}
+		return nil
 	})
 
 	v := &types.Info{

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -19,16 +19,8 @@ func setPlatformSpecificContainerFields(container *container.Container, contJSON
 }
 
 // containerInspectPre120 gets containers for pre 1.20 APIs.
-func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON, error) {
-	container, err := daemon.GetContainer(name)
-	if err != nil {
-		return nil, err
-	}
-
-	container.Lock()
-	defer container.Unlock()
-
-	base, err := daemon.getInspectData(container, false)
+func (ctx *inspectContext) containerInspectPre120(container *container.Container) (*v1p19.ContainerJSON, error) {
+	base, err := ctx.getInspectData(container)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +43,7 @@ func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON,
 		CPUShares:       container.HostConfig.CPUShares,
 		CPUSet:          container.HostConfig.CpusetCpus,
 	}
-	networkSettings := daemon.getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
+	networkSettings := ctx.daemon.getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
 
 	return &v1p19.ContainerJSON{
 		ContainerJSONBase: base,

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -25,6 +25,6 @@ func addMountPoints(container *container.Container) []types.MountPoint {
 }
 
 // containerInspectPre120 get containers for pre 1.20 APIs.
-func (daemon *Daemon) containerInspectPre120(name string) (*types.ContainerJSON, error) {
-	return daemon.containerInspectCurrent(name, false)
+func (ctx *inspectContext) containerInspectPre120(container *container.Container) (*types.ContainerJSON, error) {
+	return ctx.containerInspectCurrent(container)
 }

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -1,8 +1,8 @@
 package daemon
 
 import (
-	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -17,30 +17,6 @@ import (
 
 var acceptedVolumeFilterTags = map[string]bool{
 	"dangling": true,
-}
-
-// iterationAction represents possible outcomes happening during the container iteration.
-type iterationAction int
-
-// containerReducer represents a reducer for a container.
-// Returns the object to serialize by the api.
-type containerReducer func(*container.Container, *listContext) (*types.Container, error)
-
-const (
-	// includeContainer is the action to include a container in the reducer.
-	includeContainer iterationAction = iota
-	// excludeContainer is the action to exclude a container in the reducer.
-	excludeContainer
-	// stopIteration is the action to stop iterating over the list of containers.
-	stopIteration
-)
-
-// errStopIteration makes the iterator to stop without returning an error.
-var errStopIteration = errors.New("container list iteration stopped")
-
-// List returns an array of all containers registered in the daemon.
-func (daemon *Daemon) List() []*container.Container {
-	return daemon.containers.List()
 }
 
 // ContainersConfig is the filtering specified by the user to iterate over containers.
@@ -62,8 +38,6 @@ type ContainersConfig struct {
 // listContext is the daemon generated filtering to iterate over containers.
 // This is created based on the user specification.
 type listContext struct {
-	// idx is the container iteration index for this context
-	idx int
 	// ancestorFilter tells whether it should check ancestors or not
 	ancestorFilter bool
 	// names is a list of container names to filter with
@@ -86,11 +60,10 @@ type listContext struct {
 
 // Containers returns the list of containers to show given the user's filtering.
 func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, error) {
-	return daemon.reduceContainers(config, daemon.transformContainer)
-}
-
-// reduceContainer parses the user filtering and generates the list of containers to return based on a reducer.
-func (daemon *Daemon) reduceContainers(config *ContainersConfig, reducer containerReducer) ([]*types.Container, error) {
+	// initialize containers as an empty slice
+	// to return `[]` when there are no containers
+	// rather than `null`, like it'd return
+	// using `var containers []*types.Container`.
 	containers := []*types.Container{}
 
 	ctx, err := daemon.foldFilter(config)
@@ -98,38 +71,28 @@ func (daemon *Daemon) reduceContainers(config *ContainersConfig, reducer contain
 		return nil, err
 	}
 
-	for _, container := range daemon.List() {
-		t, err := daemon.reducePsContainer(container, ctx, reducer)
+	err = daemon.containers.ReduceAll(ctx.filterContainer, func(cont *container.Container) error {
+		t, err := daemon.transformContainer(cont, ctx)
 		if err != nil {
-			if err != errStopIteration {
-				return nil, err
-			}
-			break
+			return err
 		}
-		if t != nil {
-			containers = append(containers, t)
-			ctx.idx++
+		containers = append(containers, t)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) > 0 {
+		history := sortContainersByCreated(containers)
+		sort.Sort(history)
+		containers = history
+		if ctx.Limit > 0 {
+			containers = containers[:ctx.Limit]
 		}
 	}
+
 	return containers, nil
-}
-
-// reducePsContainer is the basic representation for a container as expected by the ps command.
-func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *listContext, reducer containerReducer) (*types.Container, error) {
-	container.Lock()
-	defer container.Unlock()
-
-	// filter containers to return
-	action := includeContainerInList(container, ctx)
-	switch action {
-	case excludeContainer:
-		return nil, nil
-	case stopIteration:
-		return nil, errStopIteration
-	}
-
-	// transform internal container struct into api structs
-	return reducer(container, ctx)
 }
 
 // foldFilter generates the container filter based in the user's filtering options.
@@ -229,30 +192,30 @@ func (daemon *Daemon) foldFilter(config *ContainersConfig) (*listContext, error)
 
 // includeContainerInList decides whether a containers should be include in the output or not based in the filter.
 // It also decides if the iteration should be stopped or not.
-func includeContainerInList(container *container.Container, ctx *listContext) iterationAction {
+func (ctx *listContext) filterContainer(container *container.Container) bool {
 	// Do not include container if it's stopped and we're not filters
 	if !container.Running && !ctx.All && ctx.Limit <= 0 && ctx.beforeFilter == nil && ctx.sinceFilter == nil {
-		return excludeContainer
+		return false
 	}
 
 	// Do not include container if the name doesn't match
 	if !ctx.filters.Match("name", container.Name) {
-		return excludeContainer
+		return false
 	}
 
 	// Do not include container if the id doesn't match
 	if !ctx.filters.Match("id", container.ID) {
-		return excludeContainer
+		return false
 	}
 
 	// Do not include container if any of the labels don't match
 	if !ctx.filters.MatchKVList("label", container.Config.Labels) {
-		return excludeContainer
+		return false
 	}
 
 	// Do not include container if the isolation mode doesn't match
-	if excludeContainer == excludeByIsolation(container, ctx) {
-		return excludeContainer
+	if excludeByIsolation(container.HostConfig.Isolation, ctx) {
+		return false
 	}
 
 	// Do not include container if it's in the list before the filter container.
@@ -261,19 +224,14 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 		if container.ID == ctx.beforeFilter.ID {
 			ctx.beforeFilter = nil
 		}
-		return excludeContainer
+		return false
 	}
 
 	// Stop iteration when the container arrives to the filter container
 	if ctx.sinceFilter != nil {
 		if container.ID == ctx.sinceFilter.ID {
-			return stopIteration
+			return false
 		}
-	}
-
-	// Stop iteration when the index is over the limit
-	if ctx.Limit > 0 && ctx.idx == ctx.Limit {
-		return stopIteration
 	}
 
 	// Do not include container if its exit code is not in the filter
@@ -286,25 +244,25 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 			}
 		}
 		if shouldSkip {
-			return excludeContainer
+			return false
 		}
 	}
 
 	// Do not include container if its status doesn't match the filter
 	if !ctx.filters.Match("status", container.State.StateString()) {
-		return excludeContainer
+		return false
 	}
 
 	if ctx.ancestorFilter {
 		if len(ctx.images) == 0 {
-			return excludeContainer
+			return false
 		}
 		if !ctx.images[container.ImageID] {
-			return excludeContainer
+			return false
 		}
 	}
 
-	return includeContainer
+	return true
 }
 
 // transformContainer generates the container type expected by the docker ps command.
@@ -456,3 +414,9 @@ func populateImageFilterByParents(ancestorMap map[image.ID]bool, imageID image.I
 		ancestorMap[imageID] = true
 	}
 }
+
+type sortContainersByCreated []*types.Container
+
+func (r sortContainersByCreated) Len() int           { return len(r) }
+func (r sortContainersByCreated) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r sortContainersByCreated) Less(i, j int) bool { return r[j].Created < r[i].Created }

--- a/daemon/list_unix.go
+++ b/daemon/list_unix.go
@@ -2,10 +2,10 @@
 
 package daemon
 
-import "github.com/docker/docker/container"
+import "github.com/docker/engine-api/types/container"
 
 // excludeByIsolation is a platform specific helper function to support PS
 // filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
-func excludeByIsolation(container *container.Container, ctx *listContext) iterationAction {
-	return includeContainer
+func excludeByIsolation(isolation container.IsolationLevel, ctx *listContext) bool {
+	return false
 }

--- a/daemon/list_windows.go
+++ b/daemon/list_windows.go
@@ -3,18 +3,15 @@ package daemon
 import (
 	"strings"
 
-	"github.com/docker/docker/container"
+	"github.com/docker/engine-api/types/container"
 )
 
 // excludeByIsolation is a platform specific helper function to support PS
 // filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
-func excludeByIsolation(container *container.Container, ctx *listContext) iterationAction {
-	i := strings.ToLower(string(container.HostConfig.Isolation))
+func excludeByIsolation(isolation container.IsolationLevel, ctx *listContext) bool {
+	i := strings.ToLower(string(isolation))
 	if i == "" {
 		i = "default"
 	}
-	if !ctx.filters.Match("isolation", i) {
-		return excludeContainer
-	}
-	return includeContainer
+	return !ctx.filters.Match("isolation", i)
 }


### PR DESCRIPTION
Implement `docker ps` and `docker inspect` without calling `container.Lock`.

It uses a name lock at the container store level to prevent accessing nil references to containers.

I'm using @LK4D4's script to check concurrency problems with this change and everything looks good so far, but I'd appreciate more :eyes: on it: https://gist.github.com/calavera/afd3ddca7f24b2e057de

Fixes #17720.
Fixes #19328.

@cpuguy83 can you double check that I'm using `locker.Locker` correctly?

/cc @ibuildthecloud

Signed-off-by: David Calavera david.calavera@gmail.com
