### PR TITLE
Add support for running a command in a container

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -39,7 +39,7 @@ type stateBackend interface {
 	ContainerRestart(name string, seconds int) error
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerStart(name string, hostConfig *container.HostConfig) error
-	ContainerStartWithCommand(name string, hostConfig *container.HostConfig, cmd string) error
+	ContainerStartWithCommand(name string, hostConfig *container.HostConfig, cmd []string) error
 	ContainerStop(name string, seconds int) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) ([]string, error)

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -39,6 +39,7 @@ type stateBackend interface {
 	ContainerRestart(name string, seconds int) error
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerStart(name string, hostConfig *container.HostConfig) error
+	ContainerStartWithCommand(name string, hostConfig *container.HostConfig, cmd string) error
 	ContainerStop(name string, seconds int) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) ([]string, error)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -122,7 +122,7 @@ type Backend interface {
 	ContainerKill(containerID string, sig uint64) error
 	// Start starts a new container
 	ContainerStart(containerID string, hostConfig *container.HostConfig) error
-	ContainerStartWithCommand(containerID string, hostConfig *container.HostConfig, cmd string) error
+	ContainerStartWithCommand(containerID string, hostConfig *container.HostConfig, cmd []string) error
 	// ContainerWait stops processing until the given container is stopped.
 	ContainerWait(containerID string, timeout time.Duration) (int, error)
 	// ContainerUpdateCmd updates container.Path and container.Args

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -122,6 +122,7 @@ type Backend interface {
 	ContainerKill(containerID string, sig uint64) error
 	// Start starts a new container
 	ContainerStart(containerID string, hostConfig *container.HostConfig) error
+	ContainerStartWithCommand(containerID string, hostConfig *container.HostConfig, cmd string) error
 	// ContainerWait stops processing until the given container is stopped.
 	ContainerWait(containerID string, timeout time.Duration) (int, error)
 	// ContainerUpdateCmd updates container.Path and container.Args

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -537,7 +537,7 @@ func (b *Builder) create() (string, error) {
 	return c.ID, nil
 }
 
-func (b *Builder) run(cID string) (err error) {
+func (b *Builder) run(cID string, cmd []string) (err error) {
 	errCh := make(chan error)
 	go func() {
 		errCh <- b.docker.ContainerAttachRaw(cID, nil, b.Stdout, b.Stderr, true)
@@ -555,7 +555,7 @@ func (b *Builder) run(cID string) (err error) {
 		}
 	}()
 
-	if err := b.docker.ContainerStart(cID, nil); err != nil {
+	if err := b.docker.ContainerStartWithCommand(cID, nil, cmd); err != nil {
 		return err
 	}
 

--- a/container/monitor.go
+++ b/container/monitor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/runconfig"
 	"github.com/docker/engine-api/types/container"
 )
 
@@ -149,6 +150,12 @@ func (m *containerMonitor) start() error {
 
 	// ensure that when the monitor finally exits we release the networking and unmount the rootfs
 	defer func() {
+		// Reset the cmd to the config's version in case we changed it
+		// during the 'docker start' cmd
+		cfg := m.container.Config
+		m.container.Path, m.container.Args =
+			runconfig.GetEntrypointAndArgs(cfg.Entrypoint, cfg.Cmd)
+
 		if afterRun {
 			m.container.Lock()
 			defer m.container.Unlock()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -35,7 +35,6 @@ import (
 	"github.com/docker/engine-api/types/filters"
 	networktypes "github.com/docker/engine-api/types/network"
 	registrytypes "github.com/docker/engine-api/types/registry"
-	"github.com/docker/engine-api/types/strslice"
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"
 	"github.com/docker/docker/daemon/logger"
@@ -495,13 +494,6 @@ func (daemon *Daemon) generateHostname(id string, config *containertypes.Config)
 	}
 }
 
-func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint strslice.StrSlice, configCmd strslice.StrSlice) (string, []string) {
-	if len(configEntrypoint) != 0 {
-		return configEntrypoint[0], append(configEntrypoint[1:], configCmd...)
-	}
-	return configCmd[0], configCmd[1:]
-}
-
 func (daemon *Daemon) newContainer(name string, config *containertypes.Config, imgID image.ID) (*container.Container, error) {
 	var (
 		id             string
@@ -514,7 +506,7 @@ func (daemon *Daemon) newContainer(name string, config *containertypes.Config, i
 	}
 
 	daemon.generateHostname(id, config)
-	entrypoint, args := daemon.getEntrypointAndArgs(config.Entrypoint, config.Cmd)
+	entrypoint, args := runconfig.GetEntrypointAndArgs(config.Entrypoint, config.Cmd)
 
 	base := daemon.newBaseContainer(id)
 	base.Created = time.Now().UTC()

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/term"
+	"github.com/docker/docker/runconfig"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/strslice"
 )
@@ -94,7 +95,7 @@ func (d *Daemon) ContainerExecCreate(config *types.ExecConfig) (string, error) {
 	}
 
 	cmd := strslice.StrSlice(config.Cmd)
-	entrypoint, args := d.getEntrypointAndArgs(strslice.StrSlice{}, cmd)
+	entrypoint, args := runconfig.GetEntrypointAndArgs(strslice.StrSlice{}, cmd)
 
 	keys := []byte{}
 	if config.DetachKeys != "" {

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -978,6 +978,8 @@ Query Parameters:
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 
+-   **cmd** - Override the command to run in the container.
+
 Status Codes:
 
 -   **204** – no error

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -15,6 +15,7 @@ parent = "smn_cli"
     Start one or more containers
 
       -a, --attach               Attach STDOUT/STDERR and forward signals
+      -c, --cmd                  Override the command to run in the container
       --detach-keys              Specify the escape key sequence used to detach a container
       --help                     Print usage
       -i, --interactive          Attach container's STDIN

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6626,3 +6626,18 @@ func (s *DockerRegistryAuthSuite) TestBuildWithExternalAuth(c *check.C) {
 	out, _, err := runCommandWithOutput(buildCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
 }
+
+// TestBuildEarlyEntrypoint tests that ENTRYPOINT before RUN doesn't
+// interfere with the RUN - seen cases where the RUN is appended to the EP
+func (s *DockerSuite) TestBuildEarlyEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+
+	_, err := buildImage("earlyep", `
+	FROM busybox
+	ENTRYPOINT exit 1
+	RUN echo HI`, true)
+
+	if err != nil {
+		c.Fatal(err)
+	}
+}

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -171,3 +171,27 @@ func (s *DockerSuite) TestStartAttachMultipleContainers(c *check.C) {
 		c.Assert(out, checker.Equals, expected)
 	}
 }
+
+func (s *DockerSuite) TestStartCmd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	out, err, ec := dockerCmdWithStdoutStderr(c, "create", "-ti", "--name=test", "busybox", "echo", "hi")
+	c.Assert(ec, checker.Equals, 0, check.Commentf("err(%d):", ec, err))
+
+	// Verify our base-line "hi\n"
+	out, err, ec = dockerCmdWithStdoutStderr(c, "start", "-a", "test")
+	out = strings.TrimSpace(out)
+	c.Assert(ec, checker.Equals, 0, check.Commentf("err(%d):", ec, err))
+	c.Assert(out, checker.Equals, "hi", check.Commentf("err: %s\n", err))
+
+	// Now do some other command
+	out, err, ec = dockerCmdWithStdoutStderr(c, "start", "-a", "--cmd=echo bye", "test")
+	out = strings.TrimSpace(out)
+	c.Assert(ec, checker.Equals, 0, check.Commentf("err(%d):", ec, err))
+	c.Assert(out, checker.Equals, "bye", check.Commentf("out: %s\n", out))
+
+	// Make sure we didn't persist the cmd
+	out, err, ec = dockerCmdWithStdoutStderr(c, "start", "-a", "test")
+	out = strings.TrimSpace(out)
+	c.Assert(ec, checker.Equals, 0, check.Commentf("err(%d):", ec, err))
+	c.Assert(out, checker.Equals, "hi", check.Commentf("out: %s\n", out))
+}

--- a/man/docker-start.1.md
+++ b/man/docker-start.1.md
@@ -7,6 +7,7 @@ docker-start - Start one or more containers
 # SYNOPSIS
 **docker start**
 [**-a**|**--attach**]
+[**-c**|**--cmd**]
 [**--detach-keys**[=*[]*]]
 [**--help**]
 [**-i**|**--interactive**]
@@ -20,6 +21,9 @@ Start one or more containers.
 **-a**, **--attach**=*true*|*false*
    Attach container's STDOUT and STDERR and forward all signals to the
    process. The default is *false*.
+
+**-c**, **--cmd**=""
+   Override the command to run in the container.
 
 **--detach-keys**=""
    Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/volume"
 	"github.com/docker/engine-api/types/container"
 	networktypes "github.com/docker/engine-api/types/network"
+	"github.com/docker/engine-api/types/strslice"
 )
 
 // DecodeContainerConfig decodes a json encoded config into a ContainerConfigWrapper
@@ -68,4 +69,13 @@ func validateVolumesAndBindSettings(c *container.Config, hc *container.HostConfi
 	}
 
 	return nil
+}
+
+// GetEntrypointAndArgs will "merge" the ENTRYPOINT command and the
+// CMD command into one command.
+func GetEntrypointAndArgs(configEntrypoint strslice.StrSlice, configCmd strslice.StrSlice) (string, []string) {
+	if len(configEntrypoint) != 0 {
+		return configEntrypoint[0], append(configEntrypoint[1:], configCmd...)
+	}
+	return configCmd[0], configCmd[1:]
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_start.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_start.go
@@ -1,8 +1,30 @@
 package client
 
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
 // ContainerStart sends a request to the docker daemon to start a container.
 func (cli *Client) ContainerStart(containerID string) error {
 	resp, err := cli.post("/containers/"+containerID+"/start", nil, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}
+
+// ContainerStartWithCommand sends a request to the docker daemon to start a
+// container, but allows the client to override the default command.
+func (cli *Client) ContainerStartWithCommand(containerID string, cmd string) error {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return fmt.Errorf("Command can not be an empty string")
+	}
+
+	query := url.Values{}
+	query.Set("cmd", cmd)
+
+	resp, err := cli.post("/containers/"+containerID+"/start", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_start.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_start.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"net/url"
-	"strings"
 )
 
 // ContainerStart sends a request to the docker daemon to start a container.
@@ -16,9 +15,8 @@ func (cli *Client) ContainerStart(containerID string) error {
 // ContainerStartWithCommand sends a request to the docker daemon to start a
 // container, but allows the client to override the default command.
 func (cli *Client) ContainerStartWithCommand(containerID string, cmd string) error {
-	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
-		return fmt.Errorf("Command can not be an empty string")
+		return fmt.Errorf("Command can not be empty")
 	}
 
 	query := url.Values{}

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -38,6 +38,7 @@ type APIClient interface {
 	ContainerStatPath(containerID, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error)
 	ContainerStart(containerID string) error
+	ContainerStartWithCommand(containerID string, cmd string) error
 	ContainerStop(containerID string, timeout int) error
 	ContainerTop(containerID string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(containerID string) error


### PR DESCRIPTION
This allows for the `docker start` command to take an optional `--cmd` (`-c`) flag to specify the cmd to use instead of the default one from cmd/entrypoint.  Note, this will require you to use `docker create` to first create the container.  The cmd is a "one time" command - meaning it does not persist in the container's config or any image. So doing a `docker inspect` on the container before, during or after the `docker start --cmd ...` will not show this override cmd - the CMD/ENTRYPOINT will remain unchanged, and doing a vanilla `docker start <id>` will use CMD/ENTRYPOINT as expected.

When thinking about moving the builder to the client we already have most of the Dockerfile actions already available - in particular `docker cp`. What's nice about this is that you can copy files to/from a container w/o being forces to create a new image each time.  I think we need the same ability for the `RUN` command.  This PR will allow people to run a command in a container w/o being forced to create a new image each time.  One big advantage of this is that it will enable clients to support the notion of squashing layers, which is one of the more popular requested features of `docker build`.

Right now this only supports the string version of the cmd, not the json array format you can use on `RUN`. If we really want to support that we can add it but for a 1st pass I wanted to keep it simple.

I also included the docker cli code (from the engine-api repo) and if this PR is ok with people then I'll create a separate PR over there for those bits - but for playing/evaluation I figured it was easier to see it all in one shot.

Signed-off-by: Doug Davis dug@us.ibm.com
