### PR TITLE
add --net options for docker build .

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -58,6 +58,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	flCPUSetCpus := cmd.String([]string{"-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 	flCPUSetMems := cmd.String([]string{"-cpuset-mems"}, "", "MEMs in which to allow execution (0-3, 0,1)")
 	flCgroupParent := cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
+	flNetMode := cmd.String([]string{"-net"}, "default", "Connect a container to a network")
 	flBuildArg := opts.NewListOpts(runconfigopts.ValidateEnv)
 	cmd.Var(&flBuildArg, []string{"-build-arg"}, "Set build-time variables")
 	isolation := cmd.String([]string{"-isolation"}, "", "Container isolation technology")
@@ -225,6 +226,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		CPUQuota:       *flCPUQuota,
 		CPUPeriod:      *flCPUPeriod,
 		CgroupParent:   *flCgroupParent,
+		NetMode:        *flNetMode,
 		Dockerfile:     relDockerfile,
 		ShmSize:        shmSize,
 		Ulimits:        flUlimits.GetList(),

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -48,6 +48,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.CPUSetCPUs = r.FormValue("cpusetcpus")
 	options.CPUSetMems = r.FormValue("cpusetmems")
 	options.CgroupParent = r.FormValue("cgroupparent")
+	options.NetMode = r.FormValue("netmode")
 	options.Tags = r.Form["t"]
 
 	if r.Form.Get("shmsize") != "" {

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -505,9 +505,10 @@ func (b *Builder) create() (string, error) {
 
 	// TODO: why not embed a hostconfig in builder?
 	hostConfig := &container.HostConfig{
-		Isolation: b.options.Isolation,
-		ShmSize:   b.options.ShmSize,
-		Resources: resources,
+		Isolation:   b.options.Isolation,
+		ShmSize:     b.options.ShmSize,
+		Resources:   resources,
+		NetworkMode: container.NetworkMode(b.options.NetMode),
 	}
 
 	config := *b.runConfig

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -182,8 +182,30 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	} else if hit {
 		return nil
 	}
+	resources := container.Resources{
+		CgroupParent: b.options.CgroupParent,
+		CPUShares:    b.options.CPUShares,
+		CPUPeriod:    b.options.CPUPeriod,
+		CPUQuota:     b.options.CPUQuota,
+		CpusetCpus:   b.options.CPUSetCPUs,
+		CpusetMems:   b.options.CPUSetMems,
+		Memory:       b.options.Memory,
+		MemorySwap:   b.options.MemorySwap,
+		Ulimits:      b.options.Ulimits,
+	}
 
-	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{Config: b.runConfig})
+	// TODO: why not embed a hostconfig in builder?
+	hostConfig := &container.HostConfig{
+		Isolation:   b.options.Isolation,
+		ShmSize:     b.options.ShmSize,
+		Resources:   resources,
+		NetworkMode: container.NetworkMode(b.options.NetMode),
+	}
+
+	container, err := b.docker.ContainerCreate(types.ContainerCreateConfig{
+		Config:     b.runConfig,
+		HostConfig: hostConfig,
+	})
 	if err != nil {
 		return err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_build.go
@@ -79,6 +79,7 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	}
 
 	query.Set("cpusetcpus", options.CPUSetCPUs)
+	query.Set("netmode", options.NetMode)
 	query.Set("cpusetmems", options.CPUSetMems)
 	query.Set("cpushares", strconv.FormatInt(options.CPUShares, 10))
 	query.Set("cpuquota", strconv.FormatInt(options.CPUQuota, 10))

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -136,6 +136,7 @@ type ImageBuildOptions struct {
 	Memory         int64
 	MemorySwap     int64
 	CgroupParent   string
+	NetMode        string
 	ShmSize        int64
 	Dockerfile     string
 	Ulimits        []*units.Ulimit


### PR DESCRIPTION
fixed [10324](https://github.com/docker/docker/issues/10324)
docker could't point a network mode when build a image ,in my case, we are unable to use bridge  network mode because my company's restriction. So when I building a docker image , I could't connect to network in container, which is quite annoying. 
So I add --net options for docker build command to use host network mode.
To verify this feature， create Dockerfile like following:

> From debian:jessie
> RUN /bin/bash -c 'ip addr'

then run:

> docker build --net=host .

to get the output the make sure use the correct mode

![image](http://cimg20.163.com/2008/2008/5/22/2008052218514385bad.jpg)
Signed-off-by: sandyskies chenmingjie0828@163.com
