### PR TITLE
Add tempates for new issues and pull requests.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information within 7 days, we cannot debug your issue and will close it. We
+will, however, reopen it if you later provide the information.
+
+For more information about reporting issues, see
+https://github.com/docker/docker/blob/master/CONTRIBUTING.md#reporting-other-issues
+
+---------------------------------------------------
+BUG REPORT INFORMATION
+---------------------------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+Output of `docker version`:
+
+```
+(paste your output here)
+```
+
+
+Output of `docker info`:
+
+```
+(paste your output here)
+```
+
+Provide additional environment details (AWS, VirtualBox, physical, etc.):
+
+
+
+List the steps to reproduce the issue:
+1.
+2.
+3.
+
+
+Describe the results you received:
+
+
+Describe the results you expected:
+
+
+Provide additional info you think is important:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Please make sure you've read and understood our contributing guidelines;
+https://github.com/docker/docker/blob/master/CONTRIBUTING.md
+
+** Make sure all your commits include a signature generated with `git commit -s` **
+
+For additional information on our contributing process, read our contributing
+guide https://docs.docker.com/opensource/code/
+
+If this is a bug fix, make sure your description includes "fixes #xxxx", or
+"closes #xxxx"
+-->
+
+Please provide the following information:
+
+- What did you do?
+
+- How did you do it?
+
+- How do I see it or verify it?
+
+- A picture of a cute animal (not mandatory but encouraged)
+


### PR DESCRIPTION
I added a new `.github` directory that includes templates for new issues and pull requests.

Fixes #20420.

TODO: after this is merged
- [ ] Add same templates to https://github.com/docker/opensource

Signed-off-by: David Calavera david.calavera@gmail.com
