### PR TITLE
Pass authentication credentials through to build

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -159,6 +159,8 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 		buildOptions.Dockerfile = dockerfileName
 	}
 
+	buildOptions.AuthConfigs = authConfigs
+
 	out = output
 	if buildOptions.SuppressOutput {
 		out = notVerboseBuffer


### PR DESCRIPTION
In Docker 1.10 and earlier, `docker build` can do a build FROM a private
repository that hasn't yet been pulled. This doesn't work on master. I
bisected this to https://github.com/docker/docker/pull/19414.
AuthConfigs is deserialized from the HTTP request, but not included in
the builder options.

ping @vieux @anusha-ragunathan 
