### PR TITLE
bash completion for `docker images --filter dangling=false`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1024,10 +1024,8 @@ _docker_history() {
 _docker_images() {
 	case "$prev" in
 		--filter|-f)
-			COMPREPLY=( $( compgen -W "dangling=true label=" -- "$cur" ) )
-			if [ "$COMPREPLY" = "label=" ]; then
-				__docker_nospace
-			fi
+			COMPREPLY=( $( compgen -S = -W "dangling label" -- "$cur" ) )
+			__docker_nospace
 			return
 			;;
                 --format)


### PR DESCRIPTION
Before #19326 (isue #19153), `docker images --filter dangling=false` would not do any filtering at all.
Therefore completion of `dangling` automatically expanded to the only sensible value, `dangling=true`.

Since #19326, `docker images --filter dangling=false` lists all images that are not dangling. Now, both `true` and `false` make sense for completion. This PR adjusts to the new behavior.

ping @jfrazelle @tianon for review
