### PR TITLE
Fix plural typo in 'save' command help

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -56,7 +56,7 @@ var dockerCommands = []Command{
 	{"rm", "Remove one or more containers"},
 	{"rmi", "Remove one or more images"},
 	{"run", "Run a command in a new container"},
-	{"save", "Save an image(s) to a tar archive"},
+	{"save", "Save images to a tar archive"},
 	{"search", "Search the Docker Hub for images"},
 	{"start", "Start one or more stopped containers"},
 	{"stats", "Display a live stream of container(s) resource usage statistics"},

--- a/cli/common.go
+++ b/cli/common.go
@@ -56,7 +56,7 @@ var dockerCommands = []Command{
 	{"rm", "Remove one or more containers"},
 	{"rmi", "Remove one or more images"},
 	{"run", "Run a command in a new container"},
-	{"save", "Save images to a tar archive"},
+	{"save", "Save one or more images to a tar archive"},
 	{"search", "Search the Docker Hub for images"},
 	{"start", "Start one or more stopped containers"},
 	{"stats", "Display a live stream of container(s) resource usage statistics"},

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -12,7 +12,7 @@ parent = "smn_cli"
 
     Usage: docker save [OPTIONS] IMAGE [IMAGE...]
 
-    Save images to a tar archive (streamed to STDOUT by default)
+    Save one or more images to a tar archive (streamed to STDOUT by default)
 
       --help             Print usage
       -o, --output=""    Write to a file, instead of STDOUT

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -12,7 +12,7 @@ parent = "smn_cli"
 
     Usage: docker save [OPTIONS] IMAGE [IMAGE...]
 
-    Save an image(s) to a tar archive (streamed to STDOUT by default)
+    Save images to a tar archive (streamed to STDOUT by default)
 
       --help             Print usage
       -o, --output=""    Write to a file, instead of STDOUT

--- a/man/docker-load.1.md
+++ b/man/docker-load.1.md
@@ -37,7 +37,7 @@ Restores both images and tags.
     fedora              latest              58394af37342        7 weeks ago         385.5 MB
 
 # See also
-**docker-save(1)** to save an image(s) to a tar archive (streamed to STDOUT by default).
+**docker-save(1)** to save images to a tar archive (streamed to STDOUT by default).
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/man/docker-load.1.md
+++ b/man/docker-load.1.md
@@ -37,7 +37,7 @@ Restores both images and tags.
     fedora              latest              58394af37342        7 weeks ago         385.5 MB
 
 # See also
-**docker-save(1)** to save images to a tar archive (streamed to STDOUT by default).
+**docker-save(1)** to save one or more images to a tar archive (streamed to STDOUT by default).
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/man/docker-save.1.md
+++ b/man/docker-save.1.md
@@ -2,7 +2,7 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-save - Save images to a tar archive (streamed to STDOUT by default)
+docker-save - Save one or more images to a tar archive (streamed to STDOUT by default)
 
 # SYNOPSIS
 **docker save**

--- a/man/docker-save.1.md
+++ b/man/docker-save.1.md
@@ -2,7 +2,7 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-save - Save an image(s) to a tar archive (streamed to STDOUT by default)
+docker-save - Save images to a tar archive (streamed to STDOUT by default)
 
 # SYNOPSIS
 **docker save**


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

The form "Save an images" is not correct.
Either "Save an image" or "Save images" work, but since
the save commands accepts multiple images, I chose the
latter.

Fixed in all places where I could grep "Save an image(s)".

Signed-off-by: Martin Mosegaard Amdisen martin.amdisen@praqma.com
