### PR TITLE
Windows CI Reliablity: TestLogsApiWithStdout

### DIFF
--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -46,7 +46,7 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 		if !strings.HasSuffix(l.out, "hello") {
 			c.Fatalf("expected log output to container 'hello', but it does not")
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(20 * time.Second):
 		c.Fatal("timeout waiting for logs to exit")
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

TestLogsApiWithStdout is another test I've seen a few windowsTP4 failures on. Bumping the timeout up to hopefully alleviate the flakiness.

![img_1270](https://cloud.githubusercontent.com/assets/10522484/13470535/763fa8e6-e061-11e5-843f-c272de191ea3.JPG)
