### PR TITLE
Fix typo in Docker Toolbox upgrade section

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -391,7 +391,7 @@ The next exercise demonstrates how to do this.
 
 ## Upgrade Docker Toolbox
 
-To upgrade Docker Toolbox, download an re-run [the Docker Toolbox
+To upgrade Docker Toolbox, download and re-run [the Docker Toolbox
 installer](https://docker.com/toolbox/).
 
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -324,7 +324,7 @@ and what it does:
 
 ## Upgrade Docker Toolbox
 
-To upgrade Docker Toolbox, download an re-run [the Docker Toolbox
+To upgrade Docker Toolbox, download and re-run [the Docker Toolbox
 installer](https://www.docker.com/toolbox).
 
 ## Container port redirection


### PR DESCRIPTION
Caught a tiny typo in the Upgrade Docker Toolbox section of the Windows and Mac installation docs.
