### PR TITLE
Add some uses of personality syscall to default seccomp filter

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -834,6 +834,42 @@
 			"args": []
 		},
 		{
+			"name": "personality",
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 0,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"name": "personality",
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 8,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
+			"name": "personality",
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 4294967295,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			]
+		},
+		{
 			"name": "pipe",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -866,6 +866,39 @@ var DefaultProfile = &types.Seccomp{
 			Args:   []*types.Arg{},
 		},
 		{
+			Name:   "personality",
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index: 0,
+					Value: 0x0,
+					Op:    types.OpEqualTo,
+				},
+			},
+		},
+		{
+			Name:   "personality",
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index: 0,
+					Value: 0x0008,
+					Op:    types.OpEqualTo,
+				},
+			},
+		},
+		{
+			Name:   "personality",
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index: 0,
+					Value: 0xffffffff,
+					Op:    types.OpEqualTo,
+				},
+			},
+		},
+		{
 			Name:   "pipe",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},


### PR DESCRIPTION
We generally want to filter the personality(2) syscall, as it
allows disabling ASLR, and turning on some poorly supported
emulations that have been the target of CVEs. However the use
cases for reading the current value, setting the default
PER_LINUX personality, and setting PER_LINUX32 for 32 bit
emulation are fine.

See issue #20634

Signed-off-by: Justin Cormack justin.cormack@docker.com
