### PR TITLE
Bug fix: stats --no-stream always print zero values

### DIFF
--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -75,6 +75,18 @@ func (s *DockerSuite) TestStatsAllRunningNoStream(c *check.C) {
 	if strings.Contains(out, id3) {
 		c.Fatalf("Did not expect %s in stats, got %s", id3, out)
 	}
+
+	// check output contains real data, but not all zeros
+	reg, _ := regexp.Compile("[1-9]+")
+	// split output with "\n", outLines[1] is id2's output
+	// outLines[2] is id1's output
+	outLines := strings.Split(out, "\n")
+	// check stat result of id2 contains real data
+	realData := reg.Find([]byte(outLines[1][12:]))
+	c.Assert(realData, checker.NotNil, check.Commentf("stat result are empty: %s", out))
+	// check stat result of id1 contains real data
+	realData = reg.Find([]byte(outLines[2][12:]))
+	c.Assert(realData, checker.NotNil, check.Commentf("stat result are empty: %s", out))
 }
 
 func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
@@ -93,6 +105,17 @@ func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
 	if !strings.Contains(out, id1) || !strings.Contains(out, id2) {
 		c.Fatalf("Expected stats output to contain both %s and %s, got %s", id1, id2, out)
 	}
+
+	// check output contains real data, but not all zeros
+	reg, _ := regexp.Compile("[1-9]+")
+	// split output with "\n", outLines[1] is id2's output
+	outLines := strings.Split(out, "\n")
+	// check stat result of id2 contains real data
+	realData := reg.Find([]byte(outLines[1][12:]))
+	c.Assert(realData, checker.NotNil, check.Commentf("stat result of %s is empty: %s", id2, out))
+	// check stat result of id1 contains all zero
+	realData = reg.Find([]byte(outLines[2][12:]))
+	c.Assert(realData, checker.IsNil, check.Commentf("stat result of %s should be empty : %s", id1, out))
 }
 
 func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?

`docker stats --no-stream` always print zero values.

```
$ docker stats --no-stream
CONTAINER           CPU %               MEM USAGE / LIMIT   MEM %
NET I/O             BLOCK I/O
7f4ef234ca8c        0.00%               0 B / 0 B           0.00%
0 B / 0 B           0 B / 0 B
f05bd18819aa        0.00%               0 B / 0 B           0.00%
0 B / 0 B           0 B / 0 B

```

This commit will let docker client sleep a while to get correct stat
data before print it on screen.
- How did you do it?

Let docker client sleep 1.5s before print it on screen
- How do I see it or verify it?

Run some containers, then run `docker stats --no-stream`, you'll see it.
- A picture of a cute animal (not mandatory but encouraged)

![831007](https://cloud.githubusercontent.com/assets/1203611/13522801/b0d9f052-e22c-11e5-905e-166b178d9937.jpg)

Signed-off-by: Zhang Wei zhangwei555@huawei.com
