### PR TITLE
Update inspect/ps to properly handle bind mounts

### DIFF
--- a/api/client/formatter/custom.go
+++ b/api/client/formatter/custom.go
@@ -146,9 +146,14 @@ func (c *containerContext) Label(name string) string {
 func (c *containerContext) Mounts() string {
 	c.addHeader(mountsHeader)
 
+	var name string
 	var mounts []string
 	for _, m := range c.c.Mounts {
-		name := m.Name
+		if m.Name == "" {
+			name = m.Source
+		} else {
+			name = m.Name
+		}
 		if c.trunc {
 			name = stringutils.Truncate(name, 15)
 		}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -328,7 +328,11 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 	if ctx.filters.Include("volume") {
 		volumesByName := make(map[string]*volume.MountPoint)
 		for _, m := range container.MountPoints {
-			volumesByName[m.Name] = m
+			if m.Name != "" {
+				volumesByName[m.Name] = m
+			} else {
+				volumesByName[m.Source] = m
+			}
 		}
 
 		volumeExist := fmt.Errorf("volume mounted in container")


### PR DESCRIPTION
- updates `docker inspect` to display a bind mount source instead of the empty string when `{{.Mounts}}` is requested
- update `docker ps --filter volume=<path>` to properly match against bind mount source

ping @calavera 

![Cute](http://allthingsruby101.weebly.com/uploads/2/9/4/8/29483869/6305117_orig.jpg)
