### PR TITLE
optimize slow tests

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2752,9 +2752,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyRootfs(c *check.C) {
 	// Not applicable on Windows which does not support --read-only
 	testRequires(c, DaemonIsLinux)
 
-	for _, f := range []string{"/file", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/sys/kernel", "/dev/.dont.touch.me"} {
-		testReadOnlyFile(f, c)
-	}
+	testReadOnlyFile(c, "/file", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/sys/kernel", "/dev/.dont.touch.me")
 }
 
 func (s *DockerSuite) TestPermissionsPtsReadonlyRootfs(c *check.C) {
@@ -2774,26 +2772,24 @@ func (s *DockerSuite) TestPermissionsPtsReadonlyRootfs(c *check.C) {
 	}
 }
 
-func testReadOnlyFile(filename string, c *check.C) {
+func testReadOnlyFile(c *check.C, filenames ...string) {
 	// Not applicable on Windows which does not support --read-only
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
+	touch := "touch " + strings.Join(filenames, " ")
+	out, _, err := dockerCmdWithError("run", "--read-only", "--rm", "busybox", "sh", "-c", touch)
+	c.Assert(err, checker.NotNil)
 
-	out, _, err := dockerCmdWithError("run", "--read-only", "--rm", "busybox", "touch", filename)
-	if err == nil {
-		c.Fatal("expected container to error on run with read only error")
-	}
-	expected := "Read-only file system"
-	if !strings.Contains(string(out), expected) {
-		c.Fatalf("expected output from failure to contain %s but contains %s", expected, out)
+	for _, f := range filenames {
+		expected := "touch: " + f + ": Read-only file system"
+		c.Assert(out, checker.Contains, expected)
 	}
 
-	out, _, err = dockerCmdWithError("run", "--read-only", "--privileged", "--rm", "busybox", "touch", filename)
-	if err == nil {
-		c.Fatal("expected container to error on run with read only error")
-	}
-	expected = "Read-only file system"
-	if !strings.Contains(string(out), expected) {
-		c.Fatalf("expected output from failure to contain %s but contains %s", expected, out)
+	out, _, err = dockerCmdWithError("run", "--read-only", "--privileged", "--rm", "busybox", "sh", "-c", touch)
+	c.Assert(err, checker.NotNil)
+
+	for _, f := range filenames {
+		expected := "touch: " + f + ": Read-only file system"
+		c.Assert(out, checker.Contains, expected)
 	}
 }
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -911,12 +911,12 @@ func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 	testRequires(c, SameHostDaemon, Apparmor)
 
 	// running w seccomp unconfined tests the apparmor profile
-	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp:unconfined", "debian:jessie", "chmod", "777", "/proc/1/cgroup")
+	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp:unconfined", "busybox", "chmod", "777", "/proc/1/cgroup")
 	if out, _, err := runCommandWithOutput(runCmd); err == nil || !(strings.Contains(out, "Permission denied") || strings.Contains(out, "Operation not permitted")) {
 		c.Fatalf("expected chmod 777 /proc/1/cgroup to fail, got %s: %v", out, err)
 	}
 
-	runCmd = exec.Command(dockerBinary, "run", "--security-opt", "seccomp:unconfined", "debian:jessie", "chmod", "777", "/proc/1/attr/current")
+	runCmd = exec.Command(dockerBinary, "run", "--security-opt", "seccomp:unconfined", "busybox", "chmod", "777", "/proc/1/attr/current")
 	if out, _, err := runCommandWithOutput(runCmd); err == nil || !(strings.Contains(out, "Permission denied") || strings.Contains(out, "Operation not permitted")) {
 		c.Fatalf("expected chmod 777 /proc/1/attr/current to fail, got %s: %v", out, err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Optimize 2 slow tests.

Before:

```
PASS: docker_cli_run_test.go:2751: DockerSuite.TestRunContainerWithReadonlyRootfs 16.561s
PASS: docker_cli_run_unix_test.go:910: DockerSuite.TestRunApparmorProcDirectory 19.075s
```

After:

```
PASS: docker_cli_run_test.go:2751: DockerSuite.TestRunContainerWithReadonlyRootfs   2.261s
PASS: docker_cli_run_unix_test.go:910: DockerSuite.TestRunApparmorProcDirectory 2.250s
```

**\- How I did it**
1. Merge multiple `docker run` command into one for `TestRunContainerWithReadonlyRootfs`
2. Change the image from `debian:jessie` to `busybox` for `TestRunApparmorProcDirectory`

**\- How to verify it**
`make test-integration-cli`

**\- A picture of a cute animal (not mandatory but encouraged)**
![1c767db5c9ea15ce0f140dbcb5003af33b87b25e](https://cloud.githubusercontent.com/assets/1496652/13722189/b88ff2c8-e877-11e5-83ca-4465da2e0ab8.jpg)

Signed-off-by: Shijiang Wei mountkin@gmail.com
