### PR TITLE
Fix remove API order in menu

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -5,7 +5,7 @@ description = "API Documentation for Docker"
 keywords = ["API, Docker, rcli, REST,  documentation"]
 [menu.main]
 parent = "smn_remoteapi"
-weight=-3
+weight=-4
 +++
 <![end-metadata]-->
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -5,7 +5,7 @@ description = "API Documentation for Docker"
 keywords = ["API, Docker, rcli, REST,  documentation"]
 [menu.main]
 parent="smn_remoteapi"
-weight=-3
+weight=-4
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
Makes the API versions appear in the right order

<img width="325" alt="screen shot 2016-01-24 at 02 50 20" src="https://cloud.githubusercontent.com/assets/1804568/12535828/4e838d48-c245-11e5-9c77-e29c8dc02c41.png">
