### PR TITLE
Backmerge 1.10.1 fixes to master

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -760,7 +760,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	migrationStart := time.Now()
 	if err := v1.Migrate(config.Root, graphDriver, d.layerStore, d.imageStore, referenceStore, distributionMetadataStore); err != nil {
-		return nil, err
+		logrus.Errorf("Graph migration failed: %q. Your old graph data was found to be too inconsistent for upgrading to content-addressable storage. Some of the old data was probably not upgraded. We recommend starting over with a clean storage directory if possible.", err)
 	}
 	logrus.Infof("Graph migration to content-addressability took %.2f seconds", time.Since(migrationStart).Seconds())
 

--- a/layer/layer_unix_test.go
+++ b/layer/layer_unix_test.go
@@ -16,7 +16,7 @@ func graphDiffSize(ls Store, l Layer) (int64, error) {
 // Unix as Windows graph driver does not support Changes which is indirectly
 // invoked by calling DiffSize on the driver
 func TestLayerSize(t *testing.T) {
-	ls, cleanup := newTestStore(t)
+	ls, _, cleanup := newTestStore(t)
 	defer cleanup()
 
 	content1 := []byte("Base contents")

--- a/layer/migration.go
+++ b/layer/migration.go
@@ -32,7 +32,7 @@ func (ls *layerStore) CreateRWLayerByGraphID(name string, graphID string, parent
 	}
 
 	if !ls.driver.Exists(graphID) {
-		return errors.New("graph ID does not exist")
+		return fmt.Errorf("graph ID does not exist: %q", graphID)
 	}
 
 	var p *roLayer

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -268,7 +268,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 }
 
 func TestMountMigration(t *testing.T) {
-	ls, cleanup := newTestStore(t)
+	ls, _, cleanup := newTestStore(t)
 	defer cleanup()
 
 	baseFiles := []FileApplier{

--- a/layer/mount_test.go
+++ b/layer/mount_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMountInit(t *testing.T) {
-	ls, cleanup := newTestStore(t)
+	ls, _, cleanup := newTestStore(t)
 	defer cleanup()
 
 	basefile := newTestFile("testfile.txt", []byte("base data!"), 0644)
@@ -63,7 +63,7 @@ func TestMountInit(t *testing.T) {
 }
 
 func TestMountSize(t *testing.T) {
-	ls, cleanup := newTestStore(t)
+	ls, _, cleanup := newTestStore(t)
 	defer cleanup()
 
 	content1 := []byte("Base contents")
@@ -105,7 +105,7 @@ func TestMountSize(t *testing.T) {
 }
 
 func TestMountChanges(t *testing.T) {
-	ls, cleanup := newTestStore(t)
+	ls, _, cleanup := newTestStore(t)
 	defer cleanup()
 
 	basefiles := []FileApplier{

--- a/migrate/v1/migratev1.go
+++ b/migrate/v1/migratev1.go
@@ -282,7 +282,8 @@ func migrateContainers(root string, ls graphIDMounter, is image.Store, imageMapp
 		}
 
 		if err := ls.CreateRWLayerByGraphID(id, id, img.RootFS.ChainID()); err != nil {
-			return err
+			logrus.Errorf("migrate container error: %v", err)
+			continue
 		}
 
 		logrus.Infof("migrated container %s to point to %s", id, imageID)


### PR DESCRIPTION
Ping @tonistiigi @aaronlehmann 
#20164, #20156 and #20175 were the only PRs open directly against the 1.10.1 branch.

I only cherrypicked the first two, since #20175 was reopened against master at #20209.

Related to #20203
