### PR TITLE
Display SystemStatus field in docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -42,6 +42,11 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		}
 
 	}
+	if info.SystemStatus != nil {
+		for _, pair := range info.SystemStatus {
+			fmt.Fprintf(cli.out, "%s: %s\n", pair[0], pair[1])
+		}
+	}
 	ioutils.FprintfIfNotEmpty(cli.out, "Execution Driver: %s\n", info.ExecutionDriver)
 	ioutils.FprintfIfNotEmpty(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -128,6 +128,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /networks/{network-id}` Now returns IPAM config options for custom IPAM plugins if any
   are available.
 * `GET /networks/<network-id>` now returns subnets info for user-defined networks.
+* `GET /info` can now return a `SystemStatus` field useful for returning additional information about applications
+  that are built on top of engine.
 
 ### v1.21 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2102,6 +2102,7 @@ Display system-wide information
         "DockerRootDir": "/var/lib/docker",
         "Driver": "btrfs",
         "DriverStatus": [[""]],
+        "SystemStatus": [["State", "Healthy"]],
         "Plugins": {
             "Volume": [
                 "local"

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -2102,6 +2102,7 @@ Display system-wide information
         "DockerRootDir": "/var/lib/docker",
         "Driver": "btrfs",
         "DriverStatus": [[""]],
+        "SystemStatus": [["State", "Healthy"]],
         "Plugins": {
             "Volume": [
                 "local"


### PR DESCRIPTION
Fixes #19277. Please also see related `docker/engine-api` PR https://github.com/docker/engine-api/pull/46 and `docker/swarm` issue https://github.com/docker/swarm/issues/1625

Signed-off-by: Nishant Totla nishanttotla@gmail.com
