### PR TITLE
remove auto-creating non-existant volume host path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,7 +183,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT f4b3a1bddd679f7531e089e9a751fc91c1907160
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -134,7 +134,7 @@ The following double-dash options are deprecated and have no replacement:
 ### Auto-creating missing host paths for bind mounts
 **Deprecated in Release: v1.9**
 
-**Target for Removal in Release: 1.11**
+**Removed in Release: 1.11**
 
 When creating a container with a bind-mounted volume-- `docker run -v /host/path:/container/path` --
 docker was automatically creating the `/host/path` if it didn't already exist.

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -580,8 +580,10 @@ func (s *DockerSuite) TestCpToErrReadOnlyRootfs(c *check.C) {
 // The `docker cp` command should also ensure that you
 // cannot write to a volume that is mounted as read-only.
 func (s *DockerSuite) TestCpToErrReadOnlyVolume(c *check.C) {
+	// TODO
 	// --read-only + userns has remount issues
-	testRequires(c, DaemonIsLinux, NotUserNamespace)
+	// win2lin: non-local daemons for now, skip
+	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
 	tmpDir := getTestDir(c, "test-cp-to-err-read-only-volume")
 	defer os.RemoveAll(tmpDir)
 

--- a/integration-cli/docker_cli_cp_utils.go
+++ b/integration-cli/docker_cli_cp_utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/docker/pkg/system"
 	"github.com/go-check/check"
 )
 
@@ -287,17 +288,20 @@ func containerStartOutputEquals(c *check.C, containerID, contents string) (err e
 
 	return
 }
-
 func defaultVolumes(tmpDir string) []string {
-	if SameHostDaemon.Condition() {
-		return []string{
-			"/vol1",
-			fmt.Sprintf("%s:/vol2", tmpDir),
-			fmt.Sprintf("%s:/vol3", filepath.Join(tmpDir, "vol3")),
-			fmt.Sprintf("%s:/vol_ro:ro", filepath.Join(tmpDir, "vol_ro")),
-		}
+
+	volumes := []string{
+		fmt.Sprintf("%s", filepath.Join(tmpDir, "vol1")),
+		fmt.Sprintf("%s:/vol2", tmpDir),
+		fmt.Sprintf("%s:/vol3", filepath.Join(tmpDir, "vol3")),
+		fmt.Sprintf("%s:/vol_ro:ro", filepath.Join(tmpDir, "vol_ro")),
 	}
 
-	// Can't bind-mount volumes with separate host daemon.
-	return []string{"/vol1", "/vol2", "/vol3", "/vol_ro:/vol_ro:ro"}
+	for _, volume := range volumes {
+		dir := strings.Split(volume, ":")
+		if dir != nil {
+			system.MkdirAll(dir[0], 0755)
+		}
+	}
+	return volumes
 }

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -12,13 +12,11 @@ func (s *DockerSuite) TestRmContainerWithRemovedVolume(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-
 	tempDir, err := ioutil.TempDir("", "test-rm-container-with-removed-volume-")
 	if err != nil {
 		c.Fatalf("failed to create temporary directory: %s", tempDir)
 	}
 	defer os.RemoveAll(tempDir)
-
 	dockerCmd(c, "run", "--name", "losemyvolumes", "-v", tempDir+":"+prefix+slash+"test", "busybox", "true")
 
 	err = os.RemoveAll(tempDir)

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -3,11 +3,9 @@ package volume
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/pkg/system"
 )
 
 // DefaultDriverName is the driver name used for the driver
@@ -70,15 +68,10 @@ func (m *MountPoint) Setup() (string, error) {
 	}
 	if len(m.Source) > 0 {
 		if _, err := os.Stat(m.Source); err != nil {
-			if !os.IsNotExist(err) {
-				return "", err
+			if os.IsNotExist(err) {
+				logrus.Errorf("non-existent volume host path %s", m.Source)
 			}
-			if runtime.GOOS != "windows" { // Windows does not have deprecation issues here
-				logrus.Warnf("Auto-creating non-existent volume host path %s, this is deprecated and will be removed soon", m.Source)
-				if err := system.MkdirAll(m.Source, 0755); err != nil {
-					return "", err
-				}
-			}
+			return "", err
 		}
 		return m.Source, nil
 	}


### PR DESCRIPTION
move from https://github.com/docker/docker/pull/19537 
currently, docker create non-existent volume host path automatically.  

e.g.

```
docker run --rm -ti -v /hello:/hello ubuntu bash
```

if the /hello dir don't exist in host, docker will create it to avoid the fail of mount.

But it is not reasonable.in fact,we can skip non-existant volume host path and remove "MkdirAll" from Setup.
Signed-off-by: yangshukui yangshukui@huawei.com
