### PR TITLE
Add documentation on the stack trace dump capability of the daemon

### DIFF
--- a/docs/admin/configuring.md
+++ b/docs/admin/configuring.md
@@ -61,6 +61,24 @@ These options :
 The command line reference has the [complete list of daemon flags](../reference/commandline/daemon.md)
 with explanations.
 
+### Daemon debugging
+
+As noted above, setting the log level of the daemon to "debug" or enabling debug mode
+with `-D` allows the administrator or operator to gain much more knowledge about the
+runtime activity of the daemon. If faced with a non-responsive daemon, the administrator
+can force a full stack trace of all threads to be added to the daemon log by sending the
+`SIGUSR1` signal to the Docker daemon. A common way to send this signal is using the `kill`
+command on Linux systems. For example, `kill -USR1 <daemon-pid>` sends the `SIGUSR1`
+signal to the daemon process, causing the stack dump to be added to the daemon log.
+
+> **Note:** The log level setting of the daemon must be at least "info" level and above for
+> the stack trace to be saved to the logfile. By default the daemon's log level is set to
+> "info".
+
+The daemon will continue operating after handling the `SIGUSR1` signal and dumping the stack
+traces to the log. The stack traces can be used to determine the state of all goroutines and
+threads within the daemon.
+
 ## Ubuntu
 
 As of `14.04`, Ubuntu uses Upstart as a process manager. By default, Upstart jobs


### PR DESCRIPTION
Add a paragraph about how to force a stack trace dump to the daemon log.
This feature was added in Docker 1.9 I believe, but documentation was
never added.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
