### PR TITLE
Windows CI: Fix unit test failures

### DIFF
--- a/docker/daemon_test.go
+++ b/docker/daemon_test.go
@@ -35,53 +35,6 @@ func TestLoadDaemonCliConfigWithoutOverriding(t *testing.T) {
 	}
 }
 
-func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
-	c := &daemon.Config{}
-	common := &cli.CommonFlags{
-		Debug:    true,
-		LogLevel: "info",
-	}
-
-	f, err := ioutil.TempFile("", "docker-config-")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	configFile := f.Name()
-	f.Write([]byte(`{"log-opts": {"max-size": "1k"}}`))
-	f.Close()
-
-	flags := mflag.NewFlagSet("test", mflag.ContinueOnError)
-	flags.String([]string{daemonConfigFileFlag}, "", "")
-	flags.BoolVar(&c.EnableSelinuxSupport, []string{"-selinux-enabled"}, true, "")
-	flags.StringVar(&c.LogConfig.Type, []string{"-log-driver"}, "json-file", "")
-	flags.Var(opts.NewNamedMapOpts("log-opts", c.LogConfig.Config, nil), []string{"-log-opt"}, "")
-	flags.Set(daemonConfigFileFlag, configFile)
-
-	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if loadedConfig == nil {
-		t.Fatalf("expected configuration %v, got nil", c)
-	}
-	if !loadedConfig.Debug {
-		t.Fatalf("expected debug mode, got false")
-	}
-	if loadedConfig.LogLevel != "info" {
-		t.Fatalf("expected info log level, got %v", loadedConfig.LogLevel)
-	}
-	if !loadedConfig.EnableSelinuxSupport {
-		t.Fatalf("expected enabled selinux support, got disabled")
-	}
-	if loadedConfig.LogConfig.Type != "json-file" {
-		t.Fatalf("expected LogConfig type json-file, got %v", loadedConfig.LogConfig.Type)
-	}
-	if maxSize := loadedConfig.LogConfig.Config["max-size"]; maxSize != "1k" {
-		t.Fatalf("expected log max-size `1k`, got %s", maxSize)
-	}
-}
-
 func TestLoadDaemonCliConfigWithTLS(t *testing.T) {
 	c := &daemon.Config{}
 	common := &cli.CommonFlags{

--- a/docker/daemon_unix_test.go
+++ b/docker/daemon_unix_test.go
@@ -12,6 +12,53 @@ import (
 	"github.com/docker/docker/pkg/mflag"
 )
 
+func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
+	c := &daemon.Config{}
+	common := &cli.CommonFlags{
+		Debug:    true,
+		LogLevel: "info",
+	}
+
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+	f.Write([]byte(`{"log-opts": {"max-size": "1k"}}`))
+	f.Close()
+
+	flags := mflag.NewFlagSet("test", mflag.ContinueOnError)
+	flags.String([]string{daemonConfigFileFlag}, "", "")
+	flags.BoolVar(&c.EnableSelinuxSupport, []string{"-selinux-enabled"}, true, "")
+	flags.StringVar(&c.LogConfig.Type, []string{"-log-driver"}, "json-file", "")
+	flags.Var(opts.NewNamedMapOpts("log-opts", c.LogConfig.Config, nil), []string{"-log-opt"}, "")
+	flags.Set(daemonConfigFileFlag, configFile)
+
+	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadedConfig == nil {
+		t.Fatalf("expected configuration %v, got nil", c)
+	}
+	if !loadedConfig.Debug {
+		t.Fatalf("expected debug mode, got false")
+	}
+	if loadedConfig.LogLevel != "info" {
+		t.Fatalf("expected info log level, got %v", loadedConfig.LogLevel)
+	}
+	if !loadedConfig.EnableSelinuxSupport {
+		t.Fatalf("expected enabled selinux support, got disabled")
+	}
+	if loadedConfig.LogConfig.Type != "json-file" {
+		t.Fatalf("expected LogConfig type json-file, got %v", loadedConfig.LogConfig.Type)
+	}
+	if maxSize := loadedConfig.LogConfig.Config["max-size"]; maxSize != "1k" {
+		t.Fatalf("expected log max-size `1k`, got %s", maxSize)
+	}
+}
+
 func TestLoadDaemonConfigWithNetwork(t *testing.T) {
 	c := &daemon.Config{}
 	common := &cli.CommonFlags{}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Moves TestLoadDaemonCliConfigWithDaemonFlags introduced in #20476 to _unix_test.go as it uses Linux specific fields causing unit test failures on the windowsTP4 context such as shown below:

```
00:04:05.367 # github.com/docker/docker/docker
00:04:05.367 docker\daemon_test.go:56: c.EnableSelinuxSupport undefined (type *daemon.Config has no field or method EnableSelinuxSupport)
00:04:05.367 docker\daemon_test.go:74: loadedConfig.EnableSelinuxSupport undefined (type *daemon.Config has no field or method EnableSelinuxSupport)
```

![image](https://cloud.githubusercontent.com/assets/10522484/13720527/0fad4366-e7c0-11e5-9d96-99354ece3d63.png)
