### PR TITLE
Memoize compiled regexps in fileutils.regexpMatch

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -202,7 +202,7 @@ func regexpMatch(pattern, path string) (bool, error) {
 
 	regStr += "$"
 
-	res, err := regexp.MatchString(regStr, path)
+	res, err := memoizeRegexpCompileMatch(regStr, path)
 
 	// Map regexp's error to filepath's so no one knows we're not using filepath
 	if err != nil {
@@ -210,6 +210,22 @@ func regexpMatch(pattern, path string) (bool, error) {
 	}
 
 	return res, err
+}
+
+var compiledRegexps = map[string]*regexp.Regexp{}
+
+func memoizeRegexpCompileMatch(regStr, testStr string) (bool, error) {
+	var err error
+
+	re, ok := compiledRegexps[regStr]
+	if !ok {
+		re, err = regexp.Compile(regStr)
+		if err != nil {
+			return false, err
+		}
+		compiledRegexps[regStr] = re
+	}
+	return re.MatchString(testStr), nil
 }
 
 // CopyFile copies from src to dst until either EOF is reached


### PR DESCRIPTION
**Headline figure**: For my large project it reduces the build context construction phase of `docker build` from a run time of ~10s to ~2s.

The observation was made using pprof that the majority of the time was
spent in regexp.Compile, so I just made it so we only do that once per
expression in the least intrusive way possible.

It creates a global map of compiled regular expressions which are
never deleted, so it could constitute a leak if this is used repeatedly.
I currently assume that there aren't enough of them for this to be a
worry since in any case it only lasts as long as the the docker client
is running a build.

Epilogue:

Before this fix, in my build context where I have 13,949 files and 4,417
non-ignored files (and 15 `.dockerignore` expressions), 43% of runtime
was spent in regexp.Compile (via fileutils.OptimizedMatches), which was
dominating. After this fix, regexp.Compile is invisible and the pprof
results don't make any sense to me any more. (go1.6rc2). I'm sure there
is more low hanging fruit but it is a bit harder to determine where it
might be now.
