### PR TITLE
change container word spell in docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.15.md
+++ b/docs/reference/api/docker_remote_api_v1.15.md
@@ -1701,7 +1701,7 @@ Status Codes:
 -   **404** – no such exec instance
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 

--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -1663,7 +1663,7 @@ Status Codes:
 -   **404** – no such exec instance
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 

--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -1826,7 +1826,7 @@ Status Codes:
 -   **404** – no such exec instance
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1945,7 +1945,7 @@ Status Codes:
 -   **404** – no such exec instance
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -2028,7 +2028,7 @@ Status Codes:
 -   **404** – no such exec instance
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -2174,7 +2174,7 @@ Status Codes:
 -   **404** – no such exec instance
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -2331,7 +2331,7 @@ Status Codes:
 -   **409** - container is paused
 
     **Stream details**:
-    Similar to the stream behavior of `POST /container/(id)/attach` API
+    Similar to the stream behavior of `POST /containers/(id or name)/attach` API
 
 ### Exec Resize
 


### PR DESCRIPTION
Previous PRs update docker_remote_api from v1.22 to v1.23 #20557  . They missed v1.15 and v1.21. So I completed the docs.

@vdemeester @thaJeztah
