### PR TITLE
Fix race condition with exec and resize

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -305,6 +305,9 @@ func (d *Daemon) monitorExec(container *container.Container, execConfig *exec.Co
 	}
 
 	if execConfig.ProcessConfig.Terminal != nil {
+		if err := execConfig.WaitResize(); err != nil {
+			logrus.Errorf("Error waiting for resize: %v", err)
+		}
 		if err := execConfig.ProcessConfig.Terminal.Close(); err != nil {
 			logrus.Errorf("Error closing terminal while running in container %s: %s", container.ID, err)
 		}


### PR DESCRIPTION
When I use `docker exec -ti test ls`, I got error:

```
ERRO[0035] Handler for POST /v1.23/exec/9677ecd7aa9de96f8e9e667519ff266ad26a5be80e80021a997fff6084ed6d75/resize returned error: bad file descriptor
```

It's because `POST /exec/<id>/start` and
`POST /exec/<id>/resize` are asynchronous, it is
possible that exec process finishes and ternimal
is closed before resize. Then `console.Fd()` will
get a large invalid number and we got the above
error.

Fix it by adding synchronization between exec and
resize.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
