### PR TITLE
Fix docs for tmpfs (pr 19688)

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -163,13 +163,12 @@ flag exists to allow special use-cases, like running Docker within Docker.
 The `-w` lets the command being executed inside directory given, here
 `/path/to/dir/`. If the path does not exists it is created inside the container.
 
-### mount tmpfs (--tmpfs)
+### Mount tmpfs (--tmpfs)
 
     $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
 
-    The --tmpfs flag mounts a tmpfs into the container with the rw,noexec,nosuid,size=65536k options.
-
-    Underlying content from the /run in the my_image image is copied into tmpfs.
+The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
+`noexec`, `nosuid`, `size=65536k` options.
 
 ### Mount volume (-v, --read-only)
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1365,9 +1365,14 @@ Similarly the operator can set the **hostname** with `-h`.
 
 ### TMPFS (mount tmpfs filesystems)
 
-    --tmpfs=[]: Create a tmpfs mount with: container-dir[:<options>], where the options are identical to the Linux `mount -t tmpfs -o` command.
+```bash
+--tmpfs=[]: Create a tmpfs mount with: container-dir[:<options>],
+            where the options are identical to the Linux
+            'mount -t tmpfs -o' command.
+```
 
-    Underlying content from the "container-dir" is copied into tmpfs.
+The example below mounts an empty tmpfs into the container with the `rw`,
+`noexec`, `nosuid`, and `size=65536k` options.
 
     $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
 


### PR DESCRIPTION
Underlying files are no longer copied to the temps; this removes some references to the old behavior
