### PR TITLE
Lock container when set state to restarting

### DIFF
--- a/container/monitor.go
+++ b/container/monitor.go
@@ -218,7 +218,7 @@ func (m *containerMonitor) start() error {
 		m.resetMonitor(err == nil && exitStatus.ExitCode == 0)
 
 		if m.shouldRestart(exitStatus.ExitCode) {
-			m.container.SetRestarting(&exitStatus)
+			m.container.SetRestartingLocking(&exitStatus)
 			m.logEvent("die")
 			m.resetContainer(true)
 


### PR DESCRIPTION
After exec driver run, container lock is lost, so we should lock
container when changing its state to `restarting`

Signed-off-by: Zhang Wei zhangwei555@huawei.com
