### PR TITLE
Run images directly from the shell as regular binaries.

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2209,3 +2209,134 @@ eval "$__docker_previous_extglob_setting"
 unset __docker_previous_extglob_setting
 
 complete -F _docker docker
+
+
+function __docker_shell_command () {
+  name=$1
+  version=$2
+  if [ -z $name ]
+  then 
+	  echo "I need at least a name for the command"
+	  exit 2
+  else
+    function_name=$(__docker_shell_to_function_name ${name})
+    if [ -z $version ]
+    then
+
+      eval "$(cat <<EOF
+      ${function_name} () {
+        if [ -z "\$DOCKER_OPTS_USER" ]
+        then 
+          docker_set_interactive
+        fi
+	# pars=\$(__docker_shell_container_default_command "\${@}")
+	command="docker run \${DOCKER_OPTS_USER} ${name} \${@}"
+        eval \$command
+      }
+EOF
+)"
+    else
+      eval "$(cat <<EOF
+      ${function_name}_${version} () {
+        if [ -z "\$DOCKER_OPTS_USER" ]
+        then 
+          docker_set_interactive
+        fi
+	# pars=\$(__docker_shell_container_default_command "\${@}")
+        command="docker run \${DOCKER_OPTS_USER} ${name}:${version} \${@}"
+echo \$command
+        eval \${command}
+      }
+EOF
+)"
+    fi
+  fi
+}
+
+# function __docker_shell_container_default_command () {
+#   command="${@}"
+#   if [ -z "$1" ]; then
+#     command="/bin/bash"
+#   fi
+#   echo "${command}"
+# }
+
+function __docker_shell_to_function_name (){
+  if [ -z $1 ]
+  then
+    echo "Name to be converted missing"
+    exit 2
+  fi
+  echo $(echo $1 | tr "/" "_")
+
+}
+
+function __docker_shell_user_id () {
+  echo `id -u`:`id -g`
+}
+
+function __docker_shell_opts () {
+  echo "--rm -u $(__docker_shell_user_id)"
+}
+
+function docker_set_interactive () {
+  export DOCKER_OPTS_USER="$(__docker_shell_opts) -i -t"
+}
+function docker_set_daemon () {
+  export DOCKER_OPTS_USER="$(__docker_shell_opts) -d"
+}
+
+function docker_shell_images_integration () {
+# inspired by function __docker_complete_images in docker/contrib/completion/bash/docker
+read -r -d '' awk_script_get_images <<'EOF'
+NR>1 && $1 != "<none>" { 
+  print $1" "$2
+}
+EOF
+
+list_images=$(docker images | awk "$awk_script_get_images" )
+
+read -r -d '' awk_script_create_image_shell_function <<'EOF'
+{ 
+  print("__docker_shell_command "$1" "$2";") 
+  if ($2 == "latest" ) { 
+    print("__docker_shell_command "$1";") 
+  } 
+}
+EOF
+
+echo "$(cat<<EOF
+With the Docker Shell Integration you can run an image diretly typing the name of the image. 
+Bash completion works out of the box and you can browse them, depending on your settings.
+You can run a container simply calling the name of the image, i.e.
+
+  ubuntu
+
+  ubuntu echo "Hello World"
+
+a container will be started with default parameters:
+
+  --rm
+  -u user_id:user_group_id
+  -i
+  -t
+
+The user can set common parameters for all containers using the env variable DOCKER_OPTS_USER.
+
+Why this? If you have images that are considered "applications" you can run them directly form 
+the shell as normal application but running inside a container; look at CMD or ENTRYPOINT in the Docker
+official docs.
+
+These are your images now available from the shell:
+
+$(echo ${list_images} | tr " /" "_")
+
+Images tagged as latest can be called omitting "latest".
+
+EOF)"
+
+create_images_functions=$(echo "${list_images}" | awk "$awk_script_create_image_shell_function" )
+eval ${create_images_functions}
+}
+
+# docker_shell_images_integration


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  I expose the name of the images and their tags as bash/shell function so that the user can directly run them from the shell i.e.:
  `$> ubuntu_latest echo "Hello World".`
  This can be useful if you want to use images/container as local binaries but without typing the whole docker run ... which can be very long sometimes. Also the bash completion works, so is simpler to explore and run your images.
- How did you do it?
  Creating bash functions (__docker_shell_...) to extract images names and tags using docker and wrap them in simple bash functions, when the functions are loaded from the shell the user need only to run 
  `docker_shell_images_integration`

I placed the function into `contrib/completion/bash/docker` because I think it was the simple place ready to host my enhancement.
I placed my functions at the bottom of the file to separate them from the original file.
- How do I see it or verify it?
  if `contrib/completion/bash/docker` is run automatically by the system then you just need to type
  `docker_shell_images_integration` and then call one of your images form the shell
  `ubuntu`

Note: I tested the it on my server ubuntu 14.04 (bash 4) and on Mac (bash3 and bash4)
- A picture of a cute animal (not mandatory but encouraged)
  [Pic](https://goo.gl/photos/WVpUvYWJdf9C9Vce9)

Signed-off-by: Raoul Jean Pierre Bonnal raoul.bonnal@gmail.com #
