### PR TITLE
Split log data without end-of-line markers.

### DIFF
--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -10,6 +10,15 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+// maxScanBufferSize is the maximum size allowed
+// for the log buffer to copy its data.
+const maxScanBufferSize = bufio.MaxScanTokenSize / 2
+
+type bufferedCopier interface {
+	Scan() bool
+	Bytes() ([]byte, error)
+}
+
 // Copier can copy logs from specified sources to Logger and attach
 // ContainerID and Timestamp.
 // Writes are concurrent, so you need implement some sync in your logger
@@ -17,19 +26,21 @@ type Copier struct {
 	// cid is the container id for which we are copying logs
 	cid string
 	// srcs is map of name -> reader pairs, for example "stdout", "stderr"
-	srcs     map[string]io.Reader
-	dst      Logger
-	copyJobs sync.WaitGroup
-	closed   chan struct{}
+	srcs       map[string]io.Reader
+	dst        Logger
+	copyJobs   sync.WaitGroup
+	closed     chan struct{}
+	copierFunc func(io.Reader) bufferedCopier
 }
 
 // NewCopier creates a new Copier
 func NewCopier(cid string, srcs map[string]io.Reader, dst Logger) *Copier {
 	return &Copier{
-		cid:    cid,
-		srcs:   srcs,
-		dst:    dst,
-		closed: make(chan struct{}),
+		cid:        cid,
+		srcs:       srcs,
+		dst:        dst,
+		closed:     make(chan struct{}),
+		copierFunc: newScannerCopier,
 	}
 }
 
@@ -43,18 +54,15 @@ func (c *Copier) Run() {
 
 func (c *Copier) copySrc(name string, src io.Reader) {
 	defer c.copyJobs.Done()
-	reader := bufio.NewReader(src)
+	bf := c.copierFunc(src)
 
-	for {
+	for bf.Scan() {
 		select {
 		case <-c.closed:
 			return
 		default:
-			line, err := reader.ReadBytes('\n')
-			line = bytes.TrimSuffix(line, []byte{'\n'})
+			line, err := bf.Bytes()
 
-			// ReadBytes can return full or partial output even when it failed.
-			// e.g. it can return a full entry and EOF.
 			if err == nil || len(line) > 0 {
 				if logErr := c.dst.Log(&Message{ContainerID: c.cid, Line: line, Source: name, Timestamp: time.Now().UTC()}); logErr != nil {
 					logrus.Errorf("Failed to log msg %q for logger %s: %s", line, c.dst.Name(), logErr)
@@ -83,4 +91,80 @@ func (c *Copier) Close() {
 	default:
 		close(c.closed)
 	}
+}
+
+type readerCopier struct {
+	r *bufio.Reader
+}
+
+func (s readerCopier) Scan() bool {
+	return true
+}
+func (s readerCopier) Bytes() ([]byte, error) {
+	line, err := s.r.ReadBytes('\n')
+	line = bytes.TrimSuffix(line, []byte{'\n'})
+	return line, err
+}
+
+func newReaderCopier(src io.Reader) bufferedCopier {
+	return readerCopier{bufio.NewReader(src)}
+}
+
+type scannerCopier struct {
+	s *bufio.Scanner
+}
+
+func (s scannerCopier) Scan() bool {
+	return s.s.Scan()
+}
+func (s scannerCopier) Bytes() ([]byte, error) {
+	return s.s.Bytes(), s.s.Err()
+}
+
+func newScannerCopier(src io.Reader) bufferedCopier {
+	scanner := bufio.NewScanner(src)
+	scanner.Split(splitLines)
+	return scannerCopier{scanner}
+}
+
+// splitLines is a split function for a Scanner that returns each line of
+// text, stripped of any trailing end-of-line marker. The returned line may
+// be empty. The end-of-line marker is one optional carriage return followed
+// by one mandatory newline. In regular expression notation, it is `\r?\n`.
+// The last non-empty line of input will be returned even if it has no
+// newline.
+// It splits the data in several parts if its size is bigger than `maxScanBufferSize` to avoid
+// infinite buffers that don't include any end-of-line marker.
+//
+// This function is a fork of bufio.ScanLines https://golang.org/pkg/bufio/#ScanLines.
+// It adds an extra check to not buffer more data than a copier can handle.
+func splitLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, dropCR(data[0:i]), nil
+	}
+
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), dropCR(data), nil
+	}
+
+	// split data if the buffer is too big.
+	if len(data) > maxScanBufferSize {
+		return maxScanBufferSize + 1, dropCR(data[0:maxScanBufferSize]), nil
+	}
+
+	// Request more data.
+	return 0, nil, nil
+}
+
+// dropCR drops a terminal \r from the data.
+func dropCR(data []byte) []byte {
+	if len(data) > 0 && data[len(data)-1] == '\r' {
+		return data[0 : len(data)-1]
+	}
+	return data
 }


### PR DESCRIPTION
This prevents memory issues when the data sent to the logs never includes the end-of-line marker, `\n`.

I change the log reader for a scanner that splits the data in the log when its length exceeds an prefixed length.

Fixes #18057.

![](https://s-media-cache-ak0.pinimg.com/736x/24/90/37/2490373fbc703c2e3cc3b0a7f2b66571.jpg)

Signed-off-by: David Calavera david.calavera@gmail.com
