### PR TITLE
Skip TestStatsAllNewContainersAdded on remote daemons

### DIFF
--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -97,7 +97,10 @@ func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
 
 func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {
 	// Windows does not support stats
-	testRequires(c, DaemonIsLinux)
+	// TODO: remove SameHostDaemon
+	//	The reason it was added is because, there seems to be some race that makes this test fail
+	//	for remote daemons (namely in the win2lin CI). We highly welcome contributions to fix this.
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
 
 	id := make(chan string)
 	addedChan := make(chan struct{})


### PR DESCRIPTION
This test is often failing on remote daemons. We tried many approaches
to fix it but none worked. In order to make the CI more reliable, this
will skip the test when running against a remote daemon (e.g. win2lin).

Signed-off-by: Tibor Vass tibor@docker.com
