### PR TITLE
Windows CI changes to support splitting into two binaries

### DIFF
--- a/hack/Jenkins/W2L/build-binary.sh
+++ b/hack/Jenkins/W2L/build-binary.sh
@@ -1,0 +1,28 @@
+
+# Build locally.
+if [ $ec -eq 0 ]; then
+	echo "INFO: Starting local build of Windows binary..."
+	set -x
+	export TIMEOUT="120m"
+	export DOCKER_HOST="tcp://$ip:$port_inner"
+	export DOCKER_TEST_HOST="tcp://$ip:$port_inner"
+	unset DOCKER_CLIENTONLY
+	export DOCKER_REMOTE_DAEMON=1
+	hack/make.sh binary
+	ec=$?
+	set +x
+	if [ 0 -ne $ec ]; then
+	    echo "ERROR: Build of binary on Windows failed"
+	fi
+fi
+
+# Make a local copy of the built binary and ensure that is first in our path
+if [ $ec -eq 0 ]; then
+	VERSION=$(< ./VERSION)
+	cp bundles/$VERSION/binary/docker.exe $TEMP
+	ec=$?
+	if [ 0 -ne $ec ]; then
+		echo "ERROR: Failed to copy built binary to $TEMP"
+	fi
+	export PATH=$TEMP:$PATH
+fi

--- a/hack/Jenkins/W2L/build-image.sh
+++ b/hack/Jenkins/W2L/build-image.sh
@@ -1,0 +1,18 @@
+
+# build the daemon image
+if [ $ec -eq 0 ]; then
+	echo "INFO: Running docker build on Linux host at $DOCKER_HOST"
+	set -x
+	docker build --rm --force-rm -t "docker:$COMMITHASH" .
+    cat <<EOF | docker build --rm --force-rm -t "docker:$COMMITHASH" -
+FROM docker:$COMMITHASH
+RUN hack/make.sh binary
+RUN cp bundles/latest/binary/docker /bin/docker
+CMD docker daemon -D -H tcp://0.0.0.0:$port_inner $daemon_extra_args
+EOF
+	ec=$?
+	set +x
+	if [ 0 -ne $ec ]; then
+		echo "ERROR: docker build failed"
+	fi
+fi

--- a/hack/Jenkins/W2L/setup.sh
+++ b/hack/Jenkins/W2L/setup.sh
@@ -168,23 +168,7 @@ if [ $ec -eq 0 ]; then
 	echo
 fi
 
-# build the daemon image
-if [ $ec -eq 0 ]; then
-	echo "INFO: Running docker build on Linux host at $DOCKER_HOST"
-	set -x
-	docker build --rm --force-rm -t "docker:$COMMITHASH" .
-    cat <<EOF | docker build --rm --force-rm -t "docker:$COMMITHASH" -
-FROM docker:$COMMITHASH
-RUN hack/make.sh binary
-RUN cp bundles/latest/binary/docker /bin/docker
-CMD docker daemon -D -H tcp://0.0.0.0:$port_inner $daemon_extra_args
-EOF
-	ec=$?
-	set +x
-	if [ 0 -ne $ec ]; then
-		echo "ERROR: docker build failed"
-	fi
-fi
+. hack/Jenkins/W2L/build-image.sh
 
 # Start the docker-in-docker daemon from the image we just built
 if [ $ec -eq 0 ]; then
@@ -199,33 +183,7 @@ if [ $ec -eq 0 ]; then
 	fi
 fi
 
-# Build locally.
-if [ $ec -eq 0 ]; then
-	echo "INFO: Starting local build of Windows binary..."
-	set -x
-	export TIMEOUT="120m"
-	export DOCKER_HOST="tcp://$ip:$port_inner"
-	export DOCKER_TEST_HOST="tcp://$ip:$port_inner"
-	unset DOCKER_CLIENTONLY
-	export DOCKER_REMOTE_DAEMON=1
-	hack/make.sh binary
-	ec=$?
-	set +x
-	if [ 0 -ne $ec ]; then
-	    echo "ERROR: Build of binary on Windows failed"
-	fi
-fi
-
-# Make a local copy of the built binary and ensure that is first in our path
-if [ $ec -eq 0 ]; then
-	VERSION=$(< ./VERSION)
-	cp bundles/$VERSION/binary/docker.exe $TEMP
-	ec=$?
-	if [ 0 -ne $ec ]; then
-		echo "ERROR: Failed to copy built binary to $TEMP"
-	fi
-	export PATH=$TEMP:$PATH
-fi
+. hack/Jenkins/W2L/build-binary.sh
 
 # Run the integration tests
 if [ $ec -eq 0 ]; then

