### PR TITLE
Temporarily removing TestBuildHistory on Windows for perf reasons

### DIFF
--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -13,6 +13,10 @@ import (
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
 // sort is not predictable it doesn't always fail.
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
+	testRequires(c, DaemonIsLinux) // TODO Windows: This test passes on Windows,
+	// but currently adds a disproportionate amount of time for the value it has.
+	// Removing it from Windows CI for now, but this will be revisited in the
+	// TP5 timeframe when perf is better.
 	name := "testbuildhistory"
 	_, err := buildImage(name, `FROM busybox
 RUN echo "A"


### PR DESCRIPTION
Signed-off-by: Darren Stahl darst@microsoft.com
