### PR TITLE
Remove daemon dependency from api/server.

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/backend"
-	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/engine-api/types"
@@ -15,7 +14,7 @@ import (
 // execBackend includes functions to implement to provide exec functionality.
 type execBackend interface {
 	ContainerExecCreate(config *types.ExecConfig) (string, error)
-	ContainerExecInspect(id string) (*exec.Config, error)
+	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(name string, height, width int) error
 	ContainerExecStart(name string, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error
 	ExecExists(name string) (bool, error)

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -42,3 +42,28 @@ type ContainerStatsConfig struct {
 	Stop      <-chan bool
 	Version   string
 }
+
+// ExecInspect holds information about a running process started
+// with docker exec.
+type ExecInspect struct {
+	ID            string
+	Running       bool
+	ExitCode      *int
+	ProcessConfig *ExecProcessConfig
+	OpenStdin     bool
+	OpenStderr    bool
+	OpenStdout    bool
+	CanRemove     bool
+	ContainerID   string
+	DetachKeys    []byte
+}
+
+// ExecProcessConfig holds information about the exec process
+// running on the host.
+type ExecProcessConfig struct {
+	Tty        bool     `json:"tty"`
+	Entrypoint string   `json:"entrypoint"`
+	Arguments  []string `json:"arguments"`
+	Privileged *bool    `json:"privileged,omitempty"`
+	User       string   `json:"user,omitempty"`
+}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/engine-api/types"
@@ -175,12 +175,26 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 
 // ContainerExecInspect returns low-level information about the exec
 // command. An error is returned if the exec cannot be found.
-func (daemon *Daemon) ContainerExecInspect(id string) (*exec.Config, error) {
-	eConfig, err := daemon.getExecConfig(id)
+func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, error) {
+	e, err := daemon.getExecConfig(id)
 	if err != nil {
 		return nil, err
 	}
-	return eConfig, nil
+
+	pc := inspectExecProcessConfig(e)
+
+	return &backend.ExecInspect{
+		ID:            e.ID,
+		Running:       e.Running,
+		ExitCode:      e.ExitCode,
+		ProcessConfig: pc,
+		OpenStdin:     e.OpenStdin,
+		OpenStdout:    e.OpenStdout,
+		OpenStderr:    e.OpenStderr,
+		CanRemove:     e.CanRemove,
+		ContainerID:   e.ContainerID,
+		DetachKeys:    e.DetachKeys,
+	}, nil
 }
 
 // VolumeInspect looks up a volume by name. An error is returned if

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -3,7 +3,9 @@
 package daemon
 
 import (
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/versions/v1p19"
 )
@@ -76,4 +78,14 @@ func addMountPoints(container *container.Container) []types.MountPoint {
 		})
 	}
 	return mountPoints
+}
+
+func inspectExecProcessConfig(e *exec.Config) *backend.ExecProcessConfig {
+	return &backend.ExecProcessConfig{
+		Tty:        e.ProcessConfig.Tty,
+		Entrypoint: e.ProcessConfig.Entrypoint,
+		Arguments:  e.ProcessConfig.Arguments,
+		Privileged: &e.ProcessConfig.Privileged,
+		User:       e.ProcessConfig.User,
+	}
 }

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/engine-api/types"
 )
 
@@ -27,4 +29,12 @@ func addMountPoints(container *container.Container) []types.MountPoint {
 // containerInspectPre120 get containers for pre 1.20 APIs.
 func (daemon *Daemon) containerInspectPre120(name string) (*types.ContainerJSON, error) {
 	return daemon.containerInspectCurrent(name, false)
+}
+
+func inspectExecProcessConfig(e *exec.Config) *backend.ExecProcessConfig {
+	return &backend.ExecProcessConfig{
+		Tty:        e.ProcessConfig.Tty,
+		Entrypoint: e.ProcessConfig.Entrypoint,
+		Arguments:  e.ProcessConfig.Arguments,
+	}
 }


### PR DESCRIPTION
I think those are the last references to the daemon package we have in the api :tada:
- Move routers initialization to the docker package.
- Extract inspect types for `docker exec`.
- Remove coupling between server reload and daemon config.

```
➜  docker git:(remove_last_daemon_references) ag 'docker/daemon' api
➜  docker git:(remove_last_daemon_references)
```

Signed-off-by: David Calavera david.calavera@gmail.com
