### PR TITLE
Windows CI: test-unit for pkg\filenotify

### DIFF
--- a/pkg/filenotify/poller_test.go
+++ b/pkg/filenotify/poller_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -36,6 +37,9 @@ func TestPollerAddRemove(t *testing.T) {
 }
 
 func TestPollerEvent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("No chmod on Windows")
+	}
 	w := NewPollingWatcher()
 
 	f, err := ioutil.TempFile("", "test-poller")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Disables a failing unit test on Windows which uses chmod.
