### PR TITLE
awslogs driver did not create logging group

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -208,7 +208,6 @@ func createGroup(client api, logGroupName string) error {
 			if awsErr.Code() == resourceAlreadyExistsCode {
 				// Allow creation to succeed
 				logrus.WithFields(fields).Info("Log group already exists")
-				return nil
 			} else {
 				logrus.WithFields(fields).Error("Failed to create log group")
 			}

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -189,7 +189,7 @@ func (l *logStream) create() error {
 	// Create log group first
 	{
 		input := &cloudwatchlogs.CreateLogGroupInput{
-			LogGroupName:  aws.String(l.logGroupName),
+			LogGroupName: aws.String(l.logGroupName),
 		}
 
 		_, err := l.client.CreateLogGroup(input)

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -85,7 +85,7 @@ func TestCreateSuccess(t *testing.T) {
 	mockClient.createLogStreamResult <- &createLogStreamResult{}
 	mockClient.createLogGroupResult <- &createLogGroupResult{}
 
-	err := stream.create(false)
+	err := stream.create()
 
 	if err != nil {
 		t.Errorf("Received unexpected err: %v\n", err)
@@ -117,7 +117,7 @@ func TestCreateError(t *testing.T) {
 		errorResult: errors.New("Error!"),
 	}
 
-	err := stream.create(false)
+	err := stream.create()
 
 	if err == nil {
 		t.Fatal("Expected non-nil err")
@@ -136,7 +136,7 @@ func TestCreateAlreadyExists(t *testing.T) {
 		errorResult: awserr.New(resourceAlreadyExistsCode, "", nil),
 	}
 
-	err := stream.create(false)
+	err := stream.create()
 
 	if err != nil {
 		t.Fatal("Expected nil err")

--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -83,8 +83,9 @@ func TestCreateSuccess(t *testing.T) {
 		logStreamName: streamName,
 	}
 	mockClient.createLogStreamResult <- &createLogStreamResult{}
+	mockClient.createLogGroupResult <- &createLogGroupResult{}
 
-	err := stream.create()
+	err := stream.create(false)
 
 	if err != nil {
 		t.Errorf("Received unexpected err: %v\n", err)
@@ -112,8 +113,11 @@ func TestCreateError(t *testing.T) {
 	mockClient.createLogStreamResult <- &createLogStreamResult{
 		errorResult: errors.New("Error!"),
 	}
+	mockClient.createLogGroupResult <- &createLogGroupResult{
+		errorResult: errors.New("Error!"),
+	}
 
-	err := stream.create()
+	err := stream.create(false)
 
 	if err == nil {
 		t.Fatal("Expected non-nil err")
@@ -128,8 +132,11 @@ func TestCreateAlreadyExists(t *testing.T) {
 	mockClient.createLogStreamResult <- &createLogStreamResult{
 		errorResult: awserr.New(resourceAlreadyExistsCode, "", nil),
 	}
+	mockClient.createLogGroupResult <- &createLogGroupResult{
+		errorResult: awserr.New(resourceAlreadyExistsCode, "", nil),
+	}
 
-	err := stream.create()
+	err := stream.create(false)
 
 	if err != nil {
 		t.Fatal("Expected nil err")

--- a/daemon/logger/awslogs/cwlogsiface_mock_test.go
+++ b/daemon/logger/awslogs/cwlogsiface_mock_test.go
@@ -61,10 +61,9 @@ func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput)
 }
 
 func (m *mockcwlogsclient) CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
-	// m.createLogGroupArgument <- input
-	// output := <-m.createLogGroupResult
-	// return output.successResult, output.errorResult
-	return nil, nil
+	m.createLogGroupArgument <- input
+	output := <-m.createLogGroupResult
+	return output.successResult, output.errorResult
 }
 
 type mockmetadataclient struct {

--- a/daemon/logger/awslogs/cwlogsiface_mock_test.go
+++ b/daemon/logger/awslogs/cwlogsiface_mock_test.go
@@ -61,9 +61,10 @@ func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput)
 }
 
 func (m *mockcwlogsclient) CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
-	m.createLogGroupArgument <- input
-	output := <-m.createLogGroupResult
-	return output.successResult, output.errorResult
+	// m.createLogGroupArgument <- input
+	// output := <-m.createLogGroupResult
+	// return output.successResult, output.errorResult
+	return nil, nil
 }
 
 type mockmetadataclient struct {

--- a/daemon/logger/awslogs/cwlogsiface_mock_test.go
+++ b/daemon/logger/awslogs/cwlogsiface_mock_test.go
@@ -7,6 +7,8 @@ type mockcwlogsclient struct {
 	createLogStreamResult   chan *createLogStreamResult
 	putLogEventsArgument    chan *cloudwatchlogs.PutLogEventsInput
 	putLogEventsResult      chan *putLogEventsResult
+	createLogGroupArgument  chan *cloudwatchlogs.CreateLogGroupInput
+	createLogGroupResult    chan *createLogGroupResult
 }
 
 type createLogStreamResult struct {
@@ -19,12 +21,19 @@ type putLogEventsResult struct {
 	errorResult   error
 }
 
+type createLogGroupResult struct {
+	successResult *cloudwatchlogs.CreateLogGroupOutput
+	errorResult   error
+}
+
 func newMockClient() *mockcwlogsclient {
 	return &mockcwlogsclient{
 		createLogStreamArgument: make(chan *cloudwatchlogs.CreateLogStreamInput, 1),
 		createLogStreamResult:   make(chan *createLogStreamResult, 1),
 		putLogEventsArgument:    make(chan *cloudwatchlogs.PutLogEventsInput, 1),
 		putLogEventsResult:      make(chan *putLogEventsResult, 1),
+		createLogGroupArgument:  make(chan *cloudwatchlogs.CreateLogGroupInput, 1),
+		createLogGroupResult:    make(chan *createLogGroupResult, 1),
 	}
 }
 
@@ -34,6 +43,8 @@ func newMockClientBuffered(buflen int) *mockcwlogsclient {
 		createLogStreamResult:   make(chan *createLogStreamResult, buflen),
 		putLogEventsArgument:    make(chan *cloudwatchlogs.PutLogEventsInput, buflen),
 		putLogEventsResult:      make(chan *putLogEventsResult, buflen),
+		createLogGroupArgument:  make(chan *cloudwatchlogs.CreateLogGroupInput, buflen),
+		createLogGroupResult:    make(chan *createLogGroupResult, buflen),
 	}
 }
 
@@ -46,6 +57,12 @@ func (m *mockcwlogsclient) CreateLogStream(input *cloudwatchlogs.CreateLogStream
 func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
 	m.putLogEventsArgument <- input
 	output := <-m.putLogEventsResult
+	return output.successResult, output.errorResult
+}
+
+func (m *mockcwlogsclient) CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+	m.createLogGroupArgument <- input
+	output := <-m.createLogGroupResult
 	return output.successResult, output.errorResult
 }
 

--- a/docs/admin/logging/awslogs.md
+++ b/docs/admin/logging/awslogs.md
@@ -51,6 +51,15 @@ for the `awslogs` logging driver.  You can specify the log group with the
 
     docker run --log-driver=awslogs --log-opt awslogs-region=us-east-1 --log-opt awslogs-group=myLogGroup ...
 
+### awslogs-create-group
+
+By default `awslogs` logging driver does not create
+[log group](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchLogs.html),
+if log group does not exist, the container fails to start.
+You can force creation of log group by specifying the `awslogs-create-group` log option:
+
+    docker run --log-driver=awslogs --log-opt awslogs-region=us-east-1 --log-opt awslogs-group=myLogGroup --log-opt awslogs-create-group=true ...
+
 ### awslogs-stream
 
 To configure which
@@ -72,14 +81,16 @@ default AWS shared credentials file (`~/.aws/credentials` of the root user), or
 (if you are running the Docker daemon on an Amazon EC2 instance) the Amazon EC2
 instance profile.
 
-Credentials must have a policy applied that allows the `logs:CreateLogStream`
-and `logs:PutLogEvents` actions, as shown in the following example.
+Credentials must have a policy applied that allows the `logs:CreateLogStream`,
+`logs:PutLogEvents`, and optionally `logs:CreateLogGroup` actions,
+as shown in the following example.
 
     {
       "Version": "2012-10-17",
       "Statement": [
         {
           "Action": [
+            "logs:CreateLogGroup",
             "logs:CreateLogStream",
             "logs:PutLogEvents"
           ],


### PR DESCRIPTION
Currently using awslogs driver with non-existing logging group leads to failing to start a container. Added code that first creates logging group.

Amazon's own awslogs agent is able to create logging group if it does not exist.

Signed-off-by: Didzis Gosko didzis.gosko@gmail.com
