### PR TITLE
Turn off GC during `make binary`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,14 @@ export DOCKERFILE
 # `docs/sources/contributing/devenvironment.md ` and `project/PACKAGERS.md` have some limited documentation of some of these
 DOCKER_ENVS := \
 	-e BUILDFLAGS \
+	-e DOCKER_BUILD_GOGC \
 	-e DOCKER_BUILD_PKGS \
 	-e DOCKER_CLIENTONLY \
 	-e DOCKER_DEBUG \
 	-e DOCKER_EXPERIMENTAL \
 	-e DOCKERFILE \
 	-e DOCKER_GRAPHDRIVER \
+	-e DOCKER_INCREMENTAL_BINARY \
 	-e DOCKER_REMAP_ROOT \
 	-e DOCKER_STORAGE_OPTS \
 	-e DOCKER_USERLANDPROXY \

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -8,6 +8,8 @@ BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 source "${MAKEDIR}/.go-autogen"
 
 (
+export GOGC=${DOCKER_BUILD_GOGC:-1000}
+
 if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
 	# must be cross-compiling!
 	case "$(go env GOOS)/$(go env GOARCH)" in


### PR DESCRIPTION
With GC:

```
real    1m14.221s
user    2m50.900s
sys 2m36.140s

real    1m12.348s
user    2m50.260s
sys 2m31.760s

real    1m11.747s
user    2m45.730s
sys 2m31.240s
```

No GC:

```
real    0m51.511s
user    1m35.400s
sys 1m4.390s

real    0m47.598s
user    1m30.110s
sys 0m49.160s

real    0m49.929s
user    1m31.450s
sys 0m53.290s
```
