### PR TITLE
closes #21119 updating documentation for Windows and OSx users

### DIFF
--- a/docs/userguide/containers/dockerrepos.md
+++ b/docs/userguide/containers/dockerrepos.md
@@ -31,17 +31,21 @@ Docker itself provides access to Docker Hub services via the `docker search`,
 `pull`, `login`, and `push` commands. This page will show you how these commands work.
 
 ### Account creation and login
-Typically, you'll want to start by creating an account on Docker Hub (if you haven't
-already) and logging in. You can create your account directly on
-[Docker Hub](https://hub.docker.com/account/signup/).
+Before you try an Engine CLI command, if you haven't already, create a Docker
+ID. You can do this through [Docker Hub](https://hub.docker.com/). Once you have
+a Docker ID, log into your account from the Engine CLI:
 
-    $ docker login
+```bash
+$ docker login
+```
 
-You can now commit and push your own images up to your repos on Docker Hub.
+The `login` command stores your Docker ID authentication credentials in the
+`$HOME/.docker/config.json` (Bash notation). For Windows `cmd` users the
+notation for this file is `%HOME%\.docker\config.json` ; for PowerShell users
+the notation is `$env:Home\.docker\config.json`. 
 
-> **Note:**
-> Your authentication credentials will be stored in the `~/.docker/config.json`
-> authentication file in your home directory.
+Once you have logged in from the command line, you can `commit` and `push`
+Engine subcommands to interact with your repos on Docker Hub.
 
 ## Searching for images
 


### PR DESCRIPTION
**\- What I did**
Updating Docker's documentation file docker configuration file on Windows hosts.
This is of importance for Windows users whom are utilizing the Docker Toolbox.

**\- How I did it**
Editing the markdown file `docs/userguide/containers/dockerrepos.md`

**\- How to verify it**
Build the docs and view the changes
With this commit, the documentation now looks as follows:
![image](https://cloud.githubusercontent.com/assets/316371/13702281/16e8c08a-e796-11e5-9307-224ac74db005.png)

**\- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/316371/13702315/522a8836-e796-11e5-83b1-9651c10b8465.png)

Signed-off-by: Liran Tal liran.tal@gmail.com
