### PR TITLE
Add authentication plugins to the docker daemon

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -28,6 +28,12 @@ func NewBadRequestError(err error) error {
 	return NewErrorWithStatusCode(err, http.StatusBadRequest)
 }
 
+// NewUnauthorizedError creates a new API error
+// that has the 401 HTTP status code associated to it.
+func NewUnauthorizedError(err error) error {
+	return NewErrorWithStatusCode(err, http.StatusUnauthorized)
+}
+
 // NewRequestForbiddenError creates a new API error
 // that has the 403 HTTP status code associated to it.
 func NewRequestForbiddenError(err error) error {

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -39,6 +39,7 @@ type CommonOptions struct {
 	TLSVerify  bool
 	TLSOptions *tlsconfig.Options
 	TrustKey   string
+	AuthnOpts  map[string]string
 }
 
 // NewCommonOptions returns a new CommonOptions
@@ -67,6 +68,9 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 
 	hostOpt := opts.NewNamedListOptsRef("hosts", &commonOpts.Hosts, opts.ValidateHost)
 	flags.VarP(hostOpt, "host", "H", "Daemon socket(s) to connect to")
+
+	commonOpts.AuthnOpts = make(map[string]string)
+	flags.Var(opts.NewMapOpts(commonOpts.AuthnOpts, nil), "authn-opt", "Authentication options to use")
 }
 
 // SetDefaultOptions sets default values for options after flag parsing is

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -155,6 +155,7 @@ func (config *Config) InstallCommonFlags(flags *pflag.FlagSet) {
 	config.ServiceOptions.InstallCliFlags(flags)
 
 	flags.Var(opts.NewNamedListOptsRef("storage-opts", &config.GraphOptions, nil), "storage-opt", "Storage driver options")
+	config.AuthorizationPlugins = []string{}
 	flags.Var(opts.NewNamedListOptsRef("authorization-plugins", &config.AuthorizationPlugins, nil), "authorization-plugin", "Authorization plugins to load")
 	flags.Var(opts.NewNamedListOptsRef("exec-opts", &config.ExecOptions, nil), "exec-opt", "Runtime execution options")
 	flags.StringVarP(&config.Pidfile, "pidfile", "p", defaultPidFile, "Path to use for daemon PID file")

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -98,7 +98,9 @@ type CommonConfig struct {
 
 	// LiveRestoreEnabled determines whether we should keep containers
 	// alive upon daemon shutdown/start
-	LiveRestoreEnabled bool `json:"live-restore,omitempty"`
+	LiveRestoreEnabled    bool              `json:"live-restore,omitempty"`
+	RequireAuthentication bool              `json:"require-authentication,omitempty"`
+	AuthenticationOptions map[string]string `json:"-"`
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
 	// multihost networking (to store networks and endpoints information) and by the node discovery
@@ -177,6 +179,7 @@ func (config *Config) InstallCommonFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", defaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
 
 	flags.StringVar(&config.SwarmDefaultAdvertiseAddr, "swarm-default-advertise-addr", "", "Set default address or interface for swarm advertised address")
+	flags.BoolVar(&config.RequireAuthentication, "authn", false, "Require clients to authenticate")
 
 	config.MaxConcurrentDownloads = &maxConcurrentDownloads
 	config.MaxConcurrentUploads = &maxConcurrentUploads

--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -27,8 +27,8 @@ example, a [volume plugin](plugins_volume.md) might enable Docker
 volumes to persist across multiple Docker hosts and a
 [network plugin](plugins_network.md) might provide network plumbing.
 
-Currently Docker supports authorization, volume and network driver plugins. In the future it
-will support additional plugin types.
+Currently Docker supports authorization, volume, network driver, and
+authentication plugins. In the future it will support additional plugin types.
 
 ## Installing a plugin
 

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -174,6 +174,7 @@ After activation, the plugin will then be sent events from this subsystem.
 
 Possible values are:
 
+* [`Authentication`](plugins_authentication.md)
 * [`authz`](plugins_authorization.md)
 * [`NetworkDriver`](plugins_network.md)
 * [`VolumeDriver`](plugins_volume.md)

--- a/docs/extend/plugins_authentication.md
+++ b/docs/extend/plugins_authentication.md
@@ -1,0 +1,110 @@
+<!--[metadata]>
++++
+title = "Authentication plugins"
+description = "How to authenticate clients with external authentication plugins"
+keywords = ["Examples, Usage, authn, docker, plugin, api"]
+[menu.main]
+parent = "mn_extend"
++++
+<![end-metadata]-->
+
+# Write an authentication plugin
+
+Docker authentication plugins enable Docker daemons to authenticate clients
+using data included in the client HTTP request.  See the [plugin
+documentation](plugins.md) for information about implementing plugins that is
+not specific to authentication plugins.
+
+# Command-line changes
+
+An authentication plugin is enabled by using the `--authn` flag and the
+`--authn-opt plugins` option with the `dockerd` command.
+
+    $ dockerd --authn --authn-opt plugins=htpasswd
+
+# Authentication protocol
+
+If a plugin registers itself as an `Authentication` plugin when activated, then
+it is expected to provide `Authentication.SetOptions` and
+`Authentication.Authenticate` handlers.
+
+### /Authentication.SetOptions
+
+**Request**:
+```
+{
+    "Options": {}
+}
+```
+#### The `Options` map contains the authentication options which were passed
+to the daemon at startup-time.
+
+**Response**:
+```
+{
+}
+```
+
+#### Implementation
+
+Authentication options which were provided to the daemon will be passed to the
+plugin using this endpoint.  Plugins which implement the "Basic" authentication
+scheme should take note of the "realm" option, if one is set.
+
+### /Authentication.Authenticate
+
+**Request**:
+```
+{
+    "Method": "GET"/"POST",
+    "URL": "",
+    "Host": "",
+    "Header": {},
+    "Certificate": ""
+}
+```
+#### The `Method` string is taken from the client request.
+#### The `URL` string is taken from the client request.
+#### The `Host` string is taken from the client request.
+#### The `Header` map contains arrays of header values indexed by their names,
+taken from the request as received by the daemon.
+#### The `Certificate` string is the client's TLS certificate, if one was
+supplied, in binary form, base64-encoded.
+
+**Response**:
+```
+{
+    "AuthedUser": {},
+    "Header": {}
+}
+```
+If authentication succeeded, the `AuthedUser` map should contain at least these items:
+#### Name: a string naming the client.  Can be empty if a UID is set.
+#### HaveUID: a boolean indicating whether or not a `UID` value is present.
+#### UID: an optional unsigned 32-bit number containing the UID of the client.
+#### Groups: an optional array of names of groups of which the client is a member.
+#### Scheme: a string naming the HTTP authentication scheme.  If not set, the
+name of the plugin will be used, which is probably not what you want.
+
+If authentication succeeded, headers returned by the succeeding plugin (and
+only that plugin) will be included in the response which is sent to the client.
+
+If authentication failed, headers returned by all plugins will be included in
+the response which is sent to the client.
+
+#### Implementation
+
+The plugin should first check if the client request included an `Authorization`
+header which matches a scheme that it implements.  If `Authorization` headers
+are present, but for a different scheme, the plugin should simply return an
+empty response.
+
+If a suitable `Authorization` header is present, the plugin should attempt to
+use it to authenticate the user.
+
+If no `Authorization` header is present, the plugin can attempt to authenticate
+the client without it.
+
+If authentication succeeds, the plugin should populate the `AuthedUser` field
+in its response.  If not, it may provide a `WWW-Authenticate` header in the
+`Header` field to be sent to the client along with a 401 response.

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -21,6 +21,8 @@ Options:
 
       --add-runtime value                     Register an additional OCI compatible runtime (default [])
       --api-cors-header string                Set CORS headers in the remote API
+      --authn                                 Require clients to authenticate (default false)
+      --authn-opt value                       Set authentication options (default [])
       --authorization-plugin value            Authorization plugins to load (default [])
       --bip string                            Specify network bridge IP
   -b, --bridge string                         Attach containers to a network bridge
@@ -1040,6 +1042,29 @@ Linux kernel has restrictions based on internal knowledge that this is a user na
 process. The most notable restriction that we are aware of at this time is the
 inability to use `mknod`. Permission will be denied for device creation even as
 container `root` inside a user namespace.
+
+## Authentication options
+
+Particular authentication schemes can be configured with options specified with
+`--authn-opt` flags.
+
+Here is the list of recognized authentication options:
+
+*  `plugins`
+
+In addition to authentication schemes implemented in and offered by the daemon,
+call the named plugin or plugins to produce challenges and check client
+responses in order to authenticate clients.
+
+Example use: `docker daemon --authn --authn-opt plugins=sss`
+
+*  `realm`
+
+When plugins offer HTTP authentication using the `Basic` scheme, they should
+use the specified name as the name of the authentication "realm".  The default
+is `localhost`.
+
+Example use: `docker daemon --authn --authn-opt realm=example.com`
 
 ## Miscellaneous options
 

--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -230,7 +230,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 			if err != nil {
 				continue
 			}
-			if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 				d.c.Logf("[%s] received status != 200 OK: %s", d.id, resp.Status)
 			}
 			d.c.Logf("[%s] daemon started", d.id)

--- a/integration-cli/docker_cli_authentication_test.go
+++ b/integration-cli/docker_cli_authentication_test.go
@@ -1,0 +1,539 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/pkg/authentication"
+	"github.com/docker/docker/pkg/authorization"
+	"github.com/docker/docker/pkg/integration/cmd"
+	"github.com/docker/docker/pkg/plugins"
+	"github.com/go-check/check"
+)
+
+type DockerAuthnSuite struct {
+	ds                              *DockerDaemonSuite
+	daemonAddr                      string
+	basic, bearer, proxy, authz     *httptest.Server
+	user, pass                      string
+	goodtoken, badtoken, othertoken string
+	authzTokens                     map[string]string
+	proxyHeaderName                 string
+	proxyHeaderNameOption           string
+	options                         map[string]string
+}
+
+func (s *DockerAuthnSuite) SetUpSuite(c *check.C) {
+	testRequires(c, UnixCli, SameHostDaemon)
+
+	mux := http.NewServeMux()
+	s.basic = httptest.NewServer(mux)
+	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		json.NewEncoder(w).Encode(plugins.Manifest{Implements: []string{authentication.PluginImplements}})
+	})
+	mux.HandleFunc("/"+authentication.AuthenticationRequestName, s.AuthenticateBasic)
+	mux.HandleFunc("/"+authentication.SetOptionsRequestName, s.SetOptions)
+
+	mux = http.NewServeMux()
+	s.bearer = httptest.NewServer(mux)
+	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		json.NewEncoder(w).Encode(plugins.Manifest{Implements: []string{authentication.PluginImplements}})
+	})
+	mux.HandleFunc("/"+authentication.AuthenticationRequestName, s.AuthenticateBearer)
+	mux.HandleFunc("/"+authentication.SetOptionsRequestName, s.SetOptions)
+
+	mux = http.NewServeMux()
+	s.proxy = httptest.NewServer(mux)
+	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		json.NewEncoder(w).Encode(plugins.Manifest{Implements: []string{authentication.PluginImplements}})
+	})
+	mux.HandleFunc("/"+authentication.AuthenticationRequestName, s.AuthenticateProxy)
+	mux.HandleFunc("/"+authentication.SetOptionsRequestName, s.SetOptions)
+
+	mux = http.NewServeMux()
+	s.authz = httptest.NewServer(mux)
+	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		json.NewEncoder(w).Encode(plugins.Manifest{Implements: []string{authorization.AuthZApiImplements}})
+	})
+	mux.HandleFunc("/AuthZPlugin.AuthZReq", s.AuthzRequest)
+	mux.HandleFunc("/AuthZPlugin.AuthZRes", s.AuthzResponse)
+
+	if err := os.MkdirAll("/etc/docker/plugins", 0755); err != nil {
+		c.Fatal(err)
+	}
+	if err := ioutil.WriteFile("/etc/docker/plugins/test-basic-authn-plugin.spec", []byte(s.basic.URL), 0644); err != nil {
+		c.Fatal(err)
+	}
+	if err := ioutil.WriteFile("/etc/docker/plugins/test-bearer-authn-plugin.spec", []byte(s.bearer.URL), 0644); err != nil {
+		c.Fatal(err)
+	}
+	if err := ioutil.WriteFile("/etc/docker/plugins/test-proxy-authn-plugin.spec", []byte(s.proxy.URL), 0644); err != nil {
+		c.Fatal(err)
+	}
+	if err := ioutil.WriteFile("/etc/docker/plugins/test-authz-plugin.spec", []byte(s.authz.URL), 0644); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerAuthnSuite) TearDownSuite(c *check.C) {
+	os.Remove("/etc/docker/plugins/test-basic-authn-plugin.spec")
+	os.Remove("/etc/docker/plugins/test-bearer-authn-plugin.spec")
+	os.Remove("/etc/docker/plugins/test-proxy-authn-plugin.spec")
+	os.Remove("/etc/docker/plugins/test-authz-plugin.spec")
+	if s.basic != nil {
+		s.basic.Close()
+	}
+	if s.bearer != nil {
+		s.bearer.Close()
+	}
+	if s.proxy != nil {
+		s.proxy.Close()
+	}
+	if s.authz != nil {
+		s.authz.Close()
+	}
+	if err := os.RemoveAll("/etc/docker/plugins"); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerAuthnSuite) SetUpTest(c *check.C) {
+	s.ds.SetUpTest(c)
+}
+
+func (s *DockerAuthnSuite) TearDownTest(c *check.C) {
+	s.ds.TearDownTest(c)
+}
+
+func (s *DockerAuthnSuite) SetOptions(w http.ResponseWriter, r *http.Request) {
+	req := authentication.AuthnPluginSetOptionsRequest{Options: make(map[string]string)}
+	resp := authentication.AuthnPluginSetOptionsResponse{}
+	w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		s.ds.d.c.Fatalf("Error parsing Authentication.SetOptions request from docker daemon: %v", err)
+		return
+	}
+	s.options = req.Options
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *DockerAuthnSuite) AuthenticateBasic(w http.ResponseWriter, r *http.Request) {
+	req := authentication.AuthnPluginAuthenticateRequest{}
+	resp := authentication.AuthnPluginAuthenticateResponse{Header: make(http.Header)}
+	w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		s.ds.d.c.Fatalf("Error parsing Authentication.Authenticate request from docker daemon: %v", err)
+		return
+	}
+	if req.Method == "" {
+		s.ds.d.c.Fatalf("Error parsing Authentication.Authenticate request from docker daemon: %#v is missing required data", req)
+		return
+	}
+	if req.URL == "" {
+		s.ds.d.c.Fatalf("Error parsing Authentication.Authenticate request from docker daemon: %#v is missing URL fields", req)
+		return
+	}
+	if len(req.Header) < 1 {
+		s.ds.d.c.Fatalf("Error parsing Authentication.Authenticate request from docker daemon: %#v is missing header fields", req)
+		return
+	}
+	realm, ok := s.options["realm"]
+	if !ok {
+		realm = "localhost"
+	}
+	headers := req.Header[http.CanonicalHeaderKey("Authorization")]
+	if len(headers) == 0 {
+		resp.Header.Add("WWW-Authenticate", "Basic realm=\""+realm+"\"")
+	} else {
+		for _, h := range headers {
+			fields := strings.SplitN(strings.Replace(h, "\t", " ", -1), " ", 2)
+			if len(fields) < 2 || strings.ToLower(fields[0]) != "basic" {
+				continue
+			}
+			token, err := base64.StdEncoding.DecodeString(fields[1])
+			if err != nil {
+				continue
+			}
+			basic := strings.SplitN(string(token), ":", 2)
+			if len(basic) < 2 {
+				continue
+			}
+			if basic[0] == s.user && basic[1] == s.pass {
+				resp.AuthedUser.Scheme = "Basic"
+				resp.AuthedUser.Name = s.user
+				break
+			}
+		}
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *DockerAuthnSuite) AuthenticateBearer(w http.ResponseWriter, r *http.Request) {
+	req := authentication.AuthnPluginAuthenticateRequest{}
+	resp := authentication.AuthnPluginAuthenticateResponse{Header: make(http.Header)}
+	w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		s.ds.d.c.Fatalf("Error parsing Authentication.Authenticate request from docker daemon: %v", err)
+		return
+	}
+	headers := req.Header[http.CanonicalHeaderKey("Authorization")]
+	if len(headers) == 0 {
+		resp.Header.Add("WWW-Authenticate", "Bearer")
+	} else {
+		for _, h := range headers {
+			fields := strings.SplitN(strings.Replace(h, "\t", " ", -1), " ", 2)
+			if len(fields) < 2 || strings.ToLower(fields[0]) != "bearer" {
+				continue
+			}
+			user, ok := s.authzTokens[fields[1]]
+			if ok {
+				resp.AuthedUser.Scheme = "Bearer"
+				resp.AuthedUser.Name = user
+			}
+		}
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *DockerAuthnSuite) AuthenticateProxy(w http.ResponseWriter, r *http.Request) {
+	req := authentication.AuthnPluginAuthenticateRequest{}
+	resp := authentication.AuthnPluginAuthenticateResponse{Header: make(http.Header)}
+	w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		s.ds.d.c.Fatalf("Error parsing Authentication.Authenticate request from docker daemon: %v", err)
+		return
+	}
+	proxyHeaderName := s.options[s.proxyHeaderNameOption]
+	headers := req.Header[http.CanonicalHeaderKey(proxyHeaderName)]
+	if len(headers) > 0 {
+		resp.AuthedUser.Scheme = "Proxy"
+		resp.AuthedUser.Name = headers[0]
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *DockerAuthnSuite) AuthzRequest(w http.ResponseWriter, r *http.Request) {
+	req := authorization.Request{}
+	resp := authorization.Response{}
+	w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		s.ds.d.c.Fatalf("Error parsing AuthZ.Req request from docker daemon: %v", err)
+		return
+	}
+	resp.Allow = req.User == s.user
+	if !resp.Allow {
+		if req.User != "" {
+			resp.Msg = "Authorization denied: not the user we were looking for."
+		} else {
+			resp.Msg = "Authorization denied: client not authenticated."
+		}
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *DockerAuthnSuite) AuthzResponse(w http.ResponseWriter, r *http.Request) {
+	req := authorization.Request{}
+	resp := authorization.Response{}
+	w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		s.ds.d.c.Fatalf("Error parsing AuthZ.Rep request from docker daemon: %v", err)
+		return
+	}
+	resp.Allow = req.User == s.user
+	if !resp.Allow {
+		if req.User != "" {
+			resp.Msg = "Authorization denied: not the user we were looking for."
+		} else {
+			resp.Msg = "Authorization denied: client not authenticated."
+		}
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func runCurlWithOutput(args ...string) (stdout, stderr string, exitCode int, err error) {
+	result := cmd.RunCommand("curl", args...)
+	return result.Stdout(), result.Stderr(), result.ExitCode, result.Error
+}
+
+func (s *DockerAuthnSuite) TestNoneAuthnBad(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-basic-authn-plugin,test-bearer-authn-plugin",
+		"--authn-opt", "realm=example.com",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-i")
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "Authenticate: Basic"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+	c.Assert(strings.Contains(stdout, "Authenticate: Bearer"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+	c.Assert(strings.Contains(stdout, "unauthenticated request rejected"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBasicAuthnGood(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-basic-authn-plugin",
+		"--authn-opt", "realm=example.com",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "--basic", "-u", s.user+":"+s.pass)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(stdout == "OK", check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBasicAuthnBad1(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-basic-authn-plugin",
+		"--authn-opt", "realm=example.com",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "--basic", "-u", "not-"+s.user+":"+s.pass)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "authentication failed for request"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBasicAuthnBad2(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-basic-authn-plugin",
+		"--authn-opt", "realm=example.com",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "--basic", "-u", s.user+":not-"+s.pass)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "authentication failed for request"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnGood1a(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-bearer-authn-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-H", "Authorization: Bearer "+s.goodtoken)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(stdout == "OK", check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnGood1b(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-bearer-authn-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-H", "Authorization: Bearer "+s.othertoken)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(stdout == "OK", check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnBad1(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-bearer-authn-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-H", "Authorization: Bearer "+s.badtoken)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "authentication failed for request"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnGood2(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-bearer-authn-plugin",
+		"--authorization-plugin", "test-authz-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-vv", "-H", "Authorization: Bearer "+s.goodtoken)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(stdout == "OK", check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnBad2a(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr,
+		"--authorization-plugin", "test-authz-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr + "/_ping")
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "authorization denied by plugin test-authz-plugin"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+	c.Assert(strings.Contains(stdout, "client not authenticated"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnBad2b(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-bearer-authn-plugin",
+		"--authorization-plugin", "test-authz-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-vv", "-H", "Authorization: Bearer "+s.othertoken)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "authorization denied by plugin test-authz-plugin"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+	c.Assert(strings.Contains(stdout, "not the user we were looking for"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestBearerAuthnBad2c(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-bearer-authn-plugin",
+		"--authorization-plugin", "test-authz-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-vv", "-H", "Authorization: Bearer "+s.badtoken)
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "authentication failed for request"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestProxyAuthnBad(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-proxy-authn-plugin",
+		"--authn-opt", s.proxyHeaderNameOption + "=" + s.proxyHeaderName,
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-vv")
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(strings.Contains(stdout, "unauthenticated request rejected"), check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func (s *DockerAuthnSuite) TestProxyAuthnGood(c *check.C) {
+	serverOpts := []string{
+		"--host", s.daemonAddr, "--authn",
+		"--authn-opt", "plugins=test-proxy-authn-plugin",
+		"--authn-opt", s.proxyHeaderNameOption + "=" + s.proxyHeaderName,
+		"--authorization-plugin", "test-authz-plugin",
+	}
+	if err := s.ds.d.Start(serverOpts...); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	stdout, stderr, code, err := runCurlWithOutput(s.daemonAddr+"/_ping", "-H", s.proxyHeaderName+": "+s.user, "-vv")
+	if code != 0 {
+		c.Fatalf("Error Occurred: exit status %d: %s(%s)", code, stdout, stderr)
+	}
+	if err != nil {
+		c.Fatalf("Error Occurred: %v and output: %s(%s)", err, stdout, stderr)
+	}
+	c.Assert(stdout == "OK", check.Equals, true, check.Commentf("actual output is: %q (stderr is %q)", stdout, stderr))
+}
+
+func init() {
+	check.Suite(&DockerAuthnSuite{
+		ds: &DockerDaemonSuite{
+			ds: &DockerSuite{},
+		},
+		daemonAddr: "localhost:4271",
+		user:       "docker",
+		pass:       "docker",
+		goodtoken:  "YES-I-AM-A-BEAR",
+		badtoken:   "NO-I-AM-NOT-A-BEAR",
+		othertoken: "SO-MANY-BEARS",
+		authzTokens: map[string]string{
+			"YES-I-AM-A-BEAR": "docker",
+			"SO-MANY-BEARS":   "otheruser",
+		},
+		proxyHeaderName:       "RemoteUser",
+		proxyHeaderNameOption: "TrustedHeader",
+	})
+}

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -8,6 +8,8 @@ dockerd - Enable daemon mode
 **dockerd**
 [**--add-runtime**[=*[]*]]
 [**--api-cors-header**=[=*API-CORS-HEADER*]]
+[**--authn**[=*false*]]
+[**--authn-opt**[=*[]*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
@@ -85,6 +87,12 @@ format.
 
 **--api-cors-header**=""
   Set CORS headers in the remote API. Default is cors disabled. Give urls like "http://foo, http://bar, ...". Give "*" to allow all.
+
+**--authn**=*true*|*false*
+  Require clients to authenticate to the docker daemon when issuing requests; the historical default is false
+
+**--authn-opt**=[]
+  Set authentication options to use when handling authentication of clients.  See AUTHENTICATION OPTIONS.
 
 **--authorization-plugin**=""
   Set authorization plugins to load
@@ -278,6 +286,30 @@ output otherwise.
 
 **--userns-remap**=*default*|*uid:gid*|*user:group*|*user*|*uid*
     Enable user namespaces for containers on the daemon. Specifying "default" will cause a new user and group to be created to handle UID and GID range remapping for the user namespace mappings used for contained processes. Specifying a user (or uid) and optionally a group (or gid) will cause the daemon to lookup the user and group's subordinate ID ranges for use as the user namespace mappings for contained processes.
+
+# AUTHENTICATION OPTIONS
+
+The Docker daemon provides multiple methods for authenticating its clients.
+Authentication is enabled by using the **--authn** flag, and particular
+authentication schemes can be enabled and configured with **--authn-opt**
+flags.
+
+Here is the list of authentication options:
+
+#### plugins
+
+Call the named plugin or plugins to produce challenges and check client
+responses in order to authenticate clients.
+
+Example use: `docker daemon --authn-opt plugins=sss`
+
+#### realm
+
+When plugins offer HTTP authentication using the `Basic` scheme, they should
+use the specified name as the name of the authentication "realm".  The default
+is `localhost`.
+
+Example use: `docker daemon --authn-opt realm=example.com`
 
 # STORAGE DRIVER OPTIONS
 

--- a/pkg/authentication/authn.go
+++ b/pkg/authentication/authn.go
@@ -1,0 +1,211 @@
+package authentication
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/plugins"
+	"github.com/gorilla/context"
+)
+
+type contextKey int
+
+// authnUser is the key to use with context.Get() to retrieve an http.Request's
+// authenticated user, if the user was authenticated.  The name and value don't
+// matter, but the type does.
+const authnUser contextKey = iota
+
+// An Authentication object wraps handles to the various authentication plugins
+// that we're using.
+type Authentication struct {
+	pluginNames   []string
+	plugins       map[string]*plugins.Plugin
+	required      bool
+	makeAuthError func(error) error
+}
+
+// Pull selected fields out of a request's URL structure and populate a request.
+func (a *Authentication) makeAuthnReq(r *http.Request) *AuthnPluginAuthenticateRequest {
+	req := &AuthnPluginAuthenticateRequest{}
+	if r != nil {
+		req.Method = r.Method
+		req.Host = r.Host
+		req.Header = r.Header
+		req.URL = r.URL.String()
+	}
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 && r.TLS.PeerCertificates[0] != nil {
+		req.Certificate = r.TLS.PeerCertificates[0].Raw
+	}
+	return req
+}
+
+// Build a properly initialized response structure.
+func makeAuthnResp() AuthnPluginAuthenticateResponse {
+	return AuthnPluginAuthenticateResponse{Header: make(http.Header)}
+}
+
+// callPlugins asks the plugins what they think about the client's request.
+func (a *Authentication) callPlugins(w http.ResponseWriter, r *http.Request) (User, error) {
+	req := a.makeAuthnReq(r)
+	headers := make(http.Header)
+	for _, pname := range a.pluginNames {
+		plugin, ok := a.plugins[pname]
+		if !ok || plugin == nil {
+			logrus.Errorf("Error looking up Authentication plugin %s", pname)
+			continue
+		}
+		client := plugin.Client()
+		if client == nil {
+			logrus.Errorf("Error obtaining client connection to Authentication plugin %s", pname)
+			continue
+		}
+		resp := makeAuthnResp()
+		if err := client.Call(AuthenticationRequestName, &req, &resp); err != nil {
+			logrus.Errorf("Error in Authentication plugin %s: %v", pname, err)
+			continue
+		}
+		if resp.AuthedUser.Name != "" || resp.AuthedUser.HaveUID {
+			// This plugin succeeded.  Make sure the scheme is
+			// populated, and add the headers returned by this
+			// plugin (and only this plugin) to the response.
+			if resp.AuthedUser.Scheme == "" {
+				resp.AuthedUser.Scheme = pname
+			}
+			for header, vals := range resp.Header {
+				for _, val := range vals {
+					w.Header().Add(header, val)
+				}
+			}
+			return resp.AuthedUser, nil
+		}
+		// This plugin didn't succeed.  Hang on to any headers it
+		// returned, which may be challenge headers.
+		for header, vals := range resp.Header {
+			for _, val := range vals {
+				headers.Add(header, val)
+			}
+		}
+	}
+	// None of the plugins succeeded.  Return all of the headers that they
+	// returned, any or all of which may be challenge headers.
+	for header, vals := range headers {
+		for _, val := range vals {
+			w.Header().Add(header, val)
+		}
+	}
+	return User{}, nil
+}
+
+// NewAuthentication runs through the configured list of authentication plugins
+// and open connections to them.  Each plugin should implement the
+// "Authentication" interface, which consists of a two entry points:
+//    /Authentication.Authenticate
+// It receives an AuthnPluginAuthenticateRequest and returns an
+// AuthnPluginAuthenticateResponse.
+//
+// If the request does not include any "Authorization" headers, the plugin can
+// attempt to derive the user's identity from other information in and about
+// the request, and if successful, return information about the user.  If it
+// fails, it can provide "WWW-Authenticate" headers to be returned to the
+// client as part of a 401 response.
+//
+// If the request contains "Authorization" headers for a scheme which the
+// plugin can check, and if the checks are successful, the plugin can return
+// information about the user.  If the request contains "Authorization" headers
+// for a different scheme, the plugin should do nothing.
+//
+//    /Authentication.SetOptions
+// It receives an AuthnPluginSetOptionsRequest and returns an
+// AuthnPluginSetOptionsResponse.
+func NewAuthentication(required bool, options map[string]string, makeAuthError func(error) error) *Authentication {
+	pnames := options["plugins"]
+	names := []string{}
+	handles := make(map[string]*plugins.Plugin)
+	for _, name := range strings.Split(pnames, ",") {
+		if name == "" || handles[name] != nil {
+			continue
+		}
+		// Connect to the plugin.
+		plugin, err := plugins.Get(name, PluginImplements)
+		if err != nil {
+			logrus.Errorf("Error looking up authentication plugin %s: %v", name, err)
+			continue
+		}
+		client := plugin.Client()
+		if client == nil {
+			logrus.Errorf("Error obtaining client connection to Authentication plugin %s", name)
+			continue
+		}
+		// Send it the authentication options, once.
+		req := AuthnPluginSetOptionsRequest{Options: options}
+		resp := AuthnPluginSetOptionsResponse{}
+		if err := client.Call(SetOptionsRequestName, &req, &resp); err != nil {
+			logrus.Errorf("Error in Authentication plugin %s: %v", name, err)
+			continue
+		}
+		names = append(names, name)
+		handles[name] = plugin
+	}
+	return &Authentication{pluginNames: names, plugins: handles, required: required, makeAuthError: makeAuthError}
+}
+
+// Authenticate checks the request for an "Authorization" header, and depending
+// on whether or not it finds one, it either asks the various configured
+// plugins either for the set of challenges to send so that the client will
+// attempt to authenticate, or to check the contents of the headers supplied by
+// a client which is attempting to authenticate.
+func (a *Authentication) Authenticate(w http.ResponseWriter, r *http.Request) (User, error) {
+	// Default to authenticating using part of the subject name in the
+	// client's certificate, if one was supplied while doing the TLS
+	// handshake.
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 && r.TLS.PeerCertificates[0] != nil {
+		user := User{Name: r.TLS.PeerCertificates[0].Subject.CommonName, Scheme: "TLS"}
+		if user.Name != "" {
+			logrus.Infof("client is \"%s\"", user.Name)
+			context.Set(r, authnUser, user)
+			return user, nil
+		}
+	}
+	// If we don't need to be authenticating, stop now, so that we don't
+	// add any challenge headers to our response
+	if !a.required {
+		return User{}, nil
+	}
+	// Check if we have any configured plugins
+	if len(a.pluginNames) == 0 {
+		err := fmt.Errorf("no authentication plugins configured")
+		return User{}, err
+	}
+	user, err := a.callPlugins(w, r)
+	if err != nil {
+		return User{}, err
+	}
+	if user.Name != "" || user.HaveUID {
+		if user.Name != "" && user.HaveUID {
+			logrus.Infof("client is \"%s\"(UID %d)", user.Name, user.UID)
+		} else if user.Name != "" {
+			logrus.Infof("client is \"%s\"", user.Name)
+		} else {
+			logrus.Infof("client is UID %d", user.UID)
+		}
+		context.Set(r, authnUser, user)
+		return user, nil
+	}
+	if len(r.Header["Authorization"]) == 0 {
+		err = fmt.Errorf("unauthenticated request rejected")
+		logrus.Debug(err.Error())
+	} else {
+		err = fmt.Errorf("authentication failed for request")
+		logrus.Error(err.Error())
+	}
+	return User{}, err
+}
+
+// GetUser reads the name of the authenticated client user, if we managed to
+// authenticate one.
+func GetUser(r *http.Request) (user User, ok bool) {
+	user, ok = context.Get(r, authnUser).(User)
+	return user, ok && (user.Name != "" || user.HaveUID)
+}

--- a/pkg/authentication/authn_plugin.go
+++ b/pkg/authentication/authn_plugin.go
@@ -1,0 +1,58 @@
+package authentication
+
+import (
+	"net/http"
+)
+
+// PluginImplements is the type of subsystem plugin that we look for.
+const (
+	PluginImplements          = "Authentication"
+	AuthenticationRequestName = PluginImplements + ".Authenticate"
+	SetOptionsRequestName     = PluginImplements + ".SetOptions"
+)
+
+// User represents an authenticated remote user.  We know at least one of the
+// user's name (if not "") and UID (if HaveUID is true), and possibly both.
+type User struct {
+	Name    string    `json:",omitempty"`
+	HaveUID bool      `json:",omitempty"`
+	UID     uint32    `json:",omitempty"`
+	Groups  *[]string `json:",omitempty"`
+	Scheme  string    `json:",omitempty"`
+}
+
+// AuthnPluginAuthenticateRequest is the structure that we pass to an
+// authentication plugin to have it authenticate a request.  It contains the
+// incoming request's method, the Scheme, Path, Fragment, RawQuery, and RawPath
+// fields of the request's net.http.URL, stored in a map, the hostname, all of
+// the request's headers, and the peer's certificate if the connection provided
+// a verified client certificate.
+type AuthnPluginAuthenticateRequest struct {
+	Method      string      `json:",omitempty"`
+	URL         string      `json:",omitempty"`
+	Host        string      `json:",omitempty"`
+	Header      http.Header `json:",omitempty"`
+	Certificate []byte      `json:",omitempty"`
+}
+
+// AuthnPluginAuthenticateResponse is the structure that we get back from an
+// authentication request.  If authentication suceeded, it contains information
+// about the authenticated user.  If authentication succeeded, only header
+// values returned by the plugin which succeeded will be included in the
+// response which is sent to the client.  If authentication fails, all headers
+// returned by all called plugins will be included in the response.
+type AuthnPluginAuthenticateResponse struct {
+	AuthedUser User        `json:",omitempty"`
+	Header     http.Header `json:",omitempty"`
+}
+
+// AuthnPluginSetOptionsRequest is the structure that we use to pass
+// authentication options to a plugin.
+type AuthnPluginSetOptionsRequest struct {
+	Options map[string]string `json:",omitempty"`
+}
+
+// AuthnPluginSetOptionsResponse is the structure that we get back from a
+// set-options request.
+type AuthnPluginSetOptionsResponse struct {
+}

--- a/pkg/authentication/middleware.go
+++ b/pkg/authentication/middleware.go
@@ -1,0 +1,38 @@
+package authentication
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+// NewMiddleware creates a new Authentication middleware, which provides a
+// method for wrapping its passed-in handler function with an authentication
+// check.
+func NewMiddleware(required bool, options map[string]string, makeError func(error) error) *Authentication {
+	return NewAuthentication(required, options, makeError)
+}
+
+// WrapHandler returns a method that wraps an authentication check around
+// handlers that are passed to it.
+func (a *Authentication) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		user, err := a.Authenticate(w, r)
+		if a.required && err == nil && user.Name == "" && !user.HaveUID {
+			err = fmt.Errorf("authentication failed")
+		}
+		if err != nil {
+			return a.makeAuthError(err)
+		}
+		if user.Name != "" && user.HaveUID {
+			logrus.Debugf("authentication succeeded for %s(uid=%d)", user.Name, user.UID)
+		} else if user.Name != "" {
+			logrus.Debugf("authentication succeeded for %s", user.Name)
+		} else {
+			logrus.Debugf("authentication succeeded for (uid=%d)", user.UID)
+		}
+		return handler(ctx, w, r, vars)
+	}
+}

--- a/pkg/authorization/api.go
+++ b/pkg/authorization/api.go
@@ -16,6 +16,9 @@ type Request struct {
 	// User holds the user extracted by AuthN mechanism
 	User string `json:"User,omitempty"`
 
+	// UID holds the uid extracted by AuthN mechanism
+	UID string `json:"UID,omitempty"`
+
 	// UserAuthNMethod holds the mechanism used to extract user details (e.g., krb)
 	UserAuthNMethod string `json:"UserAuthNMethod,omitempty"`
 

--- a/pkg/authorization/authz.go
+++ b/pkg/authorization/authz.go
@@ -30,10 +30,11 @@ const maxBodySize = 1048576 // 1MB
 // If multiple authZ plugins are specified, the block/allow decision is based on ANDing all plugin results
 // For response manipulation, the response from each plugin is piped between plugins. Plugin execution order
 // is determined according to daemon parameters
-func NewCtx(authZPlugins []Plugin, user, userAuthNMethod, requestMethod, requestURI string) *Ctx {
+func NewCtx(authZPlugins []Plugin, user, uid, userAuthNMethod, requestMethod, requestURI string) *Ctx {
 	return &Ctx{
 		plugins:         authZPlugins,
 		user:            user,
+		uid:             uid,
 		userAuthNMethod: userAuthNMethod,
 		requestMethod:   requestMethod,
 		requestURI:      requestURI,
@@ -43,6 +44,7 @@ func NewCtx(authZPlugins []Plugin, user, userAuthNMethod, requestMethod, request
 // Ctx stores a single request-response interaction context
 type Ctx struct {
 	user            string
+	uid             string
 	userAuthNMethod string
 	requestMethod   string
 	requestURI      string
@@ -69,6 +71,7 @@ func (ctx *Ctx) AuthZRequest(w http.ResponseWriter, r *http.Request) error {
 
 	ctx.authReq = &Request{
 		User:            ctx.user,
+		UID:             ctx.uid,
 		UserAuthNMethod: ctx.userAuthNMethod,
 		RequestMethod:   ctx.requestMethod,
 		RequestURI:      ctx.requestURI,

--- a/pkg/authorization/authz_unix_test.go
+++ b/pkg/authorization/authz_unix_test.go
@@ -67,6 +67,7 @@ func TestAuthZRequestPlugin(t *testing.T) {
 
 	request := Request{
 		User:           "user",
+		UID:            "1234",
 		RequestBody:    []byte("sample body"),
 		RequestURI:     "www.authz.com/auth",
 		RequestMethod:  "GET",


### PR DESCRIPTION
As promised in #18514, this is a slimmed-down authentication implementation that focuses exclusively on plugins, with enough client logic added to allow the plugin infrastructure to be tested with added integration tests, using Basic and Bearer auth, and in combination with authorization plugins.
