### PR TITLE
validate log-opt when creating containers

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/idtools"
@@ -79,6 +80,11 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 			}
 		}
 	}()
+
+	logCfg := container.GetLogConfig(daemon.defaultLogConfig)
+	if err := logger.ValidateLogOpts(logCfg.Type, logCfg.Config); err != nil {
+		return nil, err
+	}
 
 	if err := daemon.setSecurityOptions(container, params.HostConfig); err != nil {
 		return nil, err

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -440,3 +440,11 @@ func (s *DockerSuite) TestCreateWithWorkdir(c *check.C) {
 	dockerCmd(c, "create", "--name", name, "-w", dir, "busybox")
 	dockerCmd(c, "cp", fmt.Sprintf("%s:%s", name, dir), prefix+slash+"tmp")
 }
+
+func (s *DockerSuite) TestCreateWithInvalidLogOpts(c *check.C) {
+	name := "test-invalidate-log-opts"
+	_, _, err := dockerCmdWithError("create", "--name", name, "--log-opt", "invalid=true")
+	c.Assert(err, checker.NotNil)
+	out, _ := dockerCmd(c, "ps", "-a")
+	c.Assert(out, checker.Not(checker.Contains), name)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  
  Before this change, if the user provide an invalid `log-opt` in `docker run`, the container will be   successfully created but can't be started.
  This patch emits an error message and let the container creation fail.
- How did you do it?
  
  add `log-opt` validation logic to `daemon.create()`
- How do I see it or verify it?
  
  ```
  docker run -it --name=test --log-opt aaa=bbb busybox
  docker ps -a
  ```
- A picture of a cute animal (not mandatory but encouraged)
  ![3_c9b2e5aea80473eabb2f7dc5cb8ad53e_430](https://cloud.githubusercontent.com/assets/1496652/13374459/5eaec520-ddc0-11e5-8a13-52ba364e6984.jpg)

Signed-off-by: Shijiang Wei mountkin@gmail.com
