### PR TITLE
Remove v6 IT test for experimental macvlan driver

### DIFF
--- a/integration-cli/docker_experimental_network_test.go
+++ b/integration-cli/docker_experimental_network_test.go
@@ -175,6 +175,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkMacvlanMultiSubnet(c *check.C) {
 	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", strings.TrimSpace(ip))
 	c.Assert(err, check.IsNil)
 	// verify ipv6 connectivity to the explicit --ipv6 address second to first
+	c.Skip("Temporarily skipping while invesitigating sporadic v6 CI issues")
 	_, _, err = dockerCmdWithError("exec", "second", "ping6", "-c", "1", strings.TrimSpace(ip6))
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
-Temporary until we find the source of CI/v6 issue with driver

Signed-off-by: Brent Salisbury brent@docker.com
