### PR TITLE
daemon: don't prepare mountpoint for restart container

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -376,6 +376,13 @@ func (daemon *Daemon) restore() error {
 	// This must be run after any containers with a restart policy so that containerized plugins
 	// can have a chance to be running before we try to initialize them.
 	for _, c := range containers {
+		// if the container has restart policy, do not
+		// prepare the mountpoints since it has been done on restarting.
+		// This is to speed up the daemon start when a restart container
+		// has a volume and the volume dirver is not available.
+		if _, ok := restartContainers[c]; ok {
+			continue
+		}
 		group.Add(1)
 		go func(c *container.Container) {
 			defer group.Done()


### PR DESCRIPTION
The restart container has already prepared the mountpoint, there is
no need to do that again. This can speed up the daemon start if
the restart container has a volume and the volume driver is not
available. 

<pre><code>WARN[0005] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 1s
WARN[0006] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 2s
WARN[0008] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 4s
WARN[0012] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 8s
DEBU[0020] Releasing addresses for endpoint determined_meitner's interface on network bridge
DEBU[0020] ReleaseAddress(LocalDefault/172.17.0.0/16, 172.17.0.2)
ERRO[0020] Failed to start container 968a454fa5c77944eba0e45f9d1b6d2ef70d8678f73022340ee8f0d62e5c090b: get data: Error looking up volume plugin convoy: Post http://%2Fvar%2Frun%2Fconvoy%2Fconvoy.sock/Plugin.Activate: dial unix /var/run/convoy/convoy.sock: connect: no such file or directory
WARN[0020] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 1s
WARN[0021] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 2s
WARN[0023] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 4s
WARN[0027] Unable to connect to plugin: /var/run/convoy/convoy.sock, retrying in 8s
ERRO[0035] get data: Error looking up volume plugin convoy: Post http://%2Fvar%2Frun%2Fconvoy%2Fconvoy.sock/Plugin.Activate: dial unix /var/run/convoy/convoy.sock: connect: no such file or directory
</code></pre>


ping @cpuguy83 

Signed-off-by: Lei Jitang leijitang@huawei.com
