### PR TITLE
Add zsh completion for new 'docker daemon --log-opt syslog-tls-ca-cer…

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -204,7 +204,7 @@ __docker_get_log_options() {
     gelf_options=("env" "gelf-address" "labels" "tag")
     journald_options=("env" "labels")
     json_file_options=("env" "labels" "max-file" "max-size")
-    syslog_options=("syslog-address" "syslog-facility" "tag")
+    syslog_options=("syslog-address" "syslog-tls-ca-cert" "syslog-tls-cert" "syslog-tls-key" "syslog-tls-skip-verify" "syslog-facility" "tag")
     splunk_options=("env" "labels" "splunk-caname" "splunk-capath" "splunk-index" "splunk-insecureskipverify" "splunk-source" "splunk-sourcetype" "splunk-token" "splunk-url" "tag")
 
     [[ $log_driver = (awslogs|all) ]] && _describe -t awslogs-options "awslogs options" awslogs_options "$@" && ret=0


### PR DESCRIPTION
…t syslog-tls-cert syslog-tls-key syslog-tls-skip-verify' options

Ref #18998

Feature present in the 1.10 release.

@albers Thanks for the ping

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
