### PR TITLE
Move debian rules to the right place before creating the package.

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -65,7 +65,7 @@ set -e
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
 		fi
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			RUN ln -sfv hack/make/.build-deb debian
+			RUN mv -v hack/make/.build-deb debian
 			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
 			RUN dpkg-buildpackage -uc -us
 		EOF


### PR DESCRIPTION
debhelper has changed the way it performs path validations and
building the deb package fails when it tries to compress the files.

Fixes #21225

Signed-off-by: David Calavera david.calavera@gmail.com
