### PR TITLE
contrib/init/systemd: use systemd cgroups driver

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,7 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
+ExecStart=/usr/bin/docker daemon -H fd:// --exec-opt native.cgroupdriver=systemd
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
On systemd systems we should use the systemd cgroups driver. This
default was changed in this PR https://github.com/docker/docker/issues/20152

```
--exec-opt native.cgroupdriver=systemd
```

Signed-off-by: Brandon Philips brandon.philips@coreos.com
