### PR TITLE
Make test code consistent

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -67,7 +67,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 	defer loadBody.Close()
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
 
-	inspectOut, _ := dockerCmd(c, "inspect", "--format='{{ .Id }}'", id)
+	inspectOut := inspectField(c, id, "Id")
 	c.Assert(strings.TrimSpace(string(inspectOut)), checker.Equals, id, check.Commentf("load did not work properly"))
 }
 

--- a/integration-cli/docker_api_update_unix_test.go
+++ b/integration-cli/docker_api_update_unix_test.go
@@ -23,8 +23,7 @@ func (s *DockerSuite) TestApiUpdateContainer(c *check.C) {
 	_, _, err := sockRequest("POST", "/containers/"+name+"/update", hostConfig)
 	c.Assert(err, check.IsNil)
 
-	memory, err := inspectField(name, "HostConfig.Memory")
-	c.Assert(err, check.IsNil)
+	memory := inspectField(c, name, "HostConfig.Memory")
 	if memory != "314572800" {
 		c.Fatalf("Got the wrong memory value, we got %d, expected 314572800(300M).", memory)
 	}
@@ -32,8 +31,7 @@ func (s *DockerSuite) TestApiUpdateContainer(c *check.C) {
 	out, _ := dockerCmd(c, "exec", name, "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "314572800")
 
-	memorySwap, err := inspectField(name, "HostConfig.MemorySwap")
-	c.Assert(err, check.IsNil)
+	memorySwap := inspectField(c, name, "HostConfig.MemorySwap")
 	if memorySwap != "524288000" {
 		c.Fatalf("Got the wrong memorySwap value, we got %d, expected 524288000(500M).", memorySwap)
 	}

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -147,8 +147,7 @@ func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
 	c.Assert(stdin.Close(), check.IsNil)
 
 	// Expect container to still be running after stdin is closed
-	running, err := inspectField(id, "State.Running")
-	c.Assert(err, check.IsNil)
+	running := inspectField(c, id, "State.Running")
 	c.Assert(running, check.Equals, "true")
 }
 

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -161,8 +161,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 		ch <- struct{}{}
 	}()
 
-	running, err := inspectField(id, "State.Running")
-	c.Assert(err, checker.IsNil)
+	running := inspectField(c, id, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("expected container to still be running"))
 
 	go func() {
@@ -214,8 +213,7 @@ func (s *DockerSuite) TestAttachDetachTruncatedID(c *check.C) {
 		ch <- struct{}{}
 	}()
 
-	running, err := inspectField(id, "State.Running")
-	c.Assert(err, checker.IsNil)
+	running := inspectField(c, id, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("expected container to still be running"))
 
 	go func() {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -100,10 +100,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementUser(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.User")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.User")
 
 	if res != `"foo"` {
 		c.Fatal("User foo from environment not in Config.User on image")
@@ -124,10 +121,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Volumes")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Volumes")
 
 	var volumes map[string]interface{}
 
@@ -156,10 +150,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.ExposedPorts")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.ExposedPorts")
 
 	var exposedPorts map[string]interface{}
 
@@ -254,10 +245,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementEnv(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Env")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Env")
 
 	envResult := []string{}
 
@@ -315,10 +303,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 
 	var result map[string]map[string]struct{}
 
-	res, err := inspectFieldJSON(name, "Config.Volumes")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Volumes")
 
 	if err = unmarshalJSON([]byte(res), &result); err != nil {
 		c.Fatal(err)
@@ -341,10 +326,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err = inspectFieldJSON(name, "Config.Volumes")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res = inspectFieldJSON(c, name, "Config.Volumes")
 
 	if err = unmarshalJSON([]byte(res), &result); err != nil {
 		c.Fatal(err)
@@ -371,10 +353,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err = inspectFieldJSON(name, "Config.Volumes")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res = inspectFieldJSON(c, name, "Config.Volumes")
 
 	if err = unmarshalJSON([]byte(res), &result); err != nil {
 		c.Fatal(err)
@@ -1971,10 +1950,7 @@ func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Volumes")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Volumes")
 
 	err = unmarshalJSON([]byte(res), &result)
 	if err != nil {
@@ -2000,10 +1976,7 @@ func (s *DockerSuite) TestBuildMaintainer(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Author")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Author")
 	if res != expected {
 		c.Fatalf("Maintainer %s, expected %s", res, expected)
 	}
@@ -2022,10 +1995,7 @@ func (s *DockerSuite) TestBuildUser(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.User")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.User")
 	if res != expected {
 		c.Fatalf("User %s, expected %s", res, expected)
 	}
@@ -2048,10 +2018,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.WorkingDir")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.WorkingDir")
 	if res != expected {
 		c.Fatalf("Workdir %s, expected %s", res, expected)
 	}
@@ -2071,10 +2038,7 @@ func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.WorkingDir")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.WorkingDir")
 	if res != expected {
 		c.Fatalf("Workdir %s, expected %s", res, expected)
 	}
@@ -2134,10 +2098,7 @@ func (s *DockerSuite) TestBuildEnv(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Env")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Env")
 	if res != expected {
 		c.Fatalf("Env %s, expected %s", res, expected)
 	}
@@ -2152,8 +2113,7 @@ func (s *DockerSuite) TestBuildPATH(c *check.C) {
 		_, err := buildImage("testbldpath", dockerfile, true)
 		c.Assert(err, check.IsNil)
 
-		res, err := inspectField("testbldpath", "Config.Env")
-		c.Assert(err, check.IsNil)
+		res := inspectField(c, "testbldpath", "Config.Env")
 
 		if res != exp {
 			c.Fatalf("Env %q, expected %q for dockerfile:%q", res, exp, dockerfile)
@@ -2239,10 +2199,7 @@ func (s *DockerSuite) TestBuildCmd(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Cmd")
 	if res != expected {
 		c.Fatalf("Cmd %s, expected %s", res, expected)
 	}
@@ -2259,10 +2216,7 @@ func (s *DockerSuite) TestBuildExpose(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.ExposedPorts")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.ExposedPorts")
 	if res != expected {
 		c.Fatalf("Exposed ports %s, expected %s", res, expected)
 	}
@@ -2301,10 +2255,7 @@ func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
 	}
 
 	// check if all the ports are saved inside Config.ExposedPorts
-	res, err := inspectFieldJSON(name, "Config.ExposedPorts")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.ExposedPorts")
 	var exposedPorts map[string]interface{}
 	if err := json.Unmarshal([]byte(res), &exposedPorts); err != nil {
 		c.Fatal(err)
@@ -2331,10 +2282,7 @@ func (s *DockerSuite) TestBuildExposeOrder(c *check.C) {
 		if err != nil {
 			c.Fatal(err)
 		}
-		id, err := inspectField(name, "Id")
-		if err != nil {
-			c.Fatal(err)
-		}
+		id := inspectField(c, name, "Id")
 		return id
 	}
 
@@ -2356,10 +2304,7 @@ func (s *DockerSuite) TestBuildExposeUpperCaseProto(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.ExposedPorts")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.ExposedPorts")
 	if res != expected {
 		c.Fatalf("Exposed ports %s, expected %s", res, expected)
 	}
@@ -2377,10 +2322,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Entrypoint")
 
 	expected := "{[/bin/echo]}"
 	if res != expected {
@@ -2394,10 +2336,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err = inspectField(name2, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res = inspectField(c, name2, "Config.Entrypoint")
 
 	expected = "{[]}"
 
@@ -2419,10 +2358,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypoint(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Entrypoint")
 	if res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
@@ -2440,10 +2376,7 @@ func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Entrypoint")
 	if res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
@@ -3123,10 +3056,7 @@ func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Cmd")
 	// Cmd must be cleaned up
 	if res != "<nil>" {
 		c.Fatalf("Cmd %s, expected nil", res)
@@ -3185,10 +3115,7 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	ports1, err := inspectField(name, "Config.ExposedPorts")
-	if err != nil {
-		c.Fatal(err)
-	}
+	ports1 := inspectField(c, name, "Config.ExposedPorts")
 
 	_, err = buildImage(name,
 		fmt.Sprintf(`FROM %s
@@ -3198,17 +3125,11 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectField(name, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Entrypoint")
 	if expected := "{[/bin/echo]}"; res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
-	ports2, err := inspectField(name, "Config.ExposedPorts")
-	if err != nil {
-		c.Fatal(err)
-	}
+	ports2 := inspectField(c, name, "Config.ExposedPorts")
 	if ports1 != ports2 {
 		c.Fatalf("Ports must be same: %s != %s", ports1, ports2)
 	}
@@ -3345,11 +3266,7 @@ docker.com>"
 		c.Fatal(err)
 	}
 
-	res, err := inspectField(name, "Author")
-
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Author")
 
 	if res != "\"Docker IO <io@docker.com>\"" {
 		c.Fatalf("Parsed string did not match the escaped string. Got: %q", res)
@@ -4318,10 +4235,7 @@ func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Author")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Author")
 	if res != "docker" {
 		c.Fatalf("Maintainer should be docker, got %s", res)
 	}
@@ -4347,10 +4261,7 @@ func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Author")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Author")
 	if res != "docker" {
 		c.Fatalf("Maintainer should be docker, got %s", res)
 	}
@@ -4411,8 +4322,7 @@ func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
 	_, err = buildImageFromPath(name, server.URL()+"/testT.tar", true)
 	c.Assert(err, check.IsNil)
 
-	res, err := inspectField(name, "Author")
-	c.Assert(err, check.IsNil)
+	res := inspectField(c, name, "Author")
 
 	if res != "docker" {
 		c.Fatalf("Maintainer should be docker, got %s", res)
@@ -4435,18 +4345,12 @@ func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 		true); err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectField(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectField(c, name, "Config.Cmd")
 	if res != "<nil>" {
 		c.Fatalf("Cmd %s, expected nil", res)
 	}
 
-	res, err = inspectField(name, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res = inspectField(c, name, "Config.Entrypoint")
 	if expected := "{[cat]}"; res != expected {
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
@@ -4463,10 +4367,7 @@ func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Cmd")
 	if res != "[]" {
 		c.Fatalf("Cmd %s, expected %s", res, "[]")
 	}
@@ -4478,10 +4379,7 @@ func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
 	if _, err := buildImage(name, "FROM scratch\nMAINTAINER quux\n", true); err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Cmd")
 	if res != "null" {
 		c.Fatalf("Cmd %s, expected %s", res, "null")
 	}
@@ -4522,10 +4420,7 @@ func (s *DockerSuite) TestBuildCmdShDashC(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err, res)
-	}
+	res := inspectFieldJSON(c, name, "Config.Cmd")
 
 	expected := `["/bin/sh","-c","echo cmd"]`
 
@@ -4579,10 +4474,7 @@ func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name, "Config.Cmd")
-	if err != nil {
-		c.Fatal(err, res)
-	}
+	res := inspectFieldJSON(c, name, "Config.Cmd")
 
 	expected := `["echo","cmd"]`
 
@@ -4646,10 +4538,7 @@ func (s *DockerSuite) TestBuildEntrypointInheritanceInspect(c *check.C) {
 		c.Fatal(err)
 	}
 
-	res, err := inspectFieldJSON(name2, "Config.Entrypoint")
-	if err != nil {
-		c.Fatal(err, res)
-	}
+	res := inspectFieldJSON(c, name2, "Config.Entrypoint")
 
 	if res != expected {
 		c.Fatalf("Expected value %s not in Config.Entrypoint: %s", expected, res)
@@ -4756,10 +4645,7 @@ func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "ContainerConfig.Cmd")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
 	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
 	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
 	if res != expected1 && res != expected2 {
@@ -4779,10 +4665,7 @@ func (s *DockerSuite) TestBuildLabels(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	res, err := inspectFieldJSON(name, "Config.Labels")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res := inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
 		c.Fatalf("Labels %s, expected %s", res, expected)
 	}
@@ -5869,8 +5752,7 @@ func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
 		 STOPSIGNAL SIGKILL`,
 		true)
 	c.Assert(err, check.IsNil)
-	res, err := inspectFieldJSON(name, "Config.StopSignal")
-	c.Assert(err, check.IsNil)
+	res := inspectFieldJSON(c, name, "Config.StopSignal")
 
 	if res != `"SIGKILL"` {
 		c.Fatalf("Signal %s, expected SIGKILL", res)
@@ -6138,18 +6020,12 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansion(c *check.C) {
 	var resMap map[string]interface{}
 	var resArr []string
 	res := ""
-	res, err = inspectField(imgName, "Config.WorkingDir")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res = inspectField(c, imgName, "Config.WorkingDir")
 	if res != filepath.ToSlash(filepath.Clean(wdVal)) {
 		c.Fatalf("Config.WorkingDir value mismatch. Expected: %s, got: %s", filepath.ToSlash(filepath.Clean(wdVal)), res)
 	}
 
-	err = inspectFieldAndMarshall(imgName, "Config.Env", &resArr)
-	if err != nil {
-		c.Fatal(err)
-	}
+	inspectFieldAndMarshall(c, imgName, "Config.Env", &resArr)
 
 	found := false
 	for _, v := range resArr {
@@ -6163,26 +6039,17 @@ func (s *DockerSuite) TestBuildBuildTimeArgExpansion(c *check.C) {
 			envVar, envVal, resArr)
 	}
 
-	err = inspectFieldAndMarshall(imgName, "Config.ExposedPorts", &resMap)
-	if err != nil {
-		c.Fatal(err)
-	}
+	inspectFieldAndMarshall(c, imgName, "Config.ExposedPorts", &resMap)
 	if _, ok := resMap[fmt.Sprintf("%s/tcp", exposeVal)]; !ok {
 		c.Fatalf("Config.ExposedPorts value mismatch. Expected exposed port: %s/tcp, got: %v", exposeVal, resMap)
 	}
 
-	res, err = inspectField(imgName, "Config.User")
-	if err != nil {
-		c.Fatal(err)
-	}
+	res = inspectField(c, imgName, "Config.User")
 	if res != userVal {
 		c.Fatalf("Config.User value mismatch. Expected: %s, got: %s", userVal, res)
 	}
 
-	err = inspectFieldAndMarshall(imgName, "Config.Volumes", &resMap)
-	if err != nil {
-		c.Fatal(err)
-	}
+	inspectFieldAndMarshall(c, imgName, "Config.Volumes", &resMap)
 	if _, ok := resMap[volVal]; !ok {
 		c.Fatalf("Config.Volumes value mismatch. Expected volume: %s, got: %v", volVal, resMap)
 	}

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -47,8 +47,7 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 		Ulimits    []*units.Ulimit
 	}
 
-	cfg, err := inspectFieldJSON(cID, "HostConfig")
-	c.Assert(err, checker.IsNil)
+	cfg := inspectFieldJSON(c, cID, "HostConfig")
 
 	var c1 hostConfig
 	err = json.Unmarshal([]byte(cfg), &c1)
@@ -66,8 +65,7 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	// Make sure constraints aren't saved to image
 	dockerCmd(c, "run", "--name=test", name)
 
-	cfg, err = inspectFieldJSON("test", "HostConfig")
-	c.Assert(err, checker.IsNil)
+	cfg = inspectFieldJSON(c, "test", "HostConfig")
 
 	var c2 hostConfig
 	err = json.Unmarshal([]byte(cfg), &c2)

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -132,10 +132,9 @@ func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 
 	containerName := "createByDigest"
-	out, _ := dockerCmd(c, "create", "--name", containerName, imageReference)
+	dockerCmd(c, "create", "--name", containerName, imageReference)
 
-	res, err := inspectField(containerName, "Config.Image")
-	c.Assert(err, checker.IsNil, check.Commentf("failed to get Config.Image: %s", out))
+	res := inspectField(c, containerName, "Config.Image")
 	c.Assert(res, checker.Equals, imageReference)
 }
 
@@ -153,8 +152,7 @@ func (s *DockerRegistrySuite) TestRunByDigest(c *check.C) {
 	c.Assert(matches, checker.HasLen, 2, check.Commentf("unable to parse digest from pull output: %s", out))
 	c.Assert(matches[1], checker.Equals, "1", check.Commentf("Expected %q, got %q", "1", matches[1]))
 
-	res, err := inspectField(containerName, "Config.Image")
-	c.Assert(err, checker.IsNil, check.Commentf("failed to get Config.Image: %s", out))
+	res := inspectField(c, containerName, "Config.Image")
 	c.Assert(res, checker.Equals, imageReference)
 }
 
@@ -168,15 +166,14 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
 	dockerCmd(c, "pull", imageReference)
 
 	// make sure inspect runs ok
-	_, err = inspectField(imageReference, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect image"))
+	inspectField(c, imageReference, "Id")
 
 	// do the delete
 	err = deleteImages(imageReference)
 	c.Assert(err, checker.IsNil, check.Commentf("unexpected error deleting image"))
 
 	// try to inspect again - it should error this time
-	_, err = inspectField(imageReference, "Id")
+	_, err = inspectFieldWithError(imageReference, "Id")
 	//unexpected nil err trying to inspect what should be a non-existent image
 	c.Assert(err, checker.NotNil)
 	c.Assert(err.Error(), checker.Contains, "No such image")
@@ -192,8 +189,7 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 	dockerCmd(c, "pull", imageReference)
 
 	// get the image id
-	imageID, err := inspectField(imageReference, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error getting image id"))
+	imageID := inspectField(c, imageReference, "Id")
 
 	// do the build
 	name := "buildbydigest"
@@ -204,8 +200,7 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// get the build's image id
-	res, err := inspectField(name, "Config.Image")
-	c.Assert(err, checker.IsNil)
+	res := inspectField(c, name, "Config.Image")
 	// make sure they match
 	c.Assert(res, checker.Equals, imageID)
 }
@@ -223,11 +218,9 @@ func (s *DockerRegistrySuite) TestTagByDigest(c *check.C) {
 	tag := "tagbydigest"
 	dockerCmd(c, "tag", imageReference, tag)
 
-	expectedID, err := inspectField(imageReference, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error getting original image id"))
+	expectedID := inspectField(c, imageReference, "Id")
 
-	tagID, err := inspectField(tag, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error getting tagged image id"))
+	tagID := inspectField(c, tag, "Id")
 	c.Assert(tagID, checker.Equals, expectedID)
 }
 
@@ -389,8 +382,7 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 	dockerCmd(c, "pull", imageReference)
 	// just in case...
 
-	imageID, err := inspectField(imageReference, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error inspecting image id"))
+	imageID := inspectField(c, imageReference, "Id")
 
 	dockerCmd(c, "rmi", imageID)
 }
@@ -403,8 +395,7 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndTag(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 	dockerCmd(c, "pull", imageReference)
 
-	imageID, err := inspectField(imageReference, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error inspecting image id"))
+	imageID := inspectField(c, imageReference, "Id")
 
 	repoTag := repoName + ":sometag"
 	repoTag2 := repoName + ":othertag"
@@ -414,13 +405,12 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndTag(c *check.C) {
 	dockerCmd(c, "rmi", repoTag2)
 
 	// rmi should have deleted only repoTag2, because there's another tag
-	_, err = inspectField(repoTag, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("repoTag should not have been removed"))
+	inspectField(c, repoTag, "Id")
 
 	dockerCmd(c, "rmi", repoTag)
 
 	// rmi should have deleted the tag, the digest reference, and the image itself
-	_, err = inspectField(imageID, "Id")
+	_, err = inspectFieldWithError(imageID, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
 }
 

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -49,8 +49,7 @@ func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 
 	out, _ = dockerCmd(c, "commit", cleanedContainerID)
 
-	out, err := inspectField(cleanedContainerID, "State.Paused")
-	c.Assert(err, checker.IsNil, check.Commentf("%s", out))
+	out = inspectField(c, cleanedContainerID, "State.Paused")
 	// commit should not unpause a paused container
 	c.Assert(out, checker.Contains, "true")
 }
@@ -139,8 +138,7 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 	}
 
 	for conf, value := range expected {
-		res, err := inspectField(imageID, conf)
-		c.Assert(err, checker.IsNil, check.Commentf("%s('%s')", conf, res))
+		res := inspectField(c, imageID, conf)
 		if res != value {
 			c.Errorf("%s('%s'), expected %s", conf, res, value)
 		}
@@ -165,12 +163,10 @@ func (s *DockerSuite) TestCommitMergeConfigRun(c *check.C) {
 		Cmd []string
 	}
 	config1 := cfg{}
-	err := inspectFieldAndMarshall(id, "Config", &config1)
-	c.Assert(err, checker.IsNil)
+	inspectFieldAndMarshall(c, id, "Config", &config1)
 
 	config2 := cfg{}
-	err = inspectFieldAndMarshall(name, "Config", &config2)
-	c.Assert(err, checker.IsNil)
+	inspectFieldAndMarshall(c, name, "Config", &config2)
 
 	// Env has at least PATH loaded as well here, so let's just grab the FOO one
 	var env1, env2 string

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -178,8 +178,7 @@ func (s *DockerSuite) TestCreateLabels(c *check.C) {
 	dockerCmd(c, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")
 
 	actual := make(map[string]string)
-	err := inspectFieldAndMarshall(name, "Config.Labels", &actual)
-	c.Assert(err, check.IsNil)
+	inspectFieldAndMarshall(c, name, "Config.Labels", &actual)
 
 	if !reflect.DeepEqual(expected, actual) {
 		c.Fatalf("Expected %s got %s", expected, actual)
@@ -201,8 +200,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 	dockerCmd(c, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)
 
 	actual := make(map[string]string)
-	err = inspectFieldAndMarshall(name, "Config.Labels", &actual)
-	c.Assert(err, check.IsNil)
+	inspectFieldAndMarshall(c, name, "Config.Labels", &actual)
 
 	if !reflect.DeepEqual(expected, actual) {
 		c.Fatalf("Expected %s got %s", expected, actual)
@@ -411,8 +409,7 @@ func (s *DockerSuite) TestCreateStopSignal(c *check.C) {
 	name := "test_create_stop_signal"
 	dockerCmd(c, "create", "--name", name, "--stop-signal", "9", "busybox")
 
-	res, err := inspectFieldJSON(name, "Config.StopSignal")
-	c.Assert(err, check.IsNil)
+	res := inspectFieldJSON(c, name, "Config.StopSignal")
 	c.Assert(res, checker.Contains, "9")
 
 }

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -336,8 +336,7 @@ func (s *DockerSuite) TestEventsFilterContainer(c *check.C) {
 
 	for _, name := range []string{"container_1", "container_2"} {
 		dockerCmd(c, "run", "--name", name, "busybox", "true")
-		id, err := inspectField(name, "Id")
-		c.Assert(err, checker.IsNil)
+		id := inspectField(c, name, "Id")
 		nameID[name] = id
 	}
 

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -95,8 +95,7 @@ func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
 
 	c.Assert(waitRun("oomTrue"), checker.IsNil)
 	defer dockerCmd(c, "kill", "oomTrue")
-	containerID, err := inspectField("oomTrue", "Id")
-	c.Assert(err, checker.IsNil)
+	containerID := inspectField(c, "oomTrue", "Id")
 
 	testActions := map[string]chan bool{
 		"oom": make(chan bool),
@@ -119,8 +118,7 @@ func (s *DockerSuite) TestEventsOOMDisableTrue(c *check.C) {
 		}
 	}
 
-	status, err := inspectField("oomTrue", "State.Status")
-	c.Assert(err, checker.IsNil)
+	status := inspectField(c, "oomTrue", "State.Status")
 	c.Assert(strings.TrimSpace(status), checker.Equals, "running", check.Commentf("container should be still running"))
 }
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -288,23 +288,21 @@ func (s *DockerSuite) TestInspectExecID(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSuffix(out, "\n")
 
-	out, err := inspectField(id, "ExecIDs")
-	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect container: %s", out))
+	out = inspectField(c, id, "ExecIDs")
 	c.Assert(out, checker.Equals, "[]", check.Commentf("ExecIDs should be empty, got: %s", out))
 
 	// Start an exec, have it block waiting so we can do some checking
 	cmd := exec.Command(dockerBinary, "exec", id, "sh", "-c",
 		"while ! test -e /tmp/execid1; do sleep 1; done")
 
-	err = cmd.Start()
+	err := cmd.Start()
 	c.Assert(err, checker.IsNil, check.Commentf("failed to start the exec cmd"))
 
 	// Give the exec 10 chances/seconds to start then give up and stop the test
 	tries := 10
 	for i := 0; i < tries; i++ {
 		// Since its still running we should see exec as part of the container
-		out, err = inspectField(id, "ExecIDs")
-		c.Assert(err, checker.IsNil, check.Commentf("failed to inspect container: %s", out))
+		out = inspectField(c, id, "ExecIDs")
 
 		out = strings.TrimSuffix(out, "\n")
 		if out != "[]" && out != "<no value>" {
@@ -328,8 +326,7 @@ func (s *DockerSuite) TestInspectExecID(c *check.C) {
 	cmd.Wait()
 
 	// All execs for the container should be gone now
-	out, err = inspectField(id, "ExecIDs")
-	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect container: %s", out))
+	out = inspectField(c, id, "ExecIDs")
 
 	out = strings.TrimSuffix(out, "\n")
 	c.Assert(out == "[]" || out == "<no value>", checker.True)

--- a/integration-cli/docker_cli_inspect_experimental_test.go
+++ b/integration-cli/docker_cli_inspect_experimental_test.go
@@ -12,11 +12,10 @@ func (s *DockerSuite) TestInspectNamedMountPoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "data:/data", "busybox", "cat")
 
-	vol, err := inspectFieldJSON("test", "Mounts")
-	c.Assert(err, checker.IsNil)
+	vol := inspectFieldJSON(c, "test", "Mounts")
 
 	var mp []types.MountPoint
-	err = unmarshalJSON([]byte(vol), &mp)
+	err := unmarshalJSON([]byte(vol), &mp)
 	c.Assert(err, checker.IsNil)
 
 	c.Assert(mp, checker.HasLen, 1, check.Commentf("Expected 1 mount point"))

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -29,8 +29,7 @@ func (s *DockerSuite) TestInspectImage(c *check.C) {
 	// fails, fix the difference in the image serialization instead of
 	// updating this hash.
 	imageTestID := "sha256:11f64303f0f7ffdc71f001788132bca5346831939a956e3e975c93267d89a16d"
-	id, err := inspectField(imageTest, "Id")
-	c.Assert(err, checker.IsNil)
+	id := inspectField(c, imageTest, "Id")
 
 	c.Assert(id, checker.Equals, imageTestID)
 }
@@ -39,8 +38,7 @@ func (s *DockerSuite) TestInspectInt64(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	dockerCmd(c, "run", "-d", "-m=300M", "--name", "inspectTest", "busybox", "true")
-	inspectOut, err := inspectField("inspectTest", "HostConfig.Memory")
-	c.Assert(err, check.IsNil)
+	inspectOut := inspectField(c, "inspectTest", "HostConfig.Memory")
 	c.Assert(inspectOut, checker.Equals, "314572800")
 }
 
@@ -52,8 +50,7 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--name=busybox", "-d", "busybox", "true")
 	containerID := strings.TrimSpace(out)
 
-	inspectOut, err := inspectField("busybox", "Id")
-	c.Assert(err, checker.IsNil)
+	inspectOut := inspectField(c, "busybox", "Id")
 	c.Assert(strings.TrimSpace(inspectOut), checker.Equals, containerID)
 }
 
@@ -63,23 +60,19 @@ func (s *DockerSuite) TestInspectStatus(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	out = strings.TrimSpace(out)
 
-	inspectOut, err := inspectField(out, "State.Status")
-	c.Assert(err, checker.IsNil)
+	inspectOut := inspectField(c, out, "State.Status")
 	c.Assert(inspectOut, checker.Equals, "running")
 
 	dockerCmd(c, "pause", out)
-	inspectOut, err = inspectField(out, "State.Status")
-	c.Assert(err, checker.IsNil)
+	inspectOut = inspectField(c, out, "State.Status")
 	c.Assert(inspectOut, checker.Equals, "paused")
 
 	dockerCmd(c, "unpause", out)
-	inspectOut, err = inspectField(out, "State.Status")
-	c.Assert(err, checker.IsNil)
+	inspectOut = inspectField(c, out, "State.Status")
 	c.Assert(inspectOut, checker.Equals, "running")
 
 	dockerCmd(c, "stop", out)
-	inspectOut, err = inspectField(out, "State.Status")
-	c.Assert(err, checker.IsNil)
+	inspectOut = inspectField(c, out, "State.Status")
 	c.Assert(inspectOut, checker.Equals, "exited")
 
 }
@@ -137,8 +130,7 @@ func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *check.C) {
 func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
-	out, err := inspectField(imageTest, "Size")
-	c.Assert(err, checker.IsNil)
+	out := inspectField(c, imageTest, "Size")
 
 	size, err := strconv.Atoi(out)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect size of the image: %s, %v", out, err))
@@ -160,8 +152,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 
 	id := strings.TrimSpace(out)
 
-	out, err = inspectField(id, "State.ExitCode")
-	c.Assert(err, checker.IsNil)
+	out = inspectField(c, id, "State.ExitCode")
 
 	exitCode, err := strconv.Atoi(out)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect exitcode of the container: %s, %v", out, err))
@@ -177,8 +168,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
-	name, err := inspectField(imageTest, "GraphDriver.Name")
-	c.Assert(err, checker.IsNil)
+	name := inspectField(c, imageTest, "GraphDriver.Name")
 
 	checkValidGraphDriver(c, name)
 
@@ -186,14 +176,12 @@ func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 		c.Skip("requires devicemapper graphdriver")
 	}
 
-	deviceID, err := inspectField(imageTest, "GraphDriver.Data.DeviceId")
-	c.Assert(err, checker.IsNil)
+	deviceID := inspectField(c, imageTest, "GraphDriver.Data.DeviceId")
 
-	_, err = strconv.Atoi(deviceID)
+	_, err := strconv.Atoi(deviceID)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))
 
-	deviceSize, err := inspectField(imageTest, "GraphDriver.Data.DeviceSize")
-	c.Assert(err, checker.IsNil)
+	deviceSize := inspectField(c, imageTest, "GraphDriver.Data.DeviceSize")
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err))
@@ -204,8 +192,7 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	out = strings.TrimSpace(out)
 
-	name, err := inspectField(out, "GraphDriver.Name")
-	c.Assert(err, checker.IsNil)
+	name := inspectField(c, out, "GraphDriver.Name")
 
 	checkValidGraphDriver(c, name)
 
@@ -213,19 +200,16 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 		return
 	}
 
-	imageDeviceID, err := inspectField("busybox", "GraphDriver.Data.DeviceId")
-	c.Assert(err, checker.IsNil)
+	imageDeviceID := inspectField(c, "busybox", "GraphDriver.Data.DeviceId")
 
-	deviceID, err := inspectField(out, "GraphDriver.Data.DeviceId")
-	c.Assert(err, checker.IsNil)
+	deviceID := inspectField(c, out, "GraphDriver.Data.DeviceId")
 
 	c.Assert(imageDeviceID, checker.Not(checker.Equals), deviceID)
 
-	_, err = strconv.Atoi(deviceID)
+	_, err := strconv.Atoi(deviceID)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceId of the image: %s, %v", deviceID, err))
 
-	deviceSize, err := inspectField(out, "GraphDriver.Data.DeviceSize")
-	c.Assert(err, checker.IsNil)
+	deviceSize := inspectField(c, out, "GraphDriver.Data.DeviceSize")
 
 	_, err = strconv.ParseUint(deviceSize, 10, 64)
 	c.Assert(err, checker.IsNil, check.Commentf("failed to inspect DeviceSize of the image: %s, %v", deviceSize, err))
@@ -235,11 +219,10 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "/data:/data:ro,z", "busybox", "cat")
 
-	vol, err := inspectFieldJSON("test", "Mounts")
-	c.Assert(err, checker.IsNil)
+	vol := inspectFieldJSON(c, "test", "Mounts")
 
 	var mp []types.MountPoint
-	err = unmarshalJSON([]byte(vol), &mp)
+	err := unmarshalJSON([]byte(vol), &mp)
 	c.Assert(err, checker.IsNil)
 
 	// check that there is only one mountpoint
@@ -260,22 +243,18 @@ func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	id := strings.TrimSpace(out)
-	startedAt, err := inspectField(id, "State.StartedAt")
-	c.Assert(err, checker.IsNil)
-	finishedAt, err := inspectField(id, "State.FinishedAt")
-	c.Assert(err, checker.IsNil)
-	created, err := inspectField(id, "Created")
-	c.Assert(err, checker.IsNil)
+	startedAt := inspectField(c, id, "State.StartedAt")
+	finishedAt := inspectField(c, id, "State.FinishedAt")
+	created := inspectField(c, id, "Created")
 
-	_, err = time.Parse(time.RFC3339Nano, startedAt)
+	_, err := time.Parse(time.RFC3339Nano, startedAt)
 	c.Assert(err, checker.IsNil)
 	_, err = time.Parse(time.RFC3339Nano, finishedAt)
 	c.Assert(err, checker.IsNil)
 	_, err = time.Parse(time.RFC3339Nano, created)
 	c.Assert(err, checker.IsNil)
 
-	created, err = inspectField("busybox", "Created")
-	c.Assert(err, checker.IsNil)
+	created = inspectField(c, "busybox", "Created")
 
 	_, err = time.Parse(time.RFC3339Nano, created)
 	c.Assert(err, checker.IsNil)
@@ -287,10 +266,9 @@ func (s *DockerSuite) TestInspectLogConfigNoType(c *check.C) {
 	dockerCmd(c, "create", "--name=test", "--log-opt", "max-file=42", "busybox")
 	var logConfig container.LogConfig
 
-	out, err := inspectFieldJSON("test", "HostConfig.LogConfig")
-	c.Assert(err, checker.IsNil, check.Commentf("%v", out))
+	out := inspectFieldJSON(c, "test", "HostConfig.LogConfig")
 
-	err = json.NewDecoder(strings.NewReader(out)).Decode(&logConfig)
+	err := json.NewDecoder(strings.NewReader(out)).Decode(&logConfig)
 	c.Assert(err, checker.IsNil, check.Commentf("%v", out))
 
 	c.Assert(logConfig.Type, checker.Equals, "json-file")
@@ -355,16 +333,13 @@ func (s *DockerSuite) TestInspectJSONFields(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectByPrefix(c *check.C) {
-	id, err := inspectField("busybox", "Id")
-	c.Assert(err, checker.IsNil)
+	id := inspectField(c, "busybox", "Id")
 	c.Assert(id, checker.HasPrefix, "sha256:")
 
-	id2, err := inspectField(id[:12], "Id")
-	c.Assert(err, checker.IsNil)
+	id2 := inspectField(c, id[:12], "Id")
 	c.Assert(id, checker.Equals, id2)
 
-	id3, err := inspectField(strings.TrimPrefix(id, "sha256:")[:12], "Id")
-	c.Assert(err, checker.IsNil)
+	id3 := inspectField(c, strings.TrimPrefix(id, "sha256:")[:12], "Id")
 	c.Assert(id, checker.Equals, id3)
 }
 
@@ -395,11 +370,9 @@ func (s *DockerSuite) TestInspectContainerNetworkDefault(c *check.C) {
 	contName := "test1"
 	dockerCmd(c, "run", "--name", contName, "-d", "busybox", "top")
 	netOut, _ := dockerCmd(c, "network", "inspect", "--format='{{.ID}}'", "bridge")
-	out, err := inspectField(contName, "NetworkSettings.Networks")
-	c.Assert(err, checker.IsNil)
+	out := inspectField(c, contName, "NetworkSettings.Networks")
 	c.Assert(out, checker.Contains, "bridge")
-	out, err = inspectField(contName, "NetworkSettings.Networks.bridge.NetworkID")
-	c.Assert(err, checker.IsNil)
+	out = inspectField(c, contName, "NetworkSettings.Networks.bridge.NetworkID")
 	c.Assert(strings.TrimSpace(out), checker.Equals, strings.TrimSpace(netOut))
 }
 
@@ -408,10 +381,8 @@ func (s *DockerSuite) TestInspectContainerNetworkCustom(c *check.C) {
 
 	netOut, _ := dockerCmd(c, "network", "create", "net1")
 	dockerCmd(c, "run", "--name=container1", "--net=net1", "-d", "busybox", "top")
-	out, err := inspectField("container1", "NetworkSettings.Networks")
-	c.Assert(err, checker.IsNil)
+	out := inspectField(c, "container1", "NetworkSettings.Networks")
 	c.Assert(out, checker.Contains, "net1")
-	out, err = inspectField("container1", "NetworkSettings.Networks.net1.NetworkID")
-	c.Assert(err, checker.IsNil)
+	out = inspectField(c, "container1", "NetworkSettings.Networks.net1.NetworkID")
 	c.Assert(strings.TrimSpace(out), checker.Equals, strings.TrimSpace(netOut))
 }

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -55,7 +55,7 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 
 	dockerCmd(c, "kill", "-s", "SIGWINCH", cid)
 
-	running, _ := inspectField(cid, "State.Running")
+	running := inspectField(c, cid, "State.Running")
 
 	c.Assert(running, checker.Equals, "true", check.Commentf("Container should be in running state after SIGWINCH"))
 }
@@ -70,7 +70,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(out, checker.Contains, "Invalid signal: 0", check.Commentf("Kill with an invalid signal didn't error out correctly"))
 
-	running, _ := inspectField(cid, "State.Running")
+	running := inspectField(c, cid, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("Container should be in running state after an invalid signal"))
 
 	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
@@ -81,7 +81,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(out, checker.Contains, "Invalid signal: SIG42", check.Commentf("Kill with an invalid signal error out correctly"))
 
-	running, _ = inspectField(cid, "State.Running")
+	running = inspectField(c, cid, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("Container should be in running state after an invalid signal"))
 
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -69,10 +69,9 @@ func (s *DockerSuite) TestLinksInspectLinksStarted(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "top")
-	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
-	c.Assert(err, checker.IsNil)
+	links := inspectFieldJSON(c, "testinspectlink", "HostConfig.Links")
 
-	err = unmarshalJSON([]byte(links), &result)
+	err := unmarshalJSON([]byte(links), &result)
 	c.Assert(err, checker.IsNil)
 
 	output := convertSliceOfStringsToMap(result)
@@ -89,10 +88,9 @@ func (s *DockerSuite) TestLinksInspectLinksStopped(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
-	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
-	c.Assert(err, checker.IsNil)
+	links := inspectFieldJSON(c, "testinspectlink", "HostConfig.Links")
 
-	err = unmarshalJSON([]byte(links), &result)
+	err := unmarshalJSON([]byte(links), &result)
 	c.Assert(err, checker.IsNil)
 
 	output := convertSliceOfStringsToMap(result)
@@ -136,11 +134,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
 	id := strings.TrimSpace(string(out))
 
-	realIP, err := inspectField("one", "NetworkSettings.Networks.bridge.IPAddress")
-	if err != nil {
-		c.Fatal(err)
-	}
-	c.Assert(err, checker.IsNil)
+	realIP := inspectField(c, "one", "NetworkSettings.Networks.bridge.IPAddress")
 	content, err := readContainerFileWithExec(id, "/etc/hosts")
 	c.Assert(err, checker.IsNil)
 
@@ -157,8 +151,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	c.Assert(ip, checker.Equals, realIP)
 
 	dockerCmd(c, "restart", "one")
-	realIP, err = inspectField("one", "NetworkSettings.Networks.bridge.IPAddress")
-	c.Assert(err, checker.IsNil)
+	realIP = inspectField(c, "one", "NetworkSettings.Networks.bridge.IPAddress")
 
 	content, err = readContainerFileWithExec(id, "/etc/hosts")
 	c.Assert(err, checker.IsNil, check.Commentf("content: %s", string(content)))
@@ -190,8 +183,7 @@ func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
 	cid2 := strings.TrimSpace(out)
 	c.Assert(waitRun(cid2), checker.IsNil)
 
-	links, err := inspectFieldJSON(cid2, "HostConfig.Links")
-	c.Assert(err, checker.IsNil)
+	links := inspectFieldJSON(c, cid2, "HostConfig.Links")
 	c.Assert(links, checker.Equals, "[\"/shortlinkdef:/link2/shortlinkdef\"]")
 }
 

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -44,8 +44,7 @@ func getContainerLogs(c *check.C, containerID string) string {
 }
 
 func getContainerStatus(c *check.C, containerID string) string {
-	out, err := inspectField(containerID, "State.Running")
-	c.Assert(err, check.IsNil)
+	out := inspectField(c, containerID, "State.Running")
 	return out
 }
 

--- a/integration-cli/docker_cli_oom_killed_test.go
+++ b/integration-cli/docker_cli_oom_killed_test.go
@@ -15,9 +15,8 @@ func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
 
 	c.Assert(exitCode, checker.Equals, 137, check.Commentf("OOM exit should be 137"))
 
-	oomKilled, err := inspectField(name, "State.OOMKilled")
+	oomKilled := inspectField(c, name, "State.OOMKilled")
 	c.Assert(oomKilled, checker.Equals, "true")
-	c.Assert(err, checker.IsNil)
 }
 
 func (s *DockerSuite) TestInspectOomKilledFalse(c *check.C) {
@@ -26,7 +25,6 @@ func (s *DockerSuite) TestInspectOomKilledFalse(c *check.C) {
 	name := "testoomkilled"
 	dockerCmd(c, "run", "--name", name, "--memory", "32MB", "busybox", "sh", "-c", "echo hello world")
 
-	oomKilled, err := inspectField(name, "State.OOMKilled")
+	oomKilled := inspectField(c, name, "State.OOMKilled")
 	c.Assert(oomKilled, checker.Equals, "false")
-	c.Assert(err, checker.IsNil)
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -431,7 +431,7 @@ func (s *DockerSuite) TestPsRightTagName(c *check.C) {
 	id2 = strings.TrimSpace(string(out))
 
 	var imageID string
-	out, _ = dockerCmd(c, "inspect", "-f", "{{.Id}}", "busybox")
+	out = inspectField(c, "busybox", "Id")
 	imageID = strings.TrimSpace(string(out))
 
 	var id3 string

--- a/integration-cli/docker_cli_pull_trusted_test.go
+++ b/integration-cli/docker_cli_pull_trusted_test.go
@@ -235,21 +235,19 @@ func (s *DockerTrustSuite) TestTrustedPullDelete(c *check.C) {
 	c.Assert(matches, checker.HasLen, 2, check.Commentf("unable to parse digest from pull output: %s", out))
 	pullDigest := matches[1]
 
-	imageID, err := inspectField(repoName, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error inspecting image id"))
+	imageID := inspectField(c, repoName, "Id")
 
 	imageByDigest := repoName + "@" + pullDigest
-	byDigestID, err := inspectField(imageByDigest, "Id")
-	c.Assert(err, checker.IsNil, check.Commentf("error inspecting image id"))
+	byDigestID := inspectField(c, imageByDigest, "Id")
 
 	c.Assert(byDigestID, checker.Equals, imageID)
 
 	// rmi of tag should also remove the digest reference
 	dockerCmd(c, "rmi", repoName)
 
-	_, err = inspectField(imageByDigest, "Id")
+	_, err = inspectFieldWithError(imageByDigest, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("digest reference should have been removed"))
 
-	_, err = inspectField(imageID, "Id")
+	_, err = inspectFieldWithError(imageID, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
 }

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -14,12 +14,11 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	name, err := inspectField(cleanedContainerID, "Name")
+	name := inspectField(c, cleanedContainerID, "Name")
 	newName := "new_name" + stringid.GenerateNonCryptoID()
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err = inspectField(cleanedContainerID, "Name")
-	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
+	name = inspectField(c, cleanedContainerID, "Name")
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
 
 }
@@ -31,8 +30,7 @@ func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err := inspectField(cleanedContainerID, "Name")
-	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
+	name := inspectField(c, cleanedContainerID, "Name")
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
 }
 
@@ -44,15 +42,13 @@ func (s *DockerSuite) TestRenameRunningContainerAndReuse(c *check.C) {
 	ContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err := inspectField(ContainerID, "Name")
-	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
+	name := inspectField(c, ContainerID, "Name")
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container"))
 
 	out, _ = runSleepingContainer(c, "--name", "first_name")
 	c.Assert(waitRun("first_name"), check.IsNil)
 	newContainerID := strings.TrimSpace(out)
-	name, err = inspectField(newContainerID, "Name")
-	c.Assert(err, checker.IsNil, check.Commentf("Failed to reuse container name"))
+	name = inspectField(c, newContainerID, "Name")
 	c.Assert(name, checker.Equals, "/first_name", check.Commentf("Failed to reuse container name"))
 }
 
@@ -62,11 +58,10 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 	newName := "new_name" + stringid.GenerateNonCryptoID()
 	dockerCmd(c, "rename", "first_name", newName)
 
-	name, err := inspectField(newName, "Name")
-	c.Assert(err, checker.IsNil, check.Commentf("Failed to rename container %s", name))
+	name := inspectField(c, newName, "Name")
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container %s", name))
 
-	name, err = inspectField("first_name", "Name")
+	name, err := inspectFieldWithError("first_name", "Name")
 	c.Assert(err, checker.NotNil, check.Commentf(name))
 	c.Assert(err.Error(), checker.Contains, "No such image or container: first_name")
 }

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -82,8 +82,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 	// tag busybox to create 2 more images with same imageID
 	c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+2, check.Commentf("docker images shows: %q\n", imagesAfter))
 
-	imgID, err := inspectField("busybox-one:tag1", "Id")
-	c.Assert(err, checker.IsNil)
+	imgID := inspectField(c, "busybox-one:tag1", "Id")
 
 	// run a container with the image
 	out, _ = runSleepingContainerInImage(c, "busybox-one")
@@ -91,7 +90,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 	containerID = strings.TrimSpace(out)
 
 	// first checkout without force it fails
-	out, _, err = dockerCmdWithError("rmi", imgID)
+	out, _, err := dockerCmdWithError("rmi", imgID)
 	expected := fmt.Sprintf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", stringid.TruncateID(imgID), stringid.TruncateID(containerID))
 	// rmi tagged in multiple repos should have failed without force
 	c.Assert(err, checker.NotNil)
@@ -128,11 +127,10 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 		imagesAfter, _ := dockerCmd(c, "images", "-a")
 		c.Assert(strings.Count(imagesAfter, "\n"), checker.Equals, strings.Count(imagesBefore, "\n")+4, check.Commentf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter))
 	}
-	imgID, err := inspectField("busybox-test", "Id")
-	c.Assert(err, checker.IsNil)
+	imgID := inspectField(c, "busybox-test", "Id")
 
 	// first checkout without force it fails
-	out, _, err = dockerCmdWithError("rmi", imgID)
+	out, _, err := dockerCmdWithError("rmi", imgID)
 	// rmi tagged in multiple repos should have failed without force
 	c.Assert(err, checker.NotNil)
 	// rmi tagged in multiple repos should have failed without force
@@ -317,8 +315,7 @@ RUN echo 2 #layer2
 }
 
 func (*DockerSuite) TestRmiParentImageFail(c *check.C) {
-	parent, err := inspectField("busybox", "Parent")
-	c.Assert(err, check.IsNil)
+	parent := inspectField(c, "busybox", "Parent")
 	out, _, err := dockerCmdWithError("rmi", parent)
 	c.Assert(err, check.NotNil)
 	if !strings.Contains(out, "image has dependent child images") {
@@ -354,14 +351,12 @@ func (s *DockerSuite) TestRmiByIDHardConflict(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "create", "busybox")
 
-	imgID, err := inspectField("busybox:latest", "Id")
-	c.Assert(err, checker.IsNil)
+	imgID := inspectField(c, "busybox:latest", "Id")
 
-	_, _, err = dockerCmdWithError("rmi", imgID[:12])
+	_, _, err := dockerCmdWithError("rmi", imgID[:12])
 	c.Assert(err, checker.NotNil)
 
 	// check that tag was not removed
-	imgID2, err := inspectField("busybox:latest", "Id")
-	c.Assert(err, checker.IsNil)
+	imgID2 := inspectField(c, "busybox:latest", "Id")
 	c.Assert(imgID, checker.Equals, imgID2)
 }

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -130,8 +130,7 @@ func (s *DockerSuite) TestRunAttachDetach(c *check.C) {
 		c.Fatal("timed out waiting for container to exit")
 	}
 
-	running, err := inspectField(name, "State.Running")
-	c.Assert(err, checker.IsNil)
+	running := inspectField(c, name, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("expected container to still be running"))
 }
 
@@ -192,8 +191,7 @@ func (s *DockerSuite) TestRunAttachDetachFromFlag(c *check.C) {
 		c.Fatal("timed out waiting for container to exit")
 	}
 
-	running, err := inspectField(name, "State.Running")
-	c.Assert(err, checker.IsNil)
+	running := inspectField(c, name, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("expected container to still be running"))
 }
 
@@ -276,8 +274,7 @@ func (s *DockerSuite) TestRunAttachDetachFromConfig(c *check.C) {
 		c.Fatal("timed out waiting for container to exit")
 	}
 
-	running, err := inspectField(name, "State.Running")
-	c.Assert(err, checker.IsNil)
+	running := inspectField(c, name, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("expected container to still be running"))
 }
 
@@ -360,8 +357,7 @@ func (s *DockerSuite) TestRunAttachDetachKeysOverrideConfig(c *check.C) {
 		c.Fatal("timed out waiting for container to exit")
 	}
 
-	running, err := inspectField(name, "State.Running")
-	c.Assert(err, checker.IsNil)
+	running := inspectField(c, name, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("expected container to still be running"))
 }
 
@@ -373,8 +369,7 @@ func (s *DockerSuite) TestRunWithCPUQuota(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--cpu-quota", "8000", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "8000")
 
-	out, err := inspectField("test", "HostConfig.CpuQuota")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.CpuQuota")
 	c.Assert(out, checker.Equals, "8000", check.Commentf("setting the CPU CFS quota failed"))
 }
 
@@ -385,8 +380,7 @@ func (s *DockerSuite) TestRunWithCpuPeriod(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--cpu-period", "50000", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "50000")
 
-	out, err := inspectField("test", "HostConfig.CpuPeriod")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.CpuPeriod")
 	c.Assert(out, checker.Equals, "50000", check.Commentf("setting the CPU CFS period failed"))
 }
 
@@ -397,8 +391,7 @@ func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
 	stdout, _, _ := dockerCmdWithStdoutStderr(c, "run", "--kernel-memory", "50M", "--name", "test1", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(stdout), checker.Equals, "52428800")
 
-	out, err := inspectField("test1", "HostConfig.KernelMemory")
-	c.Assert(err, check.IsNil)
+	out := inspectField(c, "test1", "HostConfig.KernelMemory")
 	c.Assert(out, check.Equals, "52428800")
 }
 
@@ -423,8 +416,7 @@ func (s *DockerSuite) TestRunWithCPUShares(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--cpu-shares", "1000", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "1000")
 
-	out, err := inspectField("test", "HostConfig.CPUShares")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.CPUShares")
 	c.Assert(out, check.Equals, "1000")
 }
 
@@ -443,8 +435,7 @@ func (s *DockerSuite) TestRunWithCpusetCpus(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--cpuset-cpus", "0", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "0")
 
-	out, err := inspectField("test", "HostConfig.CpusetCpus")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.CpusetCpus")
 	c.Assert(out, check.Equals, "0")
 }
 
@@ -455,8 +446,7 @@ func (s *DockerSuite) TestRunWithCpusetMems(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--cpuset-mems", "0", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "0")
 
-	out, err := inspectField("test", "HostConfig.CpusetMems")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.CpusetMems")
 	c.Assert(out, check.Equals, "0")
 }
 
@@ -467,8 +457,7 @@ func (s *DockerSuite) TestRunWithBlkioWeight(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--blkio-weight", "300", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "300")
 
-	out, err := inspectField("test", "HostConfig.BlkioWeight")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.BlkioWeight")
 	c.Assert(out, check.Equals, "300")
 }
 
@@ -537,8 +526,7 @@ func (s *DockerSuite) TestRunWithMemoryLimit(c *check.C) {
 	stdout, _, _ := dockerCmdWithStdoutStderr(c, "run", "-m", "32M", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(stdout), checker.Equals, "33554432")
 
-	out, err := inspectField("test", "HostConfig.Memory")
-	c.Assert(err, check.IsNil)
+	out := inspectField(c, "test", "HostConfig.Memory")
 	c.Assert(out, check.Equals, "33554432")
 }
 
@@ -559,8 +547,7 @@ func (s *DockerSuite) TestRunWithSwappiness(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--memory-swappiness", "0", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "0")
 
-	out, err := inspectField("test", "HostConfig.MemorySwappiness")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.MemorySwappiness")
 	c.Assert(out, check.Equals, "0")
 }
 
@@ -583,8 +570,7 @@ func (s *DockerSuite) TestRunWithMemoryReservation(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--memory-reservation", "200M", "--name", "test", "busybox", "cat", file)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "209715200")
 
-	out, err := inspectField("test", "HostConfig.MemoryReservation")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, "test", "HostConfig.MemoryReservation")
 	c.Assert(out, check.Equals, "209715200")
 }
 
@@ -684,8 +670,7 @@ func (s *DockerSuite) TestRunWithDefaultShmSize(c *check.C) {
 	if !shmRegex.MatchString(out) {
 		c.Fatalf("Expected shm of 64MB in mount command, got %v", out)
 	}
-	shmSize, err := inspectField(name, "HostConfig.ShmSize")
-	c.Assert(err, check.IsNil)
+	shmSize := inspectField(c, name, "HostConfig.ShmSize")
 	c.Assert(shmSize, check.Equals, "67108864")
 }
 
@@ -698,8 +683,7 @@ func (s *DockerSuite) TestRunWithShmSize(c *check.C) {
 	if !shmRegex.MatchString(out) {
 		c.Fatalf("Expected shm of 1GB in mount command, got %v", out)
 	}
-	shmSize, err := inspectField(name, "HostConfig.ShmSize")
-	c.Assert(err, check.IsNil)
+	shmSize := inspectField(c, name, "HostConfig.ShmSize")
 	c.Assert(shmSize, check.Equals, "1073741824")
 }
 

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -223,7 +223,7 @@ func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
 	}
 
 	// make the list of expected layers
-	out, _ = dockerCmd(c, "inspect", "-f", "{{.Id}}", "busybox:latest")
+	out = inspectField(c, "busybox:latest", "Id")
 	expected := []string{strings.TrimSpace(out), idFoo, idBar}
 
 	// prefixes are not in tar

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
@@ -19,6 +20,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 	repoName := "foobar-save-load-test"
 	before, _ := dockerCmd(c, "commit", name, repoName)
+	before = strings.TrimRight(before, "\n")
 
 	tmpFile, err := ioutil.TempFile("", "foobar-save-load-test.tar")
 	c.Assert(err, check.IsNil)
@@ -41,9 +43,10 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 	out, _, err := runCommandWithOutput(loadCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
-	after, _ := dockerCmd(c, "inspect", "-f", "{{.Id}}", repoName)
+	after := inspectField(c, repoName, "Id")
+	after = strings.TrimRight(after, "\n")
 
-	c.Assert(before, check.Equals, after) //inspect is not the same after a save / load
+	c.Assert(after, check.Equals, before) //inspect is not the same after a save / load
 
 	deleteImages(repoName)
 

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -72,8 +72,7 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// when container runs successfully, we should not have state.Error
 	dockerCmd(c, "run", "-d", "-p", "9999:9999", "--name", "test", "busybox", "top")
-	stateErr, err := inspectField("test", "State.Error")
-	c.Assert(err, checker.IsNil, check.Commentf("stateErr: %s", stateErr))
+	stateErr := inspectField(c, "test", "State.Error")
 	// Expected to not have state error
 	c.Assert(stateErr, checker.Equals, "")
 
@@ -82,15 +81,13 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 	// err shouldn't be nil because docker run will fail
 	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
 
-	stateErr, err = inspectField("test2", "State.Error")
-	c.Assert(err, check.IsNil, check.Commentf("stateErr: %s", stateErr))
+	stateErr = inspectField(c, "test2", "State.Error")
 	c.Assert(stateErr, checker.Contains, "port is already allocated")
 
 	// Expect the conflict to be resolved when we stop the initial container
 	dockerCmd(c, "stop", "test")
 	dockerCmd(c, "start", "test2")
-	stateErr, err = inspectField("test2", "State.Error")
-	c.Assert(err, check.IsNil, check.Commentf("stateErr: %s", stateErr))
+	stateErr = inspectField(c, "test2", "State.Error")
 	// Expected to not have state error but got one
 	c.Assert(stateErr, checker.Equals, "")
 }
@@ -122,8 +119,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
 	// stop 'parent' container
 	dockerCmd(c, "stop", "parent")
 
-	out, err := inspectField("parent", "State.Running")
-	c.Assert(err, check.IsNil, check.Commentf("out: %s", out))
+	out := inspectField(c, "parent", "State.Running")
 	// Container should be stopped
 	c.Assert(out, checker.Equals, "false")
 
@@ -131,7 +127,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
 	// container 'parent' start second and then start container 'child_second'
 	expOut := "Cannot link to a non running container"
 	expErr := "failed to start containers: [child_first]"
-	out, _, err = dockerCmdWithError("start", "child_first", "parent", "child_second")
+	out, _, err := dockerCmdWithError("start", "child_first", "parent", "child_second")
 	// err shouldn't be nil because start will fail
 	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
 	// output does not correspond to what was expected
@@ -140,9 +136,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
 	}
 
 	for container, expected := range map[string]string{"parent": "true", "child_first": "false", "child_second": "true"} {
-		out, err := inspectField(container, "State.Running")
-		// Container running state wrong
-		c.Assert(err, check.IsNil, check.Commentf("out: %s", out))
+		out := inspectField(c, container, "State.Running")
 		// Container running state wrong
 		c.Assert(out, checker.Equals, expected)
 	}
@@ -171,9 +165,7 @@ func (s *DockerSuite) TestStartAttachMultipleContainers(c *check.C) {
 
 	// confirm the state of all the containers be stopped
 	for container, expected := range map[string]string{"test1": "false", "test2": "false", "test3": "false"} {
-		out, err := inspectField(container, "State.Running")
-		// Container running state wrong
-		c.Assert(err, check.IsNil, check.Commentf("out: %s", out))
+		out := inspectField(c, container, "State.Running")
 		// Container running state wrong
 		c.Assert(out, checker.Equals, expected)
 	}

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -383,8 +383,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c
 		Name   string
 		Driver string
 	}
-	out, err := inspectFieldJSON("testing", "Mounts")
-	c.Assert(err, checker.IsNil)
+	out := inspectFieldJSON(c, "testing", "Mounts")
 	c.Assert(json.NewDecoder(strings.NewReader(out)).Decode(&mounts), checker.IsNil)
 	c.Assert(len(mounts), checker.Equals, 1, check.Commentf(out))
 	c.Assert(mounts[0].Name, checker.Equals, "foo")

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -25,8 +25,7 @@ func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
 
 // tagging an image by ID in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByID(c *check.C) {
-	imageID, err := inspectField("busybox", "Id")
-	c.Assert(err, check.IsNil)
+	imageID := inspectField(c, "busybox", "Id")
 	dockerCmd(c, "tag", imageID, "testfoobarbaz")
 }
 
@@ -233,10 +232,7 @@ func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
 	truncatedImageID := stringid.TruncateID(imageID)
 	truncatedTag := fmt.Sprintf("notbusybox:%s", truncatedImageID)
 
-	id, err := inspectField(truncatedTag, "Id")
-	if err != nil {
-		c.Fatalf("Error inspecting by image id: %s", err)
-	}
+	id := inspectField(c, truncatedTag, "Id")
 
 	// Ensure inspect by image id returns image for image id
 	c.Assert(id, checker.Equals, imageID)
@@ -248,10 +244,7 @@ func (s *DockerSuite) TestTagTruncationAmbiguity(c *check.C) {
 		c.Fatalf("Error tagging with an image id: %s", err)
 	}
 
-	id, err = inspectField(truncatedTag, "Id")
-	if err != nil {
-		c.Fatalf("Error inspecting by image id: %s", err)
-	}
+	id = inspectField(c, truncatedTag, "Id")
 
 	// Ensure id is imageID and not busybox:latest
 	c.Assert(id, checker.Not(checker.Equals), imageID)

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -20,8 +20,7 @@ func (s *DockerSuite) TestUpdateRunningContainer(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", name, "-m", "300M", "busybox", "top")
 	dockerCmd(c, "update", "-m", "500M", name)
 
-	memory, err := inspectField(name, "HostConfig.Memory")
-	c.Assert(err, check.IsNil)
+	memory := inspectField(c, name, "HostConfig.Memory")
 	if memory != "524288000" {
 		c.Fatalf("Got the wrong memory value, we got %d, expected 524288000(500M).", memory)
 	}
@@ -40,8 +39,7 @@ func (s *DockerSuite) TestUpdateRunningContainerWithRestart(c *check.C) {
 	dockerCmd(c, "update", "-m", "500M", name)
 	dockerCmd(c, "restart", name)
 
-	memory, err := inspectField(name, "HostConfig.Memory")
-	c.Assert(err, check.IsNil)
+	memory := inspectField(c, name, "HostConfig.Memory")
 	if memory != "524288000" {
 		c.Fatalf("Got the wrong memory value, we got %d, expected 524288000(500M).", memory)
 	}
@@ -60,8 +58,7 @@ func (s *DockerSuite) TestUpdateStoppedContainer(c *check.C) {
 	dockerCmd(c, "run", "--name", name, "-m", "300M", "busybox", "cat", file)
 	dockerCmd(c, "update", "-m", "500M", name)
 
-	memory, err := inspectField(name, "HostConfig.Memory")
-	c.Assert(err, check.IsNil)
+	memory := inspectField(c, name, "HostConfig.Memory")
 	if memory != "524288000" {
 		c.Fatalf("Got the wrong memory value, we got %d, expected 524288000(500M).", memory)
 	}
@@ -79,8 +76,7 @@ func (s *DockerSuite) TestUpdatePausedContainer(c *check.C) {
 	dockerCmd(c, "pause", name)
 	dockerCmd(c, "update", "--cpu-shares", "500", name)
 
-	out, err := inspectField(name, "HostConfig.CPUShares")
-	c.Assert(err, check.IsNil)
+	out := inspectField(c, name, "HostConfig.CPUShares")
 	if out != "500" {
 		c.Fatalf("Got the wrong cpu shares value, we got %d, expected 500.", out)
 	}
@@ -101,8 +97,7 @@ func (s *DockerSuite) TestUpdateWithUntouchedFields(c *check.C) {
 	dockerCmd(c, "update", "-m", "500M", name)
 
 	// Update memory and not touch cpus, `cpuset.cpus` should still have the old value
-	out, err := inspectField(name, "HostConfig.CPUShares")
-	c.Assert(err, check.IsNil)
+	out := inspectField(c, name, "HostConfig.CPUShares")
 	c.Assert(out, check.Equals, "800")
 
 	file := "/sys/fs/cgroup/cpu/cpu.shares"
@@ -142,8 +137,7 @@ func (s *DockerSuite) TestUpdateKernelMemory(c *check.C) {
 	// Update kernel memory to a running container is not allowed.
 	c.Assert(err, check.NotNil)
 
-	out, err := inspectField(name, "HostConfig.KernelMemory")
-	c.Assert(err, check.IsNil)
+	out := inspectField(c, name, "HostConfig.KernelMemory")
 	// Update kernel memory to a running container with failure should not change HostConfig
 	if out != "52428800" {
 		c.Fatalf("Got the wrong memory value, we got %d, expected 52428800(50M).", out)
@@ -153,8 +147,7 @@ func (s *DockerSuite) TestUpdateKernelMemory(c *check.C) {
 	dockerCmd(c, "update", "--kernel-memory", "100M", name)
 	dockerCmd(c, "start", name)
 
-	out, err = inspectField(name, "HostConfig.KernelMemory")
-	c.Assert(err, check.IsNil)
+	out = inspectField(c, name, "HostConfig.KernelMemory")
 	if out != "104857600" {
 		c.Fatalf("Got the wrong memory value, we got %d, expected 104857600(100M).", out)
 	}


### PR DESCRIPTION
Replace raw `docker inspect -f xxx` with `inspectField`, to make code
cleaner and more consistent。

Just some cleaning work, there's no function change here.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
