### PR TITLE
Add message when finished signing image

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -425,6 +425,10 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string,
 	}
 
 	err = repo.Publish()
+	if err == nil {
+		fmt.Fprintf(cli.out, "Finished signing %q with tag %s\n", repoInfo.FullName(), tag)
+		return nil
+	}
 	if _, ok := err.(client.ErrRepoNotInitialized); !ok {
 		return notaryError(repoInfo.FullName(), err)
 	}


### PR DESCRIPTION
For now when enable DCT, the daemon will print a friendly message on the
first push of a image like:
- Finished initializing "notary-distribution:5678/illidan"

But when push the same image with different tag, v2 for example, daemon
will not display anything unless some error happens.

Signed-off-by: Hu Keping hukeping@huawei.com
