### PR TITLE
Change the way we install from backports in the deb builder (to force deps too)

### DIFF
--- a/contrib/builder/deb/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/debian-wheezy/Dockerfile
@@ -4,7 +4,8 @@
 
 FROM debian:wheezy-backports
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config  --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/contrib/builder/deb/generate.sh
+++ b/contrib/builder/deb/generate.sh
@@ -97,9 +97,13 @@ for version in "${versions[@]}"; do
 	fi
 
 	if [ "$suite" = 'wheezy' ]; then
-		# pull btrfs-toold from backports
-		backports="/$suite-backports"
-		packages=( "${packages[@]/btrfs-tools/btrfs-tools$backports}" )
+		# pull a couple packages from backports explicitly
+		# (build failures otherwise)
+		backportsPackages=( btrfs-tools libsystemd-journal-dev )
+		for pkg in "${backportsPackages[@]}"; do
+			packages=( "${packages[@]/$pkg}" )
+		done
+		echo "RUN apt-get update && apt-get install -y -t $suite-backports ${backportsPackages[*]} --no-install-recommends && rm -rf /var/lib/apt/lists/*" >> "$version/Dockerfile"
 	fi
 
 	echo "RUN apt-get update && apt-get install -y ${packages[*]} --no-install-recommends && rm -rf /var/lib/apt/lists/*" >> "$version/Dockerfile"


### PR DESCRIPTION
Also, add "libsystemd-journal-dev" to the explicit list (which is what prompted the change in how we install).

Fixes #19668

cc @jfrazelle

This builds successfully. :+1:
