### PR TITLE
Revert 3 commits from 1.10.3 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ be found.
 
 - Fix Docker client exiting with an "Unrecognized input header" error [#20706](https://github.com/docker/docker/pull/20706)
 - Fix Docker exiting if Exec is started with both `AttachStdin` and `Detach` [#20647](https://github.com/docker/docker/pull/20647)
-- Fix loss of output in short-lived containers [#20729](https://github.com/docker/docker/pull/20729)
-- Fix an issue that caused the client to hang if the container process died [#20967](https://github.com/docker/docker/pull/20967)
 
 ### Distribution
 

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -1093,9 +1093,7 @@ func killProcessDirectly(container *container.Container) error {
 				if err != syscall.ESRCH {
 					return err
 				}
-				e := errNoSuchProcess{pid, 9}
-				logrus.Debug(e)
-				return e
+				logrus.Debugf("Cannot kill process (pid=%d) with signal 9: no such process.", pid)
 			}
 		}
 	}

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/docker/docker/daemon/execdriver"
@@ -53,18 +52,12 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 	}
 
 	config := active.Config()
-	wg := sync.WaitGroup{}
-	writers, err := setupPipes(&config, processConfig, p, pipes, &wg)
-	if err != nil {
+	if err := setupPipes(&config, processConfig, p, pipes); err != nil {
 		return -1, err
 	}
 
 	if err := active.Start(p); err != nil {
 		return -1, err
-	}
-	//close the write end of any opened pipes now that they are dup'ed into the container
-	for _, writer := range writers {
-		writer.Close()
 	}
 
 	if hooks.Start != nil {
@@ -90,7 +83,5 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		}
 		ps = exitErr.ProcessState
 	}
-	// wait for all IO goroutine copiers to finish
-	wg.Wait()
 	return utils.ExitStatus(ps.Sys().(syscall.WaitStatus)), nil
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -12,22 +12,6 @@ import (
 	"github.com/docker/docker/pkg/signal"
 )
 
-type errNoSuchProcess struct {
-	pid    int
-	signal int
-}
-
-func (e errNoSuchProcess) Error() string {
-	return fmt.Sprintf("Cannot kill process (pid=%d) with signal %d: no such process.", e.pid, e.signal)
-}
-
-// isErrNoSuchProcess returns true if the error
-// is an instance of errNoSuchProcess.
-func isErrNoSuchProcess(err error) bool {
-	_, ok := err.(errNoSuchProcess)
-	return ok
-}
-
 // ContainerKill send signal to the container
 // If no signal is given (sig 0), then Kill with SIGKILL and wait
 // for the container to exit.
@@ -103,9 +87,6 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 		// So, instead we'll give it up to 2 more seconds to complete and if
 		// by that time the container is still running, then the error
 		// we got is probably valid and so we return it to the caller.
-		if isErrNoSuchProcess(err) {
-			return nil
-		}
 
 		if container.IsRunning() {
 			container.WaitStop(2 * time.Second)
@@ -117,9 +98,6 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 
 	// 2. Wait for the process to die, in last resort, try to kill the process directly
 	if err := killProcessDirectly(container); err != nil {
-		if isErrNoSuchProcess(err) {
-			return nil
-		}
 		return err
 	}
 
@@ -131,9 +109,8 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 func (daemon *Daemon) killPossiblyDeadProcess(container *container.Container, sig int) error {
 	err := daemon.killWithSignal(container, sig)
 	if err == syscall.ESRCH {
-		e := errNoSuchProcess{container.GetPID(), sig}
-		logrus.Debug(e)
-		return e
+		logrus.Debugf("Cannot kill process (pid=%d) with signal %d: no such process.", container.GetPID(), sig)
+		return nil
 	}
 	return err
 }

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -25,12 +25,6 @@ set -e
 
 url='https://get.docker.com/'
 
-key_servers="
-ha.pool.sks-keyservers.net
-pgp.mit.edu
-keyserver.ubuntu.com
-"
-
 command_exists() {
 	command -v "$@" > /dev/null 2>&1
 }
@@ -105,10 +99,7 @@ rpm_import_repository_key() {
 	local key=$1; shift
 	local tmpdir=$(mktemp -d)
 	chmod 600 "$tmpdir"
-	for key_server in $key_servers ; do
-		gpg --homedir "$tmpdir" --keyserver "$key_server" --recv-keys "$key" && break
-	done
-	gpg --homedir "$tmpdir" -k "$key" >/dev/null
+	gpg --homedir "$tmpdir" --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"
 	gpg --homedir "$tmpdir" --export --armor "$key" > "$tmpdir"/repo.key
 	rpm --import "$tmpdir"/repo.key
 	rm -rf "$tmpdir"
@@ -418,10 +409,7 @@ do_install() {
 			fi
 			(
 			set -x
-			for key_server in $key_servers ; do
-				$sh_c "apt-key adv --keyserver hkp://${key_server}:80 --recv-keys ${gpg_fingerprint}" && break
-			done
-			$sh_c "apt-key adv -k ${gpg_fingerprint} >/dev/null"
+			$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D"
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
 			$sh_c "echo deb [arch=$(dpkg --print-architecture)] https://apt.dockerproject.org/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'


### PR DESCRIPTION
Reverting 3 commits: 1 because it was incomplete and thus hurt the rc1 release (multiple keyservers), plus it can be done out-of-band, and the 2 other commits are reverted to lower the risk for 1.10.3.

It essentially reverts the cherrypicks in #21011 of the following PRs: #20967, #20729 and #20737.

Ping @icecrime @calavera 
