### PR TITLE
Daemon: do GetRWLayer after checking if container support the current graph driver

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -277,15 +277,14 @@ func (daemon *Daemon) restore() error {
 			continue
 		}
 
-		rwlayer, err := daemon.layerStore.GetRWLayer(container.ID)
-		if err != nil {
-			logrus.Errorf("Failed to load container mount %v: %v", id, err)
-			continue
-		}
-		container.RWLayer = rwlayer
-
 		// Ignore the container if it does not support the current driver being used by the graph
 		if (container.Driver == "" && currentDriver == "aufs") || container.Driver == currentDriver {
+			rwlayer, err := daemon.layerStore.GetRWLayer(container.ID)
+			if err != nil {
+				logrus.Errorf("Failed to load container mount %v: %v", id, err)
+				continue
+			}
+			container.RWLayer = rwlayer
 			logrus.Debugf("Loaded container %v", container.ID)
 
 			containers[container.ID] = container


### PR DESCRIPTION
we should check if the container support the current graph driver and
then do `GetRWLayer` since `RWLayer` is relate to graph driver.
or it will have a error message:

<pre><code>ERRO[0002] Failed to load container mount 815c216264885c4165b408f8eae2c05e39133226b27dba3b477eaf2f77028e48: mount does not exist
ERRO[0002] Failed to load container mount 82c24436b25fcd28109b6b34e527c8519e7689f07bfb6c175132d9b37c02d129: mount does not exist
ERRO[0002] Failed to load container mount 83b1059609bb3b22629c9ee0ecc606717d42fe924e294d1125aee6ff9c7f9668: mount does not exist
ERRO[0002] Failed to load container mount 86699280fe990852785be70662434276f9af554d3af82957822b17095a44171d: mount does not exist
ERRO[0002] Failed to load container mount 88a0f380d4bba71c2464160d167e5436f1fb4e1b73cb433be6e4ed0e5c6f0daf: mount does not exist
ERRO[0002] Failed to load container mount 898821093dea9702677104161626e7078185675211e44f4ad21e67eeb2b7d923: mount does not exist
ERRO[0002] Failed to load container mount 8a1152a653c82e6cac71809eea543807583efdfe2d131541488a9ed53974f54e: mount does not exist
ERRO[0002] Failed to load container mount 8a74abcee4ab477fb8b6fff0865408118b0cfc23185adf48e5c68d2a741bb104: mount does not exist
ERRO[0002] Failed to load container mount 8bd128d06efe730fb1a58b407c3464767b386d1cf49f3f5d393aead86a4ab352: mount does not exist
ERRO[0002] Failed to load container mount 8bfc37a3465c7a78a95c1f62d44f1d211872291654a22b680d6bc24a7187b80c: mount does not exist
ERRO[0002] Failed to load container mount 8c9c1d9355c51d6a709ef682fde772701a28ccfe29edd5466546eed0cdff561f: mount does not exist
ERRO[0002] Failed to load container mount 8ecb60792ba44f074bfc13e6f22e0b65419f34164a48b87b182ef15cb2c3e443: mount does not exist</code></pre>


The previous version is like this

<pre><code>DEBU[0001] Cannot load container 288b0571b235b31ceb9df357e38ea873610d4561fe83937e5fb97c7d0b3e7575 because it was created with another graph driver.
DEBU[0001] Cannot load container 2bfc1d0771d030483add60d1e74e901c9104c174d5b8e01004c18af1f181987f because it was created with another graph driver.
DEBU[0001] Cannot load container 2d0515ded3f3a740a53a655ccf6dfb725b4febd5d6b0e05b1d320bdee1c5785c because it was created with another graph driver.
DEBU[0001] Cannot load container 2dc8cb928906c72bfac72de5b37a3442031e68fc27884f0117732bdbd6a05905 because it was created with another graph driver.
DEBU[0001] Cannot load container 2f78028ab4d4fd0891de20e94176602efb5d593c23da5c07ad843746fc31c76c because it was created with another graph driver.
DEBU[0001] Cannot load container 2fe33736bc3610323a1da4f1ed48be4d118d246828dc80259a6df6e2b7c1e225 because it was created with another graph driver.
DEBU[0001] Cannot load container 3508f518cc23d60d8e43faab4dc27b511fa4dab1edba8d21a53fd560f3057c33 because it was created with another graph driver.
DEBU[0001] Cannot load container 36329496d9bc7c12eee6d13ca8257278768a6cc215a36957719acf0df6fd6336 because it was created with another graph driver.
DEBU[0001] Cannot load container 37da597875a06f012cfeb607ca7aa64e23aff7f306b67f7c971aea41a3338b03 because it was created with another graph driver.
</code></pre>

Signed-off-by: Lei Jitang leijitang@huawei.com
