### PR TITLE
Correct old virtual size

### DIFF
--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -46,7 +46,7 @@ created.  Supported `Dockerfile` instructions:
     $ docker commit c3f279d17e0a  svendowideit/testimage:version3
     f5283438590d
     $ docker images
-    REPOSITORY                        TAG                 ID                  CREATED             VIRTUAL SIZE
+    REPOSITORY                        TAG                 ID                  CREATED             SIZE
     svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
 
 ## Commit a container with new configurations

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -22,25 +22,25 @@ parent = "smn_cli"
       -q, --quiet          Only show numeric IDs
 
 The default `docker images` will show all top level
-images, their repository and tags, and their virtual size.
+images, their repository and tags, and their size.
 
 Docker images have intermediate layers that increase reusability,
 decrease disk usage, and speed up `docker build` by
 allowing each step to be cached. These intermediate layers are not shown
 by default.
 
-The `VIRTUAL SIZE` is the cumulative space taken up by the image and all
+The `SIZE` is the cumulative space taken up by the image and all
 its parent images. This is also the disk space used by the contents of the
 Tar file created when you `docker save` an image.
 
 An image will be listed more than once if it has multiple repository names
 or tags. This single image (identifiable by its matching `IMAGE ID`)
-uses up the `VIRTUAL SIZE` listed only once.
+uses up the `SIZE` listed only once.
 
 ### Listing the most recently created images
 
     $ docker images
-    REPOSITORY                TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
     <none>                    <none>              77af4d6b9913        19 hours ago        1.089 GB
     committ                   latest              b6fa739cedf5        19 hours ago        1.089 GB
     <none>                    <none>              78a85c484f71        19 hours ago        1.089 GB
@@ -61,7 +61,7 @@ given repository.
 For example, to list all images in the "java" repository, run this command :
 
     $ docker images java
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     java                8                   308e519aac60        6 days ago          824.5 MB
     java                7                   493d82594c15        3 months ago        656.3 MB
     java                latest              2711b1d6f3aa        5 months ago        603.9 MB
@@ -74,18 +74,18 @@ repository and tag are listed.  To find all local images in the "java"
 repository with tag "8" you can use:
 
     $ docker images java:8
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     java                8                   308e519aac60        6 days ago          824.5 MB
 
 If nothing matches `REPOSITORY[:TAG]`, the list is empty.
 
     $ docker images java:0
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 
 ## Listing the full length image IDs
 
     $ docker images --no-trunc
-    REPOSITORY                    TAG                 IMAGE ID                                                           CREATED             VIRTUAL SIZE
+    REPOSITORY                    TAG                 IMAGE ID                                                           CREATED             SIZE
     <none>                        <none>              77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182   19 hours ago        1.089 GB
     committest                    latest              b6fa739cedf5ea12a620a439402b6004d057da800f91c7524b5086a5e4749c9f   19 hours ago        1.089 GB
     <none>                        <none>              78a85c484f71509adeaace20e72e941f6bdd2b25b4c75da8693efd9f61a37921   19 hours ago        1.089 GB
@@ -104,7 +104,7 @@ unchanged, the digest value is predictable. To list image digest values, use
 the `--digests` flag:
 
     $ docker images --digests
-    REPOSITORY                         TAG                 DIGEST                                                                    IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY                         TAG                 DIGEST                                                                    IMAGE ID            CREATED             SIZE
     localhost:5000/test/busybox        <none>              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536        9 weeks ago         2.43 MB
 
 When pushing or pulling to a 2.0 registry, the `push` or `pull` command
@@ -126,7 +126,7 @@ The currently supported filters are:
 
     $ docker images --filter "dangling=true"
 
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     <none>              <none>              8abc22fbb042        4 weeks ago         0 B
     <none>              <none>              48e5f45168b9        4 weeks ago         2.489 MB
     <none>              <none>              bf747efa0e2f        4 weeks ago         0 B
@@ -163,20 +163,20 @@ The following filter matches images with the `com.example.version` label regardl
 
     $ docker images --filter "label=com.example.version"
 
-    REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
     match-me-1          latest              eeae25ada2aa        About a minute ago   188.3 MB
     match-me-2          latest              eeae25ada2aa        About a minute ago   188.3 MB
 
 The following filter matches images with the `com.example.version` label with the `1.0` value.
 
     $ docker images --filter "label=com.example.version=1.0"
-    REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
     match-me            latest              eeae25ada2aa        About a minute ago   188.3 MB
 
 In this example, with the `0.1` value, it returns an empty set because no matches were found.
 
     $ docker images --filter "label=com.example.version=0.1"
-    REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
 
 ## Formatting
 

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -21,14 +21,14 @@ Loads a tarred repository from a file or the standard input stream.
 Restores both images and tags.
 
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     $ docker load < busybox.tar.gz
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
     $ docker load --input fedora.tar
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
     fedora              rawhide             0d20aec6529d        7 weeks ago         387 MB
     fedora              20                  58394af37342        7 weeks ago         385.5 MB

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -63,7 +63,7 @@ command untags and removes all images that match the specified ID.
 An image pulled by digest has no tag associated with it:
 
     $ docker images --digests
-    REPOSITORY                     TAG       DIGEST                                                                    IMAGE ID        CREATED         VIRTUAL SIZE
+    REPOSITORY                     TAG       DIGEST                                                                    IMAGE ID        CREATED         SIZE
     localhost:5000/test/busybox    <none>    sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536    9 weeks ago     2.43 MB
 
 To remove an image using its digest:

