### PR TITLE
Remove channel close.

### DIFF
--- a/integration-cli/events_utils.go
+++ b/integration-cli/events_utils.go
@@ -149,7 +149,7 @@ func matchEventLine(id, eventType string, actions map[string]chan bool) eventMat
 func processEventMatch(actions map[string]chan bool) eventMatchProcessor {
 	return func(matches map[string]string) {
 		if ch, ok := actions[matches["action"]]; ok {
-			close(ch)
+			ch <- true
 		}
 	}
 }


### PR DESCRIPTION
Send a message instead, discarding duplicated messages.

Avoid panic sensing a message over a closed channel.

Signed-off-by: David Calavera david.calavera@gmail.com
