### PR TITLE
Add zsh completion for new 'docker daemon --cluster-store-opt discove…

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -690,7 +690,7 @@ __docker_subcommand() {
                     if compset -P '*='; then
                         _files && ret=0
                     else
-                        opts=('kv.cacertfile' 'kv.certfile' 'kv.keyfile')
+                        opts=('discovery.heartbeat' 'discovery.ttl' 'kv.cacertfile' 'kv.certfile' 'kv.keyfile' 'kv.path')
                         _describe -t cluster-store-opts "Cluster Store Options" opts -qS "=" && ret=0
                     fi
                     ;;


### PR DESCRIPTION
…ry.heartbeat discovery.ttl kv.path' options

Ref #19167, #18204.

Feature present in the 1.10 release.

@albers Thanks for the ping

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
