### PR TITLE
Enable seccomp for ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -71,6 +71,21 @@ RUN cd /usr/local/lvm2 \
 	&& make install_device-mapper
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
+# install seccomp: the version shipped in trusty is too old
+ENV SECCOMP_VERSION 2.3.0
+RUN set -x \
+	&& export SECCOMP_PATH="$(mktemp -d)" \
+	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
+		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
+	&& ( \
+		cd "$SECCOMP_PATH" \
+		&& ./configure --prefix=/usr/local \
+		&& make \
+		&& make install \
+		&& ldconfig \
+	) \
+	&& rm -rf "$SECCOMP_PATH"
+
 # TODO install Go, using gccgo as GOROOT_BOOTSTRAP (Go 1.5+ supports ppc64le properly)
 # possibly a ppc64le/golang image?
 
@@ -154,7 +169,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc


### PR DESCRIPTION
Since 2.3.0 libseccomp supports ppc64le. Tested by building on
Ubuntu 15.10 ppc64le, seccomp behaves as expected, no issues
so far. 

Signed-off-by: Justin Cormack justin.cormack@docker.com

This brings it in line with the other architectures, just
leaving s390x without seccomp enabled (currently have no
way to test s390x).

Note that initial testing was done before the containerd merge but should not make a difference. I will do more extensive testing as well.

Tested on `Linux sys-80017 4.2.0-34-generic #39-Ubuntu SMP Thu Mar 10 22:11:28 UTC 2016 ppc64le ppc64le ppc64le GNU/Linux`
