### PR TITLE
Windows CI: PortTestInspectApi*

### DIFF
--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -13,19 +13,29 @@ import (
 )
 
 func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 	keysBase := []string{"Id", "State", "Created", "Path", "Args", "Config", "Image", "NetworkSettings",
 		"ResolvConfPath", "HostnamePath", "HostsPath", "LogPath", "Name", "Driver", "MountLabel", "ProcessLabel", "GraphDriver"}
 
-	cases := []struct {
+	type acase struct {
 		version string
 		keys    []string
-	}{
-		{"v1.20", append(keysBase, "Mounts")},
-		{"v1.19", append(keysBase, "Volumes", "VolumesRW")},
+	}
+
+	var cases []acase
+
+	if daemonPlatform == "windows" {
+		cases = []acase{
+			{"v1.20", append(keysBase, "Mounts")},
+		}
+
+	} else {
+		cases = []acase{
+			{"v1.20", append(keysBase, "Mounts")},
+			{"v1.19", append(keysBase, "Volumes", "VolumesRW")},
+		}
 	}
 
 	for _, cs := range cases {
@@ -47,6 +57,7 @@ func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiContainerVolumeDriverLegacy(c *check.C) {
+	// No legacy implications for Windows
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
@@ -112,6 +123,7 @@ func (s *DockerSuite) TestInspectApiImageResponse(c *check.C) {
 
 // #17131, #17139, #17173
 func (s *DockerSuite) TestInspectApiEmptyFieldsInConfigPre121(c *check.C) {
+	// Not relevant on Windows
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
@@ -135,6 +147,7 @@ func (s *DockerSuite) TestInspectApiEmptyFieldsInConfigPre121(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiBridgeNetworkSettings120(c *check.C) {
+	// Not relevant on Windows, and besides it doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	containerID := strings.TrimSpace(out)
@@ -151,6 +164,7 @@ func (s *DockerSuite) TestInspectApiBridgeNetworkSettings120(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectApiBridgeNetworkSettings121(c *check.C) {
+	// Windows doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	containerID := strings.TrimSpace(out)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Adds another 3 tests for the Windows to Windows CI from docker_api_inspect_test.go. Output from a local run below:

```

E:\Docker\build\busybox>runtest w TestInspectApi
Running test TestInspectApi
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
SKIP: docker_api_inspect_test.go:150: DockerSuite.TestInspectApiBridgeNetworkSettings120 (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:167: DockerSuite.TestInspectApiBridgeNetworkSettings121 (Test requires a Linux daemon)
PASS: docker_api_inspect_test.go:15: DockerSuite.TestInspectApiContainerResponse        6.911s
PASS: docker_api_inspect_test.go:83: DockerSuite.TestInspectApiContainerVolumeDriver    5.910s
SKIP: docker_api_inspect_test.go:60: DockerSuite.TestInspectApiContainerVolumeDriverLegacy (Test requires a Linux daemon)
SKIP: docker_api_inspect_test.go:126: DockerSuite.TestInspectApiEmptyFieldsInConfigPre121 (Test requires a Linux daemon)
PASS: docker_api_inspect_test.go:107: DockerSuite.TestInspectApiImageResponse   0.097s
OK: 3 passed, 4 skipped
--- PASS: Test (18.12s)
PASS
ok      github.com/docker/docker/integration-cli        18.270s

E:\Docker\build\busybox>
```
