### PR TITLE
WIP: Move slave-mount from systemd service to the daemon

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -7,7 +7,6 @@ Requires=docker.socket
 [Service]
 Type=notify
 ExecStart=/usr/bin/docker daemon -H fd://
-MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -1079,6 +1079,11 @@ func (daemon *Daemon) mountVolumes(container *container.Container) error {
 		if err := mount.Mount(m.Source, dest, "bind", opts); err != nil {
 			return err
 		}
+
+		// WIP: why do we need this here? it should be called only once.
+		if err = daemon.enableSlaveMount(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -663,6 +663,10 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 		}
 	}()
 
+	if err := d.enableSlaveMount(); err != nil {
+		return nil, err
+	}
+
 	// Verify logging driver type
 	if config.LogConfig.Type != "none" {
 		if _, err := logger.GetLogDriver(config.LogConfig.Type); err != nil {

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -11,6 +11,10 @@ import (
 	"github.com/docker/docker/volume"
 )
 
+func (daemon *Daemon) enableSlaveMount() error {
+	return nil
+}
+
 // setupMounts configures the mount points for a container by appending each
 // of the configured mounts on the container to the execdriver mount structure
 // which will ultimately be passed into the exec driver during container creation.


### PR DESCRIPTION
This commit moves slave-mount from systemd service to the daemon.

Fix #20670

TODO (after discussion for the concept itself):
- Mount() should be called only once as in systemd
- Add tests
- Needs consideration for #17034 (mount propagation)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp

Image: https://en.wikipedia.org/wiki/Ad%C3%A9lie_penguin#/media/File:Hope_Bay-2016-Trinity_Peninsula%E2%80%93Ad%C3%A9lie_penguin_(Pygoscelis_adeliae)_04.jpg
![image](https://cloud.githubusercontent.com/assets/9248427/13341983/a2bde3b8-dc80-11e5-9bc5-b0ce88e76d95.png)
