### PR TITLE
Fix apparmor version checks

### DIFF
--- a/contrib/apparmor/main.go
+++ b/contrib/apparmor/main.go
@@ -11,8 +11,7 @@ import (
 )
 
 type profileData struct {
-	MajorVersion int
-	MinorVersion int
+	Version int
 }
 
 func main() {
@@ -23,13 +22,12 @@ func main() {
 	// parse the arg
 	apparmorProfilePath := os.Args[1]
 
-	majorVersion, minorVersion, err := aaparser.GetVersion()
+	version, err := aaparser.GetVersion()
 	if err != nil {
 		log.Fatal(err)
 	}
 	data := profileData{
-		MajorVersion: majorVersion,
-		MinorVersion: minorVersion,
+		Version: version,
 	}
 	fmt.Printf("apparmor_parser is of version %+v\n", data)
 

--- a/contrib/apparmor/template.go
+++ b/contrib/apparmor/template.go
@@ -20,11 +20,11 @@ profile /usr/bin/docker (attach_disconnected, complain) {
 
   umount,
   pivot_root,
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
   signal (receive) peer=@{profile_name},
   signal (receive) peer=unconfined,
   signal (send),
-{{end}}{{end}}
+{{end}}
   network,
   capability,
   owner /** rw,
@@ -46,12 +46,12 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   /etc/ld.so.cache r,
   /etc/passwd r,
 
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
   ptrace peer=@{profile_name},
   ptrace (read) peer=docker-default,
   deny ptrace (trace) peer=docker-default,
   deny ptrace peer=/usr/bin/docker///bin/ps,
-{{end}}{{end}}
+{{end}}
 
   /usr/lib/** rm,
   /lib/** rm,
@@ -72,11 +72,11 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   /sbin/zfs rCx,
   /sbin/apparmor_parser rCx,
 
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
   # Transitions
   change_profile -> docker-*,
   change_profile -> unconfined,
-{{end}}{{end}}
+{{end}}
 
   profile /bin/cat (complain) {
     /etc/ld.so.cache r,
@@ -98,10 +98,10 @@ profile /usr/bin/docker (attach_disconnected, complain) {
     /dev/null rw,
     /bin/ps mr,
 
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
     # We don't need ptrace so we'll deny and ignore the error.
     deny ptrace (read, trace),
-{{end}}{{end}}
+{{end}}
 
     # Quiet dac_override denials
     deny capability dac_override,
@@ -119,15 +119,15 @@ profile /usr/bin/docker (attach_disconnected, complain) {
     /proc/tty/drivers r,
   }
   profile /sbin/iptables (complain) {
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}{{end}}
+{{end}}
     capability net_admin,
   }
   profile /sbin/auplink flags=(attach_disconnected, complain) {
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}{{end}}
+{{end}}
     capability sys_admin,
     capability dac_override,
 
@@ -146,9 +146,9 @@ profile /usr/bin/docker (attach_disconnected, complain) {
     /proc/[0-9]*/mounts rw,
   }
   profile /sbin/modprobe /bin/kmod (complain) {
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}{{end}}
+{{end}}
     capability sys_module,
     /etc/ld.so.cache r,
     /lib/** rm,
@@ -162,9 +162,9 @@ profile /usr/bin/docker (attach_disconnected, complain) {
   }
   # xz works via pipes, so we do not need access to the filesystem.
   profile /usr/bin/xz (complain) {
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{if ge .Version 209000}}
     signal (receive) peer=/usr/bin/docker,
-{{end}}{{end}}
+{{end}}
     /etc/ld.so.cache r,
     /lib/** rm,
     /usr/bin/xz rm,

--- a/pkg/aaparser/aaparser_test.go
+++ b/pkg/aaparser/aaparser_test.go
@@ -5,9 +5,8 @@ import (
 )
 
 type versionExpected struct {
-	output string
-	major  int
-	minor  int
+	output  string
+	version int
 }
 
 func TestParseVersion(t *testing.T) {
@@ -18,8 +17,7 @@ Copyright (C) 1999-2008 Novell Inc.
 Copyright 2009-2012 Canonical Ltd.
 
 `,
-			major: 2,
-			minor: 10,
+			version: 210000,
 		},
 		{
 			output: `AppArmor parser version 2.8
@@ -27,8 +25,7 @@ Copyright (C) 1999-2008 Novell Inc.
 Copyright 2009-2012 Canonical Ltd.
 
 `,
-			major: 2,
-			minor: 8,
+			version: 208000,
 		},
 		{
 			output: `AppArmor parser version 2.20
@@ -36,8 +33,7 @@ Copyright (C) 1999-2008 Novell Inc.
 Copyright 2009-2012 Canonical Ltd.
 
 `,
-			major: 2,
-			minor: 20,
+			version: 220000,
 		},
 		{
 			output: `AppArmor parser version 2.05
@@ -45,21 +41,33 @@ Copyright (C) 1999-2008 Novell Inc.
 Copyright 2009-2012 Canonical Ltd.
 
 `,
-			major: 2,
-			minor: 5,
+			version: 205000,
+		},
+		{
+			output: `AppArmor parser version 2.9.95
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+
+`,
+			version: 209095,
+		},
+		{
+			output: `AppArmor parser version 3.14.159
+Copyright (C) 1999-2008 Novell Inc.
+Copyright 2009-2012 Canonical Ltd.
+
+`,
+			version: 314159,
 		},
 	}
 
 	for _, v := range versions {
-		major, minor, err := parseVersion(v.output)
+		version, err := parseVersion(v.output)
 		if err != nil {
 			t.Fatalf("expected error to be nil for %#v, got: %v", v, err)
 		}
-		if major != v.major {
-			t.Fatalf("expected major version to be %d, was %d, for: %#v\n", v.major, major, v)
-		}
-		if minor != v.minor {
-			t.Fatalf("expected minor version to be %d, was %d, for: %#v\n", v.minor, minor, v)
+		if version != v.version {
+			t.Fatalf("expected version to be %d, was %d, for: %#v\n", v.version, version, v)
 		}
 	}
 }

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -30,10 +30,8 @@ type profileData struct {
 	Imports []string
 	// InnerImports defines the apparmor functions to import in the profile.
 	InnerImports []string
-	// MajorVersion is the apparmor_parser major version.
-	MajorVersion int
-	// MinorVersion is the apparmor_parser minor version.
-	MinorVersion int
+	// Version is the {major, minor, patch} version of apparmor_parser as a single number.
+	Version int
 }
 
 // generateDefault creates an apparmor profile from ProfileData.

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -38,7 +38,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
-{{if ge .Version 208000}}
+{{if ge .Version 208095}}
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
   ptrace (trace,read) peer=docker-default,
 {{end}}

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -38,13 +38,13 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 8}}
+{{if ge .Version 208000}}
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
   ptrace (trace,read) peer=docker-default,
-{{end}}{{end}}
-{{if ge .MajorVersion 2}}{{if ge .MinorVersion 9}}
+{{end}}
+{{if ge .Version 209000}}
   # docker daemon confinement requires explict allow rule for signal
   signal (receive) set=(kill,term) peer={{.ExecPath}},
-{{end}}{{end}}
+{{end}}
 }
 `


### PR DESCRIPTION
The method used for checking the version of apparmor_parser
isn't actually correct (a version of 3.0 would cause the checks for
`>2.9` to break). In addition, one of the version checks (for suppressing
ptrace denials) was not correct due to the Ubuntu package having
a misleading version number (2.8.95 which is actually 2.9).

This includes a carry of #20270, as well as fixing how versions are checked.

Signed-off-by: Aleksa Sarai asarai@suse.com
