### PR TITLE
Windows CI: test-unit on pkg\plugins

### DIFF
--- a/pkg/plugins/discovery_test.go
+++ b/pkg/plugins/discovery_test.go
@@ -1,16 +1,13 @@
 package plugins
 
 import (
-	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 )
 
-func setup(t *testing.T) (string, func()) {
+func Setup(t *testing.T) (string, func()) {
 	tmpdir, err := ioutil.TempDir("", "docker-test")
 	if err != nil {
 		t.Fatal(err)
@@ -25,56 +22,8 @@ func setup(t *testing.T) (string, func()) {
 	}
 }
 
-func TestLocalSocket(t *testing.T) {
-	tmpdir, unregister := setup(t)
-	defer unregister()
-
-	cases := []string{
-		filepath.Join(tmpdir, "echo.sock"),
-		filepath.Join(tmpdir, "echo", "echo.sock"),
-	}
-
-	for _, c := range cases {
-		if err := os.MkdirAll(filepath.Dir(c), 0755); err != nil {
-			t.Fatal(err)
-		}
-
-		l, err := net.Listen("unix", c)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r := newLocalRegistry()
-		p, err := r.Plugin("echo")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		pp, err := r.Plugin("echo")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(p, pp) {
-			t.Fatalf("Expected %v, was %v\n", p, pp)
-		}
-
-		if p.Name != "echo" {
-			t.Fatalf("Expected plugin `echo`, got %s\n", p.Name)
-		}
-
-		addr := fmt.Sprintf("unix://%s", c)
-		if p.Addr != addr {
-			t.Fatalf("Expected plugin addr `%s`, got %s\n", addr, p.Addr)
-		}
-		if p.TLSConfig.InsecureSkipVerify != true {
-			t.Fatalf("Expected TLS verification to be skipped")
-		}
-		l.Close()
-	}
-}
-
 func TestFileSpecPlugin(t *testing.T) {
-	tmpdir, unregister := setup(t)
+	tmpdir, unregister := Setup(t)
 	defer unregister()
 
 	cases := []struct {
@@ -83,6 +32,7 @@ func TestFileSpecPlugin(t *testing.T) {
 		addr string
 		fail bool
 	}{
+		// TODO Windows: Factor out the unix:// varients.
 		{filepath.Join(tmpdir, "echo.spec"), "echo", "unix://var/lib/docker/plugins/echo.sock", false},
 		{filepath.Join(tmpdir, "echo", "echo.spec"), "echo", "unix://var/lib/docker/plugins/echo.sock", false},
 		{filepath.Join(tmpdir, "foo.spec"), "foo", "tcp://localhost:8080", false},
@@ -123,7 +73,7 @@ func TestFileSpecPlugin(t *testing.T) {
 }
 
 func TestFileJSONSpecPlugin(t *testing.T) {
-	tmpdir, unregister := setup(t)
+	tmpdir, unregister := Setup(t)
 	defer unregister()
 
 	p := filepath.Join(tmpdir, "example.json")

--- a/pkg/plugins/discovery_unix_test.go
+++ b/pkg/plugins/discovery_unix_test.go
@@ -1,0 +1,61 @@
+// +build !windows
+
+package plugins
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLocalSocket(t *testing.T) {
+	// TODO Windows: Enable a similar version for Windows named pipes
+	tmpdir, unregister := Setup(t)
+	defer unregister()
+
+	cases := []string{
+		filepath.Join(tmpdir, "echo.sock"),
+		filepath.Join(tmpdir, "echo", "echo.sock"),
+	}
+
+	for _, c := range cases {
+		if err := os.MkdirAll(filepath.Dir(c), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		l, err := net.Listen("unix", c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := newLocalRegistry()
+		p, err := r.Plugin("echo")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		pp, err := r.Plugin("echo")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(p, pp) {
+			t.Fatalf("Expected %v, was %v\n", p, pp)
+		}
+
+		if p.Name != "echo" {
+			t.Fatalf("Expected plugin `echo`, got %s\n", p.Name)
+		}
+
+		addr := fmt.Sprintf("unix://%s", c)
+		if p.Addr != addr {
+			t.Fatalf("Expected plugin addr `%s`, got %s\n", addr, p.Addr)
+		}
+		if p.TLSConfig.InsecureSkipVerify != true {
+			t.Fatalf("Expected TLS verification to be skipped")
+		}
+		l.Close()
+	}
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

(Dup of https://github.com/docker/docker/pull/20215 which was failing in Jenkins horrendously)

Fixes up the failing unit tests for the WindowsTP4 context for pkg\plugins. It moves the unix:// socket specific test "TestLocalSocket" to a unix file. It also annotates where more work needs to be done in the future. However, this does at least mean that we are closer to turning off the "ignore test-unit failures on WindowsTP4" flag.

Previously failing chunk of output:

```
00:04:43.532 --- FAIL: TestLocalSocket (0.00s)
00:04:43.532    discovery_test.go:44: listen unix C:\Windows\TEMP\docker-test763715871\echo.sock: socket: An address incompatible with the requested protocol was used.
00:04:43.532 FAIL
00:04:43.532 coverage: 34.6% of statements
00:04:43.532 FAIL   github.com/docker/docker/pkg/plugins    1.067s
```
