### PR TITLE
Update engine-api vendoring to latest commit

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api afb1638f70a4b839be80ea37a5073faa18a30194
+clone git github.com/docker/engine-api 575694d38967b53e06cafe8b722c72892dd64db0
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/image_load.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_load.go
@@ -18,7 +18,8 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (
 	if quiet {
 		v.Set("quiet", "1")
 	}
-	resp, err := cli.postRaw(ctx, "/images/load", v, input, nil)
+	headers := map[string][]string{"Content-Type": {"application/x-tar"}}
+	resp, err := cli.postRaw(ctx, "/images/load", v, input, headers)
 	if err != nil {
 		return types.ImageLoadResponse{}, err
 	}

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -148,6 +148,7 @@ type Container struct {
 		NetworkMode string `json:",omitempty"`
 	}
 	NetworkSettings *SummaryNetworkSettings
+	Mounts          []MountPoint
 }
 
 // CopyConfig contains request body of Remote API:


### PR DESCRIPTION
This picks up the change for `Content-Type` which will help solve issues
with authz plugins.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
