### PR TITLE
Eliminate redundant parsing of mountinfo

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -468,7 +468,11 @@ func (a *Driver) unmount(m *data) error {
 }
 
 func (a *Driver) mounted(m *data) (bool, error) {
-	return mountpk.Mounted(m.path)
+	var buf syscall.Statfs_t
+	if err := syscall.Statfs(m.path, &buf); err != nil {
+		return false, nil
+	}
+	return graphdriver.FsMagic(buf.Type) == graphdriver.FsMagicAufs, nil
 }
 
 // Cleanup aufs and unmount all mountpoints


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Fixes #20851.
- What did you do?
  
  I modified [aufs.mounted()](https://github.com/docker/docker/blob/621a148da3631dd19eee724fb87cf00762aef4a3/daemon/graphdriver/aufs/aufs.go#L460) so as not to invoke [mount.Mounted()](https://github.com/docker/docker/blob/621a148da3631dd19eee724fb87cf00762aef4a3/daemon/graphdriver/aufs/aufs.go#L461).
- How did you do it?
  
  ~~This fix essentially rolls back #3271 to the [original implementation](https://github.com/docker/docker/blob/75c866d6a3aa92d5d2a4e6948fff00f90b36e872/graph/mount.go#L33-L48).~~ Thanks to the suggestions by @tonistiigi, the new implementation checks whether or not a target path is mounted by invoking `statfs()` and checking whether the path is aufs. This relies on that aufs graph driver [does not allow aufs as a backing file system](https://github.com/docker/docker/blob/00f9c2ce59c54d07f934bf48f9806b31c1e667bd/daemon/graphdriver/aufs/aufs.go#L103).
- How do I see it or verify it?
  
  I will post an updated performance number also with another pull request opencontainers/runc#608.
  
  **UPDATE:** This fix and opencontainers/runc#608 accelerate the time to run 2k busybox containers [2.1x faster](https://github.com/docker/docker/issues/20851#issuecomment-192123433).
- A picture of a cute animal (not mandatory but encouraged)
  
  Mount information :mount_fuji: (sorry, it's not an animal).

Signed-off-by: Tatsushi Inagaki e29253@jp.ibm.com
