### PR TITLE
Clean up authz integration-cli test

### DIFF
--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -193,13 +193,10 @@ func (s *DockerAuthzSuite) TearDownSuite(c *check.C) {
 func (s *DockerAuthzSuite) TestAuthZPluginAllowRequest(c *check.C) {
 	// start the daemon and load busybox, --net=none build fails otherwise
 	// cause it needs to pull busybox
-	c.Assert(s.d.StartWithBusybox(), check.IsNil)
-	// restart the daemon and enable the plugin, otherwise busybox loading
-	// is blocked by the plugin itself
-	c.Assert(s.d.Restart("--authorization-plugin="+testAuthZPlugin), check.IsNil)
-
+	c.Assert(s.d.Start("--authorization-plugin="+testAuthZPlugin), check.IsNil)
 	s.ctrl.reqRes.Allow = true
 	s.ctrl.resRes.Allow = true
+	c.Assert(s.d.LoadBusybox(), check.IsNil)
 
 	// Ensure command successful
 	out, err := s.d.Cmd("run", "-d", "busybox", "top")
@@ -254,12 +251,10 @@ func (s *DockerAuthzSuite) TestAuthZPluginAllowEventStream(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	// start the daemon and load busybox to avoid pulling busybox from Docker Hub
-	c.Assert(s.d.StartWithBusybox(), check.IsNil)
-	// restart the daemon and enable the authorization plugin, otherwise busybox loading
-	// is blocked by the plugin itself
-	c.Assert(s.d.Restart("--authorization-plugin="+testAuthZPlugin), check.IsNil)
+	c.Assert(s.d.Start("--authorization-plugin="+testAuthZPlugin), check.IsNil)
 	s.ctrl.reqRes.Allow = true
 	s.ctrl.resRes.Allow = true
+	c.Assert(s.d.LoadBusybox(), check.IsNil)
 
 	startTime := strconv.FormatInt(daemonTime(c).Unix(), 10)
 	// Add another command to to enable event pipelining

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -321,24 +321,7 @@ func (d *Daemon) StartWithBusybox(arg ...string) error {
 	if err := d.Start(arg...); err != nil {
 		return err
 	}
-	bb := filepath.Join(d.folder, "busybox.tar")
-	if _, err := os.Stat(bb); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("unexpected error on busybox.tar stat: %v", err)
-		}
-		// saving busybox image from main daemon
-		if err := exec.Command(dockerBinary, "save", "--output", bb, "busybox:latest").Run(); err != nil {
-			return fmt.Errorf("could not save busybox image: %v", err)
-		}
-	}
-	// loading busybox image to this daemon
-	if out, err := d.Cmd("load", "--input", bb); err != nil {
-		return fmt.Errorf("could not load busybox image: %s", out)
-	}
-	if err := os.Remove(bb); err != nil {
-		d.c.Logf("could not remove %s: %v", bb, err)
-	}
-	return nil
+	return d.LoadBusybox()
 }
 
 // Stop will send a SIGINT every second and wait for the daemon to stop.
@@ -411,6 +394,28 @@ func (d *Daemon) Restart(arg ...string) error {
 		d.root = filepath.Dir(d.root)
 	}
 	return d.Start(arg...)
+}
+
+// LoadBusybox will load the stored busybox into a newly started daemon
+func (d *Daemon) LoadBusybox() error {
+	bb := filepath.Join(d.folder, "busybox.tar")
+	if _, err := os.Stat(bb); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("unexpected error on busybox.tar stat: %v", err)
+		}
+		// saving busybox image from main daemon
+		if err := exec.Command(dockerBinary, "save", "--output", bb, "busybox:latest").Run(); err != nil {
+			return fmt.Errorf("could not save busybox image: %v", err)
+		}
+	}
+	// loading busybox image to this daemon
+	if out, err := d.Cmd("load", "--input", bb); err != nil {
+		return fmt.Errorf("could not load busybox image: %s", out)
+	}
+	if err := os.Remove(bb); err != nil {
+		d.c.Logf("could not remove %s: %v", bb, err)
+	}
+	return nil
 }
 
 func (d *Daemon) queryRootDir() (string, error) {


### PR DESCRIPTION
- Order the flow of the handlers more cleanly--read req, do actions,
  write response.
- Add "always allowed" endpoints to handle `/_ping` and `/info` usage
  from the test framework/daemon start/restart management

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
