### PR TITLE
Fix ShouldRestart for on-failure handle

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -291,13 +291,14 @@ func (daemon *Daemon) restore() error {
 		wg.Add(1)
 		go func(c *container.Container) {
 			defer wg.Done()
+			rm := c.RestartManager(false)
 			if c.IsRunning() || c.IsPaused() {
 				// Fix activityCount such that graph mounts can be unmounted later
 				if err := daemon.layerStore.ReinitRWLayer(c.RWLayer); err != nil {
 					logrus.Errorf("Failed to ReinitRWLayer for %s due to %s", c.ID, err)
 					return
 				}
-				if err := daemon.containerd.Restore(c.ID, libcontainerd.WithRestartManager(c.RestartManager(true))); err != nil {
+				if err := daemon.containerd.Restore(c.ID, libcontainerd.WithRestartManager(rm)); err != nil {
 					logrus.Errorf("Failed to restore with containerd: %q", err)
 					return
 				}

--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -118,7 +118,7 @@ func (ctr *container) handleEvent(e *containerd.Event) error {
 			st.State = StateExitProcess
 		}
 		if st.State == StateExit && ctr.restartManager != nil {
-			restart, wait, err := ctr.restartManager.ShouldRestart(e.Status)
+			restart, wait, err := ctr.restartManager.ShouldRestart(e.Status, false)
 			if err != nil {
 				logrus.Error(err)
 			} else if restart {

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -173,7 +173,7 @@ func (ctr *container) waitExit(pid uint32, processFriendlyName string, isFirstPr
 		defer ctr.client.unlock(ctr.containerID)
 
 		if si.State == StateExit && ctr.restartManager != nil {
-			restart, wait, err := ctr.restartManager.ShouldRestart(uint32(exitCode))
+			restart, wait, err := ctr.restartManager.ShouldRestart(uint32(exitCode), false)
 			if err != nil {
 				logrus.Error(err)
 			} else if restart {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Currently if you restart docker daemon, all the containers with restart
policy `on-failure` regardless of its `RestartCount` will be started, this
will make daemon cost more extra time for restart.

This commit will stop these containers to do unnecessary start on
daemon's restart.

How to reproduce:
1. start a container with restart policy `on-failure:3`
`$docker run -tid --restart on-failure:3 busybox sh -c "sleep 1; exit 127"`
2. wait it to fail and restart 3 times, make sure it stops and `docker ps` can't see it.
3. Restart docker daemon.
4. (DO THIS QUICKLY) `docker ps` shows that the stopped container is started, and fails, and restart 3 times again. 

This is unnecessary because it already failed 3 times last time daemon is running, and starting this container will apparently lower the restart speed of daemon.

---

_Edit_: make some small refactor
Merge `Container.ShouldRestart()` and `containerMonitor.shouldRestart()`, so
they can share same logic. Besides that, some duplicated fields of
containerMonitor are removed.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
