### PR TITLE
Include all endpoints in network inspect object

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -174,11 +174,12 @@ func buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {
 			continue
 		}
 		sb := ei.Sandbox()
-		if sb == nil {
-			continue
+		key := "ep-" + e.ID()
+		if sb != nil {
+			key = sb.ContainerID()
 		}
 
-		r.Containers[sb.ContainerID()] = buildEndpointResource(e)
+		r.Containers[key] = buildEndpointResource(e)
 	}
 	return r
 }

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -28,7 +28,10 @@ bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727
 ```
 
 The `network inspect` command shows the containers, by id, in its
-results. You can specify an alternate format to execute a given
+results. For networks backed by multi-host network driver, such as Overlay,
+this command also shows the container endpoints in other hosts in the
+cluster. These endpoints are represented as "ep-{endpoint-id}" in the output.
+You can specify an alternate format to execute a given
 template for each result. Go's
 [text/template](http://golang.org/pkg/text/template/) package describes all the
 details of the format.


### PR DESCRIPTION
Prior to this change, the "docker network inspect" contains only the
endpoints that have active local container. This excludes all the remote
and stale endpoints. By including all the endpoints, it makes debugging
much simpler and also allows the user to cleanup any stale endpoints
using "docker network disconnect -f {network} {endpoint-name}".

ping @mrjana @aboch 

Signed-off-by: Madhu Venugopal madhu@docker.com
