### PR TITLE
Fixed problem with volume ls and volume path lookups

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -180,5 +180,5 @@ func (daemon *Daemon) VolumeCreate(name, driverName string, opts map[string]stri
 	}
 
 	daemon.LogVolumeEvent(v.Name(), "create", map[string]string{"driver": v.DriverName()})
-	return volumeToAPIType(v), nil
+	return volumeDetailsToAPIType(v), nil
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -190,7 +190,7 @@ func (daemon *Daemon) VolumeInspect(name string) (*types.Volume, error) {
 	if err != nil {
 		return nil, err
 	}
-	return volumeToAPIType(v), nil
+	return volumeDetailsToAPIType(v), nil
 }
 
 func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Settings) *v1p20.NetworkSettings {

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -26,6 +26,15 @@ type mounts []execdriver.Mount
 // volumeToAPIType converts a volume.Volume to the type used by the remote API
 func volumeToAPIType(v volume.Volume) *types.Volume {
 	return &types.Volume{
+		Name:   v.Name(),
+		Driver: v.DriverName(),
+	}
+}
+
+// volumeDetailsToAPIType converts a volume.Volume to the type used by the
+// remote API and does not lookup details
+func volumeDetailsToAPIType(v volume.Volume) *types.Volume {
+	return &types.Volume{
 		Name:       v.Name(),
 		Driver:     v.DriverName(),
 		Mountpoint: v.Path(),

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -392,6 +392,9 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c
 
 func (s *DockerExternalVolumeSuite) TesttExternalVolumeDriverList(c *check.C) {
 	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "--name", "abc")
+
+	s.ec.paths = 0
+	s.ec.gets = 0
 	out, _ := dockerCmd(c, "volume", "ls")
 	ls := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(ls), check.Equals, 2, check.Commentf("\n%s", out))
@@ -402,6 +405,8 @@ func (s *DockerExternalVolumeSuite) TesttExternalVolumeDriverList(c *check.C) {
 	c.Assert(vol[1], check.Equals, "abc")
 
 	c.Assert(s.ec.lists, check.Equals, 1)
+	c.Assert(s.ec.gets, check.Equals, 0)
+	c.Assert(s.ec.paths, check.Equals, 0)
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *check.C) {


### PR DESCRIPTION
This fixes a problem where when doing a volume ls
with docker, it would be followed by a Path() method
on every volume.  A test was added to ensure that
the List() method does not perform additional
lookups.

Signed-off-by: Clinton Kitson clintonskitson@gmail.com
