### PR TITLE
Allow restart_syscall in default seccomp profile

### DIFF
--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -114,7 +114,6 @@ the reason each syscall is blocked rather than white-listed.
 | `query_module`      | Deny manipulation and functions on kernel modules.                                                            |
 | `quotactl`          | Quota syscall which could let containers disable their own resource limits or process accounting. Also gated by `CAP_SYS_ADMIN`. |
 | `reboot`            | Don't let containers reboot the host. Also gated by `CAP_SYS_BOOT`.                                           |
-| `restart_syscall`   | Don't allow containers to restart a syscall. Possible seccomp bypass see: https://code.google.com/p/chromium/issues/detail?id=408827. |
 | `request_key`       | Prevent containers from using the kernel keyring, which is not namespaced.                                    |
 | `set_mempolicy`     | Syscall that modifies kernel memory and NUMA settings. Already gated by `CAP_SYS_NICE`.                       |
 | `setns`             | Deny associating a thread with a namespace. Also gated by `CAP_SYS_ADMIN`.                                    |

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -1000,6 +1000,11 @@
 			"args": []
 		},
 		{
+			"name": "restart_syscall",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
 			"name": "rmdir",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -1029,6 +1029,11 @@ var DefaultProfile = &types.Seccomp{
 			Args:   []*types.Arg{},
 		},
 		{
+			Name:   "restart_syscall",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
 			Name:   "rmdir",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},


### PR DESCRIPTION
Fixes #20818

This syscall was blocked as there was some concern that it could be
used to bypass filtering of other syscall arguments. However none of the
potential syscalls where this could be an issue (poll, nanosleep,
clock_nanosleep, futex) are blocked in the default profile anyway.
While this call is not directly used by userspace, it does get
filtered when generated by the kernel in legitimate use cases, eg
tracing applications using ftrace.

Signed-off-by: Justin Cormack justin.cormack@docker.com
