### PR TITLE
fix error message on version too low

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -147,7 +147,7 @@ func versionMiddleware(handler httputils.APIFunc) httputils.APIFunc {
 			return errors.ErrorCodeNewerClientVersion.WithArgs(apiVersion, api.DefaultVersion)
 		}
 		if apiVersion.LessThan(api.MinVersion) {
-			return errors.ErrorCodeOldClientVersion.WithArgs(apiVersion, api.DefaultVersion)
+			return errors.ErrorCodeOldClientVersion.WithArgs(apiVersion, api.MinVersion)
 		}
 
 		w.Header().Set("Server", "Docker/"+dockerversion.Version+" ("+runtime.GOOS+")")


### PR DESCRIPTION
See

```
curl 0.0.0.0:2375/v1.11/version
client version 1.11 is too old. Minimum supported API version is 1.23, please upgrade your client to a newer version
```

It should say: Minimum supported API version is **1.12** ...
