### PR TITLE
modify annotation

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -89,7 +89,7 @@ func decodeEvents(input io.Reader, ep eventProcessor) error {
 }
 
 // printOutput prints all types of event information.
-// Each output includes the event type, actor id, name and action.
+// Each output includes the event type, actor id, and action.
 // Actor attributes are printed at the end if the actor has any.
 func printOutput(event eventtypes.Message, output io.Writer) {
 	if event.TimeNano != 0 {


### PR DESCRIPTION
I fix the annotation for function "printOutput" in "event.go", because the function do not output "name" attribute for  the event information, so in order not to mislead the codes reader i fix it.

@thaJeztah please review, thank you !

Signed-off-by: huangzhendong 21551070@zju.edu.cn
