### PR TITLE
Check for 'libsystemd >= 209' when checking the availability of sd-journal APIs

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -2,7 +2,7 @@
 
 package journald
 
-// #cgo pkg-config: libsystemd-journal
+// #cgo pkg-config: libsystemd
 // #include <sys/types.h>
 // #include <sys/poll.h>
 // #include <systemd/sd-journal.h>

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -118,7 +118,7 @@ fi
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then
 	DOCKER_BUILDTAGS+=" daemon"
-	if pkg-config libsystemd-journal 2> /dev/null ; then
+	if pkg-config 'libsystemd >= 209' 2> /dev/null ; then
 		DOCKER_BUILDTAGS+=" journald"
 	fi
 fi


### PR DESCRIPTION
When checking if we have the development files for libsystemd's journal APIs, check for 'libsystemd >= 209' rather than 'libsystemd-journal'.  Starting with that version, libsystemd-journal was merged into
libsystemd, and the .pc file is no longer packaged in newer Debian and Ubuntu.

I _think_ this will fix what we're seeing in https://github.com/docker/docker/pull/13707#issuecomment-182709361, but I'm admittedly still waiting for my build box to finish up to be sure.
