### PR TITLE
Make test case name consistent

### DIFF
--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -86,7 +86,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
+func (s *DockerSuite) TestAttachTTYWithoutStdin(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -140,7 +140,7 @@ func (s *DockerSuite) TestExecPausedContainer(c *check.C) {
 }
 
 // regression test for #9476
-func (s *DockerSuite) TestExecTtyCloseStdin(c *check.C) {
+func (s *DockerSuite) TestExecTTYCloseStdin(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "-it", "--name", "exec_tty_stdin", "busybox")
 
@@ -160,7 +160,7 @@ func (s *DockerSuite) TestExecTtyCloseStdin(c *check.C) {
 	c.Assert(out, checker.Not(checker.Contains), "nsenter-exec")
 }
 
-func (s *DockerSuite) TestExecTtyWithoutStdin(c *check.C) {
+func (s *DockerSuite) TestExecTTYWithoutStdin(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 	id := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2548,7 +2548,7 @@ func (s *DockerSuite) TestRunPortFromDockerRangeInUse(c *check.C) {
 	dockerCmd(c, "port", id)
 }
 
-func (s *DockerSuite) TestRunTtyWithPipe(c *check.C) {
+func (s *DockerSuite) TestRunTTYWithPipe(c *check.C) {
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)


### PR DESCRIPTION
Just some minor changes for more convenient integration test.

Replace `Tty` with `TTY` in all test case names so that we can run
a bundle of `TTY` related test cases with TESTFLAGS like
`-check.f TestExecTTY*`

Edit: Right now some test cases are using "Tty" and some others are using "TTY", 
that's why I think they need to be consistent.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
