### PR TITLE
ppc64le: remove seccomp from Dockerfile

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -204,7 +204,7 @@ RUN set -x \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
 	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp apparmor selinux" \
+	&& make static BUILDTAGS="apparmor selinux" \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd


### PR DESCRIPTION
Removes the seccomp buildtag when building runc.
Because seccomp isn't currently being built, this would cause
the entire build to fail.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
