### PR TITLE
Add editable volume support

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -59,6 +59,7 @@ type CommonConfig struct {
 	DNS                  []string            `json:"dns,omitempty"`
 	DNSOptions           []string            `json:"dns-opts,omitempty"`
 	DNSSearch            []string            `json:"dns-search,omitempty"`
+	EditableVolume       []string            `json:"editable-volume,omitempty"`
 	ExecOptions          []string            `json:"exec-opts,omitempty"`
 	ExecRoot             string              `json:"exec-root,omitempty"`
 	GraphDriver          string              `json:"storage-driver,omitempty"`
@@ -126,6 +127,7 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.StringVar(&config.ClusterAdvertise, []string{"-cluster-advertise"}, "", usageFn("Address or interface name to advertise"))
 	cmd.StringVar(&config.ClusterStore, []string{"-cluster-store"}, "", usageFn("Set the cluster store"))
 	cmd.Var(opts.NewNamedMapOpts("cluster-store-opts", config.ClusterOpts, nil), []string{"-cluster-store-opt"}, usageFn("Set cluster store options"))
+	cmd.Var(opts.NewListOptsRef(&config.EditableVolume, nil), []string{"-editable-volume"}, usageFn("Host volume in which can create directories by user's will"))
 }
 
 // IsValueSet returns true if a configuration value

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -23,7 +23,7 @@ func (daemon *Daemon) setupMounts(container *container.Container) ([]execdriver.
 		if err := daemon.lazyInitializeVolume(container.ID, m); err != nil {
 			return nil, err
 		}
-		path, err := m.Setup()
+		path, err := m.Setup(daemon.configStore.EditableVolume)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Follow up #19953

It'll break lots of applications if container won't start
with none exist source bind volume. It could be hard for
administrator to create every directories applications need.

So we can add an option for daemon, to assign a safe volume
which can create new directories by user's will, if none
existed directories are in these editable volumes, daemon can
create them when starting containers.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
