### PR TITLE
Include a new version of notary with less verbose INFO+ logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-4
+ENV NOTARY_VERSION docker-v1.10-5
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -110,7 +110,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-4
+ENV NOTARY_VERSION docker-v1.10-5
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -144,7 +144,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-4
+ENV NOTARY_VERSION docker-v1.10-5
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -123,7 +123,7 @@ RUN set -x \
 
 # TODO update this when we upgrade to Go 1.5.1+
 # Install notary server
-#ENV NOTARY_VERSION docker-v1.10-4
+#ENV NOTARY_VERSION docker-v1.10-5
 #RUN set -x \
 #	&& export GOPATH="$(mktemp -d)" \
 #	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -116,7 +116,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION docker-v1.10-4
+ENV NOTARY_VERSION docker-v1.10-5
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -50,7 +50,7 @@ clone git github.com/docker/distribution c301f8ab27f4913c968b8d73a38e5dda79b9d3d
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile
-clone git github.com/docker/notary docker-v1.10-4
+clone git github.com/docker/notary docker-v1.10-5
 
 clone git google.golang.org/grpc 174192fc93efcb188fc8f46ca447f0da606b6885 https://github.com/grpc/grpc-go.git
 clone git github.com/miekg/pkcs11 80f102b5cac759de406949c47f0928b99bd64cdf

--- a/vendor/src/github.com/docker/notary/Makefile
+++ b/vendor/src/github.com/docker/notary/Makefile
@@ -34,7 +34,7 @@ _space := $(empty) $(empty)
 COVERDIR=.cover
 COVERPROFILE?=$(COVERDIR)/cover.out
 COVERMODE=count
-PKGS = $(shell go list ./... | tr '\n' ' ')
+PKGS ?= $(shell go list ./... | tr '\n' ' ')
 
 GO_VERSION = $(shell go version | awk '{print $$3}')
 
@@ -124,7 +124,7 @@ endef
 gen-cover: go_version
 	@mkdir -p "$(COVERDIR)"
 	$(foreach PKG,$(PKGS),$(call gocover,$(PKG)))
-	rm "$(COVERDIR)"/*testutils*.coverage.txt
+	rm -f "$(COVERDIR)"/*testutils*.coverage.txt
 
 # Generates the cover binaries and runs them all in serial, so this can be used
 # run all tests with a yubikey without any problems
@@ -139,6 +139,9 @@ ci: OPTS = -tags "${NOTARY_BUILDTAGS}" -race -coverpkg "$(shell ./coverpkg.sh $(
     GO_EXC := godep go
 # Codecov knows how to merge multiple coverage files, so covmerge is not needed
 ci: gen-cover
+
+yubikey-tests: override PKGS = github.com/docker/notary/cmd/notary github.com/docker/notary/trustmanager/yubikey
+yubikey-tests: ci
 
 covmerge:
 	@gocovmerge $(shell ls -1 $(COVERDIR)/* | tr "\n" " ") > $(COVERPROFILE)

--- a/vendor/src/github.com/docker/notary/circle.yml
+++ b/vendor/src/github.com/docker/notary/circle.yml
@@ -18,8 +18,6 @@ machine:
     CIRCLE_PAIN: "mode: set"
   # Put the coverage profile somewhere codecov's script can find it
     COVERPROFILE: coverage.out
-  # Set the pull request number so codecov can figure it out
-    PULL_REQUEST: ${CI_PULL_REQUEST##*/}
 
   hosts:
   # Not used yet

--- a/vendor/src/github.com/docker/notary/const.go
+++ b/vendor/src/github.com/docker/notary/const.go
@@ -2,6 +2,8 @@ package notary
 
 // application wide constants
 const (
+	// MinRSABitSize is the minimum bit size for RSA keys allowed in notary
+	MinRSABitSize = 2048
 	// MinThreshold requires a minimum of one threshold for roles; currently we do not support a higher threshold
 	MinThreshold = 1
 	// PrivKeyPerms are the file permissions to use when writing private keys to disk

--- a/vendor/src/github.com/docker/notary/tuf/client/client.go
+++ b/vendor/src/github.com/docker/notary/tuf/client/client.go
@@ -54,7 +54,7 @@ func (c *Client) Update() error {
 	if err != nil {
 		logrus.Debug("Error occurred. Root will be downloaded and another update attempted")
 		if err := c.downloadRoot(); err != nil {
-			logrus.Error("Client Update (Root):", err)
+			logrus.Debug("Client Update (Root):", err)
 			return err
 		}
 		// If we error again, we now have the latest root and just want to fail
@@ -68,12 +68,12 @@ func (c *Client) Update() error {
 func (c *Client) update() error {
 	err := c.downloadTimestamp()
 	if err != nil {
-		logrus.Errorf("Client Update (Timestamp): %s", err.Error())
+		logrus.Debugf("Client Update (Timestamp): %s", err.Error())
 		return err
 	}
 	err = c.downloadSnapshot()
 	if err != nil {
-		logrus.Errorf("Client Update (Snapshot): %s", err.Error())
+		logrus.Debugf("Client Update (Snapshot): %s", err.Error())
 		return err
 	}
 	err = c.checkRoot()
@@ -86,7 +86,7 @@ func (c *Client) update() error {
 	// will always need top level targets at a minimum
 	err = c.downloadTargets("targets")
 	if err != nil {
-		logrus.Errorf("Client Update (Targets): %s", err.Error())
+		logrus.Debugf("Client Update (Targets): %s", err.Error())
 		return err
 	}
 	return nil


### PR DESCRIPTION
Apologies for the quick re-vendoring in succession - during testing we noticed some confusing logging at INFO+ level, and we would like that to be more for debugging than anything else, so we've changed the log level, which would be awesome if it could make it into 1.10.

We've also added a check so that users of the notary CLI cannot use too-small RSA keys for delegation keys.
