### PR TITLE
update docs about installer

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -43,6 +43,7 @@ func main() {
 		fmt.Fprintf(stdout, "%s\n", help)
 	}
 
+    // Analysis parameters of command line.
 	flag.Parse()
 
 	if *flVersion {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -43,7 +43,7 @@ func main() {
 		fmt.Fprintf(stdout, "%s\n", help)
 	}
 
-    // Analysis parameters of command line.
+    // Analysis parameters from command line.
 	flag.Parse()
 
 	if *flVersion {

--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -197,6 +197,10 @@ install Docker using the following:
 
         $ sudo apt-get install docker-engine
 
+   Or you can install Docker with version latest 
+   
+        $ wget -qO- https://get.docker.com/ | sh
+
 4. Start the `docker` daemon.
 
         $ sudo service docker start

--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -197,7 +197,7 @@ install Docker using the following:
 
         $ sudo apt-get install docker-engine
 
-   Or you can install Docker with version latest 
+   Or you can install Docker with version latest.
    
         $ wget -qO- https://get.docker.com/ | sh
 

--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -197,7 +197,7 @@ install Docker using the following:
 
         $ sudo apt-get install docker-engine
 
-   Or you can install Docker with version latest.
+   Or you can install Docker with the latest version.
    
         $ wget -qO- https://get.docker.com/ | sh
 


### PR DESCRIPTION
related issue #19235 
 The shell `apt-get install docker` can not install the latest version docker,so we can run `wget -qO- https://get.docker.com/ | sh` to install the latest version.Thanks .
@HackToday  
