### PR TITLE
Fix debian policy rule

### DIFF
--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -6,7 +6,7 @@ override_dh_gencontrol:
 	# if we're on Ubuntu, we need to Recommends: apparmor
 	echo 'apparmor:Recommends=$(shell dpkg-vendor --is Ubuntu && echo apparmor)' >> debian/docker-engine.substvars
 	# recommend yubico-piv-tool since we include pkcs11 by default
-	echo 'yubico:Recommends="yubico-piv-tool (>= 1.1.0~)"' >> debian/docker-engine.substvars
+	echo 'yubico:Recommends=yubico-piv-tool (>= 1.1.0~)' >> debian/docker-engine.substvars
 	dh_gencontrol
 
 override_dh_auto_build:


### PR DESCRIPTION
**\- What I did**
I remove the double quotes preventing a successful build

**\- How I did it**
I used vim

**\- How to verify it**
Build a debian package using build-deb for ubuntu-trusty

**\- A picture of a cute animal (not mandatory but encouraged)**

Fix issue in debian policy by removeing double quotes.

```
# recommend yubico-piv-tool since we include pkcs11 by default
echo 'yubico:Recommends="yubico-piv-tool (>= 1.1.0~)"' >> debian/docker-engine.substvars
dh_gencontrol
dpkg-gencontrol: warning: Depends field of package docker-engine: unknown substitution variable ${perl:Depends}
dpkg-gencontrol: warning: can't parse dependency "yubico-piv-tool (>= 1.1.0~)"
dpkg-gencontrol: error: error occurred while parsing Recommends field: aufs-tools,
           ca-certificates,
           cgroupfs-mount | cgroup-lite,
           git,
           xz-utils,
           apparmor,
           "yubico-piv-tool (>= 1.1.0~)"
dh_gencontrol: dpkg-gencontrol -ldebian/changelog -Tdebian/docker-engine.substvars -Pdebian/docker-engine returned exit code 255
make[1]: *** [override_dh_gencontrol] Error 25
make[1]: Leaving directory `/usr/src/docker'
make: *** [binary] Error 2
```

Signed-off-by: Paul Liljenberg liljenberg.paul@gmail.com
