### PR TITLE
Updated docker-info output and documentation

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -31,7 +31,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	fmt.Fprintf(cli.out, " Running: %d\n", info.ContainersRunning)
 	fmt.Fprintf(cli.out, " Paused: %d\n", info.ContainersPaused)
 	fmt.Fprintf(cli.out, " Stopped: %d\n", info.ContainersStopped)
-	fmt.Fprintf(cli.out, "Images: %d\n", info.Images)
+	fmt.Fprintf(cli.out, "Untagged Images: %d\n", info.Images)
 	ioutils.FprintfIfNotEmpty(cli.out, "Server Version: %s\n", info.ServerVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Storage Driver: %s\n", info.Driver)
 	if info.DriverStatus != nil {

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -21,7 +21,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		" Running:",
 		" Paused:",
 		" Stopped:",
-		"Images:",
+		"Untagged Images:",
 		"OSType:",
 		"Architecture:",
 		"Logging Driver:",

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -11,9 +11,9 @@ docker-info - Display system-wide information
 
 # DESCRIPTION
 This command displays system wide information regarding the Docker installation.
-Information displayed includes the number of containers and images, pool name,
-data file, metadata file, data space used, total data space, metadata space used
-, total metadata space, execution driver, and the kernel version.
+Information displayed includes the number of containers and (non-tagged) images,
+pool name, data file, metadata file, data space used, total data space, metadata
+space used, total metadata space, execution driver, and the kernel version.
 
 The data file is where the images are stored and the metadata file is where the
 meta data regarding those images are stored. When run for the first time Docker
@@ -35,24 +35,40 @@ Here is a sample output:
      Running: 3
      Paused: 1
      Stopped: 10
-    Images: 52
-    Server Version: 1.9.0
-    Storage Driver: aufs
-     Root Dir: /var/lib/docker/aufs
-     Dirs: 80
+    Untagged Images: 52
+    Server Version: 1.10.3
+    Storage Driver: devicemapper
+     Pool Name: docker-202:2-25583803-pool
+     Pool Blocksize: 65.54 kB
+     Base Device Size: 10.74 GB
+     Backing Filesystem: xfs
+     Data file: /dev/loop0
+     Metadata file: /dev/loop1
+     Data Space Used: 1.68 GB
+     Data Space Total: 107.4 GB
+     Data Space Available: 7.548 GB
+     Metadata Space Used: 2.322 MB
+     Metadata Space Total: 2.147 GB
+     Metadata Space Available: 2.145 GB
+     Udev Sync Supported: true
+     Deferred Removal Enabled: false
+     Deferred Deletion Enabled: false
+     Deferred Deleted Device Count: 0
+     Data loop file: /var/lib/docker/devicemapper/devicemapper/data
+     Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
+     Library Version: 1.02.107-RHEL7 (2015-12-01)
     Execution Driver: native-0.2
     Logging Driver: json-file
-    Cgroup Driver: cgroupfs
     Plugins:
      Volume: local
-     Network: bridge null host
-    Kernel Version: 3.13.0-24-generic
-    Operating System: Ubuntu 14.04 LTS
+     Network: null host bridge
+    Kernel Version: 3.10.0-327.el7.x86_64
+    Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)
     OSType: linux
     Architecture: x86_64
     CPUs: 1
-    Total Memory: 2 GiB
-    Name: docker
+    Total Memory: 991.7 MiB
+    Name: ip-172-30-0-91.ec2.internal
     ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
     Docker Root Dir: /var/lib/docker
     Debug mode (client): false


### PR DESCRIPTION
Fixes: #20783 
- [x] Update man page description
- [x] Update man page sample output to something more current
- [x] Sample output sourced from RHEL
- [x] CLI output specifies "Untagged Images"

Tested with: `TESTFLAGS='-check.f DockerSuite.TestInfoEnsureSucceeds*'
make test-integration-cli`

Signed-off-by: Lucas Chan lucas-github@lucaschan.com
