### PR TITLE
Close resp body on plugin call error

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -124,6 +124,7 @@ func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool)
 
 		if resp.StatusCode != http.StatusOK {
 			b, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
 			if err != nil {
 				return nil, &statusError{resp.StatusCode, serviceMethod, err.Error()}
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  Fix an issue with the plugin system leaking fd's when the plugin has an error
- How did you do it?
  Make sure the resp body is closed on error
- How do I see it or verify it?
- A picture of a cute animal (not mandatory but encouraged)

![](http://www.listproducer.com/wp-content/uploads/2014/10/cute.jpg)
