### PR TITLE
Switch Dockerfile to debian:jessie ... AGAIN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM ubuntu:trusty
+FROM debian:jessie
 
 # add zfs ppa
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E871F18B51E0147C77796AC81196BA81F6B0FC61 \
@@ -58,12 +58,13 @@ RUN apt-get update && apt-get install -y \
 	libsystemd-journal-dev \
 	libtool \
 	mercurial \
+	net-tools \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \
-	s3cmd=1.1.0* \
+	s3cmd=1.5.0* \
 	ubuntu-zfs \
 	xfsprogs \
 	libzfs-dev \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,19 +11,11 @@
 # # Run the test suite:
 # docker run --privileged docker hack/make.sh test
 #
-# # Publish a release:
-# docker run --privileged \
-#  -e AWS_S3_BUCKET=baz \
-#  -e AWS_ACCESS_KEY=foo \
-#  -e AWS_SECRET_KEY=bar \
-#  -e GPG_PASSPHRASE=gloubiboulga \
-#  docker hack/release.sh
-#
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM aarch64/ubuntu:trusty
+FROM aarch64/debian:jessie
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -47,13 +39,13 @@ RUN apt-get update && apt-get install -y \
 	libsqlite3-dev \
 	libsystemd-journal-dev \
 	mercurial \
+	net-tools \
 	parallel \
 	pkg-config \
 	python-dev \
 	python-mock \
 	python-pip \
 	python-websocket \
-	s3cmd=1.1.0* \
 	--no-install-recommends
 
 # Install armhf loader to use armv6 binaries on armv8

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,19 +11,11 @@
 # # Run the test suite:
 # docker run --privileged docker hack/make.sh test
 #
-# # Publish a release:
-# docker run --privileged \
-#  -e AWS_S3_BUCKET=baz \
-#  -e AWS_ACCESS_KEY=foo \
-#  -e AWS_SECRET_KEY=bar \
-#  -e GPG_PASSPHRASE=gloubiboulga \
-#  docker hack/release.sh
-#
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM armhf/ubuntu:trusty
+FROM armhf/debian:jessie
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
 	libcap-dev \
 	libsqlite3-dev \
 	mercurial \
+	net-tools \
 	parallel \
 	python-dev \
 	python-mock \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -11,14 +11,6 @@
 # # Run the test suite:
 # docker run --privileged docker hack/make.sh test
 #
-# # Publish a release:
-# docker run --privileged \
-#  -e AWS_S3_BUCKET=baz \
-#  -e AWS_ACCESS_KEY=foo \
-#  -e AWS_SECRET_KEY=bar \
-#  -e GPG_PASSPHRASE=gloubiboulga \
-#  docker hack/release.sh
-#
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.
 #

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -11,14 +11,6 @@
 # # Run the test suite:
 # docker run --privileged docker hack/make.sh test
 #
-# # Publish a release:
-# docker run --privileged \
-#  -e AWS_S3_BUCKET=baz \
-#  -e AWS_ACCESS_KEY=foo \
-#  -e AWS_SECRET_KEY=bar \
-#  -e GPG_PASSPHRASE=gloubiboulga \
-#  docker hack/release.sh
-#
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.
 #

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -81,7 +81,8 @@ setup_s3() {
 	# s3cmd has no useful exit status, so we cannot check that.
 	# Instead, we check if it outputs anything on standard output.
 	# (When there are problems, it uses standard error instead.)
-	s3cmd info "s3://$BUCKET" | grep -q .
+	# NOTE: for some reason on debian:jessie `s3cmd info ... | grep -q .` results in a broken pipe
+	s3cmd info "s3://$BUCKET" | grep . >/dev/null
 	# Make the bucket accessible through website endpoints.
 	s3cmd ws-create --ws-index index --ws-error error "s3://$BUCKET"
 }


### PR DESCRIPTION
Signed-off-by: Tibor Vass tibor@docker.com

Previous attempts: #9481 #5214

I tested a fake release with s3cmd and it worked. I still don't know what the root cause was, but the symptom was a broken pipe between `s3cmd` and `grep -q` so I found a workaround, which was to not use `-q` but pipe it to `/dev/null`.

/cc @jfrazelle @tianon 
