### PR TITLE
Windows: Default to npipe transport

### DIFF
--- a/opts/hosts_windows.go
+++ b/opts/hosts_windows.go
@@ -3,4 +3,4 @@
 package opts
 
 // DefaultHost constant defines the default host string used by docker on Windows
-var DefaultHost = DefaultTCPHost
+var DefaultHost = "npipe://" + DefaultNamedPipe


### PR DESCRIPTION
This changes the default transport for Windows from unencrypted TCP to
npipe. This is similar to how Linux runs with the unix socket transport by
default.

Signed-off-by: John Starks jostarks@microsoft.com
