### PR TITLE
Client print error when specify wrong detach keys

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -24,11 +24,11 @@ type inputValidationError interface {
 	IsValidationError() bool
 }
 
-// WriteError decodes a specific docker error and sends it in the response.
-func WriteError(w http.ResponseWriter, err error) {
-	if err == nil || w == nil {
-		logrus.WithFields(logrus.Fields{"error": err, "writer": w}).Error("unexpected HTTP error handling")
-		return
+// GetHTTPErrorStatusCode retrieve status code from error message
+func GetHTTPErrorStatusCode(err error) int {
+	if err == nil {
+		logrus.WithFields(logrus.Fields{"error": err}).Error("unexpected HTTP error handling")
+		return http.StatusInternalServerError
 	}
 
 	var statusCode int
@@ -65,5 +65,16 @@ func WriteError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusInternalServerError
 	}
 
-	http.Error(w, errMsg, statusCode)
+	return statusCode
+}
+
+// WriteError decodes a specific docker error and sends it in the response.
+func WriteError(w http.ResponseWriter, err error) {
+	if err == nil || w == nil {
+		logrus.WithFields(logrus.Fields{"error": err, "writer": w}).Error("unexpected HTTP error handling")
+		return
+	}
+
+	statusCode := GetHTTPErrorStatusCode(err)
+	http.Error(w, err.Error(), statusCode)
 }

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -18,7 +18,7 @@ type ContainerAttachConfig struct {
 	UseStderr  bool
 	Logs       bool
 	Stream     bool
-	DetachKeys []byte
+	DetachKeys string
 
 	// Used to signify that streams are multiplexed and therefore need a StdWriter to encode stdout/sderr messages accordingly.
 	// TODO @cpuguy83: This shouldn't be needed. It was only added so that http and websocket endpoints can use the same function, and the websocket function was not using a stdwriter prior to this change...

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -101,7 +101,8 @@ func (d *Daemon) ContainerExecCreate(config *types.ExecConfig) (string, error) {
 	if config.DetachKeys != "" {
 		keys, err = term.ToBytes(config.DetachKeys)
 		if err != nil {
-			logrus.Warnf("Wrong escape keys provided (%s, error: %s) using default : ctrl-p ctrl-q", config.DetachKeys, err.Error())
+			err = fmt.Errorf("Invalid escape keys (%s) provided", config.DetachKeys)
+			return "", err
 		}
 	}
 

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api e37a82dfcea64559ca6a581776253c01d83357d9
+clone git github.com/docker/engine-api 8924d6900370b4c7e7984be5adc61f50a80d7537
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/container_wait.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_wait.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
-// ContainerWait pauses execution util a container exits.
+// ContainerWait pauses execution until a container exits.
 // It returns the API status code as response of its readiness.
 func (cli *Client) ContainerWait(ctx context.Context, containerID string) (int, error) {
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)

--- a/vendor/src/github.com/docker/engine-api/client/transport/transport.go
+++ b/vendor/src/github.com/docker/engine-api/client/transport/transport.go
@@ -4,7 +4,6 @@ package transport
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/docker/go-connections/sockets"
 )
@@ -35,10 +34,6 @@ func NewTransportWithHTTP(proto, addr string, client *http.Client) (Client, erro
 		}
 	}
 
-	if transport.TLSClientConfig != nil && transport.TLSClientConfig.ServerName == "" {
-		transport.TLSClientConfig.ServerName = hostname(addr)
-	}
-
 	return &apiTransport{
 		Client:    client,
 		tlsInfo:   &tlsInfo{transport.TLSClientConfig},
@@ -57,14 +52,6 @@ func defaultTransport(proto, addr string) *http.Transport {
 	tr := new(http.Transport)
 	sockets.ConfigureTransport(tr, proto, addr)
 	return tr
-}
-
-func hostname(addr string) string {
-	colonPos := strings.LastIndex(addr, ":")
-	if colonPos == -1 {
-		return addr
-	}
-	return addr[:colonPos]
 }
 
 var _ Client = &apiTransport{}

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -103,7 +103,7 @@ func (h *HijackedResponse) Close() {
 	h.Conn.Close()
 }
 
-// CloseWriter is an interface that implement structs
+// CloseWriter is an interface that implements structs
 // that close input streams to prevent from writing.
 type CloseWriter interface {
 	CloseWrite() error

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -236,10 +236,11 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount     int64  `json:"CpuCount"`   // CPU count
-	CPUPercent   int64  `json:"CpuPercent"` // CPU percent
-	MaximumIOps  uint64 // Maximum IOps for the container system drive
-	MaximumIOBps uint64 // Maximum IO in bytes per second for the container system drive
+	CPUCount                int64  `json:"CpuCount"`   // CPU count
+	CPUPercent              int64  `json:"CpuPercent"` // CPU percent
+	IOMaximumIOps           uint64 // Maximum IOps for the container system drive
+	IOMaximumBandwidth      uint64 // Maximum IO in bytes per second for the container system drive
+	NetworkMaximumBandwidth uint64 // Maximum bandwidth of the network endpoint in bytes per second
 }
 
 // UpdateConfig holds the mutable attributes of a Container.

--- a/vendor/src/github.com/docker/engine-api/types/stats.go
+++ b/vendor/src/github.com/docker/engine-api/types/stats.go
@@ -8,7 +8,7 @@ import "time"
 type ThrottlingData struct {
 	// Number of periods with throttling active
 	Periods uint64 `json:"periods"`
-	// Number of periods when the container hit its throttling limit.
+	// Number of periods when the container hits its throttling limit.
 	ThrottledPeriods uint64 `json:"throttled_periods"`
 	// Aggregate time the container was throttled for in nanoseconds.
 	ThrottledTime uint64 `json:"throttled_time"`


### PR DESCRIPTION
Fix #21064

Let client print error message explicitly when user specifies wrong
detach keys.

Sample output:

```
$ docker run --rm -ti  --detach-keys  "ctrl-D,ctrl-e" busybox sh
WARNING: Invalid escape keys provided (ctrl-D,ctrl-e) using default : ctrl-p ctrl-q
/ # 
```

Signed-off-by: Zhang Wei zhangwei555@huawei.com
