### PR TITLE
Don’t stop daemon on migration hard failure

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -748,7 +748,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	migrationStart := time.Now()
 	if err := v1.Migrate(config.Root, graphDriver, d.layerStore, d.imageStore, referenceStore, distributionMetadataStore); err != nil {
-		return nil, err
+		logrus.Errorf("Graph migration failed: %q. Your old graph data was found to be too inconsistent for upgrading to content-addressable storage. Some of the old data was probably not upgraded. We recommend starting over with a clean storage directory if possible.", err)
 	}
 	logrus.Infof("Graph migration to content-addressability took %.2f seconds", time.Since(migrationStart).Seconds())
 

--- a/layer/migration.go
+++ b/layer/migration.go
@@ -32,7 +32,7 @@ func (ls *layerStore) CreateRWLayerByGraphID(name string, graphID string, parent
 	}
 
 	if !ls.driver.Exists(graphID) {
-		return errors.New("graph ID does not exist")
+		return fmt.Errorf("graph ID does not exist: %q", graphID)
 	}
 
 	var p *roLayer

--- a/migrate/v1/migratev1.go
+++ b/migrate/v1/migratev1.go
@@ -282,7 +282,8 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 		}
 
 		if err := ls.CreateRWLayerByGraphID(id, id, img.RootFS.ChainID()); err != nil {
-			return err
+			logrus.Errorf("migrate container error: %v", err)
+			continue
 		}
 
 		logrus.Infof("migrated container %s to point to %s", id, imageID)


### PR DESCRIPTION
Also changes missing storage layer for container
RWLayer to a soft failure.

Fixes #20147 

Soft failure: migration of image/container is skipped
Hard failure: migration stops

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
