### PR TITLE
bash completion for journald tag support

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -411,7 +411,7 @@ __docker_complete_log_options() {
 	local awslogs_options="awslogs-region awslogs-group awslogs-stream"
 	local fluentd_options="env fluentd-address labels tag"
 	local gelf_options="env gelf-address labels tag"
-	local journald_options="env labels"
+	local journald_options="env labels tag"
 	local json_file_options="env labels max-file max-size"
 	local syslog_options="syslog-address syslog-tls-ca-cert syslog-tls-cert syslog-tls-key syslog-tls-skip-verify syslog-facility tag"
 	local splunk_options="env labels splunk-caname splunk-capath splunk-index splunk-insecureskipverify splunk-source splunk-sourcetype splunk-token splunk-url tag"


### PR DESCRIPTION
The journald log driver now supports the `tag` option.
Ref #19564
