### PR TITLE
Vendor engine-api v0.3.0

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 9524d7ae81ff55771852b6269f40f2a878315de9
+clone git github.com/docker/engine-api v0.3.0
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 


### PR DESCRIPTION
I tagged the current commit so we have a better reference of what's in this release.

https://github.com/docker/engine-api/commit/bef93d22ae36aa14aae353fc511547f3d73c19e5
https://github.com/docker/engine-api/commits/v0.3.0

Signed-off-by: David Calavera david.calavera@gmail.com
