### PR TITLE
Fix integration-cli suite setup requirements

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -48,7 +48,7 @@ type DockerRegistrySuite struct {
 }
 
 func (s *DockerRegistrySuite) SetUpTest(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, RegistryHosting)
 	s.reg = setupRegistry(c, false, false)
 	s.d = NewDaemon(c)
 }
@@ -76,7 +76,7 @@ type DockerSchema1RegistrySuite struct {
 }
 
 func (s *DockerSchema1RegistrySuite) SetUpTest(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, RegistryHosting)
 	s.reg = setupRegistry(c, true, false)
 	s.d = NewDaemon(c)
 }
@@ -104,7 +104,7 @@ type DockerRegistryAuthSuite struct {
 }
 
 func (s *DockerRegistryAuthSuite) SetUpTest(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, RegistryHosting)
 	s.reg = setupRegistry(c, false, true)
 	s.d = NewDaemon(c)
 }
@@ -158,6 +158,7 @@ type DockerTrustSuite struct {
 }
 
 func (s *DockerTrustSuite) SetUpTest(c *check.C) {
+	testRequires(c, RegistryHosting, NotaryHosting)
 	s.reg = setupRegistry(c, false, false)
 	s.not = setupNotary(c)
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1573,7 +1573,6 @@ func daemonTime(c *check.C) time.Time {
 }
 
 func setupRegistry(c *check.C, schema1, auth bool) *testRegistryV2 {
-	testRequires(c, RegistryHosting)
 	reg, err := newTestRegistryV2(c, schema1, auth)
 	c.Assert(err, check.IsNil)
 
@@ -1590,7 +1589,6 @@ func setupRegistry(c *check.C, schema1, auth bool) *testRegistryV2 {
 }
 
 func setupNotary(c *check.C) *testNotary {
-	testRequires(c, NotaryHosting)
 	ts, err := newTestNotary(c)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
Moves the testRequires check from within setupRegistry
and setupNotary to when the Suite itself starts up.

This fixes a bug where testRequires in setupRegistry would
succeed and start registry, but testRequires in setupNotary
would fail. This immediately exits the goroutine with registry
still running.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
