### PR TITLE
Document .Names format placeholder in docker-ps man page, fixes #20503.

### DIFF
--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -47,6 +47,7 @@ the running containers.
       .Ports - Exposed ports.
       .Status - Container status.
       .Size - Container disk size.
+      .Names - Container names.
       .Labels - All labels assigned to the container.
       .Label - Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
 


### PR DESCRIPTION
Simple edit to man page, adds one line to document the `.Names` placeholder for the `--format` option of `docker ps`.
