### PR TITLE
Add redirects for old Docker Cloud tutorial

### DIFF
--- a/docs/userguide/eng-image/dockerfile_best-practices.md
+++ b/docs/userguide/eng-image/dockerfile_best-practices.md
@@ -1,6 +1,6 @@
 <!--[metadata]>
 +++
-aliases = ["/engine/articles/dockerfile_best-practices/"]
+aliases = ["/engine/articles/dockerfile_best-practices/", "/docker-cloud/getting-started/intermediate/optimize-dockerfiles/", "/docker-cloud/tutorials/optimize-dockerfiles/"]
 title = "Best practices for writing Dockerfiles"
 description = "Hints, tips and guidelines for writing clean, reliable Dockerfiles"
 keywords = ["Examples, Usage, base image, docker, documentation, dockerfile, best practices, hub,  official repo"]


### PR DESCRIPTION
This page has been deleted from the Docker Cloud tutorials,
so adding redirects for the old locations.

/cc @moxiegirl (relates to TUT-738)
