### PR TITLE
Change container name to id as actual results

### DIFF
--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -28,9 +28,9 @@ Running `docker stats` on all running containers
 
     $ docker stats
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    nginx1              0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
 
 Running `docker stats` on multiple containers by name and id.
 

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -31,9 +31,9 @@ Running `docker stats` on all running containers
 
     $ docker stats
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    nginx1              0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
 
 Running `docker stats` on multiple containers by name and id.
 


### PR DESCRIPTION
Actual results:

```
# docker stats
CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
1285939c1fd3        0.00%               57.34 kB / 8.372 GB   0.00%               738 B / 648 B       0 B / 0 B
9c76f7834ae2        0.00%               876.5 kB / 8.372 GB   0.01%               2.034 kB / 648 B    733.2 kB / 0 B
d1ea048f04e4        0.05%               53.25 kB / 8.372 GB   0.00%               1.386 kB / 648 B    0 B / 0 B
```

Signed-off-by: Wen Cheng Ma wenchma@cn.ibm.com