--- a/docs/userguide/containers/dockerimages.md
+++ b/docs/userguide/containers/dockerimages.md
@@ -34,7 +34,7 @@ Let's start with listing the images you have locally on our host. You can
 do this using the `docker images` command like so:
 
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     ubuntu              14.04               1d073211c498        3 days ago          187.9 MB
     busybox             latest              2c5ac3f849df        5 days ago          1.113 MB
     training/webapp     latest              54bb4e8718e8        5 months ago        348.7 MB
@@ -214,7 +214,7 @@ You can then look at our new `ouruser/sinatra` image using the `docker images`
 command.
 
     $ docker images
-    REPOSITORY          TAG     IMAGE ID       CREATED       VIRTUAL SIZE
+    REPOSITORY          TAG     IMAGE ID       CREATED       SIZE
     training/sinatra    latest  5bc342fa0b91   10 hours ago  446.7 MB
     ouruser/sinatra     v2      3c59e02ddd1a   10 hours ago  446.7 MB
     ouruser/sinatra     latest  5db5f8471261   10 hours ago  446.7 MB
@@ -492,7 +492,7 @@ user name, the repository name and the new tag.
 Now, see your new tag using the `docker images` command.
 
     $ docker images ouruser/sinatra
-    REPOSITORY          TAG     IMAGE ID      CREATED        VIRTUAL SIZE
+    REPOSITORY          TAG     IMAGE ID      CREATED        SIZE
     ouruser/sinatra     latest  5db5f8471261  11 hours ago   446.7 MB
     ouruser/sinatra     devel   5db5f8471261  11 hours ago   446.7 MB
     ouruser/sinatra     v2      5db5f8471261  11 hours ago   446.7 MB
@@ -505,7 +505,7 @@ unchanged, the digest value is predictable. To list image digest values, use
 the `--digests` flag:
 
     $ docker images --digests | head
-    REPOSITORY        TAG      DIGEST                                                                     IMAGE ID      CREATED       VIRTUAL SIZE
+    REPOSITORY        TAG      DIGEST                                                                     IMAGE ID      CREATED       SIZE
     ouruser/sinatra   latest   sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf    5db5f8471261  11 hours ago  446.7 MB
 
 When pushing or pulling to a 2.0 registry, the `push` or `pull` command

--- a/docs/userguide/storagedriver/imagesandcontainers.md
+++ b/docs/userguide/storagedriver/imagesandcontainers.md
@@ -101,7 +101,7 @@ single 8GB general purpose SSD EBS volume. The Docker data directory
 (`/var/lib/docker`) was consuming 2GB of space.
 
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     jenkins             latest              285c9f0f9d3d        17 hours ago        708.5 MB
     mysql               latest              d39c3fa09ced        8 days ago          360.3 MB
     mongo               latest              a74137af4532        13 days ago         317.4 MB
@@ -312,7 +312,7 @@ command.
 5. Run the `docker images` command to verify the new `changed-ubuntu` image is 
 6. in the Docker host's local storage area.
 
-        REPOSITORY       TAG      IMAGE ID       CREATED           VIRTUAL SIZE
+        REPOSITORY       TAG      IMAGE ID       CREATED           SIZE
         changed-ubuntu   latest   03b964f68d06   33 seconds ago    131.4 MB
         ubuntu           15.04    013f3d01d247   6 weeks ago       131.3 MB
 

--- a/man/docker-images.1.md
+++ b/man/docker-images.1.md
@@ -70,7 +70,7 @@ To list the images in a local repository (not the registry) run:
 
 The list will contain the image repository name, a tag for the image, and an
 image ID, when it was created and its virtual size. Columns: REPOSITORY, TAG,
-IMAGE ID, CREATED, and VIRTUAL SIZE.
+IMAGE ID, CREATED, and SIZE.
 
 The `docker images` command takes an optional `[REPOSITORY[:TAG]]` argument
 that restricts the list to images that match the argument. If you specify

--- a/man/docker-load.1.md
+++ b/man/docker-load.1.md
@@ -25,11 +25,11 @@ Restores both images and tags.
 # EXAMPLES
 
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
     $ docker load --input fedora.tar
     $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
     fedora              rawhide             0d20aec6529d        7 weeks ago         387 MB
     fedora              20                  58394af37342        7 weeks ago         385.5 MB

--- a/man/docker-pull.1.md
+++ b/man/docker-pull.1.md
@@ -43,7 +43,7 @@ Note that if the  image is previously downloaded then the status would be
     Status: Downloaded newer image for fedora
 
     $ docker images
-    REPOSITORY   TAG         IMAGE ID        CREATED      VIRTUAL SIZE
+    REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
     fedora       rawhide     ad57ef8d78d7    5 days ago   359.3 MB
     fedora       20          105182bb5e8b    5 days ago   372.7 MB
     fedora       heisenbug   105182bb5e8b    5 days ago   372.7 MB
@@ -60,7 +60,7 @@ Note that if the  image is previously downloaded then the status would be
     Status: Downloaded newer image for debian:latest
     
     $ docker images
-    REPOSITORY   TAG         IMAGE ID        CREATED      VIRTUAL SIZE
+    REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
     debian       latest     4a5e6db8c069     5 days ago   125.1 MB
          
 
@@ -77,7 +77,7 @@ Note that if the  image is previously downloaded then the status would be
     Status: Downloaded newer image for registry.hub.docker.com/fedora:20
 
     $ docker images
-    REPOSITORY   TAG         IMAGE ID        CREATED      VIRTUAL SIZE
+    REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
     fedora       20          3f2fed40e4b0    4 days ago   372.7 MB
 
 


### PR DESCRIPTION
In new content addressable model, image no longer
have virtual size column, it is now 'size'. So we
need to update related docs about them.

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
