### PR TITLE
Adding sched_debug to the masked paths list

### DIFF
--- a/daemon/execdriver/native/template/default_template_linux.go
+++ b/daemon/execdriver/native/template/default_template_linux.go
@@ -87,6 +87,7 @@ func New() *configs.Config {
 			"/proc/kcore",
 			"/proc/latency_stats",
 			"/proc/timer_stats",
+			"/proc/sched_debug",
 		},
 		ReadonlyPaths: []string{
 			"/proc/asound",


### PR DESCRIPTION
Added `/proc/sched_debug` to the list of masked paths since it leaks information about the host. Already fixed in [runC](https://github.com/opencontainers/runc/blob/69fe79de1087d11bcae33bc776d7ce3875330860/utils.go#L128) but adding this to master shouldn't hurt.

Before:

``` bash
➜ docker run -it alpine cat /proc/sched_debug
Sched Debug Version: v0.11, 4.2.0-34-generic #39-Ubuntu
ktime                                   : 94777576.215701
sched_clk                               : 94853237.096260
cpu_clk                                 : 94853237.096297
jiffies                                 : 4318586691
sched_clock_stable()                    : 1
```

After:

``` bash
➜ docker run -it alpine cat /proc/sched_debug
➜ 
```

Signed-off-by: Diogo Monica diogo.monica@gmail.com
