### PR TITLE
Update statically linked libseccomp to 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN set -x \
 ENV PATH /osxcross/target/bin:$PATH
 
 # install seccomp: the version shipped in trusty is too old
-ENV SECCOMP_VERSION 2.2.3
+ENV SECCOMP_VERSION 2.3.0
 RUN set -x \
 	&& export SECCOMP_PATH="$(mktemp -d)" \
 	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -78,7 +78,7 @@ RUN cd /usr/local/lvm2 \
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # install seccomp: the version shipped in trusty is too old
-ENV SECCOMP_VERSION 2.2.3
+ENV SECCOMP_VERSION 2.3.0
 RUN set -x \
 	&& export SECCOMP_PATH="$(mktemp -d)" \
 	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -103,7 +103,7 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 
 	&& go install -v github.com/golang/lint/golint
 
 # install seccomp: the version shipped in trusty is too old
-ENV SECCOMP_VERSION 2.2.3
+ENV SECCOMP_VERSION 2.3.0
 RUN set -x \
 	&& export SECCOMP_PATH="$(mktemp -d)" \
 	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -43,7 +43,7 @@ RUN cd /usr/local/lvm2 \
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # install seccomp: the version shipped in jessie is too old
-ENV SECCOMP_VERSION v2.2.3
+ENV SECCOMP_VERSION v2.3.0
 RUN set -x \
     && export SECCOMP_PATH=$(mktemp -d) \
     && git clone https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \


### PR DESCRIPTION
Fixes #20550

This update to libseccomp supports the new versions of socket
system calls that can be called directly rather than via the
socketcall syscall in kernel versions 4.3 or later with new glibc.

Note this library version now supports s390x and ppc64le, so
seccomp can be potentially be enabled for these architectures now.

Signed-off-by: Justin Cormack justin.cormack@docker.com
