### PR TITLE
Change integration test to use declared variable

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1014,7 +1014,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 		c.Assert(err, checker.IsNil, check.Commentf(out))
 
 		// verfiy container has finished starting before killing daemon
-		err = s.d.waitRun(fmt.Sprintf("hostc-%d", i))
+		err = s.d.waitRun(cName)
 		c.Assert(err, checker.IsNil)
 	}
 


### PR DESCRIPTION
Followup to #20246, changes the test to use the variable that's
already declared.

ping @MHBauer 

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
