### PR TITLE
PPC64LE: Remove testing logrus output from ppc64le

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2068,7 +2068,7 @@ func (s *DockerDaemonSuite) TestRunLinksChanged(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonStartWithoutColors(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, NotPpc64le)
 	newD := NewDaemon(c)
 
 	infoLog := "\x1b[34mINFO\x1b"
@@ -2097,7 +2097,7 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutColors(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonDebugLog(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, NotPpc64le)
 	newD := NewDaemon(c)
 
 	debugLog := "\x1b[37mDEBU\x1b"

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -33,6 +33,10 @@ var (
 		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "arm" },
 		"Test requires a daemon not running on ARM",
 	}
+	NotPpc64le = testRequirement{
+		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "ppc64le" },
+		"Test requires a daemon not running on ppc64le",
+	}
 	SameHostDaemon = testRequirement{
 		func() bool { return isLocalDaemon },
 		"Test requires docker daemon to run on the same machine as CLI",


### PR DESCRIPTION
There is an issue with a syscall on power #8653 that causes
logrus to default to using logfmt. 

I'm removing these two tests from power for now, because they expect
logrus format, and fail if they don't see it.

ping @calavera @duglin 

I'm not sure if the daemon using logfmt is a legitimate use-case we should be
checking or not, so I decided to do this instead of modifying the test cases.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
