### PR TITLE
Do not purge github.com/ugorji/go/codec from vendor.

### DIFF
--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -117,10 +117,19 @@ clean() {
 		# This directory contains only .c and .h files which are necessary
 		-path vendor/src/github.com/mattn/go-sqlite3/code
 	)
+
+	# This package is required to build the Etcd client,
+	# but Etcd hard codes a local Godep full path.
+	# FIXME: fix_rewritten_imports fixes this problem in most platforms
+	# but it fails in very small corner cases where it makes the vendor
+	# script to remove this package.
+	# See: https://github.com/docker/docker/issues/19231
+	findArgs+=( -or -path vendor/src/github.com/ugorji/go/codec )
 	for import in "${imports[@]}"; do
 		[ "${#findArgs[@]}" -eq 0 ] || findArgs+=( -or )
 		findArgs+=( -path "vendor/src/$import" )
 	done
+
 	local IFS=$'\n'
 	local prune=( $($find vendor -depth -type d -not '(' "${findArgs[@]}" ')') )
 	unset IFS


### PR DESCRIPTION
Etcd uses a full Godep path to import this library, which is not very nice:

```
vendor/src/github.com/coreos/etcd/Godeps/_workspace/github.com/ugorji/go/codec
```

There might be a more general solution but this fixes the issue.

@tianon save me from this nightmare!

Fixes #19231.

Signed-off-by: David Calavera david.calavera@gmail.com
