### PR TITLE
fix default network name

### DIFF
--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -80,7 +80,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		flCpusetMems        = cmd.String([]string{"-cpuset-mems"}, "", "MEMs in which to allow execution (0-3, 0,1)")
 		flBlkioWeight       = cmd.Uint16([]string{"-blkio-weight"}, 0, "Block IO (relative weight), between 10 and 1000")
 		flSwappiness        = cmd.Int64([]string{"-memory-swappiness"}, -1, "Tune container memory swappiness (0 to 100)")
-		flNetMode           = cmd.String([]string{"-net"}, "default", "Connect a container to a network")
+		flNetMode           = cmd.String([]string{"-net"}, "bridge", "Connect a container to a network")
 		flMacAddress        = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
 		flIPv4Address       = cmd.String([]string{"-ip"}, "", "Container IPv4 address (e.g. 172.30.100.104)")
 		flIPv6Address       = cmd.String([]string{"-ip6"}, "", "Container IPv6 address (e.g. 2001:db8::33)")


### PR DESCRIPTION
- What did you do?  chanced the default network name as "bridge" which  normally displayed as "default" before in the usage of `$docker run --help`.  
- How did you do it?  updated the `parse.go` file
- How do I see it or verify it? `$docker run --help`
- A picture of a cute animal (not mandatory but encouraged)

Shoudn't it be "bridge" as default name rather "default" ?

Signed-off-by: Hakan Ozler hakan.ozler@kodcu.com
