### PR TITLE
Use empty response to indicate volume doesnt exist

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -141,6 +141,9 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 func (daemon *Daemon) VolumeRm(name string) error {
 	v, err := daemon.volumes.Get(name)
 	if err != nil {
+		if volumestore.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -1,8 +1,6 @@
 package volumedrivers
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/volume"
 )
 
@@ -53,9 +51,8 @@ func (a *volumeDriverAdapter) Get(name string) (volume.Volume, error) {
 		return nil, err
 	}
 
-	// plugin may have returned no volume and no error
 	if v == nil {
-		return nil, fmt.Errorf("no such volume")
+		return nil, nil
 	}
 
 	return &volumeAdapter{

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -187,7 +187,7 @@ func (r *Root) Get(name string) (volume.Volume, error) {
 	v, exists := r.volumes[name]
 	r.m.Unlock()
 	if !exists {
-		return nil, ErrNotFound
+		return nil, nil
 	}
 	return v, nil
 }


### PR DESCRIPTION
Fixes #20608

This fix addresses a couple problems with the volume plugin API:
1. There is no way to clearly indicate that a volume doesn't exist in the driver (and distinguish that from a legitimate error)
2. If docker thinks a volume exists but it the driver plugin and the user requests to create the volume, docker returns a success even though the volume was _not_ created in the driver.

I've addressed 1. by allowing response to /VolumeDriver.Get to return `{}` (no volume, no error), to indicate the volume doesn't exist.

I've addressed 2. By adding a check in the actual driver for the existence of the volume during create. If the check doesn't find the volume, the docker will call the driver to create the volume.

These fixes can be seen and verified using the steps outlined in #20608 

Signed-off-by: Craig Jellick craig@rancher.com
