### PR TITLE
profiles: apparmor: remove unused fields

### DIFF
--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -24,8 +24,6 @@ var (
 type profileData struct {
 	// Name is profile name.
 	Name string
-	// ExecPath is the path to the docker binary.
-	ExecPath string
 	// Imports defines the apparmor functions to import, before defining the profile.
 	Imports []string
 	// InnerImports defines the apparmor functions to import in the profile.

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -38,14 +38,23 @@ func (p *profileData) generateDefault(out io.Writer) error {
 	if err != nil {
 		return err
 	}
+
 	if macroExists("tunables/global") {
 		p.Imports = append(p.Imports, "#include <tunables/global>")
 	} else {
 		p.Imports = append(p.Imports, "@{PROC}=/proc/")
 	}
+
 	if macroExists("abstractions/base") {
 		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
 	}
+
+	ver, err := aaparser.GetVersion()
+	if err != nil {
+		return err
+	}
+	p.Version = ver
+
 	if err := compiled.Execute(out, p); err != nil {
 		return err
 	}

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -42,9 +42,5 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
   ptrace (trace,read) peer=docker-default,
 {{end}}
-{{if ge .Version 209000}}
-  # docker daemon confinement requires explict allow rule for signal
-  signal (receive) set=(kill,term) peer={{.ExecPath}},
-{{end}}
 }
 `


### PR DESCRIPTION
The template was referring to an apparmor profile that we don't ship, we
can just nix the lines from the profile and remove the fields in the
Data struct.

Fixes #20584

![cute kitty](http://farm4.staticflickr.com/3260/2789604490_066dd1c786_b.jpg)

Signed-off-by: Aleksa Sarai asarai@suse.de

/cc @icecrime @jfrazelle 
