### PR TITLE
consistent variable names in api/server/router

### DIFF
--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -4,14 +4,14 @@ import "github.com/docker/docker/api/server/router"
 
 // imageRouter is a router to talk with the image controller
 type imageRouter struct {
-	daemon Backend
-	routes []router.Route
+	backend Backend
+	routes  []router.Route
 }
 
 // NewRouter initializes a new image router
-func NewRouter(daemon Backend) router.Router {
+func NewRouter(backend Backend) router.Router {
 	r := &imageRouter{
-		daemon: daemon,
+		backend: backend,
 	}
 	r.initRoutes()
 	return r


### PR DESCRIPTION
- banish 'daemon'

purely cosmetic, but in theory it's not necessarily a daemon anymore.
