### PR TITLE
platform: compile on darwin and use it in `docker version` instead of GOARCH

### DIFF
--- a/api/client/version.go
+++ b/api/client/version.go
@@ -8,6 +8,7 @@ import (
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/platform"
 	"github.com/docker/docker/utils"
 	"github.com/docker/engine-api/types"
 )
@@ -61,7 +62,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 			GitCommit:    dockerversion.GitCommit,
 			BuildTime:    dockerversion.BuildTime,
 			Os:           runtime.GOOS,
-			Arch:         runtime.GOARCH,
+			Arch:         platform.Architecture,
 			Experimental: utils.ExperimentalBuild(),
 		},
 	}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -130,7 +130,7 @@ func (daemon *Daemon) SystemVersion() types.Version {
 		GitCommit:    dockerversion.GitCommit,
 		GoVersion:    runtime.Version(),
 		Os:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
+		Arch:         platform.Architecture,
 		BuildTime:    dockerversion.BuildTime,
 		Experimental: utils.ExperimentalBuild(),
 	}

--- a/pkg/platform/architecture_bsd.go
+++ b/pkg/platform/architecture_bsd.go
@@ -1,3 +1,5 @@
+// +build freebsd darwin
+
 package platform
 
 import (


### PR DESCRIPTION
Signed-off-by: Tibor Vass tibor@docker.com

Fixes #19819

Note that this changes the client and the server's output from `amd64` to `x86_64`.

Ping @vieux 
