### PR TITLE
Vendoring libnetwork 0.6.0-rc6

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -27,7 +27,7 @@ clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.6.0-rc5
+clone git github.com/docker/libnetwork v0.6.0-rc6
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.0-rc6 (2016-01-30)
+- Properly fixes https://github.com/docker/docker/issues/18814
+
 ## 0.6.0-rc5 (2016-01-26)
 - Cleanup stale overlay sandboxes
 

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_endpoint.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netutils"
+	"github.com/vishvananda/netlink"
 )
 
 type endpointTable map[string]*endpoint
@@ -97,6 +99,20 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	}
 
 	n.deleteEndpoint(eid)
+
+	if ep.ifName == "" {
+		return nil
+	}
+
+	link, err := netlink.LinkByName(ep.ifName)
+	if err != nil {
+		log.Debugf("Failed to retrieve interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+		return nil
+	}
+	if err := netlink.LinkDel(link); err != nil {
+		log.Debugf("Failed to delete interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+	}
+
 	return nil
 }
 

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -160,7 +160,9 @@ func (n *network) destroySandbox() {
 	sbox := n.sandbox()
 	if sbox != nil {
 		for _, iface := range sbox.Info().Interfaces() {
-			iface.Remove()
+			if err := iface.Remove(); err != nil {
+				logrus.Debugf("Remove interface %s failed: %v", iface.SrcName(), err)
+			}
 		}
 
 		for _, s := range n.subnets {

--- a/vendor/src/github.com/docker/libnetwork/osl/interface_linux.go
+++ b/vendor/src/github.com/docker/libnetwork/osl/interface_linux.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"syscall"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
@@ -127,7 +128,7 @@ func (i *nwIface) Remove() error {
 
 		err = netlink.LinkSetName(iface, i.SrcName())
 		if err != nil {
-			fmt.Println("LinkSetName failed: ", err)
+			log.Debugf("LinkSetName failed for interface %s: %v", i.SrcName(), err)
 			return err
 		}
 
@@ -139,7 +140,7 @@ func (i *nwIface) Remove() error {
 		} else if !isDefault {
 			// Move the network interface to caller namespace.
 			if err := netlink.LinkSetNsFd(iface, callerFD); err != nil {
-				fmt.Println("LinkSetNsPid failed: ", err)
+				log.Debugf("LinkSetNsPid failed for interface %s: %v", i.SrcName(), err)
 				return err
 			}
 		}

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -589,7 +589,7 @@ func releaseOSSboxResources(osSbox osl.Sandbox, ep *endpoint) {
 		// Only remove the interfaces owned by this endpoint from the sandbox.
 		if ep.hasInterface(i.SrcName()) {
 			if err := i.Remove(); err != nil {
-				log.Debugf("Remove interface failed: %v", err)
+				log.Debugf("Remove interface %s failed: %v", i.SrcName(), err)
 			}
 		}
 	}


### PR DESCRIPTION
- Move the delete veth operation from endpoint leave to endpoint delete in overlay driver
- Add some logs

This is the correct fix for #18814
Fixes #19884 

Signed-off-by: Alessandro Boch aboch@docker.com
