### PR TITLE
cleanup and move stuff where needed

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -40,8 +40,8 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 		return err
 	}
 
-	// Resolve the Auth config relevant for this server
-	encodedAuth, err := cli.encodeRegistryAuth(repoInfo.Index)
+	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, repoInfo.Index)
+	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -30,11 +30,6 @@ func encodeAuthToBase64(authConfig types.AuthConfig) (string, error) {
 	return base64.URLEncoding.EncodeToString(buf), nil
 }
 
-func (cli *DockerCli) encodeRegistryAuth(index *registrytypes.IndexInfo) (string, error) {
-	authConfig := registry.ResolveAuthConfig(cli.configFile.AuthConfigs, index)
-	return encodeAuthToBase64(authConfig)
-}
-
 func (cli *DockerCli) registryAuthenticationPrivilegedFunc(index *registrytypes.IndexInfo, cmdName string) client.RequestPrivilegeFunc {
 	return func() (string, error) {
 		fmt.Fprintf(cli.out, "\nPlease login prior to %s:\n", cmdName)

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -89,21 +89,8 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 		repo    = r.Form.Get("repo")
 		tag     = r.Form.Get("tag")
 		message = r.Form.Get("message")
-	)
-	authEncoded := r.Header.Get("X-Registry-Auth")
-	authConfig := &types.AuthConfig{}
-	if authEncoded != "" {
-		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
-		if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
-			// for a pull it is not an error if no auth was given
-			// to increase compatibility with the existing api it is defaulting to be empty
-			authConfig = &types.AuthConfig{}
-		}
-	}
-
-	var (
-		err    error
-		output = ioutils.NewWriteFlusher(w)
+		err     error
+		output  = ioutils.NewWriteFlusher(w)
 	)
 	defer output.Close()
 
@@ -133,6 +120,17 @@ func (s *router) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 				for k, v := range r.Header {
 					if strings.HasPrefix(k, "X-Meta-") {
 						metaHeaders[k] = v
+					}
+				}
+
+				authEncoded := r.Header.Get("X-Registry-Auth")
+				authConfig := &types.AuthConfig{}
+				if authEncoded != "" {
+					authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
+					if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
+						// for a pull it is not an error if no auth was given
+						// to increase compatibility with the existing api it is defaulting to be empty
+						authConfig = &types.AuthConfig{}
 					}
 				}
 

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -690,7 +690,7 @@ func validatePath(val string, validator func(string) bool) (string, error) {
 	return val, nil
 }
 
-// SplitN splits raw into a maximum of n parts, separated by a separator colon.
+// volumeSplitN splits raw into a maximum of n parts, separated by a separator colon.
 // A separator colon is the last `:` character in the regex `[/:\\]?[a-zA-Z]:` (note `\\` is `\` escaped).
 // This allows to correctly split strings such as `C:\foo:D:\:rw`.
 func volumeSplitN(raw string, n int) []string {


### PR DESCRIPTION
- just used twice to proxy 2 function calls - other file like pull,push,search already does this but encode the auth after
- just move auth config decoding where it can be needed

Signed-off-by: Antonio Murdaca runcom@redhat.com
