### PR TITLE
Disable flakey TestClientSetsTLSServerName

### DIFF
--- a/integration-cli/docker_cli_sni_test.go
+++ b/integration-cli/docker_cli_sni_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func (s *DockerSuite) TestClientSetsTLSServerName(c *check.C) {
+	c.Skip("Flakey test")
 	// there may be more than one hit to the server for each registry request
 	serverNameReceived := []string{}
 	var serverName string


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

TestClientSetsTLSServerName was recently merged into master and is causing test failures on multiple PRs. Turning it off for now
