### PR TITLE
Save endpoint config only if endpoint creation succeeds

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -265,7 +265,7 @@ func (container *Container) BuildJoinOptions(n libnetwork.Network) ([]libnetwork
 }
 
 // BuildCreateEndpointOptions builds endpoint options from a given network.
-func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network) ([]libnetwork.EndpointOption, error) {
+func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epConfig *network.EndpointSettings) ([]libnetwork.EndpointOption, error) {
 	var (
 		portSpecs     = make(nat.PortSet)
 		bindings      = make(nat.PortMap)
@@ -278,7 +278,7 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network) ([]
 		createOptions = append(createOptions, libnetwork.CreateOptionAnonymous())
 	}
 
-	if epConfig, ok := container.NetworkSettings.Networks[n.Name()]; ok {
+	if epConfig != nil {
 		ipam := epConfig.IPAMConfig
 		if ipam != nil && (ipam.IPv4Address != "" || ipam.IPv6Address != "") {
 			createOptions = append(createOptions,

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -775,11 +775,7 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 
 	controller := daemon.netController
 
-	if endpointConfig != nil {
-		container.NetworkSettings.Networks[n.Name()] = endpointConfig
-	}
-
-	createOptions, err := container.BuildCreateEndpointOptions(n)
+	createOptions, err := container.BuildCreateEndpointOptions(n, endpointConfig)
 	if err != nil {
 		return err
 	}
@@ -796,6 +792,10 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 			}
 		}
 	}()
+
+	if endpointConfig != nil {
+		container.NetworkSettings.Networks[n.Name()] = endpointConfig
+	}
 
 	if err := daemon.updateEndpointNetworkSettings(container, n, ep); err != nil {
 		return err


### PR DESCRIPTION
- Currently it is being save upfront...

Fixes #19669 
Fixes #19601

Signed-off-by: Alessandro Boch aboch@docker.com
