### PR TITLE
Stop referring to requested IP address as "preferred"

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1126,7 +1126,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *check.C) {
 	c.Assert(waitRun("c0"), check.IsNil)
 	verifyIPAddresses(c, "c0", "n0", "172.28.99.88", "2001:db8:1234::9988")
 
-	// connect the container to the second network specifying the preferred ip addresses
+	// connect the container to the second network specifying an ip addresses
 	dockerCmd(c, "network", "connect", "--ip", "172.30.55.44", "--ip6", "2001:db8:abcd::5544", "n1", "c0")
 	verifyIPAddresses(c, "c0", "n1", "172.30.55.44", "2001:db8:abcd::5544")
 
@@ -1134,7 +1134,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *check.C) {
 	dockerCmd(c, "stop", "c0")
 	dockerCmd(c, "start", "c0")
 
-	// verify preferred addresses are applied
+	// verify requested addresses are applied
 	verifyIPAddresses(c, "c0", "n0", "172.28.99.88", "2001:db8:1234::9988")
 	verifyIPAddresses(c, "c0", "n1", "172.30.55.44", "2001:db8:abcd::5544")
 
@@ -1145,13 +1145,13 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *check.C) {
 
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedPreferredIP(c *check.C) {
-	// preferred IP is not supported on predefined networks
+func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedRequiredIP(c *check.C) {
+	// requested IP is not supported on predefined networks
 	for _, mode := range []string{"none", "host", "bridge", "default"} {
 		checkUnsupportedNetworkAndIP(c, mode)
 	}
 
-	// preferred IP is not supported on networks with no user defined subnets
+	// requested IP is not supported on networks with no user defined subnets
 	dockerCmd(c, "network", "create", "n0")
 	assertNwIsAvailable(c, "n0")
 

--- a/runconfig/errors.go
+++ b/runconfig/errors.go
@@ -29,9 +29,9 @@ var (
 	ErrConflictNetworkPublishPorts = fmt.Errorf("Conflicting options: port publishing and the container type network mode")
 	// ErrConflictNetworkExposePorts conflict between the expose option and the network mode
 	ErrConflictNetworkExposePorts = fmt.Errorf("Conflicting options: port exposing and the container type network mode")
-	// ErrUnsupportedNetworkAndIP conflict between network mode and preferred ip address
+	// ErrUnsupportedNetworkAndIP conflict between network mode and requested ip address
 	ErrUnsupportedNetworkAndIP = fmt.Errorf("User specified IP address is supported on user defined networks only")
-	// ErrUnsupportedNetworkNoSubnetAndIP conflict between network with no configured subnet and preferred ip address
+	// ErrUnsupportedNetworkNoSubnetAndIP conflict between network with no configured subnet and requested ip address
 	ErrUnsupportedNetworkNoSubnetAndIP = fmt.Errorf("User specified IP address is supported only when connecting to networks with user configured subnets")
 	// ErrUnsupportedNetworkAndAlias conflict between network mode and alias
 	ErrUnsupportedNetworkAndAlias = fmt.Errorf("Network-scoped alias is supported only for containers in user defined networks")


### PR DESCRIPTION
The root of my confusion at https://github.com/docker/docker/pull/19286#issuecomment-174478437 was that the parameter is referred to as a "preferred IP address" in many places.  The word "preferred" to me suggests that it is OK to give a different address if that request cannot be satisfied, whereas the code and tests all believe that the request is non-negotiable.

Somewhat related to #19721
