### PR TITLE
Expose docker's root directory by default as part of `docker info`.

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -73,7 +73,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(info.MemTotal)))
 	ioutils.FprintfIfNotEmpty(cli.out, "Name: %s\n", info.Name)
 	ioutils.FprintfIfNotEmpty(cli.out, "ID: %s\n", info.ID)
-
+	fmt.Fprintf(cli.out, "Docker Root Dir: %s\n", info.DockerRootDir)
 	fmt.Fprintf(cli.out, "Debug mode (client): %v\n", utils.IsDebugEnabled())
 	fmt.Fprintf(cli.out, "Debug mode (server): %v\n", info.Debug)
 
@@ -82,7 +82,6 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, " Goroutines: %d\n", info.NGoroutines)
 		fmt.Fprintf(cli.out, " System Time: %s\n", info.SystemTime)
 		fmt.Fprintf(cli.out, " EventsListeners: %d\n", info.NEventsListener)
-		fmt.Fprintf(cli.out, " Docker Root Dir: %s\n", info.DockerRootDir)
 	}
 
 	ioutils.FprintfIfNotEmpty(cli.out, "Http Proxy: %s\n", info.HTTPProxy)

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -44,6 +44,7 @@ For example:
     Total Memory: 62.86 GiB
     Name: docker
     ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    Docker Root Dir: /var/lib/docker
     Debug mode (client): true
     Debug mode (server): true
      File Descriptors: 59

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -51,7 +51,14 @@ Here is a sample output:
     Architecture: x86_64
     CPUs: 1
     Total Memory: 2 GiB
-
+    Name: docker
+    ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    Docker Root Dir: /var/lib/docker
+    Debug mode (client): false
+    Debug mode (server): false
+    Username: xyz
+    Registry: https://index.docker.io/v1/
+	
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.


### PR DESCRIPTION
Primary use case is cAdvisor.
