### PR TITLE
Filter mountVolumes if running with `-v /dev:foo/` without `MountFlags=slave`

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -1056,6 +1056,19 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 	return nil
 }
 
+func getMountInfo(s string) (*mount.Info, error) {
+	minfos, err := mount.GetMounts()
+	if err != nil {
+		return nil, err
+	}
+	for _, mi := range minfos {
+		if mi.Mountpoint == s {
+			return mi, nil
+		}
+	}
+	return nil, fmt.Errorf("Mount info for %s not found", s)
+}
+
 func (daemon *Daemon) mountVolumes(container *container.Container) error {
 	mounts, err := daemon.setupMounts(container)
 	if err != nil {
@@ -1063,6 +1076,20 @@ func (daemon *Daemon) mountVolumes(container *container.Container) error {
 	}
 
 	for _, m := range mounts {
+		if strings.HasPrefix(m.Source, "/dev") {
+			mi, err := getMountInfo("/")
+			if err != nil {
+				logrus.Warn(err)
+				continue
+			}
+			if !strings.HasPrefix(mi.Optional, "master:") {
+				logrus.Warnf("Cannot mount %s when / is not slave-mounted. "+
+					"Please start the daemon from systemd with \"MountFlags=slave\". "+
+					"If systemd is not available in your system, please start the daemon from unshared(1).",
+					m.Source)
+				continue
+			}
+		}
 		dest, err := container.GetResourcePath(m.Destination)
 		if err != nil {
 			return err


### PR DESCRIPTION
If `-v /dev:/foo` is given when systemd option MountFlags=slave is not set, the host-side `/dev/{pts,mqueue,shm,...}` are unexpectedly unmounted. (#20670)

This commit prohibits `-v /dev:/foo` in such a case by checking the mountinfo.

How to test:
- Start the daemon via systemd with MountFlags=slave, and verify that `docker run -it --rm -v /dev:/dev busybox` succeeds
- Start the daemon via systemd _without_ MountFlags=slave, and verify that `docker run -it --rm -v /dev:/dev busybox` fails
- Start the daemon directly, and verify that `docker run -it --rm -v /dev:/dev busybox` fails

Fix #20670
Obsolete #20712

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
