### PR TITLE
Fix ReadAll to run on Windows.

### DIFF
--- a/builder/dockerignore/dockerignore.go
+++ b/builder/dockerignore/dockerignore.go
@@ -25,6 +25,7 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 			continue
 		}
 		pattern = filepath.Clean(pattern)
+		pattern = filepath.ToSlash(pattern)
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
filepath.Clean converts filenames to filenames with native path
separators. Use ToSlash to normalize.

This fixes TP4 test failure (https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP4/650/console) with error message:
15:21:58 --- FAIL: TestReadAll (0.00s)
15:21:58    dockerignore_test.go:47: Second element is not /test2
15:21:58 FAIL

Signed-off-by: Anusha Ragunathan anusha@docker.com
