### PR TITLE
Add bridgeNfIptables and bridgeNfIp6tables test request

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -972,6 +972,7 @@ func (s *DockerDaemonSuite) TestDaemonIP(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonICCPing(c *check.C) {
+	testRequires(c, bridgeNfIptables)
 	d := s.d
 
 	bridgeName := "external-bridge"

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -81,6 +81,18 @@ var (
 		},
 		"Test requires that seccomp support be enabled in the daemon.",
 	}
+	bridgeNfIptables = testRequirement{
+		func() bool {
+			return !SysInfo.BridgeNfCallIptablesDisabled
+		},
+		"Test requires that bridge-nf-call-iptables support be enabled in the daemon.",
+	}
+	bridgeNfIP6tables = testRequirement{
+		func() bool {
+			return !SysInfo.BridgeNfCallIP6tablesDisabled
+		},
+		"Test requires that bridge-nf-call-ip6tables support be enabled in the daemon.",
+	}
 )
 
 func init() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?

Add bridgeNfIptables and bridgeNfIp6tables test request,
bridgeNfIptables and bridgeNfIptables may not be enabled,
this will make the test `TestDaemonICCPing` fail. Add a test
require to skip if it was not enbaled.
- How did you do it?
  Add a test require
- How do I see it or verify it?
- A picture of a cute animal (not mandatory but encouraged)

I think it's cute :)

![image](https://cloud.githubusercontent.com/assets/8232360/13318358/45af42ce-dbf5-11e5-803f-3334cc9ae2bd.png)

Signed-off-by: Lei Jitang leijitang@huawei.com
