### PR TITLE
Revert "Set idle timeouts for HTTP reads and writes in communications with the registry"

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -45,30 +45,6 @@ func (dcs dumbCredentialStore) Basic(*url.URL) (string, string) {
 	return dcs.auth.Username, dcs.auth.Password
 }
 
-// conn wraps a net.Conn, and sets a deadline for every read
-// and write operation.
-type conn struct {
-	net.Conn
-	readTimeout  time.Duration
-	writeTimeout time.Duration
-}
-
-func (c *conn) Read(b []byte) (int, error) {
-	err := c.Conn.SetReadDeadline(time.Now().Add(c.readTimeout))
-	if err != nil {
-		return 0, err
-	}
-	return c.Conn.Read(b)
-}
-
-func (c *conn) Write(b []byte) (int, error) {
-	err := c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
-	if err != nil {
-		return 0, err
-	}
-	return c.Conn.Write(b)
-}
-
 // NewV2Repository returns a repository (v2 only). It creates a HTTP transport
 // providing timeout settings and authentication support, and also verifies the
 // remote API version.
@@ -82,22 +58,11 @@ func NewV2Repository(ctx context.Context, repoInfo *registry.RepositoryInfo, end
 	// TODO(dmcgowan): Call close idle connections when complete, use keep alive
 	base := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		Dial: func(network, address string) (net.Conn, error) {
-			dialer := &net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
-			}
-			netConn, err := dialer.Dial(network, address)
-			if err != nil {
-				return netConn, err
-			}
-			return &conn{
-				Conn:         netConn,
-				readTimeout:  time.Minute,
-				writeTimeout: time.Minute,
-			}, nil
-		},
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     endpoint.TLSConfig,
 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive


### PR DESCRIPTION
This reverts commit 84b2162c1a15256ac09396ad0d75686ea468f40c.

The intent of this commit was to set an idle timeout on a HTTP
connection. If a read took more than 60 seconds to complete, or a write
took more than 60 seconds to complete, the connection would be
considered dead.

This doesn't work properly, because the HTTP internals apparently read
from the connection concurrently while writing. An upload that doesn't
complete in 60 seconds leads to a timeout.

Fixes #19967
#12823 should be reopened
