### PR TITLE
Rotate snapshot key to server when initializing new notary repos

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -461,7 +461,8 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, tag string,
 		rootKeyID = rootPublicKey.ID()
 	}
 
-	if err := repo.Initialize(rootKeyID); err != nil {
+	// Initialize the notary repository with a remotely managed snapshot key
+	if err := repo.Initialize(rootKeyID, data.CanonicalSnapshotRole); err != nil {
 		return notaryError(repoInfo.FullName(), err)
 	}
 	fmt.Fprintf(cli.out, "Finished initializing %q\n", repoInfo.FullName())

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -286,6 +286,12 @@ func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 	out, _, err = runCommandWithOutput(pullCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
 	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
+
+	// Assert that we rotated the snapshot key to the server by checking our local keystore
+	contents, err := ioutil.ReadDir(filepath.Join(cliconfig.ConfigDir(), "trust/private/tuf_keys", privateRegistryURL, "dockerclitrusted/pushtest"))
+	c.Assert(err, check.IsNil, check.Commentf("Unable to read local tuf key files"))
+	// Check that we only have 1 key (targets key)
+	c.Assert(contents, checker.HasLen, 1)
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {


### PR DESCRIPTION
Default to having notary server manage the snapshot key when pushing a new repo with docker content trust.  This makes it easier to get started with delegations, and users can always reclaim their snapshot key to their local storage with a `notary key rotate` command if they wish (tracked in https://github.com/docker/notary/issues/605)

also, here's a cute aardvark:
![alt](https://cuteoverload.files.wordpress.com/2014/08/photo12.jpg?w=280&h=336)

Signed-off-by: Riyaz Faizullabhoy riyaz.faizullabhoy@docker.com
