### PR TITLE
Allow --hostname with --net=host

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -237,14 +237,12 @@ $ docker run -it --rm --pid=host myhtop
 The UTS namespace is for setting the hostname and the domain that is visible
 to running processes in that namespace.  By default, all containers, including
 those with `--net=host`, have their own UTS namespace.  The `host` setting will
-result in the container using the same UTS namespace as the host.
+result in the container using the same UTS namespace as the host.  Note that
+`--hostname` is invalid in `host` UTS mode.
 
 You may wish to share the UTS namespace with the host if you would like the
 hostname of the container to change as the hostname of the host changes.  A
 more advanced use case would be changing the host's hostname from a container.
-
-> **Note**: `--uts="host"` gives the container full access to change the
-> hostname of the host and is therefore considered insecure.
 
 ## IPC settings (--ipc)
 
@@ -365,8 +363,11 @@ name, they must be linked.
 With the network set to `host` a container will share the host's
 network stack and all interfaces from the host will be available to the
 container.  The container's hostname will match the hostname on the host
-system.  Note that `--add-host` `--hostname`  `--dns` `--dns-search`
-`--dns-opt` and `--mac-address` are invalid in `host` netmode.
+system.  Note that `--add-host` `--dns` `--dns-search`
+`--dns-opt` and `--mac-address` are invalid in `host` netmode. Even in `host`
+network mode a container has its own UTS namespace by default. As such
+`--hostname` is allowed in `host` network mode and will only change the
+hostname inside the container.
 
 Compared to the default `bridge` mode, the `host` mode gives *significantly*
 better networking performance since it uses the host's native networking stack

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -36,9 +36,6 @@ func (s *DockerSuite) TestNetHostname(c *check.C) {
 	out, _ = dockerCmd(c, "run", "-h=name", "--net=none", "busybox", "ps")
 	c.Assert(out, checker.Contains, stringCheckPS)
 
-	out, _ = dockerCmdWithFail(c, "run", "-h=name", "--net=host", "busybox", "ps")
-	c.Assert(out, checker.Contains, runconfig.ErrConflictNetworkHostname.Error())
-
 	out, _ = dockerCmdWithFail(c, "run", "-h=name", "--net=container:other", "busybox", "ps")
 	c.Assert(out, checker.Contains, runconfig.ErrConflictNetworkHostname.Error())
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2539,6 +2539,9 @@ func (s *DockerSuite) TestRunModeUTSHost(c *check.C) {
 	if hostUTS == out {
 		c.Fatalf("UTS should be different without --uts=host %s == %s\n", hostUTS, out)
 	}
+
+	out, _ = dockerCmdWithFail(c, "run", "-h=name", "--uts=host", "busybox", "ps")
+	c.Assert(out, checker.Contains, runconfig.ErrConflictUTSHostname.Error())
 }
 
 func (s *DockerSuite) TestRunTLSverify(c *check.C) {

--- a/runconfig/errors.go
+++ b/runconfig/errors.go
@@ -35,4 +35,6 @@ var (
 	ErrUnsupportedNetworkNoSubnetAndIP = fmt.Errorf("User specified IP address is supported only when connecting to networks with user configured subnets")
 	// ErrUnsupportedNetworkAndAlias conflict between network mode and alias
 	ErrUnsupportedNetworkAndAlias = fmt.Errorf("Network-scoped alias is supported only for containers in user defined networks")
+	// ErrConflictUTSHostname conflict between the hostname and the UTS mode
+	ErrConflictUTSHostname = fmt.Errorf("Conflicting options: hostname and the UTS mode")
 )

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -36,8 +36,12 @@ func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
 		}
 	}
 
-	if (hc.NetworkMode.IsHost() || hc.NetworkMode.IsContainer()) && c.Hostname != "" {
+	if hc.NetworkMode.IsContainer() && c.Hostname != "" {
 		return ErrConflictNetworkHostname
+	}
+
+	if hc.UTSMode.IsHost() && c.Hostname != "" {
+		return ErrConflictUTSHostname
 	}
 
 	if hc.NetworkMode.IsHost() && len(hc.Links) > 0 {


### PR DESCRIPTION
Docker creates a UTS namespace by default, even with --net=host, so it is
reasonable to let the user set the hostname. Note that --hostname is
forbidden if the user specifies --uts=host.

Closes #12076
Signed-off-by: Jason Heiss jheiss@aput.net
