### PR TITLE
Try to handle changing names for journal packages

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -2,7 +2,6 @@
 
 package journald
 
-// #cgo pkg-config: libsystemd-journal
 // #include <sys/types.h>
 // #include <sys/poll.h>
 // #include <systemd/sd-journal.h>

--- a/daemon/logger/journald/read_native.go
+++ b/daemon/logger/journald/read_native.go
@@ -1,0 +1,6 @@
+// +build linux,cgo,!static_build,journald,!journald_compat
+
+package journald
+
+// #cgo pkg-config: libsystemd
+import "C"

--- a/daemon/logger/journald/read_native_compat.go
+++ b/daemon/logger/journald/read_native_compat.go
@@ -1,0 +1,6 @@
+// +build linux,cgo,!static_build,journald,journald_compat
+
+package journald
+
+// #cgo pkg-config: libsystemd-journal
+import "C"

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -118,8 +118,10 @@ fi
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then
 	DOCKER_BUILDTAGS+=" daemon"
-	if pkg-config libsystemd-journal 2> /dev/null ; then
+	if pkg-config 'libsystemd >= 209' 2> /dev/null ; then
 		DOCKER_BUILDTAGS+=" journald"
+	elif pkg-config 'libsystemd-journal' 2> /dev/null ; then
+		DOCKER_BUILDTAGS+=" journald journald_compat"
 	fi
 fi
 


### PR DESCRIPTION
This is an attempt to fix #20497, in which we weren't always linking with the journald C APIs due to their pkg-config package name having changed between systemd releases.
