### PR TITLE
Fix TestExecApiStartWithDetach on WindowsTP4

### DIFF
--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -125,7 +125,7 @@ func (s *DockerSuite) TestExecApiStartMultipleTimesError(c *check.C) {
 // #20638
 func (s *DockerSuite) TestExecApiStartWithDetach(c *check.C) {
 	name := "foo"
-	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "top")
+	runSleepingContainer(c, "-d", "-t", "--name", name)
 	data := map[string]interface{}{
 		"cmd":         []string{"true"},
 		"AttachStdin": true,


### PR DESCRIPTION
`DockerSuite.TestExecApiStartWithDetach` is failing consistently on WindowsTP4. I think it's because of the extra checks I merged earlier today ( #20664) 🐱.

![cat1](https://cloud.githubusercontent.com/assets/6508/13320889/3615c1cc-dbcc-11e5-9450-7774595d4c5d.gif)

This PR fixes that.

/cc @jhowardmsft 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
