### PR TITLE
Remove completion for `docker tag -f`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1852,7 +1852,7 @@ _docker_stop() {
 _docker_tag() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -967,7 +967,6 @@ __docker_subcommand() {
         (tag)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help -f --force)"{-f,--force}"[force]"\
                 "($help -):source:__docker_images"\
                 "($help -):destination:__docker_repositories_with_tags" && ret=0
             ;;


### PR DESCRIPTION
Ref. #18350 
Please include in 1.10 as the feature was removed in this release.
