### PR TITLE
Fix configuration reloading

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -289,15 +289,17 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 			logrus.Errorf("Error reconfiguring the daemon: %v", err)
 			return
 		}
+		if config.IsValueSet("debug") {
+			debugEnabled := utils.IsDebugEnabled()
+			switch {
+			case debugEnabled && !config.Debug: // disable debug
+				utils.DisableDebug()
+				api.DisableProfiler()
+			case config.Debug && !debugEnabled: // enable debug
+				utils.EnableDebug()
+				api.EnableProfiler()
+			}
 
-		debugEnabled := utils.IsDebugEnabled()
-		switch {
-		case debugEnabled && !config.Debug: // disable debug
-			utils.DisableDebug()
-			api.DisableProfiler()
-		case config.Debug && !debugEnabled: // enable debug
-			utils.EnableDebug()
-			api.EnableProfiler()
 		}
 	}
 

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -896,6 +896,8 @@ The list of currently supported options that can be reconfigured is this:
 
 Updating and reloading the cluster configurations such as `--cluster-store`,
 `--cluster-advertise` and `--cluster-store-opts` will take effect only if
-these configurations were not previously configured. Configuration reload will
-log a warning message if it detects a change in previously configured cluster
-configurations.
+these configurations were not previously configured. If `--cluster-store`
+has been provided in flags and `cluster-advertise` not, `cluster-advertise`
+can be added in the configuration file without accompanied by `--cluster-store`
+Configuration reload will log a warning message if it detects a change in
+previously configured cluster configurations.


### PR DESCRIPTION
There are five options 'debug' 'labels' 'cluster-store' 'cluster-store-opts'
and 'cluster-advertise' that can be reconfigured, configure any of these
options should not affect other options which may have configured in flags.
But this is not true, for example, I start a daemon with -D to enable the
debugging, and after a while, I want reconfigure the 'label', so I add a file
'/etc/docker/daemon.json' with content '"labels":["test"]' and send SIGHUP to daemon
to reconfigure the daemon, it work, but the debugging of the daemon is also diabled.
I don't think this is a expeted behaviour.
This patch also have some minor refactor of reconfiguration of cluster-advertiser.
Enable user to reconfigure cluster-advertiser without cluster-store in config file
since cluster-store could also be already set in flag, and we only want to reconfigure
the cluster-advertiser.

Signed-off-by: Lei Jitang leijitang@huawei.com
ping @calavera 
I'll add tests if we want this.

Fixes #20954
