### PR TITLE
Return proper errors for exec failure

### DIFF
--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -110,10 +110,8 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 
 	// Now run the user process in container.
 	if err := s.backend.ContainerExecStart(execName, stdin, stdout, stderr); err != nil {
-		if execStartCheck.Detach {
-			return err
-		}
 		logrus.Errorf("Error running exec in container: %v\n", utils.GetErrorMessage(err))
+		return err
 	}
 	return nil
 }

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -46,7 +46,6 @@ func (s *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 	// Register an instance of Exec in container.
 	id, err := s.backend.ContainerExecCreate(execConfig)
 	if err != nil {
-		logrus.Errorf("Error setting up exec command in container %s: %s", name, utils.GetErrorMessage(err))
 		return err
 	}
 

--- a/container/container.go
+++ b/container/container.go
@@ -441,10 +441,11 @@ func AttachStreams(streamConfig *runconfig.StreamConfig, openStdin, stdinOnce, t
 		}()
 
 		logrus.Debugf("attach: %s: begin", name)
-		_, err := io.Copy(stream, streamPipe)
+		n, err := io.Copy(stream, streamPipe)
 		if err == io.ErrClosedPipe {
 			err = nil
 		}
+		logrus.WithField("error", err).Infof("--> copied %d", n)
 		if err != nil {
 			logrus.Errorf("attach: %s: %v", name, err)
 			errors <- err

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -137,7 +137,7 @@ func (d *Daemon) ContainerExecStart(name string, stdin io.ReadCloser, stdout io.
 
 	ec, err := d.getExecConfig(name)
 	if err != nil {
-		return derr.ErrorCodeNoExecID.WithArgs(name)
+		return err
 	}
 
 	ec.Lock()

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -193,6 +193,10 @@ func (d *Daemon) ContainerExecStart(name string, stdin io.ReadCloser, stdout io.
 
 	select {
 	case err := <-attachErr:
+		exerr, ok := <-execErr
+		if ok {
+			logrus.WithField("error", exerr).Error("----- exec fail also")
+		}
 		if err != nil {
 			return derr.ErrorCodeExecAttach.WithArgs(err)
 		}

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -2,7 +2,7 @@
 set -e
 
 bundle_test_integration_cli() {
-	TESTFLAGS="$TESTFLAGS -check.v"
+	TESTFLAGS="$TESTFLAGS -check.v -check.f TestExec"
 	go_test_dir ./integration-cli
 }
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -71,6 +71,7 @@ func (s *DockerSuite) TestExecAfterContainerRestart(c *check.C) {
 	out, _ := runSleepingContainer(c)
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
+	c.Log(cleanedContainerID)
 	dockerCmd(c, "restart", cleanedContainerID)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 


### PR DESCRIPTION
This is only to help debugging the exec errors because they correct
error message is not being returned or is being hidden from the client.

ref: #17473

Signed-off-by: Michael Crosby crosbymichael@gmail.com
