### PR TITLE
integration-cli: add suite for testing registries with auth

### DIFF
--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -17,5 +17,14 @@ func (s *DockerSuite) TestLoginWithoutTTY(c *check.C) {
 	// run the command and block until it's done
 	err := cmd.Run()
 	c.Assert(err, checker.NotNil) //"Expected non nil err when loginning in & TTY not available"
+}
 
+func (s *DockerRegistryAuthSuite) TestLoginToPrivateRegistry(c *check.C) {
+	// wrong credentials
+	out, _, err := dockerCmdWithError("login", "-u", s.reg.username, "-p", "WRONGPASSWORD", "-e", s.reg.email, privateRegistryURL)
+	c.Assert(err, checker.NotNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "401 Unauthorized")
+
+	// now it's fine
+	dockerCmd(c, "login", "-u", s.reg.username, "-p", s.reg.password, "-e", s.reg.email, privateRegistryURL)
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1554,9 +1554,9 @@ func daemonTime(c *check.C) time.Time {
 	return dt
 }
 
-func setupRegistry(c *check.C, schema1 bool) *testRegistryV2 {
+func setupRegistry(c *check.C, schema1, auth bool) *testRegistryV2 {
 	testRequires(c, RegistryHosting)
-	reg, err := newTestRegistryV2(c, schema1)
+	reg, err := newTestRegistryV2(c, schema1, auth)
 	c.Assert(err, check.IsNil)
 
 	// Wait for registry to be ready to serve requests.

--- a/integration-cli/registry.go
+++ b/integration-cli/registry.go
@@ -18,28 +18,55 @@ const (
 )
 
 type testRegistryV2 struct {
-	cmd *exec.Cmd
-	dir string
+	cmd      *exec.Cmd
+	dir      string
+	username string
+	password string
+	email    string
 }
 
-func newTestRegistryV2(c *check.C, schema1 bool) (*testRegistryV2, error) {
+func newTestRegistryV2(c *check.C, schema1, auth bool) (*testRegistryV2, error) {
+	tmp, err := ioutil.TempDir("", "registry-test-")
+	if err != nil {
+		return nil, err
+	}
 	template := `version: 0.1
 loglevel: debug
 storage:
     filesystem:
         rootdirectory: %s
 http:
-    addr: %s`
-	tmp, err := ioutil.TempDir("", "registry-test-")
-	if err != nil {
-		return nil, err
+    addr: %s
+%s`
+	var (
+		htpasswd string
+		username string
+		password string
+		email    string
+	)
+	if auth {
+		htpasswdPath := filepath.Join(tmp, "htpasswd")
+		// generated with: htpasswd -Bbn testuser testpassword
+		userpasswd := "testuser:$2y$05$sBsSqk0OpSD1uTZkHXc4FeJ0Z70wLQdAX/82UiHuQOKbNbBrzs63m"
+		username = "testuser"
+		password = "testpassword"
+		email = "test@test.org"
+		if err := ioutil.WriteFile(htpasswdPath, []byte(userpasswd), os.FileMode(0644)); err != nil {
+			return nil, err
+		}
+		htpasswd = fmt.Sprintf(`auth:
+    htpasswd:
+        realm: basic-realm
+        path: %s
+`, htpasswdPath)
 	}
+
 	confPath := filepath.Join(tmp, "config.yaml")
 	config, err := os.Create(confPath)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := fmt.Fprintf(config, template, tmp, privateRegistryURL); err != nil {
+	if _, err := fmt.Fprintf(config, template, tmp, privateRegistryURL, htpasswd); err != nil {
 		os.RemoveAll(tmp)
 		return nil, err
 	}
@@ -57,8 +84,11 @@ http:
 		return nil, err
 	}
 	return &testRegistryV2{
-		cmd: cmd,
-		dir: tmp,
+		cmd:      cmd,
+		dir:      tmp,
+		username: username,
+		password: password,
+		email:    email,
 	}, nil
 }
 
@@ -68,7 +98,14 @@ func (t *testRegistryV2) Ping() error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK {
+	resp.Body.Close()
+
+	fail := resp.StatusCode != http.StatusOK
+	if t.username != "" {
+		// unauthorized is a _good_ status when pinging v2/ and it needs auth
+		fail = fail && resp.StatusCode != http.StatusUnauthorized
+	}
+	if fail {
 		return fmt.Errorf("registry ping replied with an unexpected status code %d", resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
been investigating issues for registries' 401 for push/pull so far (i.e. https://github.com/docker/docker/issues/19159)

This patch adds a suite with a registry started to require auth (basic auth) and test against it and do not require network to connect to docker.io to test stuff like login and such.
I've added a simple login test for now, we can iterate and add more if you're ok with this.
If you're wondering why I check for string `401 Unauthorized` when login fails it's because the registry is a v2 registry and we do not show the same message we show with v1 registries.
Example

```
$ docker login -u testuser -p testpasswordwrong -e test@test.com myregistrydomain.com:5000
Error response from daemon: no successful auth challenge for https://myregistrydomain.com:5000/v2/ - errors: [basic auth attempt to https://myregistrydomain.com:5000/v2/ realm "Registry Realm" failed with status: 401 Unauthorized]

$ docker login -u runcom -p wrongpassword -e test@docker.io
Error response from daemon: Wrong login/password, please try again
```

/cc @aaronlehmann @tonistiigi @calavera @icecrime 

Signed-off-by: Antonio Murdaca runcom@redhat.com
