### PR TITLE
Graph root FS bootstrap capabilities

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -39,8 +39,15 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 			fmt.Fprintf(cli.out, " %s: %s\n", pair[0], pair[1])
 
 			// print a warning if devicemapper is using a loopback file
-			if pair[0] == "Data loop file" {
-				fmt.Fprintln(cli.err, " WARNING: Usage of loopback devices is strongly discouraged for production use. Either use `--storage-opt dm.thinpooldev` or use `--storage-opt dm.no_warn_on_loop_devices=true` to suppress this warning.")
+			if pair[0] == "Data Loop File" {
+				var options string
+				switch info.Driver {
+				case "devicemapper":
+					options = " Use `--storage-opt dm.thinpooldev` to configure a production thin pool."
+				case "zfs":
+					options = " Remove `--storage-opt zfs.loopback.generate` and configure the zpool on a Disk vdev."
+				}
+				fmt.Fprintf(cli.err, " WARNING: Usage of loopback devices is strongly discouraged for production use.%s\n", options)
 			}
 		}
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -841,11 +841,15 @@ _docker_daemon() {
  			COMPREPLY=( $( compgen -W "ext4 xfs" -- "${cur##*=}" ) )
  			return
  			;;
- 		dm.thinpooldev)
+		dm.thinpooldev|zfs.loopback.path)
 			cur=${cur##*=}
  			_filedir
  			return
  			;;
+		zfs.loopback.generate)
+			COMPREPLY=( $( compgen -W "false true" -- "${cur##*=}" ) )
+			return
+			;;
  	esac
 
 	case "$prev" in
@@ -895,7 +899,13 @@ _docker_daemon() {
 				dm.use_deferred_deletion
 				dm.use_deferred_removal
 			"
-			local zfs_options="zfs.fsname"
+			local zfs_options="
+				zfs.fsname
+				zfs.loopback.generate
+				zfs.loopback.name
+				zfs.loopback.path
+				zfs.loopback.size
+			"
 
 			case $(__docker_value_of_option '--storage-driver|-s') in
 				'')

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -969,39 +969,16 @@ func setupRemappedRoot(config *Config) ([]idtools.IDMap, []idtools.IDMap, error)
 	return uidMaps, gidMaps, nil
 }
 
