### PR TITLE
Update TestPushToCentralRegistryUnauthorized to match updated hub

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -653,7 +653,7 @@ func (s *DockerSuite) TestPushToCentralRegistryUnauthorized(c *check.C) {
 	out, _, err := dockerCmdWithError("push", repoName)
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(out, check.Not(checker.Contains), "Retrying")
-	c.Assert(out, checker.Contains, "unauthorized: access to the requested resource is not authorized")
+	c.Assert(out, checker.Contains, "unauthorized: authentication required")
 }
 
 func getTestTokenService(status int, body string) *httptest.Server {


### PR DESCRIPTION
The error message was changed from "unauthorized: access to the
requested resource is not authorized" to "unauthorized: authentication
required".

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

![miaouw](http://www.cutestpaw.com/wp-content/uploads/2012/02/So-cute..jpg)
