### PR TITLE
ppc64le: update dockerfile hashes and notary

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -95,8 +95,7 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 # ENV GOFMT_VERSION 1.3.3
 # RUN curl -sSL https://storage.googleapis.com/golang/go${GOFMT_VERSION}.$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C /go/bin -xz --strip-components=2 go/bin/gofmt
 
-# TODO update this sha when we upgrade to Go 1.5+
-ENV GO_TOOLS_COMMIT d02228d1857b9f49cd0252788516ff5584266eb6
+ENV GO_TOOLS_COMMIT 823804e1ae08dbb14eb807afc7db9993bc9e3cc3
 # Grab Go's cover tool for dead-simple code coverage testing
 # Grab Go's vet tool for examining go code to find suspicious constructs
 # and help prevent errors that the compiler might not catch
@@ -115,7 +114,7 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 
 # both. This allows integration-cli tests to cover push/pull with both schema1
 # and schema2 manifests.
 ENV REGISTRY_COMMIT_SCHEMA1 ec87e9b6971d831f0eff752ddb54fb64693e51cd
-ENV REGISTRY_COMMIT cb08de17d74bef86ce6c5abe8b240e282f5750be
+ENV REGISTRY_COMMIT 47a064d4195a9b56133891bbb13620c3ac83a827
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/distribution.git "$GOPATH/src/github.com/docker/distribution" \
@@ -127,8 +126,7 @@ RUN set -x \
 		go build -o /usr/local/bin/registry-v2-schema1 github.com/docker/distribution/cmd/registry \
 	&& rm -rf "$GOPATH"
 
-
-# Install notary server
+# Install notary and notary-server
 ENV NOTARY_VERSION v0.2.0
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
@@ -136,6 +134,8 @@ RUN set -x \
 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
 	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
 		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
+	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
+		go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests


### PR DESCRIPTION
Now that we are using gc/go 1.6, update a few hashes as well
as actually building the notary binary.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

ping @tianon 

Here is a toucan:

![toucan](https://upload.wikimedia.org/wikipedia/commons/4/47/Keel-billed_toucan,_costa_rica.jpg)
