### PR TITLE
Fix gcc compile test with proper flag ordering

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -137,7 +137,7 @@ fi
 # functionality.
 if \
 	command -v gcc &> /dev/null \
-	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -ldevmapper -o /dev/null &> /dev/null ) \
+	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null -ldevmapper &> /dev/null ) \
 ; then
        DOCKER_BUILDTAGS+=' libdm_no_deferred_remove'
 fi


### PR DESCRIPTION
This test for libdevmapper was always silently failing because the
linker never got the `-ldevmapper` information. Putting the flag last
corrects the test.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
