### PR TITLE
Optimize slow bottleneck test of DockerSuite.TestDockerNetworkInternalMode (#19425).

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1430,9 +1430,12 @@ func (s *DockerSuite) TestDockerNetworkInternalMode(c *check.C) {
 	c.Assert(waitRun("first"), check.IsNil)
 	dockerCmd(c, "run", "-d", "--net=internal", "--name=second", "busybox", "top")
 	c.Assert(waitRun("second"), check.IsNil)
-	out, _, err := dockerCmdWithError("exec", "first", "ping", "-W", "4", "-c", "1", "www.google.com")
+	// The majority of the time spent in the test are from the following `ping` test cases.
+	// In this test IPV4 (`-4`) options are used explicitly to reduce the execution time
+	// significantly.
+	out, _, err := dockerCmdWithError("exec", "first", "ping", "-4", "-W", "4", "-c", "1", "www.google.com")
 	c.Assert(err, check.NotNil)
 	c.Assert(out, checker.Contains, "ping: bad address")
-	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
+	_, _, err = dockerCmdWithError("exec", "second", "ping", "-4", "-c", "1", "first")
 	c.Assert(err, check.IsNil)
 }


### PR DESCRIPTION
This fix tries to improve the slow bottleneck test of DockerSuite.TestDockerNetworkInternalMode in #19425.

In TestDockerNetworkInternalMode, the majority of the time are spent on two ping test cases.

In this test IPV4 (`-4`) options are used explicitly to reduce the execution time significantly.

The result is a ~60% of the improvement on execution time.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
