### PR TITLE
fixes #20648 using fine grained lock from pkg/locker

### DIFF
--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -1,11 +1,15 @@
 package network
 
-import "github.com/docker/docker/api/server/router"
+import (
+	"github.com/docker/docker/api/server/router"
+	"github.com/docker/docker/pkg/locker"
+)
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
 	backend Backend
 	routes  []router.Route
+	locks   *locker.Locker
 }
 
 // NewRouter initializes a new network router
@@ -14,6 +18,7 @@ func NewRouter(b Backend) router.Router {
 		backend: b,
 	}
 	r.initRoutes()
+	r.locks = locker.New()
 	return r
 }
 

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -80,6 +80,11 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 			fmt.Sprintf("%s is a pre-defined network and cannot be created", create.Name))
 	}
 
+	if create.CheckDuplicate { // make sure GetNetworkByName and the checkDup code run in sync
+		n.locks.Lock(create.Name)
+		defer n.locks.Unlock(create.Name)
+	}
+
 	nw, err := n.backend.GetNetworkByName(create.Name)
 	if _, ok := err.(libnetwork.ErrNoSuchNetwork); err != nil && !ok {
 		return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:
- What did you do?
  this fixes #20648. I closed previous pull requests following feedback.
- How did you do it?
  I used pkg/locker.Locker to synchronize concurrent calls with the same network name, at the api router level. This is activated IFF the checkDuplicate flag is turned on, and ONLY locks between calls to create a network with the same name.
- How do I see it or verify it?
  `docker network create xyz & docker network create xyz` - creates only one `xyz` network
  I also added to the integration testing , extended the existing `TestApiNetworkCreateCheckDuplicate`

NOTE this passes `make test` except `TestRunResolvconfUpdate` which fails also on the master branch. This failure is also reported in #19937 
- A picture of a cute animal (not mandatory but encouraged)

```
       _.---._    /\\
    ./'       "--`\//
  ./              o \
 /./\  )______   \__ \
./  / /\ \   | \ \  \ \
   / /  \ \  | |\ \  \7
    "     "    "  "        VK
```
