### PR TITLE
Forbid exec a restarting container

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -247,6 +247,14 @@ func (s *State) IsPaused() bool {
 	return res
 }
 
+// IsRestarting returns whether the container is restarting or not.
+func (s *State) IsRestarting() bool {
+	s.Lock()
+	res := s.Restarting
+	s.Unlock()
+	return res
+}
+
 // SetRemovalInProgress sets the container state as being removed.
 func (s *State) SetRemovalInProgress() error {
 	s.Lock()

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -52,6 +52,9 @@ func (d *Daemon) getExecConfig(name string) (*exec.Config, error) {
 			if container.IsPaused() {
 				return nil, derr.ErrorCodeExecPaused.WithArgs(container.ID)
 			}
+			if container.IsRestarting() {
+				return nil, derr.ErrorCodeExecRestarting.WithArgs(container.ID)
+			}
 			return ec, nil
 		}
 	}
@@ -75,6 +78,9 @@ func (d *Daemon) getActiveContainer(name string) (*container.Container, error) {
 	}
 	if container.IsPaused() {
 		return nil, derr.ErrorCodeExecPaused.WithArgs(name)
+	}
+	if container.IsRestarting() {
+		return nil, derr.ErrorCodeExecRestarting.WithArgs(name)
 	}
 	return container, nil
 }

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -733,6 +733,15 @@ var (
 		HTTPStatusCode: http.StatusConflict,
 	})
 
+	// ErrorCodeExecRestarting is generated when we try to start an exec
+	// but the container is restarting.
+	ErrorCodeExecRestarting = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "EXECRESTARTING",
+		Message:        "Container %s is restarting, wait until the container is running",
+		Description:    "An attempt to start an 'exec' was made, but the owning container is restarting",
+		HTTPStatusCode: http.StatusConflict,
+	})
+
 	// ErrorCodeExecRunning is generated when we try to start an exec
 	// but its already running.
 	ErrorCodeExecRunning = errcode.Register(errGroup, errcode.ErrorDescriptor{


### PR DESCRIPTION
Currently if we exec a restarting container, client will fail silently,
and daemon will print error that container can't be found which is not a
very meaningful prompt to user.

This commit will stop user from exec a restarting container and gives
more explicit error message.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
