### PR TITLE
Fix mention of at sign in docs

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -54,7 +54,7 @@ the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
 the following:
 
 * `a-z` (a single lowercase alpha character )
-* `@` (ampersand)
+* `@` (at sign)
 * `[` (left bracket)
 * `\\` (two backward slashes)
 *  `_` (underscore)

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -111,7 +111,7 @@ property. The format of the `<sequence>` is a comma-separated list of either
 a letter [a-Z], or the `ctrl-` combined with any of the following:
 
 * `a-z` (a single lowercase alpha character )
-* `@` (ampersand)
+* `@` (at sign)
 * `[` (left bracket)
 * `\\` (two backward slashes)
 *  `_` (underscore)

--- a/man/docker-attach.1.md
+++ b/man/docker-attach.1.md
@@ -55,7 +55,7 @@ the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
 the following:
 
 * `a-z` (a single lowercase alpha character )
-* `@` (ampersand)
+* `@` (at sign)
 * `[` (left bracket)
 * `\\` (two backward slashes)
 *  `_` (underscore)


### PR DESCRIPTION
The at sign (`@`) was being referred to in the documentation as an
ampersand (`&`).

Signed-off-by: Tom X. Tobin tomxtobin@tomxtobin.com
