### PR TITLE
Fixing cliconfig getDefaultConfigDir

### DIFF
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -32,7 +32,7 @@ var (
 func getDefaultConfigDir(confFile string) string {
 	confDir := filepath.Join(homedir.Get(), confFile)
 	// if the directory doesn't exist, maybe we called docker with sudo
-	if _, err := os.Stat(configDir); err != nil {
+	if _, err := os.Stat(confDir); err != nil {
 		if os.IsNotExist(err) {
 			return filepath.Join(homedir.GetWithSudoUser(), confFile)
 		}


### PR DESCRIPTION
Something felt odd when I started to work on support xdg-dirs for the cli. I think the `getDefaultConfigDir` has a small _typo_ in it. It seems it's not really checking the right folder. 🐣

/cc @runcom 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
