### PR TITLE
Fix docker run for 64 byte hex ID

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -70,9 +70,17 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
 	}
 
 	for _, name := range names {
-		ref, err := reference.ParseNamed(name)
+		id, ref, err := reference.ParseIDOrReference(name)
 		if err != nil {
 			return nil, err
+		}
+		if id != "" {
+			_, err := l.is.Get(image.ID(id))
+			if err != nil {
+				return nil, err
+			}
+			addAssoc(image.ID(id), nil)
+			continue
 		}
 		if ref.Name() == string(digest.Canonical) {
 			imgID, err := l.is.Search(name)

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -450,3 +450,11 @@ func (s *DockerSuite) TestCreateWithInvalidLogOpts(c *check.C) {
 	out, _ = dockerCmd(c, "ps", "-a")
 	c.Assert(out, checker.Not(checker.Contains), name)
 }
+
+// #20972
+func (s *DockerSuite) TestCreate64ByteHexID(c *check.C) {
+	out := inspectField(c, "busybox", "Id")
+	imageID := strings.TrimPrefix(strings.TrimSpace(string(out)), "sha256:")
+
+	dockerCmd(c, "create", imageID)
+}

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -155,6 +155,19 @@ func IsNameOnly(ref Named) bool {
 	return true
 }
 
+// ParseIDOrReference parses string for a image ID or a reference. ID can be
+// without a default prefix.
+func ParseIDOrReference(idOrRef string) (digest.Digest, Named, error) {
+	if err := v1.ValidateID(idOrRef); err == nil {
+		idOrRef = "sha256:" + idOrRef
+	}
+	if dgst, err := digest.ParseDigest(idOrRef); err == nil {
+		return dgst, nil, nil
+	}
+	ref, err := ParseNamed(idOrRef)
+	return "", ref, err
+}
+
 // splitHostname splits a repository name to hostname and remotename string.
 // If no valid hostname is found, the default hostname is used. Repository name
 // needs to be already validated before.


### PR DESCRIPTION
Fixes #20972

Also makes sure there is no check to registry if 
no image is found for the prefixed IDs.

@aaronlehmann 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
