### PR TITLE
Add bash completion for `docker update --restart`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -515,6 +515,22 @@ __docker_complete_log_levels() {
 	COMPREPLY=( $( compgen -W "debug info warn error fatal" -- "$cur" ) )
 }
 
+__docker_complete_restart() {
+	case "$prev" in
+		--restart)
+			case "$cur" in
+				on-failure:*)
+					;;
+				*)
+					COMPREPLY=( $( compgen -W "always no on-failure on-failure: unless-stopped" -- "$cur") )
+					;;
+			esac
+			return
+			;;
+	esac
+	return 1
+}
+
 # a selection of the available signals that is most likely of interest in the
 # context of docker containers.
 __docker_complete_signals() {
@@ -1657,6 +1673,7 @@ _docker_run() {
 
 
 	__docker_complete_log_driver_options && return
+	__docker_complete_restart && return
 
 	case "$prev" in
 		--add-host)
@@ -1750,16 +1767,6 @@ _docker_run() {
 					if [ "${COMPREPLY[*]}" = "container:" ] ; then
 						__docker_nospace
 					fi
-					;;
-			esac
-			return
-			;;
-		--restart)
-			case "$cur" in
-				on-failure:*)
-					;;
-				*)
-					COMPREPLY=( $( compgen -W "always no on-failure on-failure: unless-stopped" -- "$cur") )
 					;;
 			esac
 			return
@@ -1938,6 +1945,7 @@ _docker_update() {
 		--memory -m
 		--memory-reservation
 		--memory-swap
+		--restart
 	"
 
 	local boolean_options="
@@ -1945,6 +1953,8 @@ _docker_update() {
 	"
 
 	local all_options="$options_with_args $boolean_options"
+
+	__docker_complete_restart && return
 
 	case "$prev" in
 		$(__docker_to_extglob "$options_with_args") )


### PR DESCRIPTION
Ref: #19116

Pulled out the existing completion from `docker run` and added it to `docker update`.

ping @jfrazelle, @tianon for review
/cc @sdurrheimer for zsh completion: `docker update --restart`
