### PR TITLE
Added recursive .dockerignore capabilities

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -125,14 +125,14 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			return fmt.Errorf("cannot canonicalize dockerfile path %s: %v", relDockerfile, err)
 		}
 
-		f, err := os.Open(filepath.Join(contextDir, ".dockerignore"))
+		_, err := os.Open(filepath.Join(contextDir, ".dockerignore"))
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
 
 		var excludes []string
 		if err == nil {
-			excludes, err = dockerignore.ReadAll(f)
+			excludes, err = dockerignore.ReadAllRecursive(contextDir, contextDir)
 			if err != nil {
 				return err
 			}

--- a/api/client/build.go
+++ b/api/client/build.go
@@ -19,9 +19,9 @@ import (
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/jsonmessage"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/precompiledregexp"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/urlutil"
@@ -130,15 +130,17 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			return err
 		}
 
-		var excludes []string
+		var regExpExcludes []precompiledregexp.PrecompiledRegExp
+		var stringExcludes []string
 		if err == nil {
-			excludes, err = dockerignore.ReadAllRecursive(contextDir, contextDir)
+			regExpExcludes, err = dockerignore.ReadAllRecursive(contextDir, contextDir)
+			stringExcludes = precompiledregexp.ToStringExpressions(regExpExcludes)
 			if err != nil {
 				return err
 			}
 		}
 
-		if err := builder.ValidateContextDirectory(contextDir, excludes); err != nil {
+		if err := builder.ValidateContextDirectory(contextDir, regExpExcludes); err != nil {
 			return fmt.Errorf("Error checking context: '%s'.", err)
 		}
 
@@ -150,15 +152,16 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		// parses the Dockerfile. Ignore errors here, as they will have been
 		// caught by validateContextDirectory above.
 		var includes = []string{"."}
-		keepThem1, _ := fileutils.Matches(".dockerignore", excludes)
-		keepThem2, _ := fileutils.Matches(relDockerfile, excludes)
+		keepThem1, _ := precompiledregexp.Matches(".dockerignore", regExpExcludes)
+		keepThem2, _ := precompiledregexp.Matches(relDockerfile, regExpExcludes)
 		if keepThem1 || keepThem2 {
 			includes = append(includes, ".dockerignore", relDockerfile)
 		}
 
+		// Tar the archive, using string exclusions. Works better for testing & API
 		ctx, err = archive.TarWithOptions(contextDir, &archive.TarOptions{
 			Compression:     archive.Uncompressed,
-			ExcludePatterns: excludes,
+			ExcludePatterns: stringExcludes,
 			IncludeFiles:    includes,
 		})
 		if err != nil {

--- a/builder/context.go
+++ b/builder/context.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/gitutils"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/precompiledregexp"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 )
@@ -23,7 +23,7 @@ import (
 // ValidateContextDirectory checks if all the contents of the directory
 // can be read and returns an error if some files can't be read
 // symlinks which point to non-existing files don't trigger an error
-func ValidateContextDirectory(srcPath string, excludes []string) error {
+func ValidateContextDirectory(srcPath string, excludes []precompiledregexp.PrecompiledRegExp) error {
 	contextRoot, err := getContextRoot(srcPath)
 	if err != nil {
 		return err
@@ -32,7 +32,7 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 		// skip this directory/file if it's not in the path, it won't get added to the context
 		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
 			return err
-		} else if skip, err := fileutils.Matches(relFilePath, excludes); err != nil {
+		} else if skip, err := precompiledregexp.Matches(relFilePath, excludes); err != nil {
 			return err
 		} else if skip {
 			if f.IsDir() {

--- a/builder/dockerignore/dockerignore.go
+++ b/builder/dockerignore/dockerignore.go
@@ -3,7 +3,10 @@ package dockerignore
 import (
 	"bufio"
 	"fmt"
+	"github.com/docker/docker/pkg/fileutils"
 	"io"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -31,5 +34,77 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("Error reading .dockerignore: %v", err)
 	}
+	return excludes, nil
+}
+
+// ReadAllRecursive takes a base directory and a starting directory,
+// reads all .dockerignore files in subdirectories and returns the list of file
+// patterns to ignore. Note this will trim whitespace from each line as well
+// as use GO's "clean" func to get the shortest/cleanest path for each.
+func ReadAllRecursive(baseDir string, directory string) ([]string, error) {
+
+	var excludes []string
+
+	directory = filepath.Clean(directory)
+	directory = filepath.ToSlash(directory)
+
+	dockerIgnFName := filepath.Join(directory, ".dockerignore")
+	reader, err := os.Open(dockerIgnFName)
+	// Note that a missing .dockerignore file isn't treated as an error
+	if err != nil {
+		// If file does not exist, ignore, and continue recursing as needed
+		// If file exists, and there is an error reading it, fail.
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	} else {
+		// If reader is nil, it means that something odd happened:
+		// lack of permissions, etc.
+		if reader == nil {
+			return nil, nil
+		}
+
+		ignFiles, err := ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+
+		relDirectory, err := filepath.Rel(baseDir, directory)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range ignFiles {
+			isException := ignFiles[i][0] == '!'
+			if isException && len(ignFiles[i]) > 1 {
+				ignFiles[i] = "!" + filepath.Clean(filepath.Join(relDirectory, ignFiles[i][1:len(ignFiles[i])]))
+			} else {
+				ignFiles[i] = filepath.Clean(filepath.Join(relDirectory, ignFiles[i]))
+			}
+		}
+		excludes = append(excludes, ignFiles...)
+	}
+
+	files, _ := ioutil.ReadDir(directory)
+	for _, f := range files {
+		if f.IsDir() {
+			// Calculate subDir path
+			subDir := filepath.Clean(filepath.Join(directory, f.Name()))
+			// Calculate relative subDir path
+			relSubDir, _ := filepath.Rel(baseDir, subDir)
+			// Make sure relative subDir path not in exclusions.
+			matches, _ := fileutils.Matches(relSubDir, excludes)
+			// If not excluded, recurse in
+			if !matches {
+				subDirIgnFiles, err := ReadAllRecursive(baseDir, subDir)
+				if err == nil {
+					excludes = append(excludes, subDirIgnFiles...)
+				} else {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	return excludes, nil
 }

--- a/builder/dockerignore/dockerignore_test.go
+++ b/builder/dockerignore/dockerignore_test.go
@@ -53,3 +53,283 @@ func TestReadAll(t *testing.T) {
 		t.Fatalf("Fourth element is not lastfile")
 	}
 }
+
+func TestReadAllRecursiveEmpty(t *testing.T) {
+	/*
+		Test Directory Structure:
+		> dir0_0C
+		>> .dockerignore
+		>> subdir1_1E
+		>>> subdir2_1C
+		>>>> .dockerignore
+		>> subdir1_2C
+		>>> .dockerignore
+		>> subdir1_3E
+	*/
+	baseDir, err := ioutil.TempDir("", "dockerignore-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir0_0C := baseDir
+	subdir1_1E, err := ioutil.TempDir(dir0_0C, "subdir1_1E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir2_1C, err := ioutil.TempDir(subdir1_1E, "subdir2_1C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir1_2C, err := ioutil.TempDir(dir0_0C, "subdir1_2C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ioutil.TempDir(dir0_0C, "subdir1_3E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir0_0C)
+
+	// Write content to files
+	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile")
+	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile")
+	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile")
+
+	err = ioutil.WriteFile(filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read from current directory; should give nothing - everything is in /tmp
+	di, err := ReadAllRecursive("", "")
+	if err != nil {
+		t.Fatalf("Expected not to have error, got %v", err)
+	}
+
+	if diLen := len(di); diLen != 0 {
+		t.Fatalf("Expected to have zero dockerignore entry, got %d", diLen)
+	}
+}
+func TestReadAllRecursiveFromRoot(t *testing.T) {
+	/*
+		Test Directory Structure:
+		> dir0_0C
+		>> .dockerignore
+		>> subdir1_1E
+		>>> subdir2_1C
+		>>>> .dockerignore
+		>> subdir1_2C
+		>>> .dockerignore
+		>> subdir1_3E
+	*/
+	baseDir, err := ioutil.TempDir("", "dockerignore-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir0_0C := baseDir
+	subdir1_1E, err := ioutil.TempDir(dir0_0C, "subdir1_1E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir2_1C, err := ioutil.TempDir(subdir1_1E, "subdir2_1C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir1_2C, err := ioutil.TempDir(dir0_0C, "subdir1_2C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ioutil.TempDir(dir0_0C, "subdir1_3E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir0_0C)
+
+	// Convert all paths to relative paths from base testing directory
+	dir0_0CRel, err := filepath.Rel(baseDir, dir0_0C)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir2_1CRel, err := filepath.Rel(baseDir, subdir2_1C)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir1_2CRel, err := filepath.Rel(baseDir, subdir1_2C)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write content to files
+	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile")
+	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile")
+	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile")
+
+	err = ioutil.WriteFile(filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read from root of item
+	di, err := ReadAllRecursive(dir0_0C, dir0_0C)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check result length
+	if diLen := len(di); diLen != 12 {
+		t.Fatalf("Expected to have twelve dockerignore entries, got %d", diLen)
+	}
+
+	// Test to make sure all paths are correct, relative to base testing directory
+	expected := filepath.Join(dir0_0CRel, "0_0File1")
+	if di[0] != expected {
+		t.Fatalf("9th element is not " + expected)
+	}
+	expected = filepath.Join(dir0_0CRel, "/0_0File2")
+	if di[1] != expected {
+		t.Fatalf("10th element is not " + expected)
+	}
+	expected = "!" + filepath.Join(dir0_0CRel, "/dir/subdir/0_0file")
+	if di[2] != expected {
+		t.Fatalf("11th element is not " + expected)
+	}
+	expected = filepath.Join(dir0_0CRel, "0_0lastfile")
+	if di[3] != expected {
+		t.Fatalf("12th element is not " + expected)
+	}
+	expected = filepath.Join(subdir2_1CRel, "2_1File1")
+	if di[4] != expected {
+		t.Fatalf("1st element is not " + expected)
+	}
+	expected = filepath.Join(subdir2_1CRel, "/2_1File2")
+	if di[5] != expected {
+		t.Fatalf("2nd element is not " + expected)
+	}
+	expected = "!" + filepath.Join(subdir2_1CRel, "/dir/subdir/2_1file")
+	if di[6] != expected {
+		t.Fatalf("3rd element is not " + expected)
+	}
+	expected = filepath.Join(subdir2_1CRel, "2_1lastfile")
+	if di[7] != expected {
+		t.Fatalf("4th element is not " + expected)
+	}
+	expected = filepath.Join(subdir1_2CRel, "1_2File1")
+	if di[8] != expected {
+		t.Fatalf("5th element is not " + expected)
+	}
+	expected = filepath.Join(subdir1_2CRel, "/1_2File2")
+	if di[9] != expected {
+		t.Fatalf("6th element is not " + expected)
+	}
+	expected = "!" + filepath.Join(subdir1_2CRel, "/dir/subdir/1_2file")
+	if di[10] != expected {
+		t.Fatalf("7th element is not " + expected)
+	}
+	expected = filepath.Join(subdir1_2CRel, "1_2lastfile")
+	if di[11] != expected {
+		t.Fatalf("8th element is not " + expected)
+	}
+}
+func TestReadAllRecursiveFromSubDir1_1(t *testing.T) {
+	/*
+		Test Directory Structure:
+		> dir0_0C
+		>> .dockerignore
+		>> subdir1_1E
+		>>> subdir2_1C
+		>>>> .dockerignore
+		>> subdir1_2C
+		>>> .dockerignore
+		>> subdir1_3E
+	*/
+	baseDir, err := ioutil.TempDir("", "dockerignore-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir0_0C := baseDir
+	subdir1_1E, err := ioutil.TempDir(dir0_0C, "subdir1_1E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir2_1C, err := ioutil.TempDir(subdir1_1E, "subdir2_1C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	subdir1_2C, err := ioutil.TempDir(dir0_0C, "subdir1_2C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ioutil.TempDir(dir0_0C, "subdir1_3E")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir0_0C)
+
+	// Convert all paths to relative paths from base testing directory
+	subdir2_1CRel, err := filepath.Rel(subdir1_1E, subdir2_1C)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write content to files
+	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile")
+	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile")
+	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile")
+
+	err = ioutil.WriteFile(filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read starting from subdir1_1E
+	di, err := ReadAllRecursive(subdir1_1E, subdir1_1E)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check length of result
+	if diLen := len(di); diLen != 4 {
+		t.Fatalf("Expected to have four dockerignore entries, got %d", diLen)
+	}
+
+	// Test to make sure all paths are correct, relative to base testing directory
+	expected := filepath.Join(subdir2_1CRel, "2_1File1")
+	if di[0] != expected {
+		t.Fatalf("1st element is not " + expected)
+	}
+	expected = filepath.Join(subdir2_1CRel, "/2_1File2")
+	if di[1] != expected {
+		t.Fatalf("2nd element is not " + expected)
+	}
+	expected = "!" + filepath.Join(subdir2_1CRel, "/dir/subdir/2_1file")
+	if di[2] != expected {
+		t.Fatalf("3rd element is not " + expected)
+	}
+	expected = filepath.Join(subdir2_1CRel, "2_1lastfile")
+	if di[3] != expected {
+		t.Fatalf("4th element is not " + expected)
+	}
+}

--- a/builder/dockerignore/dockerignore_test.go
+++ b/builder/dockerignore/dockerignore_test.go
@@ -2,17 +2,16 @@ package dockerignore
 
 import (
 	"fmt"
+	"github.com/docker/docker/pkg/precompiledregexp"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
 func TestReadAll(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "dockerignore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := createTmpDir(t, "", "dockerignore-test")
 	defer os.RemoveAll(tmpDir)
 
 	di, err := ReadAll(nil)
@@ -38,6 +37,10 @@ func TestReadAll(t *testing.T) {
 	di, err = ReadAll(diFd)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if len(di) != 4 {
+		t.Fatalf("Expected to have zero dockerignore entry, got %d", len(di))
 	}
 
 	if di[0] != "test1" {
@@ -66,46 +69,21 @@ func TestReadAllRecursiveEmpty(t *testing.T) {
 		>>> .dockerignore
 		>> subdir1_3E
 	*/
-	baseDir, err := ioutil.TempDir("", "dockerignore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dir0_0C := baseDir
-	subdir1_1E, err := ioutil.TempDir(dir0_0C, "subdir1_1E")
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir2_1C, err := ioutil.TempDir(subdir1_1E, "subdir2_1C")
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir1_2C, err := ioutil.TempDir(dir0_0C, "subdir1_2C")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = ioutil.TempDir(dir0_0C, "subdir1_3E")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir0_0C := createTmpDir(t, "", "dockerignore-test")
+	subdir1_1E := createTmpDir(t, dir0_0C, "subdir1_1E")
+	subdir2_1C := createTmpDir(t, subdir1_1E, "subdir2_1C")
+	subdir1_2C := createTmpDir(t, dir0_0C, "subdir1_2C")
+	ioutil.TempDir(dir0_0C, "subdir1_3E")
 	defer os.RemoveAll(dir0_0C)
 
 	// Write content to files
-	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile")
-	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile")
-	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile")
+	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile\n!")
+	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile\n!")
+	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile\n!")
 
-	err = ioutil.WriteFile(filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
+	writeFileHelper(t, filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
+	writeFileHelper(t, filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
+	writeFileHelper(t, filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
 
 	// Read from current directory; should give nothing - everything is in /tmp
 	di, err := ReadAllRecursive("", "")
@@ -129,60 +107,21 @@ func TestReadAllRecursiveFromRoot(t *testing.T) {
 		>>> .dockerignore
 		>> subdir1_3E
 	*/
-	baseDir, err := ioutil.TempDir("", "dockerignore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dir0_0C := baseDir
-	subdir1_1E, err := ioutil.TempDir(dir0_0C, "subdir1_1E")
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir2_1C, err := ioutil.TempDir(subdir1_1E, "subdir2_1C")
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir1_2C, err := ioutil.TempDir(dir0_0C, "subdir1_2C")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = ioutil.TempDir(dir0_0C, "subdir1_3E")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir0_0C := createTmpDir(t, "", "dockerignore-test")
+	subdir1_1E := createTmpDir(t, dir0_0C, "subdir1_1E")
+	subdir2_1C := createTmpDir(t, subdir1_1E, "subdir2_1C")
+	subdir1_2C := createTmpDir(t, dir0_0C, "subdir1_2C")
+	ioutil.TempDir(dir0_0C, "subdir1_3E")
 	defer os.RemoveAll(dir0_0C)
 
-	// Convert all paths to relative paths from base testing directory
-	dir0_0CRel, err := filepath.Rel(baseDir, dir0_0C)
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir2_1CRel, err := filepath.Rel(baseDir, subdir2_1C)
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir1_2CRel, err := filepath.Rel(baseDir, subdir1_2C)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Write content to files
-	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile")
-	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile")
-	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile")
+	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile\n!")
+	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile\n!")
+	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile\n!")
 
-	err = ioutil.WriteFile(filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
+	writeFileHelper(t, filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
+	writeFileHelper(t, filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
+	writeFileHelper(t, filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
 
 	// Read from root of item
 	di, err := ReadAllRecursive(dir0_0C, dir0_0C)
@@ -191,58 +130,58 @@ func TestReadAllRecursiveFromRoot(t *testing.T) {
 	}
 
 	// Check result length
-	if diLen := len(di); diLen != 12 {
+	if diLen := len(di); diLen != 15 {
 		t.Fatalf("Expected to have twelve dockerignore entries, got %d", diLen)
 	}
 
+	expectedStrings := []string{
+		getRelPath(t, dir0_0C, filepath.Join(dir0_0C, "0_0File1")),
+		getRelPath(t, dir0_0C, filepath.Join(dir0_0C, "0_0File2")),
+		"!" + getRelPath(t, dir0_0C, filepath.Join(dir0_0C, "/dir/subdir/0_0file")),
+		getRelPath(t, dir0_0C, filepath.Join(dir0_0C, "0_0lastfile")),
+		getRelPath(t, dir0_0C, filepath.Join(dir0_0C, "!")),
+		getRelPath(t, dir0_0C, filepath.Join(subdir2_1C, "2_1File1")),
+		getRelPath(t, dir0_0C, filepath.Join(subdir2_1C, "2_1File2")),
+		"!" + getRelPath(t, dir0_0C, filepath.Join(subdir2_1C, "/dir/subdir/2_1file")),
+		getRelPath(t, dir0_0C, filepath.Join(subdir2_1C, "2_1lastfile")),
+		"!" + getRelPath(t, dir0_0C, filepath.Join(subdir2_1C, "")),
+		getRelPath(t, dir0_0C, filepath.Join(subdir1_2C, "1_2File1")),
+		getRelPath(t, dir0_0C, filepath.Join(subdir1_2C, "1_2File2")),
+		"!" + getRelPath(t, dir0_0C, filepath.Join(subdir1_2C, "/dir/subdir/1_2file")),
+		getRelPath(t, dir0_0C, filepath.Join(subdir1_2C, "1_2lastfile")),
+		"!" + getRelPath(t, dir0_0C, filepath.Join(subdir1_2C, "")),
+	}
+
+	expectedNegVals := []bool{
+		false,
+		false,
+		true,
+		false,
+		true,
+		false,
+		false,
+		true,
+		false,
+		true,
+		false,
+		false,
+		true,
+		false,
+		true,
+	}
+
 	// Test to make sure all paths are correct, relative to base testing directory
-	expected := filepath.Join(dir0_0CRel, "0_0File1")
-	if di[0] != expected {
-		t.Fatalf("9th element is not " + expected)
-	}
-	expected = filepath.Join(dir0_0CRel, "/0_0File2")
-	if di[1] != expected {
-		t.Fatalf("10th element is not " + expected)
-	}
-	expected = "!" + filepath.Join(dir0_0CRel, "/dir/subdir/0_0file")
-	if di[2] != expected {
-		t.Fatalf("11th element is not " + expected)
-	}
-	expected = filepath.Join(dir0_0CRel, "0_0lastfile")
-	if di[3] != expected {
-		t.Fatalf("12th element is not " + expected)
-	}
-	expected = filepath.Join(subdir2_1CRel, "2_1File1")
-	if di[4] != expected {
-		t.Fatalf("1st element is not " + expected)
-	}
-	expected = filepath.Join(subdir2_1CRel, "/2_1File2")
-	if di[5] != expected {
-		t.Fatalf("2nd element is not " + expected)
-	}
-	expected = "!" + filepath.Join(subdir2_1CRel, "/dir/subdir/2_1file")
-	if di[6] != expected {
-		t.Fatalf("3rd element is not " + expected)
-	}
-	expected = filepath.Join(subdir2_1CRel, "2_1lastfile")
-	if di[7] != expected {
-		t.Fatalf("4th element is not " + expected)
-	}
-	expected = filepath.Join(subdir1_2CRel, "1_2File1")
-	if di[8] != expected {
-		t.Fatalf("5th element is not " + expected)
-	}
-	expected = filepath.Join(subdir1_2CRel, "/1_2File2")
-	if di[9] != expected {
-		t.Fatalf("6th element is not " + expected)
-	}
-	expected = "!" + filepath.Join(subdir1_2CRel, "/dir/subdir/1_2file")
-	if di[10] != expected {
-		t.Fatalf("7th element is not " + expected)
-	}
-	expected = filepath.Join(subdir1_2CRel, "1_2lastfile")
-	if di[11] != expected {
-		t.Fatalf("8th element is not " + expected)
+	for i := range di {
+		if di[i].Pattern() != expectedStrings[i] {
+			t.Fatalf("Element " + strconv.Itoa(i+1) + " is not " + expectedStrings[i] + ": " + di[i].Pattern())
+		}
+		if di[i].Negative() != expectedNegVals[i] {
+			if expectedNegVals[i] {
+				t.Fatalf("Element " + strconv.Itoa(i+1) + " expected to be negative")
+			} else {
+				t.Fatalf("Element " + strconv.Itoa(i+1) + " expected not to be negative")
+			}
+		}
 	}
 }
 func TestReadAllRecursiveFromSubDir1_1(t *testing.T) {
@@ -257,52 +196,21 @@ func TestReadAllRecursiveFromSubDir1_1(t *testing.T) {
 		>>> .dockerignore
 		>> subdir1_3E
 	*/
-	baseDir, err := ioutil.TempDir("", "dockerignore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dir0_0C := baseDir
-	subdir1_1E, err := ioutil.TempDir(dir0_0C, "subdir1_1E")
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir2_1C, err := ioutil.TempDir(subdir1_1E, "subdir2_1C")
-	if err != nil {
-		t.Fatal(err)
-	}
-	subdir1_2C, err := ioutil.TempDir(dir0_0C, "subdir1_2C")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = ioutil.TempDir(dir0_0C, "subdir1_3E")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir0_0C := createTmpDir(t, "", "dockerignore-test")
+	subdir1_1E := createTmpDir(t, dir0_0C, "subdir1_1E")
+	subdir2_1C := createTmpDir(t, subdir1_1E, "subdir2_1C")
+	subdir1_2C := createTmpDir(t, dir0_0C, "subdir1_2C")
+	ioutil.TempDir(dir0_0C, "subdir1_3E")
 	defer os.RemoveAll(dir0_0C)
 
-	// Convert all paths to relative paths from base testing directory
-	subdir2_1CRel, err := filepath.Rel(subdir1_1E, subdir2_1C)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Write content to files
-	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile")
-	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile")
-	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile")
+	content := fmt.Sprintf("0_0File1\n/0_0File2\n!/dir/subdir/0_0file\n\n0_0lastfile\n!")
+	content2 := fmt.Sprintf("2_1File1\n/2_1File2\n!/dir/subdir/2_1file\n\n2_1lastfile\n!")
+	content3 := fmt.Sprintf("1_2File1\n/1_2File2\n!/dir/subdir/1_2file\n\n1_2lastfile\n!")
 
-	err = ioutil.WriteFile(filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
+	writeFileHelper(t, filepath.Join(dir0_0C, ".dockerignore"), []byte(content), 0777)
+	writeFileHelper(t, filepath.Join(subdir2_1C, ".dockerignore"), []byte(content2), 0777)
+	writeFileHelper(t, filepath.Join(subdir1_2C, ".dockerignore"), []byte(content3), 0777)
 
 	// Read starting from subdir1_1E
 	di, err := ReadAllRecursive(subdir1_1E, subdir1_1E)
@@ -311,25 +219,62 @@ func TestReadAllRecursiveFromSubDir1_1(t *testing.T) {
 	}
 
 	// Check length of result
-	if diLen := len(di); diLen != 4 {
+	if diLen := len(di); diLen != 5 {
 		t.Fatalf("Expected to have four dockerignore entries, got %d", diLen)
 	}
 
+	expectedStrings := []string{
+		getRelPath(t, subdir1_1E, filepath.Join(subdir2_1C, "2_1File1")),
+		getRelPath(t, subdir1_1E, filepath.Join(subdir2_1C, "/2_1File2")),
+		"!" + getRelPath(t, subdir1_1E, filepath.Join(subdir2_1C, "/dir/subdir/2_1file")),
+		getRelPath(t, subdir1_1E, filepath.Join(subdir2_1C, "2_1lastfile")),
+		"!" + getRelPath(t, subdir1_1E, filepath.Join(subdir2_1C, "")),
+	}
+
+	expectedNegVals := []bool{
+		false,
+		false,
+		true,
+		false,
+		true,
+	}
+
 	// Test to make sure all paths are correct, relative to base testing directory
-	expected := filepath.Join(subdir2_1CRel, "2_1File1")
-	if di[0] != expected {
-		t.Fatalf("1st element is not " + expected)
+	for i := range di {
+		if di[i].Pattern() != expectedStrings[i] {
+			t.Fatalf("Element " + strconv.Itoa(i+1) + " is not " + expectedStrings[i] + ": " + di[i].Pattern())
+		}
+		if di[i].Negative() != expectedNegVals[i] {
+			if expectedNegVals[i] {
+				t.Fatalf("Element " + strconv.Itoa(i+1) + " expected to be negative")
+			} else {
+				t.Fatalf("Element " + strconv.Itoa(i+1) + " expected not to be negative")
+			}
+		}
 	}
-	expected = filepath.Join(subdir2_1CRel, "/2_1File2")
-	if di[1] != expected {
-		t.Fatalf("2nd element is not " + expected)
+
+	fmt.Println(precompiledregexp.ToStringExpressions(di))
+}
+
+func writeFileHelper(t *testing.T, filename string, data []byte, perm os.FileMode) {
+	err := ioutil.WriteFile(filename, data, perm)
+	if err != nil {
+		t.Fatal(err)
 	}
-	expected = "!" + filepath.Join(subdir2_1CRel, "/dir/subdir/2_1file")
-	if di[2] != expected {
-		t.Fatalf("3rd element is not " + expected)
+}
+func createTmpDir(t *testing.T, dir string, prefix string) string {
+
+	result, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		t.Fatal(err)
 	}
-	expected = filepath.Join(subdir2_1CRel, "2_1lastfile")
-	if di[3] != expected {
-		t.Fatalf("4th element is not " + expected)
+	return result
+}
+
+func getRelPath(t *testing.T, baseDir string, path string) string {
+	relPath, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		t.Fatal(err)
 	}
+	return relPath
 }

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -49,8 +49,9 @@ Dockerfile.
 To use a file in the build context, the `Dockerfile` refers to the file specified
 in an instruction, for example,  a `COPY` instruction. To increase the build's
 performance, exclude files and directories by adding a `.dockerignore` file to
-the context directory.  For information about how to [create a `.dockerignore`
-file](#dockerignore-file) see the documentation on this page.
+the context directory, or any of the subdirectories. For information about
+how to [create a `.dockerignore` file](#dockerignore-file) see the documentation
+on this page.
 
 Traditionally, the `Dockerfile` is called `Dockerfile` and located in the root
 of the context. You use the `-f` flag with `docker build` to point to a Dockerfile
@@ -195,19 +196,26 @@ that set `abc` to `bye`.
 ### .dockerignore file
 
 Before the docker CLI sends the context to the docker daemon, it looks
-for a file named `.dockerignore` in the root directory of the context.
-If this file exists, the CLI modifies the context to exclude files and
-directories that match patterns in it.  This helps to avoid
-unnecessarily sending large or sensitive files and directories to the
-daemon and potentially adding them to images using `ADD` or `COPY`.
+for a file named `.dockerignore` in the root directory, as well as any
+subdirectories of the context. If this file exists, the CLI modifies the
+context to exclude files and directories that match patterns in it.
+This helps to avoid unnecessarily sending large or sensitive files and
+directories to the daemon and potentially adding them to images using
+`ADD` or `COPY`.
 
 The CLI interprets the `.dockerignore` file as a newline-separated
 list of patterns similar to the file globs of Unix shells.  For the
-purposes of matching, the root of the context is considered to be both
-the working and the root directory.  For example, the patterns
-`/foo/bar` and `foo/bar` both exclude a file or directory named `bar`
-in the `foo` subdirectory of `PATH` or in the root of the git
-repository located at `URL`.  Neither excludes anything else.
+purposes of matching, the root of the context is considered to the
+root directory, and the working directory is the path of the `.dockerignore
+file`. For example, the patterns `/foo/bar` and `foo/bar` both exclude
+ a file or directory named `bar` in the `foo` subdirectory of `PATH`
+ or in the root of the git repository located at `URL`.  Neither
+ excludes anything else.
+
+Note that all relative paths listed in any `.dockerignore`
+file are relative to the directory that specific `.dockerignore` file is in.
+ For example, if the `.dockerignore` file located at `/foo/bar` had
+ `baz/text.txt`, the file to be ignored would be: `/foo/bar/baz/text.txt`.
 
 Here is an example `.dockerignore` file:
 
@@ -221,9 +229,10 @@ This file causes the following build behavior:
 
 | Rule           | Behavior                                                                                                                                                                     |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `*/temp*`      | Exclude files and directories whose names start with `temp` in any immediate subdirectory of the root.  For example, the plain file `/somedir/temporary.txt` is excluded, as is the directory `/somedir/temp`.                 |
-| `*/*/temp*`    | Exclude files and directories starting with `temp` from any subdirectory that is two levels below the root. For example, `/somedir/subdir/temporary.txt` is excluded. |
-| `temp?`        | Exclude files and directories in the root directory whose names are a one-character extension of `temp`.  For example, `/tempa` and `/tempb` are excluded.
+| `*/temp*`      | Exclude files and directories whose names start with `temp` in any immediate subdirectory of the working directory.  For example, the plain file `./somedir/temporary.txt` is excluded, as is the directory `./somedir/temp`.                 |
+| `*/*/temp*`    | Exclude files and directories starting with `temp` from any subdirectory that is two levels below the working directory. For example, `./somedir/subdir/temporary.txt` is excluded. |
+| `temp?`        | Exclude files and directories in the working directory directory whose names are a one-character extension of `temp`.  For example, `./tempa` and `./tempb` are excluded.
+| `/fromRoot.txt`| Exclude the text file "fromRoot" located in the *root* directory.
 
 
 Matching is done using Go's

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3715,7 +3715,7 @@ func (s *DockerSuite) TestBuildDockerignoringBadExclusion(c *check.C) {
 	}
 
 	if err.Error() != "failed to build the image: Error checking context: 'Illegal exclusion pattern: !'.\n" {
-		c.Fatalf("Incorrect output, got:%q", err.Error())
+		c.Fatalf("Incorrect output, got: %s", err.Error())
 	}
 }
 

--- a/pkg/precompiledregexp/precompiledregexp.go
+++ b/pkg/precompiledregexp/precompiledregexp.go
@@ -1,0 +1,281 @@
+package precompiledregexp
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/scanner"
+
+	"errors"
+	"github.com/Sirupsen/logrus"
+)
+
+// PrecompiledRegExp represents a precompiled regular expression, and some
+// pre-computed data for better performance. Meant for file pattern matching
+type PrecompiledRegExp struct {
+	pattern     string
+	regExpr     *regexp.Regexp
+	patternDirs []string
+	negative    bool
+}
+
+// Pattern retrieves pattern, with ! in front if pattern is in the negative
+func (regExpr PrecompiledRegExp) Pattern() string {
+	if regExpr.negative {
+		return "!" + regExpr.pattern
+	}
+	return regExpr.pattern
+}
+
+// RawPattern retrieves pattern, without !. Allows comparison of
+// patterns between negative and non-negative regular expressions
+func (regExpr PrecompiledRegExp) RawPattern() string {
+	return regExpr.pattern
+}
+
+// RegExpr retrieves regular expression, should it ever be needed.
+// Getter method, to prevent modification.
+func (regExpr PrecompiledRegExp) RegExpr() *regexp.Regexp {
+	return regExpr.regExpr
+}
+
+// Negative retrieves boolean flag as to whether Regular Expression is negative
+func (regExpr PrecompiledRegExp) Negative() bool {
+	return regExpr.negative
+}
+
+// PatternDirs retrieves directories that the pattern addresses.
+func (regExpr PrecompiledRegExp) PatternDirs() []string {
+	return regExpr.patternDirs
+}
+
+// Matches checks if this regular expression matches the string supplied. If pattern
+// matches the argument, but regular expression is negative, will return false.
+// The file provided should be provided as a path relative to the root context.
+func (regExpr PrecompiledRegExp) Matches(relDir string) (bool, error) {
+	matched := false
+
+	match, err := regExpr.internalMatches(relDir)
+	if err != nil {
+		return false, err
+	}
+
+	if match {
+		matched = !regExpr.negative
+	}
+
+	if matched {
+		logrus.Debugf("Skipping excluded path: %s", relDir)
+	}
+
+	return matched, nil
+}
+
+// internalMatches checks if this regular expression matches the string supplied.
+// Will not correct boolean return value of negative regular expressions.
+// THe file provided should be provided as a path relative to the root context.
+func (regExpr PrecompiledRegExp) internalMatches(relDir string) (bool, error) {
+	if regExpr.regExpr == nil {
+		return false, errors.New("Illegal exclusion pattern: " + regExpr.Pattern())
+	}
+
+	relDir = filepath.FromSlash(relDir)
+	parentPathDirs := strings.Split(relDir, string(os.PathSeparator))
+
+	match := regExpr.regExpr.MatchString(relDir)
+
+	if !match && relDir != "." && relDir != "" {
+		// Check to see if the pattern matches one of our parent dirs.
+		if len(regExpr.patternDirs) < len(parentPathDirs) {
+			match, _ = regExpr.internalMatches(strings.Join(parentPathDirs[:len(regExpr.patternDirs)], string(os.PathSeparator)))
+		}
+	}
+
+	return match, nil
+}
+
+// NewPreCompiledRegExp will create a new instance of a PrecompiledRegExp,
+// which will have the regular expression already generated. If an expression
+// is expected to be used multiple times, use this to increase performance.
+//
+// NewPreCompiledRegExp tries to match the logic of filepath.Match but
+// does so using regexp logic. We do this so that we can expand the
+// wildcard set to include other things, like "**" to mean any number
+// of directories.  This means that we should be backwards compatible
+// with filepath.Match(). We'll end up supporting more stuff, due to
+// the fact that we're using regexp, but that's ok - it does no harm.
+//
+// As per the comment in golangs filepath.Match, on Windows, escaping
+// is disabled. Instead, '\\' is treated as path separator.
+func NewPreCompiledRegExp(pattern string, isNegative bool) (*PrecompiledRegExp, error) {
+	pattern = filepath.Clean(pattern)
+	if pattern == "." {
+		if isNegative {
+			return &PrecompiledRegExp{
+				pattern:     "",
+				regExpr:     nil,
+				negative:    true,
+				patternDirs: nil,
+			}, nil
+		}
+		return nil, errors.New("Invalid pattern; current directory")
+	}
+
+	regStr := "^"
+
+	// Go through the pattern and convert it to a regexp.
+	// We use a scanner so we can support utf-8 chars.
+	var scan scanner.Scanner
+	scan.Init(strings.NewReader(pattern))
+
+	sl := string(os.PathSeparator)
+	escSL := sl
+	if sl == `\` {
+		escSL += `\`
+	}
+
+	for scan.Peek() != scanner.EOF {
+		ch := scan.Next()
+
+		if ch == '*' {
+			if scan.Peek() == '*' {
+				// is some flavor of "**"
+				scan.Next()
+
+				if scan.Peek() == scanner.EOF {
+					// is "**EOF" - to align with .gitignore just accept all
+					regStr += ".*"
+				} else {
+					// is "**"
+					regStr += "((.*" + escSL + ")|([^" + escSL + "]*))"
+				}
+
+				// Treat **/ as ** so eat the "/"
+				if string(scan.Peek()) == sl {
+					scan.Next()
+				}
+			} else {
+				// is "*" so map it to anything but "/"
+				regStr += "[^" + escSL + "]*"
+			}
+		} else if ch == '?' {
+			// "?" is any char except "/"
+			regStr += "[^" + escSL + "]"
+		} else if strings.Index(".$", string(ch)) != -1 {
+			if ch == '.' && scan.Peek() == '.' {
+				scan.Next()
+				if string(scan.Peek()) == sl {
+					return nil, errors.New("Invalid pattern: cannot traverse up directory tree")
+				}
+				regStr += `\.\.`
+			}
+			// Escape some regexp special chars that have no meaning
+			// in golang's filepath.Match
+			regStr += `\` + string(ch)
+		} else if ch == '\\' {
+			// escape next char. Note that a trailing \ in the pattern
+			// will be left alone (but need to escape it)
+			if sl == `\` {
+				// On windows map "\" to "\\", meaning an escaped backslash,
+				// and then just continue because filepath.Match on
+				// Windows doesn't allow escaping at all
+				regStr += escSL
+				continue
+			}
+			if scan.Peek() != scanner.EOF {
+				regStr += `\` + string(scan.Next())
+			} else {
+				regStr += `\`
+			}
+		} else {
+			regStr += string(ch)
+		}
+	}
+
+	regStr += "$"
+
+	regExpr, err := regexp.Compile(regStr)
+	// Map regexp's error to filepath's so no one knows we're not using filepath
+	if err != nil {
+		err = filepath.ErrBadPattern
+	}
+
+	patternDirs := strings.Split(pattern, string(os.PathSeparator))
+
+	return &PrecompiledRegExp{
+		regExpr:     regExpr,
+		pattern:     pattern,
+		negative:    isNegative,
+		patternDirs: patternDirs,
+	}, err
+}
+
+// Matches returns true if file matches any of the regular expressions,
+// and isn't excluded by any of the subsequent regular expressions.
+func Matches(relPath string, regExprs []PrecompiledRegExp) (bool, error) {
+	matches := false
+	for _, entry := range regExprs {
+		var err error
+		matchesString, err := entry.internalMatches(relPath)
+		if err != nil {
+			return false, err
+		}
+
+		if matchesString {
+			matches = !entry.Negative()
+		}
+	}
+
+	return matches, nil
+}
+
+// ToStringExpressions converts the list of regular expressions to a string list,
+// for logging or passing as command line arguments.
+func ToStringExpressions(regExprs []PrecompiledRegExp) []string {
+	stringExprs := make([]string, 0, len(regExprs))
+	for _, entry := range regExprs {
+		stringExprs = append(stringExprs, entry.Pattern())
+	}
+	return stringExprs
+}
+
+// FromStringExpressions creates a list of PrecompiledRegExps from a list of strings.
+// This is used to compile a list of regular expressions from a list of the patterns.
+func FromStringExpressions(stringExprs []string) ([]PrecompiledRegExp, error) {
+	regExprs := make([]PrecompiledRegExp, 0, len(stringExprs))
+	for _, pattern := range stringExprs {
+		var regExpr *PrecompiledRegExp
+		var err error
+
+		if pattern == "" {
+			return nil, errors.New("Illegal exclusion pattern: " + "\"\"")
+		}
+
+		isException := pattern[0] == '!'
+		if isException {
+			regExpr, err = NewPreCompiledRegExp(
+				pattern[1:], true)
+		} else {
+			regExpr, err = NewPreCompiledRegExp(
+				pattern, false)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		regExprs = append(regExprs, *regExpr)
+	}
+	return regExprs, nil
+}
+
+// HasNegatives checks if any of the regular expressions in this list are negative.
+// Allows some short-circuiting if we know none are negative.
+func HasNegatives(regExprs []PrecompiledRegExp) bool {
+	for _, entry := range regExprs {
+		if entry.negative {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/precompiledregexp/precompiledregexp_test.go
+++ b/pkg/precompiledregexp/precompiledregexp_test.go
@@ -1,0 +1,439 @@
+package precompiledregexp
+
+import (
+	"fmt"
+	"github.com/docker/docker/pkg/fileutils"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type testInstance struct {
+	pattern             []string
+	negative            bool
+	shouldErrorOnCreate bool
+	shouldErrorOnMatch  bool
+	shouldMatchStrings  map[string]bool
+}
+
+var testStrings = []string{
+	"",
+	".",
+	"a",
+	"b",
+	"c",
+	"a/b",
+	"a/c",
+	"a/b/c",
+	"/a",
+	"/b",
+	"/c",
+	"/a/b",
+	"/a/c",
+	"/a/b/c",
+	"precompiledregexp.go",
+	"precompiledregexp_test.go",
+	"builder/builder.go",
+	"docs/README.md",
+	"docs/DOCUMENTATION.md",
+}
+
+func TestPrecompiledRegExp(t *testing.T) {
+
+	tests := []testInstance{
+		{
+			pattern:             []string{""},
+			shouldErrorOnCreate: true,
+		},
+		{
+			pattern: []string{},
+		},
+		{
+			pattern:            []string{"!"},
+			shouldErrorOnMatch: true,
+		},
+		{
+			pattern:             []string{"."},
+			shouldErrorOnCreate: true,
+		},
+		{
+			pattern:             []string{"["},
+			shouldErrorOnCreate: true,
+		},
+		{
+			pattern:            []string{"!."},
+			shouldErrorOnMatch: true,
+		},
+		{
+			pattern: []string{"a"},
+			shouldMatchStrings: map[string]bool{
+				"a":     true,
+				"a/b":   true,
+				"a/c":   true,
+				"a/b/c": true,
+			},
+		},
+		{
+			pattern:            []string{"!a"},
+			shouldMatchStrings: map[string]bool{},
+		},
+		{
+			pattern: []string{"/a"},
+			shouldMatchStrings: map[string]bool{
+				"/a":     true,
+				"/a/b":   true,
+				"/a/c":   true,
+				"/a/b/c": true,
+			},
+		},
+		{
+			pattern:            []string{"!/a"},
+			shouldMatchStrings: map[string]bool{},
+		},
+		{
+			pattern: []string{"./a"},
+			shouldMatchStrings: map[string]bool{
+				"a":     true,
+				"a/b":   true,
+				"a/c":   true,
+				"a/b/c": true,
+			},
+		},
+		{
+			pattern:            []string{"!./a"},
+			shouldMatchStrings: map[string]bool{},
+		},
+		{
+			pattern:             []string{"../a"},
+			shouldErrorOnCreate: true,
+		},
+		{
+			pattern:             []string{"!../a"},
+			shouldErrorOnCreate: true,
+		},
+		{
+			pattern: []string{"/../a"},
+			shouldMatchStrings: map[string]bool{
+				"/a":     true,
+				"/a/b":   true,
+				"/a/c":   true,
+				"/a/b/c": true,
+			},
+		},
+		{
+			pattern:            []string{"!/../a"},
+			shouldMatchStrings: map[string]bool{},
+		},
+		{
+			pattern: []string{"/a/b/c"},
+			shouldMatchStrings: map[string]bool{
+				"/a/b/c": true,
+			},
+		},
+		{
+			pattern:            []string{"!/a/b/c"},
+			shouldMatchStrings: map[string]bool{},
+		},
+		{
+			pattern: []string{"/a/c"},
+			shouldMatchStrings: map[string]bool{
+				"/a/c": true,
+			},
+		},
+		{
+			pattern:            []string{"!/a/c"},
+			shouldMatchStrings: map[string]bool{},
+		},
+		{
+			pattern: []string{"*"},
+			shouldMatchStrings: map[string]bool{
+				"":                          true,
+				".":                         true,
+				"a":                         true,
+				"b":                         true,
+				"c":                         true,
+				"a/b":                       true,
+				"a/c":                       true,
+				"a/b/c":                     true,
+				"/a":                        true,
+				"/b":                        true,
+				"/c":                        true,
+				"/a/b":                      true,
+				"/a/c":                      true,
+				"/a/b/c":                    true,
+				"precompiledregexp.go":      true,
+				"precompiledregexp_test.go": true,
+				"builder/builder.go":        true,
+				"docs/README.md":            true,
+				"docs/DOCUMENTATION.md":     true,
+			},
+		},
+		{
+			pattern: []string{"**/c"},
+			shouldMatchStrings: map[string]bool{
+				"c":      true,
+				"a/c":    true,
+				"a/b/c":  true,
+				"/c":     true,
+				"/a/c":   true,
+				"/a/b/c": true,
+			},
+		},
+		{
+			pattern: []string{"*.go"},
+			shouldMatchStrings: map[string]bool{
+				"precompiledregexp.go":      true,
+				"precompiledregexp_test.go": true,
+			},
+		},
+		{
+			pattern: []string{
+				"!precompiledregexp.go",
+				"**/*.go",
+			},
+			shouldMatchStrings: map[string]bool{
+				"precompiledregexp.go":      true,
+				"precompiledregexp_test.go": true,
+				"builder/builder.go":        true,
+			},
+		},
+		{
+			pattern: []string{
+				"**/*.go",
+				"!precompiledregexp.go",
+			},
+			shouldMatchStrings: map[string]bool{
+				"precompiledregexp_test.go": true,
+				"builder/builder.go":        true,
+			},
+		},
+		{
+			pattern: []string{
+				"docs/",
+				"!docs/README.md",
+			},
+			shouldMatchStrings: map[string]bool{
+				"docs/DOCUMENTATION.md": true,
+			},
+		},
+	}
+
+	for _, entry := range tests {
+		runTestInstance(t, entry, entry.negative)
+	}
+}
+
+func runTestInstance(t *testing.T, entry testInstance, isNegative bool) {
+	precompiledRegExprs, err := FromStringExpressions(entry.pattern)
+
+	if err != nil {
+		if !entry.shouldErrorOnCreate {
+			t.Fatalf("Did not expect matching to fail pattern: [%s]", entry.pattern)
+		} else {
+			return
+		}
+	} else if entry.shouldErrorOnCreate && err == nil {
+		t.Fatalf("Expected creation to fail for pattern: [%s]", entry.pattern)
+	}
+
+	stringExprs := ToStringExpressions(precompiledRegExprs)
+	if len(entry.pattern) != len(stringExprs) {
+		t.Fatalf("Incorrect number of string expressions found: %d; expected %d for pattern [%s]",
+			len(entry.pattern),
+			len(ToStringExpressions(precompiledRegExprs)),
+			entry.pattern)
+	}
+
+	_, err = Matches("", precompiledRegExprs)
+	if err != nil {
+		if !entry.shouldErrorOnMatch {
+			t.Fatalf("Did not expect matching to fail pattern: [%s]", entry.pattern)
+		} else {
+			return
+		}
+	} else if entry.shouldErrorOnMatch && err == nil {
+		t.Fatalf("Expected matching to fail for pattern: [%s]", entry.pattern)
+	}
+
+	// Test matches using slice of precompiled regular expressions
+	for _, str := range testStrings {
+		matches, err := Matches(str, precompiledRegExprs)
+		if err != nil {
+			t.Fatalf("Encountered error when matching string [%s] using pattern [%s]",
+				str, entry.pattern)
+		}
+		if matches != entry.shouldMatchStrings[str] {
+			fmt.Printf("[%t]", entry.shouldMatchStrings[str])
+			t.Fatalf("Pattern [%s] did not match string [%s]",
+				entry.pattern, str)
+		}
+	}
+
+	// Test matches on each individual regular expression
+	for _, str := range testStrings {
+		matches := false
+		for _, regExpr := range precompiledRegExprs {
+			internalMatch, err := regExpr.internalMatches(str)
+			if err != nil {
+				t.Fatalf("Encountered error when matching string [%s] using pattern [%s]",
+					str, entry.pattern)
+			}
+			match, err := regExpr.Matches(str)
+			if err != nil {
+				t.Fatalf("Encountered error when matching string [%s] using pattern [%s]",
+					str, entry.pattern)
+			}
+
+			if internalMatch {
+				matches = !regExpr.Negative()
+				if !regExpr.Negative() != match {
+					t.Fatalf("internalMatch and Match functions did not agree for pattern [%s]",
+						entry.pattern)
+				}
+			}
+		}
+		if matches != entry.shouldMatchStrings[str] {
+			fmt.Printf("[%t]", entry.shouldMatchStrings[str])
+			t.Fatalf("Pattern [%s] did not match string [%s]",
+				entry.pattern, str)
+		}
+	}
+}
+
+func TestWorksSameAsFileUtils(t *testing.T) {
+	/*
+		Test Directory Structure:
+		> root
+		>> v.cc
+		>> bla
+		>>> .gitignore
+		>>> README.md
+		>>> foo
+		>>> Makefile
+		>>> .git
+		>>> src
+		>>>> x.go
+		>>>> _vendor
+		>>> dir
+		>>>> foo
+		>> src
+		>>> v.cc
+		>>> _vendor
+		>>>> v.cc
+
+
+	*/
+	//tests := []string{
+	//	"v.cc",
+	//	"/bla/.gitignore",
+	//	"/bla/README.md",
+	//	"/bla/foo",
+	//	"/bla/Makefile",
+	//	"/bla/.git",
+	//	"/bla/src/x.go",
+	//	"/bla/src/_vendor",
+	//	"/bla/dir/foo.x",
+	//	"src/v.cc",
+	//	"src/_vendor/v.cc",
+	//}
+
+	patterns := []string{
+		".git",
+		"pkg",
+		".gitignore",
+		"src/_vendor",
+		"*.md",
+		"**/*.cc",
+		"!src/_vendor/v.cc",
+		"dir",
+	}
+
+	baseDir := createTmpDir(t, "", "precompiledregexp_test")
+	createDir(t, filepath.Join(baseDir, "bla"))
+	createDir(t, filepath.Join(baseDir, "bla/foo"))
+	createDir(t, filepath.Join(baseDir, "bla/src/_vendor"))
+	createDir(t, filepath.Join(baseDir, "/bla/dir/foo"))
+	createDir(t, filepath.Join(baseDir, "bla/dir"))
+	createDir(t, filepath.Join(baseDir, "src/_vendor"))
+	createFile(t, filepath.Join(baseDir, "v.cc"))
+	createFile(t, filepath.Join(baseDir, "/bla/.gitignore"))
+	createFile(t, filepath.Join(baseDir, "/bla/README.md"))
+	createFile(t, filepath.Join(baseDir, "/bla/Makefile"))
+	createFile(t, filepath.Join(baseDir, "/bla/.git"))
+	createFile(t, filepath.Join(baseDir, "/bla/src/x.go"))
+	createFile(t, filepath.Join(baseDir, "/bla/src/_vendor"))
+	createFile(t, filepath.Join(baseDir, "src/v.cc"))
+	createFile(t, filepath.Join(baseDir, "src/_vendor/v.cc"))
+
+	precompiledRegExprs := make([]PrecompiledRegExp, 0, len(patterns))
+	for _, pattern := range patterns {
+		precompiledRegExprs = appendNewRegExpr(t, pattern, precompiledRegExprs)
+	}
+
+	recursiveWalk(t, baseDir, baseDir, patterns, precompiledRegExprs)
+
+}
+
+func recursiveWalk(t *testing.T, baseDir, targetDir string, patterns []string, regexps []PrecompiledRegExp) {
+	files, _ := ioutil.ReadDir(targetDir)
+	for _, f := range files {
+		// Calculate subDir path
+		subDir := filepath.Join(targetDir, f.Name())
+		// Calculate relative path
+		relSubDir, err := filepath.Rel(baseDir, subDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		stringMatched, err := fileutils.Matches(relSubDir, patterns)
+		if err != nil {
+			t.Fatal(err)
+		}
+		regexMatched, err := Matches(relSubDir, regexps)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if stringMatched != regexMatched {
+			t.Fatalf("Failed on %s; string: %t regex: %t", relSubDir, stringMatched, regexMatched)
+		}
+
+		if f.IsDir() {
+			recursiveWalk(t, baseDir, subDir, patterns, regexps)
+		}
+	}
+}
+
+func appendNewRegExpr(t *testing.T, pattern string, list []PrecompiledRegExp) []PrecompiledRegExp {
+
+	isNeg := false
+	if pattern[0] == '!' {
+		pattern = pattern[1:]
+		isNeg = true
+	}
+	new, err := NewPreCompiledRegExp(pattern, isNeg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(list, *new)
+}
+
+func createTmpDir(t *testing.T, dir string, prefix string) string {
+
+	result, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func createDir(t *testing.T, dir string) {
+
+	os.MkdirAll(dir, 0777)
+}
+
+func createFile(t *testing.T, filename string) {
+	os.MkdirAll(filepath.Dir(filename), 0777)
+	os.Create(filename)
+}


### PR DESCRIPTION
Added new functionality: `.dockerignore` files can now be placed at any directory, and relative paths will be based on the directory the `.dockerignore` file is in.
- Closes #20944 
- `builder/dockerignore/dockerignore.go` changed to allow for reading of entire recursive directory tree
- Tests added to verify functionality of recursive `.dockerignore` files, including \* matching and exceptions.
