### PR TITLE
Optimize slow bottleneck test of DockerSuite.TestBuildHistory.

### DIFF
--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -18,33 +18,33 @@ func (s *DockerSuite) TestBuildHistory(c *check.C) {
 	// Removing it from Windows CI for now, but this will be revisited in the
 	// TP5 timeframe when perf is better.
 	name := "testbuildhistory"
-	_, err := buildImage(name, `FROM busybox
-RUN echo "A"
-RUN echo "B"
-RUN echo "C"
-RUN echo "D"
-RUN echo "E"
-RUN echo "F"
-RUN echo "G"
-RUN echo "H"
-RUN echo "I"
-RUN echo "J"
-RUN echo "K"
-RUN echo "L"
-RUN echo "M"
-RUN echo "N"
-RUN echo "O"
-RUN echo "P"
-RUN echo "Q"
-RUN echo "R"
-RUN echo "S"
-RUN echo "T"
-RUN echo "U"
-RUN echo "V"
-RUN echo "W"
-RUN echo "X"
-RUN echo "Y"
-RUN echo "Z"`,
+	_, err := buildImage(name, `FROM `+minimalBaseImage()+`
+LABEL label.A="A"
+LABEL label.B="B"
+LABEL label.C="C"
+LABEL label.D="D"
+LABEL label.E="E"
+LABEL label.F="F"
+LABEL label.G="G"
+LABEL label.H="H"
+LABEL label.I="I"
+LABEL label.J="J"
+LABEL label.K="K"
+LABEL label.L="L"
+LABEL label.M="M"
+LABEL label.N="N"
+LABEL label.O="O"
+LABEL label.P="P"
+LABEL label.Q="Q"
+LABEL label.R="R"
+LABEL label.S="S"
+LABEL label.T="T"
+LABEL label.U="U"
+LABEL label.V="V"
+LABEL label.W="W"
+LABEL label.X="X"
+LABEL label.Y="Y"
+LABEL label.Z="Z"`,
 		true)
 
 	c.Assert(err, checker.IsNil)
@@ -54,7 +54,7 @@ RUN echo "Z"`,
 	expectedValues := [26]string{"Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"}
 
 	for i := 0; i < 26; i++ {
-		echoValue := fmt.Sprintf("echo \"%s\"", expectedValues[i])
+		echoValue := fmt.Sprintf("LABEL label.%s=%s", expectedValues[i], expectedValues[i])
 		actualValue := actualValues[i]
 		c.Assert(actualValue, checker.Contains, echoValue)
 	}


### PR DESCRIPTION
This PR fix the DockerSuite.TestBuildHistory test in #19425.
It changes the base image from busybox into 'minimalBaseImage()'
and changes the RUN in Dockerfile into LABEL, which greatly
reduces the executation time.
Since the test (DockerSuite.TestBuildHistory) is really about
testing docker history, not about RUN in Dockerfile, the
purpose of the test is not altered.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
