### PR TITLE
Show "seccomp" in docker info (#20909).

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -67,6 +67,17 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		}
 	})
 
+	var securityOptions []string
+	if sysInfo.AppArmor {
+		securityOptions = append(securityOptions, "apparmor")
+	}
+	if sysInfo.Seccomp {
+		securityOptions = append(securityOptions, "seccomp")
+	}
+	if selinuxEnabled() {
+		securityOptions = append(securityOptions, "selinux")
+	}
+
 	v := &types.Info{
 		ID:                 daemon.ID,
 		Containers:         int(cRunning + cPaused + cStopped),
@@ -104,6 +115,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		HTTPProxy:          sockets.GetProxyEnv("http_proxy"),
 		HTTPSProxy:         sockets.GetProxyEnv("https_proxy"),
 		NoProxy:            sockets.GetProxyEnv("no_proxy"),
+		SecurityOptions:    securityOptions,
 	}
 
 	// TODO Windows. Refactor this more once sysinfo is refactored into

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -117,6 +117,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.24](docker_remote_api_v1.24.md) documentation
 
 * `POST /containers/create` now takes `StorageOpt` field.
+* `GET /info` now returns `SecurityOptions` field, showing if `apparmor`, `seccomp`, or `selinux` is supported.
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2239,6 +2239,11 @@ Display system-wide information
                 "127.0.0.0/8"
             ]
         },
+        "SecurityOptions": [
+            "apparmor",
+            "seccomp",
+            "selinux"
+        ],
         "ServerVersion": "1.9.0",
         "SwapLimit": false,
         "SystemStatus": [["State", "Healthy"]],

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -31,7 +31,8 @@ func (s *DockerSuite) TestInfoApi(c *check.C) {
 		"MemTotal",
 		"KernelVersion",
 		"Driver",
-		"ServerVersion"}
+		"ServerVersion",
+		"SecurityOptions"}
 
 	out := string(body)
 	for _, linePrefix := range stringsToCheck {


### PR DESCRIPTION
This pull request added a `SecurityOptions` field in the `GET /info` output to show if there is apparmor, seccomp, or selinux suport.

The API changes are updated in the documentation and the update in `GET /info` is covered by the test case in `TestInfoApi`.

This pull request fixes #20909.

Note: a pull request in https://github.com/docker/engine-api will be opened separately.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
