### PR TITLE
Windows CI: Unit Test - pkg/mount is Unix specific

### DIFF
--- a/pkg/mount/mount_unix_test.go
+++ b/pkg/mount/mount_unix_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package mount
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

pkg/mount is not used on Windows - it's full of very Unix specific stuff. This turns off unit tests on Windows for that package and eliminates another chunk of bad windowsTP4 context CI output that is preventing Windows unit tests failures from being ignored.  Chunk is below...

```
E:\go\src\github.com\docker\docker\pkg\mount [master]> go test
--- FAIL: TestMountOptionsParsing (0.00s)
        mount_test.go:15: Expected size=10 got noatime,ro,size=10k
--- FAIL: TestMounted (0.01s)
panic: Not implemented [recovered]
        panic: Not implemented

goroutine 6 [running]:
testing.tRunner.func1(0xc082074090)
        c:/go/src/testing/testing.go:450 +0x178
github.com/docker/docker/pkg/mount.mount(0xc08200a980, 0x36, 0xc08200aa00, 0x36, 0x5a5698, 0x4, 0x0, 0xc082002840, 0x7,
0x0, ...)
        e:/go/src/github.com/docker/docker/pkg/mount/mounter_unsupported.go:6 +0x7e
github.com/docker/docker/pkg/mount.ForceMount(0xc08200a980, 0x36, 0xc08200aa00, 0x36, 0x5a5698, 0x4, 0x5a49c0, 0x7, 0x0,
 0x0)
        e:/go/src/github.com/docker/docker/pkg/mount/mount.go:49 +0xc2
github.com/docker/docker/pkg/mount.Mount(0xc08200a980, 0x36, 0xc08200aa00, 0x36, 0x5a5698, 0x4, 0x5a49c0, 0x7, 0x0, 0x0)

        e:/go/src/github.com/docker/docker/pkg/mount/mount.go:40 +0x107
github.com/docker/docker/pkg/mount.TestMounted(0xc082074090)
        e:/go/src/github.com/docker/docker/pkg/mount/mount_test.go:55 +0x807
testing.tRunner(0xc082074090, 0x67a8b8)
        c:/go/src/testing/testing.go:456 +0x9f
created by testing.RunTests
        c:/go/src/testing/testing.go:561 +0x874

goroutine 1 [chan receive]:
testing.RunTests(0x5ee3b0, 0x67a8a0, 0x4, 0x4, 0xc082002600)
        c:/go/src/testing/testing.go:562 +0x8b4
testing.(*M).Run(0xc082031ee8, 0xc082002630)
        c:/go/src/testing/testing.go:494 +0x77
main.main()
        github.com/docker/docker/pkg/mount/_test/_testmain.go:60 +0x11d
exit status 2
FAIL    github.com/docker/docker/pkg/mount      0.173s
```
