### PR TITLE
hack: make.sh: fix in-container check

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -40,7 +40,7 @@ else
 	fi
 fi
 
-if [ -n "$inContainer" ]; then
+if [ -z "$inContainer" ]; then
 	{
 		echo "# WARNING! I don't seem to be running in a Docker container."
 		echo "# The result of this command might be an incorrect build, and will not be"


### PR DESCRIPTION
https://github.com/docker/docker/pull/19316 wrongly checked if the
length of the `$inContainer` string is non-zero. The script should
check instead that the string is zero because we unset it if running
outside the container. Without this we aren't receiving the usual warning
that we should run `./hack/make.sh` in a container.

Signed-off-by: Antonio Murdaca runcom@redhat.com
