### PR TITLE
Move validateContextDirectory to builder package.

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerignore"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
@@ -143,7 +144,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			}
 		}
 
-		if err := validateContextDirectory(contextDir, excludes); err != nil {
+		if err := builder.ValidateContextDirectory(contextDir, excludes); err != nil {
 			return fmt.Errorf("Error checking context: '%s'.", err)
 		}
 
@@ -279,54 +280,6 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	}
 
 	return nil
-}
-
-// validateContextDirectory checks if all the contents of the directory
-// can be read and returns an error if some files can't be read
-// symlinks which point to non-existing files don't trigger an error
-func validateContextDirectory(srcPath string, excludes []string) error {
-	contextRoot, err := getContextRoot(srcPath)
-	if err != nil {
-		return err
-	}
-	return filepath.Walk(contextRoot, func(filePath string, f os.FileInfo, err error) error {
-		// skip this directory/file if it's not in the path, it won't get added to the context
-		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
-			return err
-		} else if skip, err := fileutils.Matches(relFilePath, excludes); err != nil {
-			return err
-		} else if skip {
-			if f.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if err != nil {
-			if os.IsPermission(err) {
-				return fmt.Errorf("can't stat '%s'", filePath)
-			}
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-
-		// skip checking if symlinks point to non-existing files, such symlinks can be useful
-		// also skip named pipes, because they hanging on open
-		if f.Mode()&(os.ModeSymlink|os.ModeNamedPipe) != 0 {
-			return nil
-		}
-
-		if !f.IsDir() {
-			currentFile, err := os.Open(filePath)
-			if err != nil && os.IsPermission(err) {
-				return fmt.Errorf("no permission to read from '%s'", filePath)
-			}
-			currentFile.Close()
-		}
-		return nil
-	})
 }
 
 // validateTag checks if the given image name can be resolved.

--- a/builder/context.go
+++ b/builder/context.go
@@ -1,0 +1,57 @@
+package builder
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/fileutils"
+)
+
+// ValidateContextDirectory checks if all the contents of the directory
+// can be read and returns an error if some files can't be read
+// symlinks which point to non-existing files don't trigger an error
+func ValidateContextDirectory(srcPath string, excludes []string) error {
+	contextRoot, err := getContextRoot(srcPath)
+	if err != nil {
+		return err
+	}
+	return filepath.Walk(contextRoot, func(filePath string, f os.FileInfo, err error) error {
+		// skip this directory/file if it's not in the path, it won't get added to the context
+		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
+			return err
+		} else if skip, err := fileutils.Matches(relFilePath, excludes); err != nil {
+			return err
+		} else if skip {
+			if f.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if err != nil {
+			if os.IsPermission(err) {
+				return fmt.Errorf("can't stat '%s'", filePath)
+			}
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
+		// skip checking if symlinks point to non-existing files, such symlinks can be useful
+		// also skip named pipes, because they hanging on open
+		if f.Mode()&(os.ModeSymlink|os.ModeNamedPipe) != 0 {
+			return nil
+		}
+
+		if !f.IsDir() {
+			currentFile, err := os.Open(filePath)
+			if err != nil && os.IsPermission(err) {
+				return fmt.Errorf("no permission to read from '%s'", filePath)
+			}
+			currentFile.Close()
+		}
+		return nil
+	})
+}

--- a/builder/context_unix.go
+++ b/builder/context_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package client
+package builder
 
 import (
 	"path/filepath"

--- a/builder/context_windows.go
+++ b/builder/context_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package client
+package builder
 
 import (
 	"path/filepath"


### PR DESCRIPTION
This feels like it's where it belongs and it makes it exported again (which is needed for libcompose that was using it before 1.10). 🐵

This is related to https://github.com/docker/docker/commit/9e19b4839fe32d2935306a630305e7b821544c14#commitcomment-15231269 and https://github.com/vdemeester/libcompose/commit/a5d1ea8eca6fb0fd04f39ead69e6dfb9de542ea9#commitcomment-15973077 (PR docker/libcompose#144)

I was wondering if it would make sense to move `getContextFrom…` functions, but I didn't want to make a big changes if this is not a direction worth to take :stuck_out_tongue_closed_eyes:. (I'll do a follow-up PR for thoses :wink:).

/cc @runcom @calavera @tiborvass @anusha-ragunathan @dnephin 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
