### PR TITLE
Ensure detect-daemon-osarch works for docker-1.6

### DIFF
--- a/hack/make/.detect-daemon-osarch
+++ b/hack/make/.detect-daemon-osarch
@@ -2,17 +2,17 @@
 set -e
 
 # Retrieve OS/ARCH of docker daemon, eg. linux/amd64
-export DOCKER_ENGINE_OSARCH="$(docker version | awk '
-	$1 == "Client:" { server = 0; next }
-	$1 == "Server:" { server = 1; next }
-	server && $1 == "OS/Arch:" { print $2 }
+export DOCKER_ENGINE_OSARCH="$(docker version | awk -F ": ?" '
+	$1 == "Server" { server = 1; next }
+	$1 == "OS/Arch (server)" { print $2; next; }
+	server && $1 == " OS/Arch" { gsub(/^[ \t]+/,"",$2); print $2 ; server = 0 }
 ')"
 export DOCKER_ENGINE_GOOS="${DOCKER_ENGINE_OSARCH%/*}"
 export DOCKER_ENGINE_GOARCH="${DOCKER_ENGINE_OSARCH##*/}"
 
 # and the client, just in case
-export DOCKER_CLIENT_OSARCH="$(docker version | awk '
-	$1 == "Client:" { client = 1; next }
-	$1 == "Server:" { client = 0; next }
-	client && $1 == "OS/Arch:" { print $2 }
+export DOCKER_CLIENT_OSARCH="$(docker version | awk -F ": ?" '
+        $1 == "Client" { client = 1; next }
+        $1 == "OS/Arch (client)" { print $2; next; }
+        client && $1 == " OS/Arch" { gsub(/^[ \t]+/,"",$2); print $2 ; client = 0 }
 ')"


### PR DESCRIPTION
Description of problem:

Docker version output varies between 1.6 and 1.9. The detection script only parse 1.9 correctly.

`docker version`:

$ docker version
Client version: 1.6.2
Client API version: 1.18
Go version (client): go1.4.2 gccgo (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010
Git commit (client): 7c8fca2
OS/Arch (client): linux/ppc64le
Server version: 1.6.2
Server API version: 1.18
Go version (server): go1.4.2 gccgo (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010
Git commit (server): 7c8fca2
OS/Arch (server): linux/ppc64le

`docker info`:

$ docker info
Containers: 43
Images: 227
Storage Driver: overlay
 Backing Filesystem: extfs
Execution Driver: native-0.2
Kernel Version: 4.2.0-16-generic
Operating System: Ubuntu 15.10
CPUs: 16
Total Memory: 255.3 GiB
Name: p84
ID: I62G:4BQ7:Q5SS:TETC:QVVT:FKTI:TV5C:QRGB:CCTY:4PXH:EKC5:BBXS
WARNING: No swap limit support

`uname -a`:

$ uname -a
Linux p84 4.2.0-16-generic #19-Ubuntu SMP Thu Oct 8 14:49:47 UTC 2015 ppc64le ppc64le ppc64le GNU/Linux

Environment details (AWS, VirtualBox, physical, etc.):

Physical box.

How reproducible:

Running make - runs the generic docker file rather than Dockerfile.ppc64le

Steps to Reproduce:
1. $ make

Actual Results:

docker build  -t "docker-dev:master" -f "Dockerfile" .
Sending build context to Docker daemon 115.3 MB
Sending build context to Docker daemon 

Expected Results:

make
docker build  -t "docker-dev:master" -f "Dockerfile.ppc64le" .
....

Patch test:

1.6.2 test:

$ docker version
Client version: 1.6.2
Client API version: 1.18
Go version (client): go1.4.2 gccgo (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010
Git commit (client): 7c8fca2
OS/Arch (client): linux/ppc64le
Server version: 1.6.2
Server API version: 1.18
Go version (server): go1.4.2 gccgo (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010
Git commit (server): 7c8fca2
OS/Arch (server): linux/ppc64le

$ source hack/make/.detect-daemon-osarch

$ echo $DOCKER_CLIENT_OSARCH
linux/ppc64le

$ echo $DOCKER_ENGINE_OSARCH
linux/ppc64le

1.9.1 test:

$  docker version
Client:
 Version:         1.9.1-fc23
 API version:     1.21
 Package version: docker-1.9.1-4.git6ec29ef.fc23.x86_64
 Go version:      go1.5.1
 Git commit:      110aed2-dirty
 Built:           Wed Dec  9 09:09:16 UTC 2015
 OS/Arch:         linux/amd64

Server:
 Version:         1.9.1-fc23
 API version:     1.21
 Package version: docker-1.9.1-4.git6ec29ef.fc23.x86_64
 Go version:      go1.5.1
 Git commit:      110aed2-dirty
 Built:           Wed Dec  9 09:09:16 UTC 2015
 OS/Arch:         linux/amd64

$ source hack/make/.detect-daemon-osarch

$ echo $DOCKER_CLIENT_OSARCH
linux/amd64

$  echo $DOCKER_ENGINE_OSARCH
linux/amd64
