### PR TITLE
Allow uppercase characters in image reference hostname

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -46,7 +46,7 @@ clone git github.com/boltdb/bolt v1.1.0
 clone git github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-clone git github.com/docker/distribution c301f8ab27f4913c968b8d73a38e5dda79b9d3d7
+clone git github.com/docker/distribution 0f2d99b13ae0cfbcf118eff103e6e680b726b47e
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -30,7 +30,7 @@ func (s *DockerSuite) TestTagUnprefixedRepoByID(c *check.C) {
 
 // ensure we don't allow the use of invalid repository names; these tag operations should fail
 func (s *DockerSuite) TestTagInvalidUnprefixedRepo(c *check.C) {
-	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd"}
+	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar"}
 
 	for _, repo := range invalidRepos {
 		out, _, err := dockerCmdWithError("tag", "busybox", repo)
@@ -57,7 +57,7 @@ func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
-	validRepos := []string{"fooo/bar", "fooaa/test", "foooo:t"}
+	validRepos := []string{"fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"}
 
 	for _, repo := range validRepos {
 		_, _, err := dockerCmdWithError("tag", "busybox:latest", repo)

--- a/vendor/src/github.com/docker/distribution/reference/reference.go
+++ b/vendor/src/github.com/docker/distribution/reference/reference.go
@@ -6,7 +6,7 @@
 // 	reference                       := repository [ ":" tag ] [ "@" digest ]
 //	name                            := [hostname '/'] component ['/' component]*
 //	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
-//	hostcomponent                   := /([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])/
+//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
 //	port-number                     := /[0-9]+/
 //	component                       := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/

--- a/vendor/src/github.com/docker/distribution/reference/regexp.go
+++ b/vendor/src/github.com/docker/distribution/reference/regexp.go
@@ -22,7 +22,7 @@ var (
 	// hostnameComponentRegexp restricts the registry hostname component of a
 	// repository name to start with a component as defined by hostnameRegexp
 	// and followed by an optional port.
-	hostnameComponentRegexp = match(`(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])`)
+	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
 	// hostnameRegexp defines the structure of potential hostname components
 	// that may be part of image names. This is purposely a subset of what is


### PR DESCRIPTION
This PR makes restores the pre-Docker 1.10 behavior of allowing
uppercase characters in registry hostnames.

Note that this only applies to hostnames, not remote image names.
Previous versions also prohibited uppercase letters after the hostname,
but Docker 1.10 extended this to the hostname itself.
- Vendor updated distribution docker/1.10 branch.
- Add a check to "normalize" that rejects remote names with uppercase
  letters.
- Add test cases to TestTagValidPrefixedRepo and
  TestTagInvalidUnprefixedRepo

Fixes: #20056

cc @dmcgowan @tonistiigi @tiborvass 
