### PR TITLE
Windows CI: Allow npipe protocol for sock requests

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -577,6 +577,8 @@ func sockConn(timeout time.Duration) (net.Conn, error) {
 
 	var c net.Conn
 	switch daemonURL.Scheme {
+	case "npipe":
+		return npipeDial(daemonURL.Path, timeout)
 	case "unix":
 		return net.DialTimeout(daemonURL.Scheme, daemonURL.Path, timeout)
 	case "tcp":

--- a/integration-cli/npipe.go
+++ b/integration-cli/npipe.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package main
+
+import (
+	"net"
+	"time"
+)
+
+func npipeDial(path string, timeout time.Duration) (net.Conn, error) {
+	panic("npipe protocol only supported on Windows")
+}

--- a/integration-cli/npipe_windows.go
+++ b/integration-cli/npipe_windows.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func npipeDial(path string, timeout time.Duration) (net.Conn, error) {
+	return winio.DialPipe(path, &timeout)
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Adds npipe protocol support for integration-cli tests on Windows. This relates to #20845 for switching the Windows default wire protocol to `npipe`. Have completed a local pass of CI with this change, and a modified CI script that switches the the daemon under test to listen on `npipe` rather than `tcp`.

@jstarks @icecrime @cpuguy83 

![cute](https://cloud.githubusercontent.com/assets/10522484/13477684/667f99a4-e082-11e5-9b3a-46911234d6f4.JPG)
