### PR TITLE
Add new syscalls in libseccomp 2.3.0 to seccomp default profile

### DIFF
--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -127,6 +127,7 @@ the reason each syscall is blocked rather than white-listed.
 | `umount2`           | Should be a privileged operation.                                                                             |
 | `unshare`           | Deny cloning new namespaces for processes. Also gated by `CAP_SYS_ADMIN`, with the exception of `unshare --user`. |
 | `uselib`            | Older syscall related to shared libraries, unused for a long time.                                            |
+| `userfaultfd`       | Userspace page fault handling, largely needed for process migration.                                          |
 | `ustat`             | Obsolete syscall.                                                                                             |
 | `vm86`              | In kernel x86 real mode virtual machine. Also gated by `CAP_SYS_ADMIN`.                                       |
 | `vm86old`           | In kernel x86 real mode virtual machine. Also gated by `CAP_SYS_ADMIN`.                                       |

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -114,6 +114,11 @@
 			"args": []
 		},
 		{
+			"name": "copy_file_range",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
 			"name": "creat",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -710,6 +715,11 @@
 		},
 		{
 			"name": "mlock",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "mlock2",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -146,6 +146,11 @@ var DefaultProfile = &types.Seccomp{
 			Args:   []*types.Arg{},
 		},
 		{
+			Name:   "copy_file_range",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
 			Name:   "creat",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
@@ -742,6 +747,11 @@ var DefaultProfile = &types.Seccomp{
 		},
 		{
 			Name:   "mlock",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "mlock2",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 		},


### PR DESCRIPTION
This adds the following new syscalls that are supported in libseccomp 2.3.0,
including calls added up to kernel 4.5-rc4:
mlock2 - same as mlock but with a flag
copy_file_range - copy file contents, like splice but with reflink support.

The following are not added, and mentioned in docs:
userfaultfd - userspace page fault handling, mainly designed for process migration

The following are not added, only apply to less common architectures:
switch_endian
membarrier
breakpoint
set_tls
I plan to review the other architectures, some of which can now have seccomp
enabled in the build as they are now supported.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![butterfly_tongue](https://cloud.githubusercontent.com/assets/482364/13829356/7b5ca988-ebbe-11e5-9707-ad8a33ee2520.jpg)
