### PR TITLE
vendor notary for docker1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION v0.2.0
+ENV NOTARY_VERSION docker-v1.11-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -117,7 +117,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION v0.2.0
+ENV NOTARY_VERSION docker-v1.11-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -135,7 +135,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION v0.2.0
+ENV NOTARY_VERSION docker-v1.11-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -127,7 +127,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION v0.2.0
+ENV NOTARY_VERSION docker-v1.11-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -108,7 +108,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary server
-ENV NOTARY_VERSION v0.2.0
+ENV NOTARY_VERSION docker-v1.11-3
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -52,7 +52,7 @@ clone git github.com/docker/distribution d06d6d3b093302c02a93153ac7b06ebc0ffd179
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile
-clone git github.com/docker/notary v0.2.0
+clone git github.com/docker/notary docker-v1.11-3
 
 clone git google.golang.org/grpc a22b6611561e9f0a3e0919690dd2caf48f14c517 https://github.com/grpc/grpc-go.git
 clone git github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -232,6 +232,7 @@ func notaryClientEnv(cmd *exec.Cmd) {
 		fmt.Sprintf("NOTARY_ROOT_PASSPHRASE=%s", pwd),
 		fmt.Sprintf("NOTARY_TARGETS_PASSPHRASE=%s", pwd),
 		fmt.Sprintf("NOTARY_SNAPSHOT_PASSPHRASE=%s", pwd),
+		fmt.Sprintf("NOTARY_DELEGATION_PASSPHRASE=%s", pwd),
 	}
 	cmd.Env = append(os.Environ(), env...)
 }

