### PR TITLE
fixes #20648 using a fine grained lock

### DIFF
--- a/api/server/router/network/name_locker.go
+++ b/api/server/router/network/name_locker.go
@@ -15,6 +15,15 @@ func (n *nameLocker) init() {
 	}
 }
 
+// Each goroutine that reaches this function races to create a named entry in
+// the protected map. The first one per name to succeed will:
+// 1. create the named entry
+// 2. create a channel bound to this entry
+// 3. continue to exit the function and do its thing
+//
+// The other (per name) will wait on the channel, until the first goroutine
+// calls unlock (which removes the named entry and closes the channel, releasing
+// all). They will now race to be the next to recreate the entry/channel
 func (n *nameLocker) lock(name string) chan bool {
 	acquired := false
 	for !acquired {
@@ -31,6 +40,8 @@ func (n *nameLocker) lock(name string) chan bool {
 	return n.muxMap[name]
 }
 
+// the goroutine that reaches unlock makes sure that the entry is removed, only
+// then releaseing the rest that wait on this channel
 func (n *nameLocker) unlock(name string, c chan bool) {
 	n.mutex.Lock()
 	if n.muxMap[name] != nil {

--- a/api/server/router/network/name_locker.go
+++ b/api/server/router/network/name_locker.go
@@ -1,0 +1,41 @@
+package network
+
+import "sync"
+
+type nameLocker struct {
+	mutex  sync.Mutex
+	muxMap map[string]chan bool
+}
+
+func (n *nameLocker) init() {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	if n.muxMap == nil {
+		n.muxMap = make(map[string]chan bool)
+	}
+}
+
+func (n *nameLocker) lock(name string) chan bool {
+	acquired := false
+	for !acquired {
+		n.mutex.Lock()
+		if n.muxMap[name] == nil {
+			n.muxMap[name] = make(chan bool)
+			acquired = true
+		}
+		n.mutex.Unlock()
+		if !acquired {
+			_ = <-n.muxMap[name]
+		}
+	}
+	return n.muxMap[name]
+}
+
+func (n *nameLocker) unlock(name string, c chan bool) {
+	n.mutex.Lock()
+	if n.muxMap[name] != nil {
+		delete(n.muxMap, name)
+	}
+	n.mutex.Unlock()
+	close(c)
+}

--- a/api/server/router/network/name_locker_test.go
+++ b/api/server/router/network/name_locker_test.go
@@ -1,0 +1,38 @@
+package network
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNameLocker(t *testing.T) {
+	wg := sync.WaitGroup{}
+	nl := &nameLocker{}
+	nl.init()
+	names := []string{"testnetwork1", "testnetwork2", "testnetwork3"}
+	counts := make(map[string]int)
+	for _, name := range names {
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func(name string) {
+				defer wg.Done()
+				c := nl.lock(name)
+				defer nl.unlock(name, c)
+				time.Sleep(100 * time.Millisecond)
+				counts[name]++
+
+			}(name)
+		}
+	}
+
+	wg.Wait()
+	if len(nl.muxMap) > 0 {
+		t.Fatal("Leak in named lock map")
+	}
+	for _, val := range counts {
+		if val != 50 {
+			t.Fatal("wrong count of succesful locks")
+		}
+	}
+}

--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -1,11 +1,15 @@
 package network
 
-import "github.com/docker/docker/api/server/router"
+import (
+	"github.com/docker/docker/api/server/router"
+	"sync"
+)
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
 	backend Backend
 	routes  []router.Route
+	mutex   sync.Mutex
 }
 
 // NewRouter initializes a new network router

--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -1,15 +1,12 @@
 package network
 
-import (
-	"github.com/docker/docker/api/server/router"
-	"sync"
-)
+import "github.com/docker/docker/api/server/router"
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
 	backend Backend
 	routes  []router.Route
-	mutex   sync.Mutex
+	locks   nameLocker
 }
 
 // NewRouter initializes a new network router
@@ -18,6 +15,7 @@ func NewRouter(b Backend) router.Router {
 		backend: b,
 	}
 	r.initRoutes()
+	r.locks.init()
 	return r
 }
 

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -81,8 +81,8 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 	}
 
 	if create.CheckDuplicate { // make sure GetNetworkByName and the checkDup code run in sync
-		n.mutex.Lock()
-		defer n.mutex.Unlock()
+		c := n.locks.lock(create.Name)
+		defer n.locks.unlock(create.Name, c)
 	}
 
 	nw, err := n.backend.GetNetworkByName(create.Name)

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -80,6 +80,11 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 			fmt.Sprintf("%s is a pre-defined network and cannot be created", create.Name))
 	}
 
+	if create.CheckDuplicate { // make sure GetNetworkByName and the checkDup code run in sync
+		n.mutex.Lock()
+		defer n.mutex.Unlock()
+	}
+
 	nw, err := n.backend.GetNetworkByName(create.Name)
 	if _, ok := err.(libnetwork.ErrNoSuchNetwork); err != nil && !ok {
 		return err

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -65,14 +65,14 @@ func (s *DockerSuite) TestApiNetworkCreateCheckDuplicate(c *check.C) {
 
 	// Run multiple concurrent requests to create same network - only one should
 	// succeed
-	configOnCheck.name = "testcdnconcurrent"
+	configOnCheck.Name = "testcdnconcurrent"
 	succeeded := 0
 	mux := sync.Mutex{}
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			status, resp, err := sockRequest("POST", "/networks/create", configOnCheck)
+			status, _, err := sockRequest("POST", "/networks/create", configOnCheck)
 			mux.Lock()
 			if err == nil && status == http.StatusCreated {
 				succeeded++

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/engine-api/types"
@@ -61,6 +62,27 @@ func (s *DockerSuite) TestApiNetworkCreateCheckDuplicate(c *check.C) {
 
 	// Creating another network with same name and not CheckDuplicate must succeed
 	createNetwork(c, configNotCheck, true)
+
+	// Run multiple concurrent requests to create same network - only one should
+	// succeed
+	configOnCheck.name = "testcdnconcurrent"
+	succeeded := 0
+	mux := sync.Mutex{}
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			status, resp, err := sockRequest("POST", "/networks/create", configOnCheck)
+			mux.Lock()
+			if err == nil && status == http.StatusCreated {
+				succeeded++
+			}
+			mux.Unlock()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	c.Assert(succeeded, checker.Equals, 1)
 }
 
 func (s *DockerSuite) TestApiNetworkFilter(c *check.C) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  this fixes #20648
- How did you do it?
  I added a data structure that holds temoprary named locks at the api/network router level, synching together the check-duplicate and create-network sections. This is activated IFF the checkDuplicate flag is turned on, and ONLY locks between calls to create a network with the same name (so concurrent calls with different names do not wait).

This is a twin to the simpler pull request I've made https://github.com/docker/docker/pull/20877, you can choose whatever looks better
- How do I see it or verify it?
  `docker network create xyz & docker network create xyz` - creates only one `xyz` network
  I also added to the integration testing , extended the existing `TestApiNetworkCreateCheckDuplicate`, and a unit test to the data structure.
- A picture of a cute animal (not mandatory but encouraged)

```
  ^~^  ,
 ('Y') )
 /   \/ 
(\|||/) hjw
```
