### PR TITLE
/dev/mqueue should never be mounted readonly

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -104,7 +104,7 @@ func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) 
 	if container.Readonlyfs {
 		for i := range container.Mounts {
 			switch container.Mounts[i].Destination {
-			case "/proc", "/dev", "/dev/pts":
+			case "/proc", "/dev", "/dev/pts", "/dev/mqueue":
 				continue
 			}
 			container.Mounts[i].Flags |= syscall.MS_RDONLY


### PR DESCRIPTION
If user specifies --read-only flag it should not effect /dev/mqueue.
This is causing SELinux issues in docker-1.10.  --read-only blows up
on SELinux enabled machines.  Mounting /dev/mqueue read/only would also
blow up any tool that was going to use /dev/mqueue.

Signed-off-by: Dan Walsh dwalsh@redhat.com
