### PR TITLE
docs: image layers' path in aufs-driver.md

### DIFF
--- a/docs/userguide/storagedriver/aufs-driver.md
+++ b/docs/userguide/storagedriver/aufs-driver.md
@@ -108,7 +108,7 @@ As the `docker daemon` runs with the AUFS driver, the driver stores images and c
 ### Images
 
 Image layers and their contents are stored under
-`/var/lib/docker/aufs/mnt/diff/<image-id>` directory. The contents of an image
+`/var/lib/docker/aufs/diff/<image-id>` directory. The contents of an image
 layer in this location includes all the files and directories belonging in that
 image layer.
 


### PR DESCRIPTION
Please help review it since I double check on ubuntu 14.04.

Fix typo in file path for image layers.

Signed-off-by: bjcheny companycy@gmail.com
