### PR TITLE
Allow volume drivers to provide a `Status` field

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -206,6 +206,7 @@ func (daemon *Daemon) VolumeInspect(name string) (*types.Volume, error) {
 	}
 	apiV := volumeToAPIType(v)
 	apiV.Mountpoint = v.Path()
+	apiV.Status = v.Status()
 	return apiV, nil
 }
 

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -15,6 +15,21 @@ external storage systems, such as Amazon EBS, and enable data volumes to persist
 beyond the lifetime of a single Engine host. See the [plugin
 documentation](plugins.md) for more information.
 
+## Changelog
+
+### 1.12.0
+
+- Add `Status` field to `VolumeDriver.Get` response ([#21006](https://github.com/docker/docker/pull/21006#))
+
+### 1.10.0
+
+- Add `VolumeDriver.Get` which gets the details about the volume ([#16534](https://github.com/docker/docker/pull/16534))
+- Add `VolumeDriver.List` which lists all volumes owned by the driver ([#16534](https://github.com/docker/docker/pull/16534))
+
+### 1.8.0
+
+- Initial support for volume driver plugins ([#14659](https://github.com/docker/docker/pull/14659))
+
 ## Command-line changes
 
 A volume plugin makes use of the `-v`and `--volume-driver` flag on the `docker run` command.  The `-v` flag accepts a volume name and the `--volume-driver` flag a driver type, for example:
@@ -183,6 +198,7 @@ Get the volume info.
   "Volume": {
     "Name": "volume_name",
     "Mountpoint": "/path/to/directory/on/host",
+    "Status": {}
   },
   "Err": ""
 }

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2792,7 +2792,8 @@ Create a volume
     {
       "Name": "tardis",
       "Driver": "local",
-      "Mountpoint": "/var/lib/docker/volumes/tardis"
+      "Mountpoint": "/var/lib/docker/volumes/tardis",
+      "Status": null
     }
 
 Status Codes:

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -32,7 +32,8 @@ Example output:
       {
           "Name": "85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d",
           "Driver": "local",
-          "Mountpoint": "/var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data"
+          "Mountpoint": "/var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data",
+          "Status": null
       }
     ]
 

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -64,6 +64,7 @@ func (a *volumeDriverAdapter) Get(name string) (volume.Volume, error) {
 		name:       v.Name,
 		driverName: a.Name(),
 		eMount:     v.Mountpoint,
+		status:     v.Status,
 	}, nil
 }
 
@@ -72,11 +73,13 @@ type volumeAdapter struct {
 	name       string
 	driverName string
 	eMount     string // ephemeral host volume path
+	status     map[string]interface{}
 }
 
 type proxyVolume struct {
 	Name       string
 	Mountpoint string
+	Status     map[string]interface{}
 }
 
 func (a *volumeAdapter) Name() string {
@@ -110,4 +113,12 @@ func (a *volumeAdapter) Unmount() error {
 		a.eMount = ""
 	}
 	return err
+}
+
+func (a *volumeAdapter) Status() map[string]interface{} {
+	out := make(map[string]interface{}, len(a.status))
+	for k, v := range a.status {
+		out[k] = v
+	}
+	return out
 }

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -328,3 +328,7 @@ func validateOpts(opts map[string]string) error {
 	}
 	return nil
 }
+
+func (v *localVolume) Status() map[string]interface{} {
+	return nil
+}

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -24,6 +24,9 @@ func (NoopVolume) Mount() (string, error) { return "noop", nil }
 // Unmount unmounts the volume from the container
 func (NoopVolume) Unmount() error { return nil }
 
+// Status proivdes low-level details about the volume
+func (NoopVolume) Status() map[string]interface{} { return nil }
+
 // FakeVolume is a fake volume with a random name
 type FakeVolume struct {
 	name       string
@@ -49,6 +52,9 @@ func (FakeVolume) Mount() (string, error) { return "fake", nil }
 
 // Unmount unmounts the volume from the container
 func (FakeVolume) Unmount() error { return nil }
+
+// Status proivdes low-level details about the volume
+func (FakeVolume) Status() map[string]interface{} { return nil }
 
 // FakeDriver is a driver that generates fake volumes
 type FakeDriver struct {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -41,6 +41,8 @@ type Volume interface {
 	Mount() (string, error)
 	// Unmount unmounts the volume when it is no longer in use.
 	Unmount() error
+	// Status returns low-level status information about a volume
+	Status() map[string]interface{}
 }
 
 // MountPoint is the intersection point between a volume and a container. It


### PR DESCRIPTION
The `Status` field is a `[][]string` which allows the driver to pass
back low-level details about the underlying volume.

If all are good with design review I'll open a PR to engine-api.

![7680799_orig](https://cloud.githubusercontent.com/assets/799078/13582723/ef862478-e47b-11e5-9b1d-74d806ca9a39.jpg)
