### PR TITLE
Fix flaky test TestTransfer

### DIFF
--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -41,7 +41,7 @@ func TestTransfer(t *testing.T) {
 				if p.Current != 0 {
 					t.Fatalf("got unexpected progress value: %d (expected 0)", p.Current)
 				}
-			} else if p.Current != val+1 {
+			} else if p.Current <= val {
 				t.Fatalf("got unexpected progress value: %d (expected %d)", p.Current, val+1)
 			}
 			receivedProgress[p.ID] = p.Current


### PR DESCRIPTION
This test was checking that it received every progress update that was
produced. But delivery of these intermediate progress updates is not
guaranteed. A new update can overwrite the previous one if the previous
one hasn't been sent to the channel yet.

The call to t.Fatalf exited the current goroutine which was consuming
the channel, which caused a deadlock and eventual test timeout rather
than a proper failure message.

Failure seen here:
https://jenkins.dockerproject.org/job/Docker-PRs-experimental/16400/console
