### PR TITLE
Improvements to ANSI emulation in conemu

### DIFF
--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -40,8 +40,8 @@ var usingNativeConsole bool
 func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 	switch {
 	case os.Getenv("ConEmuANSI") == "ON":
-		// The ConEmu shell emulates ANSI well by default.
-		return os.Stdin, os.Stdout, os.Stderr
+		// The ConEmu terminal emulates ANSI on output streams well.
+		return windows.ConEmuStreams()
 	case os.Getenv("MSYSTEM") != "":
 		// MSYS (mingw) does not emulate ANSI well.
 		return windows.ConsoleStreams()


### PR DESCRIPTION
Signed off by John Howard john.howard@microsoft.com

Fixes #13817: Fix input stream properties under ConEmu

ConEmu handles ANSI sequences in the output streams only. Submitting on behalf of @maximus5. This solves -some- of the console emulation when running docker client under conemu.  See my last comment on #13817 for more information
