### PR TITLE
18980 add isofficial client

### DIFF
--- a/api/client/search.go
+++ b/api/client/search.go
@@ -22,6 +22,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	cmd := Cli.Subcmd("search", []string{"TERM"}, Cli.DockerCommands["search"].Description, true)
 	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Don't truncate output")
 	automated := cmd.Bool([]string{"-automated"}, false, "Only show automated builds")
+	official := cmd.Bool([]string{"-official"}, false, "Only show official images")
 	stars := cmd.Uint([]string{"s", "-stars"}, 0, "Only displays with at least x stars")
 	cmd.Require(flag.Exact, 1)
 
@@ -61,6 +62,9 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
 	for _, res := range results {
 		if (*automated && !res.IsAutomated) || (int(*stars) > res.StarCount) {
+			continue
+		}
+		if *official && !res.IsOfficial {
 			continue
 		}
 		desc := strings.Replace(res.Description, "\n", " ", -1)

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -17,6 +17,7 @@ parent = "smn_cli"
       --automated          Only show automated builds
       --help               Print usage
       --no-trunc           Don't truncate output
+      --official           Only show official builds
       -s, --stars=0        Only displays with at least x stars
 
 Search [Docker Hub](https://hub.docker.com) for images


### PR DESCRIPTION
Adds --official as in issue https://github.com/docker/docker/issues/18980

Signed-off-by: Fabrizio Soppelsa fsoppelsa@mirantis.com

```
make test
...
ok      github.com/docker/docker/api    0.006s  coverage: 92.5% of statements
ok      github.com/docker/docker/api/client 0.007s  coverage: 1.3% of statements
ok      github.com/docker/docker/api/client/formatter   0.007s  coverage: 99.4% of statements
ok      github.com/docker/docker/api/client/inspect 0.002s  coverage: 92.7% of statements
ok      github.com/docker/docker/api/server 0.048s  coverage: 10.8% of statements
ok      github.com/docker/docker/api/server/httputils   0.004s  coverage: 19.5% of statements
?       github.com/docker/docker/api/server/router  [no test files]
?       github.com/docker/docker/api/server/router/build    [no test files]
?       github.com/docker/docker/api/server/router/container    [no test files]
?       github.com/docker/docker/api/server/router/local    [no test files]
?       github.com/docker/docker/api/server/router/network  [no test files]
?       github.com/docker/docker/api/server/router/system   [no test files]
?       github.com/docker/docker/api/server/router/volume   [no test files]
```
