### PR TITLE
[WIP] Add forwarding local (client-side) sockets to container

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -19,6 +19,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	noStdin := cmd.Bool([]string{"-no-stdin"}, false, "Do not attach STDIN")
 	proxy := cmd.Bool([]string{"-sig-proxy"}, true, "Proxy all received signals to the process")
 	detachKeys := cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
+	forwardSocket := cmd.String([]string{"-forward-socket"}, "", "Forward a socket to the container")
 
 	cmd.Require(flag.Exact, 1)
 
@@ -63,6 +64,15 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	var in io.ReadCloser
 	if options.Stdin {
 		in = cli.in
+	}
+
+	if *forwardSocket != "" {
+		chSocketStop := make(chan struct{})
+		defer close(chSocketStop)
+		go func() {
+			if err := cli.forwardSocket(options.ContainerID, *forwardSocket, chSocketStop); err != nil {
+			}
+		}()
 	}
 
 	if *proxy && !c.Config.Tty {

--- a/api/client/forward_socket.go
+++ b/api/client/forward_socket.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"io"
+	"net"
+	"net/url"
+	"strings"
+)
+
+func (cli *DockerCli) forwardSocket(id, socketURL string, stop chan struct{}) error {
+	u, err := url.Parse(socketURL)
+	if err != nil {
+		return err
+	}
+	localSock, err := net.Dial(u.Scheme, strings.TrimPrefix(socketURL, u.Scheme+"://"))
+	if err != nil {
+		return err
+	}
+	defer localSock.Close()
+
+	hijack, err := cli.client.ContainerForwardSocket(id)
+	if err != nil {
+		return err
+	}
+	defer hijack.Conn.Close()
+	chErr := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(hijack.Conn, localSock)
+		chErr <- err
+	}()
+
+	go func() {
+		_, err := io.Copy(localSock, hijack.Conn)
+		chErr <- err
+	}()
+
+	select {
+	case err = <-chErr:
+	case <-stop:
+	}
+	hijack.Conn.Close()
+	<-chErr
+
+	return err
+}

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -64,6 +64,11 @@ type attachBackend interface {
 	ContainerWsAttachWithLogs(name string, c *daemon.ContainerWsAttachWithLogsConfig) error
 }
 
+// socketBacked includes functionality to forward sockets from the remote client into the container
+type socketBackend interface {
+	ContainerForwardSocket(name, containerPath string, rwc io.ReadWriter) error
+}
+
 // Backend is all the methods that need to be implemented to provide container specific functionality.
 type Backend interface {
 	execBackend
@@ -71,4 +76,5 @@ type Backend interface {
 	stateBackend
 	monitorBackend
 	attachBackend
+	socketBackend
 }

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -58,6 +58,7 @@ func (r *containerRouter) initRoutes() {
 		local.NewPostRoute("/exec/{name:.*}/resize", r.postContainerExecResize),
 		local.NewPostRoute("/containers/{name:.*}/rename", r.postContainerRename),
 		local.NewPostRoute("/containers/{name:.*}/update", r.postContainerUpdate),
+		local.NewPostRoute("/containers/{name:.*}/forwardSocket", r.postContainerSocket),
 		// PUT
 		local.NewPutRoute("/containers/{name:.*}/archive", r.putContainersArchive),
 		// DELETE

--- a/api/server/router/container/socket.go
+++ b/api/server/router/container/socket.go
@@ -1,0 +1,27 @@
+package container
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/vendor/src/github.com/docker/engine-api/types"
+
+	"golang.org/x/net/context"
+)
+
+func (s *containerRouter) postContainerSocket(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	var cfg types.ContainerForwardSocketConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		return err
+	}
+
+	conn, _, err := w.(http.Hijacker).Hijack()
+	if err != nil {
+		return err
+	}
+	defer httputils.CloseStreams(conn)
+	conn.Write([]byte{})
+
+	return s.backend.ContainerForwardSocket(vars["name"], cfg.ContainerPath, conn)
+}

