### PR TITLE
Fix index generator for apt/yum packages

### DIFF
--- a/hack/make/generate-index-listing
+++ b/hack/make/generate-index-listing
@@ -41,7 +41,7 @@ create_index() {
 	IFS=$'\n';
 
 	# pretty sweet, will mimick the normal apache output
-	for L in $(find -L . -mount -depth -maxdepth 1 -type f ! -name 'index' -printf "<a href=\"%f\">%-44f@_@%Td-%Tb-%TY %Tk:%TM  @%f@\n"|sort|sed 's,\([\ ]\+\)@_@,</a>\1,g');
+	for L in $(find -L . -mount -depth -maxdepth 1 -type f ! -name 'index' -printf "<a href=\"%f\">%f|@_@%Td-%Tb-%TY %Tk:%TM  @%f@\n"|sort|column -t -s '|' | sed 's,\([\ ]\+\)@_@,</a>\1,g');
 	do
 		# file
 		F=$(sed -e 's,^.*@\([^@]\+\)@.*$,\1,g'<<<"$L");


### PR DESCRIPTION
fixes #20404

Some `@_@` characters could become visible if filename is longer than 44
characters.

Signed-off-by: Tibor Vass tibor@docker.com

For example (search for `@_@`):

```
<a href="docker-engine-1.7.0-1.fc21.x86_64.rpm">docker-engine-1.7.0-1.fc21.x86_64.rpm</a>       26-Oct-2015 13:17  4.6M
<a href="docker-engine-1.7.1-1.fc21.x86_64.rpm">docker-engine-1.7.1-1.fc21.x86_64.rpm</a>       26-Oct-2015 13:17  4.6M
<a href="docker-engine-1.8.0-1.fc21.x86_64.rpm">docker-engine-1.8.0-1.fc21.x86_64.rpm</a>       26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.8.1-1.fc21.x86_64.rpm">docker-engine-1.8.1-1.fc21.x86_64.rpm</a>       26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.8.2-1.fc21.x86_64.rpm">docker-engine-1.8.2-1.fc21.x86_64.rpm</a>       26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.8.3-1.fc21.x86_64.rpm">docker-engine-1.8.3-1.fc21.x86_64.rpm</a>       26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.9.0-1.fc21.src.rpm">docker-engine-1.9.0-1.fc21.src.rpm</a>          03-Nov-2015 14:05  83M
<a href="docker-engine-1.9.0-1.fc21.x86_64.rpm">docker-engine-1.9.0-1.fc21.x86_64.rpm</a>       03-Nov-2015 14:05  8.2M
<a href="docker-engine-1.9.1-1.fc21.src.rpm">docker-engine-1.9.1-1.fc21.src.rpm</a>          20-Nov-2015  9:35  83M
<a href="docker-engine-1.9.1-1.fc21.x86_64.rpm">docker-engine-1.9.1-1.fc21.x86_64.rpm</a>       20-Nov-2015  9:35  8.2M
<a href="docker-engine-selinux-1.9.0-1.fc21.noarch.rpm">docker-engine-selinux-1.9.0-1.fc21.noarch.rpm@_@03-Nov-2015 14:05  26K
<a href="docker-engine-selinux-1.9.0-1.fc21.src.rpm">docker-engine-selinux-1.9.0-1.fc21.src.rpm</a>  03-Nov-2015 14:05  26K
<a href="docker-engine-selinux-1.9.1-1.fc21.noarch.rpm">docker-engine-selinux-1.9.1-1.fc21.noarch.rpm@_@20-Nov-2015  9:35  26K
<a href="docker-engine-selinux-1.9.1-1.fc21.src.rpm">docker-engine-selinux-1.9.1-1.fc21.src.rpm</a>  20-Nov-2015  9:35  26K
```

now became:

```
<a href="docker-engine-1.7.0-1.fc21.x86_64.rpm">docker-engine-1.7.0-1.fc21.x86_64.rpm</a>                  26-Oct-2015 13:17  4.6M
<a href="docker-engine-1.7.1-1.fc21.x86_64.rpm">docker-engine-1.7.1-1.fc21.x86_64.rpm</a>                  26-Oct-2015 13:17  4.6M
<a href="docker-engine-1.8.0-1.fc21.x86_64.rpm">docker-engine-1.8.0-1.fc21.x86_64.rpm</a>                  26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.8.1-1.fc21.x86_64.rpm">docker-engine-1.8.1-1.fc21.x86_64.rpm</a>                  26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.8.2-1.fc21.x86_64.rpm">docker-engine-1.8.2-1.fc21.x86_64.rpm</a>                  26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.8.3-1.fc21.x86_64.rpm">docker-engine-1.8.3-1.fc21.x86_64.rpm</a>                  26-Oct-2015 13:17  6.2M
<a href="docker-engine-1.9.0-1.fc21.src.rpm">docker-engine-1.9.0-1.fc21.src.rpm</a>                        03-Nov-2015 14:05  83M
<a href="docker-engine-1.9.0-1.fc21.x86_64.rpm">docker-engine-1.9.0-1.fc21.x86_64.rpm</a>                  03-Nov-2015 14:05  8.2M
<a href="docker-engine-1.9.1-1.fc21.src.rpm">docker-engine-1.9.1-1.fc21.src.rpm</a>                        20-Nov-2015  9:35  83M
<a href="docker-engine-1.9.1-1.fc21.x86_64.rpm">docker-engine-1.9.1-1.fc21.x86_64.rpm</a>                  20-Nov-2015  9:35  8.2M
<a href="docker-engine-selinux-1.9.0-1.fc21.noarch.rpm">docker-engine-selinux-1.9.0-1.fc21.noarch.rpm</a>  03-Nov-2015 14:05  26K
<a href="docker-engine-selinux-1.9.0-1.fc21.src.rpm">docker-engine-selinux-1.9.0-1.fc21.src.rpm</a>        03-Nov-2015 14:05  26K
<a href="docker-engine-selinux-1.9.1-1.fc21.noarch.rpm">docker-engine-selinux-1.9.1-1.fc21.noarch.rpm</a>  20-Nov-2015  9:35  26K
<a href="docker-engine-selinux-1.9.1-1.fc21.src.rpm">docker-engine-selinux-1.9.1-1.fc21.src.rpm</a>        20-Nov-2015  9:35  26K
```

Ping @tianon @jfrazelle 

TBH I'm not sure why that `%-44f` was there in the first place :S
