### PR TITLE
Fix flaky test TestRunAttachFailedNoLeak in #21247.

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4226,6 +4226,9 @@ func (s *DockerSuite) TestRunAttachFailedNoLeak(c *check.C) {
 
 	runSleepingContainer(c, "--name=test", "-p", "8000:8000")
 
+	// Wait until container is fully up and running
+	c.Assert(waitRun("test"), check.IsNil)
+
 	out, _, err := dockerCmdWithError("run", "-p", "8000:8000", "busybox", "true")
 	c.Assert(err, checker.NotNil)
 	// check for windows error as well


### PR DESCRIPTION
The issue of the flaky test is that, when the second container starts, the first container in the detached mode may have only been created and not yet entering the running state. So the port 8000 might be used by the second container first.

This fix added a check to make sure the first container is already in running state, before the second container is invoked.

This fix fixes #21247.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
