### PR TITLE
Windows CI: Fix TestRunExitOnStdinClose flakiness

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1717,7 +1717,7 @@ func (s *DockerSuite) TestRunExitOnStdinClose(c *check.C) {
 	delay := 1
 	if daemonPlatform == "windows" {
 		meow = "cat"
-		delay = 5
+		delay = 60
 	}
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "-i", "busybox", meow)
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

While bringing up Windows to Windows CI, this test has shown to be extremely flakey as the Azure VMs are significantly slower than when running on my SSD dev box. Increasing the timeout here to give it a chance of working reliably.
