### PR TITLE
Show container names in docker stats output

### DIFF
--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDisplay(t *testing.T) {
 	c := &containerStats{
-		Name:             "app",
+		ID:               "app_id",
 		CPUPercentage:    30.0,
 		Memory:           100 * 1024 * 1024.0,
 		MemoryLimit:      2048 * 1024 * 1024.0,
@@ -20,6 +20,7 @@ func TestDisplay(t *testing.T) {
 		BlockRead:        100 * 1024 * 1024,
 		BlockWrite:       800 * 1024 * 1024,
 		PidsCurrent:      1,
+		Name:		  "app",
 		mu:               sync.RWMutex{},
 	}
 	var b bytes.Buffer
@@ -27,7 +28,7 @@ func TestDisplay(t *testing.T) {
 		t.Fatalf("c.Display() gave error: %s", err)
 	}
 	got := b.String()
-	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\n"
+	want := "app_id\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\tapp\n"
 	if got != want {
 		t.Fatalf("c.Display() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
"closes #20973"

Added a new field ID to `ContainerStats` struct to show container names along with ID.

The case where container ID or name is provided to command as an argument, inspect container on that and populate ID and Name fields for ContainerStats.
The case where no argument is provided, take ID and Names from ContainerList and populate ContainerStats.

Signed-off-by: Ginni Gidwani gigidwan@in.ibm.com
