### PR TITLE
Windows CI: Enable TestHistory* cli tests

### DIFF
--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -13,7 +13,6 @@ import (
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
 // sort is not predictable it doesn't always fail.
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	name := "testbuildhistory"
 	_, err := buildImage(name, `FROM busybox
 RUN echo "A"
@@ -59,7 +58,6 @@ RUN echo "Z"`,
 }
 
 func (s *DockerSuite) TestHistoryExistentImage(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "history", "busybox")
 }
 
@@ -69,7 +67,6 @@ func (s *DockerSuite) TestHistoryNonExistentImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	name := "testhistoryimagewithcomment"
 
 	// make a image through docker commit <container id> [ -m messages ]
@@ -89,7 +86,6 @@ func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryHumanOptionFalse(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "history", "--human=false", "busybox")
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")
@@ -108,7 +104,6 @@ func (s *DockerSuite) TestHistoryHumanOptionFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryHumanOptionTrue(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "history", "--human=true", "busybox")
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This enables the TestHistory\* tests for Windows to Windows TP4 CI. Output of local run below.

```
E:\Docker\build\busybox>runtest wl TestHistory
Running test TestHistory
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
PASS: docker_cli_history_test.go:60: DockerSuite.TestHistoryExistentImage       0.076s
PASS: docker_cli_history_test.go:88: DockerSuite.TestHistoryHumanOptionFalse    0.079s
PASS: docker_cli_history_test.go:106: DockerSuite.TestHistoryHumanOptionTrue    0.102s
PASS: docker_cli_history_test.go:69: DockerSuite.TestHistoryImageWithComment    21.422s
PASS: docker_cli_history_test.go:64: DockerSuite.TestHistoryNonExistentImage    0.090s
OK: 5 passed
--- PASS: Test (25.15s)
PASS
ok      github.com/docker/docker/integration-cli        25.433s
```
