### PR TITLE
Reverting a change to make/binary to fix make deb, and make rpm.

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -36,7 +36,7 @@ if [ "$(go env GOOS)" == "linux" ] ; then
 	esac
 fi
 
-if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ]; then
+if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ] && [ "$DOCKER_EXPERIMENTAL" ]; then
 	if  [ "${GOOS}/${GOARCH}" == "darwin/amd64" ]; then
 		export CGO_ENABLED=1
 		export CC=o64-clang


### PR DESCRIPTION
This is reverting a change that was made to `make/binary` in 2c3e9e57949d23b4453b21339da56f0424ecbe42
This change has been breaking the packaging commands (make deb, make rpm) since the commit went in.

See: https://jenkins.dockerproject.org/view/Docker/job/Docker%20Master%20(build%20deb..rpms)/372/ for more details

Copying @riyazdf since he was the one who made the commit, and he can help review, to make sure we don't revert something that was needed for his changes.

@riyazdf please look over the PR, and let me know what the goal of your change was that I am reverting, so that we can get your fix in, and keep the packages building correctly. Thanks.

To test the build packages locally, you can run `make deb`, or `make rpm`. FYI: these two steps are not done when you do a `make all`.

Signed-off-by: Ken Cochrane kencochrane@gmail.com