-func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error {
-	config.Root = rootDir
-	// the docker root metadata directory needs to have execute permissions for all users (g+x,o+x)
-	// so that syscalls executing as non-root, operating on subdirectories of the graph root
-	// (e.g. mounted layers of a container) can traverse this path.
-	// The user namespace support will create subdirectories for the remapped root host uid:gid
-	// pair owned by that same uid:gid pair for proper write access to those needed metadata and
-	// layer content subtrees.
-	if _, err := os.Stat(rootDir); err == nil {
-		// root current exists; verify the access bits are correct by setting them
-		if err = os.Chmod(rootDir, 0711); err != nil {
-			return err
-		}
-	} else if os.IsNotExist(err) {
-		// no root exists yet, create it 0711 with root:root ownership
-		if err := os.MkdirAll(rootDir, 0711); err != nil {
-			return err
-		}
+func getRealRemappedRoot(config *Config, realRoot string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+	if config.RemappedRoot == "" {
+		return realRoot, nil
 	}
 
-	// if user namespaces are enabled we will create a subtree underneath the specified root
-	// with any/all specified remapped root uid/gid options on the daemon creating
-	// a new subdirectory with ownership set to the remapped uid/gid (so as to allow
-	// `chdir()` to work for containers namespaced to that uid/gid)
-	if config.RemappedRoot != "" {
-		config.Root = filepath.Join(rootDir, fmt.Sprintf("%d.%d", rootUID, rootGID))
-		logrus.Debugf("Creating user namespaced daemon root: %s", config.Root)
-		// Create the root directory if it doesn't exist
-		if err := idtools.MkdirAllAs(config.Root, 0700, rootUID, rootGID); err != nil {
-			return fmt.Errorf("Cannot create daemon root: %s: %v", config.Root, err)
-		}
+	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+	if err != nil {
+		return "", err
 	}
-	return nil
+	return filepath.Join(realRoot, fmt.Sprintf("%d.%d", rootUID, rootGID)), nil
 }
 
 // registerLinks writes the links to a file.

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -295,13 +294,8 @@ func setupRemappedRoot(config *Config) ([]idtools.IDMap, []idtools.IDMap, error)
 	return nil, nil, nil
 }
 
-func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error {
-	config.Root = rootDir
-	// Create the root directory if it doesn't exists
-	if err := system.MkdirAll(config.Root, 0700); err != nil && !os.IsExist(err) {
-		return err
-	}
-	return nil
+func getRealRemappedRoot(config *Config, realRoot string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+	return realRoot, nil
 }
 
 // runasHyperVContainer returns true if we are going to run as a Hyper-V container

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -62,7 +62,7 @@ var (
 )
 
 func init() {
-	graphdriver.Register("aufs", Init)
+	graphdriver.Register("aufs", graphdriver.NewFSBootstrap(validateDriver, initDriver))
 }
 
 // Driver contains information about the filesystem mounted.
@@ -75,18 +75,18 @@ type Driver struct {
 	pathCache     map[string]string
 }
 
-// Init returns a new AUFS driver.
-// An error is returned if AUFS is not supported.
-func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
-
+// validateDriver validates that AUFS can be used in this host.
+// It returns an error if the kernel doesn't support AUFS
+// or the filesystem is incompatible.
+func validateDriver(root string) error {
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
-		return nil, graphdriver.ErrNotSupported
+		return graphdriver.ErrNotSupported
 	}
 
 	fsMagic, err := graphdriver.GetFSMagic(root)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if fsName, ok := graphdriver.FsNames[fsMagic]; ok {
 		backingFs = fsName
@@ -94,10 +94,16 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 
 	for _, magic := range incompatibleFsMagic {
 		if fsMagic == magic {
-			return nil, graphdriver.ErrIncompatibleFS
+			return graphdriver.ErrIncompatibleFS
 		}
 	}
 
+	return nil
+}
+
+// initDriver returns a new AUFS driver.
+// An error is returned if AUFS is not supported.
+func initDriver(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
 	paths := []string{
 		"mnt",
 		"diff",

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func testInit(dir string, t testing.TB) graphdriver.Driver {
-	d, err := Init(dir, nil, nil, nil)
+	d, err := initDriver(dir, nil, nil, nil)
 	if err != nil {
 		if err == graphdriver.ErrNotSupported {
 			t.Skip(err)

--- a/daemon/graphdriver/bootstrap.go
+++ b/daemon/graphdriver/bootstrap.go
@@ -1,0 +1,80 @@
+package graphdriver
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/idtools"
+)
+
+type validateFunc func(root string) error
+type initFunc func(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error)
+
+// Bootstrap is an interface that includes functions to
+// validate and initialize a graph driver.
+type Bootstrap interface {
+	ValidateSupport(root string) error
+	Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error)
+}
+
+// FSBootstrap is a Bootstrap struct that ensures
+// the filesystem hierarchy is generated correctly
+// for the engine's normal use.
+type FSBootstrap struct {
+	validateSupport validateFunc
+	driverInit      initFunc
+}
+
+// NewFSBootstrap creates a new FSBootstrap with a validate and an init function.
+func NewFSBootstrap(validate validateFunc, init initFunc) Bootstrap {
+	return FSBootstrap{
+		validateSupport: validate,
+		driverInit:      init,
+	}
+}
+
+// NewAlwaysValidFSBootstrap creates a new FSBootstrap object
+// which support validation is always true, like vfs on linux.
+func NewAlwaysValidFSBootstrap(init initFunc) Bootstrap {
+	return FSBootstrap{
+		validateSupport: alwaysValidDriver,
+		driverInit:      init,
+	}
+}
+
+// ValidateSupport returns an error if the graph driver
+// is not supported in the host.
+func (b FSBootstrap) ValidateSupport(root string) error {
+	return b.validateSupport(root)
+}
+
+// Init generates the root directory hierarchy and initializes the graph driver.
+func (b FSBootstrap) Init(graphRoot string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error) {
+	if err := InitRootFilesystem(filepath.Dir(graphRoot), options, uidMaps, gidMaps); err != nil {
+		return nil, err
+	}
+
+	return b.driverInit(graphRoot, options, uidMaps, gidMaps)
+}
+
+// InitRootFilesystem generates the correct root hierarchy for the engine.
+func InitRootFilesystem(root string, options []string, uidMaps, gidMaps []idtools.IDMap) error {
+	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+	if err != nil {
+		return err
+	}
+
+	if err = setupDaemonRoot(root, rootUID, rootGID); err != nil {
+		return err
+	}
+
+	daemonRepo := filepath.Join(root, "containers")
+	if err := idtools.MkdirAllAs(daemonRepo, 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
+func alwaysValidDriver(root string) error {
+	return nil
+}

--- a/daemon/graphdriver/bootstrap_unix.go
+++ b/daemon/graphdriver/bootstrap_unix.go
@@ -1,0 +1,47 @@
+// +build !windows
+
+package graphdriver
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/idtools"
+)
+
+// setupDaemonRoot initializes the root directory with the right mode.
+func setupDaemonRoot(rootDir string, rootUID, rootGID int) error {
+	// the docker root metadata directory needs to have execute permissions for all users (o+x)
+	// so that syscalls executing as non-root, operating on subdirectories of the graph root
+	// (e.g. mounted layers of a container) can traverse this path.
+	// The user namespace support will create subdirectories for the remapped root host uid:gid
+	// pair owned by that same uid:gid pair for proper write access to those needed metadata and
+	// layer content subtrees.
+	if _, err := os.Stat(rootDir); err == nil {
+		// root current exists; verify the access bits are correct by setting them
+		if rootUID == 0 && rootGID == 0 {
+			if err = os.Chmod(rootDir, 0711); err != nil {
+				return err
+			}
+		}
+	} else if os.IsNotExist(err) {
+		// if user namespaces are enabled we will create a subtree underneath the specified root
+		// with any/all specified remapped root uid/gid options on the daemon creating
+		// a new subdirectory with ownership set to the remapped uid/gid (so as to allow
+		// `chdir()` to work for containers namespaced to that uid/gid)
+		if rootUID != 0 && rootGID != 0 {
+			logrus.Debugf("Creating user namespaced daemon root: %s", rootDir)
+			// Create the root directory if it doesn't exists
+			if err := idtools.MkdirAllAs(rootDir, 0700, rootUID, rootGID); err != nil {
+				return fmt.Errorf("Cannot create daemon root: %s: %v", rootDir, err)
+			}
+		} else {
+			// no root exists yet, create it 0701 with root:root ownership
+			if err := os.MkdirAll(rootDir, 0711); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/daemon/graphdriver/bootstrap_windows.go
+++ b/daemon/graphdriver/bootstrap_windows.go
@@ -1,0 +1,16 @@
+package graphdriver
+
+import (
+	"os"
+
+	"github.com/docker/docker/pkg/system"
+)
+
+// setupDaemonRoot initializes the root directory with the right mode.
+func setupDaemonRoot(rootDir string, rootUID, rootGID int) error {
+	// Create the root directory if it doesn't exists
+	if err := system.MkdirAll(rootDir, 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1624,16 +1624,6 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	// give ourselves to libdm as a log handler
 	devicemapper.LogInit(devices)
 
-	version, err := devicemapper.GetDriverVersion()
-	if err != nil {
-		// Can't even get driver version, assume not supported
-		return graphdriver.ErrNotSupported
-	}
-
-	if err := determineDriverCapabilities(version); err != nil {
-		return graphdriver.ErrNotSupported
-	}
-
 	// If user asked for deferred removal then check both libdm library
 	// and kernel driver support deferred removal otherwise error out.
 	if enableDeferredRemoval {

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -65,7 +65,7 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 		t.Fatal(err)
 	}
 	//Reload
-	d, err := Init(driver.home, []string{
+	d, err := initDriver(driver.home, []string{
 		fmt.Sprintf("dm.loopdatasize=%d", defaultDataLoopbackSize+delta),
 		fmt.Sprintf("dm.loopmetadatasize=%d", defaultMetaDataLoopbackSize+delta),
 	}, nil, nil)

--- a/daemon/graphdriver/plugin.go
+++ b/daemon/graphdriver/plugin.go
@@ -18,15 +18,12 @@ type pluginClient interface {
 	SendFile(string, io.Reader, interface{}) error
 }
 
-func lookupPlugin(name, home string, opts []string) (Driver, error) {
+func lookupPlugin(name string) (Bootstrap, error) {
 	pl, err := plugins.Get(name, "GraphDriver")
 	if err != nil {
 		return nil, fmt.Errorf("Error looking up graphdriver plugin %s: %v", name, err)
 	}
-	return newPluginDriver(name, home, opts, pl.Client)
-}
 
-func newPluginDriver(name, home string, opts []string, c pluginClient) (Driver, error) {
-	proxy := &graphDriverProxy{name, c}
-	return proxy, proxy.Init(home, opts)
+	proxy := &graphDriverProxy{name, pl.Client}
+	return NewAlwaysValidFSBootstrap(proxy.InitBootstrap), nil
 }

--- a/daemon/graphdriver/plugin_unsupported.go
+++ b/daemon/graphdriver/plugin_unsupported.go
@@ -2,6 +2,6 @@
 
 package graphdriver
 
-func lookupPlugin(name, home string, opts []string) (Driver, error) {
+func lookupPlugin(name string) (Bootstrap, error) {
 	return nil, ErrNotSupported
 }

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/idtools"
 )
 
 type graphDriverProxy struct {
@@ -33,6 +34,13 @@ type graphDriverResponse struct {
 type graphDriverInitRequest struct {
 	Home string
 	Opts []string
+}
+
+func (d *graphDriverProxy) InitBootstrap(root string, options []string, _, _ []idtools.IDMap) (Driver, error) {
+	if err := d.Init(root, options); err != nil {
+		return nil, err
+	}
+	return d, nil
 }
 
 func (d *graphDriverProxy) Init(home string, opts []string) error {

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -18,7 +18,7 @@ var (
 )
 
 func init() {
-	graphdriver.Register("vfs", Init)
+	graphdriver.Register("vfs", graphdriver.NewAlwaysValidFSBootstrap(Init))
 }
 
 // Init returns a new VFS driver.

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -31,8 +31,8 @@ import (
 
 // init registers the windows graph drivers to the register.
 func init() {
-	graphdriver.Register("windowsfilter", InitFilter)
-	graphdriver.Register("windowsdiff", InitDiff)
+	graphdriver.Register("windowsfilter", graphdriver.NewAlwaysValidFSBootstrap(InitFilter))
+	graphdriver.Register("windowsdiff", graphdriver.NewAlwaysValidFSBootstrap(InitDiff))
 }
 
 const (

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -18,17 +18,42 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/go-units"
 	zfs "github.com/mistifyio/go-zfs"
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
+const (
+	// valid cli options
+	zfsNameOption             = "zfs.fsname"
+	zfsLoopbackGenerateOption = "zfs.loopback.generate"
+	zfsLoopbackNameOption     = "zfs.loopback.name"
+	zfsLoopbackPathOption     = "zfs.loopback.path"
+	zfsLoopbackSizeOption     = "zfs.loopback.size"
+
+	// default values
+	defaultLoopbackName = "zroot-docker-lo"
+	defaultLoopbackPath = "/var/lib/docker.img"
+	defaultLoopbackSize = "10G"
+)
+
+type activeMount struct {
+	count   int
+	path    string
+	mounted bool
+}
+
 type zfsOptions struct {
-	fsName    string
-	mountPath string
+	fsName           string
+	mountPath        string
+	loopbackPath     string
+	loopbackSize     string
+	loopbackName     string
+	loopbackGenerate bool
 }
 
 func init() {
-	graphdriver.Register("zfs", Init)
+	graphdriver.Register("zfs", bootstrapZFS{})
 }
 
 // Logger returns a zfs logger implementation.
@@ -39,44 +64,70 @@ func (*Logger) Log(cmd []string) {
 	logrus.Debugf("[zfs] %s", strings.Join(cmd, " "))
 }
 
-// Init returns a new ZFS driver.
-// It takes base mount path and a array of options which are represented as key value pairs.
-// Each option is in the for key=value. 'zfs.fsname' is expected to be a valid key in the options.
-func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
-	var err error
+type bootstrapZFS struct{}
 
+// ValidateSupport validates that DevMapper can be used in this host.
+// It returns an error if the kernel doesn't support ZFS
+// or the command line tools are not installed in the host.
+func (bootstrapZFS) ValidateSupport(_ string) error {
 	if _, err := exec.LookPath("zfs"); err != nil {
 		logrus.Debugf("[zfs] zfs command is not available: %v", err)
-		return nil, graphdriver.ErrPrerequisites
+		return graphdriver.ErrPrerequisites
 	}
 
 	file, err := os.OpenFile("/dev/zfs", os.O_RDWR, 600)
 	if err != nil {
 		logrus.Debugf("[zfs] cannot open /dev/zfs: %v", err)
-		return nil, graphdriver.ErrPrerequisites
+		return graphdriver.ErrPrerequisites
 	}
-	defer file.Close()
+	file.Close()
+	return nil
+}
 
+// Init initializes a new ZFS driver.
+// It bootstraps the Zpool and Dataset if the option is set too.
+func (bootstrapZFS) Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (d graphdriver.Driver, graphErr error) {
 	options, err := parseOptions(opt)
 	if err != nil {
 		return nil, err
 	}
 	options.mountPath = base
+	rootDir := path.Dir(base)
 
-	rootdir := path.Dir(base)
-
-	if options.fsName == "" {
-		err = checkRootdirFs(rootdir)
+	if options.loopbackGenerate {
+		fsName, err := generateZFSLoopback(rootDir, options)
 		if err != nil {
 			return nil, err
 		}
+		options.fsName = fsName
+
+		defer func() {
+			if graphErr != nil {
+				destroyLoopbackZpool(options.loopbackName)
+			}
+		}()
 	}
 
+	if err := graphdriver.InitRootFilesystem(rootDir, opt, uidMaps, gidMaps); err != nil {
+		return nil, err
+	}
+
+	return initDriver(rootDir, options, uidMaps, gidMaps)
+}
+
+// initDriver returns a new ZFS driver.
+// It takes base mount path and a array of options which are represented as key value pairs.
+// Each option is in the for key=value. 'zfs.fsname' is expected to be a valid key in the options.
+func initDriver(rootDir string, options zfsOptions, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
 	if options.fsName == "" {
-		options.fsName, err = lookupZfsDataset(rootdir)
+		if err := checkRootdirFs(rootDir); err != nil {
+			return nil, err
+		}
+		fsName, err := lookupZfsDataset(rootDir)
 		if err != nil {
 			return nil, err
 		}
+		options.fsName = fsName
 	}
 
 	zfs.SetLogger(new(Logger))
@@ -119,8 +170,23 @@ func parseOptions(opt []string) (zfsOptions, error) {
 		}
 		key = strings.ToLower(key)
 		switch key {
-		case "zfs.fsname":
+		case zfsNameOption:
 			options.fsName = val
+		case zfsLoopbackGenerateOption:
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				return options, err
+			}
+			options.loopbackGenerate = b
+		case zfsLoopbackNameOption:
+			options.loopbackName = val
+		case zfsLoopbackPathOption:
+			options.loopbackPath = val
+		case zfsLoopbackSizeOption:
+			if _, err := units.FromHumanSize(val); err != nil {
+				return options, err
+			}
+			options.loopbackSize = val
 		default:
 			return options, fmt.Errorf("Unknown option %s", key)
 		}
@@ -194,7 +260,7 @@ func (d *Driver) Status() [][2]string {
 		quota = strconv.FormatUint(d.dataset.Quota, 10)
 	}
 
-	return [][2]string{
+	status := [][2]string{
 		{"Zpool", poolName},
 		{"Zpool Health", poolHealth},
 		{"Parent Dataset", d.dataset.Name},
@@ -203,6 +269,12 @@ func (d *Driver) Status() [][2]string {
 		{"Parent Quota", quota},
 		{"Compression", d.dataset.Compression},
 	}
+
+	if d.options.loopbackGenerate {
+		status = append(status, [2]string{"Data Loop File", d.options.loopbackPath})
+	}
+
+	return status
 }
 
 // GetMetadata returns image/container metadata related to graph driver
@@ -345,4 +417,95 @@ func (d *Driver) Exists(id string) bool {
 	d.Lock()
 	defer d.Unlock()
 	return d.filesystemsCache[d.zfsPath(id)] == true
+}
+
+func generateZFSLoopback(rootDir string, options zfsOptions) (string, error) {
+	size := defaultLoopbackSize
+	if options.loopbackSize != "" {
+		size = options.loopbackSize
+	}
+	loPath := defaultLoopbackPath
+	if options.loopbackPath != "" {
+		loPath = options.loopbackPath
+	}
+	loName := defaultLoopbackName
+	if options.loopbackName != "" {
+		loName = options.loopbackName
+	}
+
+	// create the Zpool and the loopback image only when it doesn't
+	// exist already.
+	if _, err := zfs.GetZpool(loName); err != nil {
+		if err := generateLoopbackImage(loPath, size); err != nil {
+			return "", err
+		}
+
+		if _, err := zfs.CreateZpool(loName, nil, loPath, "-m", "none"); err != nil {
+			return "", err
+		}
+	}
+
+	fsName := loName + "/dataset"
+	// create the Dataset only when it doesn't exist already.
+	if _, err := zfs.GetDataset(fsName); err != nil {
+		logrus.Debugf("[zfs] creating new dataset %s, mounted in %s", fsName, rootDir)
+		props := map[string]string{
+			"compression": "lz4", // best compression
+			"mountpoint":  rootDir,
+		}
+		fi, err := os.Stat(rootDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return "", err
+			}
+			logrus.Debugf("[zfs] creating mount point in %s", rootDir)
+			if err := os.MkdirAll(rootDir, 0700); err != nil {
+				return "", err
+			}
+		} else if !fi.IsDir() {
+			return "", fmt.Errorf("%s is not a directory", fi.Name())
+		}
+
+		if _, err := zfs.CreateFilesystem(fsName, props); err != nil {
+			return "", err
+		}
+	}
+	return fsName, nil
+}
+
+func generateLoopbackImage(loPath, size string) error {
+	fi, err := os.Stat(loPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		if fi.IsDir() {
+			return fmt.Errorf("%s is a directory", fi.Name())
+		}
+		// we don't want to truncate the image
+		// if it already exists.
+		return nil
+	}
+
+	p, err := exec.LookPath("truncate")
+	if err != nil {
+		return err
+	}
+
+	return exec.Command(p, "-s", size, loPath).Run()
+}
+
+func destroyLoopbackZpool(loName string) {
+	fsName := loName + "/dataset"
+	ds, err := zfs.GetDataset(fsName)
+	if err != nil {
+		return
+	}
+	ds.Destroy(zfs.DestroyRecursive | zfs.DestroyForceUmount)
+
+	zp, err := zfs.GetZpool(loName)
+	if err != nil {
+		return
+	}
+	zp.Destroy()
 }

--- a/docs/userguide/storagedriver/zfs-driver.md
+++ b/docs/userguide/storagedriver/zfs-driver.md
@@ -294,3 +294,31 @@ performance. This is because they bypass the storage driver and do not incur
 any of the potential overheads introduced by thin provisioning and 
 copy-on-write. For this reason, you should place heavy write workloads on data 
 volumes.
+
+## Loopback Zpool
+
+Docker can generate a loopback Zpool on a sparse file for you if you want to
+test the ZFS driver without compromising any of your disks.
+
+Before starting the Docker engine, make sure you don't have already the graph
+directory created in your host. You can move the directory to another place
+if you can create a quick backup:
+
+	$ mv /var/lib/docker /var/lib/docker.backup
+
+Then, you can start the engine again with `--storage-driver zfs` and the 
+option `--storage-opt zfs.loopback.generate=true`.
+
+Docker will generate a 10GB sparse file in `/var/lib/docker.img` for you
+and use it to create a Zpool and a Dataset called `zroot-docker-lo/dataset`:
+
+	$ zfs list -t all
+	NAME                      USED  AVAIL  REFER  MOUNTPOINT
+	zroot-docker-lo           107K  9.78G    19K  none
+	zroot-docker-lo/dataset    19K  9.78G    19K  /var/lib/docker
+
+You can change the default values to create this dataset with the following options:
+
+- `zfs.loopback.name`: Is the Zpool name, `zroot-docker-lo` by default.
+- `zfs.loopback.path`: Is the absolute path to the sparse file, `/var/lib/docker.img` by default.
+- `zfs.loopback.size`: Is the size of the sparse file, `10GB` by default.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

I made the graph drivers responsible of bootstrapping the required filesystem hierarchy to work. Allowing, at the same time, to configure pools and volumes with default settings to work properly.

**\- How I did it**

I divided the drivers init functions in two calls, one to validate the driver and another one to initialize it. That way, nothing is created until a valid driver is found. That allows drivers that need full control over the root directory to start with a blank slate. As an example, the ZFS driver can create a Zpool and Dataset to mount the root directory by itself, getting full bootstrapping capabilities.

**\- How to verify it**

You can remove your graph directory from your host and restart the docker daemon. Or you can check this little demo out:

![zfs-loopback](https://cloud.githubusercontent.com/assets/1050/13717708/291a2788-e798-11e5-9e2f-887bde17d14b.gif)

**\- A picture of a cute animal (not mandatory but encouraged)**

![](http://activehappiness.com/wp-content/uploads/2012/08/baby-lion2.jpeg)

Signed-off-by: David Calavera david.calavera@gmail.com
