### PR TITLE
Windows CI: TestCreate* porting

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -20,7 +20,11 @@ import (
 
 // Make sure we can create a simple container with some args
 func (s *DockerSuite) TestCreateArgs(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	// TODO Windows. This requires further investigation for porting to
+	// Windows CI. Currently fails.
+	if daemonPlatform == "windows" {
+		c.Skip("Fails on Windows CI")
+	}
 	out, _ := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -58,7 +62,6 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 
 // Make sure we can set hostconfig options too
 func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-P", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -81,6 +84,7 @@ func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
+	// Windows does not currently support port ranges.
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
 
@@ -110,7 +114,8 @@ func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
+func (s *DockerSuite) TestCreateWithLargePortRange(c *check.C) {
+	// Windows does not currently support port ranges.
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
 
@@ -141,8 +146,6 @@ func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 
 // "test123" should be printed by docker create + start
 func (s *DockerSuite) TestCreateEchoStdout(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-
 	out, _ := dockerCmd(c, "create", "busybox", "echo", "test123")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -153,13 +156,16 @@ func (s *DockerSuite) TestCreateEchoStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateVolumesCreated(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
+	prefix := "/"
+	if daemonPlatform == "windows" {
+		prefix = `c:\`
+	}
 
 	name := "test_create_volume"
-	dockerCmd(c, "create", "--name", name, "-v", "/foo", "busybox")
+	dockerCmd(c, "create", "--name", name, "-v", prefix+"foo", "busybox")
 
-	dir, err := inspectMountSourceField(name, "/foo")
+	dir, err := inspectMountSourceField(name, prefix+"foo")
 	c.Assert(err, check.IsNil, check.Commentf("Error getting volume host path: %q", err))
 
 	if _, err := os.Stat(dir); err != nil && os.IsNotExist(err) {
@@ -172,7 +178,6 @@ func (s *DockerSuite) TestCreateVolumesCreated(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateLabels(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	name := "test_create_labels"
 	expected := map[string]string{"k1": "v1", "k2": "v2"}
 	dockerCmd(c, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")
@@ -186,7 +191,6 @@ func (s *DockerSuite) TestCreateLabels(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	imageName := "testcreatebuildlabel"
 	_, err := buildImage(imageName,
 		`FROM busybox
@@ -208,6 +212,10 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {
+	// TODO Windows. Consider enabling this in TP5 timeframe if Windows support
+	// is fully hooked up. The hostname is passed through, but only to the
+	// environment variable "COMPUTERNAME". It is not hooked up to hostname.exe
+	// or returned in ipconfig. Needs platform support in networking.
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-h", "web.0", "busybox", "hostname")
 	c.Assert(strings.TrimSpace(out), checker.Equals, "web.0", check.Commentf("hostname not set, expected `web.0`, got: %s", out))
@@ -215,7 +223,6 @@ func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateRM(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	// Test to make sure we can 'rm' a new container that is in
 	// "Created" state, and has ever been run. Test "rm -f" too.
 
@@ -233,6 +240,7 @@ func (s *DockerSuite) TestCreateRM(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
+	// Uses Linux specific functionality (--ipc)
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon, NotUserNamespace)
 
@@ -415,9 +423,20 @@ func (s *DockerSuite) TestCreateStopSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateWithWorkdir(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	// TODO Windows. This requires further investigation for porting to
+	// Windows CI. Currently fails.
+	if daemonPlatform == "windows" {
+		c.Skip("Fails on Windows CI")
+	}
 	name := "foo"
-	dir := "/home/foo/bar"
+	slash := "/"
+	prefix := ""
+	if daemonPlatform == "windows" {
+		prefix = "c:"
+		slash = `/`
+	}
+	dir := prefix + slash + "home" + slash + "foo" + slash + "bar"
+
 	dockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
-	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), "/tmp")
+	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), prefix+slash+"tmp")
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

More Windows CI test enablement, and annotation of ones which need further work/enabling in the future. Local results below

```
E:\go\src\github.com\docker\docker>runtest w TestCreate
Running test TestCreate
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
SKIP: docker_cli_create_test.go:22: DockerSuite.TestCreateArgs (Fails on Windows CI)
PASS: docker_cli_create_test.go:254: DockerSuite.TestCreateByImageID    5.696s
PASS: docker_cli_create_test.go:149: DockerSuite.TestCreateEchoStdout   4.905s
PASS: docker_cli_create_test.go:65: DockerSuite.TestCreateHostConfig    0.524s
SKIP: docker_cli_create_test.go:215: DockerSuite.TestCreateHostnameWithNumber (Test requires a Linux daemon)
PASS: docker_cli_create_test.go:194: DockerSuite.TestCreateLabelFromImage       2.858s
PASS: docker_cli_create_test.go:181: DockerSuite.TestCreateLabels       0.527s
SKIP: docker_cli_create_test.go:243: DockerSuite.TestCreateModeIpcContainer (Test requires a Linux daemon)
PASS: docker_cli_create_test.go:226: DockerSuite.TestCreateRM   1.066s
PASS: docker_cli_create_test.go:417: DockerSuite.TestCreateStopSignal   0.496s
PASS: docker_cli_create_test.go:159: DockerSuite.TestCreateVolumesCreated       0.505s
SKIP: docker_cli_create_test.go:118: DockerSuite.TestCreateWithLargePortRange (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:87: DockerSuite.TestCreateWithPortRange (Test requires a Linux daemon)
SKIP: docker_api_containers_test.go:862: DockerSuite.TestCreateWithTooLowMemoryLimit (Test requires a Linux daemon)
SKIP: docker_cli_create_test.go:426: DockerSuite.TestCreateWithWorkdir (Fails on Windows CI)
SKIP: docker_cli_by_digest_test.go:128: DockerRegistrySuite.TestCreateByDigest
SKIP: docker_cli_create_test.go:340: DockerTrustSuite.TestCreateWhenCertExpired
OK: 8 passed, 9 skipped
--- PASS: Test (21.04s)
PASS
ok      _/E_/go/src/github.com/docker/docker/integration-cli    21.173s
```
