### PR TITLE
Changing menu label from Engine > Docker Engine

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,6 +5,7 @@ title = "FAQ"
 description = "Most frequently asked questions."
 keywords = ["faq, questions, documentation,  docker"]
 [menu.main]
+identifier="engine_faq"
 parent = "engine_use"
 weight = 80
 +++

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <!-- [metadata]>
 +++
 aliases = ["/engine/misc/"]
-title = "Engine"
+title = "Docker Engine"
 description = "Engine"
 keywords = ["Engine"]
 [menu.main]


### PR DESCRIPTION
Scott would like the menu label to read "Docker Engine" not Docker. 
Also removed old dead Articles file.
Added disambiguation for the FAQ

Signed-off-by: Mary Anthony mary@docker.com
