### PR TITLE
Remove some references to "register" through login

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -42,7 +42,7 @@ var dockerCommands = []Command{
 	{"inspect", "Return low-level information on a container or image"},
 	{"kill", "Kill a running container"},
 	{"load", "Load an image from a tar archive or STDIN"},
-	{"login", "Register or log in to a Docker registry"},
+	{"login", "Log in to a Docker registry"},
 	{"logout", "Log out from a Docker registry"},
 	{"logs", "Fetch the logs of a container"},
 	{"network", "Manage Docker networks"},

--- a/man/docker-logout.1.md
+++ b/man/docker-logout.1.md
@@ -24,7 +24,7 @@ There are no available options.
     # docker logout localhost:8080
 
 # See also
-**docker-login(1)** to register or log in to a Docker registry server.
+**docker-login(1)** to log in to a Docker registry server.
 
 # HISTORY
 June 2014, Originally compiled by Daniel, Dao Quang Minh (daniel at nitrous dot io)

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -132,7 +132,7 @@ inside it)
   See **docker-load(1)** for full documentation on the **load** command.
 
 **login**
-  Register or login to a Docker Registry
+  Log in to a Docker Registry
   See **docker-login(1)** for full documentation on the **login** command.
 
 **logout**


### PR DESCRIPTION
These were left-overs from the now deprecated and removed functionality to registrer a new account through "docker login" (see https://github.com/docker/docker/pull/20565)
