### PR TITLE
Windows CI: Port docker_api_resize_test.go

### DIFF
--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
@@ -20,8 +19,7 @@ func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=foo&w=bar"
@@ -31,7 +29,6 @@ func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Porting of the tests in docker_api_resize_test.go for Windows CI. 100% port of tests in this file :smile_cat:. Output from a local run below:

```
E:\go\src\github.com\docker\docker>runtest w TestResize
Running test TestResize
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
PASS: docker_api_resize_test.go:23: DockerSuite.TestResizeApiHeightWidthNoInt   13.714s
PASS: docker_api_resize_test.go:11: DockerSuite.TestResizeApiResponse   3.073s
PASS: docker_api_resize_test.go:35: DockerSuite.TestResizeApiResponseWhenContainerNotStarted    4.585s
OK: 3 passed
--- PASS: Test (24.90s)
PASS
ok      _/E_/go/src/github.com/docker/docker/integration-cli    25.100s

E:\go\src\github.com\docker\docker>
```
