### PR TITLE
Windows CI: Porting for docker_api_images_test.go

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	name := "utest:tag1"
 	name2 := "utest/docker:tag2"
 	name3 := "utest:5000/docker:tag3"
@@ -49,9 +48,10 @@ func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
+	// TODO Windows to Windows CI: Investigate further why this test fails.
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
-	out, err := buildImage("saveandload", "FROM hello-world\nENV FOO bar", false)
+	out, err := buildImage("saveandload", "FROM busybox\nENV FOO bar", false)
 	c.Assert(err, checker.IsNil)
 	id := strings.TrimSpace(out)
 
@@ -72,10 +72,11 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
-	testRequires(c, Network)
-	testRequires(c, DaemonIsLinux)
+	if daemonPlatform != "windows" {
+		testRequires(c, Network)
+	}
 	name := "test-api-images-delete"
-	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
+	out, err := buildImage(name, "FROM busybox\nENV FOO bar", false)
 	c.Assert(err, checker.IsNil)
 	id := strings.TrimSpace(out)
 
@@ -95,10 +96,11 @@ func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiImagesHistory(c *check.C) {
-	testRequires(c, Network)
-	testRequires(c, DaemonIsLinux)
+	if daemonPlatform != "windows" {
+		testRequires(c, Network)
+	}
 	name := "test-api-images-history"
-	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
+	out, err := buildImage(name, "FROM busybox\nENV FOO bar", false)
 	c.Assert(err, checker.IsNil)
 
 	id := strings.TrimSpace(out)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

More integration-cli test enablement for Windows to Windows CI. This enables a further four tests, and marks one as needing further investigation as to why it's currently failing. (Most important is increasing Windows coverage right now).

```
E:\go\src\github.com\docker\docker>runtest wl TestApi
Running test TestApi
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
PASS: docker_api_test.go:51: DockerSuite.TestApiClientVersionNewerThanServer    0.006s
PASS: docker_api_test.go:65: DockerSuite.TestApiClientVersionOldNotSupported    0.008s
SKIP: docker_api_network_test.go:222: DockerSuite.TestApiCreateDeletePredefinedNetworks (Test requires a Linux daemon)
PASS: docker_api_create_test.go:11: DockerSuite.TestApiCreateWithNotExistImage  0.009s
PASS: docker_api_test.go:79: DockerSuite.TestApiDockerApiVersion        0.050s
PASS: docker_api_test.go:24: DockerSuite.TestApiGetEnabledCors  0.001s
PASS: docker_api_images_test.go:74: DockerSuite.TestApiImagesDelete     2.216s
PASS: docker_api_images_test.go:14: DockerSuite.TestApiImagesFilter     0.232s
PASS: docker_api_images_test.go:98: DockerSuite.TestApiImagesHistory    2.149s
SKIP: docker_api_images_test.go:50: DockerSuite.TestApiImagesSaveAndLoad (Test requires a Linux daemon)
PASS: docker_api_images_test.go:121: DockerSuite.TestApiImagesSearchJSONContentType     1.232s
SKIP: docker_api_network_test.go:122: DockerSuite.TestApiNetworkConnectDisconnect (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:43: DockerSuite.TestApiNetworkCreateCheckDuplicate (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:27: DockerSuite.TestApiNetworkCreateDelete (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:66: DockerSuite.TestApiNetworkFilter (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:18: DockerSuite.TestApiNetworkGetDefaults (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:72: DockerSuite.TestApiNetworkInspect (Test requires a Linux daemon)
SKIP: docker_api_network_test.go:163: DockerSuite.TestApiNetworkIpamMultipleBridgeNetworks (Test requires a Linux daemon)
PASS: docker_api_test.go:18: DockerSuite.TestApiOptionsRoute    0.011s
SKIP: docker_api_stats_test.go:224: DockerSuite.TestApiStatsContainerNotFound (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:82: DockerSuite.TestApiStatsNetworkStats (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:128: DockerSuite.TestApiStatsNetworkStatsVersioning (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:21: DockerSuite.TestApiStatsNoStreamGetCpu (Test requires a Linux daemon)
SKIP: docker_api_stats_test.go:46: DockerSuite.TestApiStatsStoppedContainerInGoroutines (Test requires a Linux daemon)
PASS: docker_api_test.go:36: DockerSuite.TestApiVersionStatusCode       0.005s
OK: 11 passed, 14 skipped
--- PASS: Test (12.78s)
PASS
ok      _/E_/go/src/github.com/docker/docker/integration-cli    12.925s
```
