### PR TITLE
Add missing debug client mode info in docs.

### DIFF
--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -44,6 +44,7 @@ For example:
     Total Memory: 62.86 GiB
     Name: docker
     ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    Debug mode (client): true
     Debug mode (server): true
      File Descriptors: 59
      Goroutines: 159


### PR DESCRIPTION
We added that information in #19901 but I forgot to add it to the docs, sorry :pensive:

Signed-off-by: David Calavera david.calavera@gmail.com
