### PR TITLE
Fix Mtim reference to allow build on OpenBSD

### DIFF
--- a/pkg/system/stat_openbsd.go
+++ b/pkg/system/stat_openbsd.go
@@ -1,5 +1,3 @@
-// +build !linux,!windows,!freebsd,!solaris,!openbsd
-
 package system
 
 import (
@@ -13,5 +11,5 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtimespec}, nil
+		mtim: s.Mtim}, nil
 }


### PR DESCRIPTION
This pull request adds a `stat_openbsd.go` file using the correct `Mtim` field of the `Stat_t` struct for OpenBSD, and adds a compilation tag to `stat_unsupported.go` to prevent using it in OpenBSD.

Compilation of the `github.com/docker/docker/pkg/system` package for OpenBSD prior to this change yields:

```
$ GOOS=openbsd go build .
./stat_unsupported.go:16: s.Mtimespec undefined (type *syscall.Stat_t has no field or method Mtimespec)
```

Compilation afterwards succeeds with the same command.

This should resolve https://github.com/fsouza/go-dockerclient/issues/296 when the vendored dependency is updated.
