### PR TITLE
Fix libdevmapper deferred removal detection

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -135,7 +135,7 @@ fi
 # functionality.
 if \
 	command -v gcc &> /dev/null \
-	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -ldevmapper -xc - -o /dev/null &> /dev/null ) \
+	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -ldevmapper -o /dev/null &> /dev/null ) \
 ; then
        DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
 fi


### PR DESCRIPTION
When linking, position of `-l` flags is important since
they muse come _after_ any object files which uses symbols
from a specified library, that is due to --as-needed binutils
ld flag enabled by default
