### PR TITLE
integration-cli: require Apparmor

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -726,7 +726,7 @@ func (s *DockerSuite) TestRunTmpfsMounts(c *check.C) {
 
 // TestRunSeccompProfileDenyUnshare checks that 'docker run --security-opt seccomp:/tmp/profile.json debian:jessie unshare' exits with operation not permitted.
 func (s *DockerSuite) TestRunSeccompProfileDenyUnshare(c *check.C) {
-	testRequires(c, SameHostDaemon, seccompEnabled, NotArm)
+	testRequires(c, SameHostDaemon, seccompEnabled, NotArm, Apparmor)
 	jsonData := `{
 	"defaultAction": "SCMP_ACT_ALLOW",
 	"syscalls": [
@@ -783,7 +783,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyChmod(c *check.C) {
 // TestRunSeccompProfileDenyUnshareUserns checks that 'docker run debian:jessie unshare --map-root-user --user sh -c whoami' with a specific profile to
 // deny unhare of a userns exits with operation not permitted.
 func (s *DockerSuite) TestRunSeccompProfileDenyUnshareUserns(c *check.C) {
-	testRequires(c, SameHostDaemon, seccompEnabled, NotArm)
+	testRequires(c, SameHostDaemon, seccompEnabled, NotArm, Apparmor)
 	// from sched.h
 	jsonData := fmt.Sprintf(`{
 	"defaultAction": "SCMP_ACT_ALLOW",


### PR DESCRIPTION
```
----------------------------------------------------------------------
FAIL: docker_cli_run_unix_test.go:728: DockerSuite.TestRunSeccompProfileDenyUnshare

docker_cli_run_unix_test.go:751:
    c.Fatalf("expected unshare with seccomp profile denied to fail, got %s", out)
... Error: expected unshare with seccomp profile denied to fail, got apparmor: config provided but apparmor not supported
docker: Error response from daemon: Cannot start container 38a580d5af731d70fb8fe9f3579022281eee0719f0d66c4a21b7fc8e5edf5421: [9] System error: apparmor: config provided but apparmor not supported.

----------------------------------------------------------------------
FAIL: docker_cli_run_unix_test.go:785: DockerSuite.TestRunSeccompProfileDenyUnshareUserns

docker_cli_run_unix_test.go:816:
    c.Fatalf("expected unshare userns with seccomp profile denied to fail, got %s", out)
... Error: expected unshare userns with seccomp profile denied to fail, got apparmor: config provided but apparmor not supported
docker: Error response from daemon: Cannot start container cc6a531314447e4e8ec83c0f03008e680e87505500210d4aa5ba181aaecc1102: [9] System error: apparmor: config provided but apparmor not supported.
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
