### PR TITLE
Fix a couple of races in the journald log reader

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -173,6 +173,9 @@ drain:
 }
 
 func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.ReadConfig, j *C.sd_journal, pfd [2]C.int, cursor string) {
+	s.readers.mu.Lock()
+	s.readers.readers[logWatcher] = logWatcher
+	s.readers.mu.Unlock()
 	go func() {
 		// Keep copying journal data out until we're notified to stop.
 		for C.wait_for_data_or_close(j, pfd[0]) == 1 {
@@ -184,9 +187,6 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 		delete(s.readers.readers, logWatcher)
 		s.readers.mu.Unlock()
 	}()
-	s.readers.mu.Lock()
-	s.readers.readers[logWatcher] = logWatcher
-	s.readers.mu.Unlock()
 	// Wait until we're told to stop.
 	select {
 	case <-logWatcher.WatchClose():


### PR DESCRIPTION
We started seeing sporadic crashes when we started making heavier use of journald logging and log reading (https://bugzilla.redhat.com/show_bug.cgi?id=1314463), and investigating it turned up a couple of races in the reading logic.  This pair of patches should fix them.
