### PR TITLE
Update docs: A more accurate size for debian image

### DIFF
--- a/docs/userguide/eng-image/dockerfile_best-practices.md
+++ b/docs/userguide/eng-image/dockerfile_best-practices.md
@@ -131,8 +131,8 @@ various instructions available for use in a `Dockerfile`.
 
 Whenever possible, use current Official Repositories as the basis for your
 image. We recommend the [Debian image](https://hub.docker.com/_/debian/)
-since it’s very tightly controlled and kept extremely minimal (currently under
-100 mb), while still being a full distribution.
+since it’s very tightly controlled and kept minimal (currently under 150 mb),
+while still being a full distribution.
 
 ### RUN
 


### PR DESCRIPTION
Fixes: #21195

The current size of the debian image is 125.1 MB so I have updated the Markdown to say "under 130". Documentation built and tested using `make docs`.

Signed-off-by: Lucas Chan lucas-github@lucaschan.com
