### PR TITLE
1.10.0-rc3: Check nil before set resource.OomKillDisable

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -208,10 +208,12 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		BlkioThrottleWriteBpsDevice:  writeBpsDevice,
 		BlkioThrottleReadIOpsDevice:  readIOpsDevice,
 		BlkioThrottleWriteIOpsDevice: writeIOpsDevice,
-		OomKillDisable:               *c.HostConfig.OomKillDisable,
 		MemorySwappiness:             -1,
 	}
 
+	if c.HostConfig.OomKillDisable != nil {
+		resources.OomKillDisable = *c.HostConfig.OomKillDisable
+	}
 	if c.HostConfig.MemorySwappiness != nil {
 		resources.MemorySwappiness = *c.HostConfig.MemorySwappiness
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Check if `c.HostConfig.OomKillDisable` is nil before set `resources.OomKillDisable`, 
or else this will case panic if update docker version. I can reproduce this error.
Create a container on `docker-1.6.0`
`docker run -d --restart always --name test1 busybox top`
and then upgrade the docker to `docker-1.10.0-rc3` and start docker, it will panic

<pre><code>panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x523e5a]

goroutine 16 [running]:
github.com/docker/docker/daemon.(*Daemon).populateCommand(0xc820592f00, 0xc820720e00, 0xc820818840, 0x2, 0x2, 0x0, 0x0)
        /go/src/github.com/docker/docker/daemon/container_operations_unix.go:211 +0x139a
github.com/docker/docker/daemon.(*Daemon).containerStart(0xc820592f00, 0xc820720e00, 0x0, 0x0)
        /go/src/github.com/docker/docker/daemon/start.go:127 +0x38c
github.com/docker/docker/daemon.(*Daemon).restore.func1(0xc820c1b7b0, 0xc820592f00, 0xc820c00780, 0xc820720e00, 0xc820718900)
</code></pre>
