### PR TITLE
Fix flaky test, TestDockerNetworkHostModeUngracefulDaemonRestart

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1012,6 +1012,10 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 		cName := fmt.Sprintf("hostc-%d", i)
 		out, err := s.d.Cmd("run", "-d", "--name", cName, "--net=host", "--restart=always", "busybox", "top")
 		c.Assert(err, checker.IsNil, check.Commentf(out))
+
+		// verfiy container has finished starting before killing daemon
+		err = s.d.waitRun(fmt.Sprintf("hostc-%d", i))
+		c.Assert(err, checker.IsNil)
 	}
 
 	// Kill daemon ungracefully and restart


### PR DESCRIPTION
Fixes #19368 by waiting until all container statuses are running
before killing the daemon

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
