### PR TITLE
bash completion for `docker cp --follow-link`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -670,7 +670,7 @@ _docker_commit() {
 _docker_cp() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--follow-link -L --help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)


### PR DESCRIPTION
Ref #16613
Please cherry-pick into 1.10 as the feature is present in this release.
ping @sdurrheimer for zsh completion: new boolean option `docker cp --follow-link`
