### PR TITLE
Refine error message when save non-exist image

### DIFF
--- a/image/store.go
+++ b/image/store.go
@@ -170,6 +170,9 @@ func (is *store) Search(term string) (ID, error) {
 
 	dgst, err := is.digestSet.Lookup(term)
 	if err != nil {
+		if err == digest.ErrDigestNotFound {
+			err = fmt.Errorf("No such image: %s", term)
+		}
 		return "", err
 	}
 	return ID(dgst), nil

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -167,6 +167,16 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 	c.Assert(before, checker.Equals, after, check.Commentf("inspect is not the same after a save / load"))
 }
 
+func (s *DockerSuite) TestSaveWithNoExistImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	imgName := "foobar-non-existing-image"
+
+	out, _, err := dockerCmdWithError("save", "-o", "test-img.tar", imgName)
+	c.Assert(err, checker.NotNil, check.Commentf("save image should fail for non-existing image"))
+	c.Assert(out, checker.Contains, fmt.Sprintf("No such image: %s", imgName))
+}
+
 func (s *DockerSuite) TestSaveMultipleNames(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	repoName := "foobar-save-multi-name-test"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Fixes: #20709
As discussed in the issue, we need refine the message to
help user more understood, what happened for non-exist image.

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
