### PR TITLE
Improve remote integration-cli tests

### DIFF
--- a/hack/make/.ensure-httpserver
+++ b/hack/make/.ensure-httpserver
@@ -8,7 +8,7 @@ dir="$DEST/httpserver"
 mkdir -p "$dir"
 (
 	cd "$dir"
-	GOOS=${DOCKER_ENGINE_GOOS:="linux"} GOARCH=${DOCKER_ENGINE_GOARCH:="amd64"} go build -o httpserver github.com/docker/docker/contrib/httpserver
+	GOOS=${DOCKER_ENGINE_GOOS:="linux"} GOARCH=${DOCKER_ENGINE_GOARCH:="amd64"} CGO_ENABLED=0 go build -o httpserver github.com/docker/docker/contrib/httpserver
 	cp ../../../../contrib/httpserver/Dockerfile .
 	docker build -qt httpserver . > /dev/null
 )

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -16,6 +16,7 @@ import (
 
 // #9860 Make sure attach ends when container ends (with no errors)
 func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
+	testRequires(c, SameHostDaemon)
 
 	out, _ := dockerCmd(c, "run", "-dti", "busybox", "/bin/sh", "-c", `trap 'exit 0' SIGTERM; while true; do sleep 1; done`)
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -377,6 +377,8 @@ func (s *DockerSuite) TestDaemonIPv6Enabled(c *check.C) {
 // TestDaemonIPv6FixedCIDR checks that when the daemon is started with --ipv6=true and a fixed CIDR
 // that running containers are given a link-local and global IPv6 address
 func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDR(c *check.C) {
+	// IPv6 setup is messing with local bridge address.
+	testRequires(c, SameHostDaemon)
 	err := setupV6()
 	c.Assert(err, checker.IsNil, check.Commentf("Could not set up host for IPv6 tests"))
 
@@ -406,6 +408,8 @@ func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDR(c *check.C) {
 // TestDaemonIPv6FixedCIDRAndMac checks that when the daemon is started with ipv6 fixed CIDR
 // the running containers are given a an IPv6 address derived from the MAC address and the ipv6 fixed CIDR
 func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDRAndMac(c *check.C) {
+	// IPv6 setup is messing with local bridge address.
+	testRequires(c, SameHostDaemon)
 	err := setupV6()
 	c.Assert(err, checker.IsNil)
 
@@ -1690,13 +1694,11 @@ func (s *DockerDaemonSuite) TestDaemonNoTlsCliTlsVerifyWithEnv(c *check.C) {
 
 func setupV6() error {
 	// Hack to get the right IPv6 address on docker0, which has already been created
-	err := exec.Command("ip", "addr", "add", "fe80::1/64", "dev", "docker0").Run()
-	return err
+	return exec.Command("ip", "addr", "add", "fe80::1/64", "dev", "docker0").Run()
 }
 
 func teardownV6() error {
-	err := exec.Command("ip", "addr", "del", "fe80::1/64", "dev", "docker0").Run()
-	return err
+	return exec.Command("ip", "addr", "del", "fe80::1/64", "dev", "docker0").Run()
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithContainerWithRestartPolicyAlways(c *check.C) {

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -41,7 +41,7 @@ func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecTTY(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 	dockerCmd(c, "run", "-d", "--name=test", "busybox", "sh", "-c", "echo hello > /foo && top")
 
 	cmd := exec.Command(dockerBinary, "exec", "-it", "test", "sh")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -55,7 +55,7 @@ func (s *DockerSuite) TestRunRedirectStdout(c *check.C) {
 // Test recursive bind mount works by default
 func (s *DockerSuite) TestRunWithVolumesIsRecursive(c *check.C) {
 	// /tmp gets permission denied
-	testRequires(c, NotUserNamespace)
+	testRequires(c, NotUserNamespace, SameHostDaemon)
 	tmpDir, err := ioutil.TempDir("", "docker_recursive_mount_test")
 	c.Assert(err, checker.IsNil)
 
@@ -607,7 +607,7 @@ func (s *DockerSuite) TestRunSwapLessThanMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunInvalidCpusetCpusFlagValue(c *check.C) {
-	testRequires(c, cgroupCpuset)
+	testRequires(c, cgroupCpuset, SameHostDaemon)
 
 	sysInfo := sysinfo.New(true)
 	cpus, err := parsers.ParseUintList(sysInfo.Cpus)


### PR DESCRIPTION
Progress toward being able to run integration-cli campaign using a client hitting a remote host.

Most of these fixes imply flagging tests that assume they are running on the same host than the Daemon. Also fixes the `contrib/httpserver` image that couldn't run because of a dynamically linked Go binary inside the busybox image.
