### PR TITLE
api: server: server: remove redunant debugf

### DIFF
--- a/api/server/middleware/debug.go
+++ b/api/server/middleware/debug.go
@@ -15,7 +15,7 @@ import (
 // DebugRequestMiddleware dumps the request to logger
 func DebugRequestMiddleware(handler httputils.APIFunc) httputils.APIFunc {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-		logrus.Debugf("%s %s", r.Method, r.RequestURI)
+		logrus.Debugf("Calling %s %s", r.Method, r.RequestURI)
 
 		if r.Method != "POST" {
 			return handler(ctx, w, r, vars)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -114,9 +114,6 @@ func (s *HTTPServer) Close() error {
 
 func (s *Server) makeHTTPHandler(handler httputils.APIFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// log the handler call
-		logrus.Debugf("Calling %s %s", r.Method, r.URL.Path)
-
 		// Define the context that we'll pass around to share info
 		// like the docker-request-id.
 		//


### PR DESCRIPTION
Before (also it wasn't logged the full request uri but only the URL path):

```
Mar 07 08:58:26 fedora docker[12569]: time="2016-03-07T08:58:26.424142098+01:00" level=debug msg="Calling POST /v1.23/images/runcom/testrhelbased/push"
Mar 07 08:58:26 fedora docker[12569]: time="2016-03-07T08:58:26.424219054+01:00" level=debug msg="POST /v1.23/images/runcom/testrhelbased/push?tag=7.2"
```

After:

```
Mar 07 08:58:26 fedora docker[12569]: time="2016-03-07T08:58:26.424142098+01:00" level=debug msg="Calling POST /v1.23/images/runcom/testimage/push?tag=14.04"
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
