### PR TITLE
speed up DockerDaemonSuite.TestDaemonRestartWithContainerRunning

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1590,7 +1590,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithContainerRunning(t *check.C) {
 	if err := s.d.StartWithBusybox(); err != nil {
 		t.Fatal(err)
 	}
-	if out, err := s.d.Cmd("run", "-ti", "-d", "--name", "test", "busybox"); err != nil {
+	if out, err := s.d.Cmd("run", "-d", "--name", "test", "busybox", "top"); err != nil {
 		t.Fatal(out, err)
 	}
 


### PR DESCRIPTION
Part of #19425 
PASS: docker_cli_daemon_test.go:1589: DockerDaemonSuite.TestDaemonRestartWithContainerRunning   2.148s

![screenshot from 2016-01-25 23 36 30](https://cloud.githubusercontent.com/assets/1496652/12555799/dcea91fc-c3bd-11e5-91f0-e822291881cb.png)

/cc @tiborvass @thaJeztah 
