### PR TITLE
return status code http.StatusNoContent in deleting network when OK

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -147,7 +147,14 @@ func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.Respon
 }
 
 func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return n.backend.DeleteNetwork(vars["id"])
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	if err := n.backend.DeleteNetwork(vars["id"]); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 func buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -3097,7 +3097,7 @@ JSON Parameters:
 
 `POST /networks/(id)/connect`
 
-Connects a container to a network
+Connect a container to a network
 
 **Example request**:
 
@@ -3134,7 +3134,7 @@ JSON Parameters:
 
 `POST /networks/(id)/disconnect`
 
-Disconnects a container from a network
+Disconnect a container from a network
 
 **Example request**:
 
@@ -3175,11 +3175,11 @@ Instruct the driver to remove the network (`id`).
 
 **Example response**:
 
-    HTTP/1.1 200 OK
+    HTTP/1.1 204 No Content
 
 Status Codes
 
--   **200** - no error
+-   **204** - no error
 -   **404** - no such network
 -   **500** - server error
 

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -332,6 +332,6 @@ func deleteNetwork(c *check.C, id string, shouldSucceed bool) {
 		c.Assert(status, checker.Not(checker.Equals), http.StatusOK)
 		return
 	}
-	c.Assert(status, checker.Equals, http.StatusOK)
+	c.Assert(status, checker.Equals, http.StatusNoContent)
 	c.Assert(err, checker.IsNil)
 }


### PR DESCRIPTION
1.return status code http.StatusNoContent in deleting network when successful
2.modify docker_api_network_test.go

fixes #20976 
