### PR TITLE
Give selinux pcp_pmcd_t type access to /var/lib/docker

### DIFF
--- a/contrib/docker-engine-selinux/docker.te
+++ b/contrib/docker-engine-selinux/docker.te
@@ -405,3 +405,10 @@ optional_policy(`
 
      dontaudit svirt_sandbox_domain domain:key {search link};
 ')
+
+optional_policy(`
+	gen_require(`
+		type pcp_pmcd_t;
+	')
+	docker_manage_lib_files(pcp_pmcd_t)
+')


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

This diff was taken from [here](https://github.com/fedora-cloud/docker-selinux/commit/d9b8b854ad7d3cf264c0d06362e3552a04f26998).

@rhatdan, is there a plan to actually have a pcp_pmcd module get whatever information is needed by querying the docker API instead?

atm this would give write access to all the docker files under `/var/lib/docker` if I'm not mistaken. This  includes graphs, images and more.

**Cute Animal:**

![cute_animal](http://static.boredpanda.com/blog/wp-content/uploads/2016/01/funny-animals-eating-52__605.jpg)
