### PR TITLE
Windows CI: Port TestKill*

### DIFF
--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func (s *DockerSuite) TestKillContainer(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
@@ -22,9 +21,8 @@ func (s *DockerSuite) TestKillContainer(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestKillofStoppedContainer(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+func (s *DockerSuite) TestKillOffStoppedContainer(c *check.C) {
+	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "stop", cleanedContainerID)
@@ -34,6 +32,7 @@ func (s *DockerSuite) TestKillofStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
+	// TODO Windows: Windows does not yet support -u (Feb 2016).
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
@@ -48,6 +47,7 @@ func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 
 // regression test about correct signal parsing see #13665
 func (s *DockerSuite) TestKillWithSignal(c *check.C) {
+	// Cannot port to Windows - does not support signals in the same was a Linux does
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
@@ -61,8 +61,7 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out, _ := runSleepingContainer(c, "-d")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
@@ -73,7 +72,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 	running := inspectField(c, cid, "State.Running")
 	c.Assert(running, checker.Equals, "true", check.Commentf("Container should be in running state after an invalid signal"))
 
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	out, _ = runSleepingContainer(c, "-d")
 	cid = strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
@@ -87,8 +86,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillStoppedContainerAPIPre120(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "--name", "docker-kill-test-api", "-d", "busybox", "top")
+	runSleepingContainer(c, "--name", "docker-kill-test-api", "-d")
 	dockerCmd(c, "stop", "docker-kill-test-api")
 
 	status, _, err := sockRequest("POST", fmt.Sprintf("/v1.19/containers/%s/kill", "docker-kill-test-api"), nil)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ports TestKill\* in `docker_cli_kill_test.go` to Windows CI. Output from a local TP4 run below:

```
PS E:\go\src\github.com\docker\docker\integration-cli> runtest w TestKill
Running test TestKill
DOCKER_TEST_HOST=tcp://127.0.0.1:2375
DOCKER_HOST=tcp://127.0.0.1:2375
=== RUN   Test
INFO: Testing against a local daemon
PASS: docker_cli_kill_test.go:12: DockerSuite.TestKillContainer 24.975s
SKIP: docker_cli_kill_test.go:34: DockerSuite.TestKillDifferentUserContainer (Test requires a Linux daemon)
PASS: docker_cli_kill_test.go:24: DockerSuite.TestKillOffStoppedContainer       12.765s
PASS: docker_cli_kill_test.go:88: DockerSuite.TestKillStoppedContainerAPIPre120 13.230s
PASS: docker_cli_kill_test.go:63: DockerSuite.TestKillWithInvalidSignal 20.531s
SKIP: docker_cli_kill_test.go:49: DockerSuite.TestKillWithSignal (Test requires a Linux daemon)
OK: 4 passed, 2 skipped
--- PASS: Test (88.67s)
PASS
ok      github.com/docker/docker/integration-cli        89.618s
PS E:\go\src\github.com\docker\docker\integration-cli>
```

And more cuteness :dog2: 
![img_4310](https://cloud.githubusercontent.com/assets/10522484/13301782/7ef836bc-dafb-11e5-963d-704f5ae6125c.JPG)
