### PR TITLE
integration-cli: remove not necessary -d again

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -230,7 +230,7 @@ func (s *DockerSuite) TestContainerApiStartVolumesFrom(c *check.C) {
 	volName := "voltst"
 	volPath := "/tmp"
 
-	dockerCmd(c, "run", "-d", "--name", volName, "-v", volPath, "busybox")
+	dockerCmd(c, "run", "--name", volName, "-v", volPath, "busybox")
 
 	name := "TestContainerApiStartVolumesFrom"
 	config := map[string]interface{}{

--- a/integration-cli/docker_api_volumes_test.go
+++ b/integration-cli/docker_api_volumes_test.go
@@ -12,7 +12,7 @@ import (
 
 func (s *DockerSuite) TestVolumesApiList(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
-	dockerCmd(c, "run", "-d", "-v", prefix+"/foo", "busybox")
+	dockerCmd(c, "run", "-v", prefix+"/foo", "busybox")
 
 	status, b, err := sockRequest("GET", "/volumes", nil)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -72,7 +72,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithVolumesRefs(c *check.C) {
 		c.Fatal(err)
 	}
 
-	if out, err := s.d.Cmd("run", "-d", "--name", "volrestarttest1", "-v", "/foo", "busybox"); err != nil {
+	if out, err := s.d.Cmd("run", "--name", "volrestarttest1", "-v", "/foo", "busybox"); err != nil {
 		c.Fatal(err, out)
 	}
 
@@ -1156,15 +1156,11 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefault(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, err := s.d.Cmd("run", "-d", "busybox", "echo", "testline")
-	if err != nil {
-		c.Fatal(out, err)
-	}
-	id := strings.TrimSpace(out)
+	out, err := s.d.Cmd("run", "--name=test", "busybox", "echo", "testline")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	id, err := s.d.getIDByName("test")
+	c.Assert(err, check.IsNil)
 
-	if out, err := s.d.Cmd("wait", id); err != nil {
-		c.Fatal(out, err)
-	}
 	logPath := filepath.Join(s.d.root, "containers", id, id+"-json.log")
 
 	if _, err := os.Stat(logPath); err != nil {
@@ -1198,15 +1194,13 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverDefaultOverride(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, err := s.d.Cmd("run", "-d", "--log-driver=none", "busybox", "echo", "testline")
+	out, err := s.d.Cmd("run", "--name=test", "--log-driver=none", "busybox", "echo", "testline")
 	if err != nil {
 		c.Fatal(out, err)
 	}
-	id := strings.TrimSpace(out)
+	id, err := s.d.getIDByName("test")
+	c.Assert(err, check.IsNil)
 
-	if out, err := s.d.Cmd("wait", id); err != nil {
-		c.Fatal(out, err)
-	}
 	logPath := filepath.Join(s.d.root, "containers", id, id+"-json.log")
 
 	if _, err := os.Stat(logPath); err == nil || !os.IsNotExist(err) {
@@ -1219,14 +1213,12 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNone(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, err := s.d.Cmd("run", "-d", "busybox", "echo", "testline")
+	out, err := s.d.Cmd("run", "--name=test", "busybox", "echo", "testline")
 	if err != nil {
 		c.Fatal(out, err)
 	}
-	id := strings.TrimSpace(out)
-	if out, err := s.d.Cmd("wait", id); err != nil {
-		c.Fatal(out, err)
-	}
+	id, err := s.d.getIDByName("test")
+	c.Assert(err, check.IsNil)
 
 	logPath := filepath.Join(s.d.folder, "graph", "containers", id, id+"-json.log")
 
@@ -1240,15 +1232,13 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneOverride(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, err := s.d.Cmd("run", "-d", "--log-driver=json-file", "busybox", "echo", "testline")
+	out, err := s.d.Cmd("run", "--name=test", "--log-driver=json-file", "busybox", "echo", "testline")
 	if err != nil {
 		c.Fatal(out, err)
 	}
-	id := strings.TrimSpace(out)
+	id, err := s.d.getIDByName("test")
+	c.Assert(err, check.IsNil)
 
-	if out, err := s.d.Cmd("wait", id); err != nil {
-		c.Fatal(out, err)
-	}
 	logPath := filepath.Join(s.d.root, "containers", id, id+"-json.log")
 
 	if _, err := os.Stat(logPath); err != nil {
@@ -1568,7 +1558,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {
 
 	socket := filepath.Join(s.d.folder, "docker.sock")
 
-	out, err := s.d.Cmd("run", "-d", "--restart=always", "-v", socket+":/sock", "busybox")
+	out, err := s.d.Cmd("run", "--restart=always", "-v", socket+":/sock", "busybox")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 	c.Assert(s.d.Restart(), check.IsNil)
 }

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -138,10 +138,9 @@ func (s *DockerSuite) TestLogsTail(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
-
-	id := strings.TrimSpace(out)
-	dockerCmd(c, "wait", id)
+	dockerCmd(c, "run", "--name=test", "busybox", "echo", "hello")
+	id, err := getIDByName("test")
+	c.Assert(err, check.IsNil)
 
 	logsCmd := exec.Command(dockerBinary, "logs", "-f", id)
 	c.Assert(logsCmd.Start(), checker.IsNil)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -208,7 +208,7 @@ func assertContainerList(out string, expected []string) bool {
 func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	// Problematic on Windows as it doesn't report the size correctly @swernli
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
+	dockerCmd(c, "run", "-d", "busybox")
 
 	baseOut, _ := dockerCmd(c, "ps", "-s", "-n=1")
 	baseLines := strings.Split(strings.Trim(baseOut, "\n "), "\n")
@@ -218,11 +218,12 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	name := "test_size"
-	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo 1 > test")
+	dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo 1 > test")
 	id, err := getIDByName(name)
 	c.Assert(err, checker.IsNil)
 
 	runCmd := exec.Command(dockerBinary, "ps", "-s", "-n=1")
+	var out string
 
 	wait := make(chan struct{})
 	go func() {
@@ -244,7 +245,6 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	expectedSize := fmt.Sprintf("%d B", (2 + baseBytes))
 	foundSize := lines[1][sizeIndex:]
 	c.Assert(foundSize, checker.Contains, expectedSize, check.Commentf("Expected size %q, got %q", expectedSize, foundSize))
-
 }
 
 func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
@@ -303,17 +303,17 @@ func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
 
 func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
 	// start container
-	out, _ := dockerCmd(c, "run", "-d", "--name=a_name_to_match", "busybox")
-	firstID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=a_name_to_match", "busybox")
+	id, err := getIDByName("a_name_to_match")
+	c.Assert(err, check.IsNil)
 
 	// start another container
 	runSleepingContainer(c, "--name=b_name_to_match")
 
 	// filter containers by name
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--filter=name=a_name_to_match")
+	out, _ := dockerCmd(c, "ps", "-a", "-q", "--filter=name=a_name_to_match")
 	containerOut := strings.TrimSpace(out)
-	c.Assert(containerOut, checker.Equals, firstID[:12], check.Commentf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out))
-
+	c.Assert(containerOut, checker.Equals, id[:12], check.Commentf("Expected id %s, got %s for exited filter, output: %q", id[:12], containerOut, out))
 }
 
 // Test for the ancestor filter for ps.
@@ -345,24 +345,29 @@ func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	// start containers
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
-	firstID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=first", "busybox", "echo", "hello")
+	firstID, err := getIDByName("first")
+	c.Assert(err, check.IsNil)
 
 	// start another container
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
-	secondID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=second", "busybox", "echo", "hello")
+	secondID, err := getIDByName("second")
+	c.Assert(err, check.IsNil)
 
 	// start third container
-	out, _ = dockerCmd(c, "run", "-d", imageName1, "echo", "hello")
-	thirdID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=third", imageName1, "echo", "hello")
+	thirdID, err := getIDByName("third")
+	c.Assert(err, check.IsNil)
 
 	// start fourth container
-	out, _ = dockerCmd(c, "run", "-d", imageName1Tagged, "echo", "hello")
-	fourthID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=fourth", imageName1Tagged, "echo", "hello")
+	fourthID, err := getIDByName("fourth")
+	c.Assert(err, check.IsNil)
 
 	// start fifth container
-	out, _ = dockerCmd(c, "run", "-d", imageName2, "echo", "hello")
-	fifthID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=fifth", imageName2, "echo", "hello")
+	fifthID, err := getIDByName("fifth")
+	c.Assert(err, check.IsNil)
 
 	var filterTestSuite = []struct {
 		filterName  string
@@ -387,6 +392,7 @@ func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
 		{imageID2, []string{fifthID}},
 	}
 
+	var out string
 	for _, filter := range filterTestSuite {
 		out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+filter.filterName)
 		checkPsAncestorFilterOutput(c, out, filter.filterName, filter.expectedIDs)
@@ -421,19 +427,22 @@ func checkPsAncestorFilterOutput(c *check.C, out string, filterName string, expe
 
 func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
 	// start container
-	out, _ := dockerCmd(c, "run", "-d", "-l", "match=me", "-l", "second=tag", "busybox")
-	firstID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=first", "-l", "match=me", "-l", "second=tag", "busybox")
+	firstID, err := getIDByName("first")
+	c.Assert(err, check.IsNil)
 
 	// start another container
-	out, _ = dockerCmd(c, "run", "-d", "-l", "match=me too", "busybox")
-	secondID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=second", "-l", "match=me too", "busybox")
+	secondID, err := getIDByName("second")
+	c.Assert(err, check.IsNil)
 
 	// start third container
-	out, _ = dockerCmd(c, "run", "-d", "-l", "nomatch=me", "busybox")
-	thirdID := strings.TrimSpace(out)
+	dockerCmd(c, "run", "--name=third", "-l", "nomatch=me", "busybox")
+	thirdID, err := getIDByName("third")
+	c.Assert(err, check.IsNil)
 
 	// filter containers by exact match
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")
+	out, _ := dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")
 	containerOut := strings.TrimSpace(out)
 	c.Assert(containerOut, checker.Equals, firstID, check.Commentf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out))
 

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -11,12 +11,11 @@ import (
 )
 
 func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "foobar")
+	dockerCmd(c, "run", "--name=test", "busybox", "echo", "foobar")
+	cleanedContainerID, err := getIDByName("test")
+	c.Assert(err, check.IsNil)
 
-	cleanedContainerID := strings.TrimSpace(out)
-	dockerCmd(c, "wait", cleanedContainerID)
-
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out, _ := dockerCmd(c, "logs", cleanedContainerID)
 	c.Assert(out, checker.Equals, "foobar\n")
 
 	dockerCmd(c, "restart", cleanedContainerID)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/libnetwork/netutils"
@@ -1816,8 +1817,10 @@ func (s *DockerSuite) TestRunWriteHostsFileAndNotCommit(c *check.C) {
 }
 
 func eqToBaseDiff(out string, c *check.C) bool {
-	out1, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
-	cID := strings.TrimSpace(out1)
+	name := "eqToBaseDiff" + stringutils.GenerateRandomAlphaOnlyString(32)
+	dockerCmd(c, "run", "--name", name, "busybox", "echo", "hello")
+	cID, err := getIDByName(name)
+	c.Assert(err, check.IsNil)
 
 	baseDiff, _ := dockerCmd(c, "diff", cID)
 	baseArr := strings.Split(baseDiff, "\n")

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -13,11 +13,10 @@ import (
 func (s *DockerSuite) TestStartAttachReturnsOnError(c *check.C) {
 	// Windows does not support link
 	testRequires(c, DaemonIsLinux)
-	dockerCmd(c, "run", "-d", "--name", "test", "busybox")
-	dockerCmd(c, "wait", "test")
+	dockerCmd(c, "run", "--name", "test", "busybox")
 
 	// Expect this to fail because the above container is stopped, this is what we want
-	out, _, err := dockerCmdWithError("run", "-d", "--name", "test2", "--link", "test:test", "busybox")
+	out, _, err := dockerCmdWithError("run", "--name", "test2", "--link", "test:test", "busybox")
 	// err shouldn't be nil because container test2 try to link to stopped container
 	c.Assert(err, checker.NotNil, check.Commentf("out: %s", out))
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -474,7 +474,6 @@ func (d *Daemon) waitRun(contID string) error {
 }
 
 func (d *Daemon) getBaseDeviceSize(c *check.C) int64 {
-
 	infoCmdOutput, _, err := runCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "-H", d.sock(), "info"),
 		exec.Command("grep", "Base Device Size"),
@@ -522,6 +521,23 @@ func (d *Daemon) CmdWithArgs(daemonArgs []string, name string, arg ...string) (s
 // LogFileName returns the path the the daemon's log file
 func (d *Daemon) LogFileName() string {
 	return d.logFile.Name()
+}
+
+func (d *Daemon) getIDByName(name string) (string, error) {
+	return d.inspectFieldWithError(name, "Id")
+}
+
+func (d *Daemon) inspectFilter(name, filter string) (string, error) {
+	format := fmt.Sprintf("{{%s}}", filter)
+	out, err := d.Cmd("inspect", "-f", format, name)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (d *Daemon) inspectFieldWithError(name, field string) (string, error) {
+	return d.inspectFilter(name, fmt.Sprintf(".%s", field))
 }
 
 func daemonHost() string {


### PR DESCRIPTION
another attempt to clean out tests that were using `-d` when it wasn't really needed - will avoid raciness hopefully

/cc @icecrime @cpuguy83 

Signed-off-by: Antonio Murdaca runcom@redhat.com
