### PR TITLE
Add "common flags" hooks to the client CLIs

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -19,6 +19,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	noStdin := cmd.Bool([]string{"-no-stdin"}, false, "Do not attach STDIN")
 	proxy := cmd.Bool([]string{"-sig-proxy"}, true, "Proxy all received signals to the process")
 	detachKeys := cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Exact, 1)
 

--- a/api/client/build.go
+++ b/api/client/build.go
@@ -68,6 +68,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	ulimits := make(map[string]*units.Ulimit)
 	flUlimits := runconfigopts.NewUlimitOpt(&ulimits)
 	cmd.Var(flUlimits, []string{"-ulimit"}, "Ulimit options")
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Exact, 1)
 

--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/opts"
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/engine-api/client"
 	"github.com/docker/go-connections/tlsconfig"
@@ -104,6 +105,12 @@ func (cli *DockerCli) restoreTerminal(in io.Closer) error {
 		return in.Close()
 	}
 	return nil
+}
+
+// AddCommonFlags installs command line flags which can control the
+// client's behavior, and which are common to all client commands.
+func (cli *DockerCli) AddCommonFlags(flags *flag.FlagSet) {
+	// nothing here yet
 }
 
 // NewDockerCli returns a DockerCli instance with IO output and error streams set by in, out and err.

