### PR TITLE
Fix releasing reference on deletion error

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -498,18 +498,21 @@ func (ls *layerStore) ReleaseRWLayer(l RWLayer) ([]Metadata, error) {
 
 	if err := ls.driver.Remove(m.mountID); err != nil {
 		logrus.Errorf("Error removing mounted layer %s: %s", m.name, err)
+		m.retakeReference(l)
 		return nil, err
 	}
 
 	if m.initID != "" {
 		if err := ls.driver.Remove(m.initID); err != nil {
 			logrus.Errorf("Error removing init layer %s: %s", m.name, err)
+			m.retakeReference(l)
 			return nil, err
 		}
 	}
 
 	if err := ls.store.RemoveMount(m.name); err != nil {
 		logrus.Errorf("Error removing mount metadata: %s: %s", m.name, err)
+		m.retakeReference(l)
 		return nil, err
 	}
 

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -96,6 +96,13 @@ func (ml *mountedLayer) deleteReference(ref RWLayer) error {
 	return nil
 }
 
+func (ml *mountedLayer) retakeReference(r RWLayer) {
+	if ref, ok := r.(*referencedRWLayer); ok {
+		ref.activityCount = 0
+		ml.references[ref] = ref
+	}
+}
+
 type referencedRWLayer struct {
 	*mountedLayer
 


### PR DESCRIPTION
Fixes #20268

This retakes a reference to a mounted layer if the deletion failed on graphdriver level. This does not completely fix deletion of containers with busy mounts but should make sure that they can be deleted once they are manually unmounted. When deletion fails then things can still be left in unknown state.

ping @dmcgowan 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
