### PR TITLE
Do not remove containers from stats list on err

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/Sirupsen/logrus"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/events"
@@ -169,19 +170,11 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 
 	for range time.Tick(500 * time.Millisecond) {
 		printHeader()
-		toRemove := []int{}
 		cStats.mu.Lock()
-		for i, s := range cStats.cs {
+		for _, s := range cStats.cs {
 			if err := s.Display(w); err != nil && !*noStream {
-				toRemove = append(toRemove, i)
+				logrus.Debugf("stats: got error for %s: %v", s.Name, err)
 			}
-		}
-		for j := len(toRemove) - 1; j >= 0; j-- {
-			i := toRemove[j]
-			cStats.cs = append(cStats.cs[:i], cStats.cs[i+1:]...)
-		}
-		if len(cStats.cs) == 0 && !showAll {
-			return nil
 		}
 		cStats.mu.Unlock()
 		w.Flush()

--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"sync"
 	"testing"
 
 	"github.com/docker/engine-api/types"
@@ -20,7 +19,6 @@ func TestDisplay(t *testing.T) {
 		BlockRead:        100 * 1024 * 1024,
 		BlockWrite:       800 * 1024 * 1024,
 		PidsCurrent:      1,
-		mu:               sync.RWMutex{},
 	}
 	var b bytes.Buffer
 	if err := c.Display(&b); err != nil {

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -120,10 +120,7 @@ func (s *DockerSuite) TestStatsAllNoStream(c *check.C) {
 
 func (s *DockerSuite) TestStatsAllNewContainersAdded(c *check.C) {
 	// Windows does not support stats
-	// TODO: remove SameHostDaemon
-	//	The reason it was added is because, there seems to be some race that makes this test fail
-	//	for remote daemons (namely in the win2lin CI). We highly welcome contributions to fix this.
-	testRequires(c, DaemonIsLinux, SameHostDaemon)
+	testRequires(c, DaemonIsLinux)
 
 	id := make(chan string)
 	addedChan := make(chan struct{})


### PR DESCRIPTION
Before this patch, containers are silently removed from the stats list
on error. This patch instead will display `--` for all fields for the
container that had the error, allowing it to recover from errors.

When containers have an error, they will see:
![image](https://cloud.githubusercontent.com/assets/799078/13443908/4e9e1358-dfd1-11e5-8ed0-5d5af203cc43.png)

Note: only the container with the error will have the `err` message, for the case of the screenshot I forced the error.
