### PR TITLE
Only delete existing binary on successful builds

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -284,20 +284,12 @@ bundle() {
 }
 
 main() {
-	# We want this to fail if the bundles already exist and cannot be removed.
-	# This is to avoid mixing bundles from different versions of the code.
+	# We want this to fail if the working direcory already exists and cannot be removed.
 	mkdir -p bundles
-	if [ -e "bundles/$VERSION" ] && [ -z "$KEEPBUNDLE" ]; then
-		echo "bundles/$VERSION already exists. Removing."
-		rm -fr "bundles/$VERSION" && mkdir "bundles/$VERSION" || exit 1
+	if [ -e "bundles/$VERSION-working" ]; then
+		echo "bundles/$VERSION-working already exists. Removing."
+		rm -fr "bundles/$VERSION-working" && mkdir "bundles/$VERSION-working" || exit 1
 		echo
-	fi
-
-	if [ "$(go env GOHOSTOS)" != 'windows' ]; then
-		# Windows and symlinks don't get along well
-
-		rm -f bundles/latest
-		ln -s "$VERSION" bundles/latest
 	fi
 
 	if [ $# -lt 1 ]; then
@@ -305,8 +297,9 @@ main() {
 	else
 		bundles=($@)
 	fi
+
 	for bundle in ${bundles[@]}; do
-		export DEST="bundles/$VERSION/$(basename "$bundle")"
+		export DEST="bundles/$VERSION-working/$(basename "$bundle")"
 		# Cygdrive paths don't play well with go build -o.
 		if [[ "$(uname -s)" == CYGWIN* ]]; then
 			export DEST="$(cygpath -mw "$DEST")"
@@ -316,6 +309,21 @@ main() {
 		bundle "$bundle"
 		echo
 	done
+
+	if [ -e "bundles/$VERSION" ] && [ -z "$KEEPBUNDLE" ]; then
+		echo "bundles/$VERSION already exists. Removing."
+		rm -fr "bundles/$VERSION" || exit 1
+		echo
+	fi
+
+	# move the in progress build to its final "VERSION" path
+	mv "bundles/$VERSION-working" "bundles/$VERSION"
+
+	if [ "$(go env GOHOSTOS)" != 'windows' ]; then
+		# Windows and symlinks don't get along well
+		rm -f bundles/latest
+		ln -s "$VERSION" bundles/latest
+	fi
 }
 
 main "$@"


### PR DESCRIPTION
Right now, the existing version of the docker binary is thrown away before the start of a new build. The proposed change would build in a temporary "working" directory, and then once the build is successful move it to its final destination directory (deleting any existing binary). 

The motivation here is that I'm often in a build/test cycle where I'm running the latest daemon I've built to test for changes, and then building against that same daemon (rather than stopping it and starting up the older daemon each time). When I get a build failure, I can no longer build at all, because the daemon's underlying binary has been deleted (and it eventually complains that it can't fork).
