### PR TITLE
Add @programmerq to docker/docker curators

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -71,6 +71,7 @@
 	# - close an issue or pull request when it's inappropriate or off-topic
 
 		people = [
+			"programmerq",
 			"thajeztah"
 		]
 
@@ -187,6 +188,11 @@
 	Name = "Mary Anthony"
 	Email = "mary.anthony@docker.com"
 	GitHub = "moxiegirl"
+
+	[people.programmerq]
+	Name = "Jeff Anderson"
+	Email = "jeff@docker.com"
+	GitHub = "programmerq"
 
 	[people.runcom]
 	Name = "Antonio Murdaca"


### PR DESCRIPTION
I'd like to propose adding @programmerq to our list of curators.

Jeff has always been very involved in answering user questions on IRC, Google groups, forums. He offered to help triage issues on `docker/docker`.
