### PR TITLE
[WIP] New .dockerignore implementation

### DIFF
--- a/builder/dockerignore/excluder.go
+++ b/builder/dockerignore/excluder.go
@@ -1,0 +1,230 @@
+package dockerignore
+
+import (
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// Excluder represents a set of patterns which should be excluded while walking
+// a filesystem.
+type Excluder struct {
+	Excludes []Exclude
+
+	// If specified not to be ".", specifies the directory where the
+	// exclude rules are rooted.
+	root string
+}
+
+// Exclude represents a single rule from a `.dockerignore`.
+// Note that an exclude may be negated.
+type Exclude struct {
+	Pattern string
+	Negated bool
+	IsDir   bool
+	glob.Glob
+}
+
+var errExcludeCommented = errors.New("exclude commented")
+
+// NewExclude constructs an Exclude from a single line.
+func NewExclude(line string) (Exclude, error) {
+	exclude := Exclude{Pattern: line}
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return exclude, errExcludeCommented
+	}
+
+	exclude.Pattern = filepath.Clean(exclude.Pattern)
+
+	if strings.HasPrefix(exclude.Pattern, "!") {
+		exclude.Negated = true
+		exclude.Pattern = exclude.Pattern[1:]
+	}
+	if strings.HasSuffix(exclude.Pattern, "/") {
+		exclude.IsDir = true
+		exclude.Pattern = trimTrailingSeps(exclude.Pattern)
+	}
+	var err error
+	exclude.Glob, err = glob.Compile(exclude.Pattern, string([]rune{filepath.Separator}))
+	return exclude, err
+}
+
+// NewExcluder loads the named ignoreFile path as an *Excluder.
+// It trims whitespace and removes excludes prefixed with a "#" (comments).
+func NewExcluder(root string, patterns []string) (*Excluder, error) {
+	excluder := &Excluder{root: root}
+
+	for _, pattern := range patterns {
+		exclude, err := NewExclude(pattern)
+		if err == errExcludeCommented {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		excluder.Excludes = append(excluder.Excludes, exclude)
+	}
+	return excluder, nil
+}
+
+func trimTrailingSeps(filePath string) string {
+	if filePath == string([]rune{filepath.Separator}) {
+		// Path is "/", so don't trim it.
+		return filePath
+	}
+	return strings.TrimFunc(filePath, func(r rune) bool {
+		return r == filepath.Separator
+	})
+}
+
+// LastMatch returns the last matching excluder (beware: it may be negated.)
+func (e *Excluder) LastMatch(filePath string, isDir bool) (*Exclude, bool) {
+	if isDir && strings.HasSuffix(filePath, string([]rune{filepath.Separator})) {
+		filePath = trimTrailingSeps(filePath)
+	}
+	// Consider excludes in reverse, since "last pattern wins" in the case
+	// of negation.
+	for i := len(e.Excludes) - 1; 0 <= i; i-- {
+		e := &e.Excludes[i]
+		if e.IsDir && !isDir {
+			// This exclude only applies to directories,
+			// and filePath is not a directory.
+			continue
+		}
+		if e.Match(filePath) {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+// HasAnyNegation returns true if any of the exclude rules are includes.
+func (e *Excluder) HasAnyNegation() bool {
+	for _, rule := range e.Excludes {
+		if rule.Negated {
+			return true
+		}
+	}
+	return false
+}
+
+// Wrap encloses the specified WalkFunc, only passing files to it which do not
+// match patterns which are excluded due to the Exclusion list.
+//
+// Note: This function is not optimal in the presence of negations.
+//       In particular, if there is even a single negation present, we walk all
+//       directories in the tree, in case a negation matches in a subtree.
+//       Fortunately, walking in general is quite fast, so this should only
+//       impact a small number of users. It may be worth considering optimizing
+//       this case though.
+func (e *Excluder) Wrap(wrapped filepath.WalkFunc) filepath.WalkFunc {
+
+	excludedDirectories := map[string]struct{}{}
+
+	// This is a safety net. We assert that the walk must show us the
+	// directory itself before showing the contents.
+	seenDirectories := map[string]struct{}{}
+
+	var inExcludedSubdirectory func(filePath string) bool
+	// Strip the baseName from filePath repeatedly until the bottom is
+	// reached. Returns true if any of the dirNames consider are present in
+	// excludedDirectories.
+	inExcludedSubdirectory = func(filePath string) bool {
+		dirName := trimTrailingSeps(filepath.Dir(filePath))
+		if _, seenDirectory := seenDirectories[dirName]; !seenDirectory {
+			// panic("walk function gave us invalid data")
+			// test if dirName should be ignored
+			e, match := e.LastMatch(dirName, true)
+			if match && !e.Negated {
+				log.Printf("Ignore %q", dirName)
+				excludedDirectories[dirName] = struct{}{}
+			}
+			seenDirectories[dirName] = struct{}{}
+		}
+		_, excluded := excludedDirectories[dirName]
+		if excluded {
+			return true
+		}
+		if dirName == "." || dirName == "" || dirName == "/" {
+			return false
+		}
+		return inExcludedSubdirectory(dirName)
+	}
+
+	anyNegations := e.HasAnyNegation()
+
+	return func(filePath string, f os.FileInfo, err error) error {
+		if err != nil {
+			// Forward errors directly to the wrapped function.
+			return wrapped(filePath, f, err)
+		}
+
+		// Path to find exclusion rules matching against.
+		testPath := filePath
+		if e.root != "." {
+			// We are performing a walk at some path other than ".",
+			// So it is necessary to test the paths as though
+			// they are files inside the `e.root` directory.
+			testPath, err = filepath.Rel(e.root, filePath)
+		}
+
+		if f.IsDir() {
+			seenDirectories[filePath] = struct{}{}
+		}
+
+		exclude, match := e.LastMatch(testPath, f.IsDir())
+
+		switch {
+		case match && !exclude.Negated && !f.IsDir():
+			// The path matches an exclude which is not negated
+			// and is not a directory. We can drop it.
+			return nil
+
+		case match && !exclude.Negated && f.IsDir():
+			// The path matches an exclude which is not negated
+			// but it is a directory.
+
+			if !anyNegations {
+				// There are no negation rules to consider.
+				// We can halt recursive descent.
+				return filepath.SkipDir
+			}
+
+			// In this case, there are negations.
+			// It's possible there are cases where a file in an
+			// excluded directory to become re-included, so
+			// recursive descent must continue.
+
+			// NOTE(pwaller): This is not the most efficient thing
+			//                we could do at this point, but it's
+			//                good enough for a first pass.
+			// (A better thing to do would be to compute the rules
+			//  which could affect the directory being recursed
+			//  into.)
+
+			excludedDirectories[filePath] = struct{}{}
+
+		case !match && inExcludedSubdirectory(filePath):
+			// No exclusion rule specifically matches this path,
+			// but it is in a subdirectory which matches.
+			return nil
+
+		case match && exclude.Negated:
+			// Found a match, but it was an explicit include.
+			// Pass it to wrapped.
+
+		case !match:
+			// No match found, pass it to wrapped.
+
+		default:
+			panic("unreachable")
+		}
+
+		return wrapped(filePath, f, err)
+	}
+}

--- a/builder/dockerignore/excluder_test.go
+++ b/builder/dockerignore/excluder_test.go
@@ -1,0 +1,289 @@
+package dockerignore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// collectWalker implements Walk and collects all the paths seen.
+type collectWalker struct{ Paths []string }
+
+func (wc *collectWalker) Walk(filePath string, fi os.FileInfo, err error) error {
+	wc.Paths = append(wc.Paths, filePath)
+	return err
+}
+
+type fakeFile struct {
+	filePath string
+	// use a nil pointer for everything else, since they should be unused.
+	os.FileInfo
+}
+
+func (f fakeFile) IsDir() bool {
+	return strings.HasSuffix(f.filePath, "/")
+}
+
+// mockWalk is a convenience function for walking a fake filesystem.
+// Paths ending in `/` are considered to be directories.
+func mockWalk(walkFn filepath.WalkFunc) func(string) error {
+	return func(filePath string) error {
+		return walkFn(filePath, &fakeFile{filePath, nil}, nil)
+	}
+}
+
+func TestExcluderBasicExclusion(t *testing.T) {
+	// One exclusion rule, ordinary file.
+	e, err := NewExcluder(".", []string{
+		"ignored",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	if err := walk("not-ignored"); err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if len(collector.Paths) != 1 {
+		t.Fatalf("Expected 1 walked, got: %v", len(collector.Paths))
+	}
+
+	if collector.Paths[0] != "not-ignored" {
+		t.Fatalf(`Expected "not-ignored", got %v`, collector.Paths[0])
+	}
+
+	collector.Paths = nil // Reset for the next check
+
+	if err := walk("ignored"); err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	switch {
+	case len(collector.Paths) != 0:
+		t.Fatalf("Expected 0 walked, got: %v", len(collector.Paths))
+	}
+}
+
+func TestExcluderSubdirectoryExclusion(t *testing.T) {
+	// One exclusion rule.
+	// It should apply only at the root.
+	e, err := NewExcluder(".", []string{
+		"foo",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	if err := walk("foo"); err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if err := walk("directory/foo"); err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if len(collector.Paths) != 1 {
+		t.Fatalf("Expected 1 walked, got: %q", collector.Paths)
+	}
+
+	switch {
+	case collector.Paths[0] != "directory/foo":
+		t.Fatalf(`Expected "directory/foo", got %v`, collector.Paths[0])
+	}
+}
+
+func TestExcluderDirectoryExclusion(t *testing.T) {
+	// One exclusion rule, directory.
+	e, err := NewExcluder(".", []string{
+		"ignored-directory/",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	if err := walk("not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("ignored-directory/foo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("ignored-directory/bar"); err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case len(collector.Paths) != 1:
+		t.Fatalf("Expected 1 walked, got: %v", len(collector.Paths))
+	case collector.Paths[0] != "not-ignored":
+		t.Fatalf(`Expected "not-ignored", got %v`, collector.Paths[0])
+	}
+
+}
+
+func TestExcluderNested(t *testing.T) {
+	// One exclusion rule,
+	// ignore a file named "ignored" anywhere.
+	e, err := NewExcluder(".", []string{
+		"**/ignored",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	if err := walk("not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("directory/not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("directory/directory/not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("directory/ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("directory/directory/ignored"); err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case len(collector.Paths) != 3:
+		t.Fatalf("Expected 3 walked, got: %v", len(collector.Paths))
+	case collector.Paths[0] != "not-ignored":
+		t.Fatalf(`Expected "not-ignored", got %v`, collector.Paths[0])
+	case collector.Paths[1] != "directory/not-ignored":
+		t.Fatalf(`Expected "directory/not-ignored", got %v`, collector.Paths[1])
+	case collector.Paths[2] != "directory/directory/not-ignored":
+		t.Fatalf(`Expected "directory/directory/not-ignored", got %v`, collector.Paths[2])
+	}
+}
+
+func TestExcluderIgnoredDirectoryNegation(t *testing.T) {
+	// Two rules. One directory excluded, one file within included.
+	e, err := NewExcluder(".", []string{
+		"ignored-directory/",
+		"!ignored-directory/not-ignored",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	if err := walk("not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("ignored-directory/"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("ignored-directory/ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("ignored-directory/not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case len(collector.Paths) != 3:
+		t.Fatalf("Expected 3 walked, got: %v: %v", len(collector.Paths), collector.Paths)
+	case collector.Paths[0] != "not-ignored":
+		t.Fatalf(`Expected "not-ignored", got %v`, collector.Paths[0])
+	case collector.Paths[1] != "ignored-directory/":
+		t.Fatalf(`Expected "ignored-directory/", got %v`, collector.Paths[1])
+	case collector.Paths[2] != "ignored-directory/not-ignored":
+		t.Fatalf(`Expected "not-ignored", got %v`, collector.Paths[2])
+	}
+}
+
+func TestExcluderExtension(t *testing.T) {
+	// Exclude files named *.binary found anywhere.
+	e, err := NewExcluder(".", []string{
+		"**/*.binary",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	// Only this should be visible.
+	if err := walk("not-ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("test.binary"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("test.binary/test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("directory/test.binary"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("directory/directory/test.binary"); err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case len(collector.Paths) != 1:
+		t.Fatalf("Expected 1 walked, got: %v: %v", len(collector.Paths), collector.Paths)
+	case collector.Paths[0] != "not-ignored":
+		t.Fatalf(`Expected "not-ignored", got %v`, collector.Paths[0])
+	}
+}
+
+// Taken from
+// https://github.com/docker/docker/blob/46a61b72/docs/reference/builder.md#dockerignore-file
+func TestExcluderREADMESecretmd(t *testing.T) {
+	// Two rules. One directory excluded, one file within included.
+	e, err := NewExcluder(".", []string{
+		"*.md",
+		"!README*.md",
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	collector := collectWalker{}
+	walkFn := e.Wrap(collector.Walk)
+	walk := mockWalk(walkFn)
+
+	if err := walk("boring.md"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if err := walk("README-interesting.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case len(collector.Paths) != 2:
+		t.Fatalf("Expected 2 walked, got: %v: %v", len(collector.Paths), collector.Paths)
+	case collector.Paths[0] != "README.md":
+		t.Fatalf(`Expected "README.md", got %v`, collector.Paths[0])
+	case collector.Paths[1] != "README-interesting.md":
+		t.Fatalf(`Expected "README-interesting.md", got %v`, collector.Paths[1])
+	}
+}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -11,6 +11,7 @@ clone git github.com/Microsoft/go-winio eb176a9831c54b88eaf9eb4fbc24b94080d910ad
 clone git github.com/Sirupsen/logrus v0.9.0 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 clone git github.com/go-check/check 11d3bc7aa68e238947792f30573146a3231fc0f1
+clone git github.com/gobwas/glob 3222d377756fc0940b549f57a038bc9ba2716628
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 5cf931ef8f

--- a/vendor/src/github.com/gobwas/glob/.gitignore
+++ b/vendor/src/github.com/gobwas/glob/.gitignore
@@ -1,0 +1,8 @@
+glob.iml
+.idea
+*.cpu
+*.mem
+*.test
+*.dot
+*.png
+*.svg

--- a/vendor/src/github.com/gobwas/glob/.travis.yml
+++ b/vendor/src/github.com/gobwas/glob/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+
+language: go
+
+go:
+  - 1.5.3
+
+script:
+  - go test -v ./...

--- a/vendor/src/github.com/gobwas/glob/compiler.go
+++ b/vendor/src/github.com/gobwas/glob/compiler.go
@@ -1,0 +1,679 @@
+package glob
+
+import (
+	"fmt"
+	"github.com/gobwas/glob/match"
+	"reflect"
+	"unicode/utf8"
+)
+
+func optimize(matcher match.Matcher) match.Matcher {
+	switch m := matcher.(type) {
+
+	case match.Any:
+		if m.Separators == "" {
+			return match.Super{}
+		}
+
+	case match.AnyOf:
+		if len(m.Matchers) == 1 {
+			return m.Matchers[0]
+		}
+
+		return m
+
+	case match.List:
+		if m.Not == false && utf8.RuneCountInString(m.List) == 1 {
+			return match.NewText(m.List)
+		}
+
+		return m
+
+	case match.BTree:
+		m.Left = optimize(m.Left)
+		m.Right = optimize(m.Right)
+
+		r, ok := m.Value.(match.Text)
+		if !ok {
+			return m
+		}
+
+		leftNil := m.Left == nil
+		rightNil := m.Right == nil
+
+		if leftNil && rightNil {
+			return match.NewText(r.Str)
+		}
+
+		_, leftSuper := m.Left.(match.Super)
+		lp, leftPrefix := m.Left.(match.Prefix)
+
+		_, rightSuper := m.Right.(match.Super)
+		rs, rightSuffix := m.Right.(match.Suffix)
+
+		if leftSuper && rightSuper {
+			return match.Contains{r.Str, false}
+		}
+
+		if leftSuper && rightNil {
+			return match.Suffix{r.Str}
+		}
+
+		if rightSuper && leftNil {
+			return match.Prefix{r.Str}
+		}
+
+		if leftNil && rightSuffix {
+			return match.PrefixSuffix{Prefix: r.Str, Suffix: rs.Suffix}
+		}
+
+		if rightNil && leftPrefix {
+			return match.PrefixSuffix{Prefix: lp.Prefix, Suffix: r.Str}
+		}
+
+		return m
+	}
+
+	return matcher
+}
+
+func glueMatchers(matchers []match.Matcher) match.Matcher {
+	var (
+		glued  []match.Matcher
+		winner match.Matcher
+	)
+	maxLen := -1
+
+	if m := glueAsEvery(matchers); m != nil {
+		glued = append(glued, m)
+		return m
+	}
+
+	if m := glueAsRow(matchers); m != nil {
+		glued = append(glued, m)
+		return m
+	}
+
+	for _, g := range glued {
+		if l := g.Len(); l > maxLen {
+			maxLen = l
+			winner = g
+		}
+	}
+
+	return winner
+}
+
+func glueAsRow(matchers []match.Matcher) match.Matcher {
+	if len(matchers) <= 1 {
+		return nil
+	}
+
+	var (
+		c []match.Matcher
+		l int
+	)
+	for _, matcher := range matchers {
+		if ml := matcher.Len(); ml == -1 {
+			return nil
+		} else {
+			c = append(c, matcher)
+			l += ml
+		}
+	}
+
+	return match.Row{c, l}
+}
+
+func glueAsEvery(matchers []match.Matcher) match.Matcher {
+	if len(matchers) <= 1 {
+		return nil
+	}
+
+	var (
+		hasAny    bool
+		hasSuper  bool
+		hasSingle bool
+		min       int
+		separator string
+	)
+
+	for i, matcher := range matchers {
+		var sep string
+		switch m := matcher.(type) {
+
+		case match.Super:
+			sep = ""
+			hasSuper = true
+
+		case match.Any:
+			sep = m.Separators
+			hasAny = true
+
+		case match.Single:
+			sep = m.Separators
+			hasSingle = true
+			min++
+
+		case match.List:
+			if !m.Not {
+				return nil
+			}
+			sep = m.List
+			hasSingle = true
+			min++
+
+		default:
+			return nil
+		}
+
+		// initialize
+		if i == 0 {
+			separator = sep
+		}
+
+		if sep == separator {
+			continue
+		}
+
+		return nil
+	}
+
+	if hasSuper && !hasAny && !hasSingle {
+		return match.Super{}
+	}
+
+	if hasAny && !hasSuper && !hasSingle {
+		return match.Any{separator}
+	}
+
+	if (hasAny || hasSuper) && min > 0 && separator == "" {
+		return match.Min{min}
+	}
+
+	every := match.EveryOf{}
+
+	if min > 0 {
+		every.Add(match.Min{min})
+
+		if !hasAny && !hasSuper {
+			every.Add(match.Max{min})
+		}
+	}
+
+	if separator != "" {
+		every.Add(match.Contains{separator, true})
+	}
+
+	return every
+}
+
+func minimizeMatchers(matchers []match.Matcher) []match.Matcher {
+	var done match.Matcher
+	var left, right, count int
+
+	for l := 0; l < len(matchers); l++ {
+		for r := len(matchers); r > l; r-- {
+			if glued := glueMatchers(matchers[l:r]); glued != nil {
+				var swap bool
+
+				if done == nil {
+					swap = true
+				} else {
+					cl, gl := done.Len(), glued.Len()
+					swap = cl > -1 && gl > -1 && gl > cl
+					swap = swap || count < r-l
+				}
+
+				if swap {
+					done = glued
+					left = l
+					right = r
+					count = r - l
+				}
+			}
+		}
+	}
+
+	if done == nil {
+		return matchers
+	}
+
+	next := append(append([]match.Matcher{}, matchers[:left]...), done)
+	if right < len(matchers) {
+		next = append(next, matchers[right:]...)
+	}
+
+	if len(next) == len(matchers) {
+		return next
+	}
+
+	return minimizeMatchers(next)
+}
+
+func minimizeAnyOf(children []node) node {
+	var nodes [][]node
+	var min int
+	var idx int
+	for i, desc := range children {
+		pat, ok := desc.(*nodePattern)
+		if !ok {
+			return nil
+		}
+
+		n := pat.children()
+		ln := len(n)
+		if len(nodes) == 0 || (ln < min) {
+			min = ln
+			idx = i
+		}
+
+		nodes = append(nodes, pat.children())
+	}
+
+	minNodes := nodes[idx]
+	if idx+1 < len(nodes) {
+		nodes = append(nodes[:idx], nodes[idx+1:]...)
+	} else {
+		nodes = nodes[:idx]
+	}
+
+	var commonLeft []node
+	var commonLeftCount int
+	for i, n := range minNodes {
+		has := true
+		for _, t := range nodes {
+			if !reflect.DeepEqual(n, t[i]) {
+				has = false
+				break
+			}
+		}
+
+		if has {
+			commonLeft = append(commonLeft, n)
+			commonLeftCount++
+		} else {
+			break
+		}
+	}
+
+	var commonRight []node
+	var commonRightCount int
+	for i := min - 1; i > commonLeftCount-1; i-- {
+		n := minNodes[i]
+		has := true
+		for _, t := range nodes {
+			if !reflect.DeepEqual(n, t[len(t)-(min-i)]) {
+				has = false
+				break
+			}
+		}
+
+		if has {
+			commonRight = append(commonRight, n)
+			commonRightCount++
+		} else {
+			break
+		}
+	}
+
+	if commonLeftCount == 0 && commonRightCount == 0 {
+		return nil
+	}
+
+	nodes = append(nodes, minNodes)
+	nodes[len(nodes)-1], nodes[idx] = nodes[idx], nodes[len(nodes)-1]
+
+	var result []node
+	if commonLeftCount > 0 {
+		result = append(result, &nodePattern{nodeImpl: nodeImpl{desc: commonLeft}})
+	}
+
+	var anyOf []node
+	for _, n := range nodes {
+		if commonLeftCount+commonRightCount == len(n) {
+			anyOf = append(anyOf, nil)
+		} else {
+			anyOf = append(anyOf, &nodePattern{nodeImpl: nodeImpl{desc: n[commonLeftCount : len(n)-commonRightCount]}})
+		}
+	}
+
+	anyOf = uniqueNodes(anyOf)
+	if len(anyOf) == 1 {
+		if anyOf[0] != nil {
+			result = append(result, &nodePattern{nodeImpl: nodeImpl{desc: anyOf}})
+		}
+	} else {
+		result = append(result, &nodeAnyOf{nodeImpl: nodeImpl{desc: anyOf}})
+	}
+
+	if commonRightCount > 0 {
+		result = append(result, &nodePattern{nodeImpl: nodeImpl{desc: commonRight}})
+	}
+
+	return &nodePattern{nodeImpl: nodeImpl{desc: result}}
+}
+
+func uniqueNodes(nodes []node) (result []node) {
+head:
+	for _, n := range nodes {
+		for _, e := range result {
+			if reflect.DeepEqual(e, n) {
+				continue head
+			}
+		}
+
+		result = append(result, n)
+	}
+
+	return
+}
+
+func compileMatchers(matchers []match.Matcher) (match.Matcher, error) {
+	if len(matchers) == 0 {
+		return nil, fmt.Errorf("compile error: need at least one matcher")
+	}
+
+	if len(matchers) == 1 {
+		return matchers[0], nil
+	}
+
+	if m := glueMatchers(matchers); m != nil {
+		return m, nil
+	}
+
+	var (
+		val match.Matcher
+		idx int
+	)
+	maxLen := -1
+	for i, matcher := range matchers {
+		l := matcher.Len()
+		if l >= maxLen {
+			maxLen = l
+			idx = i
+			val = matcher
+		}
+	}
+
+	left := matchers[:idx]
+	var right []match.Matcher
+	if len(matchers) > idx+1 {
+		right = matchers[idx+1:]
+	}
+
+	var l, r match.Matcher
+	var err error
+	if len(left) > 0 {
+		l, err = compileMatchers(left)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(right) > 0 {
+		r, err = compileMatchers(right)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return match.NewBTree(val, l, r), nil
+}
+
+//func complexity(m match.Matcher) int {
+//	var matchers []match.Matcher
+//	var k int
+//
+//	switch matcher := m.(type) {
+//
+//	case match.Nothing:
+//		return 0
+//
+//	case match.Max, match.Range, match.Suffix, match.Text:
+//		return 1
+//
+//	case match.PrefixSuffix, match.Single, match.Row:
+//		return 2
+//
+//	case match.Any, match.Contains, match.List, match.Min, match.Prefix, match.Super:
+//		return 4
+//
+//	case match.BTree:
+//		matchers = append(matchers, matcher.Value)
+//		if matcher.Left != nil {
+//			matchers = append(matchers, matcher.Left)
+//		}
+//		if matcher.Right != nil {
+//			matchers = append(matchers, matcher.Right)
+//		}
+//		k = 1
+//
+//	case match.AnyOf:
+//		matchers = matcher.Matchers
+//		k = 1
+//	case match.EveryOf:
+//		matchers = matcher.Matchers
+//		k = 1
+//
+//	default:
+//		return 0
+//	}
+//
+//	var sum int
+//	for _, m := range matchers {
+//		sum += complexity(m)
+//	}
+//
+//	return sum * k
+//}
+
+func doAnyOf(n *nodeAnyOf, s string) (match.Matcher, error) {
+	var matchers []match.Matcher
+	for _, desc := range n.children() {
+		if desc == nil {
+			matchers = append(matchers, match.Nothing{})
+			continue
+		}
+
+		m, err := do(desc, s)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, optimize(m))
+	}
+
+	return match.AnyOf{matchers}, nil
+}
+
+func do(leaf node, s string) (m match.Matcher, err error) {
+	switch n := leaf.(type) {
+
+	case *nodeAnyOf:
+		// todo this could be faster on pattern_alternatives_combine_lite
+		if n := minimizeAnyOf(n.children()); n != nil {
+			return do(n, s)
+		}
+
+		var matchers []match.Matcher
+		for _, desc := range n.children() {
+			if desc == nil {
+				matchers = append(matchers, match.Nothing{})
+				continue
+			}
+
+			m, err := do(desc, s)
+			if err != nil {
+				return nil, err
+			}
+			matchers = append(matchers, optimize(m))
+		}
+
+		return match.AnyOf{matchers}, nil
+
+	case *nodePattern:
+		nodes := leaf.children()
+		if len(nodes) == 0 {
+			return match.Nothing{}, nil
+		}
+
+		var matchers []match.Matcher
+		for _, desc := range nodes {
+			m, err := do(desc, s)
+			if err != nil {
+				return nil, err
+			}
+			matchers = append(matchers, optimize(m))
+		}
+
+		m, err = compileMatchers(minimizeMatchers(matchers))
+		if err != nil {
+			return nil, err
+		}
+
+	case *nodeList:
+		m = match.List{n.chars, n.not}
+
+	case *nodeRange:
+		m = match.Range{n.lo, n.hi, n.not}
+
+	case *nodeAny:
+		m = match.Any{s}
+
+	case *nodeSuper:
+		m = match.Super{}
+
+	case *nodeSingle:
+		m = match.Single{s}
+
+	case *nodeText:
+		m = match.NewText(n.text)
+
+	default:
+		return nil, fmt.Errorf("could not compile tree: unknown node type")
+	}
+
+	return optimize(m), nil
+}
+
+func do2(node node, s string) ([]match.Matcher, error) {
+	var result []match.Matcher
+
+	switch n := node.(type) {
+
+	case *nodePattern:
+		ways := [][]match.Matcher{[]match.Matcher{}}
+
+		for _, desc := range node.children() {
+			variants, err := do2(desc, s)
+			if err != nil {
+				return nil, err
+			}
+
+			fmt.Println("variants pat", variants)
+
+			for i, l := 0, len(ways); i < l; i++ {
+				for i := 0; i < len(variants); i++ {
+					o := optimize(variants[i])
+					if i == len(variants)-1 {
+						ways[i] = append(ways[i], o)
+					} else {
+						var w []match.Matcher
+						copy(w, ways[i])
+						ways = append(ways, append(w, o))
+					}
+				}
+			}
+
+			fmt.Println("ways pat", ways)
+		}
+
+		for _, matchers := range ways {
+			c, err := compileMatchers(minimizeMatchers(matchers))
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, c)
+		}
+
+	case *nodeAnyOf:
+		ways := make([][]match.Matcher, len(node.children()))
+		for _, desc := range node.children() {
+			variants, err := do2(desc, s)
+			if err != nil {
+				return nil, err
+			}
+
+			fmt.Println("variants any", variants)
+
+			for x, l := 0, len(ways); x < l; x++ {
+				for i := 0; i < len(variants); i++ {
+					o := optimize(variants[i])
+					if i == len(variants)-1 {
+						ways[x] = append(ways[x], o)
+					} else {
+						var w []match.Matcher
+						copy(w, ways[x])
+						ways = append(ways, append(w, o))
+					}
+				}
+			}
+
+			fmt.Println("ways any", ways)
+		}
+
+		for _, matchers := range ways {
+			c, err := compileMatchers(minimizeMatchers(matchers))
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, c)
+		}
+
+	case *nodeList:
+		result = append(result, match.List{n.chars, n.not})
+
+	case *nodeRange:
+		result = append(result, match.Range{n.lo, n.hi, n.not})
+
+	case *nodeAny:
+		result = append(result, match.Any{s})
+
+	case *nodeSuper:
+		result = append(result, match.Super{})
+
+	case *nodeSingle:
+		result = append(result, match.Single{s})
+
+	case *nodeText:
+		result = append(result, match.NewText(n.text))
+
+	default:
+		return nil, fmt.Errorf("could not compile tree: unknown node type")
+	}
+
+	for i, m := range result {
+		result[i] = optimize(m)
+	}
+
+	return result, nil
+}
+
+func compile(ast *nodePattern, s string) (Glob, error) {
+	//	ms, err := do2(ast, s)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//	if len(ms) == 1 {
+	//		return ms[0], nil
+	//	} else {
+	//		return match.AnyOf{ms}, nil
+	//	}
+
+	g, err := do(ast, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}

--- a/vendor/src/github.com/gobwas/glob/glob.go
+++ b/vendor/src/github.com/gobwas/glob/glob.go
@@ -1,0 +1,58 @@
+package glob
+
+import "strings"
+
+// Glob represents compiled glob pattern.
+type Glob interface {
+	Match(string) bool
+}
+
+// Compile creates Glob for given pattern and strings (if any present after pattern) as separators.
+// The pattern syntax is:
+//
+//    pattern:
+//        { term }
+//
+//    term:
+//        `*`         matches any sequence of non-separator characters
+//        `**`        matches any sequence of characters
+//        `?`         matches any single non-separator character
+//        `[` [ `!` ] { character-range } `]`
+//                    character class (must be non-empty)
+//        `{` pattern-list `}`
+//                    pattern alternatives
+//        c           matches character c (c != `*`, `**`, `?`, `\`, `[`, `{`, `}`)
+//        `\` c       matches character c
+//
+//    character-range:
+//        c           matches character c (c != `\\`, `-`, `]`)
+//        `\` c       matches character c
+//        lo `-` hi   matches character c for lo <= c <= hi
+//
+//    pattern-list:
+//        pattern { `,` pattern }
+//                    comma-separated (without spaces) patterns
+//
+func Compile(pattern string, separators ...string) (Glob, error) {
+	ast, err := parse(newLexer(pattern))
+	if err != nil {
+		return nil, err
+	}
+
+	matcher, err := compile(ast, strings.Join(separators, ""))
+	if err != nil {
+		return nil, err
+	}
+
+	return matcher, nil
+}
+
+// MustCompile is the same as Compile, except that if Compile returns error, this will panic
+func MustCompile(pattern string, separators ...string) Glob {
+	g, err := Compile(pattern, separators...)
+	if err != nil {
+		panic(err)
+	}
+
+	return g
+}

--- a/vendor/src/github.com/gobwas/glob/lexer.go
+++ b/vendor/src/github.com/gobwas/glob/lexer.go
@@ -1,0 +1,465 @@
+package glob
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	char_any           = '*'
+	char_separator     = ','
+	char_single        = '?'
+	char_escape        = '\\'
+	char_range_open    = '['
+	char_range_close   = ']'
+	char_terms_open    = '{'
+	char_terms_close   = '}'
+	char_range_not     = '!'
+	char_range_between = '-'
+)
+
+var eof rune = 0
+
+type stateFn func(*lexer) stateFn
+
+type itemType int
+
+const (
+	item_eof itemType = iota
+	item_error
+	item_text
+	item_char
+	item_any
+	item_super
+	item_single
+	item_not
+	item_separator
+	item_range_open
+	item_range_close
+	item_range_lo
+	item_range_hi
+	item_range_between
+	item_terms_open
+	item_terms_close
+)
+
+func (i itemType) String() string {
+	switch i {
+	case item_eof:
+		return "eof"
+
+	case item_error:
+		return "error"
+
+	case item_text:
+		return "text"
+
+	case item_char:
+		return "char"
+
+	case item_any:
+		return "any"
+
+	case item_super:
+		return "super"
+
+	case item_single:
+		return "single"
+
+	case item_not:
+		return "not"
+
+	case item_separator:
+		return "separator"
+
+	case item_range_open:
+		return "range_open"
+
+	case item_range_close:
+		return "range_close"
+
+	case item_range_lo:
+		return "range_lo"
+
+	case item_range_hi:
+		return "range_hi"
+
+	case item_range_between:
+		return "range_between"
+
+	case item_terms_open:
+		return "terms_open"
+
+	case item_terms_close:
+		return "terms_close"
+
+	default:
+		return "undef"
+	}
+}
+
+type item struct {
+	t itemType
+	s string
+}
+
+func (i item) String() string {
+	return fmt.Sprintf("%v<%s>", i.t, i.s)
+}
+
+type lexer struct {
+	input       string
+	start       int
+	pos         int
+	width       int
+	runes       int
+	termScopes  []int
+	termPhrases map[int]int
+	state       stateFn
+	items       chan item
+}
+
+func newLexer(source string) *lexer {
+	l := &lexer{
+		input:       source,
+		state:       lexText,
+		items:       make(chan item, 5),
+		termPhrases: make(map[int]int),
+	}
+	return l
+}
+
+func (l *lexer) run() {
+	for state := lexText; state != nil; {
+		state = state(l)
+	}
+	close(l.items)
+}
+
+func (l *lexer) nextItem() item {
+	for {
+		select {
+		case item := <-l.items:
+			return item
+		default:
+			if l.state == nil {
+				return item{t: item_eof}
+			}
+
+			l.state = l.state(l)
+		}
+	}
+
+	panic("something went wrong")
+}
+
+func (l *lexer) read() (r rune) {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += l.width
+	l.runes++
+
+	return
+}
+
+func (l *lexer) unread() {
+	l.pos -= l.width
+	l.runes--
+}
+
+func (l *lexer) reset() {
+	l.pos = l.start
+	l.runes = 0
+}
+
+func (l *lexer) ignore() {
+	l.start = l.pos
+	l.runes = 0
+}
+
+func (l *lexer) lookahead() rune {
+	r := l.read()
+	if r != eof {
+		l.unread()
+	}
+	return r
+}
+
+func (l *lexer) accept(valid string) bool {
+	if strings.IndexRune(valid, l.read()) != -1 {
+		return true
+	}
+	l.unread()
+	return false
+}
+
+func (l *lexer) acceptAll(valid string) {
+	for strings.IndexRune(valid, l.read()) != -1 {
+	}
+	l.unread()
+}
+
+func (l *lexer) emit(t itemType) {
+	if l.pos == len(l.input) {
+		l.items <- item{t, l.input[l.start:]}
+	} else {
+		l.items <- item{t, l.input[l.start:l.pos]}
+	}
+
+	l.start = l.pos
+	l.runes = 0
+	l.width = 0
+}
+
+func (l *lexer) emitMaybe(t itemType) {
+	if l.pos > l.start {
+		l.emit(t)
+	}
+}
+
+func (l *lexer) errorf(format string, args ...interface{}) {
+	l.items <- item{item_error, fmt.Sprintf(format, args...)}
+}
+
+func lexText(l *lexer) stateFn {
+	for {
+		c := l.read()
+		if c == eof {
+			break
+		}
+
+		switch c {
+		case char_escape:
+			l.unread()
+			l.emitMaybe(item_text)
+
+			l.read()
+			l.ignore()
+
+			if l.read() == eof {
+				l.errorf("unclosed '%s' character", string(char_escape))
+				return nil
+			}
+
+		case char_single:
+			l.unread()
+			l.emitMaybe(item_text)
+			return lexSingle
+
+		case char_any:
+			var n stateFn
+			if l.lookahead() == char_any {
+				n = lexSuper
+			} else {
+				n = lexAny
+			}
+
+			l.unread()
+			l.emitMaybe(item_text)
+			return n
+
+		case char_range_open:
+			l.unread()
+			l.emitMaybe(item_text)
+			return lexRangeOpen
+
+		case char_terms_open:
+			l.unread()
+			l.emitMaybe(item_text)
+			return lexTermsOpen
+
+		case char_terms_close:
+			l.unread()
+			l.emitMaybe(item_text)
+			return lexTermsClose
+
+		case char_separator:
+			l.unread()
+			l.emitMaybe(item_text)
+			return lexSeparator
+
+		}
+
+	}
+
+	if l.pos > l.start {
+		l.emit(item_text)
+	}
+
+	if len(l.termScopes) != 0 {
+		l.errorf("invalid pattern syntax: unclosed terms")
+		return nil
+	}
+
+	l.emit(item_eof)
+
+	return nil
+}
+
+func lexInsideRange(l *lexer) stateFn {
+	for {
+		c := l.read()
+		if c == eof {
+			l.errorf("unclosed range construction")
+			return nil
+		}
+
+		switch c {
+		case char_range_not:
+			// only first char makes sense
+			if l.pos-l.width == l.start {
+				l.emit(item_not)
+			}
+
+		case char_range_between:
+			if l.runes != 2 {
+				l.errorf("unexpected length of lo char inside range")
+				return nil
+			}
+
+			l.reset()
+			return lexRangeHiLo
+
+		case char_range_close:
+			l.unread()
+			l.emitMaybe(item_text)
+			return lexRangeClose
+		}
+	}
+}
+
+func lexRangeHiLo(l *lexer) stateFn {
+	start := l.start
+
+	for {
+		c := l.read()
+		if c == eof {
+			l.errorf("unexpected end of input")
+			return nil
+		}
+
+		switch c {
+		case char_range_between:
+			if l.runes != 1 {
+				l.errorf("unexpected length of range: single character expected before minus")
+				return nil
+			}
+
+			l.emit(item_range_between)
+
+		case char_range_close:
+			l.unread()
+
+			if l.runes != 1 {
+				l.errorf("unexpected length of range: single character expected before close")
+				return nil
+			}
+
+			l.emit(item_range_hi)
+			return lexRangeClose
+
+		default:
+			if start != l.start {
+				continue
+			}
+
+			if l.runes != 1 {
+				l.errorf("unexpected length of range: single character expected at the begining")
+				return nil
+			}
+
+			l.emit(item_range_lo)
+		}
+	}
+}
+
+func lexAny(l *lexer) stateFn {
+	l.pos += 1
+	l.emit(item_any)
+	return lexText
+}
+
+func lexSuper(l *lexer) stateFn {
+	l.pos += 2
+	l.emit(item_super)
+	return lexText
+}
+
+func lexSingle(l *lexer) stateFn {
+	l.pos += 1
+	l.emit(item_single)
+	return lexText
+}
+
+func lexSeparator(l *lexer) stateFn {
+	if len(l.termScopes) == 0 {
+		l.errorf("syntax error: separator not inside terms list")
+		return nil
+	}
+
+	posOpen := l.termScopes[len(l.termScopes)-1]
+
+	if l.pos-posOpen == 1 {
+		l.errorf("syntax error: empty term before separator")
+		return nil
+	}
+
+	l.termPhrases[posOpen] += 1
+	l.pos += 1
+	l.emit(item_separator)
+	return lexText
+}
+
+func lexTermsOpen(l *lexer) stateFn {
+	l.termScopes = append(l.termScopes, l.pos)
+	l.pos += 1
+	l.emit(item_terms_open)
+
+	return lexText
+}
+
+func lexTermsClose(l *lexer) stateFn {
+	if len(l.termScopes) == 0 {
+		l.errorf("unexpected closing of terms: there is no opened terms")
+		return nil
+	}
+
+	lastOpen := len(l.termScopes) - 1
+	posOpen := l.termScopes[lastOpen]
+
+	// if it is empty term
+	if posOpen == l.pos-1 {
+		l.errorf("term could not be empty")
+		return nil
+	}
+
+	if l.termPhrases[posOpen] == 0 {
+		l.errorf("term must contain >1 phrases")
+		return nil
+	}
+
+	// cleanup
+	l.termScopes = l.termScopes[:lastOpen]
+	delete(l.termPhrases, posOpen)
+
+	l.pos += 1
+	l.emit(item_terms_close)
+
+	return lexText
+}
+
+func lexRangeOpen(l *lexer) stateFn {
+	l.pos += 1
+	l.emit(item_range_open)
+	return lexInsideRange
+}
+
+func lexRangeClose(l *lexer) stateFn {
+	l.pos += 1
+	l.emit(item_range_close)
+	return lexText
+}

--- a/vendor/src/github.com/gobwas/glob/match/any.go
+++ b/vendor/src/github.com/gobwas/glob/match/any.go
@@ -1,0 +1,46 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type Any struct {
+	Separators string
+}
+
+func (self Any) Match(s string) bool {
+	return strings.IndexAny(s, self.Separators) == -1
+}
+
+func (self Any) Index(s string) (int, []int) {
+	var sub string
+
+	found := strings.IndexAny(s, self.Separators)
+	switch found {
+	case -1:
+		sub = s
+	case 0:
+		return 0, []int{0}
+	default:
+		sub = s[:found]
+	}
+
+	segments := make([]int, 0, utf8.RuneCountInString(sub)+1)
+	for i := range sub {
+		segments = append(segments, i)
+	}
+
+	segments = append(segments, len(sub))
+
+	return 0, segments
+}
+
+func (self Any) Len() int {
+	return lenNo
+}
+
+func (self Any) String() string {
+	return fmt.Sprintf("<any:![%s]>", self.Separators)
+}

--- a/vendor/src/github.com/gobwas/glob/match/any_of.go
+++ b/vendor/src/github.com/gobwas/glob/match/any_of.go
@@ -1,0 +1,84 @@
+package match
+
+import (
+	"fmt"
+)
+
+type AnyOf struct {
+	Matchers Matchers
+}
+
+func (self *AnyOf) Add(m Matcher) error {
+	self.Matchers = append(self.Matchers, m)
+	return nil
+}
+
+func (self AnyOf) Match(s string) bool {
+	for _, m := range self.Matchers {
+		if m.Match(s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (self AnyOf) Index(s string) (int, []int) {
+	if len(self.Matchers) == 0 {
+		return -1, nil
+	}
+
+	// segments to merge
+	var segments [][]int
+	index := -1
+
+	for _, m := range self.Matchers {
+		idx, seg := m.Index(s)
+		if idx == -1 {
+			continue
+		}
+
+		if index == -1 || idx < index {
+			index = idx
+			segments = [][]int{seg}
+			continue
+		}
+
+		if idx > index {
+			continue
+		}
+
+		segments = append(segments, seg)
+	}
+
+	if index == -1 {
+		return -1, nil
+	}
+
+	return index, mergeSegments(segments)
+}
+
+func (self AnyOf) Len() (l int) {
+	l = -1
+	for _, m := range self.Matchers {
+		ml := m.Len()
+		if ml == -1 {
+			return -1
+		}
+
+		if l == -1 {
+			l = ml
+			continue
+		}
+
+		if l != ml {
+			return -1
+		}
+	}
+
+	return
+}
+
+func (self AnyOf) String() string {
+	return fmt.Sprintf("<any_of:[%s]>", self.Matchers)
+}

--- a/vendor/src/github.com/gobwas/glob/match/btree.go
+++ b/vendor/src/github.com/gobwas/glob/match/btree.go
@@ -1,0 +1,129 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type BTree struct {
+	Value            Matcher
+	Left             Matcher
+	Right            Matcher
+	ValueLengthRunes int
+	LeftLengthRunes  int
+	RightLengthRunes int
+	LengthRunes      int
+}
+
+func NewBTree(Value, Left, Right Matcher) (tree BTree) {
+	tree.Value = Value
+	tree.Left = Left
+	tree.Right = Right
+
+	lenOk := true
+	if tree.ValueLengthRunes = Value.Len(); tree.ValueLengthRunes == -1 {
+		lenOk = false
+	}
+
+	if Left != nil {
+		if tree.LeftLengthRunes = Left.Len(); tree.LeftLengthRunes == -1 {
+			lenOk = false
+		}
+	}
+
+	if Right != nil {
+		if tree.RightLengthRunes = Right.Len(); tree.RightLengthRunes == -1 {
+			lenOk = false
+		}
+	}
+
+	if lenOk {
+		tree.LengthRunes = tree.LeftLengthRunes + tree.ValueLengthRunes + tree.RightLengthRunes
+	} else {
+		tree.LengthRunes = -1
+	}
+
+	return tree
+}
+
+func (self BTree) Len() int {
+	return self.LengthRunes
+}
+
+// todo?
+func (self BTree) Index(s string) (int, []int) {
+	return -1, nil
+}
+
+func (self BTree) Match(s string) bool {
+	inputLen := len(s)
+
+	// self.Length, self.RLen and self.LLen are values meaning the length of runes for each part
+	// here we manipulating byte length for better optimizations
+	// but these checks still works, cause minLen of 1-rune string is 1 byte.
+	if self.LengthRunes != -1 && self.LengthRunes > inputLen {
+		return false
+	}
+
+	//	 try to cut unnecessary parts
+	//	 by knowledge of length of right and left part
+	var offset, limit int
+	if self.LeftLengthRunes >= 0 {
+		offset = self.LeftLengthRunes
+	}
+	if self.RightLengthRunes >= 0 {
+		limit = inputLen - self.RightLengthRunes
+	} else {
+		limit = inputLen
+	}
+
+	for offset < limit {
+		// search for matching part in substring
+		index, segments := self.Value.Index(s[offset:limit])
+		if index == -1 {
+			return false
+		}
+
+		l := s[:offset+index]
+		var left bool
+		if self.Left != nil {
+			left = self.Left.Match(l)
+		} else {
+			left = l == ""
+		}
+
+		if left {
+			for i := len(segments) - 1; i >= 0; i-- {
+				length := segments[i]
+
+				var right bool
+				var r string
+				// if there is no string for the right branch
+				if inputLen <= offset+index+length {
+					r = ""
+				} else {
+					r = s[offset+index+length:]
+				}
+
+				if self.Right != nil {
+					right = self.Right.Match(r)
+				} else {
+					right = r == ""
+				}
+
+				if right {
+					return true
+				}
+			}
+		}
+
+		_, step := utf8.DecodeRuneInString(s[offset+index:])
+		offset += index + step
+	}
+
+	return false
+}
+
+func (self BTree) String() string {
+	return fmt.Sprintf("<btree:[%s<-%s->%s]>", self.Left, self.Value, self.Right)
+}

--- a/vendor/src/github.com/gobwas/glob/match/contains.go
+++ b/vendor/src/github.com/gobwas/glob/match/contains.go
@@ -1,0 +1,65 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type Contains struct {
+	Needle string
+	Not    bool
+}
+
+func (self Contains) Match(s string) bool {
+	return strings.Contains(s, self.Needle) != self.Not
+}
+
+func (self Contains) Index(s string) (int, []int) {
+	var (
+		sub    string
+		offset int
+	)
+
+	idx := strings.Index(s, self.Needle)
+
+	if !self.Not {
+		if idx == -1 {
+			return -1, nil
+		}
+
+		offset = idx + len(self.Needle)
+
+		if len(s) <= offset {
+			return 0, []int{offset}
+		}
+
+		sub = s[offset:]
+	} else {
+		switch idx {
+		case -1:
+			sub = s
+		default:
+			sub = s[:idx]
+		}
+	}
+
+	segments := make([]int, 0, utf8.RuneCountInString(sub)+1)
+	for i, _ := range sub {
+		segments = append(segments, offset+i)
+	}
+
+	return 0, append(segments, offset+len(sub))
+}
+
+func (self Contains) Len() int {
+	return lenNo
+}
+
+func (self Contains) String() string {
+	var not string
+	if self.Not {
+		not = "!"
+	}
+	return fmt.Sprintf("<contains:%s[%s]>", not, self.Needle)
+}

--- a/vendor/src/github.com/gobwas/glob/match/every_of.go
+++ b/vendor/src/github.com/gobwas/glob/match/every_of.go
@@ -1,0 +1,79 @@
+package match
+
+import (
+	"fmt"
+)
+
+type EveryOf struct {
+	Matchers Matchers
+}
+
+func (self *EveryOf) Add(m Matcher) error {
+	self.Matchers = append(self.Matchers, m)
+	return nil
+}
+
+func (self EveryOf) Len() (l int) {
+	for _, m := range self.Matchers {
+		if ml := m.Len(); l > 0 {
+			l += ml
+		} else {
+			return -1
+		}
+	}
+
+	return
+}
+
+func (self EveryOf) Index(s string) (int, []int) {
+	var index int
+	var offset int
+	var segments []int
+
+	sub := s
+	for _, m := range self.Matchers {
+		idx, seg := m.Index(sub)
+		if idx == -1 {
+			return -1, nil
+		}
+
+		var sum []int
+		if segments == nil {
+			sum = seg
+		} else {
+			delta := index - (idx + offset)
+			for _, ex := range segments {
+				for _, n := range seg {
+					if ex+delta == n {
+						sum = append(sum, n)
+					}
+				}
+			}
+		}
+
+		if len(sum) == 0 {
+			return -1, nil
+		}
+
+		segments = sum
+		index = idx + offset
+		sub = s[index:]
+		offset += idx
+	}
+
+	return index, segments
+}
+
+func (self EveryOf) Match(s string) bool {
+	for _, m := range self.Matchers {
+		if !m.Match(s) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (self EveryOf) String() string {
+	return fmt.Sprintf("<every_of:[%s]>", self.Matchers)
+}

--- a/vendor/src/github.com/gobwas/glob/match/list.go
+++ b/vendor/src/github.com/gobwas/glob/match/list.go
@@ -1,0 +1,47 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type List struct {
+	List string
+	Not  bool
+}
+
+func (self List) Match(s string) bool {
+	// if s 100% have two symbols
+	//	_, w := utf8.DecodeRuneInString(s)
+	//	if len(s) > w {
+	if len(s) > 4 {
+		return false
+	}
+
+	inList := strings.Index(self.List, s) != -1
+	return inList == !self.Not
+}
+
+func (self List) Len() int {
+	return lenOne
+}
+
+func (self List) Index(s string) (int, []int) {
+	for i, r := range s {
+		if self.Not == (strings.IndexRune(self.List, r) == -1) {
+			return i, []int{utf8.RuneLen(r)}
+		}
+	}
+
+	return -1, nil
+}
+
+func (self List) String() string {
+	var not string
+	if self.Not {
+		not = "!"
+	}
+
+	return fmt.Sprintf("<list:%s[%s]>", not, self.List)
+}

--- a/vendor/src/github.com/gobwas/glob/match/match.go
+++ b/vendor/src/github.com/gobwas/glob/match/match.go
@@ -1,0 +1,85 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+)
+
+const lenOne = 1
+const lenZero = 0
+const lenNo = -1
+
+type Matcher interface {
+	Match(string) bool
+	Index(string) (int, []int)
+	Len() int
+	String() string
+}
+
+type Matchers []Matcher
+
+func (m Matchers) String() string {
+	var s []string
+	for _, matcher := range m {
+		s = append(s, fmt.Sprint(matcher))
+	}
+
+	return fmt.Sprintf("%s", strings.Join(s, ","))
+}
+
+func appendIfNotAsPrevious(target []int, val int) []int {
+	l := len(target)
+	if l != 0 && target[l-1] == val {
+		return target
+	}
+
+	return append(target, val)
+}
+
+// mergeSegments merges and sorts given already SORTED and UNIQUE segments.
+func mergeSegments(segments [][]int) []int {
+	var current []int
+	for _, s := range segments {
+		if current == nil {
+			current = s
+			continue
+		}
+
+		var next []int
+		for x, y := 0, 0; x < len(current) || y < len(s); {
+			if x >= len(current) {
+				next = append(next, s[y:]...)
+				break
+			}
+
+			if y >= len(s) {
+				next = append(next, current[x:]...)
+				break
+			}
+
+			xValue := current[x]
+			yValue := s[y]
+
+			switch {
+
+			case xValue == yValue:
+				x++
+				y++
+				next = appendIfNotAsPrevious(next, xValue)
+
+			case xValue < yValue:
+				next = appendIfNotAsPrevious(next, xValue)
+				x++
+
+			case yValue < xValue:
+				next = appendIfNotAsPrevious(next, yValue)
+				y++
+
+			}
+		}
+
+		current = next
+	}
+
+	return current
+}

--- a/vendor/src/github.com/gobwas/glob/match/max.go
+++ b/vendor/src/github.com/gobwas/glob/match/max.go
@@ -1,0 +1,44 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Max struct {
+	Limit int
+}
+
+func (self Max) Match(s string) bool {
+	var l int
+	for range s {
+		l += 1
+		if l > self.Limit {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (self Max) Index(s string) (index int, segments []int) {
+	segments = append(segments, 0)
+	var count int
+	for i, r := range s {
+		count++
+		if count > self.Limit {
+			break
+		}
+		segments = append(segments, i+utf8.RuneLen(r))
+	}
+
+	return 0, segments
+}
+
+func (self Max) Len() int {
+	return lenNo
+}
+
+func (self Max) String() string {
+	return fmt.Sprintf("<max:%d>", self.Limit)
+}

--- a/vendor/src/github.com/gobwas/glob/match/min.go
+++ b/vendor/src/github.com/gobwas/glob/match/min.go
@@ -1,0 +1,49 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Min struct {
+	Limit int
+}
+
+func (self Min) Match(s string) bool {
+	var l int
+	for range s {
+		l += 1
+		if l >= self.Limit {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (self Min) Index(s string) (int, []int) {
+	var count int
+
+	c := utf8.RuneCountInString(s)
+	if c < self.Limit {
+		return -1, nil
+	}
+
+	segments := make([]int, 0, c-self.Limit+1)
+	for i, r := range s {
+		count++
+		if count >= self.Limit {
+			segments = append(segments, i+utf8.RuneLen(r))
+		}
+	}
+
+	return 0, segments
+}
+
+func (self Min) Len() int {
+	return lenNo
+}
+
+func (self Min) String() string {
+	return fmt.Sprintf("<min:%d>", self.Limit)
+}

--- a/vendor/src/github.com/gobwas/glob/match/nothing.go
+++ b/vendor/src/github.com/gobwas/glob/match/nothing.go
@@ -1,0 +1,23 @@
+package match
+
+import (
+	"fmt"
+)
+
+type Nothing struct{}
+
+func (self Nothing) Match(s string) bool {
+	return len(s) == 0
+}
+
+func (self Nothing) Index(s string) (int, []int) {
+	return 0, []int{0}
+}
+
+func (self Nothing) Len() int {
+	return lenZero
+}
+
+func (self Nothing) String() string {
+	return fmt.Sprintf("<nothing>")
+}

--- a/vendor/src/github.com/gobwas/glob/match/prefix.go
+++ b/vendor/src/github.com/gobwas/glob/match/prefix.go
@@ -1,0 +1,46 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+type Prefix struct {
+	Prefix string
+}
+
+func (self Prefix) Index(s string) (int, []int) {
+	idx := strings.Index(s, self.Prefix)
+	if idx == -1 {
+		return -1, nil
+	}
+
+	length := len(self.Prefix)
+	var sub string
+	if len(s) > idx+length {
+		sub = s[idx+length:]
+	} else {
+		sub = ""
+	}
+
+	segments := make([]int, 0, utf8.RuneCountInString(sub)+1)
+	segments = append(segments, length)
+	for i, r := range sub {
+		segments = append(segments, length+i+utf8.RuneLen(r))
+	}
+
+	return idx, segments
+}
+
+func (self Prefix) Len() int {
+	return lenNo
+}
+
+func (self Prefix) Match(s string) bool {
+	return strings.HasPrefix(s, self.Prefix)
+}
+
+func (self Prefix) String() string {
+	return fmt.Sprintf("<prefix:%s>", self.Prefix)
+}

--- a/vendor/src/github.com/gobwas/glob/match/prefix_suffix.go
+++ b/vendor/src/github.com/gobwas/glob/match/prefix_suffix.go
@@ -1,0 +1,59 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+)
+
+type PrefixSuffix struct {
+	Prefix, Suffix string
+}
+
+func (self PrefixSuffix) Index(s string) (int, []int) {
+	prefixIdx := strings.Index(s, self.Prefix)
+	if prefixIdx == -1 {
+		return -1, nil
+	}
+
+	var resp []int
+	suffixLen := len(self.Suffix)
+
+	if suffixLen > 0 {
+		var segments []int
+		for sub := s[prefixIdx:]; ; {
+			suffixIdx := strings.LastIndex(sub, self.Suffix)
+			if suffixIdx == -1 {
+				break
+			}
+
+			segments = append(segments, suffixIdx+suffixLen)
+			sub = sub[:suffixIdx]
+		}
+
+		segLen := len(segments)
+		if segLen == 0 {
+			return -1, nil
+		}
+
+		resp = make([]int, segLen)
+		for i, s := range segments {
+			resp[segLen-i-1] = s
+		}
+	} else {
+		resp = append(resp, len(s)-prefixIdx)
+	}
+
+	return prefixIdx, resp
+}
+
+func (self PrefixSuffix) Len() int {
+	return lenNo
+}
+
+func (self PrefixSuffix) Match(s string) bool {
+	return strings.HasPrefix(s, self.Prefix) && strings.HasSuffix(s, self.Suffix)
+}
+
+func (self PrefixSuffix) String() string {
+	return fmt.Sprintf("<prefix_suffix:[%s,%s]>", self.Prefix, self.Suffix)
+}

--- a/vendor/src/github.com/gobwas/glob/match/range.go
+++ b/vendor/src/github.com/gobwas/glob/match/range.go
@@ -1,0 +1,44 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Range struct {
+	Lo, Hi rune
+	Not    bool
+}
+
+func (self Range) Len() int {
+	return lenOne
+}
+
+func (self Range) Match(s string) bool {
+	r, w := utf8.DecodeRuneInString(s)
+	if len(s) > w {
+		return false
+	}
+
+	inRange := r >= self.Lo && r <= self.Hi
+
+	return inRange == !self.Not
+}
+
+func (self Range) Index(s string) (int, []int) {
+	for i, r := range s {
+		if self.Not != (r >= self.Lo && r <= self.Hi) {
+			return i, []int{utf8.RuneLen(r)}
+		}
+	}
+
+	return -1, nil
+}
+
+func (self Range) String() string {
+	var not string
+	if self.Not {
+		not = "!"
+	}
+	return fmt.Sprintf("<range:%s[%s,%s]>", not, string(self.Lo), string(self.Hi))
+}

--- a/vendor/src/github.com/gobwas/glob/match/row.go
+++ b/vendor/src/github.com/gobwas/glob/match/row.go
@@ -1,0 +1,78 @@
+package match
+
+import (
+	"fmt"
+)
+
+type Row struct {
+	Matchers    Matchers
+	RunesLength int
+}
+
+func (self Row) matchAll(s string) bool {
+	var idx int
+	for _, m := range self.Matchers {
+		length := m.Len()
+
+		var next, i int
+		for next = range s[idx:] {
+			i++
+			if i == length {
+				break
+			}
+		}
+
+		if i < length || !m.Match(s[idx:idx+next+1]) {
+			return false
+		}
+
+		idx += next + 1
+	}
+
+	return true
+}
+
+func (self Row) lenOk(s string) bool {
+	var i int
+	for range s {
+		i++
+		if i >= self.RunesLength {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (self Row) Match(s string) bool {
+	return self.lenOk(s) && self.matchAll(s)
+}
+
+func (self Row) Len() (l int) {
+	return self.RunesLength
+}
+
+func (self Row) Index(s string) (int, []int) {
+	if !self.lenOk(s) {
+		return -1, nil
+	}
+
+	for i := range s {
+		// this is not strict check but useful
+		// when glob will be refactored for usage with []rune
+		// it will be better
+		if len(s[i:]) < self.RunesLength {
+			break
+		}
+
+		if self.matchAll(s[i:]) {
+			return i, []int{self.RunesLength}
+		}
+	}
+
+	return -1, nil
+}
+
+func (self Row) String() string {
+	return fmt.Sprintf("<row_%d:[%s]>", self.RunesLength, self.Matchers)
+}

--- a/vendor/src/github.com/gobwas/glob/match/single.go
+++ b/vendor/src/github.com/gobwas/glob/match/single.go
@@ -1,0 +1,39 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// single represents ?
+type Single struct {
+	Separators string
+}
+
+func (self Single) Match(s string) bool {
+	r, w := utf8.DecodeRuneInString(s)
+	if len(s) > w {
+		return false
+	}
+
+	return strings.IndexRune(self.Separators, r) == -1
+}
+
+func (self Single) Len() int {
+	return lenOne
+}
+
+func (self Single) Index(s string) (int, []int) {
+	for i, r := range s {
+		if strings.IndexRune(self.Separators, r) == -1 {
+			return i, []int{utf8.RuneLen(r)}
+		}
+	}
+
+	return -1, nil
+}
+
+func (self Single) String() string {
+	return fmt.Sprintf("<single:![%s]>", self.Separators)
+}

--- a/vendor/src/github.com/gobwas/glob/match/suffix.go
+++ b/vendor/src/github.com/gobwas/glob/match/suffix.go
@@ -1,0 +1,31 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Suffix struct {
+	Suffix string
+}
+
+func (self Suffix) Index(s string) (int, []int) {
+	idx := strings.Index(s, self.Suffix)
+	if idx == -1 {
+		return -1, nil
+	}
+
+	return 0, []int{idx + len(self.Suffix)}
+}
+
+func (self Suffix) Len() int {
+	return lenNo
+}
+
+func (self Suffix) Match(s string) bool {
+	return strings.HasSuffix(s, self.Suffix)
+}
+
+func (self Suffix) String() string {
+	return fmt.Sprintf("<suffix:%s>", self.Suffix)
+}

--- a/vendor/src/github.com/gobwas/glob/match/super.go
+++ b/vendor/src/github.com/gobwas/glob/match/super.go
@@ -1,0 +1,31 @@
+package match
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type Super struct{}
+
+func (self Super) Match(s string) bool {
+	return true
+}
+
+func (self Super) Len() int {
+	return lenNo
+}
+
+func (self Super) Index(s string) (int, []int) {
+	segments := make([]int, 0, utf8.RuneCountInString(s)+1)
+	for i := range s {
+		segments = append(segments, i)
+	}
+
+	segments = append(segments, len(s))
+
+	return 0, segments
+}
+
+func (self Super) String() string {
+	return fmt.Sprintf("<super>")
+}

--- a/vendor/src/github.com/gobwas/glob/match/text.go
+++ b/vendor/src/github.com/gobwas/glob/match/text.go
@@ -1,0 +1,45 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// raw represents raw string to match
+type Text struct {
+	Str         string
+	RunesLength int
+	BytesLength int
+}
+
+func NewText(s string) Text {
+	return Text{
+		Str:         s,
+		RunesLength: utf8.RuneCountInString(s),
+		BytesLength: len(s),
+	}
+}
+
+func (self Text) Match(s string) bool {
+	return self.Str == s
+}
+
+func (self Text) Len() int {
+	return self.RunesLength
+}
+
+func (self Text) Index(s string) (index int, segments []int) {
+	index = strings.Index(s, self.Str)
+	if index == -1 {
+		return
+	}
+
+	segments = []int{self.BytesLength}
+
+	return
+}
+
+func (self Text) String() string {
+	return fmt.Sprintf("<text:%s>", self.Str)
+}

--- a/vendor/src/github.com/gobwas/glob/parser.go
+++ b/vendor/src/github.com/gobwas/glob/parser.go
@@ -1,0 +1,225 @@
+package glob
+
+import (
+	"errors"
+	"fmt"
+	"unicode/utf8"
+)
+
+type node interface {
+	children() []node
+	append(node)
+}
+
+type nodeImpl struct {
+	desc []node
+}
+
+func (n *nodeImpl) append(c node) {
+	n.desc = append(n.desc, c)
+}
+func (n *nodeImpl) children() []node {
+	return n.desc
+}
+
+type nodeList struct {
+	nodeImpl
+	not   bool
+	chars string
+}
+type nodeRange struct {
+	nodeImpl
+	not    bool
+	lo, hi rune
+}
+type nodeText struct {
+	nodeImpl
+	text string
+}
+
+type nodePattern struct{ nodeImpl }
+type nodeAny struct{ nodeImpl }
+type nodeSuper struct{ nodeImpl }
+type nodeSingle struct{ nodeImpl }
+type nodeAnyOf struct{ nodeImpl }
+
+type tree struct {
+	root    node
+	current node
+	path    []node
+}
+
+func (t *tree) enter(c node) {
+	if t.root == nil {
+		t.root = c
+		t.current = c
+		return
+	}
+
+	t.current.append(c)
+	t.path = append(t.path, c)
+	t.current = c
+}
+
+func (t *tree) leave() {
+	if len(t.path)-1 <= 0 {
+		t.current = t.root
+		t.path = nil
+		return
+	}
+
+	t.path = t.path[:len(t.path)-1]
+	t.current = t.path[len(t.path)-1]
+}
+
+type parseFn func(*tree, *lexer) (parseFn, error)
+
+func parse(lexer *lexer) (*nodePattern, error) {
+	var parser parseFn
+
+	root := &nodePattern{}
+	tree := &tree{}
+	tree.enter(root)
+
+	for parser = parserMain; ; {
+		next, err := parser(tree, lexer)
+		if err != nil {
+			return nil, err
+		}
+
+		if next == nil {
+			break
+		}
+
+		parser = next
+	}
+
+	return root, nil
+}
+
+func parserMain(tree *tree, lexer *lexer) (parseFn, error) {
+	for stop := false; !stop; {
+		item := lexer.nextItem()
+
+		switch item.t {
+		case item_eof:
+			stop = true
+			continue
+
+		case item_error:
+			return nil, errors.New(item.s)
+
+		case item_text:
+			tree.current.append(&nodeText{text: item.s})
+			return parserMain, nil
+
+		case item_any:
+			tree.current.append(&nodeAny{})
+			return parserMain, nil
+
+		case item_super:
+			tree.current.append(&nodeSuper{})
+			return parserMain, nil
+
+		case item_single:
+			tree.current.append(&nodeSingle{})
+			return parserMain, nil
+
+		case item_range_open:
+			return parserRange, nil
+
+		case item_terms_open:
+			tree.enter(&nodeAnyOf{})
+			tree.enter(&nodePattern{})
+			return parserMain, nil
+
+		case item_separator:
+			tree.leave()
+			tree.enter(&nodePattern{})
+			return parserMain, nil
+
+		case item_terms_close:
+			tree.leave()
+			tree.leave()
+			return parserMain, nil
+
+		default:
+			return nil, fmt.Errorf("unexpected token: %s", item)
+		}
+	}
+
+	return nil, nil
+}
+
+func parserRange(tree *tree, lexer *lexer) (parseFn, error) {
+	var (
+		not   bool
+		lo    rune
+		hi    rune
+		chars string
+	)
+
+	for {
+		item := lexer.nextItem()
+
+		switch item.t {
+		case item_eof:
+			return nil, errors.New("unexpected end")
+
+		case item_error:
+			return nil, errors.New(item.s)
+
+		case item_not:
+			not = true
+
+		case item_range_lo:
+			r, w := utf8.DecodeRuneInString(item.s)
+			if len(item.s) > w {
+				return nil, fmt.Errorf("unexpected length of lo character")
+			}
+
+			lo = r
+
+		case item_range_between:
+			//
+
+		case item_range_hi:
+			r, w := utf8.DecodeRuneInString(item.s)
+			if len(item.s) > w {
+				return nil, fmt.Errorf("unexpected length of lo character")
+			}
+
+			hi = r
+
+			if hi < lo {
+				return nil, fmt.Errorf("hi character '%s' should be greater than lo '%s'", string(hi), string(lo))
+			}
+
+		case item_text:
+			chars = item.s
+
+		case item_range_close:
+			isRange := lo != 0 && hi != 0
+			isChars := chars != ""
+
+			if isChars == isRange {
+				return nil, fmt.Errorf("could not parse range")
+			}
+
+			if isRange {
+				tree.current.append(&nodeRange{
+					lo:  lo,
+					hi:  hi,
+					not: not,
+				})
+			} else {
+				tree.current.append(&nodeList{
+					chars: chars,
+					not:   not,
+				})
+			}
+
+			return parserMain, nil
+		}
+	}
+}

--- a/vendor/src/github.com/gobwas/glob/readme.md
+++ b/vendor/src/github.com/gobwas/glob/readme.md
@@ -1,0 +1,145 @@
+# glob.[go](https://golang.org)
+
+[![GoDoc][godoc-image]][godoc-url] [![Build Status][travis-image]][travis-url]
+
+> Go Globbing Library.
+
+## Install
+
+```shell
+    go get github.com/gobwas/glob
+```
+
+## Example
+
+```go
+
+package main
+
+import "github.com/gobwas/glob"
+
+func main() {
+    var g glob.Glob
+    
+    // create simple glob
+    g = glob.MustCompile("*.github.com")
+    g.Match("api.github.com") // true
+    
+    // create new glob with set of delimiters as ["."]
+    g = glob.MustCompile("api.*.com", ".")
+    g.Match("api.github.com") // true
+    g.Match("api.gi.hub.com") // false
+    
+    // create new glob with set of delimiters as ["."]
+    // but now with super wildcard
+    g = glob.MustCompile("api.**.com", ".")
+    g.Match("api.github.com") // true
+    g.Match("api.gi.hub.com") // true
+        
+    // create glob with single symbol wildcard
+    g = glob.MustCompile("?at")
+    g.Match("cat") // true
+    g.Match("fat") // true
+    g.Match("at") // false
+    
+    // create glob with single symbol wildcard and delimiters ["f"]
+    g = glob.MustCompile("?at", "f")
+    g.Match("cat") // true
+    g.Match("fat") // false
+    g.Match("at") // false 
+    
+    // create glob with character-list matchers 
+    g = glob.MustCompile("[abc]at")
+    g.Match("cat") // true
+    g.Match("bat") // true
+    g.Match("fat") // false
+    g.Match("at") // false
+    
+    // create glob with character-list matchers 
+    g = glob.MustCompile("[!abc]at")
+    g.Match("cat") // false
+    g.Match("bat") // false
+    g.Match("fat") // true
+    g.Match("at") // false 
+    
+    // create glob with character-range matchers 
+    g = glob.MustCompile("[a-c]at")
+    g.Match("cat") // true
+    g.Match("bat") // true
+    g.Match("fat") // false
+    g.Match("at") // false
+    
+    // create glob with character-range matchers 
+    g = glob.MustCompile("[!a-c]at")
+    g.Match("cat") // false
+    g.Match("bat") // false
+    g.Match("fat") // true
+    g.Match("at") // false 
+    
+    
+    // create glob with pattern-alternatives list 
+    g = glob.MustCompile("{cat,bat,[fr]at}")
+    g.Match("cat") // true
+    g.Match("bat") // true
+    g.Match("fat") // true
+    g.Match("rat") // true
+    g.Match("at") // false 
+    g.Match("zat") // false 
+}
+
+```
+
+## Performance
+
+This library is created for compile-once patterns. This means, that compilation could take time, but 
+strings matching is done faster, than in case when always parsing template.
+
+If you will not use compiled `glob.Glob` object, and do `g := glob.MustCompile(pattern); g.Match(...)` every time, then your code will be much more slower.
+
+Run `go test -bench=.` from source root to see the benchmarks:
+
+Pattern | Fixture | Match | Operations | Speed (ns/op)
+--------|---------|-------|------------|--------------
+`[a-z][!a-x]*cat*[h][!b]*eyes*` | `my cat has very bright eyes` | `true` | 2000000 | 527
+`[a-z][!a-x]*cat*[h][!b]*eyes*` | `my dog has very bright eyes` | `false` | 10000000 | 229
+`https://*.google.*` | `https://account.google.com` | `true` | 10000000 | 121
+`https://*.google.*` | `https://google.com` | `false` | 20000000 | 68.6
+`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://yahoo.com` | `true` | 10000000 | 167
+`{https://*.google.*,*yandex.*,*yahoo.*,*mail.ru}` | `http://google.com` | `false` | 10000000 | 198
+`{https://*gobwas.com,http://exclude.gobwas.com}` | `https://safe.gobwas.com` | `true` | 100000000 | 23.9 
+`{https://*gobwas.com,http://exclude.gobwas.com}` | `http://safe.gobwas.com` | `false` | 50000000 | 24.7 
+`abc*` | `abcdef` | `true` | 200000000 | 8.86
+`abc*` | `af` | `false` | 300000000 | 4.99
+`*def` | `abcdef` | `true` | 200000000 | 9.23
+`*def` | `af` | `false` | 300000000 | 5.44
+`ab*ef` | `abcdef` | `true` | 100000000 | 15.2
+`ab*ef` | `af` | `false` | 100000000 | 10.4
+
+The same things with `regexp` package:
+
+Pattern | Fixture | Match | Operations | Speed (ns/op)
+--------|---------|-------|------------|--------------
+`^[a-z][^a-x].*cat.*[h][^b].*eyes.*$` | `my cat has very bright eyes` | `true` | 500000 | 2553
+`^[a-z][^a-x].*cat.*[h][^b].*eyes.*$` | `my dog has very bright eyes` | `false` | 1000000 | 1383
+`^https:\/\/.*\.google\..*$` | `https://account.google.com` | `true` | 1000000 | 1205
+`^https:\/\/.*\.google\..*$` | `https://google.com` | `false` | 2000000 | 767
+`^(https:\/\/.*\.google\..*|.*yandex\..*|.*yahoo\..*|.*mail\.ru)$` | `http://yahoo.com` | `true` | 1000000 | 1435
+`^(https:\/\/.*\.google\..*|.*yandex\..*|.*yahoo\..*|.*mail\.ru)$` | `http://google.com` | `false` | 1000000 | 1674
+`^(https:\/\/.*gobwas\.com|http://exclude.gobwas.com)$` | `https://safe.gobwas.com` | `true` | 1000000 | 1039
+`^(https:\/\/.*gobwas\.com|http://exclude.gobwas.com)$` | `http://safe.gobwas.com` | `false` | 5000000 | 272
+`^abc.*$` | `abcdef` | `true` | 5000000 | 237
+`^abc.*$` | `af` | `false` | 20000000 | 100
+`^.*def$` | `abcdef` | `true` | 5000000 | 464
+`^.*def$` | `af` | `false` | 5000000 | 265
+`^ab.*ef$` | `abcdef` | `true` | 5000000 | 375
+`^ab.*ef$` | `af` | `false` | 10000000 | 145
+
+[godoc-image]: https://godoc.org/github.com/gobwas/glob?status.svg
+[godoc-url]: https://godoc.org/github.com/gobwas/glob
+[travis-image]: https://travis-ci.org/gobwas/glob.svg?branch=master
+[travis-url]: https://travis-ci.org/gobwas/glob
+
+## Syntax
+
+Syntax is inspired by [standard wildcards](http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm),
+except that `**` is aka super-asterisk, that do not sensitive for separators.


### PR DESCRIPTION
This is a followup to #20088, and a project I wrote which [shows the context of the docker context](https://github.com/pwaller/docker-show-context).

Headline figure: This reduces the `docker build` runtime for a largish project of mine by 10x:

```
real 0m17.472s
user 0m45.672s
sys  0m1.588s
```

To:

```
real 0m1.474s
user 0m0.440s
sys  0m0.220s
```

(That's a 100x CPU speedup!).

Detail: I have 14,000 files across 2GiB, with 18 .dockerignore instructions. It turns out that the old implementation was compiling a regular expression for every 14,000 \* 18, an profiling showed it spent the majority of time there.

For a no-op docker build itself, it reduces from:

```
real 0m2.439s
user 0m3.176s
sys  0m0.320s
```

To:

```
real 0m1.339s
user 0m0.412s
sys  0m0.172s
```

Which is more modest, but only the case because docker's `.dockerignore` has only three lines in it.

---

I'm sending this PR for early review now. There is still a bit more work to be done, and a few broader implications to check as well. I could use some help there. Also I note that the logic is implemented by a few other projects (docker-compose interests me in particular) and I guess it would be good to get the logic to be the same there too at some point.

There is still a bit more work to do, including:
- Make the tests pass if they don't work (I couldn't get them working last time I tried locally, sorry)
- Rip out old code for performing ignores
- Seek out regressions and write tests
