### PR TITLE
Adding --format= flag

### DIFF
--- a/man/docker-inspect.1.md
+++ b/man/docker-inspect.1.md
@@ -209,7 +209,7 @@ To get information on a container use its ID or instance name:
 
 To get the IP address of a container use:
 
-    $ docker inspect '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' d2cc496561d6
+    $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' d2cc496561d6
     172.17.0.2
 
 ## Listing all port bindings


### PR DESCRIPTION
Correcting the syntax given for docker inspect when retrieving a container instance's IP address. Fixes #20074 

Signed-off-by: Evan Allrich evan@unguku.com
