### PR TITLE
Fix one-character directory issue in the volume option (#20122).

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4243,3 +4243,12 @@ func (s *DockerSuite) TestRunAttachFailedNoLeak(c *check.C) {
 	// NGoroutines is not updated right away, so we need to wait before failing
 	c.Assert(waitForGoroutines(nroutines), checker.IsNil)
 }
+
+// Test for one character directory name case (#20122)
+func (s *DockerSuite) TestRunVolumeWithOneCharacter(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	out, _ := dockerCmd(c, "run", "-v", "/tmp/q:/foo", "busybox", "sh", "-c", "find /foo")
+	fmt.Printf("OUTPUT: %+v", out)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "/foo")
+}

--- a/runconfig/opts/parse_test.go
+++ b/runconfig/opts/parse_test.go
@@ -801,6 +801,9 @@ func TestVolumeSplitN(t *testing.T) {
 		{`..\`, -1, []string{`..\`}},
 		{`c:\:..\`, -1, []string{`c:\`, `..\`}},
 		{`c:\:d:\:xyzzy`, -1, []string{`c:\`, `d:\`, `xyzzy`}},
+
+		// Cover directories with one-character name
+		{`/tmp/x/y:/foo/x/y`, -1, []string{`/tmp/x/y`, `/foo/x/y`}},
 	} {
 		res := volumeSplitN(x.input, x.n)
 		if len(res) < len(x.expected) {


### PR DESCRIPTION
The issue stems from the implementation of volumeSplitN() where a driver letter (`[a-zA-Z]:`) was assumed to follow either `:`, `/`, or `\\`.

In Windows driver letter appears in two situations:
a. `^[a-zA-Z]:` (A colon followed  by `^[a-zA-Z]:` is OK as colon is the separator in volume option)
b. A string in the format like `\\?\C:\Windows\...` (UNC).
Therefore, a driver letter can only follow either a `:` or `\\`

This PR removes the condition of `/` before the driver letter so that options like `-v /tmp/q:/foo` could be handled correctly. A couple of tests has also been added.

This PR fixes #20122.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
