### PR TITLE
Fixing logs file handle leak.

### DIFF
--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -84,6 +84,7 @@ func (daemon *Daemon) ContainerLogs(containerName string, config *backend.Contai
 		case msg, ok := <-logs.Msg:
 			if !ok {
 				logrus.Debugf("logs: end stream")
+				logs.Close()
 				return nil
 			}
 			logLine := msg.Line


### PR DESCRIPTION
@jhowardmsft @jstarks 
Docker logs was only closing the logger when the HTTP response writer received a close notification, however in non-follow mode the writer never receives a close. This means that the daemon would leak the file handle to the log, preventing the container from being removed on Windows (file in use error). This change explicitly closes the log when the end of stream is hit.

This fixes https://github.com/docker/docker/issues/21231.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
