### PR TITLE
Lower warning about old client to a debug

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -111,7 +111,7 @@ func (s *Server) userAgentMiddleware(handler httputils.APIFunc) httputils.APIFun
 			}
 
 			if len(userAgent) == 2 && !dockerVersion.Equal(version.Version(userAgent[1])) {
-				logrus.Warnf("Warning: client and server don't have the same version (client: %s, server: %s)", userAgent[1], dockerVersion)
+				logrus.Debug("Client and server don't have the same version (client: %s, server: %s)", userAgent[1], dockerVersion)
 			}
 		}
 		return handler(ctx, w, r, vars)


### PR DESCRIPTION
Ideally I would love to just remove this check entirely because its
seems pretty useless.  An old client talking to a new server isn't
an error condition, nor is it something to even worry about - its a normal
part of life.  Flooding my screen (and logs) with a warning that isn't
something I (as an admin) need to be concerned about is silly and a
distraction when I need to look for real issues.  If anything this should
be printed on the cli not the daemon since its the cli that needs to be
concerned, not the daemon.

However, since when you debug an issue it might be interesting to know the
client is old I decided to pull back a little and just change it from
a Warning to a Debug logrus call instead.

If others want it removed I can still do that though  :-)

Signed-off-by: Doug Davis dug@us.ibm.com
