### PR TITLE
Add parent references support to load/save

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -128,6 +128,7 @@ func (s *saveSession) save(outStream io.Writer) error {
 	reposLegacy := make(map[string]map[string]string)
 
 	var manifest []manifestItem
+	var parentLinks []parentLink
 
 	for id, imageDescr := range s.images {
 		if err = s.saveImage(id); err != nil {
@@ -154,6 +155,15 @@ func (s *saveSession) save(outStream io.Writer) error {
 			RepoTags: repoTags,
 			Layers:   layers,
 		})
+
+		parentID, _ := s.is.GetParent(id)
+		parentLinks = append(parentLinks, parentLink{id, parentID})
+	}
+
+	for i, p := range validatedParentLinks(parentLinks) {
+		if p.parentID != "" {
+			manifest[i].Parent = p.parentID
+		}
 	}
 
 	if len(reposLegacy) > 0 {

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -18,6 +18,7 @@ type manifestItem struct {
 	Config   string
 	RepoTags []string
 	Layers   []string
+	Parent   image.ID `json:",omitempty"`
 }
 
 type tarexporter struct {


### PR DESCRIPTION
Restores the correct parent chain relationship
between images on docker load if multiple images
have been saved.

cc @aaronlehmann 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
