### PR TITLE
Fix flaky test of TestRestartStoppedContainer (#21211).

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -20,6 +20,10 @@ func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
 
 	dockerCmd(c, "restart", cleanedContainerID)
 
+	// Wait until the container has stopped
+	err = waitInspect(cleanedContainerID, "{{.State.Running}}", "false", 20*time.Second)
+	c.Assert(err, checker.IsNil)
+
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 	c.Assert(out, checker.Equals, "foobar\nfoobar\n")
 }


### PR DESCRIPTION
This fix addressed the issue of test TestRestartStoppedContainer in #21211. Inside the test, a `docker restart` command is followed by a `docker logs` command. However, `docker restart` returns immediately so there is no guarantee that `docker logs` will wait until the restarted container completes the command `echo foobar`.

This fix use the check of `{{.State.Running}} = false` to make sure that the restarted container has already finished, before invoking the `docker logs` command.

This fixes #21211.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
