### PR TITLE
fix race condition between list and remove volume (option 1)

### DIFF
--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -26,19 +26,20 @@ func (NoopVolume) Unmount() error { return nil }
 
 // FakeVolume is a fake volume with a random name
 type FakeVolume struct {
-	name string
+	name       string
+	driverName string
 }
 
 // NewFakeVolume creates a new fake volume for testing
-func NewFakeVolume(name string) volume.Volume {
-	return FakeVolume{name: name}
+func NewFakeVolume(name string, driverName string) volume.Volume {
+	return FakeVolume{name: name, driverName: driverName}
 }
 
 // Name is the name of the volume
 func (f FakeVolume) Name() string { return f.name }
 
 // DriverName is the name of the driver
-func (FakeVolume) DriverName() string { return "fake" }
+func (f FakeVolume) DriverName() string { return f.driverName }
 
 // Path is the filesystem path to the volume
 func (FakeVolume) Path() string { return "fake" }
@@ -72,7 +73,7 @@ func (d *FakeDriver) Create(name string, opts map[string]string) (volume.Volume,
 	if opts != nil && opts["error"] != "" {
 		return nil, fmt.Errorf(opts["error"])
 	}
-	v := NewFakeVolume(name)
+	v := NewFakeVolume(name, d.name)
 	d.vols[name] = v
 	return v, nil
 }


### PR DESCRIPTION
fixes #21403

**\- What I did**
Fixed the race

**\- How I did it**
by checking if the volume still exists after getting the named lock and before caching it.

**\- How to verify it**
Read the code. I don't have an easy way to reproduce the issue. It would be great if someone can come up with a test for this.

**\- A picture of a cute animal (not mandatory but encouraged)**
![](http://www.portlandsocietypage.com/wp-content/uploads/2013/07/2013-06-27_Kitten-Derby-2_0895-e1372871493149.jpg)
