### PR TITLE
Clear old parent reference on resetting image parent

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -231,6 +231,9 @@ func (is *store) SetParent(id, parent ID) error {
 	if parentMeta == nil {
 		return fmt.Errorf("unknown parent image ID %s", parent.String())
 	}
+	if parent, err := is.GetParent(id); err == nil && is.images[parent] != nil {
+		delete(is.images[parent].children, id)
+	}
 	parentMeta.children[id] = struct{}{}
 	return is.fs.SetMetadata(id, "parent", []byte(parent))
 }


### PR DESCRIPTION
On migration 2 different images can end up with same
content addressable ID, meaning `SetParent` will be called
multiple times. Previous version did not clear the old
in-memory reference.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
