### PR TITLE
pkg: idtools: fix subid files parsing

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -171,7 +171,7 @@ func parseSubidFile(path, username string) (ranges, error) {
 		}
 
 		text := strings.TrimSpace(s.Text())
-		if text == "" {
+		if text == "" || strings.HasPrefix(text, "#") {
 			continue
 		}
 		parts := strings.Split(text, ":")

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -241,3 +241,31 @@ func compareTrees(left, right map[string]node) error {
 	}
 	return nil
 }
+
+func TestParseSubidFileWithNewlinesAndComments(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "parsesubid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fnamePath := filepath.Join(tmpDir, "testsubuid")
+	fcontent := `tss:100000:65536
+# empty default subuid/subgid file
+
+dockremap:231072:65536`
+	if err := ioutil.WriteFile(fnamePath, []byte(fcontent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ranges, err := parseSubidFile(fnamePath, "dockremap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ranges) != 1 {
+		t.Fatalf("wanted 1 element in ranges, got %d instead", len(ranges))
+	}
+	if ranges[0].Start != 231072 {
+		t.Fatalf("wanted 231072, got %d instead", ranges[0].Start)
+	}
+	if ranges[0].Length != 65536 {
+		t.Fatalf("wanted 65536, got %d instead", ranges[0].Length)
+	}
+}


### PR DESCRIPTION
/etc/sub{uid,gid} files can contain #-prefixed lines that are comments.
Fix those files parsing by skipping commented out lines. Add regression
unit test also.

ping @estesp 

Signed-off-by: Antonio Murdaca runcom@redhat.com
