### PR TITLE
Remove dockerfile dependency from the API.

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -3,9 +3,9 @@ package image
 import (
 	"io"
 
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/registry"
 )
 
@@ -19,7 +19,7 @@ type Backend interface {
 }
 
 type containerBackend interface {
-	Commit(name string, config *types.ContainerCommitConfig) (imageID string, err error)
+	Commit(name string, config *backend.ContainerCommitConfig) (imageID string, err error)
 }
 
 type imageBackend interface {
@@ -32,7 +32,7 @@ type imageBackend interface {
 
 type importExportBackend interface {
 	LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error
-	ImportImage(src string, newRef reference.Named, msg string, inConfig io.ReadCloser, outStream io.Writer, config *container.Config) error
+	ImportImage(src string, newRef reference.Named, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error
 	ExportImage(names []string, outStream io.Writer) error
 }
 

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -67,3 +67,11 @@ type ExecProcessConfig struct {
 	Privileged *bool    `json:"privileged,omitempty"`
 	User       string   `json:"user,omitempty"`
 }
+
+// ContainerCommitConfig is a wrapper around
+// types.ContainerCommitConfig that also
+// transports configuration changes for a container.
+type ContainerCommitConfig struct {
+	types.ContainerCommitConfig
+	Changes []string
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
@@ -117,7 +118,7 @@ type Backend interface {
 	// ContainerRm removes a container specified by `id`.
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	// Commit creates a new Docker image from an existing Docker container.
-	Commit(string, *types.ContainerCommitConfig) (string, error)
+	Commit(string, *backend.ContainerCommitConfig) (string, error)
 	// Kill stops the container execution abruptly.
 	ContainerKill(containerID string, sig uint64) error
 	// Start starts a new container

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
 	"github.com/docker/docker/pkg/archive"
@@ -70,10 +71,12 @@ func (b *Builder) commit(id string, autoCmd strslice.StrSlice, comment string) e
 	autoConfig := *b.runConfig
 	autoConfig.Cmd = autoCmd
 
-	commitCfg := &types.ContainerCommitConfig{
-		Author: b.maintainer,
-		Pause:  true,
-		Config: &autoConfig,
+	commitCfg := &backend.ContainerCommitConfig{
+		ContainerCommitConfig: types.ContainerCommitConfig{
+			Author: b.maintainer,
+			Pause:  true,
+			Config: &autoConfig,
+		},
 	}
 
 	// Commit the container

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
@@ -23,13 +24,17 @@ import (
 // inConfig (if src is "-"), or from a URI specified in src. Progress output is
 // written to outStream. Repository and tag names can optionally be given in
 // the repo and tag arguments, respectively.
-func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string, inConfig io.ReadCloser, outStream io.Writer, config *container.Config) error {
+func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
 	var (
 		sf   = streamformatter.NewJSONStreamFormatter()
 		rc   io.ReadCloser
 		resp *http.Response
 	)
 
+	config, err := dockerfile.BuildFromConfig(&container.Config{}, changes)
+	if err != nil {
+		return err
+	}
 	if src == "-" {
 		rc = inConfig
 	} else {


### PR DESCRIPTION
Move context parsing to the backend.

I know the `backend.ContainerCommitConfig` struct could be merged into the other
struct, but I rather focus in removing this dependency now and cleaning up
the struct later to move forward with the API cleaning.

/cc @MHBauer 

Signed-off-by: David Calavera david.calavera@gmail.com
