### PR TITLE
Use forked gocheck

### DIFF
--- a/hack/Jenkins/W2L/setup.sh
+++ b/hack/Jenkins/W2L/setup.sh
@@ -196,7 +196,7 @@ fi
 if [ $ec -eq 0 ]; then
 	echo "INFO: Starting local build of Windows binary..."
 	set -x
-	export TIMEOUT="120m"
+	export TIMEOUT="5m"
 	export DOCKER_HOST="tcp://$ip:$port_inner"
 	export DOCKER_TEST_HOST="tcp://$ip:$port_inner"
 	unset DOCKER_CLIENTONLY

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -169,14 +169,12 @@ BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.
 
 if [ "${DOCKER_ENGINE_GOARCH}" == "arm" ]; then
-	: ${TIMEOUT:=210m}
+	: ${TIMEOUT:=10m}
 elif [ "${DOCKER_ENGINE_GOARCH}" == "windows" ]; then
-	: ${TIMEOUT:=180m}
+	: ${TIMEOUT:=8m}
 else
-	: ${TIMEOUT:=120m}
+	: ${TIMEOUT:=5m}
 fi
-
-TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC
@@ -250,6 +248,7 @@ test_env() {
 		DOCKER_REMAP_ROOT="$DOCKER_REMAP_ROOT" \
 		DOCKER_REMOTE_DAEMON="$DOCKER_REMOTE_DAEMON" \
 		GOPATH="$GOPATH" \
+		GOTRACEBACK=all \
 		HOME="$ABS_DEST/fake-HOME" \
 		PATH="$PATH" \
 		TEMP="$TEMP" \

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -2,7 +2,7 @@
 set -e
 
 bundle_test_integration_cli() {
-	TESTFLAGS="$TESTFLAGS -check.v"
+	TESTFLAGS="$TESTFLAGS -check.v -check.timeout=${TIMEOUT} -timeout=360m"
 	go_test_dir ./integration-cli
 }
 

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -8,6 +8,7 @@ set -e
 #   TESTFLAGS='-test.run ^TestBuild$' ./hack/make.sh test-unit
 #
 bundle_test_unit() {
+	TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 	date
 	if [ -z "$TESTDIRS" ]; then
 		TEST_PATH=./...

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -11,7 +11,7 @@ clone git github.com/Microsoft/hcsshim 116e0e9f5ced0cec94ae46d0aa1b3002a325f532
 clone git github.com/Microsoft/go-winio f778f05015353be65d242f3fedc18695756153bb
 clone git github.com/Sirupsen/logrus v0.9.0 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
-clone git github.com/go-check/check 11d3bc7aa68e238947792f30573146a3231fc0f1
+clone git github.com/go-check/check a625211d932a2a643d0d17352095f03fb7774663 https://github.com/cpuguy83/check.git
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 5cf931ef8f

--- a/vendor/src/github.com/go-check/check/.travis.yml
+++ b/vendor/src/github.com/go-check/check/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.5
+  - tip
+script:
+  - go get -u github.com/golang/lint/golint
+  - # go vet ./...
+  - # test -z "$(golint ./... | tee /dev/stderr)"
+  - # test -z "$(gofmt -s -l . | tee /dev/stderr)"
+  - go test -v ./...

--- a/vendor/src/github.com/go-check/check/README.md
+++ b/vendor/src/github.com/go-check/check/README.md
@@ -1,20 +1,10 @@
-Instructions
-============
+Go-check
+========
 
-Install the package with:
+This is a fork of https://github.com/go-check/check
 
-    go get gopkg.in/check.v1
-    
-Import it with:
+The intention of this fork is not to change any of the original behavior, but add
+some specific behaviors needed for some of my projects already using this test suite.
+For documentation on the main behavior of go-check see the aforementioned repo.
 
-    import "gopkg.in/check.v1"
-
-and use _check_ as the package name inside the code.
-
-For more details, visit the project page:
-
-* http://labix.org/gocheck
-
-and the API documentation:
-
-* https://gopkg.in/check.v1
+The original branch is intact at `orig_v1`

--- a/vendor/src/github.com/go-check/check/reporter.go
+++ b/vendor/src/github.com/go-check/check/reporter.go
@@ -1,0 +1,88 @@
+package check
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// -----------------------------------------------------------------------
+// Output writer manages atomic output writing according to settings.
+
+type outputWriter struct {
+	m                    sync.Mutex
+	writer               io.Writer
+	wroteCallProblemLast bool
+	Stream               bool
+	Verbose              bool
+}
+
+func newOutputWriter(writer io.Writer, stream, verbose bool) *outputWriter {
+	return &outputWriter{writer: writer, Stream: stream, Verbose: verbose}
+}
+
+func (ow *outputWriter) Write(content []byte) (n int, err error) {
+	ow.m.Lock()
+	n, err = ow.writer.Write(content)
+	ow.m.Unlock()
+	return
+}
+
+func (ow *outputWriter) WriteCallStarted(label string, c *C) {
+	if ow.Stream {
+		header := renderCallHeader(label, c, "", "\n")
+		ow.m.Lock()
+		ow.writer.Write([]byte(header))
+		ow.m.Unlock()
+	}
+}
+
+func (ow *outputWriter) WriteCallProblem(label string, c *C) {
+	var prefix string
+	if !ow.Stream {
+		prefix = "\n-----------------------------------" +
+			"-----------------------------------\n"
+	}
+	header := renderCallHeader(label, c, prefix, "\n\n")
+	ow.m.Lock()
+	ow.wroteCallProblemLast = true
+	ow.writer.Write([]byte(header))
+	if !ow.Stream {
+		c.logb.WriteTo(ow.writer)
+	}
+	ow.m.Unlock()
+}
+
+func (ow *outputWriter) WriteCallSuccess(label string, c *C) {
+	if ow.Stream || (ow.Verbose && c.kind == testKd) {
+		// TODO Use a buffer here.
+		var suffix string
+		if c.reason != "" {
+			suffix = " (" + c.reason + ")"
+		}
+		if c.status() == succeededSt {
+			suffix += "\t" + c.timerString()
+		}
+		suffix += "\n"
+		if ow.Stream {
+			suffix += "\n"
+		}
+		header := renderCallHeader(label, c, "", suffix)
+		ow.m.Lock()
+		// Resist temptation of using line as prefix above due to race.
+		if !ow.Stream && ow.wroteCallProblemLast {
+			header = "\n-----------------------------------" +
+				"-----------------------------------\n" +
+				header
+		}
+		ow.wroteCallProblemLast = false
+		ow.writer.Write([]byte(header))
+		ow.m.Unlock()
+	}
+}
+
+func renderCallHeader(label string, c *C, prefix, suffix string) string {
+	pc := c.method.PC()
+	return fmt.Sprintf("%s%s: %s: %s%s", prefix, label, niceFuncPath(pc),
+		niceFuncName(pc), suffix)
+}

--- a/vendor/src/github.com/go-check/check/run.go
+++ b/vendor/src/github.com/go-check/check/run.go
@@ -42,6 +42,7 @@ var (
 	newBenchMem    = flag.Bool("check.bmem", false, "Report memory benchmarks")
 	newListFlag    = flag.Bool("check.list", false, "List the names of all tests that will be run")
 	newWorkFlag    = flag.Bool("check.work", false, "Display and do not remove the test working directory")
+	checkTimeout   = flag.String("check.timeout", "", "Panic if test runs longer than specified duration")
 )
 
 // TestingT runs all test suites registered with the Suite function,
@@ -60,6 +61,13 @@ func TestingT(testingT *testing.T) {
 		BenchmarkTime: benchTime,
 		BenchmarkMem:  *newBenchMem,
 		KeepWorkDir:   *oldWorkFlag || *newWorkFlag,
+	}
+	if *checkTimeout != "" {
+		timeout, err := time.ParseDuration(*checkTimeout)
+		if err != nil {
+			testingT.Fatalf("error parsing specified timeout flag: %v", err)
+		}
+		conf.CheckTimeout = timeout
 	}
 	if *oldListFlag || *newListFlag {
 		w := bufio.NewWriter(os.Stdout)


### PR DESCRIPTION
- added support for per-check timeouts (upstream is non-responsive)
- set 5m per-check timeout

---

The original PR I made to go-check had a bad rebase (and difficult to recover from), so opened a new on here: go-check/check#80

Another PR for consideration is go-check/check#70 which adds parallel tests -- this is not included here as I have not merged it into my fork's master branch in consideration of the per-check timeout being a bit more pertinent to Docker's test suite right now.

The last merge to go-check/check was 3 months ago, and that merge also broke the test suite :(
