### PR TITLE
Fix Docker core dumps when removing network with special characters (#21401).

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1452,3 +1452,16 @@ func (s *DockerSuite) TestDockerNetworkInternalMode(c *check.C) {
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
 	c.Assert(err, check.IsNil)
 }
+
+// Test for #21401
+func (s *DockerNetworkSuite) TestDockerNetworkCreateDeleteSpecialCharacters(c *check.C) {
+	dockerCmd(c, "network", "create", "test@#$")
+	assertNwIsAvailable(c, "test@#$")
+	dockerCmd(c, "network", "rm", "test@#$")
+	assertNwNotAvailable(c, "test@#$")
+
+	dockerCmd(c, "network", "create", "kiwl$%^")
+	assertNwIsAvailable(c, "kiwl$%^")
+	dockerCmd(c, "network", "rm", "kiwl$%^")
+	assertNwNotAvailable(c, "kiwl$%^")
+}

--- a/vendor/src/github.com/docker/engine-api/client/request.go
+++ b/vendor/src/github.com/docker/engine-api/client/request.go
@@ -128,7 +128,10 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 
 func (cli *Client) newRequest(method, path string, query url.Values, body io.Reader, headers map[string][]string) (*http.Request, error) {
 	apiPath := cli.getAPIPath(path, query)
-	req, err := http.NewRequest(method, apiPath, body)
+
+	// The apiPath needs to be sanitized.
+	apiPathURL := &url.URL{Path: apiPath}
+	req, err := http.NewRequest(method, apiPathURL.String(), body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fix tries to fix Docker core dumps when removing network with special characters. The issue is from the fact that when docker client tries to pass the command to API, the networkID is not escaped in case of special characters. This also means other commands (not just `docker network rm`) may face the same issue (e.g., `docker network connect`).

This fix adds the URL path escape to properly handle it. In addition, an integration test for network create and delete is added to cover the cases in #21401.

A pull request to engine-api will be created separately.

This fix fixes #21401.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
