### PR TITLE
Windows CI: In container logic flaw

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -31,7 +31,7 @@ export MAKEDIR="$SCRIPTDIR/make"
 # but really, they shouldn't. We want to be in a container!
 inContainer="AssumeSoInitially"
 if [ "$(go env GOHOSTOS)" = 'windows' ]; then
-	if [ -n "$FROM_DOCKERFILE" ]; then
+	if [ -z "$FROM_DOCKERFILE" ]; then
 		unset inContainer
 	fi
 else


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Sorry guys, I messed up the Linux detection logic, fixed in https://github.com/docker/docker/pull/19627. But that now inverts the Windows logic. Correcting that. 

@runcom @vdemeester @pandrew 
