### PR TITLE
daemon: use 0711 for /var/lib/docker

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -870,7 +870,7 @@ func setupRemappedRoot(config *Config) ([]idtools.IDMap, []idtools.IDMap, error)
 
 func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error {
 	config.Root = rootDir
-	// the docker root metadata directory needs to have execute permissions for all users (o+x)
+	// the docker root metadata directory needs to have execute permissions for all users (g+x,o+x)
 	// so that syscalls executing as non-root, operating on subdirectories of the graph root
 	// (e.g. mounted layers of a container) can traverse this path.
 	// The user namespace support will create subdirectories for the remapped root host uid:gid
@@ -878,12 +878,12 @@ func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error
 	// layer content subtrees.
 	if _, err := os.Stat(rootDir); err == nil {
 		// root current exists; verify the access bits are correct by setting them
-		if err = os.Chmod(rootDir, 0701); err != nil {
+		if err = os.Chmod(rootDir, 0711); err != nil {
 			return err
 		}
 	} else if os.IsNotExist(err) {
-		// no root exists yet, create it 0701 with root:root ownership
-		if err := os.MkdirAll(rootDir, 0701); err != nil {
+		// no root exists yet, create it 0711 with root:root ownership
+		if err := os.MkdirAll(rootDir, 0711); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This fixes problems encountered when running with a remapped root (the
syscalls related to the metadata directory will fail under user
namespaces). Using 0711 rather than 0701 (which solved the problem
previously) fixes the issue.

Fixes #21087

![bored kitteh](http://farm5.staticflickr.com/4122/4735888531_5ee92b936a_b.jpg)

Signed-off-by: Aleksa Sarai asarai@suse.de

/cc @estesp 
