### PR TITLE
Remove cluster storage advertise from reload.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1512,13 +1512,12 @@ func (daemon *Daemon) initDiscovery(config *Config) error {
 // daemon according to those changes.
 // This are the settings that Reload changes:
 // - Daemon labels.
-// - Cluster discovery (reconfigure and restart).
 func (daemon *Daemon) Reload(config *Config) error {
 	daemon.configStore.reloadLock.Lock()
-	defer daemon.configStore.reloadLock.Unlock()
-
 	daemon.configStore.Labels = config.Labels
-	return daemon.reloadClusterDiscovery(config)
+	daemon.configStore.reloadLock.Unlock()
+
+	return nil
 }
 
 func (daemon *Daemon) reloadClusterDiscovery(config *Config) error {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -437,7 +437,7 @@ func TestDaemonDiscoveryReload(t *testing.T) {
 		&discovery.Entry{Host: "127.0.0.1", Port: "5555"},
 	}
 
-	if err := daemon.Reload(newConfig); err != nil {
+	if err := daemon.reloadClusterDiscovery(newConfig); err != nil {
 		t.Fatal(err)
 	}
 	ch, errCh = daemon.discoveryWatcher.Watch(stopCh)
@@ -469,7 +469,7 @@ func TestDaemonDiscoveryReloadFromEmptyDiscovery(t *testing.T) {
 		&discovery.Entry{Host: "127.0.0.1", Port: "5555"},
 	}
 
-	if err := daemon.Reload(newConfig); err != nil {
+	if err := daemon.reloadClusterDiscovery(newConfig); err != nil {
 		t.Fatal(err)
 	}
 	stopCh := make(chan struct{})

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -875,7 +875,4 @@ if there are conflicts, but it won't stop execution.
 The list of currently supported options that can be reconfigured is this:
 
 - `debug`: it changes the daemon to debug mode when set to true.
-- `label`: it replaces the daemon labels with a new set of labels.
-- `cluster-store`: it reloads the discovery store with the new address.
-- `cluster-store-opts`: it uses the new options to reload the discovery store.
-- `cluster-advertise`: it modifies the address advertised after reloading.
+- `labels`: it replaces the daemon labels with a new set of labels.


### PR DESCRIPTION
Fixes #19732

Because libnetwork won't really send container information to the new
storage anyways.

Signed-off-by: David Calavera david.calavera@gmail.com
