### PR TITLE
Add --privileged support to `docker build`

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -61,6 +61,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	flBuildArg := opts.NewListOpts(runconfigopts.ValidateEnv)
 	cmd.Var(&flBuildArg, []string{"-build-arg"}, "Set build-time variables")
 	isolation := cmd.String([]string{"-isolation"}, "", "Container isolation technology")
+	privileged := cmd.Bool([]string{"-privileged"}, false, "Build using privileged docker containers (dangerous!)")
 
 	ulimits := make(map[string]*units.Ulimit)
 	flUlimits := runconfigopts.NewUlimitOpt(&ulimits)
@@ -230,6 +231,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		Ulimits:        flUlimits.GetList(),
 		BuildArgs:      runconfigopts.ConvertKVStringsToMap(flBuildArg.GetAll()),
 		AuthConfigs:    cli.configFile.AuthConfigs,
+		Privileged:     *privileged,
 	}
 
 	response, err := cli.client.ImageBuild(context.Background(), options)

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -51,6 +51,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.CPUSetMems = r.FormValue("cpusetmems")
 	options.CgroupParent = r.FormValue("cgroupparent")
 	options.Tags = r.Form["t"]
+	options.Privileged = httputils.BoolValue(r, "privileged")
 
 	if r.Form.Get("shmsize") != "" {
 		shmSize, err := strconv.ParseInt(r.Form.Get("shmsize"), 10, 64)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -508,6 +508,7 @@ func (b *Builder) create() (string, error) {
 		Isolation: b.options.Isolation,
 		ShmSize:   b.options.ShmSize,
 		Resources: resources,
+		Privileged: b.options.Privileged,
 	}
 
 	config := *b.runConfig

--- a/vendor/src/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_build.go
@@ -74,6 +74,10 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 		query.Set("pull", "1")
 	}
 
+	if options.Privileged {
+		query.Set("privileged", "1")
+	}
+
 	if !container.Isolation.IsDefault(options.Isolation) {
 		query.Set("isolation", string(options.Isolation))
 	}

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -141,6 +141,7 @@ type ImageBuildOptions struct {
 	Ulimits        []*units.Ulimit
 	BuildArgs      map[string]string
 	AuthConfigs    map[string]AuthConfig
+	Privileged	   bool
 	Context        io.Reader
 }
 


### PR DESCRIPTION
This patch adds a `--privileged` option to `docker build`, allowing the use of advanced functionality such as manipulating mounts during docker build time,

Implementation wise it is extremely trivial as all the architecture for this functionality already existed but was not exposed.

This patch would require matching changes to the engine-api repo, only shown here as changes to the vendored dependency for simplicity (so this PR is directly buildable).

Closes #1916
