### PR TITLE
Wait to fire start event until socket is created

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -46,15 +46,23 @@ end script
 # See https://github.com/docker/docker/issues/6647
 post-start script
 	DOCKER_OPTS=
+	DOCKER_SOCKET=
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
+
 	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
-		while ! [ -e /var/run/docker.sock ]; do
+		DOCKER_SOCKET=/var/run/docker.sock
+	else
+		DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)')
+	fi
+
+	if [ -n "$DOCKER_SOCKET" ]; then
+		while ! [ -e "$DOCKER_SOCKET" ]; do
 			initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
-			echo "Waiting for /var/run/docker.sock"
+			echo "Waiting for $DOCKER_SOCKET"
 			sleep 0.1
 		done
-		echo "/var/run/docker.sock is up"
+		echo "$DOCKER_SOCKET is up"
 	fi
 end script


### PR DESCRIPTION
Previously, this check only worked if no host was specified and was
hard coded to check for "/var/run/docker.sock"

This change generalizes that check and captures any specified socket
and waits for it to be created.

Caveat: This will only check the first socket specified, but it is an
improvement over none at all.

Fixes #18516

Signed-off-by: Andrew Guenther guenther.andrew.j@gmail.com
