### PR TITLE
Improve checking dummy kernel module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,16 +84,6 @@ binary: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
 
 build: bundles
-ifeq ($(DOCKER_OSARCH), linux/arm)
-	# A few libnetwork integration tests require that the kernel be
-	# configured with "dummy" network interface and has the module
-	# loaded. However, the dummy module is not available by default
-	# on arm images. This ensures that it's built and loaded.
-	echo "Syncing kernel modules"
-	oc-sync-kernel-modules
-	depmod
-	modprobe dummy
-endif
 	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" -f "$(DOCKERFILE)" .
 
 bundles:
@@ -101,8 +91,8 @@ bundles:
 
 cross: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross
-	
-	
+
+
 win: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh win
 

--- a/project/ARM.md
+++ b/project/ARM.md
@@ -28,3 +28,18 @@ So for example in order to build a Docker binary one has to
 1. clone the Docker/Docker repository on an ARM device `git clone git@github.com:docker/docker.git`  
 2. change into the checked out repository with `cd docker`  
 3. execute `make binary` to create a Docker Engine binary for ARM  
+
+## Kernel modules
+A few libnetwork integration tests require that the kernel be
+configured with "dummy" network interface and has the module
+loaded. However, the dummy module may be not loaded automatically.
+
+To load the kernel module permanently, run these commands as `root`.
+
+    modprobe dummy
+    echo "dummy" >> /etc/modules
+
+On some systems you also have to sync your kernel modules.
+
+    oc-sync-kernel-modules
+    depmod


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Improve the commit https://github.com/docker/docker/commit/f3b2233d126aec8ab15fa589f5a9360eec280f01 to work without root user on an ARM machine. Just check if the kernel module "dummy" is already loaded. Only if not show a warning and try to run the commands to load it (but this requires root access). Added some notes in the ARM.md as well.

**\- How I did it**

**\- How to verify it**

Create a Scaleway C1 machine with Docker image.

Run `make test-integration-cli` on a Scaleway machine as non-root user. It aborts as the  `dummy` kernel module is not loaded.

Run these commands as root user:

```
modprobe dummy
echo "dummy" >>/etc/modules
```

You now may reboot to test automatically loading the kernel image.

Run `make test-integration-cli` again as non-root user and see that it now begins to build.

closes #20793 