--- a/daemon/socket.go
+++ b/daemon/socket.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/pkg/stringid"
+)
+
+func (daemon *Daemon) ContainerForwardSocket(name, containerPath string, remoteSock io.ReadWriter) error {
+	c, err := daemon.GetContainer(name)
+	if err != nil {
+		return err
+	}
+	if !c.IsRunning() {
+		return fmt.Errorf("container must be running")
+	}
+	return daemon.containerForwardSocket(c, remoteSock)
+}
+
+func (daemon *Daemon) containerForwardSocket(c *container.Container, remoteSock io.ReadWriter) error {
+	os.MkdirAll("/run/docker/sockets", 0755)
+	sockID := stringid.GenerateNonCryptoID()
+	sockPath := filepath.Join("/run/docker/sockets", sockID+".sock")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return err
+	}
+	defer l.Close()
+	defer os.RemoveAll(sockPath)
+
+	proxyStreams := func(local io.ReadWriteCloser, remote io.ReadWriter) {
+		logrus.Debugf("proxying socket %s", sockPath)
+		chErr := make(chan error, 2)
+		go func() {
+			_, err := io.Copy(local, remote)
+			chErr <- err
+		}()
+		go func() {
+			_, err := io.Copy(remote, local)
+			chErr <- err
+		}()
+		if err := <-chErr; err != nil {
+			logrus.Warnf("Error while forwarding socket conn: %v", err)
+		}
+		local.Close()
+		<-chErr
+	}
+
+	chContainerStop := make(chan struct{})
+	go func() {
+		c.WaitStop(-1 * time.Second)
+		close(chContainerStop)
+	}()
+
+	chDone := make(chan struct{})
+	go func() {
+		defer close(chDone)
+
+		chConn := make(chan net.Conn)
+		go func() {
+			for {
+				conn, err := l.Accept()
+				if err != nil {
+					logrus.Debugf("Error while receiving connection on forwarded socket for %s: %v", c.ID, err)
+					return
+				}
+				chConn <- conn
+			}
+		}()
+
+		for {
+			select {
+			case <-chContainerStop:
+				return
+			case conn := <-chConn:
+				go proxyStreams(conn, remoteSock)
+			}
+		}
+	}()
+
+	<-chDone
+	return nil
+}

--- a/vendor/src/github.com/docker/engine-api/client/forward_socket.go
+++ b/vendor/src/github.com/docker/engine-api/client/forward_socket.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+)
+
+func (cli *Client) ContainerForwardSocket(id string) (types.HijackedResponse, error) {
+	headers := map[string][]string{"Content-Type": {"application/son"}}
+
+	body := types.ContainerForwardSocketConfig{}
+	return cli.postHijacked("/containers/"+id+"/forwardSocket", url.Values{}, body, headers)
+}

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -23,6 +23,7 @@ type APIClient interface {
 	ContainerExecResize(options types.ResizeOptions) error
 	ContainerExecStart(execID string, config types.ExecStartCheck) error
 	ContainerExport(containerID string) (io.ReadCloser, error)
+	ContainerForwardSocket(containerID string) (types.HijackedResponse, error)
 	ContainerInspect(containerID string) (types.ContainerJSON, error)
 	ContainerInspectWithRaw(containerID string, getSize bool) (types.ContainerJSON, []byte, error)
 	ContainerKill(containerID, signal string) error

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -428,3 +428,7 @@ type NetworkDisconnect struct {
 	Container string
 	Force     bool
 }
+
+type ContainerForwardSocketConfig struct {
+	ContainerPath string
+}


### PR DESCRIPTION
[WIP] -- DO NOT MERGE

Adds an API endpoint for proxying socket conns from the client.
This allows a client to forward a local socket (such as an SSH agent
sock or an X11 socket) into a running container.

This is currently just POC code, and it's not actually forwarding to the
container, only to the host for simplicity while getting the connections
actually working.

Idea here is that any of the client commands that attach to the
container in some way (exec, attach, run, build -- maybe) can take this
new optional argument `--forward-socket <scheme>://<socket>`

Signed-off-by: Brian Goff cpuguy83@gmail.com
