### PR TITLE
Unskip authz events test after fixes

### DIFF
--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -248,8 +248,6 @@ func (s *DockerAuthzSuite) TestAuthZPluginDenyResponse(c *check.C) {
 
 // TestAuthZPluginAllowEventStream verifies event stream propagates correctly after request pass through by the authorization plugin
 func (s *DockerAuthzSuite) TestAuthZPluginAllowEventStream(c *check.C) {
-	c.Skip("Flaky test")
-
 	testRequires(c, DaemonIsLinux)
 
 	// start the daemon and load busybox to avoid pulling busybox from Docker Hub


### PR DESCRIPTION
Now that the various fixes are all committed, let's see if this gets
less flaky now.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
