### PR TITLE
do not turn post-processing on for linux-cgo terminals

### DIFF
--- a/pkg/term/tc_linux_cgo.go
+++ b/pkg/term/tc_linux_cgo.go
@@ -27,7 +27,6 @@ func MakeRaw(fd uintptr) (*State, error) {
 	newState := oldState.termios
 
 	C.cfmakeraw((*C.struct_termios)(unsafe.Pointer(&newState)))
-	newState.Oflag = newState.Oflag | C.OPOST
 	if err := tcset(fd, &newState); err != 0 {
 		return nil, err
 	}

--- a/pkg/term/term.go
+++ b/pkg/term/term.go
@@ -127,6 +127,5 @@ func handleInterrupt(fd uintptr, state *State) {
 	go func() {
 		_ = <-sigchan
 		RestoreTerminal(fd, state)
-		os.Exit(0)
 	}()
 }


### PR DESCRIPTION
- fixes #15373
-  #20043 is dup with similar problem

essentially undoes 05a8de46853f8b3534ca6d0cb03121ae214e8a34. The code that was printing messages does not seem to exist anymore. I don't see any debug output at all.

@cpuguy83 @LK4D4 @icecrime @estesp @coolljt0725 y'all looked at the previous change.
