### PR TITLE
Handle IPv6 entries in discovery

### DIFF
--- a/pkg/discovery/backends.go
+++ b/pkg/discovery/backends.go
@@ -89,7 +89,7 @@ func ParseAdvertise(advertise string) (string, error) {
 		return "", fmt.Errorf("couldnt find a valid ip-address in interface %s", advertise)
 	}
 
-	addr = fmt.Sprintf("%s:%s", addr, port)
+	addr = net.JoinHostPort(addr, port)
 	return addr, nil
 }
 

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -19,6 +19,11 @@ func (s *DiscoverySuite) TestNewEntry(c *check.C) {
 	c.Assert(entry.Equals(&Entry{Host: "127.0.0.1", Port: "2375"}), check.Equals, true)
 	c.Assert(entry.String(), check.Equals, "127.0.0.1:2375")
 
+	entry, err = NewEntry("[2001:db8:0:f101::2]:2375")
+	c.Assert(err, check.IsNil)
+	c.Assert(entry.Equals(&Entry{Host: "2001:db8:0:f101::2", Port: "2375"}), check.Equals, true)
+	c.Assert(entry.String(), check.Equals, "[2001:db8:0:f101::2]:2375")
+
 	_, err = NewEntry("127.0.0.1")
 	c.Assert(err, check.NotNil)
 }
@@ -50,11 +55,12 @@ func (s *DiscoverySuite) TestCreateEntries(c *check.C) {
 	c.Assert(entries, check.DeepEquals, Entries{})
 	c.Assert(err, check.IsNil)
 
-	entries, err = CreateEntries([]string{"127.0.0.1:2375", "127.0.0.2:2375", ""})
+	entries, err = CreateEntries([]string{"127.0.0.1:2375", "127.0.0.2:2375", "[2001:db8:0:f101::2]:2375", ""})
 	c.Assert(err, check.IsNil)
 	expected := Entries{
 		&Entry{Host: "127.0.0.1", Port: "2375"},
 		&Entry{Host: "127.0.0.2", Port: "2375"},
+		&Entry{Host: "2001:db8:0:f101::2", Port: "2375"},
 	}
 	c.Assert(entries.Equals(expected), check.Equals, true)
 

--- a/pkg/discovery/entry.go
+++ b/pkg/discovery/entry.go
@@ -1,9 +1,6 @@
 package discovery
 
-import (
-	"fmt"
-	"net"
-)
+import "net"
 
 // NewEntry creates a new entry.
 func NewEntry(url string) (*Entry, error) {
@@ -27,7 +24,7 @@ func (e *Entry) Equals(cmp *Entry) bool {
 
 // String returns the string form of an entry.
 func (e *Entry) String() string {
-	return fmt.Sprintf("%s:%s", e.Host, e.Port)
+	return net.JoinHostPort(e.Host, e.Port)
 }
 
 // Entries is a list of *Entry with some helpers.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

This is part of fix for [swarm issue #1906](https://github.com/docker/swarm/issues/1906). Current discovery doesn't handle IPv6 entry properly. Entry `[2001:db8:0:f101::2]:4444` submitted to discovery would be returned as `2001:db8:0:f101::2:4444`. This change uses `net.JoinHostPort` to deal with this format issue. Unit tests are updated. 

Signed-off-by: Dong Chen dongluo.chen@docker.com
