### PR TITLE
Fix bad order of iptables filter rules

### DIFF
--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -115,6 +115,16 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 			return iptables.ProgramChain(filterChain, config.BridgeName, hairpinMode, false)
 		})
 
+		// Set Accept on incoming packets for existing connections.
+		var inRule = iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-o", config.BridgeName, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}}
+		if err := programChainRule(inRule, "ACCEPT ESTABLISHED", true); err != nil {
+			return err
+		}
+
+		n.registerIptCleanFunc(func() error {
+			return programChainRule(inRule, "ACCEPT ESTABLISHED", false)
+		})
+
 		n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
 	}
 
@@ -140,7 +150,6 @@ func setupIPTablesInternal(bridgeIface string, addr net.Addr, icc, ipmasq, hairp
 		hpNatRule = iptRule{table: iptables.Nat, chain: "POSTROUTING", preArgs: []string{"-t", "nat"}, args: []string{"-m", "addrtype", "--src-type", "LOCAL", "-o", bridgeIface, "-j", "MASQUERADE"}}
 		skipDNAT  = iptRule{table: iptables.Nat, chain: DockerChain, preArgs: []string{"-t", "nat"}, args: []string{"-i", bridgeIface, "-j", "RETURN"}}
 		outRule   = iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-i", bridgeIface, "!", "-o", bridgeIface, "-j", "ACCEPT"}}
-		inRule    = iptRule{table: iptables.Filter, chain: "FORWARD", args: []string{"-o", bridgeIface, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}}
 	)
 
 	// Set NAT.
@@ -170,11 +179,6 @@ func setupIPTablesInternal(bridgeIface string, addr net.Addr, icc, ipmasq, hairp
 
 	// Set Accept on all non-intercontainer outgoing packets.
 	if err := programChainRule(outRule, "ACCEPT NON_ICC OUTGOING", enable); err != nil {
-		return err
-	}
-
-	// Set Accept on incoming packets for existing connections.
-	if err := programChainRule(inRule, "ACCEPT INCOMING", enable); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Rules with ctstate RELATED,ESTABLISHED must be create before same rules without ctstate.

Close #18911
