### PR TITLE
added default cert generator

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"strings"
+
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/go-connections/tlsconfig"
 )
@@ -17,6 +19,17 @@ type CommonFlags struct {
 	TLSVerify  bool
 	TLSOptions *tlsconfig.Options
 	TrustKey   string
+}
+
+func (commonFlags *CommonFlags) UsingTCPSocket() bool {
+	usingTCPSocket := false
+	for _, host := range commonFlags.Hosts {
+		if strings.HasPrefix(host, "tcp") {
+			usingTCPSocket = true
+			break
+		}
+	}
+	return usingTCPSocket
 }
 
 // Command is the struct containing the command name and description

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/docker/pkg/pidfile"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/system"
+	"github.com/docker/docker/pkg/x509"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
 	"github.com/docker/go-connections/tlsconfig"
@@ -156,6 +157,27 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 	configFile := cli.flags.String([]string{daemonConfigFileFlag}, defaultDaemonConfigFile, "Daemon configuration file")
 
 	cli.flags.ParseFlags(args, true)
+
+	cmd := commonFlags.FlagSet
+	defaultTLSVerify := commonFlags.UsingTCPSocket() && !(cmd.IsSet("-"+tlsVerifyKey) || commonFlags.TLSVerify) && !cli.flags.IsSet("-no-default-tlsverify")
+
+	if defaultTLSVerify {
+		commonFlags.TLSVerify = true
+		if _, err := os.Stat(commonFlags.TLSOptions.CAFile); os.IsNotExist(err) {
+			caCertPath := filepath.Join(dockerCertPath, defaultCaFile)
+			caKeyPath := filepath.Join(dockerCertPath, "ca-key.pem")
+			x509.GenerateDefaultCA(caCertPath, caKeyPath)
+		}
+		if _, err := os.Stat(commonFlags.TLSOptions.CertFile); os.IsNotExist(err) {
+			if _, err := os.Stat(commonFlags.TLSOptions.KeyFile); os.IsNotExist(err) {
+				caPath := filepath.Join(dockerCertPath, defaultCaFile)
+				certPath := filepath.Join(dockerCertPath, defaultCertFile)
+				keyPath := filepath.Join(dockerCertPath, defaultKeyFile)
+				x509.GenerateDefaultKeys(certPath, keyPath, caPath)
+			}
+		}
+	}
+
 	commonFlags.PostParse()
 
 	if commonFlags.TrustKey == "" {

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -64,6 +64,7 @@ weight = -1
       --tlscert="~/.docker/cert.pem"         Path to TLS certificate file
       --tlskey="~/.docker/key.pem"           Path to TLS key file
       --tlsverify                            Use TLS and verify the remote
+      --no-default-tlsverify                 Turns off default remote TLS verification
       --userns-remap="default"               Enable user namespace remapping
       --userland-proxy=true                  Use userland proxy for loopback traffic
 
@@ -85,14 +86,18 @@ By default, a `unix` domain socket (or IPC socket) is created at
 membership.
 
 If you need to access the Docker daemon remotely, you need to enable the `tcp`
-Socket. Beware that the default setup provides un-encrypted and
-un-authenticated direct access to the Docker daemon - and should be secured
-either using the [built in HTTPS encrypted socket](../../security/https/), or by
-putting a secure web proxy in front of it. You can listen on port `2375` on all
+Socket. The default setup provides encrypted and authenticated access to the Docker
+daemon. If you want an un-encrypted and un-authenticated direct access you can use
+`--no-default-tlsverify` flag. You can listen on port `2375` on all
 network interfaces with `-H tcp://0.0.0.0:2375`, or on a particular network
 interface using its IP address: `-H tcp://192.168.59.103:2375`. It is
 conventional to use port `2375` for un-encrypted, and port `2376` for encrypted
-communication with the daemon.
+communication with the daemon. If the flag `--no-default-tlsverify` is not used 
+and some trusted CA certificate for client authentication is neither provided 
+in command line arguments nor is in .docker directory then a default CA is generated. 
+Moreover, if there are no cert.pem and key.pem files, then the default CA is used to 
+generate default cert and key. Clients can use them for encrypted and authenticated
+access to the Docker daemon.
 
 > **Note:**
 > If you're using an HTTPS encrypted socket, keep in mind that only
@@ -849,6 +854,7 @@ This is a full example of the allowed configuration options in the file:
 	"cluster-advertise": "",
 	"debug": true,
 	"hosts": [],
+	"no-default-tlsverify": false,
 	"log-level": "",
 	"tls": true,
 	"tlsverify": true,

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -47,6 +47,7 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 	( set -x; exec \
 		docker daemon --debug \
 		--host "$DOCKER_HOST" \
+        --no-default-tlsverify \
 		--storage-driver "$DOCKER_GRAPHDRIVER" \
 		--pidfile "$DEST/docker.pid" \
 		--userland-proxy="$DOCKER_USERLANDPROXY" \

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -226,7 +226,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		fmt.Sprintf("--userland-proxy=%t", d.userlandProxy),
 	)
 	if !(d.useDefaultHost || d.useDefaultTLSHost) {
-		args = append(args, []string{"--host", d.sock()}...)
+		args = append(args, []string{"--host", d.sock(), "--no-default-tlsverify"}...)
 	}
 	if root := os.Getenv("DOCKER_REMAP_ROOT"); root != "" {
 		args = append(args, []string{"--userns-remap", root}...)

--- a/pkg/x509/default_cert.go
+++ b/pkg/x509/default_cert.go
@@ -1,0 +1,96 @@
+package x509
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"time"
+)
+
+func GenerateDefaultCA(certPath, keyPath string) error {
+	keyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign
+	extKeyUsage := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+	return generateCert(certPath, keyPath, "", keyUsage, extKeyUsage, true)
+}
+
+func GenerateDefaultKeys(certPath, keyPath, caPath string) error {
+	keyUsage := x509.KeyUsageDigitalSignature
+	extKeyUsage := []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	return generateCert(certPath, keyPath, caPath, keyUsage, extKeyUsage, false)
+}
+
+func generateCert(certPath, keyPath, caPath string, keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage, isCA bool) error {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return fmt.Errorf("Failed to generate CA key: %v\n", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.AddDate(1, 0, 0)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return fmt.Errorf("Failed to generate cert serial number: %v\n", err)
+	}
+
+	certTemplate := x509.Certificate{
+		SignatureAlgorithm: x509.SHA512WithRSA,
+		PublicKeyAlgorithm: x509.RSA,
+
+		SerialNumber: serialNumber,
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     keyUsage,
+		ExtKeyUsage:  extKeyUsage,
+
+		BasicConstraintsValid: true,
+		IsCA: isCA,
+	}
+
+	var derBytes []byte
+	if !isCA {
+		caBytes, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			return fmt.Errorf("Could not read CA Certificate: %v\n", err)
+		}
+		block, rest := pem.Decode(caBytes)
+		if len(rest) != 0 || block.Type != "CERTIFICATE" {
+			return fmt.Errorf("Failed to decode CA Certificate\n")
+		}
+
+		caCert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("Could not parse certificate: %v\n", err)
+		}
+		derBytes, err = x509.CreateCertificate(rand.Reader, &certTemplate, caCert, &priv.PublicKey, priv)
+	} else {
+		derBytes, err = x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &priv.PublicKey, priv)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Could not create certificate: %v\n", err)
+	}
+
+	cert, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0444)
+	if err != nil {
+		return fmt.Errorf("Could not create file %s: %v\n", certPath, err)
+	}
+	pem.Encode(cert, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	cert.Close()
+
+	key, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0400)
+	if err != nil {
+		return fmt.Errorf("Could not create file %s: %v\n", keyPath, err)
+	}
+	privDerBytes := x509.MarshalPKCS1PrivateKey(priv)
+	pem.Encode(key, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privDerBytes})
+	key.Close()
+
+	return nil
+}

