### PR TITLE
Add bash completion for etwlogs logging driver

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -395,6 +395,7 @@ __docker_complete_isolation() {
 __docker_complete_log_drivers() {
 	COMPREPLY=( $( compgen -W "
 		awslogs
+		etwlogs
 		fluentd
 		gelf
 		journald


### PR DESCRIPTION
Ref: #19689
That was kind simple - it has no options at all!
