### PR TITLE
Update engine api to use net/context.Context all accross the client API

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -24,7 +26,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	c, err := cli.client.ContainerInspect(cmd.Arg(0))
+	c, err := cli.client.ContainerInspect(context.Background(), cmd.Arg(0))
 	if err != nil {
 		return err
 	}
@@ -64,7 +66,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 		defer signal.StopCatch(sigc)
 	}
 
-	resp, err := cli.client.ContainerAttach(options)
+	resp, err := cli.client.ContainerAttach(context.Background(), options)
 	if err != nil {
 		return err
 	}

--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -73,7 +75,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 		Config:         config,
 	}
 
-	response, err := cli.client.ContainerCommit(options)
+	response, err := cli.client.ContainerCommit(context.Background(), options)
 	if err != nil {
 		return err
 	}

--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -127,7 +127,7 @@ func splitCpArg(arg string) (container, path string) {
 }
 
 func (cli *DockerCli) statContainerPath(containerName, path string) (types.ContainerPathStat, error) {
-	return cli.client.ContainerStatPath(containerName, path)
+	return cli.client.ContainerStatPath(context.Background(), containerName, path)
 }
 
 func resolveLocalPath(localPath string) (absPath string, err error) {

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -111,7 +111,7 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 	}
 
 	//create the container
-	response, err := cli.client.ContainerCreate(config, hostConfig, networkingConfig, name)
+	response, err := cli.client.ContainerCreate(context.Background(), config, hostConfig, networkingConfig, name)
 
 	//if image not found try to pull it
 	if err != nil {
@@ -129,7 +129,7 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 			}
 			// Retry
 			var retryErr error
-			response, retryErr = cli.client.ContainerCreate(config, hostConfig, networkingConfig, name)
+			response, retryErr = cli.client.ContainerCreate(context.Background(), config, hostConfig, networkingConfig, name)
 			if retryErr != nil {
 				return nil, retryErr
 			}

--- a/api/client/diff.go
+++ b/api/client/diff.go
@@ -3,6 +3,8 @@ package client
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/archive"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -25,7 +27,7 @@ func (cli *DockerCli) CmdDiff(args ...string) error {
 		return fmt.Errorf("Container name cannot be empty")
 	}
 
-	changes, err := cli.client.ContainerDiff(cmd.Arg(0))
+	changes, err := cli.client.ContainerDiff(context.Background(), cmd.Arg(0))
 	if err != nil {
 		return err
 	}

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -31,7 +33,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 	// Send client escape keys
 	execConfig.DetachKeys = cli.configFile.DetachKeys
 
-	response, err := cli.client.ContainerExecCreate(*execConfig)
+	response, err := cli.client.ContainerExecCreate(context.Background(), *execConfig)
 	if err != nil {
 		return err
 	}
@@ -53,7 +55,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 			Tty:    execConfig.Tty,
 		}
 
-		if err := cli.client.ContainerExecStart(execID, execStartCheck); err != nil {
+		if err := cli.client.ContainerExecStart(context.Background(), execID, execStartCheck); err != nil {
 			return err
 		}
 		// For now don't print this - wait for when we support exec wait()
@@ -82,7 +84,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		}
 	}
 
-	resp, err := cli.client.ContainerExecAttach(execID, *execConfig)
+	resp, err := cli.client.ContainerExecAttach(context.Background(), execID, *execConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/history.go
+++ b/api/client/history.go
@@ -7,6 +7,8 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringid"
@@ -26,7 +28,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	history, err := cli.client.ImageHistory(cmd.Arg(0))
+	history, err := cli.client.ImageHistory(context.Background(), cmd.Arg(0))
 	if err != nil {
 		return err
 	}

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/client/formatter"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
@@ -48,7 +50,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		Filters:   imageFilterArgs,
 	}
 
-	images, err := cli.client.ImageList(options)
+	images, err := cli.client.ImageList(context.Background(), options)
 	if err != nil {
 		return err
 	}

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/ioutils"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -20,7 +22,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	info, err := cli.client.Info()
+	info, err := cli.client.Info(context.Background())
 	if err != nil {
 		return err
 	}

