### PR TITLE
Add notary binary requirement for tests

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -158,7 +158,7 @@ type DockerTrustSuite struct {
 }
 
 func (s *DockerTrustSuite) SetUpTest(c *check.C) {
-	testRequires(c, RegistryHosting, NotaryHosting)
+	testRequires(c, RegistryHosting, NotaryServerHosting)
 	s.reg = setupRegistry(c, false, false)
 	s.not = setupNotary(c)
 }

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -496,6 +496,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithExpiredTimestamp(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegation(c *check.C) {
+	testRequires(c, NotaryHosting)
 	repoName := fmt.Sprintf("%v/dockerclireleasedelegation/trusted", privateRegistryURL)
 	targetName := fmt.Sprintf("%s:latest", repoName)
 	pwd := "12345678"

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -97,6 +97,16 @@ var (
 		},
 		fmt.Sprintf("Test requires an environment that can host %s in the same host", notaryBinary),
 	}
+	NotaryServerHosting = testRequirement{
+		func() bool {
+			// for now notary-server binary is built only if we're running inside
+			// container through `make test`. Figure that out by testing if
+			// notary-server binary is in PATH.
+			_, err := exec.LookPath(notaryServerBinary)
+			return err == nil
+		},
+		fmt.Sprintf("Test requires an environment that can host %s in the same host", notaryServerBinary),
+	}
 	NotOverlay = testRequirement{
 		func() bool {
 			cmd := exec.Command("grep", "^overlay / overlay", "/proc/mounts")

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -19,8 +19,8 @@ import (
 	"github.com/go-check/check"
 )
 
-var notaryBinary = "notary-server"
-var notaryClientBinary = "notary"
+var notaryBinary = "notary"
+var notaryServerBinary = "notary-server"
 
 type testNotary struct {
 	cmd *exec.Cmd
@@ -91,7 +91,7 @@ func newTestNotary(c *check.C) (*testNotary, error) {
 	}
 
 	// run notary-server
-	cmd := exec.Command(notaryBinary, "-config", confPath)
+	cmd := exec.Command(notaryServerBinary, "-config", confPath)
 	if err := cmd.Start(); err != nil {
 		os.RemoveAll(tmp)
 		if os.IsNotExist(err) {
@@ -221,7 +221,7 @@ func notaryClientEnv(cmd *exec.Cmd, rootPwd, repositoryPwd string) {
 }
 
 func (s *DockerTrustSuite) setupDelegations(c *check.C, repoName, pwd string) {
-	initCmd := exec.Command(notaryClientBinary, "-c", filepath.Join(s.not.dir, "client-config.json"), "init", repoName)
+	initCmd := exec.Command(notaryBinary, "-c", filepath.Join(s.not.dir, "client-config.json"), "init", repoName)
 	notaryClientEnv(initCmd, pwd, pwd)
 	out, _, err := runCommandWithOutput(initCmd)
 	if err != nil {
@@ -243,7 +243,7 @@ func (s *DockerTrustSuite) setupDelegations(c *check.C, repoName, pwd string) {
 	}
 
 	// publishing first simulates the client pushing to a repo that they have been given delegated access to
-	pubCmd := exec.Command(notaryClientBinary, "-c", filepath.Join(s.not.dir, "client-config.json"), "publish", repoName)
+	pubCmd := exec.Command(notaryBinary, "-c", filepath.Join(s.not.dir, "client-config.json"), "publish", repoName)
 	notaryClientEnv(pubCmd, pwd, pwd)
 	out, _, err = runCommandWithOutput(pubCmd)
 	if err != nil {


### PR DESCRIPTION
This PR adds the "notary" binary requirement for tests.

Previously, NotaryHosting was checking for the "notary-server"
binary under the name notaryBinary. This renames that reference to
notaryServerBinary, so that notaryBinary can rightly refer
to the actual "notary" binary.

Currently only one test actually uses the notary binary, so it's been
updated accordingly.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

Here are some cute Russian Navy Seals:

![Russian-navy-seals](http://www.ripleys.com/wp-content/uploads/2015/05/Russian-Navy-SEALS-Header-Ripleys-750x420.jpg)
