### PR TITLE
Windows: Improve TestLogsContainers performance

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -17,7 +17,7 @@ import (
 // This used to work, it test a log of PageSize-1 (gh#4851)
 func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 	testLen := 32767
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n = >> a.a; done; echo >> a.a; cat a.a", testLen))
 
 	id := strings.TrimSpace(out)
 	dockerCmd(c, "wait", id)
@@ -30,7 +30,7 @@ func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 // Regression test: When going over the PageSize, it used to panic (gh#4851)
 func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 	testLen := 32768
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n = >> a.a; done; echo >> a.a; cat a.a", testLen))
 
 	id := strings.TrimSpace(out)
 	dockerCmd(c, "wait", id)
@@ -43,7 +43,7 @@ func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 // Regression test: When going much over the PageSize, it used to block (gh#4851)
 func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 	testLen := 33000
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n = >> a.a; done; echo >> a.a; cat a.a", testLen))
 
 	id := strings.TrimSpace(out)
 	dockerCmd(c, "wait", id)
@@ -55,7 +55,7 @@ func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 
 func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 	testLen := 100
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo = >> a.a; done; cat a.a", testLen))
 
 	id := strings.TrimSpace(out)
 	dockerCmd(c, "wait", id)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

TestLogsContainer\* tests (BiggerThanPage, MuchBiggerThanPage...) are very slow on Windows, accounting for a lot of the overall CI time. This change significantly improves the performance of these tests by directing output to a file and `cat`ing it instead of going through the console directly.

![image](https://cloud.githubusercontent.com/assets/10522484/13726524/0e86eed6-e880-11e5-9623-507e07f2d203.png)
