### PR TITLE
Be more explicit on seccomp availability

### DIFF
--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -19,9 +19,11 @@ feature to restrict your application's access.
 This feature is available only if the kernel is configured with `CONFIG_SECCOMP`
 enabled.
 
-> **Note**: On Ubuntu 14.04, Debian Wheezy, and Debian Jessie, you must download
-> the [latest static Docker Linux binary](../installation/binaries.md) to use
-> seccomp.
+> **Note**: Seccomp profiles require seccomp 2.2.1 and are only
+> available starting with Debian 9 "Stretch", Ubuntu 15.10 "Wily", and
+> Fedora 22. To use this feature on Ubuntu 14.04, Debian Wheezy, or
+> Debian Jessie, you must download the [latest static Docker Linux binary](../installation/binaries.md).
+> This feature is currently *not* available on other distributions.
 
 ## Passing a profile for a container
 


### PR DESCRIPTION
Seccomp is only _compiled_ in binaries built for distros that ship with seccomp 2.2.1 or higher, and in the static binaries.

The static binaries are not really useful for RHEL and CentOS, because devicemapper does not work properly with the static binaries, so static binaries is only an option for Ubuntu and Debian.
