### PR TITLE
fix minor bash completion issue on OSX (compopt)

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -488,13 +488,13 @@ __docker_complete_log_driver_options() {
 			;;
 		*splunk-url=*)
 			COMPREPLY=( $( compgen -W "http:// https://" -- "${cur#=}" ) )
-			compopt -o nospace
+			__docker_nospace
 			__ltrim_colon_completions "${cur}"
 			return
 			;;
 		*splunk-insecureskipverify=*)
 			COMPREPLY=( $( compgen -W "true false" -- "${cur#=}" ) )
-			compopt -o nospace
+			__docker_nospace
 			return
 			;;
 	esac


### PR DESCRIPTION
In #16492, direct use of `compopt -o nospace` was removed from bash completion because bash 3.2 (Mac OSX) does not support `compopt`.

Two new occurrences sneaked in, which cause completion of
`docker daemon --log-opt splunk-url=`and `docker daemon --log-opt splunk-insecureskipverify=`
to error out with _bash: compopt: command not found_.

This is a bugfix, please include in 1.10.
