### PR TITLE
Fix flaky test TestJSONFormatProgress (#21124)

### DIFF
--- a/pkg/streamformatter/streamformatter_test.go
+++ b/pkg/streamformatter/streamformatter_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -84,9 +85,19 @@ func TestJSONFormatProgress(t *testing.T) {
 	if msg.Status != "action" {
 		t.Fatalf("Status must be 'action', got: %s", msg.Status)
 	}
-	if msg.ProgressMessage != progress.String() {
-		t.Fatalf("ProgressMessage must be %s, got: %s", progress.String(), msg.ProgressMessage)
+
+	// The progress will always be in the format of:
+	// [=========================>                         ]     15 B/30 B 404933h7m11s
+	// The last entry '404933h7m11s' is the timeLeftBox.
+	// However, the timeLeftBox field may change as progress.String() depends on time.Now().
+	// Therefore, we have to strip the timeLeftBox from the strings to do the comparison.
+
+	// Compare the progress strings before the timeLeftBox
+	expectedProgress := "[=========================>                         ]     15 B/30 B"
+	if !strings.HasPrefix(msg.ProgressMessage, expectedProgress) {
+		t.Fatalf("ProgressMessage without the timeLeftBox must be %s, got: %s", expectedProgress, msg.ProgressMessage)
 	}
+
 	if !reflect.DeepEqual(msg.Progress, progress) {
 		t.Fatal("Original progress not equals progress from FormatProgress")
 	}


### PR DESCRIPTION
In TestJSONFormatProgress, the progress string was used for comparison.

However, the progress string (progress.String()) uses time.Now().UTC() to generate the timeLeftBox which is not a fixed value and cannot be compared reliably.

This PR fixes the issue by stripping the timeLeftBox field before doing the comparison.

This PR fixes #21124.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
