### PR TITLE
Add a --filter option to `docker search`

### DIFF
--- a/api/client/search.go
+++ b/api/client/search.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
+	"unicode"
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -21,11 +23,24 @@ import (
 func (cli *DockerCli) CmdSearch(args ...string) error {
 	cmd := Cli.Subcmd("search", []string{"TERM"}, Cli.DockerCommands["search"].Description, true)
 	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Don't truncate output")
-	automated := cmd.Bool([]string{"-automated"}, false, "Only show automated builds")
-	stars := cmd.Uint([]string{"s", "-stars"}, 0, "Only displays with at least x stars")
+	filter := cmd.String([]string{"f", "-filter"}, "", "Use filters (is-automated, is-official, has-stars)")
+
+	// Deprecated since Docker 1.13 in favor of "--filter"
+	automated := cmd.Bool([]string{"#-automated"}, false, "Only show automated builds - DEPRECATED")
+	stars := cmd.Uint([]string{"s", "#-stars"}, 0, "Only displays with at least x stars - DEPRECATED")
+
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)
+
+	// Parse --filter options and return the map with these values:
+	// * is-automated: Bool
+	// * is-official: Bool
+	// * has-stars: Number
+	filterOptions := make(map[string]string)
+	if *filter != "" {
+		filterOptions = scanFilterOptions(*filter)
+	}
 
 	name := cmd.Arg(0)
 	v := url.Values{}
@@ -60,7 +75,24 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	w := tabwriter.NewWriter(cli.out, 10, 1, 3, ' ', 0)
 	fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
 	for _, res := range results {
+		// --automated and -s, --stars are deprecated since Docker 1.13
 		if (*automated && !res.IsAutomated) || (int(*stars) > res.StarCount) {
+			continue
+		}
+		if filterOptions["is-automated"] == "true" && !res.IsAutomated {
+			continue
+		}
+		if filterOptions["is-automated"] == "false" && res.IsAutomated {
+			continue
+		}
+		if filterOptions["is-official"] == "true" && !res.IsOfficial {
+			continue
+		}
+		if filterOptions["is-official"] == "false" && res.IsOfficial {
+			continue
+		}
+		hasStars, _ := strconv.Atoi(filterOptions["has-stars"])
+		if hasStars > res.StarCount {
 			continue
 		}
 		desc := strings.Replace(res.Description, "\n", " ", -1)
@@ -89,3 +121,25 @@ type searchResultsByStars []registrytypes.SearchResult
 func (r searchResultsByStars) Len() int           { return len(r) }
 func (r searchResultsByStars) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r searchResultsByStars) Less(i, j int) bool { return r[j].StarCount < r[i].StarCount }
+
+func scanFilterOptions(filter string) map[string]string {
+	options := map[string]string{
+		"is-automated": "",
+		"is-official":  "",
+		"has-stars":    "",
+	}
+
+	optionsFields := strings.Fields(filter)
+
+	for _, option := range optionsFields {
+		if strings.Contains(option, "=") {
+			val := strings.Split(option, "=")[1]
+			if !(val != "true" && val != "false" && !unicode.IsNumber(rune(val[0]))) {
+				key := strings.Split(option, "=")[0]
+				options[key] = val
+			}
+		}
+	}
+
+	return options
+}

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -56,6 +56,15 @@ variants:
     docker build -c (--cpu-shares)
     docker create -c (--cpu-shares)
 
+The following search options are deprecated:
+
+docker search --automated
+docker search --stars
+
+In favor of the extensible --filter option:
+
+docker search --filter "is-automated=true has-stars=20" ubuntu
+
 ### Driver Specific Log Tags
 **Deprecated In Release: v1.9**
 

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -14,10 +14,12 @@ parent = "smn_cli"
 
     Search the Docker Hub for images
 
-      --automated          Only show automated builds
+      --filter             Filters with the following parameters:
+                           is-automated=true Image is automated
+                           is-official=true Image is official
+                           has-stars=n Image has at least n stars
       --help               Print usage
       --no-trunc           Don't truncate output
-      -s, --stars=0        Only displays with at least x stars
 
 Search [Docker Hub](https://hub.docker.com) for images
 
@@ -61,27 +63,38 @@ This example displays images with a name containing 'busybox':
     scottabernethy/busybox                                                           0                    [OK]
     marclop/busybox-solr
 
-### Search images by name and number of stars (-s, --stars)
+### Search images by name and number of stars (--filter has-stars)
 
 This example displays images with a name containing 'busybox' and at
 least 3 stars:
 
-    $ docker search --stars=3 busybox
+    $ docker search --filter has-stars=3 busybox
     NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
     busybox              Busybox base image.                             325       [OK]       
     progrium/busybox                                                     50                   [OK]
     radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
 
 
-### Search automated images (--automated)
+### Search automated images (--filter is-automated)
 
-This example displays images with a name containing 'busybox', at
-least 3 stars and are automated builds:
+This example displays images with a name containing 'busybox'
+and are automated builds:
 
-    $ docker search --stars=3 --automated busybox
+    $ docker search --filter is-automated busybox
     NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
     progrium/busybox                                                     50                   [OK]
     radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+
+### Search official images (--filter is-official)
+
+This example displays images with a name containing 'busybox', at least
+3 stars and are official builds:
+
+    $ docker search --filter "is-automated=true has-stars=3" busybox
+    NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
+    progrium/busybox                                                     50                   [OK]
+    radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+
 
 
 ### Display non-truncated description (--no-trunc)


### PR DESCRIPTION
The following search parameters are allowed:
- is-official
- is-automated
- has-stars

They deprecate

--automated
-s --stars

Signed-off-by: Fabrizio Soppelsa fsoppelsa@mirantis.com
