### PR TITLE
Proof of concept: support IPv6 addresses in -p

### DIFF
--- a/vendor/src/github.com/docker/libnetwork/portmapper/mapper.go
+++ b/vendor/src/github.com/docker/libnetwork/portmapper/mapper.go
@@ -128,16 +128,20 @@ func (pm *PortMapper) MapRange(container net.Addr, hostIP net.IP, hostPortStart,
 	}
 
 	containerIP, containerPort := getIPAndPort(m.container)
-	if err := pm.forward(iptables.Append, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
-		return nil, err
+	if hostIP.To4() != nil {
+		if err := pm.forward(iptables.Append, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort); err != nil {
+			return nil, err
+		}
 	}
 
 	cleanup := func() error {
 		// need to undo the iptables rules before we return
 		m.userlandProxy.Stop()
-		pm.forward(iptables.Delete, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
-		if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
-			return err
+		if hostIP.To4() != nil {
+			pm.forward(iptables.Delete, m.proto, hostIP, allocatedHostPort, containerIP.String(), containerPort)
+			if err := pm.Allocator.ReleasePort(hostIP, m.proto, allocatedHostPort); err != nil {
+				return err
+			}
 		}
 
 		return nil


### PR DESCRIPTION
see issue #11518

I’m aware that I’m changing vendored code, but this way the change is easy for people to play with. Once the discussion reaches agreement, I can open pull requests for the individual repositories.

When running the patched docker daemon, I can use:

```
# docker run -p 80:80 nginx:1 &
# netstat -lnpt
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp6       0      0 :::80                   :::*                    LISTEN      752/docker-proxy
```

And now, with an IPv6 address:

```
# docker run -p [::1]:80:80 nginx:1 &
# netstat -lnpt
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp6       0      0 ::1:80                  :::*                    LISTEN      790/docker-proxy
```

Any feedback welcome.
