### PR TITLE
Revert PR 19790 (breaks windowsTP4 CI on cache bust)

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/symlink"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
 	containertypes "github.com/docker/engine-api/types/container"
@@ -182,34 +181,6 @@ func (container *Container) WriteHostConfig() error {
 	defer f.Close()
 
 	return json.NewEncoder(f).Encode(&container.HostConfig)
-}
-
-// SetupWorkingDirectory sets up the container's working directory as set in container.Config.WorkingDir
-func (container *Container) SetupWorkingDirectory() error {
-	if container.Config.WorkingDir == "" {
-		return nil
-	}
-	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
-
-	pth, err := container.GetResourcePath(container.Config.WorkingDir)
-	if err != nil {
-		return err
-	}
-
-	pthInfo, err := os.Stat(pth)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-
-		if err := system.MkdirAll(pth, 0755); err != nil {
-			return err
-		}
-	}
-	if pthInfo != nil && !pthInfo.IsDir() {
-		return derr.ErrorCodeNotADir.WithArgs(container.Config.WorkingDir)
-	}
-	return nil
 }
 
 // GetResourcePath evaluates `path` in the scope of the container's BaseFS, with proper path

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -22,6 +22,12 @@ func (container *Container) CreateDaemonEnvironment(linkedEnv []string) []string
 	return container.Config.Env
 }
 
+// SetupWorkingDirectory initializes the container working directory.
+// This is a NOOP In windows.
+func (container *Container) SetupWorkingDirectory() error {
+	return nil
+}
+
 // UnmountIpcMounts unmount Ipc related mounts.
 // This is a NOOP on windows.
 func (container *Container) UnmountIpcMounts(unmount func(pth string) error) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1724,7 +1724,7 @@ func (s *DockerSuite) TestRunWorkdirExistsAndIsFile(c *check.C) {
 	expected := "Cannot mkdir: /bin/cat is not a directory"
 	if daemonPlatform == "windows" {
 		existingFile = `\windows\system32\ntdll.dll`
-		expected = `Cannot mkdir: \windows\system32\ntdll.dll is not a directory.`
+		expected = "The directory name is invalid"
 	}
 
 	out, exitCode, err := dockerCmdWithError("run", "-w", existingFile, "busybox")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Revert "Combine SetupWorkingDirectory for Linux and Windows"

This reverts commit ec31741ca186278ea60faf49f85087c493e78806.

@darrenstahlmsft @swernli @tiborvass @vdemeester @thaJeztah . Ugh, #19790 has broken the ability to docker build if a RUN statement follows a WORKDIR statement. This has the consequence of breaking windowsTP4 CI if the cache is bust (such as it is on a couple of machines following the test of moving to GOLang 1.6RC1). I'll work with @darrenstahlmsft to get the right fix in on Monday. In the meantime, #19814 should not be merged.
