### PR TITLE
Fix race condition when exec with tty

### DIFF
--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -49,7 +49,7 @@ func (s *DockerSuite) TestExecTTY(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer p.Close()
 
-	_, err = p.Write([]byte("cat /foo && sleep 2 && exit\n"))
+	_, err = p.Write([]byte("cat /foo && exit\n"))
 	c.Assert(err, checker.IsNil)
 
 	chErr := make(chan error)


### PR DESCRIPTION
I can reproduce this easily on one of my servers, `docker exec -ti my_cont ls` will not print anything, without `-t` it acts normally.

It also revert hack in TestExecTTY, I think this PR can fix https://github.com/docker/docker/issues/18544
