### PR TITLE
Grep for installed AND held packages.

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -372,7 +372,7 @@ do_install() {
 
 			# aufs is preferred over devicemapper; try to ensure the driver is available.
 			if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
-				if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -q '^ii' 2>/dev/null; then
+				if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | egrep '^ii|^hi' 2>/dev/null; then
 					kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
 
 					apt_get_update

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -372,7 +372,7 @@ do_install() {
 
 			# aufs is preferred over devicemapper; try to ensure the driver is available.
 			if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
-				if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | egrep '^ii|^hi' 2>/dev/null; then
+				if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -qE '^ii|^hi' 2>/dev/null; then
 					kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
 
 					apt_get_update


### PR DESCRIPTION
See: [Issue #19977](https://github.com/docker/docker/issues/19977) - apt marks held packages (packages not to touch on upgrade/autoremove), which are not matched by ^ii.
