### PR TITLE
Properly close and remove file in daemon test

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2170,7 +2170,9 @@ func (s *DockerSuite) TestDaemonDiscoveryBackendConfigReload(c *check.C) {
 
 	configFile, err = os.Create(configFilePath)
 	c.Assert(err, checker.IsNil)
+	defer os.Remove(configFilePath)
 	fmt.Fprintf(configFile, "%s", daemonConfig)
+	configFile.Close()
 
 	syscall.Kill(d.cmd.Process.Pid, syscall.SIGHUP)
 


### PR DESCRIPTION
Fixes a bug where a file (test.json) would be created and not deleted in
DockerSuite.TestDaemonDiscoveryBackendConfigReload

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
