### PR TITLE
Fix docker top a restarting container

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -53,7 +53,7 @@ func (d *Daemon) getExecConfig(name string) (*exec.Config, error) {
 				return nil, derr.ErrorCodeExecPaused.WithArgs(container.ID)
 			}
 			if container.IsRestarting() {
-				return nil, derr.ErrorCodeExecRestarting.WithArgs(container.ID)
+				return nil, derr.ErrorCodeContainerRestarting.WithArgs(container.ID)
 			}
 			return ec, nil
 		}
@@ -80,7 +80,7 @@ func (d *Daemon) getActiveContainer(name string) (*container.Container, error) {
 		return nil, derr.ErrorCodeExecPaused.WithArgs(name)
 	}
 	if container.IsRestarting() {
-		return nil, derr.ErrorCodeExecRestarting.WithArgs(name)
+		return nil, derr.ErrorCodeContainerRestarting.WithArgs(name)
 	}
 	return container, nil
 }

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -30,6 +30,9 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 		return nil, derr.ErrorCodeNotRunning.WithArgs(name)
 	}
 
+	if container.IsRestarting() {
+		return nil, derr.ErrorCodeContainerRestarting.WithArgs(name)
+	}
 	pids, err := daemon.ExecutionDriver().GetPidsForContainer(container.ID)
 	if err != nil {
 		return nil, err

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -715,6 +715,15 @@ var (
 		HTTPStatusCode: http.StatusConflict,
 	})
 
+	// ErrorCodeContainerRestarting is generated when an operation was made
+	// on a restarting container.
+	ErrorCodeContainerRestarting = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "CONTAINERRESTARTING",
+		Message:        "Container %s is restarting, wait until the container is running",
+		Description:    "An operation was made on a restarting container",
+		HTTPStatusCode: http.StatusConflict,
+	})
+
 	// ErrorCodeNoExecID is generated when we try to get the info
 	// on an exec but it can't be found.
 	ErrorCodeNoExecID = errcode.Register(errGroup, errcode.ErrorDescriptor{
@@ -730,15 +739,6 @@ var (
 		Value:          "EXECPAUSED",
 		Message:        "Container %s is paused, unpause the container before exec",
 		Description:    "An attempt to start an 'exec' was made, but the owning container is paused",
-		HTTPStatusCode: http.StatusConflict,
-	})
-
-	// ErrorCodeExecRestarting is generated when we try to start an exec
-	// but the container is restarting.
-	ErrorCodeExecRestarting = errcode.Register(errGroup, errcode.ErrorDescriptor{
-		Value:          "EXECRESTARTING",
-		Message:        "Container %s is restarting, wait until the container is running",
-		Description:    "An attempt to start an 'exec' was made, but the owning container is restarting",
 		HTTPStatusCode: http.StatusConflict,
 	})
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

When top a restarting container, the error is 
`Error response from daemon: active container for 8861eb8a7b581f0bcf8ad89e07f2b924db5990fd91044d32bbc5c01f3cda3465 does not exist`
It's not quite correct, the error should tell the user the container is restarting and failed to top
