### PR TITLE
Fix the vendoring script on MacOS X

### DIFF
--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -118,13 +118,6 @@ clean() {
 		-path vendor/src/github.com/mattn/go-sqlite3/code
 	)
 
-	# This package is required to build the Etcd client,
-	# but Etcd hard codes a local Godep full path.
-	# FIXME: fix_rewritten_imports fixes this problem in most platforms
-	# but it fails in very small corner cases where it makes the vendor
-	# script to remove this package.
-	# See: https://github.com/docker/docker/issues/19231
-	findArgs+=( -or -path vendor/src/github.com/ugorji/go/codec )
 	for import in "${imports[@]}"; do
 		[ "${#findArgs[@]}" -eq 0 ] || findArgs+=( -or )
 		findArgs+=( -path "vendor/src/$import" )
@@ -141,6 +134,10 @@ clean() {
 	echo -n 'pruning unused files, '
 	$find vendor -type f -name '*_test.go' -exec rm -v '{}' ';'
 
+	# These are the files that are left over after fix_rewritten_imports is run.
+	echo -n 'pruning .orig files, '
+	$find vendor -type f -name '*.orig' -exec rm -v '{}' ';'
+
 	echo done
 }
 
@@ -151,5 +148,5 @@ fix_rewritten_imports () {
        local target="vendor/src/$pkg"
 
        echo "$pkg: fixing rewritten imports"
-       $find "$target" -name \*.go -exec sed -i -e "s|\"${remove}|\"|g" {} \;
+       $find "$target" -name \*.go -exec sed -i'.orig' -e "s|\"${remove}|\"|g" {} \;
 }

--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -118,6 +118,13 @@ clean() {
 		-path vendor/src/github.com/mattn/go-sqlite3/code
 	)
 
+	# This package is required to build the Etcd client,
+	# but Etcd hard codes a local Godep full path.
+	# FIXME: fix_rewritten_imports fixes this problem in most platforms
+	# but it fails in very small corner cases where it makes the vendor
+	# script to remove this package.
+	# See: https://github.com/docker/docker/issues/19231
+	findArgs+=( -or -path vendor/src/github.com/ugorji/go/codec )
 	for import in "${imports[@]}"; do
 		[ "${#findArgs[@]}" -eq 0 ] || findArgs+=( -or )
 		findArgs+=( -path "vendor/src/$import" )


### PR DESCRIPTION
Please provide the following information:
- What did you do? 

I fixed an issue with the vendoring script on Mac OSX
- How did you do it?

I added a parameter that was optional in linux, but required on Mac OSX
- How do I see it or verify it?

I ran the vendoring script locally. It wasn't working before, and now it is.

Full Details:

The version of sed on MacOS X is different then the one on linux. The mac version
requires a parameter for the inline (-i) flag, where this isn't required on linux.
On the mac it thinks the -e flag is the parameter, and it causes the vendoring script
to fail.

This fix adds an empty string '' as a parameter to sed, which works fine on both the
mac and linux versions.

For more info see: http://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux

Signed-off-by: Ken Cochrane kencochrane@gmail.com
