### PR TITLE
Windows CI: Bump timeout for tests

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -170,6 +170,8 @@ BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 
 if [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
 	: ${TIMEOUT:=210m}
+elif [ "${DOCKER_ENGINE_GOARCH}" == "windows" ]; then
+	: ${TIMEOUT:=180m}
 else
 	: ${TIMEOUT:=120m}
 fi


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Several of the windowsTP4 nodes are pushing very close to 120m for a CI run, and there's been a few timeouts this week. Simply due to the increasing number of tests. (TP5 will be much faster). So bumping the timeout to keep CI more reliable.

![image](https://cloud.githubusercontent.com/assets/10522484/13534944/6f8fa0be-e1ec-11e5-99ed-ba353e5e6f8f.png)
