### PR TITLE
Windows CI: Initial porting CLI TestExec*

### DIFF
--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -19,6 +19,8 @@ var (
 	// the private registry to use for tests
 	privateRegistryURL = "127.0.0.1:5000"
 
+	// TODO Windows CI. These are incorrect and need fixing into
+	// platform specific pieces.
 	runtimePath    = "/var/run/docker"
 	execDriverPath = runtimePath + "/execdriver/native"
 
@@ -84,7 +86,7 @@ func init() {
 	// to evaluate whether the daemon is local or remote is not possible through
 	// a build tag.
 	//
-	// For example Windows CI under Jenkins test the 64-bit
+	// For example Windows to Linux CI under Jenkins tests the 64-bit
 	// Windows binary build with the daemon build tag, but calls a remote
 	// Linux daemon.
 	//
@@ -99,6 +101,8 @@ func init() {
 		isLocalDaemon = true
 	}
 
+	// TODO Windows CI. This are incorrect and need fixing into
+	// platform specific pieces.
 	// This is only used for a tests with local daemon true (Linux-only today)
 	// default is "/var/lib/docker", but we'll try and ask the
 	// /info endpoint for the specific root dir


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This ports more integration tests to Windows - specifically TestExec\* found in docker_cli_exec_test. It annotates tests which cannot run due to Linux specific functionality, or for other reasons. It also annotates those tests which are problematic and require further investigation (the initial goal is to increase test coverage as much as possible). Results from a local run are below (ignore those in docker_api_exec_test.go)

```
E:\Docker\build\busybox>runtest w TestExec
Running test TestExec
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
SKIP: docker_cli_exec_test.go:22: DockerSuite.TestExec (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:66: DockerSuite.TestExecAPIStart (Test requires a Linux daemon)
PASS: docker_api_exec_test.go:89: DockerSuite.TestExecAPIStartBackwardsCompatible       6.437s
PASS: docker_api_exec_test.go:103: DockerSuite.TestExecAPIStartMultipleTimesError       6.160s
PASS: docker_cli_exec_test.go:68: DockerSuite.TestExecAfterContainerRestart     8.306s
SKIP: docker_api_exec_test.go:52: DockerSuite.TestExecApiCreateContainerPaused (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:18: DockerSuite.TestExecApiCreateNoCmd (Test requires a Linux daemon)
SKIP: docker_api_exec_test.go:31: DockerSuite.TestExecApiCreateNoValidContentType (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:245: DockerSuite.TestExecCgroup (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:376: DockerSuite.TestExecDir (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:107: DockerSuite.TestExecEnv (Test requires a Linux daemon)
PASS: docker_cli_exec_test.go:122: DockerSuite.TestExecExitStatus       4.727s
PASS: docker_cli_exec_test.go:298: DockerSuite.TestExecInspectID        6.750s
SKIP: docker_cli_exec_test.go:32: DockerSuite.TestExecInteractive (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:531: DockerSuite.TestExecOnReadonlyContainer (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:204: DockerSuite.TestExecParseError (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:131: DockerSuite.TestExecPausedContainer (Test requires a Linux daemon)
SKIP: docker_api_exec_resize_test.go:16: DockerSuite.TestExecResizeApiHeightWidthNoInt (Test requires a Linux daemon)
SKIP: docker_api_exec_resize_test.go:28: DockerSuite.TestExecResizeImmediatelyAfterExecStart (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:540: DockerSuite.TestExecStartFails (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:217: DockerSuite.TestExecStopNotHanging (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:148: DockerSuite.TestExecTTYCloseStdin (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:169: DockerSuite.TestExecTTYWithoutStdin (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:514: DockerSuite.TestExecWithImageUser (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:480: DockerSuite.TestExecWithPrivileged (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:467: DockerSuite.TestExecWithUser (Test requires a Linux daemon)
SKIP: docker_cli_exec_test.go:82: DockerDaemonSuite.TestExecAfterDaemonRestart
OK: 5 passed, 22 skipped
--- PASS: Test (44.93s)
PASS
ok      _/E_/go/src/github.com/docker/docker/integration-cli    45.224s
```
