### PR TITLE
Prevent mqueue from implicitely becoming a bind mount with --ipc=host

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -44,7 +44,6 @@ type Container struct {
 	HostnamePath    string
 	HostsPath       string
 	ShmPath         string
-	MqueuePath      string
 	ResolvConfPath  string
 	SeccompProfile  string
 }
@@ -573,15 +572,6 @@ func (container *Container) IpcMounts() []execdriver.Mount {
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.ShmPath,
 			Destination: "/dev/shm",
-			Writable:    true,
-			Propagation: volume.DefaultPropagationMode,
-		})
-	}
-	if !container.HasMountFor("/dev/mqueue") &&
-		container.MqueuePath != "" {
-		mounts = append(mounts, execdriver.Mount{
-			Source:      container.MqueuePath,
-			Destination: "/dev/mqueue",
 			Writable:    true,
 			Propagation: volume.DefaultPropagationMode,
 		})

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -106,11 +106,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 			if _, err := os.Stat("/dev/shm"); err != nil {
 				return fmt.Errorf("/dev/shm is not mounted, but must be for --ipc=host")
 			}
-			if _, err := os.Stat("/dev/mqueue"); err != nil {
-				return fmt.Errorf("/dev/mqueue is not mounted, but must be for --ipc=host")
-			}
 			c.ShmPath = "/dev/shm"
-			c.MqueuePath = "/dev/mqueue"
 		}
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2433,7 +2433,7 @@ func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
 
 func (s *DockerSuite) TestRunMountShmMqueueFromHost(c *check.C) {
 	// Not applicable on Windows as uses Unix-specific capabilities
-	testRequires(c, SameHostDaemon, DaemonIsLinux)
+	testRequires(c, SameHostDaemon, DaemonIsLinux, NotUserNamespace)
 
 	dockerCmd(c, "run", "-d", "--name", "shmfromhost", "-v", "/dev/shm:/dev/shm", "-v", "/dev/mqueue:/dev/mqueue", "busybox", "sh", "-c", "echo -n test > /dev/shm/test && touch /dev/mqueue/toto && top")
 	defer os.Remove("/dev/mqueue/toto")


### PR DESCRIPTION
Currently, when running a container with `--ipc=host`, if `/dev/mqueue` is
a standard directory on the hos the daemon will bind mount it allowing
the container to create/modify files on the host.

This commit forces `/dev/mqueue` to always be of type `mqueue` except when
the user explicitely requested something to be bind mounted to
`/dev/mqueue`.

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com

---

ping @crosbymichael @rhatdan 
