### PR TITLE
Set cgroup pids.max default systemd value for docker daemon

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -14,6 +14,7 @@ MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity
+TasksMax=1048576
 TimeoutStartSec=0
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Updated the docker.service file for systemd
**\- How I did it**
Typed
**\- How to verify it**
 cat /sys/fs/cgroup/pids/system.slice/docker.service/pids.max 
Should be 1048576
**\- A picture of a cute animal (not mandatory but encouraged)**

![gc-stp-2](https://cloud.githubusercontent.com/assets/4493281/13852696/4206dc4e-ec31-11e5-97c1-7b48905db4a3.jpg)

With the newer cgrouop PIDs limits in the 4.3 kernel, make sure
that the docker daemon isn't unreasonably limited.

Test failure with a basic docker command:
        'docker run --rm -p 600:800 busybox /bin/sh'

See http://man7.org/linux/man-pages/man5/systemd.resource-control.5.html

```
    TasksMax=N
       "This controls the "pids.max" control group attribute."
       "Implies 'TasksAccounting=true'"
```

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
