### PR TITLE
Add pids max in stats

### DIFF
--- a/daemon/stats_linux.go
+++ b/daemon/stats_linux.go
@@ -64,6 +64,7 @@ func convertStatsToAPITypes(ls *libcontainer.Stats) *types.StatsJSON {
 		pids := cs.PidsStats
 		s.PidsStats = types.PidsStats{
 			Current: pids.Current,
+			Limit:   pids.Limit,
 		}
 	}
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -849,7 +849,8 @@ This endpoint returns a live stream of a container's resource usage statistics.
       {
          "read" : "2015-01-08T22:57:31.547920715Z",
          "pids_stats": {
-            "current": 3
+            "current": 3,
+            "limit": 16
          },
          "networks": {
                  "eth0": {

--- a/vendor/src/github.com/docker/engine-api/types/stats.go
+++ b/vendor/src/github.com/docker/engine-api/types/stats.go
@@ -91,6 +91,8 @@ type NetworkStats struct {
 type PidsStats struct {
 	// Current is the number of pids in the cgroup
 	Current uint64 `json:"current,omitempty"`
+	// Limit is the hard limit on the number of pids in the cgroup
+	Limit uint64 `json:"limit,omitempty"`
 }
 
 // Stats is Ultimate struct aggregating all types of stats of one container

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/pids.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/pids.go
@@ -4,6 +4,7 @@ package fs
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
@@ -47,11 +48,26 @@ func (s *PidsGroup) Remove(d *cgroupData) error {
 }
 
 func (s *PidsGroup) GetStats(path string, stats *cgroups.Stats) error {
-	value, err := getCgroupParamUint(path, "pids.current")
+	current, err := getCgroupParamUint(path, "pids.current")
 	if err != nil {
 		return fmt.Errorf("failed to parse pids.current - %s", err)
 	}
 
-	stats.PidsStats.Current = value
+	maxString, err := getCgroupParamString(path, "pids.max")
+	if err != nil {
+		return fmt.Errorf("failed to parse pids.max - %s", err)
+	}
+
+	// Default if pids.max == "max" is 0 -- which represents "no limit".
+	var max uint64
+	if maxString != "max" {
+		max, err = parseUint(maxString, 10, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse pids.max - unable to parse %q as a uint from Cgroup file %q", maxString, filepath.Join(path, "pids.max"))
+		}
+	}
+
+	stats.PidsStats.Current = current
+	stats.PidsStats.Limit = max
 	return nil
 }

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
@@ -46,7 +46,7 @@ type MemoryStats struct {
 	Usage MemoryData `json:"usage,omitempty"`
 	// usage of memory + swap
 	SwapUsage MemoryData `json:"swap_usage,omitempty"`
-	// usafe of kernel memory
+	// usage of kernel memory
 	KernelUsage MemoryData        `json:"kernel_usage,omitempty"`
 	Stats       map[string]uint64 `json:"stats,omitempty"`
 }
@@ -54,6 +54,8 @@ type MemoryStats struct {
 type PidsStats struct {
 	// number of pids in the cgroup
 	Current uint64 `json:"current,omitempty"`
+	// active pids hard limit
+	Limit uint64 `json:"limit,omitempty"`
 }
 
 type BlkioStatEntry struct {
@@ -80,7 +82,7 @@ type HugetlbStats struct {
 	Usage uint64 `json:"usage,omitempty"`
 	// maximum usage ever recorded.
 	MaxUsage uint64 `json:"max_usage,omitempty"`
-	// number of times htgetlb usage allocation failure.
+	// number of times hugetlb usage allocation failure.
 	Failcnt uint64 `json:"failcnt"`
 }
 


### PR DESCRIPTION
This allows clients to display the current PIDs usage as a percentage
of total allocated resources in a container.

This depends on docker/engine-api#145.

![bunni](http://www.twitrcovers.com/wp-content/uploads/2013/12/Bunnies-Pet-l.jpg)

/cc @jfrazelle @calavera 
