### PR TITLE
Fix error-checking when looking at empty log

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -218,8 +218,8 @@ func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
 
 	since := t.Unix() + 2
 	out, _ = dockerCmd(c, "logs", "-t", "-f", fmt.Sprintf("--since=%v", since), name)
+	c.Assert(out, checker.Not(checker.HasLen), 0, check.Commentf("cannot read from empty log"))
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	c.Assert(lines, checker.Not(checker.HasLen), 0)
 	for _, v := range lines {
 		ts, err := time.Parse(time.RFC3339Nano, strings.Split(v, " ")[0])
 		c.Assert(err, checker.IsNil, check.Commentf("cannot parse timestamp output from log: '%v'", v))


### PR DESCRIPTION
Fixes a bug when the log output is empty.

The length of a slice containing an empty string is 1, not 0, so
the test fails to catch when the log is empty. Instead, take a look at
out, which is just a string representation of the log.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
