### PR TITLE
Windows: Fix mountinfo

### DIFF
--- a/pkg/mount/mountinfo_unsupported.go
+++ b/pkg/mount/mountinfo_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!freebsd freebsd,!cgo
+// +build !windows,!linux,!freebsd freebsd,!cgo
 
 package mount
 

--- a/pkg/mount/mountinfo_windows.go
+++ b/pkg/mount/mountinfo_windows.go
@@ -1,0 +1,6 @@
+package mount
+
+func parseMountTable() ([]*Info, error) {
+	// Do NOT return an error!
+	return nil, nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@tonistiigi @icecrime The rework for libcontainerd is causing errors in the daemon log during docker build. 
