### PR TITLE
update the dockfile of dockerizing a Node.js app.

### DIFF
--- a/docs/examples/nodejs_web_app.md
+++ b/docs/examples/nodejs_web_app.md
@@ -89,7 +89,7 @@ Install your app dependencies using the `npm` binary:
 
     # Install app dependencies
     COPY package.json /src/package.json
-    RUN cd /src; npm install
+    RUN cd /src; npm install --production
 
 To bundle your app's source code inside the Docker image, use the `COPY`
 instruction:
@@ -119,7 +119,7 @@ Your `Dockerfile` should now look like this:
 
     # Install app dependencies
     COPY package.json /src/package.json
-    RUN cd /src; npm install
+    RUN cd /src; npm install --production
 
     # Bundle app source
     COPY . /src


### PR DESCRIPTION
In official documentation on dockerizing a Node.js app, I'll change `npm install` in dockerfile to `npm install --production` in order to make sure only production dependencies are installed. Fixes #20368

Signed-off-by: Zhenan Ye 21551168@zju.edu.cn
