### PR TITLE
distribution: errors: do not retry if no credentials provided

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
+	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/distribution/xfer"
 )
 
@@ -90,6 +91,9 @@ func retryOnError(err error) error {
 			return xfer.DoNotRetry{Err: err}
 		}
 	case *url.Error:
+		if v.Err == auth.ErrNoBasicAuthCredentials {
+			return xfer.DoNotRetry{Err: v.Err}
+		}
 		return retryOnError(v.Err)
 	case *client.UnexpectedHTTPResponseError:
 		return xfer.DoNotRetry{Err: err}

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -254,3 +254,12 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
 	_, err = s.CmdWithError("inspect", repoName)
 	c.Assert(err, checker.NotNil, check.Commentf("image was pulled after client disconnected"))
 }
+
+func (s *DockerRegistryAuthSuite) TestPullNoCredentialsNotFound(c *check.C) {
+	// we don't care about the actual image, we just want to see image not found
+	// because that means v2 call returned 401 and we fell back to v1 which usually
+	// gives a 404 (in this case the test registry doesn't handle v1 at all)
+	out, _, err := dockerCmdWithError("pull", privateRegistryURL+"/busybox")
+	c.Assert(err, check.NotNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "Error: image busybox not found")
+}

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -535,3 +535,13 @@ func (s *DockerRegistryAuthSuite) TestPushNoCredentialsNoRetry(c *check.C) {
 	c.Assert(out, check.Not(checker.Contains), "Retrying")
 	c.Assert(out, checker.Contains, "no basic auth credentials")
 }
+
+// This may be flaky but it's needed not to regress on unauthorized push, see #21054
+func (s *DockerSuite) TestPushToCentralRegistryUnauthorized(c *check.C) {
+	testRequires(c, Network)
+	repoName := "test/busybox"
+	dockerCmd(c, "tag", "busybox", repoName)
+	out, _, err := dockerCmdWithError("push", repoName)
+	c.Assert(err, check.NotNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "unauthorized: access to the requested resource is not authorized")
+}

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -526,3 +526,12 @@ func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegation(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf("Unable to read targets/releases metadata"))
 	c.Assert(string(contents), checker.Contains, `"latest"`, check.Commentf(string(contents)))
 }
+
+func (s *DockerRegistryAuthSuite) TestPushNoCredentialsNoRetry(c *check.C) {
+	repoName := fmt.Sprintf("%s/busybox", privateRegistryURL)
+	dockerCmd(c, "tag", "busybox", repoName)
+	out, _, err := dockerCmdWithError("push", repoName)
+	c.Assert(err, check.NotNil, check.Commentf(out))
+	c.Assert(out, check.Not(checker.Contains), "Retrying")
+	c.Assert(out, checker.Contains, "no basic auth credentials")
+}


### PR DESCRIPTION
Fixes case `c)` in #21054

/cc @aaronlehmann 

Signed-off-by: Antonio Murdaca runcom@redhat.com
