### PR TITLE
Close input stream as soon as the output is closed.

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -19,6 +19,9 @@ func (cli *DockerCli) holdHijackedConnection(tty bool, inputStream io.ReadCloser
 			} else {
 				_, err = stdcopy.StdCopy(outputStream, errorStream, resp.Reader)
 			}
+			if inputStream != nil {
+				inputStream.Close()
+			}
 			logrus.Debugf("[hijack] End of stdout")
 			receiveStdout <- err
 		}()


### PR DESCRIPTION
That way remote connections don't need an extra signal to exit.

Fixes #19888.

Signed-off-by: David Calavera david.calavera@gmail.com
