### PR TITLE
Split api cleanup

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/backend"
-	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/engine-api/types"
@@ -15,7 +14,7 @@ import (
 // execBackend includes functions to implement to provide exec functionality.
 type execBackend interface {
 	ContainerExecCreate(config *types.ExecConfig) (string, error)
-	ContainerExecInspect(id string) (*exec.Config, error)
+	ContainerExecInspect(id string) (interface{}, error)
 	ContainerExecResize(name string, height, width int) error
 	ContainerExecStart(name string, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error
 	ExecExists(name string) (bool, error)

--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -4,14 +4,14 @@ import "github.com/docker/docker/api/server/router"
 
 // imageRouter is a router to talk with the image controller
 type imageRouter struct {
-	daemon Backend
-	routes []router.Route
+	backend Backend
+	routes  []router.Route
 }
 
 // NewRouter initializes a new image router
-func NewRouter(daemon Backend) router.Router {
+func NewRouter(b Backend) router.Router {
 	r := &imageRouter{
-		daemon: daemon,
+		backend: b,
 	}
 	r.initRoutes()
 	return r

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/engine-api/types"
@@ -175,7 +174,7 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 
 // ContainerExecInspect returns low-level information about the exec
 // command. An error is returned if the exec cannot be found.
-func (daemon *Daemon) ContainerExecInspect(id string) (*exec.Config, error) {
+func (daemon *Daemon) ContainerExecInspect(id string) (interface{}, error) {
 	eConfig, err := daemon.getExecConfig(id)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
little cleanup things.
- seeing `deamon` in the image router was personally irritating.
- using the `interface{}` return value matches ContainerInspect, and was in the original #19133, but I'm not sure why it was dropped from #19772

With this, the only reference to the daemon is in api/server/server.go

Still some references to builder, but mainly involving the calculation of context and context handling. Maybe that functionality should become a pkg for reuse.
