### PR TITLE
Update libcontainer to 3d8a20bb772defc28c355534d83

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -57,7 +57,7 @@ clone git github.com/miekg/pkcs11 80f102b5cac759de406949c47f0928b99bd64cdf
 clone git github.com/jfrazelle/go v1.5.1-1
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
-clone git github.com/opencontainers/runc f36b00aa12b3cb4e9c42506059fce4145cfbd626 # libcontainer
+clone git github.com/opencontainers/runc 3d8a20bb772defc28c355534d83486416d1719b4 # libcontainer
 clone git github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v4

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/container_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/container_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/criurpc"
+	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/vishvananda/netlink/nl"
 )
 
@@ -968,7 +969,7 @@ func (c *linuxContainer) updateState(process parentProcess) error {
 	}
 	defer f.Close()
 	os.Remove(filepath.Join(c.root, "checkpoint"))
-	return json.NewEncoder(f).Encode(state)
+	return utils.WriteJSON(f, state)
 }
 
 func (c *linuxContainer) currentStatus() (Status, error) {

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/factory_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/factory_linux.go
@@ -5,7 +5,6 @@ package libcontainer
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +18,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 const (
@@ -226,10 +226,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 		// if we have an error during the initialization of the container's init then send it back to the
 		// parent process in the form of an initError.
 		if err != nil {
-			// ensure that any data sent from the parent is consumed so it doesn't
-			// receive ECONNRESET when the child writes to the pipe.
-			ioutil.ReadAll(pipe)
-			if err := json.NewEncoder(pipe).Encode(newSystemError(err)); err != nil {
+			if err := utils.WriteJSON(pipe, newSystemError(err)); err != nil {
 				panic(err)
 			}
 		}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/process_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/process_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 type parentProcess interface {
@@ -83,7 +84,7 @@ func (p *setnsProcess) start() (err error) {
 			return newSystemError(err)
 		}
 	}
-	if err := json.NewEncoder(p.parentPipe).Encode(p.config); err != nil {
+	if err := utils.WriteJSON(p.parentPipe, p.config); err != nil {
 		return newSystemError(err)
 	}
 	if err := syscall.Shutdown(int(p.parentPipe.Fd()), syscall.SHUT_WR); err != nil {
@@ -270,7 +271,7 @@ func (p *initProcess) startTime() (string, error) {
 
 func (p *initProcess) sendConfig() error {
 	// send the state to the container's init process then shutdown writes for the parent
-	if err := json.NewEncoder(p.parentPipe).Encode(p.config); err != nil {
+	if err := utils.WriteJSON(p.parentPipe, p.config); err != nil {
 		return err
 	}
 	// shutdown writes for the parent side of the pipe

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/utils/utils.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"path/filepath"
 	"syscall"
@@ -36,10 +37,20 @@ func ResolveRootfs(uncleanRootfs string) (string, error) {
 }
 
 // ExitStatus returns the correct exit status for a process based on if it
-// was signaled or exited cleanly.
+// was signaled or exited cleanly
 func ExitStatus(status syscall.WaitStatus) int {
 	if status.Signaled() {
 		return exitSignalOffset + int(status.Signal())
 	}
 	return status.ExitStatus()
+}
+
+// WriteJSON writes the provided struct v to w using standard json marshaling
+func WriteJSON(w io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
 }


### PR DESCRIPTION
Fixes #14203

This bump fixes the issue of having the container's pipes connection
reset by peer because of using the json.Encoder and having a \n added to
the output.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
