### PR TITLE
Move getContext… function to builder package

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -6,13 +6,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"strings"
 
 	"golang.org/x/net/context"
 
@@ -23,9 +20,6 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
-	"github.com/docker/docker/pkg/gitutils"
-	"github.com/docker/docker/pkg/httputils"
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/progress"
@@ -103,13 +97,13 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	switch {
 	case specifiedContext == "-":
-		ctx, relDockerfile, err = getContextFromReader(cli.in, *dockerfileName)
+		ctx, relDockerfile, err = builder.GetContextFromReader(cli.in, *dockerfileName)
 	case urlutil.IsGitURL(specifiedContext):
-		tempDir, relDockerfile, err = getContextFromGitURL(specifiedContext, *dockerfileName)
+		tempDir, relDockerfile, err = builder.GetContextFromGitURL(specifiedContext, *dockerfileName)
 	case urlutil.IsURL(specifiedContext):
-		ctx, relDockerfile, err = getContextFromURL(progBuff, specifiedContext, *dockerfileName)
+		ctx, relDockerfile, err = builder.GetContextFromURL(progBuff, specifiedContext, *dockerfileName)
 	default:
-		contextDir, relDockerfile, err = getContextFromLocalDir(specifiedContext, *dockerfileName)
+		contextDir, relDockerfile, err = builder.GetContextFromLocalDir(specifiedContext, *dockerfileName)
 	}
 
 	if err != nil {
@@ -292,96 +286,6 @@ func validateTag(rawRepo string) (string, error) {
 	return rawRepo, nil
 }
 
-// isUNC returns true if the path is UNC (one starting \\). It always returns
-// false on Linux.
-func isUNC(path string) bool {
-	return runtime.GOOS == "windows" && strings.HasPrefix(path, `\\`)
-}
-
-// getDockerfileRelPath uses the given context directory for a `docker build`
-// and returns the absolute path to the context directory, the relative path of
-// the dockerfile in that context directory, and a non-nil error on success.
-func getDockerfileRelPath(givenContextDir, givenDockerfile string) (absContextDir, relDockerfile string, err error) {
-	if absContextDir, err = filepath.Abs(givenContextDir); err != nil {
-		return "", "", fmt.Errorf("unable to get absolute context directory: %v", err)
-	}
-
-	// The context dir might be a symbolic link, so follow it to the actual
-	// target directory.
-	//
-	// FIXME. We use isUNC (always false on non-Windows platforms) to workaround
-	// an issue in golang. On Windows, EvalSymLinks does not work on UNC file
-	// paths (those starting with \\). This hack means that when using links
-	// on UNC paths, they will not be followed.
-	if !isUNC(absContextDir) {
-		absContextDir, err = filepath.EvalSymlinks(absContextDir)
-		if err != nil {
-			return "", "", fmt.Errorf("unable to evaluate symlinks in context path: %v", err)
-		}
-	}
-
-	stat, err := os.Lstat(absContextDir)
-	if err != nil {
-		return "", "", fmt.Errorf("unable to stat context directory %q: %v", absContextDir, err)
-	}
-
-	if !stat.IsDir() {
-		return "", "", fmt.Errorf("context must be a directory: %s", absContextDir)
-	}
-
-	absDockerfile := givenDockerfile
-	if absDockerfile == "" {
-		// No -f/--file was specified so use the default relative to the
-		// context directory.
-		absDockerfile = filepath.Join(absContextDir, api.DefaultDockerfileName)
-
-		// Just to be nice ;-) look for 'dockerfile' too but only
-		// use it if we found it, otherwise ignore this check
-		if _, err = os.Lstat(absDockerfile); os.IsNotExist(err) {
-			altPath := filepath.Join(absContextDir, strings.ToLower(api.DefaultDockerfileName))
-			if _, err = os.Lstat(altPath); err == nil {
-				absDockerfile = altPath
-			}
-		}
-	}
-
-	// If not already an absolute path, the Dockerfile path should be joined to
-	// the base directory.
-	if !filepath.IsAbs(absDockerfile) {
-		absDockerfile = filepath.Join(absContextDir, absDockerfile)
-	}
-
-	// Evaluate symlinks in the path to the Dockerfile too.
-	//
-	// FIXME. We use isUNC (always false on non-Windows platforms) to workaround
-	// an issue in golang. On Windows, EvalSymLinks does not work on UNC file
-	// paths (those starting with \\). This hack means that when using links
-	// on UNC paths, they will not be followed.
-	if !isUNC(absDockerfile) {
-		absDockerfile, err = filepath.EvalSymlinks(absDockerfile)
-		if err != nil {
-			return "", "", fmt.Errorf("unable to evaluate symlinks in Dockerfile path: %v", err)
-		}
-	}
-
-	if _, err := os.Lstat(absDockerfile); err != nil {
-		if os.IsNotExist(err) {
-			return "", "", fmt.Errorf("Cannot locate Dockerfile: %q", absDockerfile)
-		}
-		return "", "", fmt.Errorf("unable to stat Dockerfile: %v", err)
-	}
-
-	if relDockerfile, err = filepath.Rel(absContextDir, absDockerfile); err != nil {
-		return "", "", fmt.Errorf("unable to get relative Dockerfile path: %v", err)
-	}
-
-	if strings.HasPrefix(relDockerfile, ".."+string(filepath.Separator)) {
-		return "", "", fmt.Errorf("The Dockerfile (%s) must be within the build context (%s)", givenDockerfile, givenContextDir)
-	}
-
-	return absContextDir, relDockerfile, nil
-}
-
 // writeToFile copies from the given reader and writes it to a file with the
 // given filename.
 func writeToFile(r io.Reader, filename string) error {
@@ -396,107 +300,6 @@ func writeToFile(r io.Reader, filename string) error {
 	}
 
 	return nil
-}
-
-// getContextFromReader will read the contents of the given reader as either a
-// Dockerfile or tar archive. Returns a tar archive used as a context and a
-// path to the Dockerfile inside the tar.
-func getContextFromReader(r io.ReadCloser, dockerfileName string) (out io.ReadCloser, relDockerfile string, err error) {
-	buf := bufio.NewReader(r)
-
-	magic, err := buf.Peek(archive.HeaderSize)
-	if err != nil && err != io.EOF {
-		return nil, "", fmt.Errorf("failed to peek context header from STDIN: %v", err)
-	}
-
-	if archive.IsArchive(magic) {
-		return ioutils.NewReadCloserWrapper(buf, func() error { return r.Close() }), dockerfileName, nil
-	}
-
-	// Input should be read as a Dockerfile.
-	tmpDir, err := ioutil.TempDir("", "docker-build-context-")
-	if err != nil {
-		return nil, "", fmt.Errorf("unbale to create temporary context directory: %v", err)
-	}
-
-	f, err := os.Create(filepath.Join(tmpDir, api.DefaultDockerfileName))
-	if err != nil {
-		return nil, "", err
-	}
-	_, err = io.Copy(f, buf)
-	if err != nil {
-		f.Close()
-		return nil, "", err
-	}
-
-	if err := f.Close(); err != nil {
-		return nil, "", err
-	}
-	if err := r.Close(); err != nil {
-		return nil, "", err
-	}
-
-	tar, err := archive.Tar(tmpDir, archive.Uncompressed)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return ioutils.NewReadCloserWrapper(tar, func() error {
-		err := tar.Close()
-		os.RemoveAll(tmpDir)
-		return err
-	}), api.DefaultDockerfileName, nil
-
-}
-
-// getContextFromGitURL uses a Git URL as context for a `docker build`. The
-// git repo is cloned into a temporary directory used as the context directory.
-// Returns the absolute path to the temporary context directory, the relative
-// path of the dockerfile in that context directory, and a non-nil error on
-// success.
-func getContextFromGitURL(gitURL, dockerfileName string) (absContextDir, relDockerfile string, err error) {
-	if _, err := exec.LookPath("git"); err != nil {
-		return "", "", fmt.Errorf("unable to find 'git': %v", err)
-	}
-	if absContextDir, err = gitutils.Clone(gitURL); err != nil {
-		return "", "", fmt.Errorf("unable to 'git clone' to temporary context directory: %v", err)
-	}
-
-	return getDockerfileRelPath(absContextDir, dockerfileName)
-}
-
-// getContextFromURL uses a remote URL as context for a `docker build`. The
-// remote resource is downloaded as either a Dockerfile or a tar archive.
-// Returns the tar archive used for the context and a path of the
-// dockerfile inside the tar.
-func getContextFromURL(out io.Writer, remoteURL, dockerfileName string) (io.ReadCloser, string, error) {
-	response, err := httputils.Download(remoteURL)
-	if err != nil {
-		return nil, "", fmt.Errorf("unable to download remote context %s: %v", remoteURL, err)
-	}
-	progressOutput := streamformatter.NewStreamFormatter().NewProgressOutput(out, true)
-
-	// Pass the response body through a progress reader.
-	progReader := progress.NewProgressReader(response.Body, progressOutput, response.ContentLength, "", fmt.Sprintf("Downloading build context from remote url: %s", remoteURL))
-
-	return getContextFromReader(ioutils.NewReadCloserWrapper(progReader, func() error { return response.Body.Close() }), dockerfileName)
-}
-
-// getContextFromLocalDir uses the given local directory as context for a
-// `docker build`. Returns the absolute path to the local context directory,
-// the relative path of the dockerfile in that context directory, and a non-nil
-// error on success.
-func getContextFromLocalDir(localDir, dockerfileName string) (absContextDir, relDockerfile string, err error) {
-	// When using a local context directory, when the Dockerfile is specified
-	// with the `-f/--file` option then it is considered relative to the
-	// current directory and not the context directory.
-	if dockerfileName != "" {
-		if dockerfileName, err = filepath.Abs(dockerfileName); err != nil {
-			return "", "", fmt.Errorf("unable to get absolute path to Dockerfile: %v", err)
-		}
-	}
-
-	return getDockerfileRelPath(localDir, dockerfileName)
 }
 
 var dockerfileFromLinePattern = regexp.MustCompile(`(?i)^[\s]*FROM[ \f\r\t\v]+(?P<image>[^ \f\r\t\v\n#]+)`)

--- a/api/common.go
+++ b/api/common.go
@@ -23,9 +23,6 @@ const (
 	// MinVersion represents Minimum REST API version supported
 	MinVersion version.Version = "1.12"
 
-	// DefaultDockerfileName is the Default filename with Docker commands, read by docker build
-	DefaultDockerfileName string = "Dockerfile"
-
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.
 	NoBaseImageSpecifier string = "scratch"

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -14,6 +14,11 @@ import (
 	"github.com/docker/engine-api/types/container"
 )
 
+const (
+	// DefaultDockerfileName is the Default filename with Docker commands, read by docker build
+	DefaultDockerfileName string = "Dockerfile"
+)
+
 // Context represents a file system tree.
 type Context interface {
 	// Close allows to signal that the filesystem tree won't be used anymore.

--- a/builder/context.go
+++ b/builder/context.go
@@ -1,11 +1,23 @@
 package builder
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
+	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
+	"github.com/docker/docker/pkg/gitutils"
+	"github.com/docker/docker/pkg/httputils"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/streamformatter"
 )
 
 // ValidateContextDirectory checks if all the contents of the directory
@@ -54,4 +66,195 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 		}
 		return nil
 	})
