### PR TITLE
Setting labels on a file system without Xattr support shouldn't retur…

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/execdriver"
@@ -132,7 +133,9 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 		}
 		if label.RelabelNeeded(bind.Mode) {
 			if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
-				return err
+				if err != syscall.ENOTSUP {
+					return err
+				}
 			}
 		}
 		binds[bind.Destination] = true


### PR DESCRIPTION
…n an error

If we mount a volume into a container that does not support Xattrs (SELinux), we
need to check for ENOTSUP and not return an error

Signed-off-by: Dan Walsh dwalsh@redhat.com
