### PR TITLE
Add containerd and runc binaries to tgz output

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -302,10 +302,12 @@ copy_containerd() {
             cp /usr/local/bin/ctr "$dir/"
             cp /usr/local/bin/containerd "$dir/"
             cp /usr/local/bin/containerd-shim "$dir/"
-            hash_files "$dir/runc"
-            hash_files "$dir/ctr"
-            hash_files "$dir/containerd"
-            hash_files "$dir/containerd-shim"
+            if [ "$2" == "hash" ]; then
+                hash_files "$dir/runc"
+                hash_files "$dir/ctr"
+                hash_files "$dir/containerd"
+                hash_files "$dir/containerd-shim"
+            fi
         fi
         )
     fi

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -289,6 +289,28 @@ bundle() {
 	source "$SCRIPTDIR/make/$bundle" "$@"
 }
 
+copy_containerd() {
+    dir="$1"
+    # Add nested executables to bundle dir so we have complete set of
+    # them available, but only if the native OS/ARCH is the same as the
+    # OS/ARCH of the build target
+    if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+        (set -x
+        if [ -x /usr/local/bin/runc ]; then
+            echo "Copying nested executables into $dir"
+            cp /usr/local/bin/runc "$dir/"
+            cp /usr/local/bin/ctr "$dir/"
+            cp /usr/local/bin/containerd "$dir/"
+            cp /usr/local/bin/containerd-shim "$dir/"
+            hash_files "$dir/runc"
+            hash_files "$dir/ctr"
+            hash_files "$dir/containerd"
+            hash_files "$dir/containerd-shim"
+        fi
+        )
+    fi
+}
+
 main() {
 	# We want this to fail if the bundles already exist and cannot be removed.
 	# This is to avoid mixing bundles from different versions of the code.

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -61,19 +61,5 @@ go build \
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
+copy_containerd "$DEST"
 hash_files "$DEST/$BINARY_FULLNAME"
-
-# Add nested executables to bundle dir so we have complete set of
-# them available, but only if the native OS/ARCH is the same as the
-# OS/ARCH of the build target
-if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
-	echo "Copying nested executables into $DEST"
-	(set -x
-	if [ -x /usr/local/bin/runc ]; then
-		cp /usr/local/bin/runc $DEST/
-		cp /usr/local/bin/ctr $DEST/
-		cp /usr/local/bin/containerd $DEST/
-		cp /usr/local/bin/containerd-shim $DEST/
-	fi
-	)
-fi

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -61,5 +61,5 @@ go build \
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
-copy_containerd "$DEST"
+copy_containerd "$DEST" "hash"
 hash_files "$DEST/$BINARY_FULLNAME"

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -26,19 +26,5 @@ go build -compiler=gccgo \
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
+copy_containerd "$DEST"
 hash_files "$DEST/$BINARY_FULLNAME"
-
-# Add nested executables to bundle dir so we have complete set of
-# them available, but only if the native OS/ARCH is the same as the
-# OS/ARCH of the build target
-if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
-    echo "Copying nested executables into $DEST"
-    (set -x
-    if [ -x /usr/local/bin/runc ]; then
-        cp /usr/local/bin/runc $DEST/
-        cp /usr/local/bin/ctr $DEST/
-        cp /usr/local/bin/containerd $DEST/
-        cp /usr/local/bin/containerd-shim $DEST/
-    fi
-    )
-fi

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -26,5 +26,5 @@ go build -compiler=gccgo \
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
-copy_containerd "$DEST"
+copy_containerd "$DEST" "hash"
 hash_files "$DEST/$BINARY_FULLNAME"

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -22,6 +22,7 @@ for d in "$CROSS/"*/*; do
 
 	mkdir -p "$DEST/build/usr/local/bin"
 	cp -L "$d/$BINARY_FULLNAME" "$DEST/build/usr/local/bin/docker$BINARY_EXTENSION"
+	copy_containerd "$DEST/build/usr/local/bin/"
 
 	tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
 

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -9,9 +9,10 @@ if [ ! -d "$CROSS/linux/amd64" ]; then
 	false
 fi
 
+(
 for d in "$CROSS/"*/*; do
-	GOARCH="$(basename "$d")"
-	GOOS="$(basename "$(dirname "$d")")"
+	export GOARCH="$(basename "$d")"
+	export GOOS="$(basename "$(dirname "$d")")"
 	BINARY_NAME="docker-$VERSION"
 	BINARY_EXTENSION="$(export GOOS && binary_extension)"
 	BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
@@ -32,3 +33,4 @@ for d in "$CROSS/"*/*; do
 
 	echo "Created tgz: $TGZ"
 done
+)


### PR DESCRIPTION
This adds containerd and runc hashes as well as the binaries to the `tgz` make output.  
