### PR TITLE
Creates docker group for non-root access

### DIFF
--- a/docs/installation/linux/centos.md
+++ b/docs/installation/linux/centos.md
@@ -141,15 +141,19 @@ To create the `docker` group and add your user:
 
 1. Log into Centos as a user with `sudo` privileges.
 
-2. Create the `docker` group and add your user.
+2. Create the `docker` group.
+
+    `sudo groupadd docker`
+
+3. Add your user to `docker` group.
 
     `sudo usermod -aG docker your_username`
 
-3. Log out and log back in.
+4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-4. Verify your work by running `docker` without `sudo`.
+5. Verify your work by running `docker` without `sudo`.
 
 		$ docker run hello-world
 

--- a/docs/installation/linux/fedora.md
+++ b/docs/installation/linux/fedora.md
@@ -135,15 +135,19 @@ To create the `docker` group and add your user:
 
 1. Log into your system as a user with `sudo` privileges.
 
-2. Create the `docker` group and add your user.
+2. Create the `docker` group.
+
+    `sudo groupadd docker`
+
+3. Add your user to `docker` group.
 
     `sudo usermod -aG docker your_username`
 
-3. Log out and log back in.
+4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-4. Verify your work by running `docker` without `sudo`.
+5. Verify your work by running `docker` without `sudo`.
 
         $ docker run hello-world
 

--- a/docs/installation/linux/gentoolinux.md
+++ b/docs/installation/linux/gentoolinux.md
@@ -76,6 +76,7 @@ To use Docker, the `docker` daemon must be running as **root**.
 To use Docker as a **non-root** user, add yourself to the **docker**
 group by running the following command:
 
+    $ sudo groupadd docker
     $ sudo usermod -a -G docker user
 
 ### OpenRC

--- a/docs/installation/linux/oracle.md
+++ b/docs/installation/linux/oracle.md
@@ -113,15 +113,19 @@ To create the `docker` group and add your user:
 
 1. Log into Oracle Linux as a user with `sudo` privileges.
 
-2. Create the `docker` group and add your user.
+2. Create the `docker` group.
+
+        sudo groupadd docker
+
+3. Add your user to `docker` group.
 
         sudo usermod -aG docker username
 
-3. Log out and log back in.
+4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-4. Verify your work by running `docker` without `sudo`.
+5. Verify your work by running `docker` without `sudo`.
 
         $ docker run hello-world
 

--- a/docs/installation/linux/rhel.md
+++ b/docs/installation/linux/rhel.md
@@ -133,15 +133,19 @@ To create the `docker` group and add your user:
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Create the `docker` group and add your user.
+2. Create the `docker` group.
+
+    `sudo groupadd docker`
+
+3. Add your user to `docker` group.
 
     `sudo usermod -aG docker your_username`
 
-3. Log out and log back in.
+4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-4. Verify your work by running `docker` without `sudo`.
+5. Verify your work by running `docker` without `sudo`.
 
 			$ docker run hello-world
 

--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -239,15 +239,19 @@ To create the `docker` group and add your user:
 
     This procedure assumes you log in as the `ubuntu` user.
 
-3. Create the `docker` group and add your user.
+2. Create the `docker` group.
+
+        $ sudo groupadd docker
+
+3. Add your user to `docker` group.
 
         $ sudo usermod -aG docker ubuntu
 
-3. Log out and log back in.
+4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-4. Verify your work by running `docker` without `sudo`.
+5. Verify your work by running `docker` without `sudo`.
 
         $ docker run hello-world
 


### PR DESCRIPTION
Fixes #21031 

`sudo groupadd docker` creates the group docker.
Thus `usermod: group 'docker' does not exist` is resolved.

Thanks!

Signed-off-by: trishnaguha trishnaguha17@gmail.com
