### PR TITLE
Remove flush(stdout) in pkg/chrootarchive/diff_unix.go

### DIFF
--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -46,7 +46,10 @@ func untar() {
 		fatal(err)
 	}
 	// fully consume stdin in case it is zero padded
-	flush(os.Stdin)
+	if _, err := flush(os.Stdin); err != nil {
+		fatal(err)
+	}
+
 	os.Exit(0)
 }
 

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -65,8 +65,10 @@ func applyLayer() {
 		fatal(fmt.Errorf("unable to encode layerSize JSON: %s", err))
 	}
 
-	flush(os.Stdout)
-	flush(os.Stdin)
+	if _, err := flush(os.Stdin); err != nil {
+		fatal(err)
+	}
+
 	os.Exit(0)
 }
 

--- a/pkg/chrootarchive/init_unix.go
+++ b/pkg/chrootarchive/init_unix.go
@@ -23,6 +23,6 @@ func fatal(err error) {
 
 // flush consumes all the bytes from the reader discarding
 // any errors
-func flush(r io.Reader) {
-	io.Copy(ioutil.Discard, r)
+func flush(r io.Reader) (bytes int64, err error) {
+	return io.Copy(ioutil.Discard, r)
 }


### PR DESCRIPTION
Fixes #21103

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
pkg/chrootarchive/diff_unix.go erroneously calls flush on stdout, which tries to read from stdout returning an error. I fixed this.
**\- How I did it**
This has been fixed by removing the call and by modifying flush to return errors and checking for these errors on calls to flush.

**\- How to verify it**
As I removed the line causing the error and since there is no change in behavior this cannot be verified. Running docker pull can be used for regression testing as it stresses this code path.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Amit Krishnan krish.amit@gmail.com
