### PR TITLE
Improve wording about re-assigning IP addresses

### DIFF
--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -56,12 +56,14 @@ $ docker network connect --alias db --alias mysql multi-host-network container2
 You can pause, restart, and stop containers that are connected to a network.
 Paused containers remain connected and can be revealed by a `network inspect`.
 When the container is stopped, it does not appear on the network until you restart
-it. If specified, the container's IP address(es) will be reapplied (if still available)
-when a stopped container rejoins the network. One way to guarantee that the container
-will be assigned the same IP addresses when it rejoins the network after a stop
-or a disconnect, is to specify the `--ip-range` when creating the network, and choose
-the static IP address(es) from outside the range. This will ensure that the IP address
-will not be given to other dynamic containers while this container is not on the network.
+it.
+
+If specified, the container's IP address(es) is reapplied when a stopped
+container is restarted. If the IP address is no longer available, the container
+fails to start. One way to guarantee that the IP address is available is
+to specify an `--ip-range` when creating the network, and choose the static IP
+address(es) from outside that range. This ensures that the IP address is not
+given to another container while this container is not on the network.
 
 ```bash
 $ docker network create --subnet 172.20.0.0/16 --ip-range 172.20.240.0/20 multi-host-network

--- a/man/docker-network-connect.1.md
+++ b/man/docker-network-connect.1.md
@@ -28,12 +28,14 @@ $ docker run -itd --net=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::882
 You can pause, restart, and stop containers that are connected to a network.
 Paused containers remain connected and can be revealed by a `network inspect`.
 When the container is stopped, it does not appear on the network until you restart
-it. If specified, the container's IP address(es) will be reapplied (if still available)
-when a stopped container rejoins the network. One way to guarantee that the container
-will be assigned the same IP addresses when it rejoins the network after a stop
-or a disconnect, is to specify the `--ip-range` when creating the network, and choose
-the static IP address(es) from outside the range. This will ensure that the IP address
-will not be given to other dynamic containers while this container is not on the network.
+it.
+
+If specified, the container's IP address(es) is reapplied when a stopped
+container is restarted. If the IP address is no longer available, the container
+fails to start. One way to guarantee that the IP address is available is
+to specify an `--ip-range` when creating the network, and choose the static IP
+address(es) from outside that range. This ensures that the IP address is not
+given to another container while this container is not on the network.
 
 ```bash
 $ docker network create --subnet 172.20.0.0/16 --ip-range 172.20.240.0/20 multi-host-network


### PR DESCRIPTION
As requested at https://github.com/docker/docker/pull/19286#issuecomment-174633736

I tried to make it unambiguous what happens if the address is not available on restart.
