### PR TITLE
Add support for NoNewPrivileges in docker

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -50,6 +50,7 @@ type Container struct {
 	ShmPath         string
 	ResolvConfPath  string
 	SeccompProfile  string
+	NoNewPrivileges bool
 }
 
 // CreateDaemonEnvironment returns the list of all environment variables given the list of

--- a/contrib/nnp-test/Dockerfile
+++ b/contrib/nnp-test/Dockerfile
@@ -1,0 +1,9 @@
+FROM buildpack-deps:jessie
+
+COPY . /usr/src/
+
+WORKDIR /usr/src/
+
+RUN gcc -g -Wall -static nnp-test.c -o /usr/bin/nnp-test
+
+RUN chmod +s /usr/bin/nnp-test

--- a/contrib/nnp-test/nnp-test.c
+++ b/contrib/nnp-test/nnp-test.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+int main(int argc, char *argv[])
+{
+        printf("EUID=%d\n", geteuid());
+        return 0;
+}
+

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -270,6 +270,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		SeccompProfile:     c.SeccompProfile,
 		UIDMapping:         uidMap,
 		UTS:                uts,
+		NoNewPrivileges:    c.NoNewPrivileges,
 	}
 	if c.HostConfig.CgroupParent != "" {
 		c.Command.CgroupParent = c.HostConfig.CgroupParent

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -75,17 +75,23 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 	for _, opt := range config.SecurityOpt {
 		con := strings.SplitN(opt, ":", 2)
 		if len(con) == 1 {
-			return fmt.Errorf("Invalid --security-opt: %q", opt)
-		}
-		switch con[0] {
-		case "label":
-			labelOpts = append(labelOpts, con[1])
-		case "apparmor":
-			container.AppArmorProfile = con[1]
-		case "seccomp":
-			container.SeccompProfile = con[1]
-		default:
-			return fmt.Errorf("Invalid --security-opt: %q", opt)
+			switch con[0] {
+			case "no-new-privileges":
+				container.NoNewPrivileges = true
+			default:
+				return fmt.Errorf("Invalid --security-opt 1: %q", opt)
+			}
+		} else {
+			switch con[0] {
+			case "label":
+				labelOpts = append(labelOpts, con[1])
+			case "apparmor":
+				container.AppArmorProfile = con[1]
+			case "seccomp":
+				container.SeccompProfile = con[1]
+			default:
+				return fmt.Errorf("Invalid --security-opt 2: %q", opt)
+			}
 		}
 	}
 

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -124,6 +124,7 @@ type Command struct {
 	SeccompProfile     string            `json:"seccomp_profile"`
 	UIDMapping         []idtools.IDMap   `json:"uidmapping"`
 	UTS                *UTS              `json:"uts"`
+	NoNewPrivileges    bool              `json:"no_new_privileges"`
 }
 
 // SetRootPropagation sets the root mount propagation mode.

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -122,6 +122,8 @@ func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) 
 
 	d.setupLabels(container, c)
 	d.setupRlimits(container, c)
+
+	container.NoNewPrivileges = c.NoNewPrivileges
 	return container, nil
 }
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -605,6 +605,8 @@ with the same logic -- if the original volume was specified with a name it will 
     --security-opt="label:disable"     : Turn off label confinement for the container
     --security-opt="apparmor:PROFILE"  : Set the apparmor profile to be applied
                                          to the container
+    --security-opt="no-new-privileges" : Disable container processes from gaining
+                                         new privileges
 
 You can override the default labeling scheme for each container by specifying
 the `--security-opt` flag. For example, you can specify the MCS/MLS level, a
@@ -630,6 +632,13 @@ command:
     $ docker run --security-opt label:type:svirt_apache_t -it centos bash
 
 > **Note**: You would have to write policy defining a `svirt_apache_t` type.
+
+If you want to prevent your container processes from gaining additional
+privileges, you can execute the following command:
+
+    $ docker run --security-opt no-new-privileges -it centos bash
+
+For more details, see [kernel documentation](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt).
 
 ## Specifying custom cgroups
 

--- a/hack/make/.ensure-nnp-test
+++ b/hack/make/.ensure-nnp-test
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Build a C binary for testing no-new-privileges
+# and compile it for target daemon
+if [ "$DOCKER_ENGINE_GOOS" = "linux" ]; then
+	if [ "$DOCKER_ENGINE_OSARCH" = "$DOCKER_CLIENT_OSARCH" ]; then
+		tmpdir=$(mktemp -d)
+		gcc -g -Wall -static contrib/nnp-test/nnp-test.c -o "${tmpdir}/nnp-test"
+
+		dockerfile="${tmpdir}/Dockerfile"
+		cat <<-EOF > "$dockerfile"
+		FROM debian:jessie
+		COPY . /usr/bin/
+		RUN chmod +s /usr/bin/nnp-test
+		EOF
+		docker build --force-rm ${DOCKER_BUILD_ARGS} -qt nnp-test "${tmpdir}" > /dev/null
+		rm -rf "${tmpdir}"
+	else
+		docker build ${DOCKER_BUILD_ARGS} -qt nnp-test contrib/nnp-test > /dev/null
+	fi
+fi

