### PR TITLE
pkg: truncindex: provide more info in error

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -16,16 +16,22 @@ var (
 	// ErrEmptyPrefix is an error returned if the prefix was empty.
 	ErrEmptyPrefix = errors.New("Prefix can't be empty")
 
-	// ErrAmbiguousPrefix is returned if the prefix was ambiguous
-	// (multiple ids for the prefix).
-	ErrAmbiguousPrefix = errors.New("Multiple IDs found with provided prefix")
-
 	// ErrIllegalChar is returned when a space is in the ID
 	ErrIllegalChar = errors.New("illegal character: ' '")
 
 	// ErrNotExist is returned when ID or its prefix not found in index.
 	ErrNotExist = errors.New("ID does not exist")
 )
+
+// ErrAmbiguousPrefix is returned if the prefix was ambiguous
+// (multiple ids for the prefix).
+type ErrAmbiguousPrefix struct {
+	prefix string
+}
+
+func (e ErrAmbiguousPrefix) Error() string {
+	return fmt.Sprintf("Multiple IDs found with provided prefix: %s", e.prefix)
+}
 
 // TruncIndex allows the retrieval of string identifiers by any of their unique prefixes.
 // This is used to retrieve image and container IDs by more convenient shorthand prefixes.
@@ -105,7 +111,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs
 			id = ""
-			return ErrAmbiguousPrefix
+			return ErrAmbiguousPrefix{prefix: string(prefix)}
 		}
 		id = string(prefix)
 		return nil


### PR DESCRIPTION
I got the error but I wasn't unable at all to trace it back to which container actually did that, so I'm adding a more detailed error message to debug further.

Signed-off-by: Antonio Murdaca runcom@redhat.com
