### PR TITLE
Use pool for pubsub `Publish`'s waitgroups

### DIFF
--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var wgPool = sync.Pool{New: func() interface{} { return new(sync.WaitGroup) }}
+
 // NewPublisher creates a new pub/sub publisher to broadcast messages.
 // The duration is used as the send timeout as to not block the publisher publishing
 // messages to other clients if one client is slow or unresponsive.
@@ -69,12 +71,13 @@ func (p *Publisher) Publish(v interface{}) {
 		return
 	}
 
-	wg := new(sync.WaitGroup)
+	wg := wgPool.Get().(*sync.WaitGroup)
 	for sub, topic := range p.subscribers {
 		wg.Add(1)
 		go p.sendTopic(sub, topic, v, wg)
 	}
 	wg.Wait()
+	wgPool.Put(wg)
 	p.m.RUnlock()
 }
 


### PR DESCRIPTION
```
benchmark             old ns/op      new ns/op      delta
BenchmarkPubSub-8     1036494796     1032443513     -0.39%

benchmark             old allocs     new allocs     delta
BenchmarkPubSub-8     2467           1441           -41.59%

benchmark             old bytes     new bytes     delta
BenchmarkPubSub-8     212216        187792        -11.51%
```
