### PR TITLE
Add the name of the exe that's trying to be executed

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	errCmdNotFound          = "Container command not found or does not exist."
-	errCmdCouldNotBeInvoked = "Container command could not be invoked."
+	errCmdNotFound          = "not found or does not exist."
+	errCmdCouldNotBeInvoked = "could not be invoked."
 )
 
 func (cid *cidFile) Close() error {
@@ -51,12 +51,14 @@ func runStartContainerErr(err error) error {
 	trimmedErr := strings.Trim(err.Error(), "Error response from daemon: ")
 	statusError := Cli.StatusError{StatusCode: 125}
 
-	switch trimmedErr {
-	case errCmdNotFound:
-		statusError = Cli.StatusError{StatusCode: 127}
-	case errCmdCouldNotBeInvoked:
-		statusError = Cli.StatusError{StatusCode: 126}
+	if strings.HasPrefix(trimmedErr, "Container command") {
+		if strings.Contains(trimmedErr, errCmdNotFound) {
+			statusError = Cli.StatusError{StatusCode: 127}
+		} else if strings.Contains(trimmedErr, errCmdCouldNotBeInvoked) {
+			statusError = Cli.StatusError{StatusCode: 126}
+		}
 	}
+
 	return statusError
 }
 

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -140,12 +140,12 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 			strings.Contains(err.Error(), "no such file or directory") ||
 			strings.Contains(err.Error(), "system cannot find the file specified") {
 			container.ExitCode = 127
-			err = fmt.Errorf("Container command not found or does not exist.")
+			err = fmt.Errorf("Container command '%s' not found or does not exist.", container.Path)
 		}
 		// set to 126 for container cmd can't be invoked errors
 		if strings.Contains(err.Error(), syscall.EACCES.Error()) {
 			container.ExitCode = 126
-			err = fmt.Errorf("Container command could not be invoked.")
+			err = fmt.Errorf("Container command '%s' could not be invoked.", container.Path)
 		}
 
 		container.Reset(false)


### PR DESCRIPTION
so that the user knows what's not in the container but should be.
Its not always easy for the user to know what exact command is being run
when the 'docker run' is embedded deep in something else, like a Makefile.
Saw this while dealing with the containerd migration.

Signed-off-by: Doug Davis dug@us.ibm.com
