### PR TITLE
Fix stuck restarting container

### DIFF
--- a/container/monitor.go
+++ b/container/monitor.go
@@ -245,10 +245,9 @@ func (m *containerMonitor) start() error {
 // an execution time of more than 10s then reset the timer back to the default
 func (m *containerMonitor) resetMonitor(successful bool) {
 	executionTime := time.Now().Sub(m.lastStartTime).Seconds()
+	incrementTime := (time.Duration(m.timeIncrement) * time.Millisecond).Seconds()
 
-	if executionTime > 10 {
-		m.timeIncrement = defaultTimeIncrement
-	} else {
+	if executionTime < 10 && incrementTime < 60 {
 		// otherwise we need to increment the amount of time we wait before restarting
 		// the process.  We will build up by multiplying the increment by 2
 		m.timeIncrement *= 2


### PR DESCRIPTION
If we run a container with this command:

$ docker run -tid --restart always busybox sleep 1

the container will keep restarting, every restart will cost 2 times
of previous restart time(2 \* m.timeIncrement), finally you'll find the
container takes a long long time (even forever) to restart.

This commit will reset timeIncrement to default after it's longer than
10 seconds.

ping @vdemeester 

Signed-off-by: Zhang Wei zhangwei555@huawei.com
