### PR TITLE
vendor libnetwork v0.6.1-rc3

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -27,7 +27,7 @@ clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.6.1-rc2
+clone git github.com/docker/libnetwork v0.6.1-rc3
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.1-rc3 (2016-02-11)
+- Fixes getNetworksFromStore to not fail on inconsistent network state
+
 ## 0.6.1-rc2 (2016-02-09)
 - Fixes https://github.com/docker/docker/issues/20132
 - Fixes https://github.com/docker/docker/issues/20140

--- a/vendor/src/github.com/docker/libnetwork/store.go
+++ b/vendor/src/github.com/docker/libnetwork/store.go
@@ -139,7 +139,8 @@ func (c *controller) getNetworksFromStore() ([]*network, error) {
 			ec := &endpointCnt{n: n}
 			err = store.GetObject(datastore.Key(ec.Key()...), ec)
 			if err != nil {
-				return nil, fmt.Errorf("could not find endpoint count key %s for network %s while listing: %v", datastore.Key(ec.Key()...), n.Name(), err)
+				log.Warnf("could not find endpoint count key %s for network %s while listing: %v", datastore.Key(ec.Key()...), n.Name(), err)
+				continue
 			}
 
 			n.epCnt = ec


### PR DESCRIPTION
- fixes https://github.com/docker/docker/issues/20140

This is a P3 issue and not specific to 1.10 release (seen also in 1.9).
cherry-picking this patch from master since it was marked for 1.10.1 (and the master has diverged for libnetwork).

Signed-off-by: Madhu Venugopal madhu@docker.com
