### PR TITLE
Fix -check.v to -check.vv but why oh why?!

### DIFF
--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -2,7 +2,7 @@
 set -e
 
 bundle_test_integration_cli() {
-	TESTFLAGS="$TESTFLAGS -check.v"
+	TESTFLAGS="$TESTFLAGS -check.vv"
 	go_test_dir ./integration-cli
 }
 


### PR DESCRIPTION
Signed-off-by: Tibor Vass tibor@docker.com

I don't know why go-checker needed to change `v` to `vv`
