### PR TITLE
inherit the daemon log options when creating containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT 7befe694bd21e3c54bb1d7825270ea4bd6864c13
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -130,7 +130,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT 7befe694bd21e3c54bb1d7825270ea4bd6864c13
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -141,7 +141,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT 7befe694bd21e3c54bb1d7825270ea4bd6864c13
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -60,7 +60,7 @@ RUN set -x \
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT 7befe694bd21e3c54bb1d7825270ea4bd6864c13
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -137,7 +137,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT 7befe694bd21e3c54bb1d7825270ea4bd6864c13
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -143,7 +143,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2878cbcc3a7eef99917adc1be252800b0e41ece
+ENV DOCKER_PY_COMMIT 7befe694bd21e3c54bb1d7825270ea4bd6864c13
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -69,6 +69,10 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 		return nil, err
 	}
 
+	if err := daemon.mergeAndVerifyLogConfig(&params.HostConfig.LogConfig); err != nil {
+		return nil, err
+	}
+
 	if container, err = daemon.newContainer(params.Name, params.Config, imgID); err != nil {
 		return nil, err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -35,7 +35,6 @@ import (
 	"github.com/docker/engine-api/types/strslice"
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"
-	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/network"
 	dmetadata "github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
@@ -669,12 +668,6 @@ func NewDaemon(config *Config, registryService *registry.Service, containerdRemo
 		return nil, fmt.Errorf("error setting default isolation mode: %v", err)
 	}
 
-	// Verify logging driver type
-	if config.LogConfig.Type != "none" {
-		if _, err := logger.GetLogDriver(config.LogConfig.Type); err != nil {
-			return nil, fmt.Errorf("error finding the logging driver: %v", err)
-		}
-	}
 	logrus.Debugf("Using default logging driver %s", config.LogConfig.Type)
 
 	if err := configureMaxThreads(config); err != nil {
@@ -1349,11 +1342,6 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostCon
 
 	if hostConfig == nil {
 		return nil, nil
-	}
-
-	logCfg := daemon.getLogConfig(hostConfig.LogConfig)
-	if err := logger.ValidateLogOpts(logCfg.Type, logCfg.Config); err != nil {
-		return nil, err
 	}
 
 	for port := range hostConfig.PortBindings {

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -19,14 +19,21 @@ type logdriverFactory struct {
 }
 
 func (lf *logdriverFactory) register(name string, c Creator) error {
-	lf.m.Lock()
-	defer lf.m.Unlock()
-
-	if _, ok := lf.registry[name]; ok {
+	if lf.driverRegistered(name) {
 		return fmt.Errorf("logger: log driver named '%s' is already registered", name)
 	}
+
+	lf.m.Lock()
 	lf.registry[name] = c
+	lf.m.Unlock()
 	return nil
+}
+
+func (lf *logdriverFactory) driverRegistered(name string) bool {
+	lf.m.Lock()
+	_, ok := lf.registry[name]
+	lf.m.Unlock()
+	return ok
 }
 
 func (lf *logdriverFactory) registerLogOptValidator(name string, l LogOptValidator) error {
@@ -81,9 +88,17 @@ func GetLogDriver(name string) (Creator, error) {
 // ValidateLogOpts checks the options for the given log driver. The
 // options supported are specific to the LogDriver implementation.
 func ValidateLogOpts(name string, cfg map[string]string) error {
-	l := factory.getLogOptValidator(name)
-	if l != nil {
-		return l(cfg)
+	if name == "none" {
+		return nil
+	}
+
+	if !factory.driverRegistered(name) {
+		return fmt.Errorf("logger: no log driver named '%s' is registered", name)
+	}
+
+	validator := factory.getLogOptValidator(name)
+	if validator != nil {
+		return validator(cfg)
 	}
 	return nil
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -41,6 +41,9 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 			if err := daemon.setSecurityOptions(container, hostConfig); err != nil {
 				return err
 			}
+			if err := daemon.mergeAndVerifyLogConfig(&hostConfig.LogConfig); err != nil {
+				return err
+			}
 			if err := daemon.setHostConfig(container, hostConfig); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
1. Inherit all the daemon log options when creating containers if using the default log driver of daemon. (Fixed #21118)
2. Expose the merged log config to `docker inspect` result.
3. Remove some redundant log driver related validations. 

**\- How I did it**

**\- How to verify it**
Start daemon with some log options, then create a container and inspect it to see if the daemon log options are shown in the result of the inspect output.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Shijiang Wei mountkin@gmail.com
