### PR TITLE
Fail when devicemapper doesn't support udev-sync

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1621,7 +1621,10 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 
 	// https://github.com/docker/docker/issues/4036
 	if supported := devicemapper.UdevSetSyncSupport(true); !supported {
-		logrus.Warn("devmapper: Udev sync is not supported. This will lead to unexpected behavior, data loss and errors. For more information, see https://docs.docker.com/reference/commandline/daemon/#daemon-storage-driver-option")
+		logrus.Errorf("devmapper: Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a dynamic binary to use devicemapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/daemon/#daemon-storage-driver-option")
+		if !devices.overrideUdevSyncCheck {
+			return graphdriver.ErrNotSupported
+		}
 	}
 
 	//create the root dir of the devmapper driver ownership to match this


### PR DESCRIPTION
Now what we provide dynamic binaries for all platforms, 
we shouldn't try to run docker without udev sync support.

This change changes the previous warning to an Error,
unless the user explicitly overrides the warning, in
which case they're at their own risk.

This is a continuation of the discussions in https://github.com/docker/docker/pull/14292
and https://github.com/docker/docker/pull/14415

In https://github.com/docker/docker/pull/14415#issuecomment-119024476 it was decided to "allow" running without udev sync, because;

> The alternative will come in the form of dynamically linked binaries for all distros, which will take some time (but we're hoping to have them for 1.8.0). Once we do have those, we'll reconsider making devicemapper without udev sync an error, but right now it seems premature.

Now that that's in place, I think we should refuse to run without udev sync.

This PR is just to get that discussion started, possibly we can customize the
error based on if the user is running a "dynamic" or "static" binary.
