### PR TITLE
Fix flaky TestUpdateRestartPolicy on Windows

### DIFF
--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -12,7 +12,7 @@ func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "sh", "-c", "sleep 1 && false")
 	timeout := 60 * time.Second
 	if daemonPlatform == "windows" {
-		timeout = 150 * time.Second
+		timeout = 180 * time.Second
 	}
 
 	id := strings.TrimSpace(string(out))


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/20922

Add another 30 seconds, because it still fails sometimes :'(
