### PR TITLE
Windows: Add network bandwidth control

### DIFF
--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -72,6 +72,7 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 		CommonResources: execdriver.CommonResources{
 			CPUShares: c.HostConfig.CPUShares,
 		},
+		NetworkBandwidth: c.HostConfig.NetworkBandwidth,
 	}
 
 	processConfig := execdriver.ProcessConfig{

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -359,6 +359,13 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		resources.BlkioDeviceWriteIOps = []*pblkiodev.ThrottleDevice{}
 	}
 
+	// network subsystem checks and adjustments
+	if resources.NetworkBandwidth > 0 {
+		warnings = append(warnings, "%s does not support network bandwidth limiting. Bandwidth discarded.", runtime.GOOS)
+		logrus.Warnf("%s does not support network bandwidth limiting. Bandwidth discarded.", runtime.GOOS)
+		resources.NetworkBandwidth = 0
+	}
+
 	return warnings, nil
 }
 

--- a/daemon/execdriver/driver_windows.go
+++ b/daemon/execdriver/driver_windows.go
@@ -15,6 +15,7 @@ type Resources struct {
 	CommonResources
 
 	// Fields below here are platform specific
+	NetworkBandwidth int64 // Maximum network egress in bytes per second
 }
 
 // ProcessConfig is the platform specific structure that describes a process

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -89,6 +89,7 @@ type containerInit struct {
 	MappedDirectories       []mappedDir // List of mapped directories (volumes/mounts)
 	SandboxPath             string      // Location of unmounted sandbox (used for Hyper-V containers, not Windows Server containers)
 	HvPartition             bool        // True if it a Hyper-V Container
+	NetworkBandwidth        int64       // Maximum network egress in bytes per second
 }
 
 // defaultOwner is a tag passed to HCS to allow it to differentiate between
@@ -114,6 +115,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 		LayerFolderPath:         c.LayerFolder,
 		ProcessorWeight:         c.Resources.CPUShares,
 		HostName:                c.Hostname,
+		NetworkBandwidth:        c.Resources.NetworkBandwidth,
 	}
 
 	cu.HvPartition = c.HvPartition

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -294,6 +294,7 @@ Create a container
              "GroupAdd": ["newgroup"],
              "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
              "NetworkMode": "bridge",
+             "NetworkBandwidth": "8000",
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
@@ -407,6 +408,7 @@ Json Parameters:
     -   **NetworkMode** - Sets the networking mode for the container. Supported
           standard values are: `bridge`, `host`, `none`, and `container:<name|id>`. Any other value is taken
           as a custom network's name to which this container should connect to.
+    -   **NetworkBandwidth** - An integer value representing the maximum network egress in bytes per second.
     -   **Devices** - A list of devices to add to the container specified as a JSON object in the
       form
           `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
@@ -524,6 +526,7 @@ Return low-level information on the container `id`
 			"OomKillDisable": false,
 			"OomScoreAdj": 500,
 			"NetworkMode": "bridge",
+			"NetworkBandwidth": "8000",
 			"PortBindings": {},
 			"Privileged": false,
 			"ReadonlyRootfs": false,

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -81,6 +81,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		flBlkioWeight       = cmd.Uint16([]string{"-blkio-weight"}, 0, "Block IO (relative weight), between 10 and 1000")
 		flSwappiness        = cmd.Int64([]string{"-memory-swappiness"}, -1, "Tune container memory swappiness (0 to 100)")
 		flNetMode           = cmd.String([]string{"-net"}, "default", "Connect a container to a network")
+		flNetworkBandwidth  = cmd.String([]string{"-network-bandwidth"}, "", "Maximum network egress in bytes per second (Windows only)")
 		flMacAddress        = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
 		flIPv4Address       = cmd.String([]string{"-ip"}, "", "Container IPv4 address (e.g. 172.30.100.104)")
 		flIPv6Address       = cmd.String([]string{"-ip6"}, "", "Container IPv6 address (e.g. 2001:db8::33)")
@@ -197,6 +198,14 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 	var shmSize int64
 	if *flShmSize != "" {
 		shmSize, err = units.RAMInBytes(*flShmSize)
+		if err != nil {
+			return nil, nil, nil, cmd, err
+		}
+	}
+
+	var networkBandwidth int64
+	if *flNetworkBandwidth != "" {
+		networkBandwidth, err = units.RAMInBytes(*flNetworkBandwidth)
 		if err != nil {
 			return nil, nil, nil, cmd, err
 		}
@@ -343,6 +352,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		CpusetCpus:           *flCpusetCpus,
 		CpusetMems:           *flCpusetMems,
 		CPUQuota:             *flCPUQuota,
+		NetworkBandwidth:     networkBandwidth,
 		BlkioWeight:          *flBlkioWeight,
 		BlkioWeightDevice:    flBlkioWeightDevice.GetList(),
 		BlkioDeviceReadBps:   flDeviceReadBps.GetList(),

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -188,6 +188,9 @@ type Resources struct {
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
+
+	// Applicable to Windows
+	NetworkBandwidth int64 // Maximum network egress in bytes per second
 }
 
 // UpdateConfig holds the mutable attributes of a Container.


### PR DESCRIPTION
This adds network bandwidth control for Windows (Disabled for now, but enabled in TP5). Manually vendored in the engine-api changes from https://github.com/docker/engine-api/pull/118. I'll revendor correctly when all the batch of PRs are merged to engine-api.

Signed-off-by: Darren Stahl darst@microsoft.com
