### PR TITLE
Windows CI: Up timeout TestRunRestartMaxRetries

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2683,7 +2683,7 @@ func (s *DockerSuite) TestRunRestartMaxRetries(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false")
 	timeout := 10 * time.Second
 	if daemonPlatform == "windows" {
-		timeout = 45 * time.Second
+		timeout = 120 * time.Second
 	}
 
 	id := strings.TrimSpace(string(out))


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I've seen TestRunRestartMaxRetries fail several times on windowsTP4 CI, eg https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP4/663/console. Upping the timeout to hopefully make it more reliable and not cause false failures in Jenkins runs.
