### PR TITLE
Add "dummy" network module for arm images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,16 @@ binary: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
 
 build: bundles
+ifeq ($(DOCKER_OSARCH), linux/arm)
+	# A few libnetwork integration tests require that the kernel be
+	# configured with "dummy" network interface and has the module
+	# loaded. However, the dummy module is not available by default
+	# on arm images. This ensures that it's built and loaded.
+	echo "Syncing kernel modules"
+	oc-sync-kernel-modules
+	depmod
+	modprobe dummy
+endif
 	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
 
 bundles:


### PR DESCRIPTION
A few libnetwork integration tests require that the kernel be configured
with the "dummy" network interface and has the module loaded. However,
the dummy module is not available by default on arm images. This ensures
that it is built and loaded.

Signed-off-by: Anusha Ragunathan anusha@docker.com
