### PR TITLE
Making auth endpoint relative to given registry's domain

### DIFF
--- a/registry/token.go
+++ b/registry/token.go
@@ -14,11 +14,12 @@ type tokenResponse struct {
 }
 
 func getToken(username, password string, params map[string]string, registryEndpoint *Endpoint) (string, error) {
-	realm, ok := params["realm"]
+	path, ok := params["realm"]
 	if !ok {
 		return "", errors.New("no realm specified for token auth challenge")
 	}
 
+	realm := fmt.Sprintf("%s%s", registryEndpoint.URL, path)
 	realmURL, err := url.Parse(realm)
 	if err != nil {
 		return "", fmt.Errorf("invalid token auth challenge realm: %s", err)


### PR DESCRIPTION
Realm points to a path relative to a given registry's domain.

This is a part of a change that's also dependent on changes to [docker registry](https://github.com/docker/distribution/pull/1458)
