### PR TITLE
Update docker-php link library from stage1

### DIFF
--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -187,7 +187,7 @@ will add the libraries here.
     <tr>
       <td>PHP</td>
       <td>Docker-PHP</td>
-      <td><a class="reference external" href="http://stage1.github.io/docker-php/">http://stage1.github.io/docker-php/</a></td>
+      <td><a class="reference external" href="https://github.com/docker-php/docker-php">https://github.com/docker-php/docker-php</a></td>
       <td>Active</td>
     </tr>
     <tr>


### PR DESCRIPTION
Stage1 library has moved to a new repo and the github pages site no longer exist.
