### PR TITLE
remove tasksmax, people on newer kernels can add it themselves

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,7 +11,6 @@ MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
-TasksMax=1048576
 TimeoutStartSec=0
 
 [Install]


### PR DESCRIPTION
fix #20036
