### PR TITLE
[1.10] Fix volume driver API compatibility mode (a little)

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -192,9 +192,6 @@ func (s *VolumeStore) create(name, driverName string, opts map[string]string) (v
 		return nil, &OpErr{Op: "create", Name: name, Err: err}
 	}
 
-	if v, err := vd.Get(name); err == nil {
-		return v, nil
-	}
 	return vd.Create(name, opts)
 }
 


### PR DESCRIPTION
So the changes in #19528 added backwards compatibility mode for the volume driver API for drivers that did not yet support `List` or `Get`. But it also unfortunately introduced a couple regressions from previous (1.9) behavior.  This PR fixes one of them.

Problem:

For a volume driver operating in compatibility mode (ie. always returns 404 for /VolumeDriver.Get), any volume options passed to the driver (ie. volume create --opt opt1 --opt opt2) would get dropped. The options are no longer sent to the /VolumeDriver.Create call. This PR fixes this problem.

**PLEASE NOTE**: This means currently in 1.10 _no volume options will be sent to a volume driver, unless that driver has implemented the `Get` API call_. This is a regression from 1.9. A volume driver either has to be updated for the 1.10 API and support `Get`, or this fix has to be included in 1.10. Until then, any volume options specified on create will be dropped.

Secondary Problem:

The other problem (not addressed in this PR), is that if a driver is operating in compatibility mode, doing a **volume inspect** on a non existent volume name, will end up _creating the volume_. This is also a regression from previous (1.9) behavior. The old (1.9) behavior was to look at the metadata in docker itself, and to **not** send a `Create` to the driver. The compatibility mode introduced in 1.10 now **always** sends the `Create` to the driver if `Get` fails with a 404. 

This means if a driver is operating in compatibility mode, and someone _typos_ a volume name on **volume inspect**, that volume will end up getting created. This would not have happened in 1.9.

Recommendation:

I recommend taking this fix in 1.10 whenever possible. Or alternatively, removing the compatibility mode, and requiring drivers to be updated for 1.10. Until that time, 1.10 volumes are not fully functional.

/cc: @cpuguy83 @calavera @thaJeztah 
