### PR TITLE
Bypass retry in plugin loading if plugin not found.

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -129,7 +129,7 @@ func loadWithRetry(name string, retry bool) (*Plugin, error) {
 	for {
 		pl, err := registry.Plugin(name)
 		if err != nil {
-			if !retry {
+			if !retry || err == ErrNotFound {
 				return nil, err
 			}
 


### PR DESCRIPTION
Retry doesn't make sense if there is not such plugin.
This patch speeds up test case `DockerSuite.TestVolumeCliCreate` in issue #19425 .

Signed-off-by: Pei Su sillyousu@gmail.com
