### PR TITLE
Fix some typos in comments and strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1771,7 +1771,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 + Containers can expose public UDP ports (eg, '-p 123/udp')
 + Optionally specify an exact public port (eg. '-p 80:4500')
 * 'docker login' supports additional options
-- Dont save a container`s hostname when committing an image.
+- Don't save a container`s hostname when committing an image.
 
 #### Registry
 

--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -71,7 +71,7 @@ func parseWords(rest string) []string {
 			if unicode.IsSpace(ch) { // skip spaces
 				continue
 			}
-			phase = inWord // found it, fall thru
+			phase = inWord // found it, fall through
 		}
 		if (phase == inWord || phase == inQuote) && (pos == len(rest)) {
 			if blankOK || len(word) > 0 {

--- a/builder/dockerfile/parser/utils.go
+++ b/builder/dockerfile/parser/utils.go
@@ -118,7 +118,7 @@ func extractBuilderFlags(line string) (string, []string, error) {
 				return line[pos:], words, nil
 			}
 
-			phase = inWord // found someting with "--", fall thru
+			phase = inWord // found someting with "--", fall through
 		}
 		if (phase == inWord || phase == inQuote) && (pos == len(line)) {
 			if word != "--" && (blankOK || len(word) > 0) {

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -142,7 +142,7 @@ func TestNetworkOptions(t *testing.T) {
 	}
 
 	if _, err := daemon.networkOptions(dconfigCorrect); err != nil {
-		t.Fatalf("Expect networkOptions sucess, got error: %v", err)
+		t.Fatalf("Expect networkOptions success, got error: %v", err)
 	}
 
 	dconfigWrong := &Config{

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -573,7 +573,7 @@ func determineDefaultFS() string {
 		return "xfs"
 	}
 
-	logrus.Warn("devmapper: XFS is not supported in your system. Either the kernel doesnt support it or mkfs.xfs is not in your PATH. Defaulting to ext4 filesystem")
+	logrus.Warn("devmapper: XFS is not supported in your system. Either the kernel doesn't support it or mkfs.xfs is not in your PATH. Defaulting to ext4 filesystem")
 	return "ext4"
 }
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -26,7 +26,7 @@ group.
 
 To connect to the Docker daemon with cURL you need to use cURL 7.40 or
 later, as these versions have the `--unix-socket` flag available. To
-run `curl` against the deamon on the default socket, use the
+run `curl` against the daemon on the default socket, use the
 following:
 
     curl --unix-socket /var/run/docker.sock http://containers/json

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -5,7 +5,7 @@ VERSION = $(shell cat VERSION)
 override_dh_gencontrol:
 	# if we're on Ubuntu, we need to Recommends: apparmor
 	echo 'apparmor:Recommends=$(shell dpkg-vendor --is Ubuntu && echo apparmor)' >> debian/docker-engine.substvars
-	# if we are building experimental we reccomend yubico-piv-tool
+	# if we are building experimental we recommend yubico-piv-tool
 	echo 'yubico:Recommends=$(shell [ "$DOCKER_EXPERIMENTAL" ] && echo "yubico-piv-tool (>= 1.1.0~)")' >> debian/docker-engine.substvars
 	dh_gencontrol
 

--- a/image/v1/imagev1.go
+++ b/image/v1/imagev1.go
@@ -97,7 +97,7 @@ func MakeConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []im
 
 	delete(c, "id")
 	delete(c, "parent")
-	delete(c, "Size") // Size is calculated from data on disk and is inconsitent
+	delete(c, "Size") // Size is calculated from data on disk and is inconsistent
 	delete(c, "parent_id")
 	delete(c, "layer_id")
 	delete(c, "throwaway")

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -438,7 +438,7 @@ func (s *DockerSuite) TestGetStoppedContainerStats(c *check.C) {
 		c.Assert(r.err, checker.IsNil)
 		c.Assert(r.status, checker.Equals, http.StatusOK)
 	case <-time.After(10 * time.Second):
-		c.Fatal("timeout waiting for stats reponse for stopped container")
+		c.Fatal("timeout waiting for stats response for stopped container")
 	}
 }
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2029,10 +2029,10 @@ func (s *DockerSuite) TestRunInspectMacAddress(c *check.C) {
 	}
 }
 
-// test docker run use a invalid mac address
+// test docker run use an invalid mac address
 func (s *DockerSuite) TestRunWithInvalidMacAddress(c *check.C) {
 	out, _, err := dockerCmdWithError("run", "--mac-address", "92:d0:c6:0a:29", "busybox")
-	//use a invalid mac address should with a error out
+	//use an invalid mac address should with an error out
 	if err == nil || !strings.Contains(out, "is not a valid mac address") {
 		c.Fatalf("run with an invalid --mac-address should with error out")
 	}
@@ -2918,7 +2918,7 @@ func (s *DockerSuite) TestRunReadProcLatency(c *check.C) {
 	// some kernels don't have this configured so skip the test if this file is not found
 	// on the host running the tests.
 	if _, err := os.Stat("/proc/latency_stats"); err != nil {
-		c.Skip("kernel doesnt have latency_stats configured")
+		c.Skip("kernel doesn't have latency_stats configured")
 		return
 	}
 	out, code, err := dockerCmdWithError("run", "busybox", "cat", "/proc/latency_stats")

--- a/man/docker-logs.1.md
+++ b/man/docker-logs.1.md
@@ -42,9 +42,9 @@ logging drivers.
 **--tail**="*all*"
    Output the specified number of lines at the end of logs (defaults to all logs)
 
-The `--since` option can be Unix timestamps, date formated timestamps, or Go
+The `--since` option can be Unix timestamps, date formatted timestamps, or Go
 duration strings (e.g. `10m`, `1h30m`) computed relative to the client machine’s
-time. Supported formats for date formated time stamps include RFC3339Nano,
+time. Supported formats for date formatted time stamps include RFC3339Nano,
 RFC3339, `2006-01-02T15:04:05`, `2006-01-02T15:04:05.999999999`,
 `2006-01-02Z07:00`, and `2006-01-02`. The local timezone on the client will be
 used if you do not provide either a `Z` or a `+-00:00` timezone offset at the

--- a/pkg/authorization/response.go
+++ b/pkg/authorization/response.go
@@ -148,7 +148,7 @@ func (rm *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 	hijacker, ok := rm.rw.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("Internal reponse writer doesn't support the Hijacker interface")
+		return nil, nil, fmt.Errorf("Internal response writer doesn't support the Hijacker interface")
 	}
 	return hijacker.Hijack()
 }
@@ -157,7 +157,7 @@ func (rm *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 func (rm *responseModifier) CloseNotify() <-chan bool {
 	closeNotifier, ok := rm.rw.(http.CloseNotifier)
 	if !ok {
-		logrus.Errorf("Internal reponse writer doesn't support the CloseNotifier interface")
+		logrus.Errorf("Internal response writer doesn't support the CloseNotifier interface")
 		return nil
 	}
 	return closeNotifier.CloseNotify()
@@ -167,7 +167,7 @@ func (rm *responseModifier) CloseNotify() <-chan bool {
 func (rm *responseModifier) Flush() {
 	flusher, ok := rm.rw.(http.Flusher)
 	if !ok {
-		logrus.Errorf("Internal reponse writer doesn't support the Flusher interface")
+		logrus.Errorf("Internal response writer doesn't support the Flusher interface")
 		return
 	}
 

--- a/pkg/httputils/resumablerequestreader_test.go
+++ b/pkg/httputils/resumablerequestreader_test.go
@@ -96,7 +96,7 @@ type errorReaderCloser struct{}
 func (errorReaderCloser) Close() error { return nil }
 
 func (errorReaderCloser) Read(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("A error occured")
+	return 0, fmt.Errorf("An error occurred")
 }
 
 // If a an unknown error is encountered, return 0, nil and log it

--- a/pkg/plugins/errors.go
+++ b/pkg/plugins/errors.go
@@ -11,7 +11,7 @@ type statusError struct {
 	err    string
 }
 
-// Error returns a formated string for this error type
+// Error returns a formatted string for this error type
 func (e *statusError) Error() string {
 	return fmt.Sprintf("%s: %v", e.method, e.err)
 }

--- a/pkg/stdcopy/stdcopy_test.go
+++ b/pkg/stdcopy/stdcopy_test.go
@@ -72,7 +72,7 @@ func TestWriteWithWriterError(t *testing.T) {
 		t.Fatalf("Didn't get expected error.")
 	}
 	if n != expectedReturnedBytes {
-		t.Fatalf("Didn't get expected writen bytes %d, got %d.",
+		t.Fatalf("Didn't get expected written bytes %d, got %d.",
 			expectedReturnedBytes, n)
 	}
 }


### PR DESCRIPTION
Most of them were found and fixed by codespell.

Signed-off-by: Stefan Weil sw@weilnetz.de
