### PR TITLE
remove leftover Ubuntu 15.04 from install docs

### DIFF
--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -109,10 +109,9 @@ packages from the new repository:
 ### Prerequisites by Ubuntu Version
 
 - Ubuntu Wily 15.10
-- Ubuntu Vivid 15.04
 - Ubuntu Trusty 14.04 (LTS)
 
-For Ubuntu Trusty, Vivid, and Wily, it's recommended to install the
+For Ubuntu Trusty and Wily, it's recommended to install the
 `linux-image-extra` kernel package. The `linux-image-extra` package
 allows you use the `aufs` storage driver.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do? I read the docs \o/
- How did you do it? By opening the documentation in my browser
- How do I see it or verify it? Look at the diff!
- A picture of a cute animal (not mandatory but encouraged)

![cute-animals-baby-polar-bear-cub-pics](https://cloud.githubusercontent.com/assets/1804568/13351848/d75904f0-dc89-11e5-992f-916f5a08adab.jpg)
