### PR TITLE
Windows CI: Turning off pkg\symlink unit testing

### DIFF
--- a/pkg/symlink/fs_unix_test.go
+++ b/pkg/symlink/fs_unix_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Licensed under the Apache License, Version 2.0; See LICENSE.APACHE
 
 package symlink
@@ -9,6 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 )
+
+// TODO Windows: This needs some serious work to port to Windows. For now,
+// turning off testing in this package.
 
 type dirOrLink struct {
 	path   string


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This turns off unit tests on Windows for pkg\symlink so that we can get closer to turning off the flag which ignores unit test failures on Windows. This particular file needs a lot of work to port to Windows.
