### PR TITLE
Update notary to 1.10-3 in all Dockerfiles

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -110,11 +110,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_COMMIT 0c11a970826e62479379ccc75a45184460b9200f
+ENV NOTARY_VERSION docker-v1.10-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
-	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_COMMIT") \
+	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
 	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
 		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
 	&& rm -rf "$GOPATH"

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -144,7 +144,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-2
+ENV NOTARY_VERSION docker-v1.10-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -123,11 +123,11 @@ RUN set -x \
 
 # TODO update this when we upgrade to Go 1.5.1+
 # Install notary server
-#ENV NOTARY_COMMIT 8e8122eb5528f621afcd4e2854c47302f17392f7
+#ENV NOTARY_VERSION docker-v1.10-3
 #RUN set -x \
 #	&& export GOPATH="$(mktemp -d)" \
 #	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
-#	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_COMMIT") \
+#	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
 #	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
 #		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
 #	&& rm -rf "$GOPATH"

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -116,11 +116,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_COMMIT 8e8122eb5528f621afcd4e2854c47302f17392f7
+ENV NOTARY_VERSION docker-v1.10-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
-	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_COMMIT") \
+	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
 	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
 		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
 	&& rm -rf "$GOPATH"


### PR DESCRIPTION
I noticed there was a mix of notary-versions being used in the different Dockerfiles.
