### PR TITLE
Fix bridge config serialization with Go 1.6.

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -95,7 +95,7 @@ type CommonConfig struct {
 	// deserialization without the full struct.
 	CommonTLSOptions
 	LogConfig
-	bridgeConfig // bridgeConfig holds bridge network specific configuration.
+	BridgeConfig // BridgeConfig holds bridge network specific configuration.
 
 	reloadLock sync.Mutex
 	valuesSet  map[string]interface{}

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -33,9 +33,9 @@ type Config struct {
 	Ulimits              map[string]*units.Ulimit `json:"default-ulimits,omitempty"`
 }
 
-// bridgeConfig stores all the bridge driver specific
+// BridgeConfig stores all the bridge driver specific
 // configuration.
-type bridgeConfig struct {
+type BridgeConfig struct {
 	EnableIPv6                  bool   `json:"ipv6,omitempty"`
 	EnableIPTables              bool   `json:"iptables,omitempty"`
 	EnableIPForward             bool   `json:"ip-forward,omitempty"`
@@ -64,19 +64,19 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.StringVar(&config.SocketGroup, []string{"G", "-group"}, "docker", usageFn("Group for the unix socket"))
 	config.Ulimits = make(map[string]*units.Ulimit)
 	cmd.Var(runconfigopts.NewUlimitOpt(&config.Ulimits), []string{"-default-ulimit"}, usageFn("Set default ulimits for containers"))
-	cmd.BoolVar(&config.bridgeConfig.EnableIPTables, []string{"#iptables", "-iptables"}, true, usageFn("Enable addition of iptables rules"))
-	cmd.BoolVar(&config.bridgeConfig.EnableIPForward, []string{"#ip-forward", "-ip-forward"}, true, usageFn("Enable net.ipv4.ip_forward"))
-	cmd.BoolVar(&config.bridgeConfig.EnableIPMasq, []string{"-ip-masq"}, true, usageFn("Enable IP masquerading"))
-	cmd.BoolVar(&config.bridgeConfig.EnableIPv6, []string{"-ipv6"}, false, usageFn("Enable IPv6 networking"))
-	cmd.StringVar(&config.bridgeConfig.IP, []string{"#bip", "-bip"}, "", usageFn("Specify network bridge IP"))
-	cmd.StringVar(&config.bridgeConfig.Iface, []string{"b", "-bridge"}, "", usageFn("Attach containers to a network bridge"))
-	cmd.StringVar(&config.bridgeConfig.FixedCIDR, []string{"-fixed-cidr"}, "", usageFn("IPv4 subnet for fixed IPs"))
-	cmd.StringVar(&config.bridgeConfig.FixedCIDRv6, []string{"-fixed-cidr-v6"}, "", usageFn("IPv6 subnet for fixed IPs"))
-	cmd.Var(opts.NewIPOpt(&config.bridgeConfig.DefaultGatewayIPv4, ""), []string{"-default-gateway"}, usageFn("Container default gateway IPv4 address"))
-	cmd.Var(opts.NewIPOpt(&config.bridgeConfig.DefaultGatewayIPv6, ""), []string{"-default-gateway-v6"}, usageFn("Container default gateway IPv6 address"))
-	cmd.BoolVar(&config.bridgeConfig.InterContainerCommunication, []string{"#icc", "-icc"}, true, usageFn("Enable inter-container communication"))
-	cmd.Var(opts.NewIPOpt(&config.bridgeConfig.DefaultIP, "0.0.0.0"), []string{"#ip", "-ip"}, usageFn("Default IP when binding container ports"))
-	cmd.BoolVar(&config.bridgeConfig.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
+	cmd.BoolVar(&config.BridgeConfig.EnableIPTables, []string{"#iptables", "-iptables"}, true, usageFn("Enable addition of iptables rules"))
+	cmd.BoolVar(&config.BridgeConfig.EnableIPForward, []string{"#ip-forward", "-ip-forward"}, true, usageFn("Enable net.ipv4.ip_forward"))
+	cmd.BoolVar(&config.BridgeConfig.EnableIPMasq, []string{"-ip-masq"}, true, usageFn("Enable IP masquerading"))
+	cmd.BoolVar(&config.BridgeConfig.EnableIPv6, []string{"-ipv6"}, false, usageFn("Enable IPv6 networking"))
+	cmd.StringVar(&config.BridgeConfig.IP, []string{"#bip", "-bip"}, "", usageFn("Specify network bridge IP"))
+	cmd.StringVar(&config.BridgeConfig.Iface, []string{"b", "-bridge"}, "", usageFn("Attach containers to a network bridge"))
+	cmd.StringVar(&config.BridgeConfig.FixedCIDR, []string{"-fixed-cidr"}, "", usageFn("IPv4 subnet for fixed IPs"))
+	cmd.StringVar(&config.BridgeConfig.FixedCIDRv6, []string{"-fixed-cidr-v6"}, "", usageFn("IPv6 subnet for fixed IPs"))
+	cmd.Var(opts.NewIPOpt(&config.BridgeConfig.DefaultGatewayIPv4, ""), []string{"-default-gateway"}, usageFn("Container default gateway IPv4 address"))
+	cmd.Var(opts.NewIPOpt(&config.BridgeConfig.DefaultGatewayIPv6, ""), []string{"-default-gateway-v6"}, usageFn("Container default gateway IPv6 address"))
+	cmd.BoolVar(&config.BridgeConfig.InterContainerCommunication, []string{"#icc", "-icc"}, true, usageFn("Enable inter-container communication"))
+	cmd.Var(opts.NewIPOpt(&config.BridgeConfig.DefaultIP, "0.0.0.0"), []string{"#ip", "-ip"}, usageFn("Default IP when binding container ports"))
+	cmd.BoolVar(&config.BridgeConfig.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))
 	cmd.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", usageFn("Set CORS headers in the remote API"))
 	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))

--- a/daemon/config_unix_test.go
+++ b/daemon/config_unix_test.go
@@ -1,0 +1,34 @@
+// +build !windows
+
+package daemon
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestGetConflictFreeConfigurationWithSerializedBridgeConfig(t *testing.T) {
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+	f.Write([]byte(`{
+		"ipv6": true,
+		"iptables": true
+}`))
+	f.Close()
+
+	c, err := getConflictFreeConfiguration(configFile, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !c.EnableIPv6 {
+		t.Fatalf("expected IPv6 to be enabled, got disabled")
+	}
+	if !c.EnableIPTables {
+		t.Fatalf("expected IPTables to be enabled, got disabled")
+	}
+}

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -12,9 +12,9 @@ var (
 	defaultExec    = "windows"
 )
 
-// bridgeConfig stores all the bridge driver specific
+// BridgeConfig stores all the bridge driver specific
 // configuration.
-type bridgeConfig struct {
+type BridgeConfig struct {
 	VirtualSwitchName string `json:"bridge,omitempty"`
 }
 
@@ -37,6 +37,6 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	config.InstallCommonFlags(cmd, usageFn)
 
 	// Then platform-specific install flags.
-	cmd.StringVar(&config.bridgeConfig.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
+	cmd.StringVar(&config.BridgeConfig.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
 	cmd.StringVar(&config.SocketGroup, []string{"G", "-group"}, "", usageFn("Users or groups that can access the named pipe"))
 }

--- a/daemon/config_windows_test.go
+++ b/daemon/config_windows_test.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestGetConflictFreeConfigurationWithSerializedBridgeConfig(t *testing.T) {
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+	f.Write([]byte(`{
+		"bridge": "win-virtual-switch"
+}`))
+	f.Close()
+
+	c, err := getConflictFreeConfiguration(configFile, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.VirtualSwitchName != "win-virtual-switch" {
+		t.Fatalf("expected virtual switch `win-virtual-switch`, got %s\n", c.VirtualSwitchName)
+	}
+}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -495,7 +495,7 @@ func (daemon *Daemon) updateEndpointNetworkSettings(container *container.Contain
 	}
 
 	if container.HostConfig.NetworkMode == containertypes.NetworkMode("bridge") {
-		container.NetworkSettings.Bridge = daemon.configStore.bridgeConfig.Iface
+		container.NetworkSettings.Bridge = daemon.configStore.BridgeConfig.Iface
 	}
 
 	return nil

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -54,7 +54,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		if !c.Config.NetworkDisabled {
 			en.Interface = &execdriver.NetworkInterface{
 				MacAddress:   c.Config.MacAddress,
-				Bridge:       daemon.configStore.bridgeConfig.VirtualSwitchName,
+				Bridge:       daemon.configStore.BridgeConfig.VirtualSwitchName,
 				PortBindings: c.HostConfig.PortBindings,
 
 				// TODO Windows. Include IPAddress. There already is a

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -126,8 +126,8 @@ func isBridgeNetworkDisabled(config *Config) bool {
 
 func (daemon *Daemon) initNetworkController(config *Config) (libnetwork.NetworkController, error) {
 	// Set the name of the virtual switch if not specified by -b on daemon start
-	if config.bridgeConfig.VirtualSwitchName == "" {
-		config.bridgeConfig.VirtualSwitchName = defaultVirtualSwitch
+	if config.BridgeConfig.VirtualSwitchName == "" {
+		config.BridgeConfig.VirtualSwitchName = defaultVirtualSwitch
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Go 1.6 doesn't deserialize non-exported embedded structures properly.
This issue is described in the release notes:

https://golang.org/doc/go1.6#reflect

This PR changes the bridge configuration to be exported, making it
possible for the JSON parser to deserialize it from the configuration file.

Signed-off-by: David Calavera david.calavera@gmail.com
