### PR TITLE
fix apparmor default profile for version 2.8.*

### DIFF
--- a/contrib/apparmor/main.go
+++ b/contrib/apparmor/main.go
@@ -13,6 +13,7 @@ import (
 type profileData struct {
 	MajorVersion int
 	MinorVersion int
+	PatchLevel   int
 }
 
 func main() {
@@ -23,13 +24,14 @@ func main() {
 	// parse the arg
 	apparmorProfilePath := os.Args[1]
 
-	majorVersion, minorVersion, err := aaparser.GetVersion()
+	majorVersion, minorVersion, patchLevel, err := aaparser.GetVersion()
 	if err != nil {
 		log.Fatal(err)
 	}
 	data := profileData{
 		MajorVersion: majorVersion,
 		MinorVersion: minorVersion,
+		PatchLevel:   patchLevel,
 	}
 	fmt.Printf("apparmor_parser is of version %+v\n", data)
 

--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-// GetVersion returns the major and minor version of apparmor_parser
-func GetVersion() (int, int, error) {
+// GetVersion returns the major, minor and patch level version of apparmor_parser
+func GetVersion() (int, int, int, error) {
 	// get the apparmor_version version
 	cmd := exec.Command("apparmor_parser", "--version")
 
@@ -29,17 +29,25 @@ func GetVersion() (int, int, error) {
 	// split by major minor version
 	v := strings.Split(version, ".")
 	if len(v) < 2 {
-		return -1, -1, fmt.Errorf("parsing major minor version failed for %q", version)
+		return -1, -1, -1, fmt.Errorf("parsing major minor and patch level version failed for %q", version)
 	}
 
 	majorVersion, err := strconv.Atoi(v[0])
 	if err != nil {
-		return -1, -1, err
+		return -1, -1, -1, err
 	}
 	minorVersion, err := strconv.Atoi(v[1])
 	if err != nil {
-		return -1, -1, err
+		return -1, -1, -1, err
 	}
 
-	return majorVersion, minorVersion, nil
+	patchLevel := 0
+
+	if len(v) == 3 {
+		patchLevel, err = strconv.Atoi(v[2])
+		if err != nil {
+			return -1, -1, -1, err
+		}
+	}
+	return majorVersion, minorVersion, patchLevel, nil
 }


### PR DESCRIPTION
This commit

https://github.com/docker/docker/commit/6480feb7668851d3878bf36eedc5fd8ffa789e25

added a ptrace rule to the default apparmor profile

However, ptrace is not supported until version 2.9

See release notes:
http://wiki.apparmor.net/index.php/ReleaseNotes_2_9_0

and the specific commit:
http://bazaar.launchpad.net/~apparmor-dev/apparmor/2.9/revision/2480

The confusion came because Ubuntu has version 2.8.95 of apparmor in
Ubuntu 14.04 LTS (The Trusty Tahr)

version 2.8.95 is a beta version for 2.9, that is why it has support for
the ptrace rule, but this is not the general case for 2.8.*.

I've checked the version of apparmor in Ubuntu:

https://launchpad.net/ubuntu/+source/apparmor

and there is no other 2.8.\* version other than 2.8.95

Thanks to Christian Boltz for his help

Signed-off-by: Jordi Massaguer Pla jmassaguerpla@suse.de

Fixes #20269
