### PR TITLE
Add check for RHEL7/CentOS7 experimental userns disabled

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -115,6 +115,17 @@ check_device() {
 	fi
 }
 
+check_distro_userns() {
+	source /etc/os-release 2>/dev/null || /bin/true
+	if [[ "${ID}" =~ ^(centos|rhel)$ && "${VERSION_ID}" =~ ^7 ]]; then
+		# this is a CentOS7 or RHEL7 system
+		grep -q "user_namespace.enable=1" /proc/cmdline || {
+			# no user namespace support enabled
+			wrap_bad "  (RHEL7/CentOS7" "User namespaces disabled; add 'user_namespace.enable=1' to boot command line)"
+		}
+	fi
+}
+
 if [ ! -e "$CONFIG" ]; then
 	wrap_warning "warning: $CONFIG does not exist, searching other paths for kernel config ..."
 	for tryConfig in "${possibleConfigs[@]}"; do
@@ -185,6 +196,7 @@ echo
 echo 'Optional Features:'
 {
 	check_flags USER_NS
+	check_distro_userns
 }
 {
 	check_flags SECCOMP


### PR DESCRIPTION
Fixes: #20193 

Add a check in `check-config.sh` to see if we are running on a RHEL7 or
CentOS7 system, which may report that CONFIG_USERNS is OK/enabled, but
user namespaces still won't work because of the experimental feature
flag added by Redhat.

This will add a warning if it is actually disabled and notes what has to
be added to the grub/boot command line to enable it.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
