### PR TITLE
Refactor Container State

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -30,11 +30,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	}
 
 	if !c.State.Running {
-		return fmt.Errorf("You cannot attach to a stopped container, start it first")
-	}
-
-	if c.State.Paused {
-		return fmt.Errorf("You cannot attach to a paused container, unpause it first")
+		return fmt.Errorf("You can only attach to a running container")
 	}
 
 	if err := cli.CheckTtyInput(!*noStdin, c.Config.Tty); err != nil {

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -261,7 +261,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		if err != nil {
 			return runStartContainerErr(err)
 		}
-		if js.State.Running == true || js.State.Paused == true {
+		if js.State.Running || js.State.Paused {
 			fmt.Fprintf(cli.out, "Detached from %s, awaiting its termination in order to uphold \"--rm\".\n",
 				stringid.TruncateID(createResponse.ID))
 		}

--- a/container/container.go
+++ b/container/container.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/container/state"
 	"github.com/docker/docker/daemon/exec"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/logger"
@@ -52,7 +53,7 @@ var (
 type CommonContainer struct {
 	*runconfig.StreamConfig
 	// embed for Container to support states directly.
-	*State          `json:"State"` // Needed for remote api version <= 1.11
+	*state.State    `json:"State"` // Needed for remote api version <= 1.11
 	Root            string         `json:"-"` // Path to the "home" of the container, including metadata.
 	BaseFS          string         `json:"-"` // Path to the graphdriver mountpoint
 	RWLayer         layer.RWLayer  `json:"-"`
@@ -89,7 +90,7 @@ func NewBaseContainer(id, root string) *Container {
 	return &Container{
 		CommonContainer: CommonContainer{
 			ID:            id,
-			State:         NewState(),
+			State:         state.NewState(),
 			ExecCommands:  exec.NewStore(),
 			Root:          root,
 			MountPoints:   make(map[string]*volume.MountPoint),

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -309,11 +309,11 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	// resources will be updated when the container is started again.
 	// If container is running (including paused), we need to update
 	// the command so we can update configs to the real world.
-	if container.IsRunning() {
-		container.Lock()
+	container.Lock()
+	if container.IsRunning() || container.IsPaused() {
 		updateCommand(container.Command, *cResources)
-		container.Unlock()
 	}
+	container.Unlock()
 
 	if err := container.ToDiskLocking(); err != nil {
 		logrus.Errorf("Error saving updated container: %v", err)

--- a/container/state/state_test.go
+++ b/container/state/state_test.go
@@ -1,4 +1,4 @@
-package container
+package state
 
 import (
 	"sync/atomic"
@@ -22,7 +22,7 @@ func TestStateRunStop(t *testing.T) {
 		s.SetRunning(i + 100)
 		s.Unlock()
 
-		if !s.IsRunning() {
+		if !s.IsRunningLocking() {
 			t.Fatal("State not running")
 		}
 		if s.Pid != i+100 {
@@ -53,7 +53,7 @@ func TestStateRunStop(t *testing.T) {
 			close(stopped)
 		}()
 		s.SetStoppedLocking(&execdriver.ExitStatus{ExitCode: i})
-		if s.IsRunning() {
+		if s.IsRunningLocking() {
 			t.Fatal("State is running")
 		}
 		if s.ExitCode != i {

--- a/container/state/state_unix.go
+++ b/container/state/state_unix.go
@@ -1,6 +1,6 @@
 // +build linux freebsd
 
-package container
+package state
 
 import "github.com/docker/docker/daemon/execdriver"
 

--- a/container/state/state_windows.go
+++ b/container/state/state_windows.go
@@ -1,4 +1,4 @@
-package container
+package state
 
 import "github.com/docker/docker/daemon/execdriver"
 

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -19,7 +19,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, c *backend.ContainerA
 	if err != nil {
 		return err
 	}
-	if container.IsPaused() {
+	if container.IsPausedLocking() {
 		err := fmt.Errorf("Container %s is paused. Unpause the container before attach", prefixOrName)
 		return errors.NewRequestConflictError(err)
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -105,11 +105,12 @@ func (daemon *Daemon) Commit(name string, c *types.ContainerCommitConfig) (strin
 	}
 
 	// It is not possible to commit a running container on Windows
-	if runtime.GOOS == "windows" && container.IsRunning() {
+	if runtime.GOOS == "windows" &&
+		(container.IsRunningLocking() || container.IsPausedLocking() || container.IsRestartingLocking()) {
 		return "", fmt.Errorf("Windows does not support commit of a running container")
 	}
 
-	if c.Pause && !container.IsPaused() {
+	if c.Pause && !container.IsPausedLocking() {
 		daemon.containerPause(container)
 		defer daemon.containerUnpause(container)
 	}

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -695,12 +695,9 @@ func (daemon *Daemon) getNetworkedContainer(containerID, connectedContainerID st
 	if containerID == nc.ID {
 		return nil, fmt.Errorf("cannot join own network")
 	}
-	if !nc.IsRunning() {
+	if !nc.IsRunningLocking() && !nc.IsPausedLocking() {
 		err := fmt.Errorf("cannot join network of a non running container: %s", connectedContainerID)
 		return nil, derr.NewRequestConflictError(err)
-	}
-	if nc.IsRestarting() {
-		return nil, errContainerIsRestarting(connectedContainerID)
 	}
 	return nc, nil
 }

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/container/state"
 	"github.com/docker/engine-api/types"
 	containertypes "github.com/docker/engine-api/types/container"
 )
@@ -25,14 +26,14 @@ func TestContainerDoubleDelete(t *testing.T) {
 	container := &container.Container{
 		CommonContainer: container.CommonContainer{
 			ID:     "test",
-			State:  container.NewState(),
+			State:  state.NewState(),
 			Config: &containertypes.Config{},
 		},
 	}
 	daemon.containers.Add(container.ID, container)
 
 	// Mark the container as having a delete in progress
-	container.SetRemovalInProgress()
+	container.SetRemovalInProgressLocking()
 
 	// Try to remove the container when it's start is removalInProgress.
 	// It should ignore the container and not return an error.

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -40,18 +40,3 @@ func (e errNotRunning) Error() string {
 func (e errNotRunning) ContainerIsRunning() bool {
 	return false
 }
-
-func errContainerIsRestarting(containerID string) error {
-	err := fmt.Errorf("Container %s is restarting, wait until the container is running", containerID)
-	return errors.NewRequestConflictError(err)
-}
-
-func errExecNotFound(id string) error {
-	err := fmt.Errorf("No such exec instance '%s' found in daemon", id)
-	return errors.NewRequestNotFoundError(err)
-}
-
-func errExecPaused(id string) error {
-	err := fmt.Errorf("Container %s is paused, unpause the container before exec", id)
-	return errors.NewRequestConflictError(err)
-}

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -30,7 +30,9 @@ func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON,
 	container.Lock()
 	defer container.Unlock()
 
-	base, err := daemon.getInspectData(container, false)
+	// feed getInspectData with a fake version number 1.19
+	// any number less than 1.20 is OK here
+	base, err := daemon.getInspectData(container, false, "1.19")
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -28,7 +28,9 @@ func addMountPoints(container *container.Container) []types.MountPoint {
 
 // containerInspectPre120 get containers for pre 1.20 APIs.
 func (daemon *Daemon) containerInspectPre120(name string) (*types.ContainerJSON, error) {
-	return daemon.containerInspectCurrent(name, false)
+	// feed getInspectData with a fake version number 1.19
+	// any number less than 1.20 is OK here
+	return daemon.containerInspectCurrent(name, false, "1.19")
 }
 
 func inspectExecProcessConfig(e *exec.Config) *backend.ExecProcessConfig {

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -53,7 +53,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 		"oldName": oldName,
 	}
 
-	if !container.Running {
+	if !container.IsRunning() && !container.IsPaused() && !container.IsRestarting() {
 		daemon.LogContainerEventWithAttributes(container, "rename", attributes)
 		return nil
 	}

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -10,7 +10,7 @@ func (daemon *Daemon) ContainerResize(name string, height, width int) error {
 		return err
 	}
 
-	if !container.IsRunning() {
+	if !container.IsRunningLocking() {
 		return errNotRunning{container.ID}
 	}
 

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -28,7 +28,7 @@ func (daemon *Daemon) ContainerStats(prefixOrName string, config *backend.Contai
 	}
 
 	// If the container is not running and requires no stream, return an empty stats.
-	if !container.IsRunning() && !config.Stream {
+	if !container.IsRunningLocking() && !container.IsPausedLocking() && !config.Stream {
 		return json.NewEncoder(config.OutStream).Encode(&types.Stats{})
 	}
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -21,7 +21,7 @@ func (daemon *Daemon) ContainerStop(name string, seconds int) error {
 	if err != nil {
 		return err
 	}
-	if !container.IsRunning() {
+	if !container.IsRunning() && !container.IsPaused() && !container.IsRestarting() {
 		err := fmt.Errorf("Container %s is already stopped", name)
 		return errors.NewErrorWithStatusCode(err, http.StatusNotModified)
 	}
@@ -37,7 +37,7 @@ func (daemon *Daemon) ContainerStop(name string, seconds int) error {
 // for the initial signal forever. If the container is not running Stop returns
 // immediately.
 func (daemon *Daemon) containerStop(container *container.Container, seconds int) error {
-	if !container.IsRunning() {
+	if !container.IsRunning() && !container.IsPaused() && !container.IsRestarting() {
 		return nil
 	}
 

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -26,12 +26,8 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 		return nil, err
 	}
 
-	if !container.IsRunning() {
+	if !container.IsRunningLocking() && !container.IsPausedLocking() {
 		return nil, errNotRunning{container.ID}
-	}
-
-	if container.IsRestarting() {
-		return nil, errContainerIsRestarting(container.ID)
 	}
 	pids, err := daemon.ExecutionDriver().GetPidsForContainer(container.ID)
 	if err != nil {

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/container/state"
 )
 
 // ContainerUnpause unpauses a container
@@ -25,13 +26,8 @@ func (daemon *Daemon) containerUnpause(container *container.Container) error {
 	container.Lock()
 	defer container.Unlock()
 
-	// We cannot unpause the container which is not running
-	if !container.Running {
-		return errNotRunning{container.ID}
-	}
-
 	// We cannot unpause the container which is not paused
-	if !container.Paused {
+	if !container.IsPaused() {
 		return fmt.Errorf("Container %s is not paused", container.ID)
 	}
 
@@ -39,7 +35,7 @@ func (daemon *Daemon) containerUnpause(container *container.Container) error {
 		return fmt.Errorf("Cannot unpause container %s: %s", container.ID, err)
 	}
 
-	container.Paused = false
+	container.SetRawState(state.Running)
 	daemon.LogContainerEvent(container, "unpause")
 	return nil
 }

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -55,11 +55,12 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 		}
 	}()
 
-	if container.RemovalInProgress || container.Dead {
+	if container.RemovalInProgress || container.IsDead() {
 		return errCannotUpdate(container.ID, fmt.Errorf("Container is marked for removal and cannot be \"update\"."))
 	}
 
-	if container.IsRunning() && hostConfig.KernelMemory != 0 {
+	if (container.IsRunningLocking() || container.IsPausedLocking() || container.IsRestartingLocking()) &&
+		hostConfig.KernelMemory != 0 {
 		return errCannotUpdate(container.ID, fmt.Errorf("Can not update kernel memory to a running container, please stop it first."))
 	}
 
@@ -80,7 +81,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 	// resources will be updated when the container is started again.
 	// If container is running (including paused), we need to update configs
 	// to the real world.
-	if container.IsRunning() && !container.IsRestarting() {
+	if container.IsRunningLocking() || container.IsPausedLocking() {
 		if err := daemon.execDriver.Update(container.Command); err != nil {
 			restoreConfig = true
 			return errCannotUpdate(container.ID, err)

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -56,10 +56,10 @@ func (s *DockerSuite) TestExecApiCreateContainerPaused(c *check.C) {
 	dockerCmd(c, "pause", name)
 	status, body, err := sockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), map[string]interface{}{"Cmd": []string{"true"}})
 	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusConflict)
+	c.Assert(status, checker.Equals, http.StatusInternalServerError)
 
 	comment := check.Commentf("Expected message when creating exec command with Container %s is paused", name)
-	c.Assert(string(body), checker.Contains, "Container "+name+" is paused, unpause the container before exec", comment)
+	c.Assert(string(body), checker.Contains, "is not running", comment)
 }
 
 func (s *DockerSuite) TestExecApiStart(c *check.C) {
@@ -80,7 +80,7 @@ func (s *DockerSuite) TestExecApiStart(c *check.C) {
 	// make sure exec is created before pausing
 	id = createExec(c, "test")
 	dockerCmd(c, "pause", "test")
-	startExec(c, id, http.StatusConflict)
+	startExec(c, id, http.StatusInternalServerError)
 	dockerCmd(c, "unpause", "test")
 	startExec(c, id, http.StatusOK)
 }

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -40,5 +40,5 @@ func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(string(body), checker.Contains, "is not running", check.Commentf("resize should fail with message 'Container is not running'"))
+	c.Assert(string(body), checker.Contains, "is not running", check.Commentf("resize should fail with message 'Can't operate on container'"))
 }

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -158,5 +158,5 @@ func (s *DockerSuite) TestAttachPausedContainer(c *check.C) {
 	dockerCmd(c, "pause", "test")
 	out, _, err := dockerCmdWithError("attach", "test")
 	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "You cannot attach to a paused container, unpause it first")
+	c.Assert(out, checker.Contains, "You can only attach to a running container")
 }

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -140,7 +140,7 @@ func (s *DockerSuite) TestExecPausedContainer(c *check.C) {
 	out, _, err := dockerCmdWithError("exec", "-i", "-t", ContainerID, "echo", "hello")
 	c.Assert(err, checker.NotNil, check.Commentf("container should fail to exec new conmmand if it is paused"))
 
-	expected := ContainerID + " is paused, unpause the container before exec"
+	expected := "is not running"
 	c.Assert(out, checker.Contains, expected, check.Commentf("container should not exec new command if it is paused"))
 }
 


### PR DESCRIPTION
Using enum value format to represent container's state as:

```
type Cstate int64
const (
    Stopped Cstate = 0
    Running Cstate = (1 << iota)
    Paused
    Restarting
    Dead
)
```

so as to replace redundant bool values such as `Running, Paused bool`

Currently we have some places didn't handle state `restarting` right,  which is caused by confused container state from my point of view. . `IsRunning()` includes `IsPaused()` and `IsRestarting()`, this is ridiculous and I guess this is for easier code implementation before.

This PR will end this design, it will confine container in a single and precise state, a container can only be either running or restarting but can't be both at the same time, it will make code more clear, and easier to control.

As `docker inspect` makes use of the container state, I have done some translation in code so it **WON'T** break backward compatibility.

Unfinished:
- [x] Fix test cases.
- [x] Check whether expecting container `state` is right what we really want.
- [x] Clean some unused daemon error, maybe throw same error `ErrorCodeInvalidState` instead of specific error for each.

_This is a initial commit for showing the design_

Signed-off-by: Zhang Wei zhangwei555@huawei.com
