### PR TITLE
Don't smoosh hostname and domainname in API

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -44,15 +44,10 @@ type Container struct {
 // Sets PATH, HOSTNAME and if container.Config.Tty is set: TERM.
 // The defaults set here do not override the values in container.Config.Env
 func (container *Container) CreateDaemonEnvironment(linkedEnv []string) []string {
-	// if a domain name was specified, append it to the hostname (see #7851)
-	fullHostname := container.Config.Hostname
-	if container.Config.Domainname != "" {
-		fullHostname = fmt.Sprintf("%s.%s", fullHostname, container.Config.Domainname)
-	}
 	// Setup environment
 	env := []string{
 		"PATH=" + system.DefaultPathEnv,
-		"HOSTNAME=" + fullHostname,
+		"HOSTNAME=" + container.Config.Hostname,
 	}
 	if container.Config.Tty {
 		env = append(env, "TERM=xterm")
@@ -92,10 +87,6 @@ func (container *Container) BuildHostnameFile() error {
 		return err
 	}
 	container.HostnamePath = hostnamePath
-
-	if container.Config.Domainname != "" {
-		return ioutil.WriteFile(container.HostnamePath, []byte(fmt.Sprintf("%s.%s\n", container.Config.Hostname, container.Config.Domainname)), 0644)
-	}
 	return ioutil.WriteFile(container.HostnamePath, []byte(container.Config.Hostname+"\n"), 0644)
 }
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -671,13 +671,6 @@ func (daemon *Daemon) initializeNetworking(container *container.Container) error
 		if err != nil {
 			return err
 		}
-
-		parts := strings.SplitN(container.Config.Hostname, ".", 2)
-		if len(parts) > 1 {
-			container.Config.Hostname = parts[0]
-			container.Config.Domainname = parts[1]
-		}
-
 	}
 
 	if err := daemon.allocateNetwork(container); err != nil {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -127,6 +127,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /containers/(id or name)/stats` now returns `pids_stats`, if the kernel is >= 4.3 and the pids cgroup is supported.
 * `POST /containers/create` now allows you to override usernamespaces remapping and use privileged options for the container.
 * `POST /auth` now returns an `IdentityToken` when supported by a registry.
+* `POST /containers/create` with both `Hostname` and `Domainname` fields specified will result in the container's hostname being set to `Hostname`, rather than `Hostname.Domainname`.
 
 ### v1.22 API changes
 

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -241,16 +241,6 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		entrypoint = strslice.StrSlice{*flEntrypoint}
 	}
 
-	var (
-		domainname string
-		hostname   = *flHostname
-		parts      = strings.SplitN(hostname, ".", 2)
-	)
-	if len(parts) > 1 {
-		hostname = parts[0]
-		domainname = parts[1]
-	}
-
 	ports, portBindings, err := nat.ParsePortSpecs(flPublish.GetAll())
 	if err != nil {
 		return nil, nil, nil, cmd, err
@@ -362,8 +352,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 	}
 
 	config := &container.Config{
-		Hostname:     hostname,
-		Domainname:   domainname,
+		Hostname:     *flHostname,
 		ExposedPorts: ports,
 		User:         *flUser,
 		Tty:          *flTty,

--- a/runconfig/opts/parse_test.go
+++ b/runconfig/opts/parse_test.go
@@ -391,11 +391,11 @@ func TestParseHostname(t *testing.T) {
 	if config, _ := mustParse(t, hostname); config.Hostname != "hostname" && config.Domainname != "" {
 		t.Fatalf("Expected the config to have 'hostname' as hostname, got '%v'", config.Hostname)
 	}
-	if config, _ := mustParse(t, hostnameWithDomain); config.Hostname != "hostname" && config.Domainname != "domainname" {
-		t.Fatalf("Expected the config to have 'hostname' as hostname, got '%v'", config.Hostname)
+	if config, _ := mustParse(t, hostnameWithDomain); config.Hostname != "hostname.domainname" && config.Domainname != "" {
+		t.Fatalf("Expected the config to have 'hostname' as hostname.domainname, got '%v'", config.Hostname)
 	}
-	if config, _ := mustParse(t, hostnameWithDomainTld); config.Hostname != "hostname" && config.Domainname != "domainname.tld" {
-		t.Fatalf("Expected the config to have 'hostname' as hostname, got '%v'", config.Hostname)
+	if config, _ := mustParse(t, hostnameWithDomainTld); config.Hostname != "hostname.domainname.tld" && config.Domainname != "" {
+		t.Fatalf("Expected the config to have 'hostname' as hostname.domainname.tld, got '%v'", config.Hostname)
 	}
 }
 


### PR DESCRIPTION
Fixes #14282 

I think this is a better solution than #20196.  Rather than make the CLI split `--hostname`, let it happen at the backend.  This preserve's the user's intentions all the way through.  No API change needed.  No behavioral change from the CLI.  The results of `docker inspect` will be different for `--hostname=foo.bar.com` containers, but the user-visible behavior is the same.  The only behavioral change is for API users that specify both `hostname` and `domainname`, in which case the container's hostname will just be the `hostname` field.  Otherwise it behaves exactly the same.

Tests and docs are not updated yet, pending someone saying they don't hate this.  And yes, it obviously has to go into libnetwork, not here.  I'll do all that if folks say this is OK.