--- a/hack/Jenkins/W2L/setup.sh
+++ b/hack/Jenkins/W2L/setup.sh
@@ -1,9 +1,9 @@
 # Jenkins CI script for Windows to Linux CI.
 # Heavily modified by John Howard (@jhowardmsft) December 2015 to try to make it more reliable.
 set +xe
-SCRIPT_VER="Thu Feb 25 18:54:57 UTC 2016"
+SCRIPT_VER="Fri Feb 26 23:32:56 UTC 2016"
 
-# TODO to make (even) more resilient: 
+# TODO to make (even) more resilient:
 #  - Wait for daemon to be running before executing docker commands
 #  - Check if jq is installed
 #  - Make sure bash is v4.3 or later. Can't do until all Azure nodes on the latest version
@@ -78,7 +78,7 @@ if [ $ec -eq 0 ]; then
 		ping $ip
 	else
 		echo "INFO: The Linux nodes outer daemon replied to a ping. Good!"
-	fi 
+	fi
 fi
 
 # Get the version from the remote node. Note this may fail if jq is not installed.
@@ -126,24 +126,25 @@ fi
 # Tidy up time
 if [ $ec -eq 0 ]; then
 	echo INFO: Deleting pre-existing containers and images...
+
 	# Force remove all containers based on a previously built image with this commit
 	! docker rm -f $(docker ps -aq --filter "ancestor=docker:$COMMITHASH") &>/dev/null
 
 	# Force remove any container with this commithash as a name
 	! docker rm -f $(docker ps -aq --filter "name=docker-$COMMITHASH") &>/dev/null
 
-	# Force remove the image if it exists
-	! docker rmi -f "docker-$COMMITHASH" &>/dev/null
-	
 	# This SHOULD never happen, but just in case, also blow away any containers
-	# that might be around. 
-	! if [ ! `docker ps -aq | wc -l` -eq 0 ]; then
+	# that might be around.
+    ! if [ ! $(docker ps -aq | wc -l) -eq 0 ]; then
 		echo WARN: There were some leftover containers. Cleaning them up.
 		! docker rm -f $(docker ps -aq)
 	fi
+
+    # Force remove the image if it exists
+    ! docker rmi -f "docker-$COMMITHASH" &>/dev/null
 fi
 
-# Provide the docker version for debugging purposes. If these fail, game over. 
+# Provide the docker version for debugging purposes. If these fail, game over.
 # as the Linux box isn't responding for some reason.
 if [ $ec -eq 0 ]; then
 	echo INFO: Docker version and info of the outer daemon on the Linux node
@@ -172,6 +173,12 @@ if [ $ec -eq 0 ]; then
 	echo "INFO: Running docker build on Linux host at $DOCKER_HOST"
 	set -x
 	docker build --rm --force-rm -t "docker:$COMMITHASH" .
+    cat <<EOF | docker build --rm --force-rm -t "docker:$COMMITHASH" -
+FROM docker:$COMMITHASH
+RUN hack/make.sh binary
+RUN cp bundles/latest/binary/docker /bin/docker
+CMD docker daemon -D -H tcp://0.0.0.0:$port_inner $daemon_extra_args
+EOF
 	ec=$?
 	set +x
 	if [ 0 -ne $ec ]; then
@@ -184,7 +191,7 @@ if [ $ec -eq 0 ]; then
 	echo "INFO: Starting build of a Linux daemon to test against, and starting it..."
 	set -x
 	# aufs in aufs is faster than vfs in aufs
