### PR TITLE
add the support for Private Registry Mirror

### DIFF
--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -45,13 +45,34 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 		return endpoints, nil
 	}
 
+	for _, mirror := range s.config.Mirrors {
+                        if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
+                                mirror = "https://" + mirror
+                        }
+                        mirrorURL, err := url.Parse(mirror)
+                        if err != nil {
+                                return nil, err
+                        }
+                        mirrorTLSConfig, err := s.tlsConfigForMirror(mirrorURL)
+                        if err != nil {
+                                return nil, err
+                        }
+                        endpoints = append(endpoints, APIEndpoint{
+                                URL: mirrorURL,
+                                // guess mirrors are v2
+                                Version:      APIVersion2,
+                                Mirror:       true,
+                                TrimHostname: true,
+                                TLSConfig:    mirrorTLSConfig,
+                        })
+	}
+	
 	tlsConfig, err = s.TLSConfig(hostname)
 	if err != nil {
 		return nil, err
 	}
 
-	endpoints = []APIEndpoint{
-		{
+	endpoints = append(endpoints, APIEndpoint{
 			URL: &url.URL{
 				Scheme: "https",
 				Host:   hostname,
@@ -59,8 +80,8 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 			Version:      APIVersion2,
 			TrimHostname: true,
 			TLSConfig:    tlsConfig,
-		},
-	}
+	})
+
 
 	if tlsConfig.InsecureSkipVerify {
 		endpoints = append(endpoints, APIEndpoint{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Ar present,it's currently not possible to mirror another private registry. Only the central Hub can be mirrored.But in the company,as you konw,there is always a need for private Hub Mirror instead of central Hub Mirror.In other words,it is useful and important to support private registry mirror! 

**\- How I did it**
By adding  the Private Registry Mirror endpoints when docker pull request has been sent for private image  
**\- How to verify it**
First of all,My Test is successful !
And,here is my configurations for Docker client,Private Registry Mirror and Registry V2 hub

1,Docker client:
The --registry-mirror option should be like:
**--registry-mirror=http://PRM_URL:5000**
(Attention:It is http instead of https,and PRM_URL is your Private Registry Mirror URL)

2.Private Registry Mirror(In short, I call it PRM)
**running in port 5000**
Here is configuration file:
**version: 0.1
log:
# level: debug

fields:
service: registry
storage:
cache:
blobdescriptor: inmemory
filesystem:
rootdirectory: /data/Registry_v2_storage
http:
addr: 0.0.0.0:5000
headers:
X-Content-Type-Options: [nosniff]
health:
storagedriver:
enabled: true
interval: 10s
threshold: 3
proxy:
remoteurl: http://your_RegistryV2_hub:5000**
(Attention:The your_RegistryV2_hub is your Registry V2 hub URL)

3.Registry V2 hub(running in port 5000)
Here is configuration file:
**version: 0.1
log:
# level: debug

fields:
service: registry
storage:
cache:
blobdescriptor: inmemory
filesystem:
rootdirectory: /data/Registry_v2_storage
http:
addr: 0.0.0.0:5000
headers:
X-Content-Type-Options: [nosniff]
health:
storagedriver:
enabled: true
interval: 10s
threshold: 3**

**\- A picture of a cute animal (not mandatory but encouraged)**
