### PR TITLE
make the json log writer much faster

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -94,7 +94,6 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 		return err
 	}
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	err = (&jsonlog.JSONLogs{
 		Log:      append(msg.Line, '\n'),
 		Stream:   msg.Source,
@@ -102,6 +101,7 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 		RawAttrs: l.extra,
 	}).MarshalJSONBuf(l.buf)
 	if err != nil {
+		l.mu.Unlock()
 		return err
 	}
 
@@ -109,6 +109,7 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 	_, err = l.writer.Write(l.buf.Bytes())
 	l.writeNotifier.Publish(struct{}{})
 	l.buf.Reset()
+	l.mu.Unlock()
 
 	return err
 }


### PR DESCRIPTION
`go test -v -benchtime 10s -test.bench BenchmarkJSONFileLogger -test.benchmem -test.run=BenchmarkJSONFileLogger`

Before:
`BenchmarkJSONFileLogger-8    200000         66593 ns/op      54.51 MB/s         960 B/op         30 allocs/op`
After:
`BenchmarkJSONFileLogger-8    300000         56547 ns/op      64.19 MB/s         960 B/op         30 allocs/op`
Signed-off-by: Shijiang Wei mountkin@gmail.com
