### PR TITLE
PS and Inspect without container lock, take 2.

### DIFF
--- a/container/memory_store.go
+++ b/container/memory_store.go
@@ -1,11 +1,14 @@
 package container
 
-import "sync"
+import (
+	"reflect"
+	"sync"
+)
 
 // memoryStore implements a Store in memory.
 type memoryStore struct {
-	s map[string]*Container
-	sync.Mutex
+	s    map[string]*Container
+	lock sync.Mutex
 }
 
 // NewMemoryStore initializes a new memory store.
@@ -18,50 +21,51 @@ func NewMemoryStore() Store {
 // Add appends a new container to the memory store.
 // It overrides the id if it existed before.
 func (c *memoryStore) Add(id string, cont *Container) {
-	c.Lock()
+	c.lock.Lock()
 	c.s[id] = cont
-	c.Unlock()
+	c.lock.Unlock()
 }
 
 // Get returns a container from the store by id.
 func (c *memoryStore) Get(id string) *Container {
-	c.Lock()
+	c.lock.Lock()
 	res := c.s[id]
-	c.Unlock()
+	c.lock.Unlock()
 	return res
 }
 
 // Delete removes a container from the store by id.
 func (c *memoryStore) Delete(id string) {
-	c.Lock()
+	c.lock.Lock()
 	delete(c.s, id)
-	c.Unlock()
+	c.lock.Unlock()
 }
 
 // List returns a sorted list of containers from the store.
 // The containers are ordered by creation date.
 func (c *memoryStore) List() []*Container {
 	containers := new(History)
-	c.Lock()
+	c.lock.Lock()
 	for _, cont := range c.s {
 		containers.Add(cont)
 	}
-	c.Unlock()
+	c.lock.Unlock()
 	containers.sort()
 	return *containers
 }
 
 // Size returns the number of containers in the store.
 func (c *memoryStore) Size() int {
-	c.Lock()
-	defer c.Unlock()
-	return len(c.s)
+	c.lock.Lock()
+	l := len(c.s)
+	c.lock.Unlock()
+	return l
 }
 
 // First returns the first container found in the store by a given filter.
 func (c *memoryStore) First(filter StoreFilter) *Container {
-	c.Lock()
-	defer c.Unlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	for _, cont := range c.s {
 		if filter(cont) {
 			return cont
@@ -73,8 +77,8 @@ func (c *memoryStore) First(filter StoreFilter) *Container {
 // ApplyAll calls the reducer function with every container in the store.
 // This operation is asyncronous in the memory store.
 func (c *memoryStore) ApplyAll(apply StoreReducer) {
-	c.Lock()
-	defer c.Unlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	wg := new(sync.WaitGroup)
 	for _, cont := range c.s {
@@ -88,4 +92,112 @@ func (c *memoryStore) ApplyAll(apply StoreReducer) {
 	wg.Wait()
 }
 
+// ReduceAll filters a list of containers and calls the reducer function with each one of them.
+func (c *memoryStore) ReduceAll(filter StoreFilter, apply StoreReducer) error {
+	var containers []*Container
+	c.lock.Lock()
+	for _, cont := range c.s {
+		if filter(cont) {
+			cp := copyContainer(cont)
+			containers = append(containers, cp)
+		}
+	}
+	c.lock.Unlock()
+
+	for _, cont := range containers {
+		if err := apply(cont); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReduceOne gets a controller and calls the reducer function with it.
+func (c *memoryStore) ReduceOne(id string, apply StoreReducer) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	cont := c.s[id]
+	if cont == nil {
+		return nil
+	}
+	return apply(copyContainer(cont))
+}
+
 var _ Store = &memoryStore{}
+
+// copyContainer recursively deep copies a container pointer.
+func copyContainer(cont *Container) *Container {
+	original := reflect.ValueOf(cont)
+	cp := reflect.New(original.Type()).Elem()
+
+	copyRecursive(original, cp)
+	copied := cp.Interface().(*Container)
+
+	return copied
+}
+
+// copyRecursive iterates recursively over the structure and
+// copies its values.
+func copyRecursive(original, cp reflect.Value) {
+	// handle according to original's Kind
+	switch original.Kind() {
+	case reflect.Ptr:
+		// Get the actual value being pointed to.
+		originalValue := original.Elem()
+		// if  it isn't valid, return.
+		if !originalValue.IsValid() {
+			return
+		}
+		cp.Set(reflect.New(originalValue.Type()))
+		copyRecursive(originalValue, cp.Elem())
+	case reflect.Interface:
+		// Get the value for the interface, not the pointer.
+		originalValue := original.Elem()
+		if !originalValue.IsValid() {
+			return
+		}
+		// Get the value by calling Elem().
+		copyValue := reflect.New(originalValue.Type()).Elem()
+		copyRecursive(originalValue, copyValue)
+		cp.Set(copyValue)
+	case reflect.Struct:
+		// Go through each field of the struct and copy it.
+		var exported bool
+		for i := 0; i < original.NumField(); i++ {
+			if cp.Field(i).CanSet() {
+				copyRecursive(original.Field(i), cp.Field(i))
+				exported = true
+			}
+		}
+		// Copy the complete struct if none of the fields were exported.
+		// This means it's a stdlib struct, like time.Time.
+		if !exported {
+			cp.Set(original)
+		}
+	case reflect.Slice:
+		// Make a new slice and copy each element.
+		cp.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
+		for i := 0; i < original.Len(); i++ {
+			copyRecursive(original.Index(i), cp.Index(i))
+		}
+	case reflect.Map:
+		cp.Set(reflect.MakeMap(original.Type()))
+		for _, key := range original.MapKeys() {
+			originalValue := original.MapIndex(key)
+			copyValue := reflect.New(originalValue.Type()).Elem()
+			copyRecursive(originalValue, copyValue)
+			cp.SetMapIndex(key, copyValue)
+		}
+	// Set the actual values from here on.
+	case reflect.String:
+		cp.SetString(original.String())
+	case reflect.Int:
+		cp.SetInt(original.Int())
+	case reflect.Bool:
+		cp.SetBool(original.Bool())
+	case reflect.Float64:
+		cp.SetFloat(original.Float())
+	default:
+		cp.Set(original)
+	}
+}

--- a/container/store.go
+++ b/container/store.go
@@ -6,7 +6,7 @@ type StoreFilter func(*Container) bool
 
 // StoreReducer defines a function to
 // manipulate containers in the store
-type StoreReducer func(*Container)
+type StoreReducer func(*Container) error
 
 // Store defines an interface that
 // any container store must implement.
@@ -25,4 +25,8 @@ type Store interface {
 	First(StoreFilter) *Container
 	// ApplyAll calls the reducer function with every container in the store.
 	ApplyAll(StoreReducer)
+	// ReduceAll filters a list of containers and calls the reducer function with each one of them.
+	ReduceAll(StoreFilter, StoreReducer) error
+	// ReduceOne gets a controller and calls the reducer function with it.
+	ReduceOne(string, StoreReducer) error
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -856,16 +856,17 @@ func (daemon *Daemon) Shutdown() error {
 	daemon.shutdown = true
 	if daemon.containers != nil {
 		logrus.Debug("starting clean shutdown of all containers...")
-		daemon.containers.ApplyAll(func(c *container.Container) {
+		daemon.containers.ApplyAll(func(c *container.Container) error {
 			if !c.IsRunning() {
-				return
+				return nil
 			}
 			logrus.Debugf("stopping %s", c.ID)
 			if err := daemon.shutdownContainer(c); err != nil {
 				logrus.Errorf("Stop container error: %v", err)
-				return
+				return err
 			}
 			logrus.Debugf("container stopped %s", c.ID)
+			return nil
 		})
 	}
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -57,7 +57,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	sysInfo := sysinfo.New(true)
 
 	var cRunning, cPaused, cStopped int32
-	daemon.containers.ApplyAll(func(c *container.Container) {
+	daemon.containers.ApplyAll(func(c *container.Container) error {
 		switch c.StateString() {
 		case "paused":
 			atomic.AddInt32(&cPaused, 1)
@@ -66,6 +66,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		default:
 			atomic.AddInt32(&cStopped, 1)
 		}
+		return nil
 	})
 
 	v := &types.Info{

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -19,16 +19,8 @@ func setPlatformSpecificContainerFields(container *container.Container, contJSON
 }
 
 // containerInspectPre120 gets containers for pre 1.20 APIs.
-func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON, error) {
-	container, err := daemon.GetContainer(name)
-	if err != nil {
-		return nil, err
-	}
-
-	container.Lock()
-	defer container.Unlock()
-
-	base, err := daemon.getInspectData(container, false)
+func (ctx *inspectContext) containerInspectPre120(container *container.Container) (*v1p19.ContainerJSON, error) {
+	base, err := ctx.getInspectData(container)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +43,7 @@ func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON,
 		CPUShares:       container.HostConfig.CPUShares,
 		CPUSet:          container.HostConfig.CpusetCpus,
 	}
-	networkSettings := daemon.getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
+	networkSettings := ctx.daemon.getBackwardsCompatibleNetworkSettings(container.NetworkSettings)
 
 	return &v1p19.ContainerJSON{
 		ContainerJSONBase: base,

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -25,6 +25,6 @@ func addMountPoints(container *container.Container) []types.MountPoint {
 }
 
 // containerInspectPre120 get containers for pre 1.20 APIs.
-func (daemon *Daemon) containerInspectPre120(name string) (*types.ContainerJSON, error) {
-	return daemon.containerInspectCurrent(name, false)
+func (ctx *inspectContext) containerInspectPre120(container *container.Container) (*types.ContainerJSON, error) {
+	return ctx.containerInspectCurrent(container)
 }

--- a/daemon/list_unix.go
+++ b/daemon/list_unix.go
@@ -2,10 +2,10 @@
 
 package daemon
 
-import "github.com/docker/docker/container"
+import "github.com/docker/engine-api/types/container"
 
 // excludeByIsolation is a platform specific helper function to support PS
 // filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
-func excludeByIsolation(container *container.Container, ctx *listContext) iterationAction {
-	return includeContainer
+func excludeByIsolation(isolation container.IsolationLevel, ctx *listContext) bool {
+	return false
 }

--- a/daemon/list_windows.go
+++ b/daemon/list_windows.go
@@ -3,18 +3,15 @@ package daemon
 import (
 	"strings"
 
-	"github.com/docker/docker/container"
+	"github.com/docker/engine-api/types/container"
 )
 
 // excludeByIsolation is a platform specific helper function to support PS
 // filtering by Isolation. This is a Windows-only concept, so is a no-op on Unix.
-func excludeByIsolation(container *container.Container, ctx *listContext) iterationAction {
-	i := strings.ToLower(string(container.HostConfig.Isolation))
+func excludeByIsolation(isolation container.IsolationLevel, ctx *listContext) bool {
+	i := strings.ToLower(string(isolation))
 	if i == "" {
 		i = "default"
 	}
-	if !ctx.filters.Match("isolation", i) {
-		return excludeContainer
-	}
-	return includeContainer
+	return !ctx.filters.Match("isolation", i)
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -539,7 +539,7 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 	for _, l := range lines {
 		names = append(names, l)
 	}
-	c.Assert(expected, checker.DeepEquals, names, check.Commentf("Expected array with non-truncated names: %v, got: %v", expected, names))
+	c.Assert(names, checker.DeepEquals, expected, check.Commentf("Expected array with non-truncated names: %v, got: %v", expected, names))
 
 	//now list without turning off truncation and make sure we only get the non-link names
 	out, _ = dockerCmd(c, "ps", "--format", "{{.Names}}")
@@ -549,7 +549,7 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 	for _, l := range lines {
 		truncNames = append(truncNames, l)
 	}
-	c.Assert(expected, checker.DeepEquals, truncNames, check.Commentf("Expected array with truncated names: %v, got: %v", expected, truncNames))
+	c.Assert(truncNames, checker.DeepEquals, expected, check.Commentf("Expected array with truncated names: %v, got: %v", expected, truncNames))
 
 }
 


### PR DESCRIPTION
This is a different take on #19595. 

Implement `docker ps` and `docker inspect` without calling
`container.Lock`.

It copies the container structure recursively to avoid
nil concurrent references outside the store lock.

/cc @ibuildthecloud, @cpuguy83

Signed-off-by: David Calavera david.calavera@gmail.com