+}
+
+// GetContextFromReader will read the contents of the given reader as either a
+// Dockerfile or tar archive. Returns a tar archive used as a context and a
+// path to the Dockerfile inside the tar.
+func GetContextFromReader(r io.ReadCloser, dockerfileName string) (out io.ReadCloser, relDockerfile string, err error) {
+	buf := bufio.NewReader(r)
+
+	magic, err := buf.Peek(archive.HeaderSize)
+	if err != nil && err != io.EOF {
+		return nil, "", fmt.Errorf("failed to peek context header from STDIN: %v", err)
+	}
+
+	if archive.IsArchive(magic) {
+		return ioutils.NewReadCloserWrapper(buf, func() error { return r.Close() }), dockerfileName, nil
+	}
+
+	// Input should be read as a Dockerfile.
+	tmpDir, err := ioutil.TempDir("", "docker-build-context-")
+	if err != nil {
+		return nil, "", fmt.Errorf("unbale to create temporary context directory: %v", err)
+	}
+
+	f, err := os.Create(filepath.Join(tmpDir, DefaultDockerfileName))
+	if err != nil {
+		return nil, "", err
+	}
+	_, err = io.Copy(f, buf)
+	if err != nil {
+		f.Close()
+		return nil, "", err
+	}
+
+	if err := f.Close(); err != nil {
+		return nil, "", err
+	}
+	if err := r.Close(); err != nil {
+		return nil, "", err
+	}
+
+	tar, err := archive.Tar(tmpDir, archive.Uncompressed)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return ioutils.NewReadCloserWrapper(tar, func() error {
+		err := tar.Close()
+		os.RemoveAll(tmpDir)
+		return err
+	}), DefaultDockerfileName, nil
+
+}
+
+// GetContextFromGitURL uses a Git URL as context for a `docker build`. The
+// git repo is cloned into a temporary directory used as the context directory.
+// Returns the absolute path to the temporary context directory, the relative
+// path of the dockerfile in that context directory, and a non-nil error on
+// success.
+func GetContextFromGitURL(gitURL, dockerfileName string) (absContextDir, relDockerfile string, err error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", "", fmt.Errorf("unable to find 'git': %v", err)
+	}
+	if absContextDir, err = gitutils.Clone(gitURL); err != nil {
+		return "", "", fmt.Errorf("unable to 'git clone' to temporary context directory: %v", err)
+	}
+
+	return getDockerfileRelPath(absContextDir, dockerfileName)
+}
+
+// GetContextFromURL uses a remote URL as context for a `docker build`. The
+// remote resource is downloaded as either a Dockerfile or a tar archive.
+// Returns the tar archive used for the context and a path of the
+// dockerfile inside the tar.
+func GetContextFromURL(out io.Writer, remoteURL, dockerfileName string) (io.ReadCloser, string, error) {
+	response, err := httputils.Download(remoteURL)
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to download remote context %s: %v", remoteURL, err)
+	}
+	progressOutput := streamformatter.NewStreamFormatter().NewProgressOutput(out, true)
+
+	// Pass the response body through a progress reader.
+	progReader := progress.NewProgressReader(response.Body, progressOutput, response.ContentLength, "", fmt.Sprintf("Downloading build context from remote url: %s", remoteURL))
+
+	return GetContextFromReader(ioutils.NewReadCloserWrapper(progReader, func() error { return response.Body.Close() }), dockerfileName)
+}
+
+// GetContextFromLocalDir uses the given local directory as context for a
+// `docker build`. Returns the absolute path to the local context directory,
+// the relative path of the dockerfile in that context directory, and a non-nil
+// error on success.
+func GetContextFromLocalDir(localDir, dockerfileName string) (absContextDir, relDockerfile string, err error) {
+	// When using a local context directory, when the Dockerfile is specified
+	// with the `-f/--file` option then it is considered relative to the
+	// current directory and not the context directory.
+	if dockerfileName != "" {
+		if dockerfileName, err = filepath.Abs(dockerfileName); err != nil {
+			return "", "", fmt.Errorf("unable to get absolute path to Dockerfile: %v", err)
+		}
+	}
+
+	return getDockerfileRelPath(localDir, dockerfileName)
+}
+
+// getDockerfileRelPath uses the given context directory for a `docker build`
+// and returns the absolute path to the context directory, the relative path of
+// the dockerfile in that context directory, and a non-nil error on success.
+func getDockerfileRelPath(givenContextDir, givenDockerfile string) (absContextDir, relDockerfile string, err error) {
+	if absContextDir, err = filepath.Abs(givenContextDir); err != nil {
+		return "", "", fmt.Errorf("unable to get absolute context directory: %v", err)
+	}
+
+	// The context dir might be a symbolic link, so follow it to the actual
+	// target directory.
+	//
+	// FIXME. We use isUNC (always false on non-Windows platforms) to workaround
+	// an issue in golang. On Windows, EvalSymLinks does not work on UNC file
+	// paths (those starting with \\). This hack means that when using links
+	// on UNC paths, they will not be followed.
+	if !isUNC(absContextDir) {
+		absContextDir, err = filepath.EvalSymlinks(absContextDir)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to evaluate symlinks in context path: %v", err)
+		}
+	}
+
+	stat, err := os.Lstat(absContextDir)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to stat context directory %q: %v", absContextDir, err)
+	}
+
+	if !stat.IsDir() {
+		return "", "", fmt.Errorf("context must be a directory: %s", absContextDir)
+	}
+
+	absDockerfile := givenDockerfile
+	if absDockerfile == "" {
+		// No -f/--file was specified so use the default relative to the
+		// context directory.
+		absDockerfile = filepath.Join(absContextDir, DefaultDockerfileName)
+
+		// Just to be nice ;-) look for 'dockerfile' too but only
+		// use it if we found it, otherwise ignore this check
+		if _, err = os.Lstat(absDockerfile); os.IsNotExist(err) {
+			altPath := filepath.Join(absContextDir, strings.ToLower(DefaultDockerfileName))
+			if _, err = os.Lstat(altPath); err == nil {
+				absDockerfile = altPath
+			}
+		}
+	}
+
+	// If not already an absolute path, the Dockerfile path should be joined to
+	// the base directory.
+	if !filepath.IsAbs(absDockerfile) {
+		absDockerfile = filepath.Join(absContextDir, absDockerfile)
+	}
+
+	// Evaluate symlinks in the path to the Dockerfile too.
+	//
+	// FIXME. We use isUNC (always false on non-Windows platforms) to workaround
+	// an issue in golang. On Windows, EvalSymLinks does not work on UNC file
+	// paths (those starting with \\). This hack means that when using links
+	// on UNC paths, they will not be followed.
+	if !isUNC(absDockerfile) {
+		absDockerfile, err = filepath.EvalSymlinks(absDockerfile)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to evaluate symlinks in Dockerfile path: %v", err)
+		}
+	}
+
+	if _, err := os.Lstat(absDockerfile); err != nil {
+		if os.IsNotExist(err) {
+			return "", "", fmt.Errorf("Cannot locate Dockerfile: %q", absDockerfile)
+		}
+		return "", "", fmt.Errorf("unable to stat Dockerfile: %v", err)
+	}
+
+	if relDockerfile, err = filepath.Rel(absContextDir, absDockerfile); err != nil {
+		return "", "", fmt.Errorf("unable to get relative Dockerfile path: %v", err)
+	}
+
+	if strings.HasPrefix(relDockerfile, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("The Dockerfile (%s) must be within the build context (%s)", givenDockerfile, givenContextDir)
+	}
+
+	return absContextDir, relDockerfile, nil
+}
+
+// isUNC returns true if the path is UNC (one starting \\). It always returns
+// false on Linux.
+func isUNC(path string) bool {
+	return runtime.GOOS == "windows" && strings.HasPrefix(path, `\\`)
 }

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/pkg/archive"
@@ -604,7 +603,7 @@ func (b *Builder) readDockerfile() error {
 	// that then look for 'dockerfile'.  If neither are found then default
 	// back to 'Dockerfile' and use that in the error message.
 	if b.options.Dockerfile == "" {
-		b.options.Dockerfile = api.DefaultDockerfileName
+		b.options.Dockerfile = builder.DefaultDockerfileName
 		if _, _, err := b.context.Stat(b.options.Dockerfile); os.IsNotExist(err) {
 			lowercase := strings.ToLower(b.options.Dockerfile)
 			if _, _, err := b.context.Stat(lowercase); err == nil {

--- a/builder/remote.go
+++ b/builder/remote.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"regexp"
 
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/urlutil"
@@ -87,7 +86,7 @@ func DetectContextFromRemoteURL(r io.ReadCloser, remoteURL string, createProgres
 
 				// dockerfileName is set to signal that the remote was interpreted as a single Dockerfile, in which case the caller
 				// should use dockerfileName as the new name for the Dockerfile, irrespective of any other user input.
-				dockerfileName = api.DefaultDockerfileName
+				dockerfileName = DefaultDockerfileName
 
 				// TODO: return a context without tarsum
 				return archive.Generate(dockerfileName, string(dockerfile))


### PR DESCRIPTION
Follow up to #20165, moving `getContext…` function to the `builder` package as it feels it belongs more there.  🐰

/cc @runcom @calavera @tiborvass @anusha-ragunathan @dnephin

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
