### PR TITLE
Intro volume drivers in dockervolumes.md

### DIFF
--- a/docs/userguide/containers/dockervolumes.md
+++ b/docs/userguide/containers/dockervolumes.md
@@ -159,6 +159,48 @@ user with access to host and its mounted directory.
 >should be portable. A host directory wouldn't be available on all potential
 >hosts.
 
+### Mount a shared-storage volume as a data volume
+
+In addition to mounting a host directory in your container, some Docker
+[volume plugins](../../extend/plugins_volume.md) allow you to 
+provision and mount shared storage, such as iSCSI, NFS, or FC.
+
+A benefit of using shared volumes is that they are host-independent. This
+means that a volume can be made available on any host that a container is
+started on as long as it has access to the shared storage backend, and has
+the plugin installed.
+
+One way to use volume drivers is through the `docker run` command. 
+Volume drivers create volumes by name, instead of by path like in
+the other examples.
+
+The following command creates a named volume, called `my-named-volume`,
+using the `flocker` volume driver, and makes it available within the container
+at `/opt/webapp`:
+
+```bash
+$ docker run -d -P \
+  --volume-driver=flocker \
+  -v my-named-volume:/opt/webapp \
+  --name web training/webapp python app.py
+```
+
+You may also use the `docker volume create` command, to create a volume before
+using it in a container.
+
+The following example also creates the `my-named-volume` volume, this time
+using the `docker volume create` command.
+
+```bash
+$ docker volume create -d flocker --name my-named-volume -o size=20GB
+$ docker run -d -P \
+  -v my-named-volume:/opt/webapp \
+  --name web training/webapp python app.py
+```
+
+A list of available plugins, including volume plugins, is available
+[here](../../extend/plugins.md).
+
 ### Volume labels
 
 Labeling systems like SELinux require that proper labels are placed on volume


### PR DESCRIPTION
`docs/userguide/containers/dockervolumes.md` does a good job at introducing users to volumes but it does not mention volume drivers. This PR introduces just enough information for using volume drivers for data volumes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Signed-off-by: Ryan Wallner ryan.wallner@clusterhq.com