--- a/hack/make/.integration-daemon-setup
+++ b/hack/make/.integration-daemon-setup
@@ -7,6 +7,7 @@ if [ $DOCKER_ENGINE_GOOS != "windows" ]; then
 	bundle .ensure-frozen-images
 	bundle .ensure-httpserver
 	bundle .ensure-syscall-test
+	bundle .ensure-nnp-test
 else
 	# Note this is Windows to Windows CI, not Windows to Linux CI
 	bundle .ensure-frozen-images-windows

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -895,6 +895,18 @@ func (s *DockerSuite) TestRunSeccompDefaultProfile(c *check.C) {
 	}
 }
 
+// TestRunNoNewPrivSetuid checks that --security-opt=no-new-privileges prevents
+// effective uid transtions on executing setuid binaries.
+func (s *DockerSuite) TestRunNoNewPrivSetuid(c *check.C) {
+	testRequires(c, DaemonIsLinux, NotUserNamespace, SameHostDaemon)
+
+	// test that running a setuid binary results in no effective uid transition
+	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "no-new-privileges", "--user", "1000", "nnp-test", "/usr/bin/nnp-test")
+	if out, _, err := runCommandWithOutput(runCmd); err != nil || !strings.Contains(out, "EUID=1000") {
+		c.Fatalf("expected output to contain EUID=1000, got %s: %v", out, err)
+	}
+}
+
 func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 	testRequires(c, SameHostDaemon, Apparmor)
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -459,6 +459,8 @@ its root filesystem mounted as read only prohibiting any writes.
     "label:type:TYPE"   : Set the label type for the container
     "label:level:LEVEL" : Set the label level for the container
     "label:disable"     : Turn off label confinement for the container
+    "no-new-privileges" : Disable container processes from gaining additional privileges
+
 
 **--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -500,8 +500,8 @@ func parseLoggingOpts(loggingDriver string, loggingOpts []string) (map[string]st
 func parseSecurityOpts(securityOpts []string) ([]string, error) {
 	for key, opt := range securityOpts {
 		con := strings.SplitN(opt, ":", 2)
-		if len(con) == 1 {
-			return securityOpts, fmt.Errorf("invalid --security-opt: %q", opt)
+		if len(con) == 1 && con[0] != "no-new-privileges" {
+			return securityOpts, fmt.Errorf("Invalid --security-opt: %q", opt)
 		}
 		if con[0] == "seccomp" && con[1] != "unconfined" {
 			f, err := ioutil.ReadFile(con[1])


### PR DESCRIPTION
Addresses #20329 
This PR adds support for setting the NoNewPrivileges in docker as a security-opt.
Here is how to run docker with this bit set.

```
docker run -it --rm --security-opt=no-new-privileges fedora bash
```

Here is how to test it:

```
# Create a setuid binary that displays the effective uid
[root@dhcp-16-129 dockerfiles]# cat testnnp.c 
#include <stdio.h>
#include <unistd.h>
#include <sys/types.h>

int main(int argc, char *argv[])
{
        printf("Effective uid: %d\n", geteuid());
        return 0;
}
[root@dhcp-16-129 dockerfiles]# make testnnp
cc     testnnp.c   -o testnnp

# Add the binary to a docker image
[root@dhcp-16-129 dockerfiles]# cat Dockerfile 
FROM fedora:latest
ADD testnnp /root/testnnp
RUN chmod +s /root/testnnp
ENTRYPOINT /root/testnnp

[root@dhcp-16-129 dockerfiles]# /root/gosrc/src/github.com/docker/docker/bundles/latest/dynbinary/docker build -t testnnp .
Sending build context to Docker daemon 12.29 kB
Step 1 : FROM fedora:latest
 ---> 760a896a323f
Step 2 : ADD testnnp /root/testnnp
 ---> 6c700f277948
Removing intermediate container 0981144fe404
Step 3 : RUN chmod +s /root/testnnp
 ---> Running in c1215bfbe825
 ---> f1f07d05a691
Removing intermediate container c1215bfbe825
Step 4 : ENTRYPOINT /root/testnnp
 ---> Running in 5a4d324d54fa
 ---> 44f767c67e30
Removing intermediate container 5a4d324d54fa
Successfully built 44f767c67e30

# Running without no-new-privileges
root@dhcp-16-129 dockerfiles]# /root/gosrc/src/github.com/docker/docker/bundles/latest/dynbinary/docker run -it --rm --user=1000  testnnp
Effective uid: 0
# Running with no-new-privileges prevents the uid transition while running a setuid binary
[root@dhcp-16-129 dockerfiles]# /root/gosrc/src/github.com/docker/docker/bundles/latest/dynbinary/docker run -it --rm --user=1000 --security-opt=no-new-privileges testnnp
Effective uid: 1000
```

Signed-off-by: Mrunal Patel mrunalp@gmail.com
