### PR TITLE
Require linux for TestExecAfterContainerRestart

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -66,6 +66,7 @@ func (s *DockerSuite) TestExecInteractive(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecAfterContainerRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)


### PR DESCRIPTION
All the other exec tests require linux except this one and it is
causing failures in the TP4 test runs.

ref:
https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP4/1076/console

Signed-off-by: Michael Crosby crosbymichael@gmail.com
