### PR TITLE
Add check about filter name for containers

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -20,6 +20,19 @@ var acceptedVolumeFilterTags = map[string]bool{
 	"dangling": true,
 }
 
+var acceptedPsFilterTags = map[string]bool{
+	"ancestor":  true,
+	"before":    true,
+	"exited":    true,
+	"id":        true,
+	"isolation": true,
+	"label":     true,
+	"name":      true,
+	"status":    true,
+	"since":     true,
+	"volume":    true,
+}
+
 // iterationAction represents possible outcomes happening during the container iteration.
 type iterationAction int
 
@@ -128,7 +141,12 @@ func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *lis
 func (daemon *Daemon) foldFilter(config *types.ContainerListOptions) (*listContext, error) {
 	psFilters := config.Filter
 
+	if err := psFilters.Validate(acceptedPsFilterTags); err != nil {
+		return nil, err
+	}
+
 	var filtExited []int
+
 	err := psFilters.WalkValues("exited", func(value string) error {
 		code, err := strconv.Atoi(value)
 		if err != nil {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -213,6 +213,12 @@ func assertContainerList(out string, expected []string) bool {
 	return true
 }
 
+func (s *DockerSuite) TestPsListContainersInvalidFilterName(c *check.C) {
+	out, _, err := dockerCmdWithError("ps", "-f", "invalidFilter=test")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Invalid filter")
+}
+
 func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	// Problematic on Windows as it doesn't report the size correctly @swernli
 	testRequires(c, DaemonIsLinux)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes: #21202
We add valid check about filters like network, images,
volumes did.

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
