### PR TITLE
Remove stray printf

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -378,7 +378,6 @@ func (s *DockerSuite) TestExecDir(c *check.C) {
 	id := strings.TrimSpace(out)
 
 	execDir := filepath.Join(execDriverPath, id)
-	fmt.Println(execDriverPath)
 	stateFile := filepath.Join(execDir, "state.json")
 
 	{


### PR DESCRIPTION
This came in with the Windows CI work and I assume was meant for local
debug, but adds a bare printf line to the test output.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
