### PR TITLE
Fix migration diffid atomic write

### DIFF
--- a/migrate/v1/migratev1.go
+++ b/migrate/v1/migratev1.go
@@ -160,7 +160,12 @@ func calculateLayerChecksum(graphDir, id string, ls checksumCalculator) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(graphDir, id, migrationDiffIDFileName), []byte(diffID), 0600); err != nil {
+	tmpFile := filepath.Join(graphDir, id, migrationDiffIDFileName+".tmp")
+	if err := ioutil.WriteFile(tmpFile, []byte(diffID), 0600); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpFile, filepath.Join(graphDir, id, migrationDiffIDFileName)); err != nil {
 		return err
 	}
 
@@ -422,7 +427,11 @@ func migrateImage(id, root string, ls graphIDRegistrar, is image.Store, ms metad
 		history = parentImg.History
 	}
 
-	diffID, err := ioutil.ReadFile(filepath.Join(root, graphDirName, id, migrationDiffIDFileName))
+	diffIDData, err := ioutil.ReadFile(filepath.Join(root, graphDirName, id, migrationDiffIDFileName))
+	if err != nil {
+		return err
+	}
+	diffID, err := digest.ParseDigest(string(diffIDData))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #20267

From the  #20267 debug info it seems that empty diffid file was created during the calculation phase. This makes sure that if calculation is cancelled it can not leave a layer in a broken state. There is also added validation that we don't create broken image configurations but error out if a layer diffid is not a valid digest.

cc @dmcgowan @aaronlehmann 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
