### PR TITLE
Move registry service options to the daemon configuration.

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/discovery"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/registry"
 	"github.com/imdario/mergo"
 )
 
@@ -96,6 +97,7 @@ type CommonConfig struct {
 	CommonTLSOptions
 	LogConfig
 	bridgeConfig // bridgeConfig holds bridge network specific configuration.
+	registry.ServiceOptions
 
 	reloadLock sync.Mutex
 	valuesSet  map[string]interface{}
@@ -106,6 +108,8 @@ type CommonConfig struct {
 // Subsequent calls to `flag.Parse` will populate config with values parsed
 // from the command-line.
 func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string) string) {
+	config.ServiceOptions.InstallCliFlags(cmd, usageFn)
+
 	cmd.Var(opts.NewNamedListOptsRef("storage-opts", &config.GraphOptions, nil), []string{"-storage-opt"}, usageFn("Set storage driver options"))
 	cmd.Var(opts.NewNamedListOptsRef("authorization-plugins", &config.AuthorizationPlugins, nil), []string{"-authorization-plugin"}, usageFn("List authorization plugins in order from first evaluator to last"))
 	cmd.Var(opts.NewNamedListOptsRef("exec-opts", &config.ExecOptions, nil), []string{"-exec-opt"}, usageFn("Set exec driver options"))

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -90,7 +90,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		IndexServerAddress: registry.IndexServer,
 		OSType:             platform.OSType,
 		Architecture:       platform.Architecture,
-		RegistryConfig:     daemon.RegistryService.Config,
+		RegistryConfig:     daemon.RegistryService.ServiceConfig(),
 		NCPU:               runtime.NumCPU(),
 		MemTotal:           meminfo.MemTotal,
 		DockerRootDir:      daemon.configStore.Root,

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -883,7 +883,10 @@ This is a full example of the allowed configuration options in the file:
 	"default-gateway": "",
 	"default-gateway-v6": "",
 	"icc": false,
-	"raw-logs": false
+	"raw-logs": false,
+	"registry-mirrors": [],
+	"insecure-registries": [],
+	"disable-legacy-registry": false
 }
 ```
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -25,12 +24,6 @@ var (
 	// already exists on the remote side
 	ErrAlreadyExists = errors.New("Image already exists")
 )
-
-func init() {
-	if runtime.GOOS != "linux" {
-		V2Only = true
-	}
-}
 
 func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/opts"
 	"github.com/docker/docker/reference"
 	registrytypes "github.com/docker/engine-api/types/registry"
 	"github.com/gorilla/mux"
@@ -174,23 +173,13 @@ func makePublicIndex() *registrytypes.IndexInfo {
 	return index
 }
 
-func makeServiceConfig(mirrors []string, insecureRegistries []string) *registrytypes.ServiceConfig {
-	options := &Options{
-		Mirrors:            opts.NewListOpts(nil),
-		InsecureRegistries: opts.NewListOpts(nil),
-	}
-	if mirrors != nil {
-		for _, mirror := range mirrors {
-			options.Mirrors.Set(mirror)
-		}
-	}
-	if insecureRegistries != nil {
-		for _, insecureRegistries := range insecureRegistries {
-			options.InsecureRegistries.Set(insecureRegistries)
-		}
+func makeServiceConfig(mirrors []string, insecureRegistries []string) *serviceConfig {
+	options := ServiceOptions{
+		Mirrors:            mirrors,
+		InsecureRegistries: insecureRegistries,
 	}
 
-	return NewServiceConfig(options)
+	return newServiceConfig(options)
 }
 
 func writeHeaders(w http.ResponseWriter) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -523,7 +523,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 }
 
 func TestNewIndexInfo(t *testing.T) {
-	testIndexInfo := func(config *registrytypes.ServiceConfig, expectedIndexInfos map[string]*registrytypes.IndexInfo) {
+	testIndexInfo := func(config *serviceConfig, expectedIndexInfos map[string]*registrytypes.IndexInfo) {
 		for indexName, expectedIndexInfo := range expectedIndexInfos {
 			index, err := newIndexInfo(config, indexName)
 			if err != nil {
@@ -537,7 +537,7 @@ func TestNewIndexInfo(t *testing.T) {
 		}
 	}
 
-	config := NewServiceConfig(nil)
+	config := newServiceConfig(ServiceOptions{})
 	noMirrors := []string{}
 	expectedIndexInfos := map[string]*registrytypes.IndexInfo{
 		IndexName: {
@@ -661,7 +661,7 @@ func TestMirrorEndpointLookup(t *testing.T) {
 		}
 		return false
 	}
-	s := Service{Config: makeServiceConfig([]string{"my.mirror"}, nil)}
+	s := Service{config: makeServiceConfig([]string{"my.mirror"}, nil)}
 
 	imageName, err := reference.WithName(IndexName + "/test/image")
 	if err != nil {

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -12,7 +12,7 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 	tlsConfig := &cfg
 	if hostname == DefaultNamespace {
 		// v2 mirrors
-		for _, mirror := range s.Config.Mirrors {
+		for _, mirror := range s.config.Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
 				mirror = "https://" + mirror
 			}


### PR DESCRIPTION
This change allows to to set the registry service options in the daemon configuration file.
Fixes #21000.

I moved the options inside `daemon.CommonConfig`, so they're not global anymore.

![](http://cdn0.lacdn.com/wp-content/uploads/2014/08/chimpanzee-webcam.jpg)

Signed-off-by: David Calavera david.calavera@gmail.com
