### PR TITLE
docker stats: add blkio rate and blkio IOPS

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -164,7 +164,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 			fmt.Fprint(cli.out, "\033[2J")
 			fmt.Fprint(cli.out, "\033[H")
 		}
-		io.WriteString(w, "CONTAINER\tCPU %\tMEM USAGE / LIMIT\tMEM %\tNET I/O\tBLOCK I/O\tPIDS\n")
+		io.WriteString(w, "CONTAINER\tCPU %\tMEM USAGE / LIMIT\tMEM %\tNET I/O\tBIO(Bytes)\tBIO(Rate)\tBIO(IOPS)\tPIDS\n")
 	}
 
 	for range time.Tick(500 * time.Millisecond) {

--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/engine-api/types"
 )
@@ -17,8 +18,12 @@ func TestDisplay(t *testing.T) {
 		MemoryPercentage: 100.0 / 2048.0 * 100.0,
 		NetworkRx:        100 * 1024 * 1024,
 		NetworkTx:        800 * 1024 * 1024,
-		BlockRead:        100 * 1024 * 1024,
-		BlockWrite:       800 * 1024 * 1024,
+		BlockReadByte:    100 * 1024 * 1024,
+		BlockWriteByte:   800 * 1024 * 1024,
+		BlockReadRate:    100 * 1024 * 1024,
+		BlockWriteRate:   800 * 1024 * 1024,
+		BlockReadIOPS:    10.00,
+		BlockWriteIOPS:   8.00,
 		PidsCurrent:      1,
 		mu:               sync.RWMutex{},
 	}
@@ -27,21 +32,41 @@ func TestDisplay(t *testing.T) {
 		t.Fatalf("c.Display() gave error: %s", err)
 	}
 	got := b.String()