--- a/pkg/x509/default_cert_test.go
+++ b/pkg/x509/default_cert_test.go
@@ -1,0 +1,51 @@
+package x509
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGenerateDefaultCA(t *testing.T) {
+	caName, keyName := "default_ca.pem", "default_key.pem"
+	if _, err := os.Stat(caName); !os.IsNotExist(err) {
+		os.Remove(caName)
+	}
+	if _, err := os.Stat(keyName); !os.IsNotExist(err) {
+		os.Remove(keyName)
+	}
+	err := GenerateDefaultCA(caName, keyName)
+	if err != nil {
+		t.Fatalf("Failed to generate default CA: caName: %s, keyName: %s; %v\n", caName, keyName, err)
+	}
+	os.Remove(caName)
+	os.Remove(keyName)
+}
+
+func TestGenerateDefaultKeys(t *testing.T) {
+	caName, caKeyName := "default_ca.pem", "default_ca_key.pem"
+	certName, keyName := "default_cert.pem", "default_key.pem"
+	if _, err := os.Stat(caName); !os.IsNotExist(err) {
+		os.Remove(caName)
+	}
+	if _, err := os.Stat(caKeyName); !os.IsNotExist(err) {
+		os.Remove(caKeyName)
+	}
+	if _, err := os.Stat(certName); !os.IsNotExist(err) {
+		os.Remove(certName)
+	}
+	if _, err := os.Stat(keyName); !os.IsNotExist(err) {
+		os.Remove(keyName)
+	}
+	err := GenerateDefaultCA(caName, caKeyName)
+	if err != nil {
+		t.Fatalf("Failed to generate default CA: caName: %s, caKeyName: %s; %v\n", caName, caKeyName, err)
+	}
+	err = GenerateDefaultKeys(certName, keyName, caName)
+	if err != nil {
+		t.Fatalf("Failed to generate default keys from ca: certName: %s, keyName: %s, caName: %s; %v\n", certName, keyName, caName, err)
+	}
+	os.Remove(caName)
+	os.Remove(caKeyName)
+	os.Remove(certName)
+	os.Remove(keyName)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  Changed default tcp socket setup for daemon to use tls remote verification. If there is no default trusted CA and non is specified in command line args then a default one is generated. User can use this CA to generate keys for clients to authenticate themselves. If there are no keys in .docker dir then the default CA is used to generate default key and cert for clients.
  Added new flag --no-default-tlsverify for turning this off, so that raw tcp socket is exposed.
  Solves #6816
- How did you do it?
  Added functions GenerateDefaultCA and GenerateDefaultKeys in pkg/x509/default_cert.go
  During daemon initianlization after flags are parsed but before the post parse common is run there is a check wheter tls verify should be turned on - accordingly to this new behaviour.
- How do I see it or verify it?
  Added test for CA and keys generations. As this just turns old tls variable old tests cover this.
- A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Michał Świętek michalswietek88@gmail.com

new flag --no-default-tlsverify

Signed-off-by: Michał Świętek michalswietek88@gmail.com

new flag -no-default-tlsverify adjustments

Signed-off-by: Michał Świętek michalswietek88@gmail.com

Added UsingTLSSocket method to CommonFlags

Signed-off-by: Michał Świętek michalswietek88@gmail.com

corrected no-default-tlsverify flag's json tag

Signed-off-by: Michał Świętek michalswietek88@gmail.com

added default keys generation

Signed-off-by: Michał Świętek michalswietek88@gmail.com

TCP socket description adjusted to default tls

Signed-off-by: Michał Świętek michalswietek88@gmail.com

added default keys generation

Signed-off-by: Michał Świętek michalswietek88@gmail.com
