### PR TITLE
Add insecure registries to docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -151,5 +151,19 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if info.ClusterAdvertise != "" {
 		fmt.Fprintf(cli.out, "Cluster Advertise: %s\n", info.ClusterAdvertise)
 	}
+
+	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
+		fmt.Fprintln(cli.out, "Insecure registries:")
+		for _, registry := range info.RegistryConfig.IndexConfigs {
+			if registry.Secure == false {
+				fmt.Fprintf(cli.out, " %s\n", registry.Name)
+			}
+		}
+
+		for _, registry := range info.RegistryConfig.InsecureRegistryCIDRs {
+			mask, _ := registry.Mask.Size()
+			fmt.Fprintf(cli.out, " %s/%d\n", registry.IP.String(), mask)
+		}
+	}
 	return nil
 }

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -62,6 +62,9 @@ For example:
     Registry: [https://index.docker.io/v1/]
     Labels:
      storage=ssd
+    Insecure registries:
+     myinsecurehost:5000
+     127.0.0.0/8
 
 The global `-D` option tells all `docker` commands to output debug information.
 

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -164,3 +164,21 @@ func (s *DockerSuite) TestInfoDebug(c *check.C) {
 	c.Assert(out, checker.Contains, "EventsListeners")
 	c.Assert(out, checker.Contains, "Docker Root Dir")
 }
+
+func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	registryCIDR := "192.168.1.0/24"
+	registryHost := "insecurehost.com:5000"
+
+	d := NewDaemon(c)
+	err := d.Start("--insecure-registry="+registryCIDR, "--insecure-registry="+registryHost)
+	c.Assert(err, checker.IsNil)
+	defer d.Stop()
+
+	out, err := d.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "Insecure registries:\n")
+	c.Assert(out, checker.Contains, fmt.Sprintf(" %s\n", registryHost))
+	c.Assert(out, checker.Contains, fmt.Sprintf(" %s\n", registryCIDR))
+}

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -59,6 +59,9 @@ Here is a sample output:
     Debug mode (server): false
     Username: xyz
     Registry: https://index.docker.io/v1/
+    Insecure registries:
+     myinsecurehost:5000
+     127.0.0.0/8
 	
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)


### PR DESCRIPTION
Adding additional section to docker info: Insecure registries.
I think we don't need to make any additional changes in engine-api but let me know if I missed something.

Also, I haven't written any test because I haven't found any for docker info command. If you think it should be covered somehow, I will add it to this PR.

Fixes #20236 

Signed-off-by: Tomasz Kopczynski tomek@kopczynski.net.pl