--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -3,6 +3,8 @@ package client
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/client/inspect"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -41,23 +43,23 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 
 func (cli *DockerCli) inspectContainers(getSize bool) inspectSearcher {
 	return func(ref string) (interface{}, []byte, error) {
-		return cli.client.ContainerInspectWithRaw(ref, getSize)
+		return cli.client.ContainerInspectWithRaw(context.Background(), ref, getSize)
 	}
 }
 
 func (cli *DockerCli) inspectImages(getSize bool) inspectSearcher {
 	return func(ref string) (interface{}, []byte, error) {
-		return cli.client.ImageInspectWithRaw(ref, getSize)
+		return cli.client.ImageInspectWithRaw(context.Background(), ref, getSize)
 	}
 }
 
 func (cli *DockerCli) inspectAll(getSize bool) inspectSearcher {
 	return func(ref string) (interface{}, []byte, error) {
-		c, rawContainer, err := cli.client.ContainerInspectWithRaw(ref, getSize)
+		c, rawContainer, err := cli.client.ContainerInspectWithRaw(context.Background(), ref, getSize)
 		if err != nil {
 			// Search for image with that id if a container doesn't exist.
 			if client.IsErrContainerNotFound(err) {
-				i, rawImage, err := cli.client.ImageInspectWithRaw(ref, getSize)
+				i, rawImage, err := cli.client.ImageInspectWithRaw(context.Background(), ref, getSize)
 				if err != nil {
 					if client.IsErrImageNotFound(err) {
 						return nil, nil, fmt.Errorf("Error: No such image or container: %s", ref)

--- a/api/client/kill.go
+++ b/api/client/kill.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -20,7 +22,7 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerKill(name, *signal); err != nil {
+		if err := cli.client.ContainerKill(context.Background(), name, *signal); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/cliconfig/credentials"
@@ -52,7 +54,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		return err
 	}
 
-	response, err := cli.client.RegistryLogin(authConfig)
+	response, err := cli.client.RegistryLogin(context.Background(), authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -32,7 +32,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 
 	name := cmd.Arg(0)
 
-	c, err := cli.client.ContainerInspect(name)
+	c, err := cli.client.ContainerInspect(context.Background(), name)
 	if err != nil {
 		return err
 	}

--- a/api/client/network.go
+++ b/api/client/network.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -82,7 +84,7 @@ func (cli *DockerCli) CmdNetworkCreate(args ...string) error {
 		EnableIPv6:     *flIPv6,
 	}
 
-	resp, err := cli.client.NetworkCreate(nc)
+	resp, err := cli.client.NetworkCreate(context.Background(), nc)
 	if err != nil {
 		return err
 	}
@@ -102,7 +104,7 @@ func (cli *DockerCli) CmdNetworkRm(args ...string) error {
 
 	status := 0
 	for _, net := range cmd.Args() {
-		if err := cli.client.NetworkRemove(net); err != nil {
+		if err := cli.client.NetworkRemove(context.Background(), net); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			status = 1
 			continue
@@ -137,7 +139,7 @@ func (cli *DockerCli) CmdNetworkConnect(args ...string) error {
 		Links:   flLinks.GetAll(),
 		Aliases: flAliases.GetAll(),
 	}
-	return cli.client.NetworkConnect(cmd.Arg(0), cmd.Arg(1), epConfig)
+	return cli.client.NetworkConnect(context.Background(), cmd.Arg(0), cmd.Arg(1), epConfig)
 }
 
 // CmdNetworkDisconnect disconnects a container from a network
@@ -151,7 +153,7 @@ func (cli *DockerCli) CmdNetworkDisconnect(args ...string) error {
 		return err
 	}
 
-	return cli.client.NetworkDisconnect(cmd.Arg(0), cmd.Arg(1), *force)
+	return cli.client.NetworkDisconnect(context.Background(), cmd.Arg(0), cmd.Arg(1), *force)
 }
 
 // CmdNetworkLs lists all the networks managed by docker daemon
@@ -184,7 +186,7 @@ func (cli *DockerCli) CmdNetworkLs(args ...string) error {
 		Filters: netFilterArgs,
 	}
 
-	networkResources, err := cli.client.NetworkList(options)
+	networkResources, err := cli.client.NetworkList(context.Background(), options)
 	if err != nil {
 		return err
 	}
@@ -236,7 +238,7 @@ func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
 	}
 
 	inspectSearcher := func(name string) (interface{}, []byte, error) {
-		i, err := cli.client.NetworkInspect(name)
+		i, err := cli.client.NetworkInspect(context.Background(), name)
 		return i, nil, err
 	}
 

--- a/api/client/pause.go
+++ b/api/client/pause.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -19,7 +21,7 @@ func (cli *DockerCli) CmdPause(args ...string) error {
 
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerPause(name); err != nil {
+		if err := cli.client.ContainerPause(context.Background(), name); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/port.go
+++ b/api/client/port.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/go-connections/nat"
@@ -19,7 +21,7 @@ func (cli *DockerCli) CmdPort(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	c, err := cli.client.ContainerInspect(cmd.Arg(0))
+	c, err := cli.client.ContainerInspect(context.Background(), cmd.Arg(0))
 	if err != nil {
 		return err
 	}

--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/client/formatter"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
@@ -56,7 +58,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		Filter: psFilterArgs,
 	}
 
-	containers, err := cli.client.ContainerList(options)
+	containers, err := cli.client.ContainerList(context.Background(), options)
 	if err != nil {
 		return err
 	}

--- a/api/client/rename.go
+++ b/api/client/rename.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -24,7 +26,7 @@ func (cli *DockerCli) CmdRename(args ...string) error {
 		return fmt.Errorf("Error: Neither old nor new names may be empty")
 	}
 
-	if err := cli.client.ContainerRename(oldName, newName); err != nil {
+	if err := cli.client.ContainerRename(context.Background(), oldName, newName); err != nil {
 		fmt.Fprintf(cli.err, "%s\n", err)
 		return fmt.Errorf("Error: failed to rename container named %s", oldName)
 	}

--- a/api/client/restart.go
+++ b/api/client/restart.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -20,7 +22,7 @@ func (cli *DockerCli) CmdRestart(args ...string) error {
 
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerRestart(name, *nSeconds); err != nil {
+		if err := cli.client.ContainerRestart(context.Background(), name, *nSeconds); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/engine-api/types"
@@ -47,7 +49,7 @@ func (cli *DockerCli) removeContainer(containerID string, removeVolumes, removeL
 		RemoveLinks:   removeLinks,
 		Force:         force,
 	}
-	if err := cli.client.ContainerRemove(options); err != nil {
+	if err := cli.client.ContainerRemove(context.Background(), options); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/rmi.go
+++ b/api/client/rmi.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/engine-api/types"
@@ -37,7 +39,7 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 			PruneChildren: !*noprune,
 		}
 
-		dels, err := cli.client.ImageRemove(options)
+		dels, err := cli.client.ImageRemove(context.Background(), options)
 		if err != nil {
 			errs = append(errs, err.Error())
 		} else {

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -203,7 +203,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			DetachKeys:  cli.configFile.DetachKeys,
 		}
 
-		resp, err := cli.client.ContainerAttach(options)
+		resp, err := cli.client.ContainerAttach(context.Background(), options)
 		if err != nil {
 			return err
 		}
@@ -227,7 +227,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	}
 
 	//start the container
-	if err := cli.client.ContainerStart(createResponse.ID); err != nil {
+	if err := cli.client.ContainerStart(context.Background(), createResponse.ID); err != nil {
 		cmd.ReportError(err.Error(), false)
 		return runStartContainerErr(err)
 	}
@@ -257,7 +257,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	// Attached mode
 	if *flAutoRemove {
 		// Warn user if they detached us
-		js, err := cli.client.ContainerInspect(createResponse.ID)
+		js, err := cli.client.ContainerInspect(context.Background(), createResponse.ID)
 		if err != nil {
 			return runStartContainerErr(err)
 		}

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/stringutils"
@@ -49,7 +51,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		RegistryAuth: encodedAuth,
 	}
 
-	unorderedResults, err := cli.client.ImageSearch(options, requestPrivilege)
+	unorderedResults, err := cli.client.ImageSearch(context.Background(), options, requestPrivilege)
 	if err != nil {
 		return err
 	}

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -34,7 +36,7 @@ func (cli *DockerCli) forwardAllSignals(cid string) chan os.Signal {
 				continue
 			}
 
-			if err := cli.client.ContainerKill(cid, sig); err != nil {
+			if err := cli.client.ContainerKill(context.Background(), cid, sig); err != nil {
 				logrus.Debugf("Error sending signal: %s", err)
 			}
 		}
@@ -63,7 +65,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 
 		// 2. Attach to the container.
 		containerID := cmd.Arg(0)
-		c, err := cli.client.ContainerInspect(containerID)
+		c, err := cli.client.ContainerInspect(context.Background(), containerID)
 		if err != nil {
 			return err
 		}
@@ -91,7 +93,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			in = cli.in
 		}
 
-		resp, err := cli.client.ContainerAttach(options)
+		resp, err := cli.client.ContainerAttach(context.Background(), options)
 		if err != nil {
 			return err
 		}
@@ -108,7 +110,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		})
 
 		// 3. Start the container.
-		if err := cli.client.ContainerStart(containerID); err != nil {
+		if err := cli.client.ContainerStart(context.Background(), containerID); err != nil {
 			return err
 		}
 
@@ -140,7 +142,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 func (cli *DockerCli) startContainersWithoutAttachments(containerIDs []string) error {
 	var failedContainers []string
 	for _, containerID := range containerIDs {
-		if err := cli.client.ContainerStart(containerID); err != nil {
+		if err := cli.client.ContainerStart(context.Background(), containerID); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			failedContainers = append(failedContainers, containerID)
 		} else {

--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -70,7 +70,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 		options := types.ContainerListOptions{
 			All: *all,
 		}
-		cs, err := cli.client.ContainerList(options)
+		cs, err := cli.client.ContainerList(context.Background(), options)
 		if err != nil {
 			closeChan <- err
 		}

--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -22,7 +24,7 @@ func (cli *DockerCli) CmdStop(args ...string) error {
 
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerStop(name, *nSeconds); err != nil {
+		if err := cli.client.ContainerStop(context.Background(), name, *nSeconds); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -3,6 +3,8 @@ package client
 import (
 	"errors"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/reference"
@@ -40,5 +42,5 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 		Force:          *force,
 	}
 
-	return cli.client.ImageTag(options)
+	return cli.client.ImageTag(context.Background(), options)
 }

--- a/api/client/top.go
+++ b/api/client/top.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -23,7 +25,7 @@ func (cli *DockerCli) CmdTop(args ...string) error {
 		arguments = cmd.Args()[1:]
 	}
 
-	procList, err := cli.client.ContainerTop(cmd.Arg(0), arguments)
+	procList, err := cli.client.ContainerTop(context.Background(), cmd.Arg(0), arguments)
 	if err != nil {
 		return err
 	}

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/client/auth"
@@ -276,7 +278,7 @@ func (cli *DockerCli) tagTrusted(trustedRef reference.Canonical, ref reference.N
 		Force:          true,
 	}
 
-	return cli.client.ImageTag(options)
+	return cli.client.ImageTag(context.Background(), options)
 }
 
 func notaryError(repoName string, err error) error {

--- a/api/client/unpause.go
+++ b/api/client/unpause.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -19,7 +21,7 @@ func (cli *DockerCli) CmdUnpause(args ...string) error {
 
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerUnpause(name); err != nil {
+		if err := cli.client.ContainerUnpause(context.Background(), name); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/update.go
+++ b/api/client/update.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/runconfig/opts"
@@ -100,7 +102,7 @@ func (cli *DockerCli) CmdUpdate(args ...string) error {
 	names := cmd.Args()
 	var errs []string
 	for _, name := range names {
-		if err := cli.client.ContainerUpdate(name, updateConfig); err != nil {
+		if err := cli.client.ContainerUpdate(context.Background(), name, updateConfig); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/term"
@@ -27,7 +29,7 @@ func (cli *DockerCli) electAuthServer() string {
 	// example a Linux client might be interacting with a Windows daemon, hence
 	// the default registry URL might be Windows specific.
 	serverAddress := registry.IndexServer
-	if info, err := cli.client.Info(); err != nil {
+	if info, err := cli.client.Info(context.Background()); err != nil {
 		fmt.Fprintf(cli.out, "Warning: failed to get default registry endpoint from daemon (%v). Using system default: %s\n", err, serverAddress)
 	} else {
 		serverAddress = info.IndexServerAddress
@@ -74,9 +76,9 @@ func (cli *DockerCli) resizeTtyTo(id string, height, width int, isExec bool) {
 
 	var err error
 	if isExec {
-		err = cli.client.ContainerExecResize(options)
+		err = cli.client.ContainerExecResize(context.Background(), options)
 	} else {
-		err = cli.client.ContainerResize(options)
+		err = cli.client.ContainerResize(context.Background(), options)
 	}
 
 	if err != nil {
@@ -87,7 +89,7 @@ func (cli *DockerCli) resizeTtyTo(id string, height, width int, isExec bool) {
 // getExitCode perform an inspect on the container. It returns
 // the running state and the exit code.
 func getExitCode(cli *DockerCli, containerID string) (bool, int, error) {
-	c, err := cli.client.ContainerInspect(containerID)
+	c, err := cli.client.ContainerInspect(context.Background(), containerID)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.
 		if err != client.ErrConnectionFailed {
@@ -102,7 +104,7 @@ func getExitCode(cli *DockerCli, containerID string) (bool, int, error) {
 // getExecExitCode perform an inspect on the exec command. It returns
 // the running state and the exit code.
 func getExecExitCode(cli *DockerCli, execID string) (bool, int, error) {
-	resp, err := cli.client.ContainerExecInspect(execID)
+	resp, err := cli.client.ContainerExecInspect(context.Background(), execID)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.
 		if err != client.ErrConnectionFailed {

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -5,6 +5,8 @@ import (
 	"text/template"
 	"time"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -67,7 +69,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 		},
 	}
 
-	serverVersion, err := cli.client.ServerVersion()
+	serverVersion, err := cli.client.ServerVersion(context.Background())
 	if err == nil {
 		vd.Server = &serverVersion
 	}

--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -59,7 +61,7 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 		}
 	}
 
-	volumes, err := cli.client.VolumeList(volFilterArgs)
+	volumes, err := cli.client.VolumeList(context.Background(), volFilterArgs)
 	if err != nil {
 		return err
 	}
@@ -108,7 +110,7 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 	}
 
 	inspectSearcher := func(name string) (interface{}, []byte, error) {
-		i, err := cli.client.VolumeInspect(name)
+		i, err := cli.client.VolumeInspect(context.Background(), name)
 		return i, nil, err
 	}
 
@@ -135,7 +137,7 @@ func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
 		Name:       *flName,
 	}
 
-	vol, err := cli.client.VolumeCreate(volReq)
+	vol, err := cli.client.VolumeCreate(context.Background(), volReq)
 	if err != nil {
 		return err
 	}
@@ -155,7 +157,7 @@ func (cli *DockerCli) CmdVolumeRm(args ...string) error {
 	var status = 0
 
 	for _, name := range cmd.Args() {
-		if err := cli.client.VolumeRemove(name); err != nil {
+		if err := cli.client.VolumeRemove(context.Background(), name); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			status = 1
 			continue

--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -140,6 +140,7 @@ clean() {
 
 	echo -n 'pruning unused files, '
 	$find vendor -type f -name '*_test.go' -exec rm -v '{}' ';'
+	$find vendor -type f -name 'Vagrantfile' -exec rm -v '{}' ';'
 
 	# These are the files that are left over after fix_rewritten_imports is run.
 	echo -n 'pruning .orig files, '

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 9bab0d5b73872e53dfadfa055dcc519e57b09439
+clone git github.com/docker/engine-api 6de18e18540cda038b00e71a1f2946d779e83f87
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/container_attach.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_attach.go
@@ -4,13 +4,14 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerAttach attaches a connection to a container in the server.
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerAttach(options types.ContainerAttachOptions) (types.HijackedResponse, error) {
+func (cli *Client) ContainerAttach(ctx context.Context, options types.ContainerAttachOptions) (types.HijackedResponse, error) {
 	query := url.Values{}
 	if options.Stream {
 		query.Set("stream", "1")
@@ -29,5 +30,5 @@ func (cli *Client) ContainerAttach(options types.ContainerAttachOptions) (types.
 	}
 
 	headers := map[string][]string{"Content-Type": {"text/plain"}}
-	return cli.postHijacked("/containers/"+options.ContainerID+"/attach", query, nil, headers)
+	return cli.postHijacked(ctx, "/containers/"+options.ContainerID+"/attach", query, nil, headers)
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_commit.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_commit.go
@@ -5,10 +5,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerCommit applies changes into a container and creates a new tagged image.
-func (cli *Client) ContainerCommit(options types.ContainerCommitOptions) (types.ContainerCommitResponse, error) {
+func (cli *Client) ContainerCommit(ctx context.Context, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error) {
 	query := url.Values{}
 	query.Set("container", options.ContainerID)
 	query.Set("repo", options.RepositoryName)
@@ -23,7 +24,7 @@ func (cli *Client) ContainerCommit(options types.ContainerCommitOptions) (types.
 	}
 
 	var response types.ContainerCommitResponse
-	resp, err := cli.post("/commit", query, options.Config, nil)
+	resp, err := cli.post(ctx, "/commit", query, options.Config, nil)
 	if err != nil {
 		return response, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_copy.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_copy.go
@@ -16,12 +16,12 @@ import (
 )
 
 // ContainerStatPath returns Stat information about a path inside the container filesystem.
-func (cli *Client) ContainerStatPath(containerID, path string) (types.ContainerPathStat, error) {
+func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error) {
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
 	urlStr := fmt.Sprintf("/containers/%s/archive", containerID)
-	response, err := cli.head(urlStr, query, nil)
+	response, err := cli.head(ctx, urlStr, query, nil)
 	if err != nil {
 		return types.ContainerPathStat{}, err
 	}
@@ -40,7 +40,7 @@ func (cli *Client) CopyToContainer(ctx context.Context, options types.CopyToCont
 
 	path := fmt.Sprintf("/containers/%s/archive", options.ContainerID)
 
-	response, err := cli.putRawWithContext(ctx, path, query, options.Content, nil)
+	response, err := cli.putRaw(ctx, path, query, options.Content, nil)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
 	apiPath := fmt.Sprintf("/containers/%s/archive", containerID)
-	response, err := cli.getWithContext(ctx, apiPath, query, nil)
+	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
 		return nil, types.ContainerPathStat{}, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
+	"golang.org/x/net/context"
 )
 
 type configWrapper struct {
@@ -18,7 +19,7 @@ type configWrapper struct {
 
 // ContainerCreate creates a new container based in the given configuration.
 // It can be associated with a name, but it's not mandatory.
-func (cli *Client) ContainerCreate(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error) {
+func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error) {
 	var response types.ContainerCreateResponse
 	query := url.Values{}
 	if containerName != "" {
@@ -31,7 +32,7 @@ func (cli *Client) ContainerCreate(config *container.Config, hostConfig *contain
 		NetworkingConfig: networkingConfig,
 	}
 
-	serverResp, err := cli.post("/containers/create", query, body, nil)
+	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
 	if err != nil {
 		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 			return response, imageNotFoundError{config.Image}

--- a/vendor/src/github.com/docker/engine-api/client/container_diff.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_diff.go
@@ -5,13 +5,14 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerDiff shows differences in a container filesystem since it was started.
-func (cli *Client) ContainerDiff(containerID string) ([]types.ContainerChange, error) {
+func (cli *Client) ContainerDiff(ctx context.Context, containerID string) ([]types.ContainerChange, error) {
 	var changes []types.ContainerChange
 
-	serverResp, err := cli.get("/containers/"+containerID+"/changes", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
 	if err != nil {
 		return changes, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_exec.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_exec.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerExecCreate creates a new exec configuration to run an exec process.
-func (cli *Client) ContainerExecCreate(config types.ExecConfig) (types.ContainerExecCreateResponse, error) {
+func (cli *Client) ContainerExecCreate(ctx context.Context, config types.ExecConfig) (types.ContainerExecCreateResponse, error) {
 	var response types.ContainerExecCreateResponse
-	resp, err := cli.post("/containers/"+config.Container+"/exec", nil, config, nil)
+	resp, err := cli.post(ctx, "/containers/"+config.Container+"/exec", nil, config, nil)
 	if err != nil {
 		return response, err
 	}
@@ -19,8 +20,8 @@ func (cli *Client) ContainerExecCreate(config types.ExecConfig) (types.Container
 }
 
 // ContainerExecStart starts an exec process already create in the docker host.
-func (cli *Client) ContainerExecStart(execID string, config types.ExecStartCheck) error {
-	resp, err := cli.post("/exec/"+execID+"/start", nil, config, nil)
+func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
+	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
 	ensureReaderClosed(resp)
 	return err
 }
@@ -29,15 +30,15 @@ func (cli *Client) ContainerExecStart(execID string, config types.ExecStartCheck
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerExecAttach(execID string, config types.ExecConfig) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error) {
 	headers := map[string][]string{"Content-Type": {"application/json"}}
-	return cli.postHijacked("/exec/"+execID+"/start", nil, config, headers)
+	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, headers)
 }
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.
-func (cli *Client) ContainerExecInspect(execID string) (types.ContainerExecInspect, error) {
+func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
 	var response types.ContainerExecInspect
-	resp, err := cli.get("/exec/"+execID+"/json", nil, nil)
+	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
 	if err != nil {
 		return response, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_export.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_export.go
@@ -11,7 +11,7 @@ import (
 // and returns them as a io.ReadCloser. It's up to the caller
 // to close the stream.
 func (cli *Client) ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error) {
-	serverResp, err := cli.getWithContext(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_inspect.go
@@ -8,11 +8,12 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerInspect returns the container information.
-func (cli *Client) ContainerInspect(containerID string) (types.ContainerJSON, error) {
-	serverResp, err := cli.get("/containers/"+containerID+"/json", nil, nil)
+func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, containerNotFoundError{containerID}
@@ -27,12 +28,12 @@ func (cli *Client) ContainerInspect(containerID string) (types.ContainerJSON, er
 }
 
 // ContainerInspectWithRaw returns the container information and it's raw representation.
-func (cli *Client) ContainerInspectWithRaw(containerID string, getSize bool) (types.ContainerJSON, []byte, error) {
+func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID string, getSize bool) (types.ContainerJSON, []byte, error) {
 	query := url.Values{}
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get("/containers/"+containerID+"/json", query, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, nil, containerNotFoundError{containerID}
@@ -52,8 +53,8 @@ func (cli *Client) ContainerInspectWithRaw(containerID string, getSize bool) (ty
 	return response, body, err
 }
 
-func (cli *Client) containerInspectWithResponse(containerID string, query url.Values) (types.ContainerJSON, *serverResponse, error) {
-	serverResp, err := cli.get("/containers/"+containerID+"/json", nil, nil)
+func (cli *Client) containerInspectWithResponse(ctx context.Context, containerID string, query url.Values) (types.ContainerJSON, *serverResponse, error) {
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		return types.ContainerJSON{}, serverResp, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_kill.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_kill.go
@@ -1,13 +1,17 @@
 package client
 
-import "net/url"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ContainerKill terminates the container process but does not remove the container from the docker host.
-func (cli *Client) ContainerKill(containerID, signal string) error {
+func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string) error {
 	query := url.Values{}
 	query.Set("signal", signal)
 
-	resp, err := cli.post("/containers/"+containerID+"/kill", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_list.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // ContainerList returns the list of containers in the docker host.
-func (cli *Client) ContainerList(options types.ContainerListOptions) ([]types.Container, error) {
+func (cli *Client) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	query := url.Values{}
 
 	if options.All {
@@ -42,7 +43,7 @@ func (cli *Client) ContainerList(options types.ContainerListOptions) ([]types.Co
 		query.Set("filters", filterJSON)
 	}
 
-	resp, err := cli.get("/containers/json", query, nil)
+	resp, err := cli.get(ctx, "/containers/json", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_logs.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_logs.go
@@ -40,7 +40,7 @@ func (cli *Client) ContainerLogs(ctx context.Context, options types.ContainerLog
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.getWithContext(ctx, "/containers/"+options.ContainerID+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+options.ContainerID+"/logs", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_pause.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_pause.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // ContainerPause pauses the main process of a given container without terminating it.
-func (cli *Client) ContainerPause(containerID string) error {
-	resp, err := cli.post("/containers/"+containerID+"/pause", nil, nil, nil)
+func (cli *Client) ContainerPause(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/pause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_remove.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_remove.go
@@ -4,10 +4,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerRemove kills and removes a container from the docker host.
-func (cli *Client) ContainerRemove(options types.ContainerRemoveOptions) error {
+func (cli *Client) ContainerRemove(ctx context.Context, options types.ContainerRemoveOptions) error {
 	query := url.Values{}
 	if options.RemoveVolumes {
 		query.Set("v", "1")
@@ -20,7 +21,7 @@ func (cli *Client) ContainerRemove(options types.ContainerRemoveOptions) error {
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete("/containers/"+options.ContainerID, query, nil)
+	resp, err := cli.delete(ctx, "/containers/"+options.ContainerID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_rename.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_rename.go
@@ -1,12 +1,16 @@
 package client
 
-import "net/url"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ContainerRename changes the name of a given container.
-func (cli *Client) ContainerRename(containerID, newContainerName string) error {
+func (cli *Client) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
 	query := url.Values{}
 	query.Set("name", newContainerName)
-	resp, err := cli.post("/containers/"+containerID+"/rename", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_resize.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_resize.go
@@ -5,24 +5,25 @@ import (
 	"strconv"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerResize changes the size of the tty for a container.
-func (cli *Client) ContainerResize(options types.ResizeOptions) error {
-	return cli.resize("/containers/"+options.ID, options.Height, options.Width)
+func (cli *Client) ContainerResize(ctx context.Context, options types.ResizeOptions) error {
+	return cli.resize(ctx, "/containers/"+options.ID, options.Height, options.Width)
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(options types.ResizeOptions) error {
-	return cli.resize("/exec/"+options.ID, options.Height, options.Width)
+func (cli *Client) ContainerExecResize(ctx context.Context, options types.ResizeOptions) error {
+	return cli.resize(ctx, "/exec/"+options.ID, options.Height, options.Width)
 }
 
-func (cli *Client) resize(basePath string, height, width int) error {
+func (cli *Client) resize(ctx context.Context, basePath string, height, width int) error {
 	query := url.Values{}
 	query.Set("h", strconv.Itoa(height))
 	query.Set("w", strconv.Itoa(width))
 
-	resp, err := cli.post(basePath+"/resize", query, nil, nil)
+	resp, err := cli.post(ctx, basePath+"/resize", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_restart.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_restart.go
@@ -3,15 +3,17 @@ package client
 import (
 	"net/url"
 	"strconv"
+
+	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(containerID string, timeout int) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout int) error {
 	query := url.Values{}
 	query.Set("t", strconv.Itoa(timeout))
-	resp, err := cli.post("/containers/"+containerID+"/restart", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_start.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_start.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // ContainerStart sends a request to the docker daemon to start a container.
-func (cli *Client) ContainerStart(containerID string) error {
-	resp, err := cli.post("/containers/"+containerID+"/start", nil, nil, nil)
+func (cli *Client) ContainerStart(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_stats.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_stats.go
@@ -16,7 +16,7 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 		query.Set("stream", "1")
 	}
 
-	resp, err := cli.getWithContext(ctx, "/containers/"+containerID+"/stats", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_stop.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_stop.go
@@ -3,14 +3,16 @@ package client
 import (
 	"net/url"
 	"strconv"
+
+	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(containerID string, timeout int) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout int) error {
 	query := url.Values{}
 	query.Set("t", strconv.Itoa(timeout))
-	resp, err := cli.post("/containers/"+containerID+"/stop", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_top.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_top.go
@@ -6,17 +6,18 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerTop shows process information from within a container.
-func (cli *Client) ContainerTop(containerID string, arguments []string) (types.ContainerProcessList, error) {
+func (cli *Client) ContainerTop(ctx context.Context, containerID string, arguments []string) (types.ContainerProcessList, error) {
 	var response types.ContainerProcessList
 	query := url.Values{}
 	if len(arguments) > 0 {
 		query.Set("ps_args", strings.Join(arguments, " "))
 	}
 
-	resp, err := cli.get("/containers/"+containerID+"/top", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/top", query, nil)
 	if err != nil {
 		return response, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/container_unpause.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_unpause.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // ContainerUnpause resumes the process execution within a container
-func (cli *Client) ContainerUnpause(containerID string) error {
-	resp, err := cli.post("/containers/"+containerID+"/unpause", nil, nil, nil)
+func (cli *Client) ContainerUnpause(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/unpause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_update.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_update.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"github.com/docker/engine-api/types/container"
+	"golang.org/x/net/context"
 )
 
 // ContainerUpdate updates resources of a container
-func (cli *Client) ContainerUpdate(containerID string, updateConfig container.UpdateConfig) error {
-	resp, err := cli.post("/containers/"+containerID+"/update", nil, updateConfig, nil)
+func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/container_wait.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_wait.go
@@ -11,7 +11,7 @@ import (
 // ContainerWait pauses execution util a container is exits.
 // It returns the API status code as response of its readiness.
 func (cli *Client) ContainerWait(ctx context.Context, containerID string) (int, error) {
-	resp, err := cli.postWithContext(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)
 	if err != nil {
 		return -1, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/errors.go
+++ b/vendor/src/github.com/docker/engine-api/client/errors.go
@@ -72,7 +72,7 @@ func (e volumeNotFoundError) Error() string {
 // IsErrVolumeNotFound returns true if the error is caused
 // when a volume is not found in the docker host.
 func IsErrVolumeNotFound(err error) bool {
-	_, ok := err.(networkNotFoundError)
+	_, ok := err.(volumeNotFoundError)
 	return ok
 }
 

--- a/vendor/src/github.com/docker/engine-api/client/events.go
+++ b/vendor/src/github.com/docker/engine-api/client/events.go
@@ -40,7 +40,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (io.
 		query.Set("filters", filterJSON)
 	}
 
-	serverResponse, err := cli.getWithContext(ctx, "/events", query, nil)
+	serverResponse, err := cli.get(ctx, "/events", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/image_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_create.go
@@ -24,5 +24,5 @@ func (cli *Client) ImageCreate(ctx context.Context, options types.ImageCreateOpt
 
 func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (*serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.postWithContext(ctx, "/images/create", query, nil, headers)
+	return cli.post(ctx, "/images/create", query, nil, headers)
 }

--- a/vendor/src/github.com/docker/engine-api/client/image_history.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_history.go
@@ -5,12 +5,13 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageHistory returns the changes in an image in history format.
-func (cli *Client) ImageHistory(imageID string) ([]types.ImageHistory, error) {
+func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]types.ImageHistory, error) {
 	var history []types.ImageHistory
-	serverResp, err := cli.get("/images/"+imageID+"/history", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", url.Values{}, nil)
 	if err != nil {
 		return history, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/image_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_inspect.go
@@ -8,15 +8,16 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageInspectWithRaw returns the image information and it's raw representation.
-func (cli *Client) ImageInspectWithRaw(imageID string, getSize bool) (types.ImageInspect, []byte, error) {
+func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (types.ImageInspect, []byte, error) {
 	query := url.Values{}
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get("/images/"+imageID+"/json", query, nil)
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ImageInspect{}, nil, imageNotFoundError{imageID}

--- a/vendor/src/github.com/docker/engine-api/client/image_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_list.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // ImageList returns a list of images in the docker host.
-func (cli *Client) ImageList(options types.ImageListOptions) ([]types.Image, error) {
+func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error) {
 	var images []types.Image
 	query := url.Values{}
 
@@ -28,7 +29,7 @@ func (cli *Client) ImageList(options types.ImageListOptions) ([]types.Image, err
 		query.Set("all", "1")
 	}
 
-	serverResp, err := cli.get("/images/json", query, nil)
+	serverResp, err := cli.get(ctx, "/images/json", query, nil)
 	if err != nil {
 		return images, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/image_push.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_push.go
@@ -34,5 +34,5 @@ func (cli *Client) ImagePush(ctx context.Context, options types.ImagePushOptions
 
 func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (*serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.postWithContext(ctx, "/images/"+imageID+"/push", query, nil, headers)
+	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, headers)
 }

--- a/vendor/src/github.com/docker/engine-api/client/image_remove.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_remove.go
@@ -5,10 +5,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageRemove removes an image from the docker host.
-func (cli *Client) ImageRemove(options types.ImageRemoveOptions) ([]types.ImageDelete, error) {
+func (cli *Client) ImageRemove(ctx context.Context, options types.ImageRemoveOptions) ([]types.ImageDelete, error) {
 	query := url.Values{}
 
 	if options.Force {
@@ -18,7 +19,7 @@ func (cli *Client) ImageRemove(options types.ImageRemoveOptions) ([]types.ImageD
 		query.Set("noprune", "1")
 	}
 
-	resp, err := cli.delete("/images/"+options.ImageID, query, nil)
+	resp, err := cli.delete(ctx, "/images/"+options.ImageID, query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/image_save.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_save.go
@@ -14,7 +14,7 @@ func (cli *Client) ImageSave(ctx context.Context, imageIDs []string) (io.ReadClo
 		"names": imageIDs,
 	}
 
-	resp, err := cli.getWithContext(ctx, "/images/get", query, nil)
+	resp, err := cli.get(ctx, "/images/get", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/image_tag.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_tag.go
@@ -4,10 +4,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageTag tags an image in the docker host
-func (cli *Client) ImageTag(options types.ImageTagOptions) error {
+func (cli *Client) ImageTag(ctx context.Context, options types.ImageTagOptions) error {
 	query := url.Values{}
 	query.Set("repo", options.RepositoryName)
 	query.Set("tag", options.Tag)
@@ -15,7 +16,7 @@ func (cli *Client) ImageTag(options types.ImageTagOptions) error {
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.post("/images/"+options.ImageID+"/tag", query, nil, nil)
+	resp, err := cli.post(ctx, "/images/"+options.ImageID+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/info.go
+++ b/vendor/src/github.com/docker/engine-api/client/info.go
@@ -6,12 +6,13 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // Info returns information about the docker server.
-func (cli *Client) Info() (types.Info, error) {
+func (cli *Client) Info(ctx context.Context) (types.Info, error) {
 	var info types.Info
-	serverResp, err := cli.get("/info", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/info", url.Values{}, nil)
 	if err != nil {
 		return info, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -15,63 +15,63 @@ import (
 // APIClient is an interface that clients that talk with a docker server must implement.
 type APIClient interface {
 	ClientVersion() string
-	ContainerAttach(options types.ContainerAttachOptions) (types.HijackedResponse, error)
-	ContainerCommit(options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
-	ContainerCreate(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
-	ContainerDiff(containerID string) ([]types.ContainerChange, error)
-	ContainerExecAttach(execID string, config types.ExecConfig) (types.HijackedResponse, error)
-	ContainerExecCreate(config types.ExecConfig) (types.ContainerExecCreateResponse, error)
-	ContainerExecInspect(execID string) (types.ContainerExecInspect, error)
-	ContainerExecResize(options types.ResizeOptions) error
-	ContainerExecStart(execID string, config types.ExecStartCheck) error
+	ContainerAttach(ctx context.Context, options types.ContainerAttachOptions) (types.HijackedResponse, error)
+	ContainerCommit(ctx context.Context, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
+	ContainerDiff(ctx context.Context, ontainerID string) ([]types.ContainerChange, error)
+	ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error)
+	ContainerExecCreate(ctx context.Context, config types.ExecConfig) (types.ContainerExecCreateResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
+	ContainerExecResize(ctx context.Context, options types.ResizeOptions) error
+	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
 	ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error)
-	ContainerInspect(containerID string) (types.ContainerJSON, error)
-	ContainerInspectWithRaw(containerID string, getSize bool) (types.ContainerJSON, []byte, error)
-	ContainerKill(containerID, signal string) error
-	ContainerList(options types.ContainerListOptions) ([]types.Container, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	ContainerInspectWithRaw(ctx context.Context, containerID string, getSize bool) (types.ContainerJSON, []byte, error)
+	ContainerKill(ctx context.Context, containerID, signal string) error
+	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerLogs(ctx context.Context, options types.ContainerLogsOptions) (io.ReadCloser, error)
-	ContainerPause(containerID string) error
-	ContainerRemove(options types.ContainerRemoveOptions) error
-	ContainerRename(containerID, newContainerName string) error
-	ContainerResize(options types.ResizeOptions) error
-	ContainerRestart(containerID string, timeout int) error
-	ContainerStatPath(containerID, path string) (types.ContainerPathStat, error)
+	ContainerPause(ctx context.Context, containerID string) error
+	ContainerRemove(ctx context.Context, options types.ContainerRemoveOptions) error
+	ContainerRename(ctx context.Context, containerID, newContainerName string) error
+	ContainerResize(ctx context.Context, options types.ResizeOptions) error
+	ContainerRestart(ctx context.Context, containerID string, timeout int) error
+	ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error)
-	ContainerStart(containerID string) error
-	ContainerStop(containerID string, timeout int) error
-	ContainerTop(containerID string, arguments []string) (types.ContainerProcessList, error)
-	ContainerUnpause(containerID string) error
-	ContainerUpdate(containerID string, updateConfig container.UpdateConfig) error
+	ContainerStart(ctx context.Context, containerID string) error
+	ContainerStop(ctx context.Context, containerID string, timeout int) error
+	ContainerTop(ctx context.Context, containerID string, arguments []string) (types.ContainerProcessList, error)
+	ContainerUnpause(ctx context.Context, containerID string) error
+	ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) error
 	ContainerWait(ctx context.Context, containerID string) (int, error)
 	CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, options types.CopyToContainerOptions) error
 	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
 	ImageBuild(ctx context.Context, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImageCreate(ctx context.Context, options types.ImageCreateOptions) (io.ReadCloser, error)
-	ImageHistory(imageID string) ([]types.ImageHistory, error)
+	ImageHistory(ctx context.Context, imageID string) ([]types.ImageHistory, error)
 	ImageImport(ctx context.Context, options types.ImageImportOptions) (io.ReadCloser, error)
-	ImageInspectWithRaw(imageID string, getSize bool) (types.ImageInspect, []byte, error)
-	ImageList(options types.ImageListOptions) ([]types.Image, error)
+	ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (types.ImageInspect, []byte, error)
+	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error)
 	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
 	ImagePull(ctx context.Context, options types.ImagePullOptions, privilegeFunc RequestPrivilegeFunc) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, options types.ImagePushOptions, privilegeFunc RequestPrivilegeFunc) (io.ReadCloser, error)
-	ImageRemove(options types.ImageRemoveOptions) ([]types.ImageDelete, error)
-	ImageSearch(options types.ImageSearchOptions, privilegeFunc RequestPrivilegeFunc) ([]registry.SearchResult, error)
+	ImageRemove(ctx context.Context, options types.ImageRemoveOptions) ([]types.ImageDelete, error)
+	ImageSearch(ctx context.Context, options types.ImageSearchOptions, privilegeFunc RequestPrivilegeFunc) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, imageIDs []string) (io.ReadCloser, error)
-	ImageTag(options types.ImageTagOptions) error
-	Info() (types.Info, error)
-	NetworkConnect(networkID, containerID string, config *network.EndpointSettings) error
-	NetworkCreate(options types.NetworkCreate) (types.NetworkCreateResponse, error)
-	NetworkDisconnect(networkID, containerID string, force bool) error
-	NetworkInspect(networkID string) (types.NetworkResource, error)
-	NetworkList(options types.NetworkListOptions) ([]types.NetworkResource, error)
-	NetworkRemove(networkID string) error
-	RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error)
-	ServerVersion() (types.Version, error)
-	VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error)
-	VolumeInspect(volumeID string) (types.Volume, error)
-	VolumeList(filter filters.Args) (types.VolumesListResponse, error)
-	VolumeRemove(volumeID string) error
+	ImageTag(ctx context.Context, options types.ImageTagOptions) error
+	Info(ctx context.Context) (types.Info, error)
+	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkCreate(ctx context.Context, options types.NetworkCreate) (types.NetworkCreateResponse, error)
+	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
+	NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error)
+	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
+	NetworkRemove(ctx context.Context, networkID string) error
+	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
+	ServerVersion(ctx context.Context) (types.Version, error)
+	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
+	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
+	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
+	VolumeRemove(ctx context.Context, volumeID string) error
 }
 
 // Ensure that Client always implements APIClient.

--- a/vendor/src/github.com/docker/engine-api/client/login.go
+++ b/vendor/src/github.com/docker/engine-api/client/login.go
@@ -6,12 +6,13 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // RegistryLogin authenticates the docker server with a given docker registry.
 // It returns UnauthorizerError when the authentication fails.
-func (cli *Client) RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error) {
-	resp, err := cli.post("/auth", url.Values{}, auth, nil)
+func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error) {
+	resp, err := cli.post(ctx, "/auth", url.Values{}, auth, nil)
 
 	if resp != nil && resp.statusCode == http.StatusUnauthorized {
 		return types.AuthResponse{}, unauthorizedError{err}

--- a/vendor/src/github.com/docker/engine-api/client/network_connect.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_connect.go
@@ -3,15 +3,16 @@ package client
 import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/network"
+	"golang.org/x/net/context"
 )
 
 // NetworkConnect connects a container to an existent network in the docker host.
-func (cli *Client) NetworkConnect(networkID, containerID string, config *network.EndpointSettings) error {
+func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error {
 	nc := types.NetworkConnect{
 		Container:      containerID,
 		EndpointConfig: config,
 	}
-	resp, err := cli.post("/networks/"+networkID+"/connect", nil, nc, nil)
+	resp, err := cli.post(ctx, "/networks/"+networkID+"/connect", nil, nc, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/network_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_create.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // NetworkCreate creates a new network in the docker host.
-func (cli *Client) NetworkCreate(options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+func (cli *Client) NetworkCreate(ctx context.Context, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
 	var response types.NetworkCreateResponse
-	serverResp, err := cli.post("/networks/create", nil, options, nil)
+	serverResp, err := cli.post(ctx, "/networks/create", nil, options, nil)
 	if err != nil {
 		return response, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/network_disconnect.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_disconnect.go
@@ -2,12 +2,13 @@ package client
 
 import (
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
-func (cli *Client) NetworkDisconnect(networkID, containerID string, force bool) error {
+func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
 	nd := types.NetworkDisconnect{Container: containerID, Force: force}
-	resp, err := cli.post("/networks/"+networkID+"/disconnect", nil, nd, nil)
+	resp, err := cli.post(ctx, "/networks/"+networkID+"/disconnect", nil, nd, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/network_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_inspect.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(networkID string) (types.NetworkResource, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
 	var networkResource types.NetworkResource
-	resp, err := cli.get("/networks/"+networkID, nil, nil)
+	resp, err := cli.get(ctx, "/networks/"+networkID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return networkResource, networkNotFoundError{networkID}

--- a/vendor/src/github.com/docker/engine-api/client/network_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_list.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(options types.NetworkListOptions) ([]types.NetworkResource, error) {
+func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToParam(options.Filters)
@@ -20,7 +21,7 @@ func (cli *Client) NetworkList(options types.NetworkListOptions) ([]types.Networ
 		query.Set("filters", filterJSON)
 	}
 	var networkResources []types.NetworkResource
-	resp, err := cli.get("/networks", query, nil)
+	resp, err := cli.get(ctx, "/networks", query, nil)
 	if err != nil {
 		return networkResources, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/network_remove.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_remove.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // NetworkRemove removes an existent network from the docker host.
-func (cli *Client) NetworkRemove(networkID string) error {
-	resp, err := cli.delete("/networks/"+networkID, nil, nil)
+func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
+	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/request.go
+++ b/vendor/src/github.com/docker/engine-api/client/request.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/client/transport/cancellable"
-
 	"golang.org/x/net/context"
 )
 
@@ -23,57 +22,41 @@ type serverResponse struct {
 }
 
 // head sends an http request to the docker API using the method HEAD.
-func (cli *Client) head(path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(context.Background(), "HEAD", path, query, nil, headers)
-}
-
-// get sends an http request to the docker API using the method GET.
-func (cli *Client) get(path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
-	return cli.getWithContext(context.Background(), path, query, headers)
+func (cli *Client) head(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "HEAD", path, query, nil, headers)
 }
 
 // getWithContext sends an http request to the docker API using the method GET with a specific go context.
-func (cli *Client) getWithContext(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
 	return cli.sendRequest(ctx, "GET", path, query, nil, headers)
 }
 
-// post sends an http request to the docker API using the method POST.
-func (cli *Client) post(path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	return cli.postWithContext(context.Background(), path, query, body, headers)
-}
-
 // postWithContext sends an http request to the docker API using the method POST with a specific go context.
-func (cli *Client) postWithContext(ctx context.Context, path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(ctx, "POST", path, query, body, headers)
+func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "POST", path, query, obj, headers)
 }
 
-// postRaw sends the raw input to the docker API using the method POST with a specific go context.
 func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
 	return cli.sendClientRequest(ctx, "POST", path, query, body, headers)
 }
 
 // put sends an http request to the docker API using the method PUT.
-func (cli *Client) put(path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(context.Background(), "PUT", path, query, body, headers)
+func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "PUT", path, query, obj, headers)
 }
 
-// putRaw sends the raw input to the docker API using the method PUT.
-func (cli *Client) putRaw(path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
-	return cli.putRawWithContext(context.Background(), path, query, body, headers)
-}
-
-// putRawWithContext sends the raw input to the docker API using the method PUT with a specific go context.
-func (cli *Client) putRawWithContext(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
+// put sends an http request to the docker API using the method PUT.
+func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
 	return cli.sendClientRequest(ctx, "PUT", path, query, body, headers)
 }
 
 // delete sends an http request to the docker API using the method DELETE.
-func (cli *Client) delete(path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(context.Background(), "DELETE", path, query, nil, headers)
+func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "DELETE", path, query, nil, headers)
 }
 
-func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	params, err := encodeData(body)
+func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+	body, err := encodeData(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +68,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 		headers["Content-Type"] = []string{"application/json"}
 	}
 
-	return cli.sendClientRequest(ctx, method, path, query, params, headers)
+	return cli.sendClientRequest(ctx, method, path, query, body, headers)
 }
 
 func (cli *Client) sendClientRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {

--- a/vendor/src/github.com/docker/engine-api/client/version.go
+++ b/vendor/src/github.com/docker/engine-api/client/version.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ServerVersion returns information of the docker client and server host.
-func (cli *Client) ServerVersion() (types.Version, error) {
-	resp, err := cli.get("/version", nil, nil)
+func (cli *Client) ServerVersion(ctx context.Context) (types.Version, error) {
+	resp, err := cli.get(ctx, "/version", nil, nil)
 	if err != nil {
 		return types.Version{}, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/volume_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/volume_create.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // VolumeCreate creates a volume in the docker host.
-func (cli *Client) VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error) {
+func (cli *Client) VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error) {
 	var volume types.Volume
-	resp, err := cli.post("/volumes/create", nil, options, nil)
+	resp, err := cli.post(ctx, "/volumes/create", nil, options, nil)
 	if err != nil {
 		return volume, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/volume_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/volume_inspect.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // VolumeInspect returns the information about a specific volume in the docker host.
-func (cli *Client) VolumeInspect(volumeID string) (types.Volume, error) {
+func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error) {
 	var volume types.Volume
-	resp, err := cli.get("/volumes/"+volumeID, nil, nil)
+	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return volume, volumeNotFoundError{volumeID}

--- a/vendor/src/github.com/docker/engine-api/client/volume_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/volume_list.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // VolumeList returns the volumes configured in the docker host.
-func (cli *Client) VolumeList(filter filters.Args) (types.VolumesListResponse, error) {
+func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error) {
 	var volumes types.VolumesListResponse
 	query := url.Values{}
 
@@ -20,7 +21,7 @@ func (cli *Client) VolumeList(filter filters.Args) (types.VolumesListResponse, e
 		}
 		query.Set("filters", filterJSON)
 	}
-	resp, err := cli.get("/volumes", query, nil)
+	resp, err := cli.get(ctx, "/volumes", query, nil)
 	if err != nil {
 		return volumes, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/volume_remove.go
+++ b/vendor/src/github.com/docker/engine-api/client/volume_remove.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // VolumeRemove removes a volume from the docker host.
-func (cli *Client) VolumeRemove(volumeID string) error {
-	resp, err := cli.delete("/volumes/"+volumeID, nil, nil)
+func (cli *Client) VolumeRemove(ctx context.Context, volumeID string) error {
+	resp, err := cli.delete(ctx, "/volumes/"+volumeID, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -89,6 +89,27 @@ func (n UsernsMode) Valid() bool {
 	return true
 }
 
+// Cgroup Spec represents the cgroup to use for the container.
+type CgroupSpec string
+
+func (c CgroupSpec) IsContainer() bool {
+	parts := strings.SplitN(string(c), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+func (c CgroupSpec) Valid() bool {
+	return c.IsContainer() || c == ""
+}
+
+// Container returns the name of the container whose cgroup will be used.
+func (c CgroupSpec) Container() string {
+	parts := strings.SplitN(string(c), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
 // UTSMode represents the UTS namespace of the container.
 type UTSMode string
 
@@ -215,6 +236,8 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
+	CPUCount    int64  `json:"CpuCount"`   // CPU count
+	CPUPercent  int64  `json:"CpuPercent"` // CPU percent
 	BlkioIOps   uint64 // Maximum IOps for the container system drive
 	BlkioBps    uint64 // Maximum Bytes per second for the container system drive
 	SandboxSize uint64 // System drive will be expanded to at least this size (in bytes)
@@ -252,6 +275,7 @@ type HostConfig struct {
 	ExtraHosts      []string          // List of extra hosts
 	GroupAdd        []string          // List of additional groups that the container process will run as
 	IpcMode         IpcMode           // IPC namespace to use for the container
+	Cgroup          CgroupSpec        // Cgroup to use for the container
 	Links           []string          // List of links (in the name:alias form)
 	OomScoreAdj     int               // Container preference for OOM-killing
 	PidMode         PidMode           // PID namespace to use for the container
@@ -259,7 +283,7 @@ type HostConfig struct {
 	PublishAllPorts bool              // Should docker publish all exposed port for the container
 	ReadonlyRootfs  bool              // Is the container root filesystem in read-only
 	SecurityOpt     []string          // List of string values to customize labels for MLS systems, such as SELinux.
-	StorageOpt      []string          // Storage driver options per container.
+	StorageOpt      map[string]string // Storage driver options per container.
 	Tmpfs           map[string]string `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container


### PR DESCRIPTION
Updating `engine-api` vendor to make `docker/docker` up-to-date with docker/engine-api#140 (@stevvooe). I felt this change should be vendored quick and on its own to ease the review (and the next PR that needs to vendor `engine-api`) 🐙.

Hopefully, all is green 🐸.

/cc @calavera @cpuguy83 @stevvooe @runcom @LK4D4 @tiborvass 

Signed-off-by: Vincent Demeester vincent@sbr.pm
