### PR TITLE
Add check for non-systemd fd use case

### DIFF
--- a/docker/listeners/listeners_unix.go
+++ b/docker/listeners/listeners_unix.go
@@ -59,7 +59,7 @@ func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
 	}
 
 	if len(listeners) == 0 {
-		return nil, fmt.Errorf("No sockets found")
+		return nil, fmt.Errorf("No sockets found. Make sure the docker daemon was started by systemd.")
 	}
 
 	// default to all fds just like unix:// and tcp://


### PR DESCRIPTION
Fixes: #20468
We make the check more user-friendly, and users can know
exactly they specify wrong socket protocol on non-systemd
system.

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
