### PR TITLE
Use exec processConfig for exec start hook

### DIFF
--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -79,7 +79,7 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		// non-blocking and return the correct result when read.
 		chOOM := make(chan struct{})
 		close(chOOM)
-		hooks.Start(&c.ProcessConfig, pid, chOOM)
+		hooks.Start(processConfig, pid, chOOM)
 	}
 
 	ps, err := p.Wait()


### PR DESCRIPTION
I don't see any reasons why we handle container's processConfig
after exec process started.

IIUC there is no error before because container's processConfig have no
`processConfig.Stdout.(io.Closer)` and stdout of exec's processConfig
will be closed in `execConfig.CloseStreams()` in `monitorExec`.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
