### PR TITLE
WIP: Dump daemon stacks when getting close to test timeout

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -54,6 +54,16 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 		$extra_params \
 			&> "$DEST/docker.log"
 	) &
+	( set -x; \
+		timeout=$(echo $TIMEOUT | sed 's/\([0-9]*\)[dhms]/\1/') ; \
+		unit=$(echo $TIMEOUT | sed 's/[0-9]*\([dhms]\)/\1/') ; \
+		dumptimeout=$(( $timeout - 5 )) ; \
+		if [ $dumptimeout -gt 0 ] ; then \
+		   sleep $dumptimeout$unit ; \
+		   kill -USR1 $(cat "$DEST/docker.pid") ; \
+		   grep goroutine "$DEST/docker.log" | sed 's/\\n/\n/g' | sed 's/\\t/\t/g' ; \
+		fi
+	) &
 	# make sure that if the script exits unexpectedly, we stop this daemon we just started
 	trap 'bundle .integration-daemon-stop' EXIT
 else
@@ -75,14 +85,14 @@ while ! docker version &> /dev/null; do
 			docker version >&2 || true
 			# Additional Windows CI debugging as this is a common error as of
 			# January 2016
-			if [ "$(go env GOOS)" = 'windows' ]; then	
+			if [ "$(go env GOOS)" = 'windows' ]; then
 				echo >&2 "Container log below:"
 				echo >&2 "---"
 				# Important - use the docker on the CI host, not the one built locally
 				# which is currently in our path.
 				! /c/bin/docker -H=$MAIN_DOCKER_HOST logs docker-$COMMITHASH
 				echo >&2 "---"
-			fi			
+			fi
 		fi
 		false
 	fi

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -61,9 +61,11 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 		if [ $dumptimeout -gt 0 ] ; then \
 		   sleep $dumptimeout$unit ; \
 		   kill -USR1 $(cat "$DEST/docker.pid") ; \
+	       bridge link show ; \
 		   grep goroutine "$DEST/docker.log" | sed 's/\\n/\n/g' | sed 's/\\t/\t/g' ; \
 		fi
 	) &
+	echo $! > "$DEST/stackdump.pid"
 	# make sure that if the script exits unexpectedly, we stop this daemon we just started
 	trap 'bundle .integration-daemon-stop' EXIT
 else
@@ -100,3 +102,5 @@ while ! docker version &> /dev/null; do
 	sleep 2
 done
 printf "\n"
+
+(set -x; bridge link show)

--- a/hack/make/.integration-daemon-stop
+++ b/hack/make/.integration-daemon-stop
@@ -11,6 +11,14 @@ if [ ! "$(go env GOOS)" = 'windows' ]; then
 		fi
 	done
 
+	for pidFile in $(find "$DEST" -name stackdump.pid); do
+		pid=$(set -x; cat "$pidFile")
+		( set -x; kill "$pid" )
+		if ! wait "$pid"; then
+			echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
+		fi
+	done
+
 	if [ -z "$DOCKER_TEST_HOST" ]; then
 		# Stop apparmor if it is enabled
 		if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
@@ -21,7 +29,7 @@ if [ ! "$(go env GOOS)" = 'windows' ]; then
 		fi
 	fi
 else
-	# Note this script is not actionable on Windows to Linux CI. Instead the 
+	# Note this script is not actionable on Windows to Linux CI. Instead the
 	# DIND daemon under test is torn down by the Jenkins tear-down script
 	echo "INFO: Not stopping daemon on Windows CI"
 fi


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com

---

Trying to get more details on the random timeouts we had on integration tests lately (mainly on userns but not only).

I haven't been able to reproduce those locally, and assuming it is due to a deadlock, this should help pinpointing its origin.
