### PR TITLE
Consolidate security options to use `=` as separator.

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1788,17 +1788,17 @@ _docker_run() {
 			;;
 		--security-opt)
 			case "$cur" in
-				label:*:*)
+				label=*:*)
 					;;
-				label:*)
-					local cur=${cur##*:}
+				label=*)
+					local cur=${cur##*=}
 					COMPREPLY=( $( compgen -W "user: role: type: level: disable" -- "$cur") )
 					if [ "${COMPREPLY[*]}" != "disable" ] ; then
 						__docker_nospace
 					fi
 					;;
-				seccomp:*)
-					local cur=${cur##*:}
+				seccomp=*)
+					local cur=${cur##*=}
 					_filedir
 					COMPREPLY+=( $( compgen -W "unconfined" -- "$cur" ) )
 					;;

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -73,15 +73,21 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 	)
 
 	for _, opt := range config.SecurityOpt {
-		con := strings.SplitN(opt, ":", 2)
-		if len(con) == 1 {
-			switch con[0] {
-			case "no-new-privileges":
-				container.NoNewPrivileges = true
-			default:
+		if opt == "no-new-privileges" {
+			container.NoNewPrivileges = true
+		} else {
+			var con []string
+			if strings.Contains(opt, "=") {
+				con = strings.SplitN(opt, "=", 2)
+			} else if strings.Contains(opt, ":") {
+				con = strings.SplitN(opt, ":", 2)
+				logrus.Warnf("Security options with `:` as a separator are deprecated and will be completely unsupported in 1.13, use `=` instead.")
+			}
+
+			if len(con) != 2 {
 				return fmt.Errorf("Invalid --security-opt 1: %q", opt)
 			}
-		} else {
+
 			switch con[0] {
 			case "label":
 				labelOpts = append(labelOpts, con[1])

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -21,6 +21,8 @@ The following list of features are deprecated in Engine.
 
 The docker login command is removing the ability to automatically register for an account with the target registry if the given username doesn't exist. Due to this change, the email flag is no longer required, and will be deprecated.
 
+The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consinstency with other similar flags, like `--storage-opt`.
+
 ### Ambiguous event fields in API
 **Deprecated In Release: v1.10**
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -599,12 +599,12 @@ but the volume for `/bar` will not. Volumes inheritted via `--volumes-from` will
 with the same logic -- if the original volume was specified with a name it will **not** be removed.
 
 ## Security configuration
-    --security-opt="label:user:USER"   : Set the label user for the container
-    --security-opt="label:role:ROLE"   : Set the label role for the container
-    --security-opt="label:type:TYPE"   : Set the label type for the container
-    --security-opt="label:level:LEVEL" : Set the label level for the container
-    --security-opt="label:disable"     : Turn off label confinement for the container
-    --security-opt="apparmor:PROFILE"  : Set the apparmor profile to be applied
+    --security-opt="label=user:USER"   : Set the label user for the container
+    --security-opt="label=role:ROLE"   : Set the label role for the container
+    --security-opt="label=type:TYPE"   : Set the label type for the container
+    --security-opt="label=level:LEVEL" : Set the label level for the container
+    --security-opt="label=disable"     : Turn off label confinement for the container
+    --security-opt="apparmor=PROFILE"  : Set the apparmor profile to be applied
                                          to the container
     --security-opt="no-new-privileges" : Disable container processes from gaining
                                          new privileges
@@ -617,23 +617,23 @@ the `--security-opt` flag. For example, you can specify the MCS/MLS level, a
 requirement for MLS systems. Specifying the level in the following command
 allows you to share the same content between containers.
 
-    $ docker run --security-opt label:level:s0:c100,c200 -it fedora bash
+    $ docker run --security-opt label=level:s0:c100,c200 -it fedora bash
 
 An MLS example might be:
 
-    $ docker run --security-opt label:level:TopSecret -it rhel7 bash
+    $ docker run --security-opt label=level:TopSecret -it rhel7 bash
 
 To disable the security labeling for this container versus running with the
 `--permissive` flag, use the following command:
 
-    $ docker run --security-opt label:disable -it fedora bash
+    $ docker run --security-opt label=disable -it fedora bash
 
 If you want a tighter security policy on the processes within a container,
 you can specify an alternate type for the container. You could run a container
 that is only allowed to listen on Apache ports by executing the following
 command:
 
-    $ docker run --security-opt label:type:svirt_apache_t -it centos bash
+    $ docker run --security-opt label=type:svirt_apache_t -it centos bash
 
 > **Note**: You would have to write policy defining a `svirt_apache_t` type.
 
@@ -1078,7 +1078,7 @@ one can use this flag:
 > these cases to create your own custom seccomp profile based off our
 > [default](https://github.com/docker/docker/blob/master/profiles/seccomp/default.json).
 > Or if you don't want to run with the default seccomp profile, you can pass
-> `--security-opt=seccomp:unconfined` on run.
+> `--security-opt=seccomp=unconfined` on run.
 
 By default, Docker containers are "unprivileged" and cannot, for
 example, run a Docker daemon inside a Docker container. This is because

--- a/docs/security/apparmor.md
+++ b/docs/security/apparmor.md
@@ -69,7 +69,7 @@ override it with the `security-opt` option. For example, the following
 explicitly specifies the default policy:
 
 ```bash
-$ docker run --rm -it --security-opt apparmor:docker-default hello-world
+$ docker run --rm -it --security-opt apparmor=docker-default hello-world
 ```
 
 ## Loading and Unloading Profiles
@@ -83,7 +83,7 @@ $ apparmor_parser -r -W /path/to/your_profile
 Then you can run the custom profile with `--security-opt` like so:
 
 ```bash
-$ docker run --rm -it --security-opt apparmor:your_profile hello-world
+$ docker run --rm -it --security-opt apparmor=your_profile hello-world
 ```
 
 To unload a profile from AppArmor:

--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -66,7 +66,7 @@ it with the `security-opt` option. For example, the following explicitly
 specifies the default policy:
 
 ```
-$ docker run --rm -it --security-opt seccomp:/path/to/seccomp/profile.json hello-world
+$ docker run --rm -it --security-opt seccomp=/path/to/seccomp/profile.json hello-world
 ```
 
 ### Significant syscalls blocked by the default profile
@@ -138,6 +138,6 @@ You can pass `unconfined` to run a container without the default seccomp
 profile.
 
 ```
-$ docker run --rm -it --security-opt seccomp:unconfined debian:jessie \
+$ docker run --rm -it --security-opt seccomp=unconfined debian:jessie \
     unshare --map-root-user --user sh -c whoami
 ```

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2971,7 +2971,7 @@ func (s *DockerSuite) TestRunReadFilteredProc(c *check.C) {
 		name := fmt.Sprintf("procsieve-%d", i)
 		shellCmd := fmt.Sprintf("exec 3<%s", filePath)
 
-		out, exitCode, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
+		out, exitCode, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor=docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
 		if exitCode != 0 {
 			return
 		}
@@ -3006,7 +3006,7 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 
 	go func() {
 		name := "acidburn"
-		out, _, err := dockerCmdWithError("run", "--name", name, "--security-opt", "seccomp:unconfined", "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "--mount-proc=/proc", "mount")
+		out, _, err := dockerCmdWithError("run", "--name", name, "--security-opt", "seccomp=unconfined", "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "--mount-proc=/proc", "mount")
 		if err == nil ||
 			!(strings.Contains(strings.ToLower(out), "permission denied") ||
 				strings.Contains(strings.ToLower(out), "operation not permitted")) {
@@ -3018,7 +3018,7 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 
 	go func() {
 		name := "cereal"
-		out, _, err := dockerCmdWithError("run", "--name", name, "--security-opt", "seccomp:unconfined", "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
+		out, _, err := dockerCmdWithError("run", "--name", name, "--security-opt", "seccomp=unconfined", "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
 		if err == nil ||
 			!(strings.Contains(strings.ToLower(out), "mount: cannot mount none") ||
 				strings.Contains(strings.ToLower(out), "permission denied")) {
@@ -3031,7 +3031,7 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 	/* Ensure still fails if running privileged with the default policy */
 	go func() {
 		name := "crashoverride"
-		out, _, err := dockerCmdWithError("run", "--privileged", "--security-opt", "seccomp:unconfined", "--security-opt", "apparmor:docker-default", "--name", name, "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
+		out, _, err := dockerCmdWithError("run", "--privileged", "--security-opt", "seccomp=unconfined", "--security-opt", "apparmor=docker-default", "--name", name, "debian:jessie", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
 		if err == nil ||
 			!(strings.Contains(strings.ToLower(out), "mount: cannot mount none") ||
 				strings.Contains(strings.ToLower(out), "permission denied")) {
@@ -3128,7 +3128,7 @@ func (s *DockerSuite) TestRunWriteFilteredProc(c *check.C) {
 		name := fmt.Sprintf("writeprocsieve-%d", i)
 
 		shellCmd := fmt.Sprintf("exec 3>%s", filePath)
-		out, code, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
+		out, code, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor=docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
 		if code != 0 {
 			return
 		}

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -463,16 +463,18 @@ its root filesystem mounted as read only prohibiting any writes.
 **--security-opt**=[]
    Security Options
 
-   "label:user:USER"   : Set the label user for the container
-    "label:role:ROLE"   : Set the label role for the container
-    "label:type:TYPE"   : Set the label type for the container
-    "label:level:LEVEL" : Set the label level for the container
-    "label:disable"     : Turn off label confinement for the container
-
+    "label=user:USER"   : Set the label user for the container
+    "label=role:ROLE"   : Set the label role for the container
+    "label=type:TYPE"   : Set the label type for the container
+    "label=level:LEVEL" : Set the label level for the container
+    "label=disable"     : Turn off label confinement for the container
     "no-new-privileges" : Disable container processes from gaining additional privileges
 
-    "seccomp:unconfined" : Turn off seccomp confinement for the container
-    "seccomp:profile.json :  White listed syscalls seccomp Json file to be used as a seccomp filter
+    "seccomp=unconfined" : Turn off seccomp confinement for the container
+    "seccomp=profile.json :  White listed syscalls seccomp Json file to be used as a seccomp filter
+
+    "apparmor=unconfined" : Turn off apparmor confinement for the container
+    "apparmor=your-profile" : Set the apparmor confinement profile for the container
 
 **--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.
@@ -880,23 +882,23 @@ the `--security-opt` flag. For example, you can specify the MCS/MLS level, a
 requirement for MLS systems. Specifying the level in the following command
 allows you to share the same content between containers.
 
-    # docker run --security-opt label:level:s0:c100,c200 -i -t fedora bash
+    # docker run --security-opt label=level:s0:c100,c200 -i -t fedora bash
 
 An MLS example might be:
 
-    # docker run --security-opt label:level:TopSecret -i -t rhel7 bash
+    # docker run --security-opt label=level:TopSecret -i -t rhel7 bash
 
 To disable the security labeling for this container versus running with the
 `--permissive` flag, use the following command:
 
-    # docker run --security-opt label:disable -i -t fedora bash
+    # docker run --security-opt label=disable -i -t fedora bash
 
 If you want a tighter security policy on the processes within a container,
 you can specify an alternate type for the container. You could run a container
 that is only allowed to listen on Apache ports by executing the following
 command:
 
-    # docker run --security-opt label:type:svirt_apache_t -i -t centos bash
+    # docker run --security-opt label=type:svirt_apache_t -i -t centos bash
 
 Note:
 

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -508,9 +508,13 @@ func parseLoggingOpts(loggingDriver string, loggingOpts []string) (map[string]st
 // takes a local seccomp daemon, reads the file contents for sending to the daemon
 func parseSecurityOpts(securityOpts []string) ([]string, error) {
 	for key, opt := range securityOpts {
-		con := strings.SplitN(opt, ":", 2)
+		con := strings.SplitN(opt, "=", 2)
 		if len(con) == 1 && con[0] != "no-new-privileges" {
-			return securityOpts, fmt.Errorf("Invalid --security-opt: %q", opt)
+			if strings.Index(opt, ":") != -1 {
+				con = strings.SplitN(opt, ":", 2)
+			} else {
+				return securityOpts, fmt.Errorf("Invalid --security-opt: %q", opt)
+			}
 		}
 		if con[0] == "seccomp" && con[1] != "unconfined" {
 			f, err := ioutil.ReadFile(con[1])
@@ -521,7 +525,7 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 			if err := json.Compact(b, f); err != nil {
 				return securityOpts, fmt.Errorf("compacting json for seccomp profile (%s) failed: %v", con[1], err)
 			}
-			securityOpts[key] = fmt.Sprintf("seccomp:%s", b.Bytes())
+			securityOpts[key] = fmt.Sprintf("seccomp=%s", b.Bytes())
 		}
 	}
 


### PR DESCRIPTION
All other options we have use `=` as separator, labels,
log configurations, graph configurations and so on.
We should be consistent and use `=` for the security
options too.

I change the daemon parsing to accept `=`. It still
supports `:` but it logs a warning when this separator
is used.

Let's decide if we want to do this and I'll complete it
with tests and documentation changes.

Signed-off-by: David Calavera david.calavera@gmail.com
