### PR TITLE
fixes #20648 using a coarse lock

### DIFF
--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -1,11 +1,15 @@
 package network
 
-import "github.com/docker/docker/api/server/router"
+import (
+	"github.com/docker/docker/api/server/router"
+	"sync"
+)
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
 	backend Backend
 	routes  []router.Route
+	mutex   sync.Mutex
 }
 
 // NewRouter initializes a new network router

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -80,6 +80,11 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 			fmt.Sprintf("%s is a pre-defined network and cannot be created", create.Name))
 	}
 
+	if create.CheckDuplicate { // make sure GetNetworkByName and the checkDup code run in sync
+		n.mutex.Lock()
+		defer n.mutex.Unlock()
+	}
+
 	nw, err := n.backend.GetNetworkByName(create.Name)
 	if _, ok := err.(libnetwork.ErrNoSuchNetwork); err != nil && !ok {
 		return err

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -65,14 +65,14 @@ func (s *DockerSuite) TestApiNetworkCreateCheckDuplicate(c *check.C) {
 
 	// Run multiple concurrent requests to create same network - only one should
 	// succeed
-	configOnCheck.name = "testcdnconcurrent"
+	configOnCheck.Name = "testcdnconcurrent"
 	succeeded := 0
 	mux := sync.Mutex{}
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			status, resp, err := sockRequest("POST", "/networks/create", configOnCheck)
+			status, _, err := sockRequest("POST", "/networks/create", configOnCheck)
 			mux.Lock()
 			if err == nil && status == http.StatusCreated {
 				succeeded++

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/engine-api/types"
@@ -61,6 +62,27 @@ func (s *DockerSuite) TestApiNetworkCreateCheckDuplicate(c *check.C) {
 
 	// Creating another network with same name and not CheckDuplicate must succeed
 	createNetwork(c, configNotCheck, true)
+
+	// Run multiple concurrent requests to create same network - only one should
+	// succeed
+	configOnCheck.name = "testcdnconcurrent"
+	succeeded := 0
+	mux := sync.Mutex{}
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			status, resp, err := sockRequest("POST", "/networks/create", configOnCheck)
+			mux.Lock()
+			if err == nil && status == http.StatusCreated {
+				succeeded++
+			}
+			mux.Unlock()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	c.Assert(succeeded, checker.Equals, 1)
 }
 
 func (s *DockerSuite) TestApiNetworkFilter(c *check.C) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  this fixes #20648, 
- How did you do it?
  I added a mutex at the api/network router level, synching together the check-duplicate and create-network sections. This is activated IFF the checkDuplicate flag is turned on.
- How do I see it or verify it?
  `docker network create xyz & docker network create xyz` - creates only one `xyz` network
  I also added to the integration testing , extended the existing `TestApiNetworkCreateCheckDuplicate`
- A picture of a cute animal (not mandatory but encouraged)

```
  __      _
o'')}____//
 `_/      )
 (_(_/-(_/
```