-	docker run $run_extra_args -e DOCKER_GRAPHDRIVER=aufs --pid host --privileged -d --name "docker-$COMMITHASH" --net host "docker:$COMMITHASH" bash -c "echo 'INFO: Compiling' && date && hack/make.sh binary && echo 'INFO: Compile complete' && date && cp bundles/$(cat VERSION)/binary/docker /bin/docker && echo 'INFO: Starting daemon' && exec docker daemon -D -H tcp://0.0.0.0:$port_inner $daemon_extra_args"
+    docker run -d $run_extra_args -e DOCKER_GRAPHDRIVER=aufs --pid host --privileged --name "docker-$COMMITHASH" --net host "docker:$COMMITHASH"
 	ec=$?
 	set +x
 	if [ 0 -ne $ec ]; then
@@ -201,7 +208,7 @@ if [ $ec -eq 0 ]; then
 	export DOCKER_TEST_HOST="tcp://$ip:$port_inner"
 	unset DOCKER_CLIENTONLY
 	export DOCKER_REMOTE_DAEMON=1
-	hack/make.sh binary 
+	hack/make.sh binary
 	ec=$?
 	set +x
 	if [ 0 -ne $ec ]; then
@@ -232,7 +239,7 @@ if [ $ec -eq 0 ]; then
 	if [ 0 -ne $ec ]; then
 		echo "ERROR: CLI test failed."
 		# Next line is useful, but very long winded if included
-		# docker -H=$MAIN_DOCKER_HOST logs "docker-$COMMITHASH"
+        docker -H=$MAIN_DOCKER_HOST logs --tail 100 "docker-$COMMITHASH"
 	fi
 fi
 
@@ -267,7 +274,7 @@ fi
 
 # Tell the user how we did.
 if [ $ec -eq 0 ]; then
-	echo INFO: Completed successfully at `date`. 
+	echo INFO: Completed successfully at `date`.
 else
 	echo ERROR: Failed with exitcode $ec at `date`.
 fi

--- a/hack/Jenkins/WinTP4/build-binary.sh
+++ b/hack/Jenkins/WinTP4/build-binary.sh
@@ -1,0 +1,35 @@
+
+# Build the binary in a container
+if [ $ec -eq 0 ]; then
+    echo "INFO: Building the test binary..."
+    set -x
+    docker run --rm -v "$TEMPWIN:c:\target" docker \
+        sh -c 'cd /c/go/src/github.com/docker/docker; \
+            hack/make.sh binary; \
+            ec=$?; \
+            if [ $ec -eq 0 ]; then \
+                robocopy /c/go/src/github.com/docker/docker/bundles/$(cat VERSION)/binary /c/target/binary; \
+            fi; \
+            exit $ec'
+    ec=$?
+    set +x
+    if [ 0 -ne $ec ]; then
+        echo
+        echo "----------------------------------"
+        echo "ERROR: Failed to build test binary"
+        echo "----------------------------------"
+        echo
+    fi
+fi
+
+# Copy the built docker.exe to docker-$COMMITHASH.exe so that it is
+# easily spotted in task manager, and to make sure the built binaries are first
+# on our path
+if [ $ec -eq 0 ]; then
+    echo "INFO: Linking the built binary to $TEMP/docker-$COMMITHASH.exe..."
+    ln $TEMP/binary/docker.exe $TEMP/binary/docker-$COMMITHASH.exe
+    ec=$?
+    if [ 0 -ne $ec ]; then
+        echo "ERROR: Failed to link"
+    fi
+fi


### PR DESCRIPTION
These changes are required to support #20639. The Windows CI builds run scripts in Jenkins, which assume a single binary at a specific path. That assumption is broken by #20639, but we need a way to make it backwards compatible with a single binary.

Instead of adding more complexity to an already long and complex bash script, we can split off the pieces that are aware of the binaries and paths, and version them in git.  Once this is in master we can update Jenkins to call these scripts.

That way #20362 can modify the scripts to be aware of the new paths and extra binary, and no builds will break.

I just copy and pasted some bash around. I don't know of any good way to test this... suggestions?

Commit 2 is not my change, I just brought the checked-in version of the script up-to-date with what is actually being run by jenkins... 

cc @icecrime, @kencochrane, @jhowardmsft 
