### PR TITLE
client: stats: fill in stats info on client

### DIFF
--- a/api/client/stats_helpers.go
+++ b/api/client/stats_helpers.go
@@ -116,6 +116,7 @@ func (s *containerStats) Collect(cli client.APIClient, streamStats bool, waitFir
 			s.NetworkRx, s.NetworkTx = calculateNetwork(v.Networks)
 			s.BlockRead = float64(blkRead)
 			s.BlockWrite = float64(blkWrite)
+			s.PidsCurrent = v.PidsStats.Current
 			s.mu.Unlock()
 			u <- nil
 			if !streamStats {
@@ -137,6 +138,7 @@ func (s *containerStats) Collect(cli client.APIClient, streamStats bool, waitFir
 			s.NetworkTx = 0
 			s.BlockRead = 0
 			s.BlockWrite = 0
+			s.PidsCurrent = 0
 			s.mu.Unlock()
 			// if this is the first stat you get, release WaitGroup
 			if !getFirst {


### PR DESCRIPTION
This code was lost in a rebase in the PIDs cgroup merge, fix it so that
`docker stats` actually shows statistics from the PIDs cgroup.

![drunk kitty](http://www.mattpilsner.com/Pets/Dynamo/DSC02325/165966958_SG2xQ-L-2.jpg)

Signed-off-by: Aleksa Sarai asarai@suse.com

/cc @jfrazelle @calavera @tonistiigi 
