### PR TITLE
Fix Remote API doc double slash typo in cURL command

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -29,7 +29,7 @@ later, as these versions have the `--unix-socket` flag available. To
 run `curl` against the daemon on the default socket, use the
 following:
 
-    curl --unix-socket /var/run/docker.sock http://containers/json
+    curl --unix-socket /var/run/docker.sock http:/containers/json
 
 If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the


### PR DESCRIPTION
Either a single slash or `localhost` should be specified after http in the cURL URL, not http:// (double slash)

Signed-off-by: Ohad Schneider ohad188@gmail.com
