### PR TITLE
Changed the Example request in Remote API reference to connect a container to a network

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -3072,7 +3072,7 @@ Content-Type: application/json
 {
   "Container":"3613f73ba0e4",
   "EndpointConfig": {
-    "test_nw": {
+    "IPAMConfig": {
         "IPv4Address":"172.24.56.89",
         "IPv6Address":"2001:db8::5689"
     }

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -3106,7 +3106,7 @@ Content-Type: application/json
 {
   "Container":"3613f73ba0e4",
   "EndpointConfig": {
-    "test_nw": {
+    "IPAMConfig": {
         "IPv4Address":"172.24.56.89",
         "IPv6Address":"2001:db8::5689"
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  changed "test_nw" to "IPAMConfig" in the Example request to connect a container to a network
- How did you do it?
  edited docs/reference/api/docker_remote_api_v1.22.md and docs/reference/api/docker_remote_api_v1.23.md
- How do I see it or verify it?
  Build Docs and have a look at:
  Documentation -> Docker Engine -> API Reference -> Remote API v1.22 -> Connect a container to a network (/engine/reference/api/docker_remote_api_v1.22/#connect-a-container-to-a-network)

Documentation -> Docker Engine -> API Reference -> Remote API v1.23 -> Connect a container to a network (/engine/reference/api/docker_remote_api_v1.23/#connect-a-container-to-a-network)

Signed-off-by: Christian Böhme development@boehme3d.de
