### PR TITLE
Add containerd/runc exes to bundle dir after build

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -62,3 +62,18 @@ echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
 hash_files "$DEST/$BINARY_FULLNAME"
+
+# Add nested executables to bundle dir so we have complete set of
+# them available, but only if the native OS/ARCH is the same as the
+# OS/ARCH of the build target
+if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+	echo "Copying nested executables into $DEST"
+	(set -x
+	if [ -x /usr/local/bin/runc ]; then
+		cp /usr/local/bin/runc $DEST/
+		cp /usr/local/bin/ctr $DEST/
+		cp /usr/local/bin/containerd $DEST/
+		cp /usr/local/bin/containerd-shim $DEST/
+	fi
+	)
+fi

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -27,3 +27,18 @@ echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
 hash_files "$DEST/$BINARY_FULLNAME"
+
+# Add nested executables to bundle dir so we have complete set of
+# them available, but only if the native OS/ARCH is the same as the
+# OS/ARCH of the build target
+if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+    echo "Copying nested executables into $DEST"
+    (set -x
+    if [ -x /usr/local/bin/runc ]; then
+        cp /usr/local/bin/runc $DEST/
+        cp /usr/local/bin/ctr $DEST/
+        cp /usr/local/bin/containerd $DEST/
+        cp /usr/local/bin/containerd-shim $DEST/
+    fi
+    )
+fi


### PR DESCRIPTION
Not sure if this is the right setup given the containerd change but I need
to have the built version of the nested exes (containerd, runc...) available
to me after the build is completed so I'm always testing using the latest
versions.  This PR will copy them into the same bundles dir so people can
them use them if they wish w/o having to build each separately.

Signed-off-by: Doug Davis dug@us.ibm.com
