### PR TITLE
Fix typo in config-json man page

### DIFF
--- a/man/config-json.5.md
+++ b/man/config-json.5.md
@@ -2,7 +2,7 @@
 % Docker Community
 % JANUARY 2016
 # NAME
-HOME/.docker/confg.json - Default Docker configuration file
+HOME/.docker/config.json - Default Docker configuration file
 
 # INTRODUCTION
 


### PR DESCRIPTION
In the NAME section: "confg.json" -> "config.json"
