### PR TITLE
docker/docker#8513 : Add a test for trailing carriage return in output of 'docker exec -it 

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -230,7 +231,9 @@ func (s *DockerSuite) TestExecTTYWithStdin(c *check.C) {
 				output = scanner.Text()
 			}
 		}()
-
+		go func() {
+			io.Copy(tty, os.Stdin)
+		}()
 		select {
 		case <-time.After(10 * time.Second):
 			c.Fatal("command timeout")

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -230,11 +230,6 @@ func (s *DockerSuite) TestExecTTYWithStdin(c *check.C) {
 				output = scanner.Text()
 			}
 		}()
-		go func() {
-			io.Copy(tty, os.Stdin)
-		}()
-
-		out, _ := dockerCmd(c, "exec", "-ti", "testing", "uname")
 
 		select {
 		case <-time.After(10 * time.Second):
@@ -250,8 +245,7 @@ func (s *DockerSuite) TestExecTTYWithStdin(c *check.C) {
 	c.Assert(out, checker.Equals, "Linux")
 	c.Assert(out, checker.Not(checker.Contains), '\r')
 
-	out := ttyExecCommand(`echo "\n\n\n"`)
-	out, _ = dockerCmd(c, "exec", "-ti", "testing", `echo "\n\n\n"`)
+	out = ttyExecCommand(`echo "\n\n\n"`)
 	c.Assert(out, checker.Equals, `\n\n\n`)
 	c.Assert(out, checker.Not(checker.Contains), '\r')
 }

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -205,6 +205,16 @@ func (s *DockerSuite) TestExecParseError(c *check.C) {
 	c.Assert(stderr, checker.Contains, "See '"+dockerBinary+" exec --help'")
 }
 
+func (s *DockerSuite) TestExecTTYCarriageReturn(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	dockerCmd(c, "run", "-d", "-it", "--name", "testing", "busybox", "top")
+
+	cmd := exec.Command(dockerBinary, "exec", "-it", "testing", "uname")
+	out, _, err := runCommandWithOutput(cmd)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "\r")
+}
+
 func (s *DockerSuite) TestExecStopNotHanging(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -5,7 +5,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+  "io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"


### PR DESCRIPTION
This just adds the test, still needs a fix. See docker/docker#8513
