### PR TITLE
Remove Windows-specific default registry definitions

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -34,7 +34,17 @@ var (
 	// NotaryServer is the endpoint serving the Notary trust server
 	NotaryServer = "https://notary.docker.io"
 
-	// IndexServer = "https://registry-stage.hub.docker.com/v1/"
+	// DefaultV1Registry is the URI of the default v1 registry
+	DefaultV1Registry = &url.URL{
+		Scheme: "https",
+		Host:   "index.docker.io",
+	}
+
+	// DefaultV2Registry is the URI of the default v2 registry
+	DefaultV2Registry = &url.URL{
+		Scheme: "https",
+		Host:   "registry-1.docker.io",
+	}
 )
 
 var (

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -2,24 +2,6 @@
 
 package registry
 
-import (
-	"net/url"
-)
-
-var (
-	// DefaultV1Registry is the URI of the default v1 registry
-	DefaultV1Registry = &url.URL{
-		Scheme: "https",
-		Host:   "index.docker.io",
-	}
-
-	// DefaultV2Registry is the URI of the default v2 registry
-	DefaultV2Registry = &url.URL{
-		Scheme: "https",
-		Host:   "registry-1.docker.io",
-	}
-)
-
 var (
 	// CertsDir is the directory where certificates are stored
 	CertsDir = "/etc/docker/certs.d"

--- a/registry/config_windows.go
+++ b/registry/config_windows.go
@@ -1,28 +1,9 @@
 package registry
 
 import (
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-)
-
-var (
-	// DefaultV1Registry is the URI of the default v1 registry
-	DefaultV1Registry = &url.URL{
-		Scheme: "https",
-		Host:   "registry-win-tp3.docker.io",
-	}
-
-	// DefaultV2Registry is the URI of the default (official) v2 registry.
-	// This is the windows-specific endpoint.
-	//
-	// Currently it is a TEMPORARY link that allows Microsoft to continue
-	// development of Docker Engine for Windows.
-	DefaultV2Registry = &url.URL{
-		Scheme: "https",
-		Host:   "registry-win-tp3.docker.io",
-	}
 )
 
 // CertsDir is the directory where certificates are stored


### PR DESCRIPTION
Going forward, Docker won't use a different default registry on Windows.
This changes Windows to use the standard Docker Hub registry as the
default registry.

There is a plan in place to migrate existing images from the Windows
registry to Hub's normal registry, in advance of the 1.11 release. In
the mean time, images on the Windows registry can be accessed by
prefixing them with `registry-win-tp3.docker.io/`.

cc @dmp42 @friism @icecrime @jhowardmsft @jstarks 
