### PR TITLE
bash completion for `docker ps --filter status=dead`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1425,7 +1425,7 @@ _docker_ps() {
 			return
 			;;
 		*status=*)
-			COMPREPLY=( $( compgen -W "exited paused restarting running" -- "${cur#=}" ) )
+			COMPREPLY=( $( compgen -W "created dead exited paused restarting running" -- "${cur#=}" ) )
 			return
 			;;
 	esac


### PR DESCRIPTION
Ref #17908
Also added missing value `created`.
Please include in 1.10 as this feature is present in that release.
