### PR TITLE
Windows CI: One more reliability hack

### DIFF
--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -240,7 +240,8 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 				if !strings.Contains(err.Error(), `Win32 API call returned error r1=0x800401f3`) && // Invalid class string
 					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x80070490`) && // Element not found
 					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x80070002`) && // The system cannot find the file specified
-					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x800704c6`) { // The network is not present or not started
+					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x800704c6`) && // The network is not present or not started
+					!strings.Contains(err.Error(), `Win32 API call returned error r1=0x800700a1`) { // The specified path is invalid
 					logrus.Debugln("Failed to create temporary container ", err)
 					return execdriver.ExitStatus{ExitCode: -1}, err
 				}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

The last update to Windows CI for reliability works well! :smiley_cat: But found one more instance: https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP4/549/console. Adding that to the list of retry cases.
