### PR TITLE
Introduce `status/failing-ci` label

### DIFF
--- a/project/REVIEWING.md
+++ b/project/REVIEWING.md
@@ -26,6 +26,7 @@ exist on the repository should apply to issues.
 
 Special status labels:
 
+ * `status/failing-ci`: indicates that the PR in its current state fails the test suite
  * `status/needs-attention`: calls for a collective discussion during a review session
 
 ## Specialty group labels


### PR DESCRIPTION
This has proved quite useful in the past days to distinguish between CI infrastructure quirks and legitimate failures.
