### PR TITLE
adding note about go version 1.5 requirement for hardware signing

### DIFF
--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -44,7 +44,8 @@ need to package Docker your way, without denaturing it in the process.
 To build Docker, you will need the following:
 
 * A recent version of Git and Mercurial
-* Go version 1.4 or later
+* Go version 1.4 or later (Go version 1.5 or later required for hardware signing
+  support in Docker Content Trust)
 * A clean checkout of the source added to a valid [Go
   workspace](https://golang.org/doc/code.html#Workspaces) under the path
   *src/github.com/docker/docker* (unless you plan to use `AUTO_GOPATH`,


### PR DESCRIPTION
At @jfrazelle's request. A note about hardware signing requiring Go 1.5 or newer.

Signed-off-by: David Lawrence david.lawrence@docker.com (github: endophage)
