### PR TITLE
Debug left over containers.

### DIFF
--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -18,6 +19,9 @@ func (s *DockerSuite) TestRmContainerWithRemovedVolume(c *check.C) {
 		c.Fatalf("failed to create temporary directory: %s", tempDir)
 	}
 	defer os.RemoveAll(tempDir)
+
+	out, _, _ := dockerCmdWithStdoutStderr(c, "ps", "-a")
+	fmt.Printf("out: %s", out)
 
 	dockerCmd(c, "run", "--name", "losemyvolumes", "-v", tempDir+":"+prefix+slash+"test", "busybox", "true")
 


### PR DESCRIPTION
Recently, DockerSuite.TestRmContainerWithRemovedVolume started failing
due to container name conflict. However, this should not theoritically
happen because the container running the docker tests (DinD) is
destroyed and recreated for every integration test run.

This change prints all containers, to confirm whether there is indeed a
name conflict or if another error is masking itself here.

Failing test reference:
https://jenkins.dockerproject.org/job/Docker-PRs/23445/console
https://jenkins.dockerproject.org/job/Docker-PRs/23441/console

Signed-off-by: Anusha Ragunathan anusha@docker.com