--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -25,6 +25,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply Dockerfile instruction to the created image")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
 	flConfig := cmd.String([]string{"#-run"}, "", "This option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Max, 2)
 	cmd.Require(flag.Min, 1)
 

--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -53,6 +53,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	)
 
 	followLink := cmd.Bool([]string{"L", "-follow-link"}, false, "Always follow symbol link in SRC_PATH")
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Exact, 2)
 	cmd.ParseFlags(args, true)

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -157,6 +157,7 @@ func (cli *DockerCli) CmdCreate(args ...string) error {
 	var (
 		flName = cmd.String([]string{"-name"}, "", "Assign a name to the container")
 	)
+	cli.AddCommonFlags(cmd)
 
 	config, hostConfig, networkingConfig, cmd, err := runconfigopts.Parse(cmd, args)
 

--- a/api/client/diff.go
+++ b/api/client/diff.go
@@ -17,6 +17,7 @@ import (
 // Usage: docker diff CONTAINER
 func (cli *DockerCli) CmdDiff(args ...string) error {
 	cmd := Cli.Subcmd("diff", []string{"CONTAINER"}, Cli.DockerCommands["diff"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -26,6 +26,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 	until := cmd.String([]string{"-until"}, "", "Stream events until this timestamp")
 	flFilter := opts.NewListOpts(nil)
 	cmd.Var(&flFilter, []string{"f", "-filter"}, "Filter output based on conditions provided")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 0)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -17,6 +17,7 @@ import (
 func (cli *DockerCli) CmdExec(args ...string) error {
 	cmd := Cli.Subcmd("exec", []string{"CONTAINER COMMAND [ARG...]"}, Cli.DockerCommands["exec"].Description, true)
 	detachKeys := cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
+	cli.AddCommonFlags(cmd)
 
 	execConfig, err := ParseExec(cmd, args)
 	// just in case the ParseExec does not exit

--- a/api/client/export.go
+++ b/api/client/export.go
@@ -16,6 +16,7 @@ import (
 func (cli *DockerCli) CmdExport(args ...string) error {
 	cmd := Cli.Subcmd("export", []string{"CONTAINER"}, Cli.DockerCommands["export"].Description, true)
 	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/history.go
+++ b/api/client/history.go
@@ -22,6 +22,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 	human := cmd.Bool([]string{"H", "-human"}, true, "Print sizes and dates in human readable format")
 	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only show numeric IDs")
 	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Don't truncate output")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -22,6 +22,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 
 	flFilter := opts.NewListOpts(nil)
 	cmd.Var(&flFilter, []string{"f", "-filter"}, "Filter output based on conditions provided")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Max, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/import.go
+++ b/api/client/import.go
@@ -24,6 +24,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 	flChanges := opts.NewListOpts(nil)
 	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply Dockerfile instruction to the created image")
 	message := cmd.String([]string{"m", "-message"}, "", "Set commit message for imported image")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -16,6 +16,7 @@ import (
 // Usage: docker info
 func (cli *DockerCli) CmdInfo(args ...string) error {
 	cmd := Cli.Subcmd("info", nil, Cli.DockerCommands["info"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 0)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -26,6 +26,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	tmplStr := cmd.String([]string{"f", "-format"}, "", "Format the output using the given go template")
 	inspectType := cmd.String([]string{"-type"}, "", "Return JSON for specified type, (e.g image or container)")
 	size := cmd.Bool([]string{"s", "-size"}, false, "Display total file sizes if the type is container")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/kill.go
+++ b/api/client/kill.go
@@ -14,6 +14,7 @@ import (
 func (cli *DockerCli) CmdKill(args ...string) error {
 	cmd := Cli.Subcmd("kill", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["kill"].Description, true)
 	signal := cmd.String([]string{"s", "-signal"}, "KILL", "Signal to send to the container")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/load.go
+++ b/api/client/load.go
@@ -17,6 +17,7 @@ import (
 func (cli *DockerCli) CmdLoad(args ...string) error {
 	cmd := Cli.Subcmd("load", nil, Cli.DockerCommands["load"].Description, true)
 	infile := cmd.String([]string{"i", "-input"}, "", "Read from a tar archive file, instead of STDIN")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 0)
 	cmd.ParseFlags(args, true)
 

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -22,6 +22,7 @@ import (
 // Usage: docker login SERVER
 func (cli *DockerCli) CmdLogin(args ...string) error {
 	cmd := Cli.Subcmd("login", []string{"[SERVER]"}, Cli.DockerCommands["login"].Description+".\nIf no server is specified, the default is defined by the daemon.", true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Max, 1)
 
 	flUser := cmd.String([]string{"u", "-username"}, "", "Username")

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -14,6 +14,7 @@ import (
 // Usage: docker logout [SERVER]
 func (cli *DockerCli) CmdLogout(args ...string) error {
 	cmd := Cli.Subcmd("logout", []string{"[SERVER]"}, Cli.DockerCommands["logout"].Description+".\nIf no server is specified, the default is defined by the daemon.", true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Max, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -24,6 +24,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	since := cmd.String([]string{"-since"}, "", "Show logs since timestamp")
 	times := cmd.Bool([]string{"t", "-timestamps"}, false, "Show timestamps")
 	tail := cmd.String([]string{"-tail"}, "all", "Number of lines to show from the end of the logs")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/network.go
+++ b/api/client/network.go
@@ -21,6 +21,7 @@ import (
 // Usage: docker network <COMMAND> [OPTIONS]
 func (cli *DockerCli) CmdNetwork(args ...string) error {
 	cmd := Cli.Subcmd("network", []string{"COMMAND [OPTIONS]"}, networkUsage(), false)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 	err := cmd.ParseFlags(args, true)
 	cmd.Usage()
@@ -48,6 +49,7 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 	cmd.Var(flIpamAux, []string{"-aux-address"}, "auxiliary ipv4 or ipv6 addresses used by Network driver")
 	cmd.Var(flOpts, []string{"o", "-opt"}, "set driver specific options")
 	cmd.Var(flIpamOpt, []string{"-ipam-opt"}, "set IPAM driver specific options")
+	cli.AddCommonFlags(cmd)
 
 	flInternal := cmd.Bool([]string{"-internal"}, false, "restricts external access to the network")
 
@@ -92,6 +94,7 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 // Usage: docker network rm NETWORK-NAME|NETWORK-ID [NETWORK-NAME|NETWORK-ID...]
 func (cli *DockerCli) CmdNetworkRm(args ...string) error {
 	cmd := Cli.Subcmd("network rm", []string{"NETWORK [NETWORK...]"}, "Deletes one or more networks", false)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 	if err := cmd.ParseFlags(args, true); err != nil {
 		return err
@@ -122,6 +125,7 @@ func (cli *DockerCli) CmdNetworkConnect(args ...string) error {
 	cmd.Var(&flLinks, []string{"-link"}, "Add link to another container")
 	flAliases := opts.NewListOpts(nil)
 	cmd.Var(&flAliases, []string{"-alias"}, "Add network-scoped alias for the container")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 2)
 	if err := cmd.ParseFlags(args, true); err != nil {
 		return err
@@ -143,6 +147,7 @@ func (cli *DockerCli) CmdNetworkConnect(args ...string) error {
 func (cli *DockerCli) CmdNetworkDisconnect(args ...string) error {
 	cmd := Cli.Subcmd("network disconnect", []string{"NETWORK CONTAINER"}, "Disconnects container from a network", false)
 	force := cmd.Bool([]string{"f", "-force"}, false, "Force the container to disconnect from a network")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 2)
 	if err := cmd.ParseFlags(args, true); err != nil {
 		return err
@@ -158,6 +163,7 @@ func (cli *DockerCli) CmdNetworkLs(args ...string) error {
 	cmd := Cli.Subcmd("network ls", nil, "Lists networks", true)
 	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only display numeric IDs")
 	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Do not truncate the output")
+	cli.AddCommonFlags(cmd)
 
 	flFilter := opts.NewListOpts(nil)
 	cmd.Var(&flFilter, []string{"f", "-filter"}, "Filter output based on conditions provided")
@@ -220,6 +226,7 @@ func (cli *DockerCli) CmdNetworkLs(args ...string) error {
 func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
 	cmd := Cli.Subcmd("network inspect", []string{"NETWORK [NETWORK...]"}, "Displays detailed information on one or more networks", false)
 	tmplStr := cmd.String([]string{"f", "-format"}, "", "Format the output using the given go template")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	if err := cmd.ParseFlags(args, true); err != nil {

--- a/api/client/pause.go
+++ b/api/client/pause.go
@@ -13,6 +13,7 @@ import (
 // Usage: docker pause CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdPause(args ...string) error {
 	cmd := Cli.Subcmd("pause", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["pause"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/port.go
+++ b/api/client/port.go
@@ -15,6 +15,7 @@ import (
 // Usage: docker port CONTAINER [PRIVATE_PORT[/PROTO]]
 func (cli *DockerCli) CmdPort(args ...string) error {
 	cmd := Cli.Subcmd("port", []string{"CONTAINER [PRIVATE_PORT[/PROTO]]"}, Cli.DockerCommands["port"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -30,6 +30,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		format   = cmd.String([]string{"-format"}, "", "Pretty-print containers using a Go template")
 		flFilter = opts.NewListOpts(nil)
 	)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 0)
 
 	cmd.Var(&flFilter, []string{"f", "-filter"}, "Filter output based on conditions provided")

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -20,6 +20,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	cmd := Cli.Subcmd("pull", []string{"NAME[:TAG|@DIGEST]"}, Cli.DockerCommands["pull"].Description, true)
 	allTags := cmd.Bool([]string{"a", "-all-tags"}, false, "Download all tagged images in the repository")
 	addTrustedFlags(cmd, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -19,6 +19,7 @@ import (
 func (cli *DockerCli) CmdPush(args ...string) error {
 	cmd := Cli.Subcmd("push", []string{"NAME[:TAG]"}, Cli.DockerCommands["push"].Description, true)
 	addTrustedFlags(cmd, false)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/rename.go
+++ b/api/client/rename.go
@@ -13,6 +13,7 @@ import (
 // Usage: docker rename OLD_NAME NEW_NAME
 func (cli *DockerCli) CmdRename(args ...string) error {
 	cmd := Cli.Subcmd("rename", []string{"OLD_NAME NEW_NAME"}, Cli.DockerCommands["rename"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 2)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/restart.go
+++ b/api/client/restart.go
@@ -14,6 +14,7 @@ import (
 func (cli *DockerCli) CmdRestart(args ...string) error {
 	cmd := Cli.Subcmd("restart", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["restart"].Description, true)
 	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Seconds to wait for stop before killing the container")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -17,6 +17,7 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 	v := cmd.Bool([]string{"v", "-volumes"}, false, "Remove the volumes associated with the container")
 	link := cmd.Bool([]string{"l", "-link"}, false, "Remove the specified link")
 	force := cmd.Bool([]string{"f", "-force"}, false, "Force the removal of a running container (uses SIGKILL)")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/rmi.go
+++ b/api/client/rmi.go
@@ -17,6 +17,7 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 	cmd := Cli.Subcmd("rmi", []string{"IMAGE [IMAGE...]"}, Cli.DockerCommands["rmi"].Description, true)
 	force := cmd.Bool([]string{"f", "-force"}, false, "Force removal of the image")
 	noprune := cmd.Bool([]string{"-no-prune"}, false, "Do not delete untagged parents")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -82,6 +82,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		ErrConflictRestartPolicyAndAutoRemove = fmt.Errorf("Conflicting options: --restart and --rm")
 		ErrConflictDetachAutoRemove           = fmt.Errorf("Conflicting options: --rm and -d")
 	)
+	cli.AddCommonFlags(cmd)
 
 	config, hostConfig, networkingConfig, cmd, err := runconfigopts.Parse(cmd, args)
 

--- a/api/client/save.go
+++ b/api/client/save.go
@@ -16,6 +16,7 @@ import (
 func (cli *DockerCli) CmdSave(args ...string) error {
 	cmd := Cli.Subcmd("save", []string{"IMAGE [IMAGE...]"}, Cli.DockerCommands["save"].Description+" (streamed to STDOUT by default)", true)
 	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -23,6 +23,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Don't truncate output")
 	automated := cmd.Bool([]string{"-automated"}, false, "Only show automated builds")
 	stars := cmd.Uint([]string{"s", "-stars"}, 0, "Only displays with at least x stars")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -50,6 +50,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	attach := cmd.Bool([]string{"a", "-attach"}, false, "Attach STDOUT/STDERR and forward signals")
 	openStdin := cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's STDIN")
 	detachKeys := cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -142,6 +142,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 	cmd := Cli.Subcmd("stats", []string{"[CONTAINER...]"}, Cli.DockerCommands["stats"].Description, true)
 	all := cmd.Bool([]string{"a", "-all"}, false, "Show all containers (default shows just running)")
 	noStream := cmd.Bool([]string{"-no-stream"}, false, "Disable streaming stats and only pull the first result")
+	cli.AddCommonFlags(cmd)
 
 	cmd.ParseFlags(args, true)
 

--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -16,6 +16,7 @@ import (
 func (cli *DockerCli) CmdStop(args ...string) error {
 	cmd := Cli.Subcmd("stop", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["stop"].Description+".\nSending SIGTERM and then SIGKILL after a grace period", true)
 	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Seconds to wait for stop before killing it")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -15,6 +15,7 @@ import (
 func (cli *DockerCli) CmdTag(args ...string) error {
 	cmd := Cli.Subcmd("tag", []string{"IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]"}, Cli.DockerCommands["tag"].Description, true)
 	force := cmd.Bool([]string{"#f", "#-force"}, false, "Force the tagging even if there's a conflict")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 2)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/top.go
+++ b/api/client/top.go
@@ -14,6 +14,7 @@ import (
 // Usage: docker top CONTAINER
 func (cli *DockerCli) CmdTop(args ...string) error {
 	cmd := Cli.Subcmd("top", []string{"CONTAINER [ps OPTIONS]"}, Cli.DockerCommands["top"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/unpause.go
+++ b/api/client/unpause.go
@@ -13,6 +13,7 @@ import (
 // Usage: docker unpause CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdUnpause(args ...string) error {
 	cmd := Cli.Subcmd("unpause", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["unpause"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -38,6 +38,7 @@ Server:
 func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	cmd := Cli.Subcmd("version", nil, Cli.DockerCommands["version"].Description, true)
 	tmplStr := cmd.String([]string{"f", "#format", "-format"}, "", "Format the output using the given go template")
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Exact, 0)
 
 	cmd.ParseFlags(args, true)

--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -29,6 +29,7 @@ func (cli *DockerCli) CmdVolume(args ...string) error {
 
 	description += "\nRun 'docker volume COMMAND --help' for more information on a command"
 	cmd := Cli.Subcmd("volume", []string{"[COMMAND]"}, description, false)
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Exact, 0)
 	err := cmd.ParseFlags(args, true)
@@ -45,6 +46,7 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only display volume names")
 	flFilter := opts.NewListOpts(nil)
 	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values (i.e. 'dangling=true')")
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Exact, 0)
 	cmd.ParseFlags(args, true)
@@ -89,6 +91,7 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 	cmd := Cli.Subcmd("volume inspect", []string{"VOLUME [VOLUME...]"}, "Return low-level information on a volume", true)
 	tmplStr := cmd.String([]string{"f", "-format"}, "", "Format the output using the given go template")
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Min, 1)
 	cmd.ParseFlags(args, true)
@@ -115,6 +118,7 @@ func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
 
 	flDriverOpts := opts.NewMapOpts(nil, nil)
 	cmd.Var(flDriverOpts, []string{"o", "-opt"}, "Set driver specific options")
+	cli.AddCommonFlags(cmd)
 
 	cmd.Require(flag.Exact, 0)
 	cmd.ParseFlags(args, true)
@@ -139,6 +143,7 @@ func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
 // Usage: docker volume rm VOLUME [VOLUME...]
 func (cli *DockerCli) CmdVolumeRm(args ...string) error {
 	cmd := Cli.Subcmd("volume rm", []string{"VOLUME [VOLUME...]"}, "Remove a volume", true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 	cmd.ParseFlags(args, true)
 

--- a/api/client/wait.go
+++ b/api/client/wait.go
@@ -15,6 +15,7 @@ import (
 // Usage: docker wait CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdWait(args ...string) error {
 	cmd := Cli.Subcmd("wait", []string{"CONTAINER [CONTAINER...]"}, Cli.DockerCommands["wait"].Description, true)
+	cli.AddCommonFlags(cmd)
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)


### PR DESCRIPTION
Add an AddCommonFlags() method to the client object, so that if we find ourselves needing to add a set of flags to the command line for every client command, we'll only have to do it in one place.  Broken out from #18514, where we use it to add authentication flags to clients.

Signed-off-by: Nalin Dahyabhai nalin@redhat.com (github: nalind)
