### PR TITLE
Windows: Turn off stats

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
+	"runtime"
 
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/version"
@@ -22,6 +24,10 @@ type ContainerStatsConfig struct {
 // ContainerStats writes information about the container to the stream
 // given in the config object.
 func (daemon *Daemon) ContainerStats(prefixOrName string, config *ContainerStatsConfig) error {
+	if runtime.GOOS == "windows" {
+		return errors.New("Windows does not support stats")
+	}
+
 	container, err := daemon.GetContainer(prefixOrName)
 	if err != nil {
 		return err

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestStatsNoStream(c *check.C) {
+	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
@@ -40,6 +41,7 @@ func (s *DockerSuite) TestStatsNoStream(c *check.C) {
 }
 
 func (s *DockerSuite) TestStatsContainerNotFound(c *check.C) {
+	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
 	out, _, err := dockerCmdWithError("stats", "notfound")
@@ -52,6 +54,7 @@ func (s *DockerSuite) TestStatsContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestStatsAllRunningNoStream(c *check.C) {
+	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -75,6 +78,7 @@ func (s *DockerSuite) TestStatsAllRunningNoStream(c *check.C) {
 }
 
 func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
+	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -92,6 +96,7 @@ func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
 }
 
 func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {
+	// Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
 	id := make(chan string)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This returns an error from the daemon if docker stats is called against Windows. It also annotates the integration tests to indicate why they are `testRequires(c, DaemonIsLinux)`
