### PR TITLE
Windows: Minimal docker top implementation

### DIFF
--- a/daemon/top_windows.go
+++ b/daemon/top_windows.go
@@ -1,12 +1,32 @@
 package daemon
 
 import (
-	"fmt"
+	"errors"
+	"strconv"
 
 	"github.com/docker/engine-api/types"
 )
 
-// ContainerTop is not supported on Windows and returns an error.
-func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
-	return nil, fmt.Errorf("Top is not supported on Windows")
+// ContainerTop is a minimal implementation on Windows currently.
+// TODO Windows: This needs more work, but needs platform API support.
+// All we can currently return (particularly in the case of Hyper-V containers)
+// is a PID and the command.
+func (daemon *Daemon) ContainerTop(containerID string, psArgs string) (*types.ContainerProcessList, error) {
+
+	// It's really not an equivalent to linux 'ps' on Windows
+	if psArgs != "" {
+		return nil, errors.New("Windows does not support arguments to top")
+	}
+
+	s, err := daemon.containerd.Summary(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	procList := &types.ContainerProcessList{}
+
+	for _, v := range s {
+		procList.Titles = append(procList.Titles, strconv.Itoa(int(v.Pid))+" "+v.Command)
+	}
+	return procList, nil
 }

--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -299,6 +299,12 @@ func (clnt *client) GetPidsForContainer(containerID string) ([]int, error) {
 	return pids, nil
 }
 
+// Summary returns a summary of the processes running in a container.
+// This is a no-op on Linux.
+func (clnt *client) Summary(containerID string) ([]Summary, error) {
+	return nil, nil
+}
+
 func (clnt *client) getContainerdContainer(containerID string) (*containerd.Container, error) {
 	resp, err := clnt.remote.apiClient.State(context.Background(), &containerd.StateRequest{Id: containerID})
 	if err != nil {

--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -8,7 +8,10 @@ import (
 type process struct {
 	processCommon
 
-	// Platform specific fields are below here. There are none presently on Windows.
+	// Platform specific fields are below here.
+
+	// commandLine is to support returning summary information for docker top
+	commandLine string
 }
 
 func openReaderFromPipe(p io.ReadCloser) io.Reader {

--- a/libcontainerd/types.go
+++ b/libcontainerd/types.go
@@ -42,6 +42,7 @@ type Client interface {
 	Restore(containerID string, options ...CreateOption) error
 	Stats(containerID string) (*Stats, error)
 	GetPidsForContainer(containerID string) ([]int, error)
+	Summary(containerID string) ([]Summary, error)
 	UpdateResources(containerID string, resources Resources) error
 }
 

--- a/libcontainerd/types_linux.go
+++ b/libcontainerd/types_linux.go
@@ -36,6 +36,9 @@ type Process struct {
 // Stats contains a stats properties from containerd.
 type Stats containerd.StatsResponse
 
+// Summary container a container summary from containerd
+type Summary struct{}
+
 // User specifies linux specific user and group information for the container's
 // main process.
 type User specs.User

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -11,6 +11,12 @@ type Process windowsoci.Process
 // User specifies user information for the containers main process.
 type User windowsoci.User
 
+// Summary container a container summary from containerd
+type Summary struct {
+	Pid     uint32
+	Command string
+}
+
 // Stats contains a stats properties from containerd.
 type Stats struct{}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This needs platform support to get rich information like is returned on Linux, but at least it's better than returning an error `not supported on Windows`. While I was there, although not used on Windows, I also implemented `GetPidsForContainer` in `libcontainerd` - that is the function Linux uses to support `docker top`. 

![image](https://cloud.githubusercontent.com/assets/10522484/13908255/39df61ac-eebc-11e5-9bb2-39aede78c944.png)