-	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\n"
+	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t10.00 / 8.00\t1\n"
 	if got != want {
 		t.Fatalf("c.Display() = %q, want %q", got, want)
 	}
 }
 
 func TestCalculBlockIO(t *testing.T) {
+	preblkio := types.BlkioStats{
+		IoServiceBytesRecursive: []types.BlkioStatEntry{{8, 0, "read", 1200}, {8, 1, "read", 4522}, {8, 0, "write", 112}, {8, 1, "write", 435}},
+		IoServicedRecursive:     []types.BlkioStatEntry{{8, 0, "read", 12}, {8, 1, "read", 45}, {8, 0, "write", 11}, {8, 1, "write", 43}},
+	}
 	blkio := types.BlkioStats{
 		IoServiceBytesRecursive: []types.BlkioStatEntry{{8, 0, "read", 1234}, {8, 1, "read", 4567}, {8, 0, "write", 123}, {8, 1, "write", 456}},
+		IoServicedRecursive:     []types.BlkioStatEntry{{8, 0, "read", 13}, {8, 1, "read", 67}, {8, 0, "write", 23}, {8, 1, "write", 56}},
 	}
-	blkRead, blkWrite := calculateBlockIO(blkio)
-	if blkRead != 5801 {
-		t.Fatalf("blkRead = %d, want 5801", blkRead)
+	preread := time.Now()
+	read := preread.Add(time.Second)
+
+	blkReadByte, blkWriteByte, blkReadRate, blkWriteRate, blkReadIOPS, blkWriteIOPS := calculateBlockIO(blkio, preblkio, read, preread)
+	if blkReadByte != 5801 {
+		t.Fatalf("blkReadByte = %d, want 5801", blkReadByte)
 	}
-	if blkWrite != 579 {
-		t.Fatalf("blkWrite = %d, want 579", blkWrite)
+	if blkWriteByte != 579 {
+		t.Fatalf("blkWriteByte = %d, want 579", blkWriteByte)
+	}
+	if blkReadRate != 79 {
+		t.Fatalf("blkReadRate = %d, want 79", blkReadRate)
+	}
+	if blkWriteRate != 32 {
+		t.Fatalf("blkWriteRate = %d, want 32", blkWriteRate)
+	}
+	if blkReadIOPS != 23.00 {
+		t.Fatalf("blkReadIOPS = %.2f, want 23.00", blkReadIOPS)
+	}
+	if blkWriteIOPS != 25.00 {
+		t.Fatalf("blkWriteIOPS = %.2f, want 25.00", blkWriteIOPS)
 	}
 }

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"runtime"
+	"time"
 
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/daemon/execdriver"
@@ -40,15 +41,24 @@ func (daemon *Daemon) ContainerStats(prefixOrName string, config *backend.Contai
 		outStream = wf
 	}
 
-	var preCPUStats types.CPUStats
+	var (
+		preCPUStats   types.CPUStats
+		preBlkioStats types.BlkioStats
+		preRead       time.Time
+	)
+
 	getStatJSON := func(v interface{}) *types.StatsJSON {
 		update := v.(*execdriver.ResourceStats)
 		ss := convertStatsToAPITypes(update.Stats)
 		ss.PreCPUStats = preCPUStats
+		ss.PreBlkioStats = preBlkioStats
+		ss.PreRead = preRead
 		ss.MemoryStats.Limit = uint64(update.MemoryLimit)
 		ss.Read = update.Read
 		ss.CPUStats.SystemUsage = update.SystemUsage
 		preCPUStats = ss.CPUStats
+		preBlkioStats = ss.BlkioStats
+		preRead = ss.Read
 		return ss
 	}
 

--- a/docs/admin/runmetrics.md
+++ b/docs/admin/runmetrics.md
@@ -22,9 +22,9 @@ and network IO metrics.
 The following is a sample output from the `docker stats` command
 
     $ docker stats redis1 redis2
-    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BIO(Bytes)            BIO(Rate)           BIO(IOPS)               PIDS
+    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB     0 B / 0 B           0.00 / 0.00               0
+    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B         0 B / 0 B           0.00 / 0.00               0
 
 
 The [docker stats](../reference/commandline/stats.md) reference page has

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -27,10 +27,10 @@ If you want more detailed information about a container's resource usage, use th
 Running `docker stats` on all running containers
 
     $ docker stats
-    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BIO(Bytes)          BIO(Rate)           BIO(IOPS)               PIDS
+    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB   0 B / 0 B           0.00 / 0.00               0
+    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B       0 B / 0 B           0.00 / 0.00               0
+    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B       0 B / 0 B           0.00 / 0.00               0
 
 Running `docker stats` on multiple containers by name and id.
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -409,7 +409,7 @@ func (s *DockerSuite) TestGetContainerStatsNoStream(c *check.C) {
 
 		s := string(sr.body)
 		// count occurrences of "read" of types.Stats
-		c.Assert(strings.Count(s, "read"), checker.Equals, 1, check.Commentf("Expected only one stat streamed, got %d", strings.Count(s, "read")))
+		c.Assert(strings.Count(s, "read"), checker.Equals, 2, check.Commentf("Expected only one stat streamed, got %d", strings.Count(s, "read")))
 	}
 }
 

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -30,10 +30,10 @@ Display a live stream of one or more containers' resource usage statistics
 Running `docker stats` on all running containers
 
     $ docker stats
-    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BIO(Bytes)          BIO(Rate)           BIO(IOPS)               PIDS
+    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB   0 B / 0 B           0.00 / 0.00               0
+    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B       0 B / 0 B           0.00 / 0.00               0
+    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B       0 B / 0 B           0.00 / 0.00               0
 
 Running `docker stats` on multiple containers by name and id.
 

--- a/vendor/src/github.com/docker/engine-api/types/stats.go
+++ b/vendor/src/github.com/docker/engine-api/types/stats.go
@@ -95,12 +95,14 @@ type PidsStats struct {
 
 // Stats is Ultimate struct aggregating all types of stats of one container
 type Stats struct {
-	Read        time.Time   `json:"read"`
-	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"`
-	CPUStats    CPUStats    `json:"cpu_stats,omitempty"`
-	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
-	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
-	PidsStats   PidsStats   `json:"pids_stats,omitempty"`
+	Read          time.Time   `json:"read"`
+	PreCPUStats   CPUStats    `json:"precpu_stats,omitempty"`
+	CPUStats      CPUStats    `json:"cpu_stats,omitempty"`
+	MemoryStats   MemoryStats `json:"memory_stats,omitempty"`
+	BlkioStats    BlkioStats  `json:"blkio_stats,omitempty"`
+	PidsStats     PidsStats   `json:"pids_stats,omitempty"`
+	PreBlkioStats BlkioStats  `json:"preblkio_stats,omitempty"`
+	PreRead       time.Time   `json:"preread,omitempty"`
 }
 
 // StatsJSON is newly used Networks


### PR DESCRIPTION
replaces https://github.com/docker/docker/pull/20741

blkio rate and IOPS is calculated by introducing PreBlkioStats and PreRead in
types.Stats, thus we can get the rate/IOPS by (BlkioStats - PreBlkioStats)/(Read - PreRead)

Now with the patch docker stats shows like below:

```
    $ docker stats
    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BIO(Bytes)          BIO(Rate)           BIO(IOPS)
    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB   0 B / 0 B           0.00 / 0.00
    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B       0 B / 0 B           0.00 / 0.00
    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B       0 B / 0 B           0.00 / 0.00
```

Signed-off-by: Zhang Yong zhangyong23@huawei.com
