### PR TITLE
validate log-opt when creating containers AGAIN (fixing drunkard's code)

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -282,19 +282,6 @@ func (container *Container) exposes(p nat.Port) bool {
 	return exists
 }
 
-// GetLogConfig returns the log configuration for the container.
-func (container *Container) GetLogConfig(defaultConfig containertypes.LogConfig) containertypes.LogConfig {
-	cfg := container.HostConfig.LogConfig
-	if cfg.Type != "" || len(cfg.Config) > 0 { // container has log driver configured
-		if cfg.Type == "" {
-			cfg.Type = jsonfilelog.Name
-		}
-		return cfg
-	}
-	// Use daemon's default log config for containers
-	return defaultConfig
-}
-
 // StartLogger starts a new logger driver for the container.
 func (container *Container) StartLogger(cfg containertypes.LogConfig) (logger.Logger, error) {
 	c, err := logger.GetLogDriver(cfg.Type)

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/idtools"
@@ -80,11 +79,6 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 			}
 		}
 	}()
-
-	logCfg := container.GetLogConfig(daemon.defaultLogConfig)
-	if err := logger.ValidateLogOpts(logCfg.Type, logCfg.Config); err != nil {
-		return nil, err
-	}
 
 	if err := daemon.setSecurityOptions(container, params.HostConfig); err != nil {
 		return nil, err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1472,6 +1472,11 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostCon
 		return nil, nil
 	}
 
+	logCfg := daemon.getLogConfig(hostConfig.LogConfig)
+	if err := logger.ValidateLogOpts(logCfg.Type, logCfg.Config); err != nil {
+		return nil, err
+	}
+
 	for port := range hostConfig.PortBindings {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -443,8 +443,10 @@ func (s *DockerSuite) TestCreateWithWorkdir(c *check.C) {
 
 func (s *DockerSuite) TestCreateWithInvalidLogOpts(c *check.C) {
 	name := "test-invalidate-log-opts"
-	_, _, err := dockerCmdWithError("create", "--name", name, "--log-opt", "invalid=true")
+	out, _, err := dockerCmdWithError("create", "--name", name, "--log-opt", "invalid=true", "busybox")
 	c.Assert(err, checker.NotNil)
-	out, _ := dockerCmd(c, "ps", "-a")
+	c.Assert(out, checker.Contains, "unknown log opt")
+
+	out, _ = dockerCmd(c, "ps", "-a")
 	c.Assert(out, checker.Not(checker.Contains), name)
 }


### PR DESCRIPTION
This is a followup of https://github.com/docker/docker/pull/20749
The previous fix is complete wrong and it doesn't work at all.
`container.HostConfig` is assigned by `daemon.setHostConfig`, which is called after `container.GetLogConfig` is called. But `container.GetLogConfig` depends on the `HostConfig` of the container. So in the previous PR https://github.com/docker/docker/pull/20749/files#diff-72dc1842ed7b5a92b4e98f84456a2c0cR85 always returns the  default log config of the daemon.

Moreover, the test case added in https://github.com/docker/docker/pull/20749/files#diff-4b1e56bb77ac16f2ccf956fc24cf0a82R446 didn't provide an image to the `docker run` command, which made it always fail and the subsequential test passed unexpectedly.

Oh my! I must be drunk when writing that code :innocent:  Deeply sorry for the carelessness :sweat: 

Signed-off-by: Shijiang Wei mountkin@gmail.com
