### PR TITLE
Support OpenBSD build

### DIFF
--- a/layer/layer_unix.go
+++ b/layer/layer_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd darwin
+// +build linux freebsd darwin openbsd
 
 package layer
 

--- a/pkg/system/stat_openbsd.go
+++ b/pkg/system/stat_openbsd.go
@@ -1,5 +1,3 @@
-// +build !linux,!windows,!freebsd,!solaris,!openbsd
-
 package system
 
 import (
@@ -13,5 +11,5 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtimespec}, nil
+		mtim: s.Mtim}, nil
 }

--- a/pkg/term/termios_openbsd.go
+++ b/pkg/term/termios_openbsd.go
@@ -1,0 +1,69 @@
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	getTermios = syscall.TIOCGETA
+	setTermios = syscall.TIOCSETA
+)
+
+// Termios magic numbers, passthrough to the ones defined in syscall.
+const (
+	IGNBRK = syscall.IGNBRK
+	PARMRK = syscall.PARMRK
+	INLCR  = syscall.INLCR
+	IGNCR  = syscall.IGNCR
+	ECHONL = syscall.ECHONL
+	CSIZE  = syscall.CSIZE
+	ICRNL  = syscall.ICRNL
+	ISTRIP = syscall.ISTRIP
+	PARENB = syscall.PARENB
+	ECHO   = syscall.ECHO
+	ICANON = syscall.ICANON
+	ISIG   = syscall.ISIG
+	IXON   = syscall.IXON
+	BRKINT = syscall.BRKINT
+	INPCK  = syscall.INPCK
+	OPOST  = syscall.OPOST
+	CS8    = syscall.CS8
+	IEXTEN = syscall.IEXTEN
+)
+
+// Termios is the Unix API for terminal I/O.
+type Termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]byte
+	Ispeed uint32
+	Ospeed uint32
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd uintptr) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	newState.Iflag &^= (IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
+	newState.Oflag &^= OPOST
+	newState.Lflag &^= (ECHO | ECHONL | ICANON | ISIG | IEXTEN)
+	newState.Cflag &^= (CSIZE | PARENB)
+	newState.Cflag |= CS8
+	newState.Cc[syscall.VMIN] = 1
+	newState.Cc[syscall.VTIME] = 0
+
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(&newState))); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}


### PR DESCRIPTION
This commit makes the cli binary compile correctly on OpenBSD. One other change is needed in vendor/src/github.com/docker/engine-api/client/client_unix.go, for which I'll open a pull request there.
