### PR TITLE
Windows CI: TP4 reliability retry hack

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -74,6 +74,12 @@ func init() {
 				windowsDaemonKV, _ = strconv.Atoi(strings.Split(server.KernelVersion, " ")[1])
 			}
 		}
+		// Hack for Windows TP4 to ensure we retry dockerCmd if we get the intermittent known return
+		// "HCSShim::CreateComputeSystem - Win32 API call returned error r1=2147746291 err=Invalid class string"
+		// This bug is fixed in TP5 builds.
+		if windowsDaemonKV < 14250 {
+			integration.EnableWindowsRetryHack()
+		}
 	}
 
 	// Now we know the daemon platform, can set paths used by tests.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@mikedougherty @jfrazelle @icecrime @powersplay @friism

I loathe this patch with a vengence :imp:!!! But, needs must as the `windowsTP4` jenkins context will be with us for a little while. There is a (networking) bug in TP4 Windows where calls into HCS can return intermittently with `HCSShim::CreateComputeSystem - Win32 API call returned error r1=2147746291 err=Invalid class string`. I've seen multiple `windowsTP4` runs failing tests with that error. 

This PR makes Windows TP4 builds retry `RunCommandWithOutput` which is the predominant end point of `dockerCmd` in integration tests. Note I haven't as yet applied retry logic to the other `RunCommand...` calls as they are much less frequent in the test code. If I see more unreliability attributed to this, I'll follow up with a future PR to fix that too.

Obviously the intention is to remove this for TP5. @runcom - This also explains the false negative in one of your PRs I noticed and commented on. Can't recall the PR number though :smile:

Here's one example of a `windowsTP4` failure which this PR hopes to address: https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP4/401/console
