### PR TITLE
Test utils: fix daemon start utils

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -224,17 +224,20 @@ func (d *Daemon) Start(arg ...string) error {
 
 	// If we don't explicitly set the log-level or debug flag(-D) then
 	// turn on debug mode
-	foundIt := false
+	foundLog := false
+	foundSd := false
 	for _, a := range arg {
 		if strings.Contains(a, "--log-level") || strings.Contains(a, "-D") || strings.Contains(a, "--debug") {
-			foundIt = true
+			foundLog = true
+		}
+		if strings.Contains(a, "--storage-driver") {
+			foundSd = true
 		}
 	}
-	if !foundIt {
+	if !foundLog {
 		args = append(args, "--debug")
 	}
-
-	if d.storageDriver != "" {
+	if d.storageDriver != "" && !foundSd {
 		args = append(args, "--storage-driver", d.storageDriver)
 	}
 


### PR DESCRIPTION
User call `Start` could with args, and the args could
contains `--storage-driver`, but in `Start`, it will add
`--storage-driver` even though user has specified `--storage-driver`
in args.
hit this issues when I working on PR #19711 

Signed-off-by: Lei Jitang leijitang@huawei.com
