### PR TITLE
distribution: registry: do not access the errors slice if it's empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ be found.
 
 ### Distribution
 
-- Fix a crash when pushing multiple images sharing the same layers to the same repository in parallel  [#20831](https://github.com/docker/docker/pull/20831)
+- Fix a crash when pushing multiple images sharing the same layers to the same repository in parallel [#20831](https://github.com/docker/docker/pull/20831)
+- Fix a panic when pushing images to a registry which uses a misconfigured token service [#21030](https://github.com/docker/docker/pull/21030)
 
 ### Plugin system
 

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -140,7 +140,9 @@ func (th *existingTokenHandler) AuthorizeRequest(req *http.Request, params map[s
 func retryOnError(err error) error {
 	switch v := err.(type) {
 	case errcode.Errors:
-		return retryOnError(v[0])
+		if len(v) != 0 {
+			return retryOnError(v[0])
+		}
 	case errcode.Error:
 		switch v.Code {
 		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied:


### PR DESCRIPTION
Fix #21027
Regression from 1.9 which just prompt for user/pass on 401
See the discussion in the issue for more information

Signed-off-by: Antonio Murdaca runcom@redhat.com
