### PR TITLE
Fish tab completion lists all containers on "docker rm -f"

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -290,6 +290,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -l help -d 'Print u
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s l -l link -d 'Remove the specified link and not the underlying container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s v -l volumes -d 'Remove the volumes associated with the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -a '(__fish_print_docker_containers stopped)' -d "Container"
+complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s f -l force -a '(__fish_print_docker_containers all)' -d "Container"
 
 # rmi
 complete -c docker -f -n '__fish_docker_no_subcommand' -a rmi -d 'Remove one or more images'


### PR DESCRIPTION
Previously the Fish-shell tab completions only listed the running containers when tab completing on `docker rm -f`, which was quite annoying. This change makes `docker rm` only complete on stopped containers, and `docker rm -f` complete on both stopped and running containers.

The following is an example of the old and new behavior.

Current containers:

```
> docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                     PORTS               NAMES
04748671e7c9        busybox             "sleep 1"           5 seconds ago       Exited (0) 4 seconds ago                       determined_noether
a765d8f5ecea        busybox             "sleep 3600"        35 seconds ago      Up 34 seconds                                  silly_raman
```

Old behavior:

```
> docker rm <tab>
04748671e7c9c11990d5d7e8ba050e4718472a9dc4bf9d168b337c4249b2ac3c  (Container)  determined_noether  (Container)
> docker rm -f <tab>
04748671e7c9c11990d5d7e8ba050e4718472a9dc4bf9d168b337c4249b2ac3c  (Container)  determined_noether  (Container)
```

New behavior:

```
> docker rm <tab>
04748671e7c9c11990d5d7e8ba050e4718472a9dc4bf9d168b337c4249b2ac3c  (Container)  determined_noether  (Container)
> docker rm -f <tab>
04748671e7c9c11990d5d7e8ba050e4718472a9dc4bf9d168b337c4249b2ac3c  (Container)  determined_noether  (Container)
a765d8f5ecea7476688f658c28d55c2035f4ac43314e41744a00991edba4404a  (Container)  silly_raman         (Container)
```
