### PR TITLE
Update UserNamespaceInKernel test requirement to handle redhat

### DIFF
--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -20,7 +20,7 @@ import (
 // 1. validate uid/gid maps are set properly
 // 2. verify that files created are owned by remapped root
 func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
-	testRequires(c, DaemonIsLinux, SameHostDaemon)
+	testRequires(c, DaemonIsLinux, SameHostDaemon, UserNamespaceInKernel)
 
 	c.Assert(s.d.StartWithBusybox("--userns-remap", "default"), checker.IsNil)
 

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -149,9 +149,20 @@ var (
 				 */
 				return false
 			}
+
+			// We need extra check on redhat based distributions
+			if f, err := os.Open("/sys/module/user_namespace/parameters/enable"); err == nil {
+				b := make([]byte, 1)
+				_, _ = f.Read(b)
+				if string(b) == "N" {
+					return false
+				}
+				return true
+			}
+
 			return true
 		},
-		"Kernel must have user namespaces configured.",
+		"Kernel must have user namespaces configured and enabled.",
 	}
 	NotUserNamespace = testRequirement{
 		func() bool {


### PR DESCRIPTION
On redhat based distribution, checking that USER_NS is compiled in the
kernel is not sufficient, we also have to check that the feature as
been enabled.

With this commit, it is now done by checking the content of
`/sys/module/user_namespace/parameters/enable`.

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

Should fix our CI failures on the centos/redhat nodes

![cute](http://www.uroubc.ca/wp-content/uploads/2015/07/7030094-cute-animals.jpg)
