### PR TITLE
Windows: Don't create working dir for Hyper-V Containers

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -188,6 +188,13 @@ func (container *Container) SetupWorkingDirectory() error {
 	if container.Config.WorkingDir == "" {
 		return nil
 	}
+
+	// If can't mount container FS at this point (eg Hyper-V Containers on
+	// Windows) bail out now with no action.
+	if !container.canMountFS() {
+		return nil
+	}
+
 	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
 
 	pth, err := container.GetResourcePath(container.Config.WorkingDir)

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -727,3 +727,9 @@ func (container *Container) TmpfsMounts() []execdriver.Mount {
 func cleanResourcePath(path string) string {
 	return filepath.Join(string(os.PathSeparator), path)
 }
+
+// canMountFS determines if the file system for the container
+// can be mounted locally. A no-op on non-Windows platforms
+func (container *Container) canMountFS() bool {
+	return true
+}

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/volume"
-	"github.com/docker/engine-api/types/container"
+	containertypes "github.com/docker/engine-api/types/container"
 )
 
 // Container holds fields specific to the Windows implementation. See
@@ -47,7 +47,7 @@ func (container *Container) TmpfsMounts() []execdriver.Mount {
 }
 
 // UpdateContainer updates configuration of a container
-func (container *Container) UpdateContainer(hostConfig *container.HostConfig) error {
+func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
 	resources := hostConfig.Resources
@@ -82,4 +82,11 @@ func cleanResourcePath(path string) string {
 		}
 	}
 	return filepath.Join(string(os.PathSeparator), path)
+}
+
+// canMountFS determines if the file system for the container
+// can be mounted locally. In the case of Windows, this is not possible
+// for Hyper-V containers during WORKDIR execution for example.
+func (container *Container) canMountFS() bool {
+	return !containertypes.Isolation.IsHyperV(container.HostConfig.Isolation)
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

For a Hyper-V container, the containers filesystem is not mounted on the host, therefore it is not possible for docker to pre-create a working directory if it doesn't exist. This moves the behaviour back to how it was before #19790 for Hyper-V containers, and has no effect on Windows Server Containers. 

@darrenstahlmsft @swernli 
