### PR TITLE
Remove unnecessary call to `/info` endpoint

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -35,9 +35,11 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		cli.in = os.Stdin
 	}
 
-	serverAddress := cli.electAuthServer()
+	var serverAddress string
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
+	} else {
+		serverAddress = cli.electAuthServer()
 	}
 
 	authConfig, err := cli.configureAuth(*flUser, *flPassword, *flEmail, serverAddress)

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -18,9 +18,11 @@ func (cli *DockerCli) CmdLogout(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	serverAddress := cli.electAuthServer()
+	var serverAddress string
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
+	} else {
+		serverAddress = cli.electAuthServer()
 	}
 
 	if _, ok := cli.configFile.AuthConfigs[serverAddress]; !ok {


### PR DESCRIPTION
Sorry for this: #19891 was missing its `logout` counterpart.
