### PR TITLE
Improve github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,33 +19,33 @@ Use the commands below to provide key information from your environment:
 You do NOT have to include this information if this is a FEATURE REQUEST
 -->
 
-Output of `docker version`:
+**Output of `docker version`:**
 
 ```
 (paste your output here)
 ```
 
 
-Output of `docker info`:
+**Output of `docker info`:**
 
 ```
 (paste your output here)
 ```
 
-Provide additional environment details (AWS, VirtualBox, physical, etc.):
+**Additional environment details (AWS, VirtualBox, physical, etc.):**
 
 
 
-List the steps to reproduce the issue:
+**Steps to reproduce the issue:**
 1.
 2.
 3.
 
 
-Describe the results you received:
+**Describe the results you received:**
 
 
-Describe the results you expected:
+**Describe the results you expected:**
 
 
-Provide additional info you think is important:
+**Additional information you deem important (e.g. issue happens only occasionally):**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,15 +9,15 @@ guide https://docs.docker.com/opensource/code/
 
 If this is a bug fix, make sure your description includes "fixes #xxxx", or
 "closes #xxxx"
--->
 
 Please provide the following information:
+-->
 
-- What did you do?
+**- What I did**
 
-- How did you do it?
+**- How I did it**
 
-- How do I see it or verify it?
+**- How to verify it**
 
-- A picture of a cute animal (not mandatory but encouraged)
+**- A picture of a cute animal (not mandatory but encouraged)**
 


### PR DESCRIPTION
**\- What I did**

Improved contrast in the github templates for easier reading and rephrased some parts.

**\- How I did it**

Made it bold. Changed `you`-phrases with `I`-phrases instead.

**\- How to verify it**

I manually changed this PR description for an example but you can also just use any markdown previewer on github and paste it there.

**\- A picture of a cute animal (not mandatory but encouraged)**

[picture of younger me]

Signed-off-by: Tibor Vass tibor@docker.com
