### PR TITLE
Pin tpoechtrager/osxcross commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,9 +91,11 @@ RUN cd /usr/local/lvm2 \
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk
+ENV OSX_CROSS_COMMIT 8aa9b71a394905e6c5f4b59e2b97b87a004658a4
 RUN set -x \
 	&& export OSXCROSS_PATH="/osxcross" \
-	&& git clone --depth 1 https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
 	&& curl -sSL https://s3.dockerproject.org/darwin/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
 	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
 ENV PATH /osxcross/target/bin:$PATH


### PR DESCRIPTION
This is an attempt to fix the `experimental` CI which has been consistently failing in the past 12 hours (see [this log](https://jenkins.dockerproject.org/job/Docker-PRs-experimental/15516/consoleFull) for an example).

I'm seeing one line in the Dockerfile that relies on a git repo without a pinned version, and that coincidentally changed in the past 12 hours.
