### PR TITLE
Fix events test flakiness.

### DIFF
--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -265,8 +265,8 @@ func (s *DockerAuthzSuite) TestAuthZPluginAllowEventStream(c *check.C) {
 	c.Assert(s.d.waitRun(containerID), checker.IsNil)
 
 	events := map[string]chan bool{
-		"create": make(chan bool),
-		"start":  make(chan bool),
+		"create": make(chan bool, 1),
+		"start":  make(chan bool, 1),
 	}
 
 	matcher := matchEventLine(containerID, "container", events)
@@ -277,7 +277,7 @@ func (s *DockerAuthzSuite) TestAuthZPluginAllowEventStream(c *check.C) {
 	for event, eventChannel := range events {
 
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(30 * time.Second):
 			// Fail the test
 			observer.CheckEventError(c, containerID, event, matcher)
 			c.FailNow()

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -171,8 +171,8 @@ func (s *DockerSuite) TestBuildCancellationKillsSleep(c *check.C) {
 	}
 
 	testActions := map[string]chan bool{
-		"start": make(chan bool),
-		"die":   make(chan bool),
+		"start": make(chan bool, 1),
+		"die":   make(chan bool, 1),
 	}
 
 	matcher := matchEventLine(buildID, "container", testActions)

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -232,10 +232,10 @@ func (s *DockerSuite) TestEventsStreaming(c *check.C) {
 	containerID := strings.TrimSpace(out)
 
 	testActions := map[string]chan bool{
-		"create":  make(chan bool),
-		"start":   make(chan bool),
-		"die":     make(chan bool),
-		"destroy": make(chan bool),
+		"create":  make(chan bool, 1),
+		"start":   make(chan bool, 1),
+		"die":     make(chan bool, 1),
+		"destroy": make(chan bool, 1),
 	}
 
 	matcher := matchEventLine(containerID, "container", testActions)
@@ -291,8 +291,8 @@ func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
 	c.Assert(deleteImages(name), checker.IsNil)
 
 	testActions := map[string]chan bool{
-		"untag":  make(chan bool),
-		"delete": make(chan bool),
+		"untag":  make(chan bool, 1),
+		"delete": make(chan bool, 1),
 	}
 
 	matcher := matchEventLine(imageID, "image", testActions)


### PR DESCRIPTION
ok, for realz this time (I hope!).

Since channel is getting a send instead of a close now, this can cause
random issues ranging through the list of channels if the channel is
unbuffered since the send may be blocked.

Let's run gccgo a few times where this was really having problems.
