### PR TITLE
Bump libcontainer to 27dd48f6919a9bf8c25b41e97ca12

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -57,7 +57,7 @@ clone git github.com/miekg/pkcs11 80f102b5cac759de406949c47f0928b99bd64cdf
 clone git github.com/docker/go v1.5.1-1-1-gbaf439e
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
-clone git github.com/opencontainers/runc 3d8a20bb772defc28c355534d83486416d1719b4 # libcontainer
+clone git github.com/opencontainers/runc 27dd48f6919a9bf8c25b41e97ca12f6fa73f8f77 # libcontainer
 clone git github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v4

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
@@ -29,6 +29,7 @@ var (
 		&NetPrioGroup{},
 		&PerfEventGroup{},
 		&FreezerGroup{},
+		&NameGroup{GroupName: "name=systemd", Join: true},
 	}
 	CgroupProcesses  = "cgroup.procs"
 	HugePageSizes, _ = cgroups.GetHugePageSize()

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/name.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/name.go
@@ -9,6 +9,7 @@ import (
 
 type NameGroup struct {
 	GroupName string
+	Join      bool
 }
 
 func (s *NameGroup) Name() string {
@@ -16,6 +17,10 @@ func (s *NameGroup) Name() string {
 }
 
 func (s *NameGroup) Apply(d *cgroupData) error {
+	if s.Join {
+		// ignore errors if the named cgroup does not exist
+		d.join(s.GroupName)
+	}
 	return nil
 }
 
@@ -24,6 +29,9 @@ func (s *NameGroup) Set(path string, cgroup *configs.Cgroup) error {
 }
 
 func (s *NameGroup) Remove(d *cgroupData) error {
+	if s.Join {
+		removePath(d.path(s.GroupName))
+	}
 	return nil
 }
 


### PR DESCRIPTION
This includes the fix for moving the process out of the name=systemd
cgroup so that systemd does not delete the container's cgroups when its
configuration is reloaded.

Signed-off-by: Michael Crosby crosbymichael@gmail.com

Fixes #20152.
