### PR TITLE
Windows: Updates for virtual user account

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -658,7 +658,12 @@ func (s *DockerSuite) TestRunExitCode(c *check.C) {
 func (s *DockerSuite) TestRunUserDefaults(c *check.C) {
 	expected := "uid=0(root) gid=0(root)"
 	if daemonPlatform == "windows" {
-		expected = "uid=1000(SYSTEM) gid=1000(SYSTEM)"
+		// TODO Windows: Remove this check once TP4 is no longer supported.
+		if windowsDaemonKV < 14250 {
+			expected = "uid=1000(SYSTEM) gid=1000(SYSTEM)"
+		} else {
+			expected = "uid=1000(ContainerAdministrator) gid=1000(ContainerAdministrator)"
+		}
 	}
 	out, _ := dockerCmd(c, "run", "busybox", "id")
 	if !strings.Contains(out, expected) {
@@ -1710,7 +1715,12 @@ func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 	out = strings.TrimSpace(out)
 	expected := "root"
 	if daemonPlatform == "windows" {
-		expected = `nt authority\system`
+		// TODO Windows: Remove this check once TP4 is no longer supported.
+		if windowsDaemonKV < 14250 {
+			expected = `nt authority\system`
+		} else {
+			expected = `user manager\containeradministrator`
+		}
 	}
 	if out != expected {
 		c.Fatalf("Expected output %s, got %q", expected, out)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

TP5 introduces a virtual account for apps running in containers. This updates the tests which were checking for local system ("SYSTEM") on TP4 to be compatible with TP5 once that CI comes online.

Cute animals below :) 
![img_5376](https://cloud.githubusercontent.com/assets/10522484/13261021/11a95e6c-da13-11e5-9e9a-dc6ff0008029.JPG)
