### PR TITLE
docs: point out known issue with nginx/vboxfs

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -384,6 +384,10 @@ The next exercise demonstrates how to do this.
         $ docker stop mysite
         $ docker rm mysite
 
+> **Note**: There is a [known
+> issue](https://docs.docker.com/machine/drivers/virtualbox/#known-issues) that
+> may cause files shared with your nginx container to not update correctly as you
+> modify them on your host.
 
 ## Upgrade Docker Toolbox
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -345,6 +345,11 @@ reported to you using:
 Typically, the IP is 192.168.59.103, but it could get changed by VirtualBox's
 DHCP implementation.
 
+> **Note**: There is a [known
+> issue](https://docs.docker.com/machine/drivers/virtualbox/#known-issues) that
+> may cause files shared with your nginx container to not update correctly as you
+> modify them on your host.
+
 ## Login with PUTTY instead of using the CMD
 
 Docker Machine generates and uses the public/private key pair in your


### PR DESCRIPTION
see https://github.com/docker/docker/issues/18666

Signed-off-by: Felix Geisendörfer felix@debuggable.com

https://github.com/docker/docker/issues/18666 should be closed after this. I was also going to make this change to the windows docs, but realized they don't include the same example, so I just updated the mac version.
