### PR TITLE
Fix the driver name empty case

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -194,11 +194,13 @@ func (s *VolumeStore) create(name, driverName string, opts map[string]string) (v
 		}
 	}
 
-	logrus.Debugf("Registering new volume reference: driver %q, name %q", driverName, name)
 	vd, err := volumedrivers.GetDriver(driverName)
+
 	if err != nil {
 		return nil, &OpErr{Op: "create", Name: name, Err: err}
 	}
+
+	logrus.Debugf("Registering new volume reference: driver %q, name %q", vd.Name(), name)
 
 	if v, _ := vd.Get(name); v != nil {
 		return v, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

As drivername maybe "" in hostconfig, so we should not
directly print dirvername with var drivername,
instead, we use the real driver name property to print it.

Fixes: #20900
Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
