### PR TITLE
Close tarsplit gzip writer when creating tar-split.json.gz files during layer migration

### DIFF
--- a/layer/migration.go
+++ b/layer/migration.go
@@ -127,6 +127,7 @@ func (ls *layerStore) checksumForGraphIDNoTarsplit(id, parent, newTarDataPath st
 	}
 	defer f.Close()
 	mfz := gzip.NewWriter(f)
+	defer mfz.Close()
 	metaPacker := storage.NewJSONPacker(mfz)
 
 	packerCounter := &packSizeCounter{metaPacker, &size}


### PR DESCRIPTION
There is a missing call to Close on the gzip.Writer that is used to
compress newly created tar-split files during layer migration. This can
result in corrupt tar-split files that later cause docker push and
docker save to fail. The Close call is necessary to flush buffered data
to the stream.

Fixes #20104

cc @tonistiigi @dmcgowan 
