### PR TITLE
Windows: Add support for named pipe protocol

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -176,12 +176,7 @@ func getServerHost(hosts []string, tlsOptions *tlsconfig.Options) (host string, 
 		return "", errors.New("Please specify only one -H")
 	}
 
-	defaultHost := opts.DefaultTCPHost
-	if tlsOptions != nil {
-		defaultHost = opts.DefaultTLSHost
-	}
-
-	host, err = opts.ParseHost(defaultHost, host)
+	host, err = opts.ParseHost(tlsOptions != nil, host)
 	return
 }
 

--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -4,8 +4,11 @@ package server
 
 import (
 	"errors"
+	"fmt"
+	"github.com/Microsoft/go-winio"
 	"net"
 	"net/http"
+	"strings"
 )
 
 // NewServer sets up the required Server and does protocol specific checking.
@@ -21,8 +24,26 @@ func (s *Server) newServer(proto, addr string) ([]*HTTPServer, error) {
 		}
 		ls = append(ls, l)
 
+	case "npipe":
+		// allow Administrators and SYSTEM, plus whatever additional users or groups were specified
+		sddl := "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
+		if s.cfg.SocketGroup != "" {
+			for _, g := range strings.Split(s.cfg.SocketGroup, ",") {
+				sid, err := winio.LookupSidByName(g)
+				if err != nil {
+					return nil, err
+				}
+				sddl += fmt.Sprintf("(A;;GRGW;;;%s)", sid)
+			}
+		}
+		l, err := winio.ListenPipe(addr, sddl)
+		if err != nil {
+			return nil, err
+		}
+		ls = append(ls, l)
+
 	default:
