### PR TITLE
Fix typo for download and upload retry messages

### DIFF
--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -263,7 +263,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 
 			selectLoop:
 				for {
-					progress.Updatef(progressOutput, descriptor.ID(), "Retrying in %d seconds", delay)
+					progress.Updatef(progressOutput, descriptor.ID(), "Retrying in %d second%s", delay, (map[bool]string{true: "s"})[delay != 1])
 					select {
 					case <-ticker.C:
 						delay--

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -141,7 +141,7 @@ func (lum *LayerUploadManager) makeUploadFunc(descriptor UploadDescriptor) DoFun
 
 			selectLoop:
 				for {
-					progress.Updatef(progressOutput, descriptor.ID(), "Retrying in %d seconds", delay)
+					progress.Updatef(progressOutput, descriptor.ID(), "Retrying in %d second%s", delay, (map[bool]string{true: "s"})[delay != 1])
 					select {
 					case <-ticker.C:
 						delay--


### PR DESCRIPTION
Please provide the following information:
- What did you do?
  Fixed a grammar error: `Retrying in 1 seconds` should be `Retrying in 1 second`.
- How did you do it?
  Added a check to see if `delay` equals to 1: if it's true, return `second`, otherwise `seconds`.
- How do I see it or verify it?
  Compile docker and try to get a retry delay.

Signed-off-by: Jay jay@imjching.com
