### PR TITLE
Inherit StopSignal from Dockerfile.

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -89,6 +89,10 @@ func merge(userConf, imageConf *containertypes.Config) error {
 			userConf.Volumes[k] = v
 		}
 	}
+
+	if userConf.StopSignal == "" {
+		userConf.StopSignal = imageConf.StopSignal
+	}
 	return nil
 }
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5777,14 +5777,21 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 
 func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	name := "test_build_stop_signal"
-	_, err := buildImage(name,
+	imgName := "test_build_stop_signal"
+	_, err := buildImage(imgName,
 		`FROM busybox
 		 STOPSIGNAL SIGKILL`,
 		true)
 	c.Assert(err, check.IsNil)
-	res := inspectFieldJSON(c, name, "Config.StopSignal")
+	res := inspectFieldJSON(c, imgName, "Config.StopSignal")
+	if res != `"SIGKILL"` {
+		c.Fatalf("Signal %s, expected SIGKILL", res)
+	}
 
+	containerName := "test-container-stop-signal"
+	dockerCmd(c, "run", "-d", "--name", containerName, imgName, "top")
+
+	res = inspectFieldJSON(c, containerName, "Config.StopSignal")
 	if res != `"SIGKILL"` {
 		c.Fatalf("Signal %s, expected SIGKILL", res)
 	}

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -375,7 +375,9 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 		Labels:          ConvertKVStringsToMap(labels),
-		StopSignal:      *flStopSignal,
+	}
+	if cmd.IsSet("-stop-signal") {
+		config.StopSignal = *flStopSignal
 	}
 
 	hostConfig := &container.HostConfig{


### PR DESCRIPTION
Make sure the image configuration is not overriden by the default
value in the `create` flag.

Fixes #19300.

Signed-off-by: David Calavera david.calavera@gmail.com
