### PR TITLE
Validate repo fetch with exponential backoff.

### DIFF
--- a/hack/make/.validate
+++ b/hack/make/.validate
@@ -14,7 +14,25 @@ if [ -z "$VALIDATE_UPSTREAM" ]; then
 
 	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
 
+	# Fetch remote branch. Retry several times if the connection fails.
+	# It uses a exponential backoff to control timing.
+	RETRY=1
+	BACKOFF=5
 	git fetch -q "$VALIDATE_REPO" "refs/heads/$VALIDATE_BRANCH"
+	until [ $? -eq 0 ]; do
+		if [ $RETRY -eq 6 ]; then
+			echo "connection to $VALIDATE_REPO failed after 5 attempts"
+			exit -1
+		else
+			EXP=$(($BACKOFF * $RETRY))
+			echo "unable to connect to $VALIDATE_REPO, sleeping $EXP seconds before retrying"
+			sleep $EXP
+		fi
+
+		RETRY=$(($RETRY + 1))
+		git fetch -q "$VALIDATE_REPO" "refs/heads/$VALIDATE_BRANCH"
+	done
+
 	VALIDATE_UPSTREAM="$(git rev-parse --verify FETCH_HEAD)"
 
 	VALIDATE_COMMIT_LOG="$VALIDATE_UPSTREAM..$VALIDATE_HEAD"


### PR DESCRIPTION
This should fix errors like the one below that we see every now and then due to networking glitches:

```
18:54:46 INFO: Running validation tests...
18:54:46 + docker run --rm docker sh -c 'cd /c/go/src/github.com/docker/docker; \
18:54:46     sleep 5; \
18:54:46     hack/make.sh validate-dco validate-gofmt validate-pkg'
18:55:04 
18:55:06 ---> Making bundle: validate-dco (in bundles/1.11.0-dev/validate-dco)
18:55:07 fatal: unable to access 'https://github.com/docker/docker.git/': Couldn't resolve host 'github.com'
18:55:18 + ec=128
18:55:18 + set +x
```

Signed-off-by: David Calavera david.calavera@gmail.com
