### PR TITLE
integration-cli: fix minimum and default api version test

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -59,7 +60,8 @@ func (s *DockerSuite) TestApiClientVersionNewerThanServer(c *check.C) {
 	status, body, err := sockRequest("GET", "/v"+version+"/version", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusBadRequest)
-	c.Assert(len(string(body)), check.Not(checker.Equals), 0) // Expected not empty body
+	expected := fmt.Sprintf("client is newer than server (client API version: %s, server API version: %s)", version, api.DefaultVersion)
+	c.Assert(strings.TrimSpace(string(body)), checker.Equals, expected)
 }
 
 func (s *DockerSuite) TestApiClientVersionOldNotSupported(c *check.C) {
@@ -73,7 +75,8 @@ func (s *DockerSuite) TestApiClientVersionOldNotSupported(c *check.C) {
 	status, body, err := sockRequest("GET", "/v"+version+"/version", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusBadRequest)
-	c.Assert(len(string(body)), checker.Not(check.Equals), 0) // Expected not empty body
+	expected := fmt.Sprintf("client version %s is too old. Minimum supported API version is %s, please upgrade your client to a newer version", version, api.MinVersion)
+	c.Assert(strings.TrimSpace(string(body)), checker.Equals, expected)
 }
 
 func (s *DockerSuite) TestApiDockerApiVersion(c *check.C) {


### PR DESCRIPTION
This test would have caught #19936 (if it was right :smile:) 

```
INFO: Testing against a local daemon

----------------------------------------------------------------------
FAIL: docker_api_test.go:67: DockerSuite.TestApiClientVersionOldNotSupported

docker_api_test.go:79:
    c.Assert(strings.TrimSpace(string(body)), checker.Equals, expected)
... obtained string = "client version 1.11 is too old. Minimum supported API version is 1.23, please upgrade your client to a newer version"
... expected string = "client version 1.11 is too old. Minimum supported API version is 1.12, please upgrade your client to a newer version"

OOPS: 0 passed, 1 FAILED
--- FAIL: Test (0.13s)
FAIL

```

Signed-off-by: Antonio Murdaca runcom@redhat.com
