### PR TITLE
Windows CI: Temporarily disable TestPsListContainers*

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
 	out, _ := runSleepingContainer(c, "-d")
 	firstID := strings.TrimSpace(out)
 
@@ -119,6 +123,11 @@ func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
 
 // FIXME remove this for 1.12 as --since and --before are deprecated
 func (s *DockerSuite) TestPsListContainersDeprecatedSinceAndBefore(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	out, _ := runSleepingContainer(c, "-d")
 	firstID := strings.TrimSpace(out)
 
@@ -214,6 +223,11 @@ func assertContainerList(out string, expected []string) bool {
 }
 
 func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// Problematic on Windows as it doesn't report the size correctly @swernli
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "busybox")
@@ -256,6 +270,11 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// start exited container
 	out, _ := dockerCmd(c, "run", "-d", "busybox")
 	firstID := strings.TrimSpace(out)
@@ -295,6 +314,11 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// start container
 	out, _ := dockerCmd(c, "run", "-d", "busybox")
 	firstID := strings.TrimSpace(out)
@@ -310,6 +334,11 @@ func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// start container
 	dockerCmd(c, "run", "--name=a_name_to_match", "busybox")
 	id, err := getIDByName("a_name_to_match")
@@ -333,6 +362,11 @@ func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
 // - Run containers for each of those image (busybox, images_ps_filter_test1, images_ps_filter_test2)
 // - Filter them out :P
 func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// Build images
 	imageName1 := "images_ps_filter_test1"
 	imageID1, err := buildImage(imageName1,
@@ -434,6 +468,11 @@ func checkPsAncestorFilterOutput(c *check.C, out string, filterName string, expe
 }
 
 func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// start container
 	dockerCmd(c, "run", "--name=first", "-l", "match=me", "-l", "second=tag", "busybox")
 	firstID, err := getIDByName("first")
@@ -473,6 +512,11 @@ func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	runSleepingContainer(c, "--name=sleep")
 
 	dockerCmd(c, "run", "--name", "zero1", "busybox", "true")
@@ -592,6 +636,11 @@ func (s *DockerSuite) TestPsWithSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterCreated(c *check.C) {
+	// TODO Windows: Figure out why TestPsListContainers* are flakey
+	if daemonPlatform == "windows" {
+		c.Skip("Flaky on windowsTP4")
+	}
+
 	// create a container
 	out, _ := dockerCmd(c, "create", "busybox")
 	cID := strings.TrimSpace(out)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@darrenstahlmsft Please investigate the failures as per https://github.com/docker/docker/issues/20819. @thaJeztah @icecrime 

These tests are just causing way too much grief on so many PRs. Reluctantly disabling them to try and get windowsTP4 context more reliable. I can only repro the failure locally 1 in >100 times on TP4 (I ran 100 cycles today with no repro, will kick it off again overnight), yet the CI servers seem to hit it closer to 1 in 3 times.

:dog2: 
![image](https://cloud.githubusercontent.com/assets/10522484/13485047/4eeb8d9e-e0b8-11e5-8822-9d22582ad71c.png)
