### PR TITLE
cliconfig: credentials: set default for unix

### DIFF
--- a/cliconfig/credentials/default_store_linux.go
+++ b/cliconfig/credentials/default_store_linux.go
@@ -1,0 +1,3 @@
+package credentials
+
+const defaultCredentialsStore = "secretservice"

--- a/cliconfig/credentials/default_store_unsupported.go
+++ b/cliconfig/credentials/default_store_unsupported.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin
+// +build !windows,!darwin,!linux
 
 package credentials
 

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -51,6 +51,7 @@ program to be in the client's host `$PATH`.
 This is the list of currently available credentials helpers and where
 you can download them from:
 
+- D-Bus Secret Service: https://github.com/docker/docker-credential-helpers/releases
 - Apple OS X keychain: https://github.com/docker/docker-credential-helpers/releases
 - Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases
 


### PR DESCRIPTION
~~depends on https://github.com/docker/docker-credential-helpers/pull/7~~

Signed-off-by: Antonio Murdaca runcom@redhat.com
