### PR TITLE
Windows CI: TestUpdateRestartPolicy flakiness

### DIFF
--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -12,7 +12,7 @@ func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "sh", "-c", "sleep 1 && false")
 	timeout := 60 * time.Second
 	if daemonPlatform == "windows" {
-		timeout = 100 * time.Second
+		timeout = 150 * time.Second
 	}
 
 	id := strings.TrimSpace(string(out))


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I've seen this test fail quite a few times now on the windowsTP4 context. Bumping up the timeout.
![img_1018](https://cloud.githubusercontent.com/assets/10522484/13468459/78631f22-e057-11e5-9571-642c5cafda8e.JPG)
