### PR TITLE
optimize DockerSuite.TestEventsAttach

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -461,7 +461,7 @@ func (s *DockerSuite) TestEventsAttach(c *check.C) {
 
 	c.Assert(stdin.Close(), checker.IsNil)
 
-	dockerCmd(c, "stop", cID)
+	dockerCmd(c, "kill", cID)
 
 	out, _ = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
 	c.Assert(out, checker.Contains, "attach", check.Commentf("Missing 'attach' log event"))


### PR DESCRIPTION
Part of #19425
PASS: docker_cli_events_test.go:438: DockerSuite.TestEventsAttach   1.260s
