### PR TITLE
Proof of Concept fix for #20865

### DIFF
--- a/docker/listeners/listeners_unix.go
+++ b/docker/listeners/listeners_unix.go
@@ -33,7 +33,7 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) (ls []net.List
 		if err != nil {
 			return nil, fmt.Errorf("can't create unix socket %s: %v", addr, err)
 		}
-		ls = append(ls, l)
+		ls = append(ls, &LookMaNoHands{l})
 	default:
 		return nil, fmt.Errorf("Invalid protocol format: %q", proto)
 	}

--- a/docker/listeners/look_ma_no_hands.go
+++ b/docker/listeners/look_ma_no_hands.go
@@ -1,0 +1,62 @@
+// +build !windows
+
+package listeners
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+type LookMaNoHands struct {
+	net.Listener
+}
+
+type LookMaNoHandsConn struct {
+	net.Conn
+	first bool
+}
+
+func (l *LookMaNoHandsConn) Read(b []byte) (n int, err error) {
+	// yeah, http.Server uses a 4k buffer
+	if l.first && len(b) == 4096 {
+		l.first = false
+		c, err := l.Conn.Read(b[:1048])
+		if err != nil {
+			return c, err
+		}
+
+		fmt.Println("!!!WAS!!!", string(b[:c]))
+
+		parts := strings.Split(string(b[:c]), "\n")
+		hackedUp := []string{parts[0]}
+
+		// Sanitize Host header
+		hackedUp = append(hackedUp, "Host: docker")
+
+		// Inject `Connection: close` to ensure we don't reuse this connection
+		hackedUp = append(hackedUp, "Connection: close")
+
+		for i, leftOver := range parts {
+			if i > 1 {
+				hackedUp = append(hackedUp, string(leftOver))
+			}
+		}
+		newContent := strings.Join(hackedUp, "\n")
+
+		fmt.Println("!!!NOW!!!", newContent)
+
+		copy(b, []byte(newContent))
+		return len(newContent), nil
+	}
+
+	return l.Conn.Read(b)
+}
+
+func (l *LookMaNoHands) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return c, err
+	}
+	return &LookMaNoHandsConn{c, true}, nil
+}


### PR DESCRIPTION
Okay, don't judge me for the crappiness of this code.  The point is to prove this idea should work and then people can choose either revert to golang 1.5 or go with a proper production quality version of this hack.

The basic idea here is that we wrap net.Listener to create a custom net.Conn.  We inject this listener only for the unix socket.  The wrapped net.Conn does two things.  First it sanitizes the host header so that `http.Server` doesn't blow up.  Second it injects the `Connection: close` header.  This will ensure the server closes the connection.  We can't reuse connections because we can only sanitize at connection start.

For a proper production quality implementation what we would do is that we look at the incoming bytes just for the first two lines `GET ....` and then `Host: ....`.  If we see `Host: /` (hostname starting with /), we assume this is a old client.  We then sanitize host header and add connection close.  If we see `Host:` followed by a non-/ we don't manipulate the input at all and just pass all data through.  What this means is that only for bad old client will we do anything.  For newer clients the overhead is practically nothing as we just look at a couple bytes on connection start.
