### PR TITLE
Windows CI: Re-do TP4 CI reliability hack

### DIFF
--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -237,10 +237,10 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 		err = hcsshim.CreateComputeSystem(c.ID, configuration)
 		if err != nil {
 			if TP4RetryHack {
-				if !strings.Contains(err.Error(), `Win32 API call returned error r1=2147746291`) && // Invalid class string
-					!strings.Contains(err.Error(), `Win32 API call returned error r1=2147943568`) && // Element not found
-					!strings.Contains(err.Error(), `Win32 API call returned error r1=2147942402`) && // The system cannot find the file specified
-					!strings.Contains(err.Error(), `Win32 API call returned error r1=2147943622`) { // The network is not present or not started
+				if !strings.Contains(err.Error(), `Win32 API call returned error r1=0x800401f3`) && // Invalid class string
+					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x80070490`) && // Element not found
+					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x80070002`) && // The system cannot find the file specified
+					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x800704c6`) { // The network is not present or not started
 					logrus.Debugln("Failed to create temporary container ", err)
 					return execdriver.ExitStatus{ExitCode: -1}, err
 				}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@thaJeztah @jstarks @icecrime @tiborvass 

Aaaargh! Just noticed that yesterdays TP4 reliability hack https://github.com/docker/docker/pull/19889 which got merged stopped working. Found the cause. There was subtle change to HCSShim which got revendored in https://github.com/docker/docker/pull/19902, breaking the string comparison. This should make the reliability hack work again.
