### PR TITLE
The following syscalls should not be blocked by seccomp

### DIFF
--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -1650,5 +1650,30 @@ var DefaultProfile = &types.Seccomp{
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 		},
+		{
+			Name:   "mount",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "umount2",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "reboot",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "name_to_handle_at",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "unshare",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
 	},
 }


### PR DESCRIPTION
Capbilities block these syscalls, we don not need to block using seccomp

mount, umount2, unshare, reboot and name_to_handle_at are all needed to
run systemd as pid1 in a container, they work fine with sys_admin disabled
and have functionality in the kernel that is available to a non privileged
process.  There is no easy way to discover which syscalls are blocked, so
we end up more likely with the user doing a --privileged.

With UserNamespace we want to allow users to potentially setup unshare additional
namespaces.

man reboot
...
   Behavior inside PID namespaces
       Since Linux 3.4, when reboot() is called from a PID namespace (see
       pid_namespaces(7)) other than the initial PID namespace, the effect
       of the call is to send a signal to the namespace "init" process.
       LINUX_REBOOT_CMD_RESTART and LINUX_REBOOT_CMD_RESTART2 cause a SIGHUP
       signal to be sent.  LINUX_REBOOT_CMD_POWER_OFF and
       LINUX_REBOOT_CMD_HALT cause a SIGINT signal to be sent.

Signed-off-by: Dan Walsh dwalsh@redhat.com
