### PR TITLE
Graphdriver/btrfs: Avoid using single d.Get()

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -256,9 +256,13 @@ func (d *Driver) Create(id, parent, mountLabel string) error {
 			return err
 		}
 	} else {
-		parentDir, err := d.Get(parent, "")
+		parentDir := d.subvolumesDirID(parent)
+		st, err := os.Stat(parentDir)
 		if err != nil {
 			return err
+		}
+		if !st.IsDir() {
+			return fmt.Errorf("%s: not a direcotory", parentDir)
 		}
 		if err := subvolSnapshot(parentDir, subvolumes, id); err != nil {
 			return err


### PR DESCRIPTION
For btrfs driver, in d.Create(), Get() of parentDir is called but not followed
by Put().

If we apply SElinux mount label, we need to mount btrfs subvolumes in d.Get(),
without a Put() would end up with a later Remove() failure on
"Device resourse is busy".

This calls the subvolume helper function directly in d.Create().

Signed-off-by: Liu Bo bo.li.liu@oracle.com
