### PR TITLE
If file system does not support xattrs do not return error

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/execdriver"
@@ -131,7 +132,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			bind = setBindModeIfNull(bind)
 		}
 		if label.RelabelNeeded(bind.Mode) {
-			if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
+			if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil && err != syscall.ENOTSUP {
 				return err
 			}
 		}


### PR DESCRIPTION
Setting labels on a file system without Xattr support shouldn't
return an error

If we mount a volume into a container that does not support
Xattrs (SELinux), docker should for ENOTSUP and not return an error

We might need policy changes for these types of file systems, but
failing for label issues is a mistake.

Signed-off-by: Dan Walsh dwalsh@redhat.com
