### PR TITLE
Add mounts to docker ps.

### DIFF
--- a/api/client/formatter/custom.go
+++ b/api/client/formatter/custom.go
@@ -31,6 +31,7 @@ const (
 	repositoryHeader   = "REPOSITORY"
 	tagHeader          = "TAG"
 	digestHeader       = "DIGEST"
+	mountsHeader       = "MOUNTS"
 )
 
 type containerContext struct {
@@ -140,6 +141,20 @@ func (c *containerContext) Label(name string) string {
 		return ""
 	}
 	return c.c.Labels[name]
+}
+
+func (c *containerContext) Mounts() string {
+	c.addHeader(mountsHeader)
+
+	var mounts []string
+	for _, m := range c.c.Mounts {
+		name := m.Name
+		if c.trunc {
+			name = stringutils.Truncate(name, 15)
+		}
+		mounts = append(mounts, name)
+	}
+	return strings.Join(mounts, ",")
 }
 
 type imageContext struct {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -116,6 +116,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.23](docker_remote_api_v1.23.md) documentation
 
 * `GET /containers/json` returns the state of the container, one of `created`, `restarting`, `running`, `paused`, `exited` or `dead`.
+* `GET /containers/json` returns the mount points for the container.
 * `GET /networks/(name)` now returns an `Internal` field showing whether the network is internal or not.
 
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -73,7 +73,18 @@ List containers
                                           "MacAddress": "02:42:ac:11:00:02"
                                   }
                          }
-                 }
+                 },
+                 "Mounts": [
+                         {
+                                  "Name": "fac362...80535",
+                                  "Source": "/data",
+                                  "Destination": "/data",
+                                  "Driver": "local",
+                                  "Mode": "ro,Z",
+                                  "RW": false,
+                                  "Propagation": ""
+                         }
+                 ]
          },
          {
                  "Id": "9cd87474be90",
@@ -102,8 +113,8 @@ List containers
                                           "MacAddress": "02:42:ac:11:00:08"
                                   }
                          }
-                 }
-
+                 },
+                 "Mounts": []
          },
          {
                  "Id": "3176a2479c92",
@@ -132,8 +143,8 @@ List containers
                                           "MacAddress": "02:42:ac:11:00:06"
                                   }
                          }
-                 }
-
+                 },
+                 "Mounts": []
          },
          {
                  "Id": "4cb07b47f9fb",
@@ -162,8 +173,8 @@ List containers
                                           "MacAddress": "02:42:ac:11:00:05"
                                   }
                          }
-                 }
-
+                 },
+                 "Mounts": []
          }
     ]
 
@@ -184,6 +195,10 @@ Query Parameters:
   -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`|`dead`)
   -   `label=key` or `label="key=value"` of a container label
   -   `isolation=`(`default`|`process`|`hyperv`)   (Windows daemon only)
+  -   `ancestor`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+  -   `before`=(`<container id>` or `<container name>`)
+  -   `since`=(`<container id>` or `<container name>`)
+  -   `volume`=(`<volume name>` or `<mount point destination>`)
 
 Status Codes:
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -60,6 +60,7 @@ The currently supported filters are:
 * before (container's id or name) - filters containers created before given id or name
 * since (container's id or name) - filters containers created since given id or name
 * isolation (default|process|hyperv)   (Windows daemon only)
+* volume (volume name or mount point) - filters containers that mount volumes.
 
 
 #### Label
@@ -193,6 +194,18 @@ with the same containers as in `before` filter:
     9c3527ed70ce        busybox     "top"         10 minutes ago      Up 10 minutes                           desperate_dubinsky
     4aace5031105        busybox     "top"         10 minutes ago      Up 10 minutes                           focused_hamilton
 
+#### Volume
+
+The `volume` filter shows only containers that mount a specific volume or have a volume mounted in a specific path:
+
+    $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
+    CONTAINER ID        MOUNTS
+    9c3527ed70ce        remote-volume
+
+    $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
+    CONTAINER ID        MOUNTS
+    9c3527ed70ce        remote-volume
+
 
 ## Formatting
 
@@ -213,6 +226,7 @@ Placeholder | Description
 `.Names` | Container names.
 `.Labels` | All labels assigned to the container.
 `.Label` | Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
+`.Mounts` | Names of the volumes mounted in this container.
 
 When using the `--format` option, the `ps` command will either output the data exactly as the template
 declares or, when using the `table` directive, will include column headers as well.

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -35,6 +35,7 @@ the running containers.
    - before=(<container-name>|<container-id>)
    - since=(<container-name>|<container-id>)
    - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
+   - volume=(<volume-name>|<mount-point-destination>)
 
 **--format**="*TEMPLATE*"
    Pretty-print containers using a Go template.
@@ -50,6 +51,7 @@ the running containers.
       .Names - Container names.
       .Labels - All labels assigned to the container.
       .Label - Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
+      .Mounts - Names of the volumes mounted in this container.
 
 **--help**
   Print usage statement
@@ -117,6 +119,18 @@ the running containers.
     01946d9d34d8
     c1d3b0166030        debian
     41d50ecd2f57        fedora
+
+# Display containers with `remote-volume` mounted
+
+    $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
+    CONTAINER ID        MOUNTS
+    9c3527ed70ce        remote-volume
+
+# Display containers with a volume mounted in `/data`
+
+    $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
+    CONTAINER ID        MOUNTS
+    9c3527ed70ce        remote-volume
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)


### PR DESCRIPTION
- Allow to filter containers by volume with `--filter volume=name` and `filter volume=/dest`.
- Show their names in the list with the custom format `{{ .Mounts }}`.

This is consistent with the Network information we added recently.

Signed-off-by: David Calavera david.calavera@gmail.com
