### PR TITLE
Add pkg-config to our RPM build environment

### DIFF
--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -6,7 +6,7 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -15,3 +15,4 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV AUTO_GOPATH 1
 
 ENV DOCKER_BUILDTAGS selinux
+

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:22
 
 RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar
 
 ENV SECCOMP_VERSION 2.2.3
 RUN buildDeps=' \
@@ -35,3 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV AUTO_GOPATH 1
 
 ENV DOCKER_BUILDTAGS seccomp selinux
+

--- a/contrib/builder/rpm/fedora-23/Dockerfile
+++ b/contrib/builder/rpm/fedora-23/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:23
 
 RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar
 
 ENV SECCOMP_VERSION 2.2.3
 RUN buildDeps=' \
@@ -35,3 +35,4 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV AUTO_GOPATH 1
 
 ENV DOCKER_BUILDTAGS seccomp selinux
+

--- a/contrib/builder/rpm/generate.sh
+++ b/contrib/builder/rpm/generate.sh
@@ -71,9 +71,11 @@ for version in "${versions[@]}"; do
 		libseccomp-devel # for "seccomp.h" & "libseccomp.so"
 		libselinux-devel # for "libselinux.so"
 		libtool-ltdl-devel # for pkcs11 "ltdl.h"
+		pkgconfig # for the pkg-config command
 		selinux-policy
 		selinux-policy-devel
 		sqlite-devel # for "sqlite3.h"
+		systemd-devel # for "sd-journal.h" and libraries
 		tar # older versions of dev-tools do not have tar
 	)
 
@@ -81,6 +83,13 @@ for version in "${versions[@]}"; do
 		oraclelinux:7)
 			# Enable the optional repository
 			packages=( --enablerepo=ol7_optional_latest "${packages[*]}" )
+			;;
+	esac
+
+	case "$from" in
+		oraclelinux:6)
+			# doesn't use systemd, doesn't have a devel package for it
+			packages=( "${packages[@]/systemd-devel}" )
 			;;
 	esac
 
@@ -98,6 +107,7 @@ for version in "${versions[@]}"; do
 	case "$from" in
 		opensuse:*)
 			packages=( "${packages[@]/btrfs-progs-devel/libbtrfs-devel}" )
+			packages=( "${packages[@]/pkgconfig/pkg-config}" )
 			# use zypper
 			echo "RUN zypper --non-interactive install ${packages[*]}" >> "$version/Dockerfile"
 			;;

--- a/contrib/builder/rpm/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/opensuse-13.2/Dockerfile
@@ -5,7 +5,7 @@
 FROM opensuse:13.2
 
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
-RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -14,3 +14,4 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV AUTO_GOPATH 1
 
 ENV DOCKER_BUILDTAGS selinux
+

--- a/contrib/builder/rpm/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-6/Dockerfile
@@ -5,12 +5,12 @@
 FROM oraclelinux:6
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel  tar
 
 RUN yum install -y yum-utils && curl -o /etc/yum.repos.d/public-yum-ol6.repo http://yum.oracle.com/public-yum-ol6.repo && yum-config-manager -q --enable ol6_UEKR4
 RUN yum install -y kernel-uek-devel-4.1.12-32.el6uek
 
-ENV GO_VERSION 1.5.2
+ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -5,7 +5,7 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local


### PR DESCRIPTION
While hack/make.sh checks for systemd headers using pkg-config (part of https://github.com/docker/docker/pull/13707), we forgot to ensure that they were there in the images that we use for building binaries for RPM-based distributions.  Add the right packages to the generate.sh that we use for them, and update the copies of the generated files that we carry in the source tree.  This is more or less the complement to https://github.com/docker/docker/pull/19598.

Notes: Fedora, CentOS, and Oracle Linux put the pkg-config command in the "pkgconfig" package, while OpenSUSE calls the package "pkg-config".  The systemd-devel package, like systemd, is not in Oracle Linux 6.
