### PR TITLE
Fix documentation on --security-opt seccomp

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -608,6 +608,9 @@ with the same logic -- if the original volume was specified with a name it will 
                                          to the container
     --security-opt="no-new-privileges" : Disable container processes from gaining
                                          new privileges
+    --security-opt="seccomp:unconfined": Turn off seccomp confinement for the container
+    --security-opt="seccomp:profile.json: White listed syscalls seccomp Json file to be used as a seccomp filter
+
 
 You can override the default labeling scheme for each container by specifying
 the `--security-opt` flag. For example, you can specify the MCS/MLS level, a

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -316,6 +316,15 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 **--security-opt**=[]
    Security Options
 
+   "label:user:USER"   : Set the label user for the container
+    "label:role:ROLE"   : Set the label role for the container
+    "label:type:TYPE"   : Set the label type for the container
+    "label:level:LEVEL" : Set the label level for the container
+    "label:disable"     : Turn off label confinement for the container
+    "no-new-privileges" : Disable container processes from gaining additional privileges
+    "seccomp:unconfined" : Turn off seccomp confinement for the container
+    "seccomp:profile.json :  White listed syscalls seccomp Json file to be used as a seccomp filter
+
 **--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -468,8 +468,11 @@ its root filesystem mounted as read only prohibiting any writes.
     "label:type:TYPE"   : Set the label type for the container
     "label:level:LEVEL" : Set the label level for the container
     "label:disable"     : Turn off label confinement for the container
+
     "no-new-privileges" : Disable container processes from gaining additional privileges
 
+    "seccomp:unconfined" : Turn off seccomp confinement for the container
+    "seccomp:profile.json :  White listed syscalls seccomp Json file to be used as a seccomp filter
 
 **--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Missing documentation and man pages on seccomp options.
Signed-off-by: Dan Walsh dwalsh@redhat.com
