### PR TITLE
Make mqueue container specific

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -559,18 +559,6 @@ func (container *Container) UnmountIpcMounts(unmount func(pth string) error) {
 		}
 	}
 
-	if !container.HasMountFor("/dev/mqueue") {
-		mqueuePath, err := container.MqueueResourcePath()
-		if err != nil {
-			logrus.Error(err)
-			warnings = append(warnings, err.Error())
-		} else if mqueuePath != "" {
-			if err := unmount(mqueuePath); err != nil {
-				warnings = append(warnings, fmt.Sprintf("failed to umount %s: %v", mqueuePath, err))
-			}
-		}
-	}
-
 	if len(warnings) > 0 {
 		logrus.Warnf("failed to cleanup ipc mounts:\n%v", strings.Join(warnings, "\n"))
 	}
@@ -589,9 +577,8 @@ func (container *Container) IpcMounts() []execdriver.Mount {
 			Propagation: volume.DefaultPropagationMode,
 		})
 	}
-
-	if !container.HasMountFor("/dev/mqueue") {
-		label.SetFileLabel(container.MqueuePath, container.MountLabel)
+	if !container.HasMountFor("/dev/mqueue") &&
+		container.MqueuePath != "" {
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.MqueuePath,
 			Destination: "/dev/mqueue",

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -93,11 +93,6 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		return err
 	}
 
-	c.MqueuePath, err = c.MqueueResourcePath()
-	if err != nil {
-		return err
-	}
-
 	if c.HostConfig.IpcMode.IsContainer() {
 		ic, err := daemon.getIpcContainer(c)
 		if err != nil {
@@ -105,7 +100,6 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		}
 		ipc.ContainerID = ic.ID
 		c.ShmPath = ic.ShmPath
-		c.MqueuePath = ic.MqueuePath
 	} else {
 		ipc.HostIpc = c.HostConfig.IpcMode.IsHost()
 		if ipc.HostIpc {
@@ -1059,21 +1053,6 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 		}
 		if err := os.Chown(shmPath, rootUID, rootGID); err != nil {
 			return err
-		}
-	}
-
-	if !c.HasMountFor("/dev/mqueue") {
-		mqueuePath, err := c.MqueueResourcePath()
-		if err != nil {
-			return err
-		}
-
-		if err := idtools.MkdirAllAs(mqueuePath, 0700, rootUID, rootGID); err != nil {
-			return err
-		}
-
-		if err := syscall.Mount("mqueue", mqueuePath, "mqueue", uintptr(syscall.MS_NOEXEC|syscall.MS_NOSUID|syscall.MS_NODEV), ""); err != nil {
-			return fmt.Errorf("mounting mqueue mqueue : %s", err)
 		}
 	}
 

--- a/daemon/execdriver/native/template/default_template_linux.go
+++ b/daemon/execdriver/native/template/default_template_linux.go
@@ -65,6 +65,12 @@ func New() *configs.Config {
 				Data:        "newinstance,ptmxmode=0666,mode=0620,gid=5",
 			},
 			{
+				Source:      "mqueue",
+				Destination: "/dev/mqueue",
+				Device:      "mqueue",
+				Flags:       defaultMountFlags,
+			},
+			{
 				Source:      "sysfs",
 				Destination: "/sys",
 				Device:      "sysfs",


### PR DESCRIPTION
mqueue can not be mounted on the host os and then shared into the container.
There is only one mqueue per mount namespace, so current code ends up leaking
the /dev/mqueue from the host into ALL containers.  Since SELinux changes the
label of the mqueue, only the last container is able to use the mqueue, all
other containers will get a permission denied.  If you don't have SELinux protections
sharing of the /dev/mqueue allows one container to interact in potentially hostile
ways with other containers.

Signed-off-by: Dan Walsh dwalsh@redhat.com
