### PR TITLE
Factorize sleeping containers

### DIFF
--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -8,14 +8,6 @@ import (
 	"github.com/go-check/check"
 )
 
-var sleepCmd = "/bin/sleep"
-
-func init() {
-	if daemonPlatform == "windows" {
-		sleepCmd = "sleep"
-	}
-}
-
 func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
 
@@ -45,7 +37,7 @@ func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRenameRunningContainerAndReuse(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", sleepCmd, "60")
+	out, _ := runSleepingContainer(c, "--name", "first_name")
 	c.Assert(waitRun("first_name"), check.IsNil)
 
 	newName := "new_name"
@@ -56,7 +48,7 @@ func (s *DockerSuite) TestRenameRunningContainerAndReuse(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container"))
 
-	out, _ = dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", sleepCmd, "60")
+	out, _ = runSleepingContainer(c, "--name", "first_name")
 	c.Assert(waitRun("first_name"), check.IsNil)
 	newContainerID := strings.TrimSpace(out)
 	name, err = inspectField(newContainerID, "Name")
@@ -80,7 +72,7 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 }
 
 func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
-	dockerCmd(c, "run", "--name", "myname", "-d", "busybox", sleepCmd, "60")
+	runSleepingContainer(c, "--name", "myname")
 
 	out, _, err := dockerCmdWithError("rename", "myname", "new:invalid")
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -11,12 +11,6 @@ import (
 	"github.com/go-check/check"
 )
 
-func init() {
-	if daemonPlatform == "windows" {
-		sleepCmd = "sleep"
-	}
-}
-
 func (s *DockerSuite) TestRmiWithContainerFails(c *check.C) {
 	errSubstr := "is using it"
 
@@ -92,7 +86,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// run a container with the image
-	out, _ = dockerCmd(c, "run", "-d", "busybox-one", sleepCmd, "60")
+	out, _ = runSleepingContainerInImage(c, "busybox-one")
 
 	containerID = strings.TrimSpace(out)
 
@@ -160,7 +154,7 @@ func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c 
 
 	newTag := "newtag"
 	dockerCmd(c, "tag", imgID, newTag)
-	dockerCmd(c, "run", "-d", imgID, sleepCmd, "60")
+	runSleepingContainerInImage(c, imgID)
 
 	out, _, err := dockerCmdWithError("rmi", "-f", imgID)
 	// rmi -f should not delete image with running containers
@@ -262,7 +256,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 	}
 
 	// Create a long-running container.
-	dockerCmd(c, "run", "-d", imageNames[0], sleepCmd, "60")
+	runSleepingContainerInImage(c, imageNames[0])
 
 	// Create a stopped container, and then force remove its image.
 	dockerCmd(c, "run", imageNames[1], "true")

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1707,3 +1707,19 @@ func getInspectBody(c *check.C, version, id string) []byte {
 	c.Assert(status, check.Equals, http.StatusOK)
 	return body
 }
+
+// Run a long running idle task in a background container using the
+// system-specific default image and command.
+func runSleepingContainer(c *check.C, extraArgs ...string) (string, int) {
+	return runSleepingContainerInImage(c, defaultSleepImage, extraArgs...)
+}
+
+// Run a long running idle task in a background container using the specified
+// image and the system-specific command.
+func runSleepingContainerInImage(c *check.C, image string, extraArgs ...string) (string, int) {
+	args := []string{"run", "-d"}
+	args = append(args, extraArgs...)
+	args = append(args, image)
+	args = append(args, defaultSleepCommand...)
+	return dockerCmd(c, args...)
+}

--- a/integration-cli/test_vars_unix.go
+++ b/integration-cli/test_vars_unix.go
@@ -7,4 +7,10 @@ const (
 	isUnixCli = true
 
 	expectedFileChmod = "-rw-r--r--"
+
+	// On Unix variants, the busybox image comes with the `top` command which
+	// runs indefinitely while still being interruptible by a signal.
+	defaultSleepImage = "busybox"
 )
+
+var defaultSleepCommand = []string{"top"}

--- a/integration-cli/test_vars_windows.go
+++ b/integration-cli/test_vars_windows.go
@@ -8,4 +8,10 @@ const (
 
 	// this is the expected file permission set on windows: gh#11395
 	expectedFileChmod = "-rwxr-xr-x"
+
+	// On Windows, the busybox image doesn't have the `top` command, so we rely
+	// on `sleep` with a high duration.
+	defaultSleepImage = "busybox"
 )
+
+var defaultSleepCommand = []string{"sleep", "60"}


### PR DESCRIPTION
Add `runSleepingContainer` and `runSleepingContainerInImage` helper
functions to factor out the way to run system-specific idle containers.

Define a sleeping container as command `top` in image `busybox` for
Unix and as command `sleep 60` in image `busybox` for Windows. Provide a
single point of code to update those.

Ping @jhowardmsft
