### PR TITLE
Adding readOnly parameter to graphdriver Create method

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -201,7 +201,7 @@ func (a *Driver) Exists(id string) bool {
 
 // Create three folders for each id
 // mnt, layers, and diff
-func (a *Driver) Create(id, parent, mountLabel string) error {
+func (a *Driver) Create(id, parent, mountLabel string, readOnly bool) error {
 	if err := a.createDirsFor(id); err != nil {
 		return err
 	}

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -242,7 +242,7 @@ func (d *Driver) subvolumesDirID(id string) string {
 }
 
 // Create the filesystem with given id.
-func (d *Driver) Create(id, parent, mountLabel string) error {
+func (d *Driver) Create(id, parent, mountLabel string, readOnly bool) error {
 	subvolumes := path.Join(d.home, "subvolumes")
 	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
 	if err != nil {

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -118,7 +118,7 @@ func (d *Driver) Cleanup() error {
 }
 
 // Create adds a device with a given id and the parent.
-func (d *Driver) Create(id, parent, mountLabel string) error {
+func (d *Driver) Create(id, parent, mountLabel string, readOnly bool) error {
 	if err := d.DeviceSet.AddDevice(id, parent); err != nil {
 		return err
 	}

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -47,7 +47,9 @@ type ProtoDriver interface {
 	String() string
 	// Create creates a new, empty, filesystem layer with the
 	// specified id and parent and mountLabel. Parent and mountLabel may be "".
-	Create(id, parent, mountLabel string) error
+	// If readOnly is true, a read-only layer will be created, otherwise the
+	// layer will be set up as read/write.
+	Create(id, parent, mountLabel string, readOnly bool) error
 	// Remove attempts to remove the filesystem layer with this id.
 	Remove(id string) error
 	// Get returns the mountpoint for the layered filesystem referred

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -230,7 +230,7 @@ func (d *Driver) Cleanup() error {
 
 // Create is used to create the upper, lower, and merge directories required for overlay fs for a given id.
 // The parent filesystem is used to configure these directories for the overlay.
-func (d *Driver) Create(id, parent, mountLabel string) (retErr error) {
+func (d *Driver) Create(id, parent, mountLabel string, readOnly bool) (retErr error) {
 	dir := d.dir(id)
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -54,7 +54,7 @@ func (d *graphDriverProxy) String() string {
 	return d.name
 }
 
-func (d *graphDriverProxy) Create(id, parent, mountLabel string) error {
+func (d *graphDriverProxy) Create(id, parent, mountLabel string, readOnly bool) error {
 	args := &graphDriverRequest{
 		ID:         id,
 		Parent:     parent,

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -69,7 +69,7 @@ func (d *Driver) Cleanup() error {
 }
 
 // Create prepares the filesystem for the VFS driver and copies the directory for the given id under the parent.
-func (d *Driver) Create(id, parent, mountLabel string) error {
+func (d *Driver) Create(id, parent, mountLabel string, readOnly bool) error {
 	dir := d.dir(id)
 	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
 	if err != nil {

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -249,7 +249,7 @@ func (d *Driver) mountPath(id string) string {
 }
 
 // Create prepares the dataset and filesystem for the ZFS driver for the given id under the parent.
-func (d *Driver) Create(id string, parent string, mountLabel string) error {
+func (d *Driver) Create(id string, parent string, mountLabel string, readOnly bool) error {
 	err := d.create(id, parent)
 	if err == nil {
 		return nil

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -263,7 +263,7 @@ func (ls *layerStore) Register(ts io.Reader, parent ChainID) (Layer, error) {
 		references:     map[Layer]struct{}{},
 	}
 
-	if err = ls.driver.Create(layer.cacheID, pid, ""); err != nil {
+	if err = ls.driver.Create(layer.cacheID, pid, "", true); err != nil {
 		return nil, err
 	}
 
@@ -458,7 +458,7 @@ func (ls *layerStore) CreateRWLayer(name string, parent ChainID, mountLabel stri
 		m.initID = pid
 	}
 
-	if err = ls.driver.Create(m.mountID, pid, ""); err != nil {
+	if err = ls.driver.Create(m.mountID, pid, "", false); err != nil {
 		return nil, err
 	}
 
@@ -553,7 +553,7 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 	// then the initID should be randomly generated.
 	initID := fmt.Sprintf("%s-init", graphID)
 
-	if err := ls.driver.Create(initID, parent, mountLabel); err != nil {
+	if err := ls.driver.Create(initID, parent, mountLabel, true); err != nil {
 		return "", err
 	}
 	p, err := ls.driver.Get(initID, "")


### PR DESCRIPTION
@jhowardmsft @jstarks @tonistiigi @cpuguy83 

Since the layer store was introduced, the level above the graphdriver
now differentiates between read/write and read-only layers.  This
distinction is useful for graphdrivers that need to take special steps
when creating a layer based on whether it is read-only or not.
Adding this parameter allows the graphdrivers to differentiate, which
in the case of the Windows graphdriver, removes our dependence on parsing
the id of the parent for "-init" in order to infer this information.

This will also set the stage for unblocking some of the layer store
unit tests in the next preview build of Windows.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
