### PR TITLE
getImagesSearch: default authConfig to nil

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -358,8 +358,7 @@ func (s *router) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *
 		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
 		if err := json.NewDecoder(authJSON).Decode(&config); err != nil {
 			// for a search it is not an error if no auth was given
-			// to increase compatibility with the existing api it is defaulting to be empty
-			config = &types.AuthConfig{}
+			// to increase compatibility with the existing api it is defaulting to be nil
 		}
 	}
 	for k, v := range r.Header {


### PR DESCRIPTION
in
https://github.com/docker/docker/blob/master/registry/session.go#L182
we are checking if `authConfig` is not `nil` to always set basic auth.
However in
https://github.com/docker/docker/blob/master/api/server/router/local/image.go#L362
if there's an error in decoding X-Registry-Auth the previous check
isn't true anymore since we initialized `config`
https://github.com/docker/docker/blob/master/api/server/router/local/image.go#L352
with a pointer struct literal.
This patch simply remove the literal initialization so the check in
https://github.com/docker/docker/blob/master/registry/session.go#L182
can be performed correctly.

ping @tiborvass (and sorry, I just deducted the above scenario, no tests but I'd love to have one :cry:)

Signed-off-by: Antonio Murdaca runcom@redhat.com
