### PR TITLE
Add zsh completion for 'docker cp -L --follow-link'

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -592,6 +592,7 @@ __docker_subcommand() {
         (cp)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help -L --follow-link)"{-L,--follow-link}"[Always follow symbol link in SRC_PATH]" \
                 "($help -)1:container:->container" \
                 "($help -)2:hostpath:_files" && ret=0
             case $state in


### PR DESCRIPTION
Ref #16613

Feature present in the 1.10 release.

@albers Thanks for the ping

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
