### PR TITLE
Do not wait for container on stop if the process doesn't exist.

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -1099,7 +1099,9 @@ func killProcessDirectly(container *container.Container) error {
 				if err != syscall.ESRCH {
 					return err
 				}
-				logrus.Debugf("Cannot kill process (pid=%d) with signal 9: no such process.", pid)
+				e := errNoSuchProcess{pid, 9}
+				logrus.Debug(e)
+				return e
 			}
 		}
 	}

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -11,6 +11,22 @@ import (
 	"github.com/docker/docker/pkg/signal"
 )
 
+type errNoSuchProcess struct {
+	pid    int
+	signal int
+}
+
+func (e errNoSuchProcess) Error() string {
+	return fmt.Sprintf("Cannot kill process (pid=%d) with signal %d: no such process.", e.pid, e.signal)
+}
+
+// isErrNoSuchProcess returns true if the error
+// is an instance of errNoSuchProcess.
+func isErrNoSuchProcess(err error) bool {
+	_, ok := err.(errNoSuchProcess)
+	return ok
+}
+
 // ContainerKill send signal to the container
 // If no signal is given (sig 0), then Kill with SIGKILL and wait
 // for the container to exit.
@@ -89,6 +105,9 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 		// So, instead we'll give it up to 2 more seconds to complete and if
 		// by that time the container is still running, then the error
 		// we got is probably valid and so we return it to the caller.
+		if isErrNoSuchProcess(err) {
+			return nil
+		}
 
 		if container.IsRunning() {
 			container.WaitStop(2 * time.Second)
@@ -100,6 +119,9 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 
 	// 2. Wait for the process to die, in last resort, try to kill the process directly
 	if err := killProcessDirectly(container); err != nil {
+		if isErrNoSuchProcess(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -111,8 +133,9 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 func (daemon *Daemon) killPossiblyDeadProcess(container *container.Container, sig int) error {
 	err := daemon.killWithSignal(container, sig)
 	if err == syscall.ESRCH {
-		logrus.Debugf("Cannot kill process (pid=%d) with signal %d: no such process.", container.GetPID(), sig)
-		return nil
+		e := errNoSuchProcess{container.GetPID(), sig}
+		logrus.Debug(e)
+		return e
 	}
 	return err
 }


### PR DESCRIPTION
This fixes an issue that caused the client to hang forever if the process died before
the code arrived to exit the `Kill` function.

This is the log in the server, but the client never arrived to exit because
the daemon hanged forever in `container.WaitStop(-1 * time.Second)`:

```
DEBU Calling POST /v1.23/containers/18ba5acac76a805e0ce6d36bc1cb8e19572bb97bafbaeb2a6f75737982b15506/stop                                                
DEBU POST /v1.23/containers/18ba5acac76a805e0ce6d36bc1cb8e19572bb97bafbaeb2a6f75737982b15506/stop?t=10                                                   
DEBU Sending 15 to 18ba5acac76a805e0ce6d36bc1cb8e19572bb97bafbaeb2a6f75737982b15506                                                                      
INFO Container 18ba5acac76a805e0ce6d36bc1cb8e19572bb97bafbaeb2a6f75737982b15506 failed to exit within 10 seconds of signal 15 - using the force          
DEBU Sending 9 to 18ba5acac76a805e0ce6d36bc1cb8e19572bb97bafbaeb2a6f75737982b15506                                                                       
INFO Container 18ba5acac76a failed to exit within 10 seconds of kill - trying direct SIGKILL                                                             
DEBU Cannot kill process (pid=15097) with signal 9: no such process.
```

I added an error check to immediately return if killing a container fails because the
process dissapears.

![](http://cdn.modernfarmer.com/wp-content/uploads/2014/12/squirrel.jpg)

Signed-off-by: David Calavera david.calavera@gmail.com
