### PR TITLE
registry: service: fix login

### DIFF
--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -9,7 +9,7 @@ import (
 func (s *Service) lookupV1Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
-	if hostname == DefaultNamespace {
+	if hostname == IndexServer || hostname == DefaultNamespace {
 		endpoints = append(endpoints, APIEndpoint{
 			URL:          DefaultV1Registry,
 			Version:      APIVersion1,

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -10,7 +10,7 @@ import (
 func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
-	if hostname == DefaultNamespace {
+	if hostname == IndexServer || hostname == DefaultNamespace {
 		// v2 mirrors
 		for _, mirror := range s.Config.Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {


### PR DESCRIPTION
This is a regression introduced in https://github.com/docker/docker/pull/20832 (at https://github.com/docker/docker/commit/f2d481a299f7404f5cabbe0f8e6a4ae3c3211c1e#diff-0b84f69edd22d3597c88124e0172a47eL15), this is breaking docker login to the default docker registry.
@aaronlehmann @dmcgowan could you check this? I can write a regression test to login against docker, not sure it won't be flaky by default though. The issue is `hostname` could be the login index server stored in `authConfig` which is not just `docker.io`.

```
$ docker login

Login with your Docker ID to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com to create one.
Username: runcom
Password: 
Error response from daemon: parse https://https:%2F%2Findex.docker.io%2Fv1%2F/v1/users/: percent-encoded characters in host
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
