### PR TITLE
Fix error for restarting container

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -975,6 +975,9 @@ func (daemon *Daemon) getIpcContainer(container *container.Container) (*containe
 	if !c.IsRunning() {
 		return nil, derr.ErrorCodeIPCRunning.WithArgs(containerID)
 	}
+	if c.IsRestarting() {
+		return nil, derr.ErrorCodeContainerRestarting.WithArgs(containerID)
+	}
 	return c, nil
 }
 
@@ -988,6 +991,9 @@ func (daemon *Daemon) getNetworkedContainer(containerID, connectedContainerID st
 	}
 	if !nc.IsRunning() {
 		return nil, derr.ErrorCodeJoinRunning.WithArgs(connectedContainerID)
+	}
+	if nc.IsRestarting() {
+		return nil, derr.ErrorCodeContainerRestarting.WithArgs(connectedContainerID)
 	}
 	return nc, nil
 }

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -226,12 +226,12 @@ var (
 	})
 
 	// ErrorCodeIPCRunning is generated when we try to join a container's
-	// IPC but its not running.
+	// IPC but it's not running.
 	ErrorCodeIPCRunning = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:          "IPCRUNNING",
 		Message:        "cannot join IPC of a non running container: %s",
 		Description:    "An attempt was made to join the IPC of a container, but the container is not running",
-		HTTPStatusCode: http.StatusInternalServerError,
+		HTTPStatusCode: http.StatusConflict,
 	})
 
 	// ErrorCodeNotADir is generated when we try to create a directory
@@ -265,7 +265,7 @@ var (
 		Value:          "JOINRUNNING",
 		Message:        "cannot join network of a non running container: %s",
 		Description:    "An attempt to join the network of a container, but that container isn't running",
-		HTTPStatusCode: http.StatusInternalServerError,
+		HTTPStatusCode: http.StatusConflict,
 	})
 
 	// ErrorCodeModeNotContainer is generated when we try to network to


### PR DESCRIPTION
Fix error message for `--net container:b` and `--ipc container:b`,
container `b` is a restarting container.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

Actually this can be classified into same class with #19722, #19914, #19913 , the root cause is same:
when `IsRestarting` is true, `IsRunning` is always true. But sometimes, some actions can only apply to running containers but don't apply to a restarting container.

We should check all places calling `IsRunning()` or simply checking `Running` state, some other files besides these mentioned PRs are also impacted, maybe we should file an issue for tracking this?  @coolljt0725 @cpuguy83 @vdemeester @maintainers
