### PR TITLE
Clean up container rootf mounts on daemon start, fixes #19679

### DIFF
--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -14,7 +14,7 @@ import (
 
 // cleanupMounts umounts shm/mqueue mounts for old containers
 func (daemon *Daemon) cleanupMounts() error {
-	logrus.Debugf("Cleaning up old shm/mqueue mounts: start.")
+	logrus.Debugf("Cleaning up old container shm/mqueue/rootfs mounts: start.")
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return err
@@ -33,11 +33,11 @@ func (daemon *Daemon) cleanupMountsFromReader(reader io.Reader, unmount func(tar
 	for sc.Scan() {
 		line := sc.Text()
 		fields := strings.Fields(line)
-		if strings.HasPrefix(fields[4], daemon.repository) {
-			logrus.Debugf("Mount base: %v, repository %s", fields[4], daemon.repository)
+		if strings.HasPrefix(fields[4], daemon.root) {
+			logrus.Debugf("Mount base: %v", fields[4])
 			mnt := fields[4]
 			mountBase := filepath.Base(mnt)
-			if mountBase == "mqueue" || mountBase == "shm" {
+			if mountBase == "mqueue" || mountBase == "shm" || mountBase == "merged" {
 				logrus.Debugf("Unmounting %v", mnt)
 				if err := unmount(mnt); err != nil {
 					logrus.Error(err)
@@ -55,6 +55,6 @@ func (daemon *Daemon) cleanupMountsFromReader(reader io.Reader, unmount func(tar
 		return fmt.Errorf("Error cleaningup mounts:\n%v", strings.Join(errors, "\n"))
 	}
 
-	logrus.Debugf("Cleaning up old shm/mqueue mounts: done.")
+	logrus.Debugf("Cleaning up old container shm/mqueue/rootfs mounts: done.")
 	return nil
 }


### PR DESCRIPTION
When the daemon shutdown ungracefull, it will left the running
containers' rootfs still be mounted. This will cause some error
when trying to remove the containers.

<del>and remove 
`daemon.Unmount(container)` from `Register` since it's duplicate 
with https://github.com/docker/docker/blob/master/daemon/daemon.go#L805</del>

This is for overlay graphdriver

ping @cpuguy83 
/cc @ibuildthecloud 

Signed-off-by: Lei Jitang leijitang@huawei.com
