### PR TITLE
Make error message consistent when removing containers fail.

### DIFF
--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -28,21 +28,27 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 		}
 		name = strings.Trim(name, "/")
 
-		options := types.ContainerRemoveOptions{
-			ContainerID:   name,
-			RemoveVolumes: *v,
-			RemoveLinks:   *link,
-			Force:         *force,
-		}
-
-		if err := cli.client.ContainerRemove(options); err != nil {
-			errs = append(errs, fmt.Sprintf("Failed to remove container (%s): %s", name, err))
+		if err := cli.removeContainer(name, *v, *link, *force); err != nil {
+			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)
 		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func (cli *DockerCli) removeContainer(containerID string, removeVolumes, removeLinks, force bool) error {
+	options := types.ContainerRemoveOptions{
+		ContainerID:   containerID,
+		RemoveVolumes: removeVolumes,
+		RemoveLinks:   removeLinks,
+		Force:         force,
+	}
+	if err := cli.client.ContainerRemove(options); err != nil {
+		return fmt.Errorf("Failed to remove container (%s): %v", containerID, err)
 	}
 	return nil
 }

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -218,17 +218,13 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		})
 	}
 
-	defer func() {
-		if *flAutoRemove {
-			options := types.ContainerRemoveOptions{
-				ContainerID:   createResponse.ID,
-				RemoveVolumes: true,
+	if *flAutoRemove {
+		defer func() {
+			if err := cli.removeContainer(createResponse.ID, true, false, false); err != nil {
+				fmt.Fprintf(cli.err, "%v\n", err)
 			}
-			if err := cli.client.ContainerRemove(options); err != nil {
-				fmt.Fprintf(cli.err, "Error deleting container: %s\n", err)
-			}
-		}
-	}()
+		}()
+	}
 
 	//start the container
 	if err := cli.client.ContainerStart(createResponse.ID); err != nil {


### PR DESCRIPTION
`docker rm ...` and `docker run --rm ...` display different messages if removing a container fails.
This makes both commands to return the same message:

```
Failed to remove container (CONTAINER_ID): ERROR
```

Signed-off-by: David Calavera david.calavera@gmail.com