-		return nil, errors.New("Invalid protocol format. Windows only supports tcp.")
+		return nil, errors.New("Invalid protocol format. Windows only supports tcp and npipe.")
 	}
 
 	var res []*HTTPServer

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -59,6 +59,7 @@ type CommonConfig struct {
 	Pidfile              string              `json:"pidfile,omitempty"`
 	RawLogs              bool                `json:"raw-logs,omitempty"`
 	Root                 string              `json:"graph,omitempty"`
+	SocketGroup          string              `json:"group,omitempty"`
 	TrustKeyPath         string              `json:"-"`
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -29,7 +29,6 @@ type Config struct {
 	EnableCors           bool                     `json:"api-enable-cors,omitempty"`
 	EnableSelinuxSupport bool                     `json:"selinux-enabled,omitempty"`
 	RemappedRoot         string                   `json:"userns-remap,omitempty"`
-	SocketGroup          string                   `json:"group,omitempty"`
 	CgroupParent         string                   `json:"cgroup-parent,omitempty"`
 	Ulimits              map[string]*units.Ulimit `json:"default-ulimits,omitempty"`
 }

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -38,4 +38,5 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 
 	// Then platform-specific install flags.
 	cmd.StringVar(&config.bridgeConfig.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
+	cmd.StringVar(&config.SocketGroup, []string{"G", "-group"}, "", usageFn("Users or groups that can access the named pipe"))
 }

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -200,11 +200,11 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 	serverConfig := &apiserver.Config{
 		AuthorizationPluginNames: cli.Config.AuthorizationPlugins,
 		Logging:                  true,
+		SocketGroup:              cli.Config.SocketGroup,
 		Version:                  dockerversion.Version,
 	}
 	serverConfig = setPlatformServerConfig(serverConfig, cli.Config)
 
-	defaultHost := opts.DefaultHost
 	if cli.Config.TLS {
 		tlsOptions := tlsconfig.Options{
 			CAFile:   cli.Config.CommonTLSOptions.CAFile,
@@ -221,7 +221,6 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 			logrus.Fatal(err)
 		}
 		serverConfig.TLSConfig = tlsConfig
-		defaultHost = opts.DefaultTLSHost
 	}
 
 	if len(cli.Config.Hosts) == 0 {
@@ -229,7 +228,7 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 	}
 	for i := 0; i < len(cli.Config.Hosts); i++ {
 		var err error
-		if cli.Config.Hosts[i], err = opts.ParseHost(defaultHost, cli.Config.Hosts[i]); err != nil {
+		if cli.Config.Hosts[i], err = opts.ParseHost(cli.Config.TLS, cli.Config.Hosts[i]); err != nil {
 			logrus.Fatalf("error parsing -H %s : %v", cli.Config.Hosts[i], err)
 		}
 

--- a/docker/daemon_unix.go
+++ b/docker/daemon_unix.go
@@ -19,7 +19,6 @@ import (
 const defaultDaemonConfigFile = "/etc/docker/daemon.json"
 
 func setPlatformServerConfig(serverConfig *apiserver.Config, daemonCfg *daemon.Config) *apiserver.Config {
-	serverConfig.SocketGroup = daemonCfg.SocketGroup
 	serverConfig.EnableCors = daemonCfg.EnableCors
 	serverConfig.CorsHeaders = daemonCfg.CorsHeaders
 

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -1,7 +1,7 @@
 package opts
 
 import (
-	"runtime"
+	"fmt"
 	"testing"
 )
 
@@ -15,51 +15,41 @@ func TestParseHost(t *testing.T) {
 		"tcp://invalid":      "Invalid bind address format: invalid",
 		"tcp://invalid:port": "Invalid bind address format: invalid:port",
 	}
-	const defaultHTTPHost = "tcp://127.0.0.1:2375"
-	var defaultHOST = "unix:///var/run/docker.sock"
-
-	if runtime.GOOS == "windows" {
-		defaultHOST = defaultHTTPHost
-	}
 	valid := map[string]string{
-		"":                         defaultHOST,
+		"":                         DefaultHost,
+		" ":                        DefaultHost,
+		"  ":                       DefaultHost,
 		"fd://":                    "fd://",
 		"fd://something":           "fd://something",
-		"tcp://host:":              "tcp://host:2375",
-		"tcp://":                   "tcp://localhost:2375",
-		"tcp://:2375":              "tcp://localhost:2375", // default ip address
-		"tcp://:2376":              "tcp://localhost:2376", // default ip address
+		"tcp://host:":              fmt.Sprintf("tcp://host:%d", DefaultHTTPPort),
+		"tcp://":                   DefaultTCPHost,
+		"tcp://:2375":              fmt.Sprintf("tcp://%s:2375", DefaultHTTPHost),
+		"tcp://:2376":              fmt.Sprintf("tcp://%s:2376", DefaultHTTPHost),
 		"tcp://0.0.0.0:8080":       "tcp://0.0.0.0:8080",
 		"tcp://192.168.0.0:12000":  "tcp://192.168.0.0:12000",
 		"tcp://192.168:8080":       "tcp://192.168:8080",
 		"tcp://0.0.0.0:1234567890": "tcp://0.0.0.0:1234567890", // yeah it's valid :P
+		" tcp://:7777/path ":       fmt.Sprintf("tcp://%s:7777/path", DefaultHTTPHost),
 		"tcp://docker.com:2375":    "tcp://docker.com:2375",
-		"unix://":                  "unix:///var/run/docker.sock", // default unix:// value
+		"unix://":                  "unix://" + DefaultUnixSocket,
 		"unix://path/to/socket":    "unix://path/to/socket",
+		"npipe://":                 "npipe://" + DefaultNamedPipe,
+		"npipe:////./pipe/foo":     "npipe:////./pipe/foo",
 	}
 
 	for value, errorMessage := range invalid {
-		if _, err := ParseHost(defaultHTTPHost, value); err == nil || err.Error() != errorMessage {
-			t.Fatalf("Expected an error for %v with [%v], got [%v]", value, errorMessage, err)
+		if _, err := ParseHost(false, value); err == nil || err.Error() != errorMessage {
+			t.Errorf("Expected an error for %v with [%v], got [%v]", value, errorMessage, err)
 		}
 	}
 	for value, expected := range valid {
-		if actual, err := ParseHost(defaultHTTPHost, value); err != nil || actual != expected {
-			t.Fatalf("Expected for %v [%v], got [%v, %v]", value, expected, actual, err)
+		if actual, err := ParseHost(false, value); err != nil || actual != expected {
+			t.Errorf("Expected for %v [%v], got [%v, %v]", value, expected, actual, err)
 		}
 	}
 }
 
 func TestParseDockerDaemonHost(t *testing.T) {
-	var (
-		defaultHTTPHost  = "tcp://localhost:2375"
-		defaultHTTPSHost = "tcp://localhost:2376"
-		defaultUnix      = "/var/run/docker.sock"
-		defaultHOST      = "unix:///var/run/docker.sock"
-	)
-	if runtime.GOOS == "windows" {
-		defaultHOST = defaultHTTPHost
-	}
 	invalids := map[string]string{
 		"0.0.0.0":                       "Invalid bind address format: 0.0.0.0",
 		"tcp:a.b.c.d":                   "Invalid bind address format: tcp:a.b.c.d",
@@ -67,9 +57,11 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"udp://127.0.0.1":               "Invalid bind address format: udp://127.0.0.1",
 		"udp://127.0.0.1:2375":          "Invalid bind address format: udp://127.0.0.1:2375",
 		"tcp://unix:///run/docker.sock": "Invalid bind address format: unix",
-		"tcp":  "Invalid bind address format: tcp",
-		"unix": "Invalid bind address format: unix",
-		"fd":   "Invalid bind address format: fd",
+		" tcp://:7777/path ":            "Invalid bind address format:  tcp://:7777/path ",
+		"tcp":                           "Invalid bind address format: tcp",
+		"unix":                          "Invalid bind address format: unix",
+		"fd":                            "Invalid bind address format: fd",
+		"":                              "Invalid bind address format: ",
 	}
 	valids := map[string]string{
 		"0.0.0.1:":                    "tcp://0.0.0.1:2375",
@@ -79,17 +71,13 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"[::1]:5555/path":             "tcp://[::1]:5555/path",
 		"[0:0:0:0:0:0:0:1]:":          "tcp://[0:0:0:0:0:0:0:1]:2375",
 		"[0:0:0:0:0:0:0:1]:5555/path": "tcp://[0:0:0:0:0:0:0:1]:5555/path",
-		":6666":                   "tcp://localhost:6666",
-		":6666/path":              "tcp://localhost:6666/path",
-		"":                        defaultHOST,
-		" ":                       defaultHOST,
-		"  ":                      defaultHOST,
-		"tcp://":                  defaultHTTPHost,
-		"tcp://:7777":             "tcp://localhost:7777",
-		"tcp://:7777/path":        "tcp://localhost:7777/path",
-		" tcp://:7777/path ":      "tcp://localhost:7777/path",
+		":6666":                   fmt.Sprintf("tcp://%s:6666", DefaultHTTPHost),
+		":6666/path":              fmt.Sprintf("tcp://%s:6666/path", DefaultHTTPHost),
+		"tcp://":                  DefaultTCPHost,
+		"tcp://:7777":             fmt.Sprintf("tcp://%s:7777", DefaultHTTPHost),
+		"tcp://:7777/path":        fmt.Sprintf("tcp://%s:7777/path", DefaultHTTPHost),
 		"unix:///run/docker.sock": "unix:///run/docker.sock",
-		"unix://":                 "unix:///var/run/docker.sock",
+		"unix://":                 "unix://" + DefaultUnixSocket,
 		"fd://":                   "fd://",
 		"fd://something":          "fd://something",
 		"localhost:":              "tcp://localhost:2375",
@@ -97,12 +85,12 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"localhost:5555/path":     "tcp://localhost:5555/path",
 	}
 	for invalidAddr, expectedError := range invalids {
-		if addr, err := parseDockerDaemonHost(defaultHTTPHost, defaultHTTPSHost, defaultUnix, "", invalidAddr); err == nil || err.Error() != expectedError {
+		if addr, err := parseDockerDaemonHost(invalidAddr); err == nil || err.Error() != expectedError {
 			t.Errorf("tcp %v address expected error %v return, got %s and addr %v", invalidAddr, expectedError, err, addr)
 		}
 	}
 	for validAddr, expectedAddr := range valids {
-		if addr, err := parseDockerDaemonHost(defaultHTTPHost, defaultHTTPSHost, defaultUnix, "", validAddr); err != nil || addr != expectedAddr {
+		if addr, err := parseDockerDaemonHost(validAddr); err != nil || addr != expectedAddr {
 			t.Errorf("%v -> expected %v, got (%v) addr (%v)", validAddr, expectedAddr, err, addr)
 		}
 	}
@@ -152,13 +140,13 @@ func TestParseTCP(t *testing.T) {
 }
 
 func TestParseInvalidUnixAddrInvalid(t *testing.T) {
-	if _, err := parseUnixAddr("tcp://127.0.0.1", "unix:///var/run/docker.sock"); err == nil || err.Error() != "Invalid proto, expected unix: tcp://127.0.0.1" {
+	if _, err := parseSimpleProtoAddr("unix", "tcp://127.0.0.1", "unix:///var/run/docker.sock"); err == nil || err.Error() != "Invalid proto, expected unix: tcp://127.0.0.1" {
 		t.Fatalf("Expected an error, got %v", err)
 	}
-	if _, err := parseUnixAddr("unix://tcp://127.0.0.1", "/var/run/docker.sock"); err == nil || err.Error() != "Invalid proto, expected unix: tcp://127.0.0.1" {
+	if _, err := parseSimpleProtoAddr("unix", "unix://tcp://127.0.0.1", "/var/run/docker.sock"); err == nil || err.Error() != "Invalid proto, expected unix: tcp://127.0.0.1" {
 		t.Fatalf("Expected an error, got %v", err)
 	}
-	if v, err := parseUnixAddr("", "/var/run/docker.sock"); err != nil || v != "unix:///var/run/docker.sock" {
+	if v, err := parseSimpleProtoAddr("unix", "", "/var/run/docker.sock"); err != nil || v != "unix:///var/run/docker.sock" {
 		t.Fatalf("Expected an %v, got %v", v, "unix:///var/run/docker.sock")
 	}
 }


### PR DESCRIPTION
This adds an npipe protocol option for Windows hosts, akin to unix
sockets for Linux hosts. This should become the default transport
for Windows, but this change does not yet do that.

It also does not add support for the client side yet since that
code is in engine-api, which will have to be revendored separately.

Signed-off-by: John Starks jostarks@microsoft.com
