### PR TITLE
Correcting `overlay` -> `bridge` driver in run.md

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -409,7 +409,7 @@ The following example creates a network using the built-in `bridge` network
 driver and running a container in the created network
 
 ```
-$ docker network create -d overlay my-net
+$ docker network create -d bridge my-net
 $ docker run --net=my-net -itd --name=container3 busybox
 ```
 


### PR DESCRIPTION
Correcting `overlay` -> `bridge` driver in run.md to match the preceding paragraph.