--- a/vendor/src/github.com/docker/notary/CHANGELOG.md
+++ b/vendor/src/github.com/docker/notary/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [v0.2](https://github.com/docker/notary/releases/tag/v0.2.0) 2/24/2016
++ Add support for delegation roles in `notary` server and client
++ Add `notary CLI` commands for managing delegation roles: `notary delegation`
+    + `add`, `list` and `remove` subcommands
++ Enhance `notary CLI` commands for adding targets to delegation roles
+    + `notary add --roles` and `notary remove --roles` to manipulate targets for delegations
++ Support for rotating the snapshot key to one managed by the `notary` server
++ Add consistent download functionality to download metadata and content by checksum
++ Update `docker-compose` configuration to use official mariadb image
+    + deprecate `notarymysql`
+    + default to using a volume for `data` directory
+    + use separate databases for `notary-server` and `notary-signer` with separate users
++ Add `notary CLI` command for changing private key passphrases: `notary key passwd`
++ Enhance `notary CLI` commands for importing and exporting keys
++ Change default `notary CLI` log level to fatal, introduce new verbose (error-level) and debug-level settings
++ Store roles as PEM headers in private keys, incompatible with previous notary v0.1 key format
+    + No longer store keys as `<KEY_ID>_role.key`, instead store as `<KEY_ID>.key`; new private keys from new notary clients will crash old notary clients
++ Support logging as JSON format on server and signer
++ Support mutual TLS between notary client and notary server
+
+## [v0.1](https://github.com/docker/notary/releases/tag/v0.1) 11/15/2015
++ Initial non-alpha `notary` version
++ Implement TUF (the update framework) with support for root, targets, snapshot, and timestamp roles
++ Add PKCS11 interface to store and sign with keys in HSMs (i.e. Yubikey)

--- a/vendor/src/github.com/docker/notary/Dockerfile
+++ b/vendor/src/github.com/docker/notary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.1
+FROM golang:1.6.0
 
 RUN apt-get update && apt-get install -y \
 	libltdl-dev \
@@ -11,7 +11,5 @@ RUN go get golang.org/x/tools/cmd/vet \
 	&& go get github.com/tools/godep
 
 COPY . /go/src/github.com/docker/notary
-
-ENV GOPATH /go/src/github.com/docker/notary/Godeps/_workspace:$GOPATH
 
 WORKDIR /go/src/github.com/docker/notary

--- a/vendor/src/github.com/docker/notary/const.go
+++ b/vendor/src/github.com/docker/notary/const.go
@@ -20,6 +20,10 @@ const (
 	PubCertPerms = 0755
 	// Sha256HexSize is how big a Sha256 hex is in number of characters
 	Sha256HexSize = 64
+	// SHA256 is the name of SHA256 hash algorithm
+	SHA256 = "sha256"
+	// SHA512 is the name of SHA512 hash algorithm
+	SHA512 = "sha512"
 	// TrustedCertsDir is the directory, under the notary repo base directory, where trusted certs are stored
 	TrustedCertsDir = "trusted_certificates"
 	// PrivDir is the directory, under the notary repo base directory, where private keys are stored
@@ -38,6 +42,13 @@ const (
 	NotaryTargetsExpiry   = 3 * Year
 	NotarySnapshotExpiry  = 3 * Year
 	NotaryTimestampExpiry = 14 * Day
+
+	ConsistentMetadataCacheMaxAge = 30 * Day
+	CurrentMetadataCacheMaxAge    = 5 * time.Minute
+	// CacheMaxAgeLimit is the generally recommended maximum age for Cache-Control headers
+	// (one year, in seconds, since one year is forever in terms of internet
+	// content)
+	CacheMaxAgeLimit = 1 * Year
 )
 
 // NotaryDefaultExpiries is the construct used to configure the default expiry times of

--- a/vendor/src/github.com/docker/notary/coverpkg.sh
+++ b/vendor/src/github.com/docker/notary/coverpkg.sh
@@ -5,6 +5,6 @@
 # subpackage's dependencies within the containing package, as well as the
 # subpackage itself.
 
-DEPENDENCIES="$(go list -f $'{{range $f := .Deps}}{{$f}}\n{{end}}' ${1} | grep ${2})"
+DEPENDENCIES="$(go list -f $'{{range $f := .Deps}}{{$f}}\n{{end}}' ${1} | grep ${2} | grep -v ${2}/vendor)"
 
 echo "${1} ${DEPENDENCIES}" | xargs echo -n | tr ' ' ','

--- a/vendor/src/github.com/docker/notary/cryptoservice/crypto_service.go
+++ b/vendor/src/github.com/docker/notary/cryptoservice/crypto_service.go
@@ -3,7 +3,6 @@ package cryptoservice
 import (
 	"crypto/rand"
 	"fmt"
-	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/notary/trustmanager"
@@ -17,17 +16,16 @@ const (
 // CryptoService implements Sign and Create, holding a specific GUN and keystore to
 // operate on
 type CryptoService struct {
-	gun       string
 	keyStores []trustmanager.KeyStore
 }
 
 // NewCryptoService returns an instance of CryptoService
-func NewCryptoService(gun string, keyStores ...trustmanager.KeyStore) *CryptoService {
-	return &CryptoService{gun: gun, keyStores: keyStores}
+func NewCryptoService(keyStores ...trustmanager.KeyStore) *CryptoService {
+	return &CryptoService{keyStores: keyStores}
 }
 
 // Create is used to generate keys for targets, snapshots and timestamps
-func (cs *CryptoService) Create(role, algorithm string) (data.PublicKey, error) {
+func (cs *CryptoService) Create(role, gun, algorithm string) (data.PublicKey, error) {
 	var privKey data.PrivateKey
 	var err error
 
@@ -52,16 +50,9 @@ func (cs *CryptoService) Create(role, algorithm string) (data.PublicKey, error) 
 	}
 	logrus.Debugf("generated new %s key for role: %s and keyID: %s", algorithm, role, privKey.ID())
 
-	// Store the private key into our keystore with the name being: /GUN/ID.key with an alias of role
-	var keyPath string
-	if role == data.CanonicalRootRole {
-		keyPath = privKey.ID()
-	} else {
-		keyPath = filepath.Join(cs.gun, privKey.ID())
-	}
-
+	// Store the private key into our keystore
 	for _, ks := range cs.keyStores {
-		err = ks.AddKey(keyPath, role, privKey)
+		err = ks.AddKey(trustmanager.KeyInfo{Role: role, Gun: gun}, privKey)
 		if err == nil {
 			return data.PublicKeyFromPrivate(privKey), nil
 		}
@@ -74,23 +65,16 @@ func (cs *CryptoService) Create(role, algorithm string) (data.PublicKey, error) 
 }
 
 // GetPrivateKey returns a private key and role if present by ID.
-// It tries to get the key first without a GUN (in which case it's a root key).
-// If that fails, try to get the key with the GUN (non-root key).
-// If that fails, then we don't have the key.
 func (cs *CryptoService) GetPrivateKey(keyID string) (k data.PrivateKey, role string, err error) {
-	keyPaths := []string{keyID, filepath.Join(cs.gun, keyID)}
 	for _, ks := range cs.keyStores {
-		for _, keyPath := range keyPaths {
-			k, role, err = ks.GetKey(keyPath)
-			if err == nil {
-				return
-			}
-			switch err.(type) {
-			case trustmanager.ErrPasswordInvalid, trustmanager.ErrAttemptsExceeded:
-				return
-			default:
-				continue
-			}
+		if k, role, err = ks.GetKey(keyID); err == nil {
+			return
+		}
+		switch err.(type) {
+		case trustmanager.ErrPasswordInvalid, trustmanager.ErrAttemptsExceeded:
+			return
+		default:
+			continue
 		}
 	}
 	return // returns whatever the final values were
@@ -105,12 +89,42 @@ func (cs *CryptoService) GetKey(keyID string) data.PublicKey {
 	return data.PublicKeyFromPrivate(privKey)
 }
 
+// GetKeyInfo returns role and GUN info of a key by ID
+func (cs *CryptoService) GetKeyInfo(keyID string) (trustmanager.KeyInfo, error) {
+	for _, store := range cs.keyStores {
+		if info, err := store.GetKeyInfo(keyID); err == nil {
+			return info, nil
+		}
+	}
+	return trustmanager.KeyInfo{}, fmt.Errorf("Could not find info for keyID %s", keyID)
+}
+
 // RemoveKey deletes a key by ID
 func (cs *CryptoService) RemoveKey(keyID string) (err error) {
-	keyPaths := []string{keyID, filepath.Join(cs.gun, keyID)}
 	for _, ks := range cs.keyStores {
-		for _, keyPath := range keyPaths {
-			ks.RemoveKey(keyPath)
+		ks.RemoveKey(keyID)
+	}
+	return // returns whatever the final values were
+}
+
+// AddKey adds a private key to a specified role.
+// The GUN is inferred from the cryptoservice itself for non-root roles
+func (cs *CryptoService) AddKey(role, gun string, key data.PrivateKey) (err error) {
+	// First check if this key already exists in any of our keystores
+	for _, ks := range cs.keyStores {
+		if keyInfo, err := ks.GetKeyInfo(key.ID()); err == nil {
+			if keyInfo.Role != role {
+				return fmt.Errorf("key with same ID already exists for role: %s", keyInfo.Role)
+			}
+			logrus.Debugf("key with same ID %s and role %s already exists", key.ID(), keyInfo.Role)
+			return nil
+		}
+	}
+	// If the key didn't exist in any of our keystores, add and return on the first successful keystore
+	for _, ks := range cs.keyStores {
+		// Try to add to this keystore, return if successful
+		if err = ks.AddKey(trustmanager.KeyInfo{Role: role, Gun: gun}, key); err == nil {
+			return nil
 		}
 	}
 	return // returns whatever the final values were
@@ -121,7 +135,7 @@ func (cs *CryptoService) ListKeys(role string) []string {
 	var res []string
 	for _, ks := range cs.keyStores {
 		for k, r := range ks.ListKeys() {
-			if r == role {
+			if r.Role == role {
 				res = append(res, k)
 			}
 		}
@@ -134,7 +148,7 @@ func (cs *CryptoService) ListAllKeys() map[string]string {
 	res := make(map[string]string)
 	for _, ks := range cs.keyStores {
 		for k, r := range ks.ListKeys() {
-			res[k] = r // keys are content addressed so don't care about overwrites
+			res[k] = r.Role // keys are content addressed so don't care about overwrites
 		}
 	}
 	return res

--- a/vendor/src/github.com/docker/notary/cryptoservice/import_export.go
+++ b/vendor/src/github.com/docker/notary/cryptoservice/import_export.go
@@ -11,10 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/notary"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
-	"github.com/docker/notary/tuf/data"
 )
 
 const zipMadeByUNIX = 3 << 8
@@ -41,9 +39,6 @@ func (cs *CryptoService) ExportKey(dest io.Writer, keyID, role string) error {
 		err      error
 	)
 
-	if role != data.CanonicalRootRole {
-		keyID = filepath.Join(cs.gun, keyID)
-	}
 	for _, ks := range cs.keyStores {
 		pemBytes, err = ks.ExportKey(keyID)
 		if err != nil {
@@ -67,7 +62,12 @@ func (cs *CryptoService) ExportKey(dest io.Writer, keyID, role string) error {
 // ExportKeyReencrypt exports the specified private key to an io.Writer in
 // PEM format. The key is reencrypted with a new passphrase.
 func (cs *CryptoService) ExportKeyReencrypt(dest io.Writer, keyID string, newPassphraseRetriever passphrase.Retriever) error {
-	privateKey, role, err := cs.GetPrivateKey(keyID)
+	privateKey, _, err := cs.GetPrivateKey(keyID)
+	if err != nil {
+		return err
+	}
+
+	keyInfo, err := cs.GetKeyInfo(keyID)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (cs *CryptoService) ExportKeyReencrypt(dest io.Writer, keyID string, newPas
 		return err
 	}
 
-	err = tempKeyStore.AddKey(keyID, role, privateKey)
+	err = tempKeyStore.AddKey(keyInfo, privateKey)
 	if err != nil {
 		return err
 	}
@@ -98,56 +98,6 @@ func (cs *CryptoService) ExportKeyReencrypt(dest io.Writer, keyID string, newPas
 		return errors.New("Unable to finish writing exported key.")
 	}
 	return nil
-}
-
-// ImportRootKey imports a root in PEM format key from an io.Reader
-// It prompts for the key's passphrase to verify the data and to determine
-// the key ID.
-func (cs *CryptoService) ImportRootKey(source io.Reader) error {
-	pemBytes, err := ioutil.ReadAll(source)
-	if err != nil {
-		return err
-	}
-	return cs.ImportRoleKey(pemBytes, data.CanonicalRootRole, nil)
-}
-
-// ImportRoleKey imports a private key in PEM format key from a byte array
-// It prompts for the key's passphrase to verify the data and to determine
-// the key ID.
-func (cs *CryptoService) ImportRoleKey(pemBytes []byte, role string, newPassphraseRetriever passphrase.Retriever) error {
-	var alias string
-	var err error
-	if role == data.CanonicalRootRole {
-		alias = role
-		if err = checkRootKeyIsEncrypted(pemBytes); err != nil {
-			return err
-		}
-	} else {
-		// Parse the private key to get the key ID so that we can import it to the correct location
-		privKey, err := trustmanager.ParsePEMPrivateKey(pemBytes, "")
-		if err != nil {
-			privKey, _, err = trustmanager.GetPasswdDecryptBytes(newPassphraseRetriever, pemBytes, role, string(role))
-			if err != nil {
-				return err
-			}
-		}
-		// Since we're importing a non-root role, we need to pass the path as an alias
-		alias = filepath.Join(notary.NonRootKeysSubdir, cs.gun, privKey.ID())
-		// We also need to ensure that the role is properly set in the PEM headers
-		pemBytes, err = trustmanager.KeyToPEM(privKey, role)
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, ks := range cs.keyStores {
-		// don't redeclare err, we want the value carried out of the loop
-		if err = ks.ImportKey(pemBytes, alias); err == nil {
-			return nil //bail on the first keystore we import to
-		}
-	}
-
-	return err
 }
 
 // ExportAllKeys exports all keys to an io.Writer in zip format.
@@ -182,7 +132,7 @@ func (cs *CryptoService) ExportAllKeys(dest io.Writer, newPassphraseRetriever pa
 // ImportKeysZip imports keys from a zip file provided as an zip.Reader. The
 // keys in the root_keys directory are left encrypted, but the other keys are
 // decrypted with the specified passphrase.
-func (cs *CryptoService) ImportKeysZip(zipReader zip.Reader) error {
+func (cs *CryptoService) ImportKeysZip(zipReader zip.Reader, retriever passphrase.Retriever) error {
 	// Temporarily store the keys in maps, so we can bail early if there's
 	// an error (for example, wrong passphrase), without leaving the key
 	// store in an inconsistent state
@@ -191,7 +141,6 @@ func (cs *CryptoService) ImportKeysZip(zipReader zip.Reader) error {
 	// Iterate through the files in the archive. Don't add the keys
 	for _, f := range zipReader.File {
 		fNameTrimmed := strings.TrimSuffix(f.Name, filepath.Ext(f.Name))
-
 		rc, err := f.Open()
 		if err != nil {
 			return err
@@ -206,7 +155,7 @@ func (cs *CryptoService) ImportKeysZip(zipReader zip.Reader) error {
 		// Note that using / as a separator is okay here - the zip
 		// package guarantees that the separator will be /
 		if fNameTrimmed[len(fNameTrimmed)-5:] == "_root" {
-			if err = checkRootKeyIsEncrypted(fileBytes); err != nil {
+			if err = CheckRootKeyIsEncrypted(fileBytes); err != nil {
 				return err
 			}
 		}
@@ -214,22 +163,21 @@ func (cs *CryptoService) ImportKeysZip(zipReader zip.Reader) error {
 	}
 
 	for keyName, pemBytes := range newKeys {
-		if keyName[len(keyName)-5:] == "_root" {
-			keyName = "root"
+		// Get the key role information as well as its data.PrivateKey representation
+		_, keyInfo, err := trustmanager.KeyInfoFromPEM(pemBytes, keyName)
+		if err != nil {
+			return err
 		}
-		// try to import the key to all key stores. As long as one of them
-		// succeeds, consider it a success
-		var tmpErr error
-		for _, ks := range cs.keyStores {
-			if err := ks.ImportKey(pemBytes, keyName); err != nil {
-				tmpErr = err
-			} else {
-				tmpErr = nil
-				break
+		privKey, err := trustmanager.ParsePEMPrivateKey(pemBytes, "")
+		if err != nil {
+			privKey, _, err = trustmanager.GetPasswdDecryptBytes(retriever, pemBytes, "", "imported "+keyInfo.Role)
+			if err != nil {
+				return err
 			}
 		}
-		if tmpErr != nil {
-			return tmpErr
+		// Add the key to our cryptoservice, will add to the first successful keystore
+		if err = cs.AddKey(keyInfo.Role, keyInfo.Gun, privKey); err != nil {
+			return err
 		}
 	}
 
@@ -271,18 +219,18 @@ func (cs *CryptoService) ExportKeysByGUN(dest io.Writer, gun string, passphraseR
 }
 
 func moveKeysByGUN(oldKeyStore, newKeyStore trustmanager.KeyStore, gun string) error {
-	for relKeyPath := range oldKeyStore.ListKeys() {
+	for keyID, keyInfo := range oldKeyStore.ListKeys() {
 		// Skip keys that aren't associated with this GUN
-		if !strings.HasPrefix(relKeyPath, filepath.FromSlash(gun)) {
+		if keyInfo.Gun != gun {
 			continue
 		}
 
-		privKey, alias, err := oldKeyStore.GetKey(relKeyPath)
+		privKey, _, err := oldKeyStore.GetKey(keyID)
 		if err != nil {
 			return err
 		}
 
-		err = newKeyStore.AddKey(relKeyPath, alias, privKey)
+		err = newKeyStore.AddKey(keyInfo, privKey)
 		if err != nil {
 			return err
 		}
@@ -292,13 +240,13 @@ func moveKeysByGUN(oldKeyStore, newKeyStore trustmanager.KeyStore, gun string) e
 }
 
 func moveKeys(oldKeyStore, newKeyStore trustmanager.KeyStore) error {
-	for f := range oldKeyStore.ListKeys() {
-		privateKey, role, err := oldKeyStore.GetKey(f)
+	for keyID, keyInfo := range oldKeyStore.ListKeys() {
+		privateKey, _, err := oldKeyStore.GetKey(keyID)
 		if err != nil {
 			return err
 		}
 
-		err = newKeyStore.AddKey(f, role, privateKey)
+		err = newKeyStore.AddKey(keyInfo, privateKey)
 
 		if err != nil {
 			return err
@@ -349,9 +297,9 @@ func addKeysToArchive(zipWriter *zip.Writer, newKeyStore *trustmanager.KeyFileSt
 	return nil
 }
 
-// checkRootKeyIsEncrypted makes sure the root key is encrypted. We have
+// CheckRootKeyIsEncrypted makes sure the root key is encrypted. We have
 // internal assumptions that depend on this.
-func checkRootKeyIsEncrypted(pemBytes []byte) error {
+func CheckRootKeyIsEncrypted(pemBytes []byte) error {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return ErrNoValidPrivateKey

--- a/vendor/src/github.com/docker/notary/server.Dockerfile
+++ b/vendor/src/github.com/docker/notary/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.3
+FROM golang:1.6.0
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apt-get update && apt-get install -y \
@@ -12,9 +12,6 @@ EXPOSE 4443
 RUN go get github.com/mattes/migrate
 
 ENV NOTARYPKG github.com/docker/notary
-ENV GOPATH /go/src/${NOTARYPKG}/Godeps/_workspace:$GOPATH
-
-
 
 # Copy the local repo to the expected go path
 COPY . /go/src/github.com/docker/notary

--- a/vendor/src/github.com/docker/notary/signer.Dockerfile
+++ b/vendor/src/github.com/docker/notary/signer.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.3
+FROM golang:1.6.0
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
 RUN apt-get update && apt-get install -y \
@@ -12,7 +12,6 @@ EXPOSE 4444
 RUN go get github.com/mattes/migrate
 
 ENV NOTARYPKG github.com/docker/notary
-ENV GOPATH /go/src/${NOTARYPKG}/Godeps/_workspace:$GOPATH
 ENV NOTARY_SIGNER_DEFAULT_ALIAS="timestamp_1"
 ENV NOTARY_SIGNER_TIMESTAMP_1="testpassword"
 

--- a/vendor/src/github.com/docker/notary/trustmanager/keyfilestore.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/keyfilestore.go
@@ -13,12 +13,15 @@ import (
 	"github.com/docker/notary/tuf/data"
 )
 
+type keyInfoMap map[string]KeyInfo
+
 // KeyFileStore persists and manages private keys on disk
 type KeyFileStore struct {
 	sync.Mutex
 	SimpleFileStore
 	passphrase.Retriever
 	cachedKeys map[string]*cachedKey
+	keyInfoMap
 }
 
 // KeyMemoryStore manages private keys in memory
@@ -27,6 +30,14 @@ type KeyMemoryStore struct {
 	MemoryFileStore
 	passphrase.Retriever
 	cachedKeys map[string]*cachedKey
+	keyInfoMap
+}
+
+// KeyInfo stores the role, path, and gun for a corresponding private key ID
+// It is assumed that each private key ID is unique
+type KeyInfo struct {
+	Gun  string
+	Role string
 }
 
 // NewKeyFileStore returns a new KeyFileStore creating a private directory to
@@ -38,10 +49,93 @@ func NewKeyFileStore(baseDir string, passphraseRetriever passphrase.Retriever) (
 		return nil, err
 	}
 	cachedKeys := make(map[string]*cachedKey)
+	keyInfoMap := make(keyInfoMap)
 
-	return &KeyFileStore{SimpleFileStore: *fileStore,
+	keyStore := &KeyFileStore{SimpleFileStore: *fileStore,
 		Retriever:  passphraseRetriever,
-		cachedKeys: cachedKeys}, nil
+		cachedKeys: cachedKeys,
+		keyInfoMap: keyInfoMap,
+	}
+
+	// Load this keystore's ID --> gun/role map
+	keyStore.loadKeyInfo()
+	return keyStore, nil
+}
+
+func generateKeyInfoMap(s LimitedFileStore) map[string]KeyInfo {
+	keyInfoMap := make(map[string]KeyInfo)
+	for _, keyPath := range s.ListFiles() {
+		d, err := s.Get(keyPath)
+		if err != nil {
+			logrus.Error(err)
+			continue
+		}
+		keyID, keyInfo, err := KeyInfoFromPEM(d, keyPath)
+		if err != nil {
+			logrus.Error(err)
+			continue
+		}
+		keyInfoMap[keyID] = keyInfo
+	}
+	return keyInfoMap
+}
+
+// Attempts to infer the keyID, role, and GUN from the specified key path.
+// Note that non-root roles can only be inferred if this is a legacy style filename: KEYID_ROLE.key
+func inferKeyInfoFromKeyPath(keyPath string) (string, string, string) {
+	var keyID, role, gun string
+	keyID = filepath.Base(keyPath)
+	underscoreIndex := strings.LastIndex(keyID, "_")
+
+	// This is the legacy KEYID_ROLE filename
+	// The keyID is the first part of the keyname
+	// The keyRole is the second part of the keyname
+	// in a key named abcde_root, abcde is the keyID and root is the KeyAlias
+	if underscoreIndex != -1 {
+		role = keyID[underscoreIndex+1:]
+		keyID = keyID[:underscoreIndex]
+	}
+
+	if filepath.HasPrefix(keyPath, notary.RootKeysSubdir+"/") {
+		return keyID, data.CanonicalRootRole, ""
+	}
+
+	keyPath = strings.TrimPrefix(keyPath, notary.NonRootKeysSubdir+"/")
+	gun = getGunFromFullID(keyPath)
+	return keyID, role, gun
+}
+
+func getGunFromFullID(fullKeyID string) string {
+	keyGun := filepath.Dir(fullKeyID)
+	// If the gun is empty, Dir will return .
+	if keyGun == "." {
+		keyGun = ""
+	}
+	return keyGun
+}
+
+func (s *KeyFileStore) loadKeyInfo() {
+	s.keyInfoMap = generateKeyInfoMap(s)
+}
+
+func (s *KeyMemoryStore) loadKeyInfo() {
+	s.keyInfoMap = generateKeyInfoMap(s)
+}
+
+// GetKeyInfo returns the corresponding gun and role key info for a keyID
+func (s *KeyFileStore) GetKeyInfo(keyID string) (KeyInfo, error) {
+	if info, ok := s.keyInfoMap[keyID]; ok {
+		return info, nil
+	}
+	return KeyInfo{}, fmt.Errorf("Could not find info for keyID %s", keyID)
+}
+
+// GetKeyInfo returns the corresponding gun and role key info for a keyID
+func (s *KeyMemoryStore) GetKeyInfo(keyID string) (KeyInfo, error) {
+	if info, ok := s.keyInfoMap[keyID]; ok {
+		return info, nil
+	}
+	return KeyInfo{}, fmt.Errorf("Could not find info for keyID %s", keyID)
 }
 
 // Name returns a user friendly name for the location this store
@@ -51,45 +145,63 @@ func (s *KeyFileStore) Name() string {
 }
 
 // AddKey stores the contents of a PEM-encoded private key as a PEM block
-func (s *KeyFileStore) AddKey(name, role string, privKey data.PrivateKey) error {
+func (s *KeyFileStore) AddKey(keyInfo KeyInfo, privKey data.PrivateKey) error {
 	s.Lock()
 	defer s.Unlock()
-	return addKey(s, s.Retriever, s.cachedKeys, name, role, privKey)
+	if keyInfo.Role == data.CanonicalRootRole || data.IsDelegation(keyInfo.Role) || !data.ValidRole(keyInfo.Role) {
+		keyInfo.Gun = ""
+	}
+	err := addKey(s, s.Retriever, s.cachedKeys, filepath.Join(keyInfo.Gun, privKey.ID()), keyInfo.Role, privKey)
+	if err != nil {
+		return err
+	}
+	s.keyInfoMap[privKey.ID()] = keyInfo
+	return nil
 }
 
 // GetKey returns the PrivateKey given a KeyID
 func (s *KeyFileStore) GetKey(name string) (data.PrivateKey, string, error) {
 	s.Lock()
 	defer s.Unlock()
+	// If this is a bare key ID without the gun, prepend the gun so the filestore lookup succeeds
+	if keyInfo, ok := s.keyInfoMap[name]; ok {
+		name = filepath.Join(keyInfo.Gun, name)
+	}
 	return getKey(s, s.Retriever, s.cachedKeys, name)
 }
 
-// ListKeys returns a list of unique PublicKeys present on the KeyFileStore.
-func (s *KeyFileStore) ListKeys() map[string]string {
-	return listKeys(s)
+// ListKeys returns a list of unique PublicKeys present on the KeyFileStore, by returning a copy of the keyInfoMap
+func (s *KeyFileStore) ListKeys() map[string]KeyInfo {
+	return copyKeyInfoMap(s.keyInfoMap)
 }
 
 // RemoveKey removes the key from the keyfilestore
-func (s *KeyFileStore) RemoveKey(name string) error {
+func (s *KeyFileStore) RemoveKey(keyID string) error {
 	s.Lock()
 	defer s.Unlock()
-	return removeKey(s, s.cachedKeys, name)
+	// If this is a bare key ID without the gun, prepend the gun so the filestore lookup succeeds
+	if keyInfo, ok := s.keyInfoMap[keyID]; ok {
+		keyID = filepath.Join(keyInfo.Gun, keyID)
+	}
+	err := removeKey(s, s.cachedKeys, keyID)
+	if err != nil {
+		return err
+	}
+	// Remove this key from our keyInfo map if we removed from our filesystem
+	delete(s.keyInfoMap, filepath.Base(keyID))
+	return nil
 }
 
-// ExportKey exportes the encrypted bytes from the keystore and writes it to
-// dest.
-func (s *KeyFileStore) ExportKey(name string) ([]byte, error) {
-	keyBytes, _, err := getRawKey(s, name)
+// ExportKey exports the encrypted bytes from the keystore
+func (s *KeyFileStore) ExportKey(keyID string) ([]byte, error) {
+	if keyInfo, ok := s.keyInfoMap[keyID]; ok {
+		keyID = filepath.Join(keyInfo.Gun, keyID)
+	}
+	keyBytes, _, err := getRawKey(s, keyID)
 	if err != nil {
 		return nil, err
 	}
 	return keyBytes, nil
-}
-
-// ImportKey imports the private key in the encrypted bytes into the keystore
-// with the given key ID and alias.
-func (s *KeyFileStore) ImportKey(pemBytes []byte, alias string) error {
-	return importKey(s, s.Retriever, s.cachedKeys, alias, pemBytes)
 }
 
 // NewKeyMemoryStore returns a new KeyMemoryStore which holds keys in memory
@@ -97,9 +209,17 @@ func NewKeyMemoryStore(passphraseRetriever passphrase.Retriever) *KeyMemoryStore
 	memStore := NewMemoryFileStore()
 	cachedKeys := make(map[string]*cachedKey)
 
-	return &KeyMemoryStore{MemoryFileStore: *memStore,
+	keyInfoMap := make(keyInfoMap)
+
+	keyStore := &KeyMemoryStore{MemoryFileStore: *memStore,
 		Retriever:  passphraseRetriever,
-		cachedKeys: cachedKeys}
+		cachedKeys: cachedKeys,
+		keyInfoMap: keyInfoMap,
+	}
+
+	// Load this keystore's ID --> gun/role map
+	keyStore.loadKeyInfo()
+	return keyStore
 }
 
 // Name returns a user friendly name for the location this store
@@ -109,45 +229,84 @@ func (s *KeyMemoryStore) Name() string {
 }
 
 // AddKey stores the contents of a PEM-encoded private key as a PEM block
-func (s *KeyMemoryStore) AddKey(name, alias string, privKey data.PrivateKey) error {
+func (s *KeyMemoryStore) AddKey(keyInfo KeyInfo, privKey data.PrivateKey) error {
 	s.Lock()
 	defer s.Unlock()
-	return addKey(s, s.Retriever, s.cachedKeys, name, alias, privKey)
+	if keyInfo.Role == data.CanonicalRootRole || data.IsDelegation(keyInfo.Role) || !data.ValidRole(keyInfo.Role) {
+		keyInfo.Gun = ""
+	}
+	err := addKey(s, s.Retriever, s.cachedKeys, filepath.Join(keyInfo.Gun, privKey.ID()), keyInfo.Role, privKey)
+	if err != nil {
+		return err
+	}
+	s.keyInfoMap[privKey.ID()] = keyInfo
+	return nil
 }
 
 // GetKey returns the PrivateKey given a KeyID
 func (s *KeyMemoryStore) GetKey(name string) (data.PrivateKey, string, error) {
 	s.Lock()
 	defer s.Unlock()
+	// If this is a bare key ID without the gun, prepend the gun so the filestore lookup succeeds
+	if keyInfo, ok := s.keyInfoMap[name]; ok {
+		name = filepath.Join(keyInfo.Gun, name)
+	}
 	return getKey(s, s.Retriever, s.cachedKeys, name)
 }
 
-// ListKeys returns a list of unique PublicKeys present on the KeyFileStore.
-func (s *KeyMemoryStore) ListKeys() map[string]string {
-	return listKeys(s)
+// ListKeys returns a list of unique PublicKeys present on the KeyFileStore, by returning a copy of the keyInfoMap
+func (s *KeyMemoryStore) ListKeys() map[string]KeyInfo {
+	return copyKeyInfoMap(s.keyInfoMap)
+}
+
+// copyKeyInfoMap returns a deep copy of the passed-in keyInfoMap
+func copyKeyInfoMap(keyInfoMap map[string]KeyInfo) map[string]KeyInfo {
+	copyMap := make(map[string]KeyInfo)
+	for keyID, keyInfo := range keyInfoMap {
+		copyMap[keyID] = KeyInfo{Role: keyInfo.Role, Gun: keyInfo.Gun}
+	}
+	return copyMap
 }
 
 // RemoveKey removes the key from the keystore
-func (s *KeyMemoryStore) RemoveKey(name string) error {
+func (s *KeyMemoryStore) RemoveKey(keyID string) error {
 	s.Lock()
 	defer s.Unlock()
-	return removeKey(s, s.cachedKeys, name)
+	// If this is a bare key ID without the gun, prepend the gun so the filestore lookup succeeds
+	if keyInfo, ok := s.keyInfoMap[keyID]; ok {
+		keyID = filepath.Join(keyInfo.Gun, keyID)
+	}
+	err := removeKey(s, s.cachedKeys, keyID)
+	if err != nil {
+		return err
+	}
+	// Remove this key from our keyInfo map if we removed from our filesystem
+	delete(s.keyInfoMap, filepath.Base(keyID))
+	return nil
 }
 
-// ExportKey exportes the encrypted bytes from the keystore and writes it to
-// dest.
-func (s *KeyMemoryStore) ExportKey(name string) ([]byte, error) {
-	keyBytes, _, err := getRawKey(s, name)
+// ExportKey exports the encrypted bytes from the keystore
+func (s *KeyMemoryStore) ExportKey(keyID string) ([]byte, error) {
+	keyBytes, _, err := getRawKey(s, keyID)
 	if err != nil {
 		return nil, err
 	}
 	return keyBytes, nil
 }
 
-// ImportKey imports the private key in the encrypted bytes into the keystore
-// with the given key ID and alias.
-func (s *KeyMemoryStore) ImportKey(pemBytes []byte, alias string) error {
-	return importKey(s, s.Retriever, s.cachedKeys, alias, pemBytes)
+// KeyInfoFromPEM attempts to get a keyID and KeyInfo from the filename and PEM bytes of a key
+func KeyInfoFromPEM(pemBytes []byte, filename string) (string, KeyInfo, error) {
+	keyID, role, gun := inferKeyInfoFromKeyPath(filename)
+	if role == "" {
+		block, _ := pem.Decode(pemBytes)
+		if block == nil {
+			return "", KeyInfo{}, fmt.Errorf("could not decode PEM block for key %s", filename)
+		}
+		if keyRole, ok := block.Headers["role"]; ok {
+			role = keyRole
+		}
+	}
+	return keyID, KeyInfo{Gun: gun, Role: role}, nil
 }
 
 func addKey(s LimitedFileStore, passphraseRetriever passphrase.Retriever, cachedKeys map[string]*cachedKey, name, role string, privKey data.PrivateKey) error {
@@ -229,50 +388,6 @@ func getKey(s LimitedFileStore, passphraseRetriever passphrase.Retriever, cached
 	return privKey, keyAlias, nil
 }
 
-// ListKeys returns a map of unique PublicKeys present on the KeyFileStore and
-// their corresponding aliases.
-func listKeys(s LimitedFileStore) map[string]string {
-	keyIDMap := make(map[string]string)
-
-	for _, f := range s.ListFiles() {
-		// Remove the prefix of the directory from the filename
-		var keyIDFull string
-		if strings.HasPrefix(f, notary.RootKeysSubdir+"/") {
-			keyIDFull = strings.TrimPrefix(f, notary.RootKeysSubdir+"/")
-		} else {
-			keyIDFull = strings.TrimPrefix(f, notary.NonRootKeysSubdir+"/")
-		}
-
-		keyIDFull = strings.TrimSpace(keyIDFull)
-
-		// If the key does not have a _, we'll attempt to
-		// read it as a PEM
-		underscoreIndex := strings.LastIndex(keyIDFull, "_")
-		if underscoreIndex == -1 {
-			d, err := s.Get(f)
-			if err != nil {
-				logrus.Error(err)
-				continue
-			}
-			block, _ := pem.Decode(d)
-			if block == nil {
-				continue
-			}
-			if role, ok := block.Headers["role"]; ok {
-				keyIDMap[keyIDFull] = role
-			}
-		} else {
-			// The keyID is the first part of the keyname
-			// The KeyAlias is the second part of the keyname
-			// in a key named abcde_root, abcde is the keyID and root is the KeyAlias
-			keyID := keyIDFull[:underscoreIndex]
-			keyAlias := keyIDFull[underscoreIndex+1:]
-			keyIDMap[keyID] = keyAlias
-		}
-	}
-	return keyIDMap
-}
-
 // RemoveKey removes the key from the keyfilestore
 func removeKey(s LimitedFileStore, cachedKeys map[string]*cachedKey, name string) error {
 	role, legacy, err := getKeyRole(s, name)
@@ -296,7 +411,7 @@ func removeKey(s LimitedFileStore, cachedKeys map[string]*cachedKey, name string
 
 // Assumes 2 subdirectories, 1 containing root keys and 1 containing tuf keys
 func getSubdir(alias string) string {
-	if alias == "root" {
+	if alias == data.CanonicalRootRole {
 		return notary.RootKeysSubdir
 	}
 	return notary.NonRootKeysSubdir
@@ -379,22 +494,4 @@ func encryptAndAddKey(s LimitedFileStore, passwd string, cachedKeys map[string]*
 
 	cachedKeys[name] = &cachedKey{alias: role, key: privKey}
 	return s.Add(filepath.Join(getSubdir(role), name), pemPrivKey)
-}
-
-func importKey(s LimitedFileStore, passphraseRetriever passphrase.Retriever, cachedKeys map[string]*cachedKey, alias string, pemBytes []byte) error {
-
-	if alias != data.CanonicalRootRole {
-		return s.Add(alias, pemBytes)
-	}
-
-	privKey, passphrase, err := GetPasswdDecryptBytes(
-		passphraseRetriever, pemBytes, "", "imported "+alias)
-
-	if err != nil {
-		return err
-	}
-
-	var name string
-	name = privKey.ID()
-	return encryptAndAddKey(s, passphrase, cachedKeys, name, alias, privKey)
 }

--- a/vendor/src/github.com/docker/notary/trustmanager/keystore.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/keystore.go
@@ -40,14 +40,14 @@ const (
 
 // KeyStore is a generic interface for private key storage
 type KeyStore interface {
-	// Add Key adds a key to the KeyStore, and if the key already exists,
+	// AddKey adds a key to the KeyStore, and if the key already exists,
 	// succeeds.  Otherwise, returns an error if it cannot add.
-	AddKey(name, alias string, privKey data.PrivateKey) error
-	GetKey(name string) (data.PrivateKey, string, error)
-	ListKeys() map[string]string
-	RemoveKey(name string) error
-	ExportKey(name string) ([]byte, error)
-	ImportKey(pemBytes []byte, alias string) error
+	AddKey(keyInfo KeyInfo, privKey data.PrivateKey) error
+	GetKey(keyID string) (data.PrivateKey, string, error)
+	GetKeyInfo(keyID string) (KeyInfo, error)
+	ListKeys() map[string]KeyInfo
+	RemoveKey(keyID string) error
+	ExportKey(keyID string) ([]byte, error)
 	Name() string
 }
 

--- a/vendor/src/github.com/docker/notary/trustmanager/x509utils.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/x509utils.go
@@ -517,7 +517,7 @@ func EncryptPrivateKey(key data.PrivateKey, role, passphrase string) ([]byte, er
 // ReadRoleFromPEM returns the value from the role PEM header, if it exists
 func ReadRoleFromPEM(pemBytes []byte) string {
 	pemBlock, _ := pem.Decode(pemBytes)
-	if pemBlock.Headers == nil {
+	if pemBlock == nil || pemBlock.Headers == nil {
 		return ""
 	}
 	role, ok := pemBlock.Headers["role"]

--- a/vendor/src/github.com/docker/notary/tuf/data/root.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/root.go
@@ -129,7 +129,7 @@ func (r SignedRoot) ToSigned() (*Signed, error) {
 	copy(sigs, r.Signatures)
 	return &Signed{
 		Signatures: sigs,
-		Signed:     signed,
+		Signed:     &signed,
 	}, nil
 }
 
@@ -146,7 +146,7 @@ func (r SignedRoot) MarshalJSON() ([]byte, error) {
 // that it is a valid SignedRoot
 func RootFromSigned(s *Signed) (*SignedRoot, error) {
 	r := Root{}
-	if err := defaultSerializer.Unmarshal(s.Signed, &r); err != nil {
+	if err := defaultSerializer.Unmarshal(*s.Signed, &r); err != nil {
 		return nil, err
 	}
 	if err := isValidRootStructure(r); err != nil {

--- a/vendor/src/github.com/docker/notary/tuf/data/targets.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/targets.go
@@ -162,7 +162,7 @@ func (t *SignedTargets) ToSigned() (*Signed, error) {
 	copy(sigs, t.Signatures)
 	return &Signed{
 		Signatures: sigs,
-		Signed:     signed,
+		Signed:     &signed,
 	}, nil
 }
 
@@ -179,7 +179,7 @@ func (t *SignedTargets) MarshalJSON() ([]byte, error) {
 // a role name (so it can validate the SignedTargets object)
 func TargetsFromSigned(s *Signed, roleName string) (*SignedTargets, error) {
 	t := Targets{}
-	if err := defaultSerializer.Unmarshal(s.Signed, &t); err != nil {
+	if err := defaultSerializer.Unmarshal(*s.Signed, &t); err != nil {
 		return nil, err
 	}
 	if err := isValidTargetsStructure(t, roleName); err != nil {

--- a/vendor/src/github.com/docker/notary/tuf/signed/ed25519.go
+++ b/vendor/src/github.com/docker/notary/tuf/signed/ed25519.go
@@ -3,10 +3,7 @@ package signed
 import (
 	"crypto/rand"
 	"errors"
-	"io"
-	"io/ioutil"
 
-	"github.com/agl/ed25519"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
 )
@@ -27,6 +24,12 @@ func NewEd25519() *Ed25519 {
 	return &Ed25519{
 		make(map[string]edCryptoKey),
 	}
+}
+
+// AddKey allows you to add a private key
+func (e *Ed25519) AddKey(role, gun string, k data.PrivateKey) error {
+	e.addKey(role, k)
+	return nil
 }
 
 // addKey allows you to add a private key
@@ -64,7 +67,7 @@ func (e *Ed25519) ListAllKeys() map[string]string {
 }
 
 // Create generates a new key and returns the public part
-func (e *Ed25519) Create(role, algorithm string) (data.PublicKey, error) {
+func (e *Ed25519) Create(role, gun, algorithm string) (data.PublicKey, error) {
 	if algorithm != data.ED25519Key {
 		return nil, errors.New("only ED25519 supported by this cryptoservice")
 	}
@@ -101,23 +104,4 @@ func (e *Ed25519) GetPrivateKey(keyID string) (data.PrivateKey, string, error) {
 		return k.privKey, k.role, nil
 	}
 	return nil, "", trustmanager.ErrKeyNotFound{KeyID: keyID}
-}
-
-// ImportRootKey adds an Ed25519 key to the store as a root key
-func (e *Ed25519) ImportRootKey(r io.Reader) error {
-	raw, err := ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	dataSize := ed25519.PublicKeySize + ed25519.PrivateKeySize
-	if len(raw) < dataSize || len(raw) > dataSize {
-		return errors.New("Wrong length of data for Ed25519 Key Import")
-	}
-	public := data.NewED25519PublicKey(raw[:ed25519.PublicKeySize])
-	private, err := data.NewED25519PrivateKey(*public, raw[ed25519.PublicKeySize:])
-	e.keys[private.ID()] = edCryptoKey{
-		role:    "root",
-		privKey: private,
-	}
-	return nil
 }

--- a/vendor/src/github.com/docker/notary/tuf/signed/interface.go
+++ b/vendor/src/github.com/docker/notary/tuf/signed/interface.go
@@ -2,7 +2,6 @@ package signed
 
 import (
 	"github.com/docker/notary/tuf/data"
-	"io"
 )
 
 // KeyService provides management of keys locally. It will never
@@ -11,9 +10,10 @@ import (
 type KeyService interface {
 	// Create issues a new key pair and is responsible for loading
 	// the private key into the appropriate signing service.
-	// The role isn't currently used for anything, but it's here to support
-	// future features
-	Create(role, algorithm string) (data.PublicKey, error)
+	Create(role, gun, algorithm string) (data.PublicKey, error)
+
+	// AddKey adds a private key to the specified role and gun
+	AddKey(role, gun string, key data.PrivateKey) error
 
 	// GetKey retrieves the public key if present, otherwise it returns nil
 	GetKey(keyID string) data.PublicKey
@@ -30,10 +30,6 @@ type KeyService interface {
 
 	// ListAllKeys returns a map of all available signing key IDs to role
 	ListAllKeys() map[string]string
-
-	// ImportRootKey imports a root key to the highest priority keystore associated with
-	// the cryptoservice
-	ImportRootKey(source io.Reader) error
 }
 
 // CryptoService is deprecated and all instances of its use should be

--- a/vendor/src/github.com/docker/notary/tuf/utils/utils.go
+++ b/vendor/src/github.com/docker/notary/tuf/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/tls"
@@ -32,24 +31,6 @@ func Upload(url string, body io.Reader) (*http.Response, error) {
 	}
 	client := &http.Client{Transport: tr}
 	return client.Post(url, "application/json", body)
-}
-
-// ValidateTarget ensures that the data read from reader matches
-// the known metadata
-func ValidateTarget(r io.Reader, m *data.FileMeta) error {
-	h := sha256.New()
-	length, err := io.Copy(h, r)
-	if err != nil {
-		return err
-	}
-	if length != m.Length {
-		return fmt.Errorf("Size of downloaded target did not match targets entry.\nExpected: %d\nReceived: %d\n", m.Length, length)
-	}
-	hashDigest := h.Sum(nil)
-	if bytes.Compare(m.Hashes["sha256"], hashDigest[:]) != 0 {
-		return fmt.Errorf("Hash of downloaded target did not match targets entry.\nExpected: %x\nReceived: %x\n", m.Hashes["sha256"], hashDigest)
-	}
-	return nil
 }
 
 // StrSliceContains checks if the given string appears in the slice


### PR DESCRIPTION
This vendors Notary for Docker 1.11 -- this version of Notary doesn't fallback when attempting to sign delegation roles, and instead leaves this logic to Docker (handled in #21046). Also general improvements  and fixes around error messaging, passphrase handling, and metadata manipulation and validation.

<img src="https://s-media-cache-ak0.pinimg.com/236x/ae/25/d7/ae25d7219f25a819681481c16829f9ac.jpg">

Signed-off-by: Riyaz Faizullabhoy riyaz.faizullabhoy@docker.com
