### PR TITLE
fix race condition between list and remove volume

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -127,9 +127,8 @@ func (s *VolumeStore) List() ([]volume.Volume, []string, error) {
 
 		s.locks.Lock(name)
 		storedV, exists := s.getNamed(name)
-		if !exists {
-			s.setNamed(v, "")
-		}
+		// Note: it's not safe to populate the cache here because the volume may have been
+		// deleted before we acquire a lock on its name
 		if exists && storedV.DriverName() != v.DriverName() {
 			logrus.Warnf("Volume name %s already exists for driver %s, not including volume returned by %s", v.Name(), storedV.DriverName(), v.DriverName())
 			s.locks.Unlock(v.Name())

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -26,19 +26,20 @@ func (NoopVolume) Unmount() error { return nil }
 
 // FakeVolume is a fake volume with a random name
 type FakeVolume struct {
-	name string
+	name       string
+	driverName string
 }
 
 // NewFakeVolume creates a new fake volume for testing
-func NewFakeVolume(name string) volume.Volume {
-	return FakeVolume{name: name}
+func NewFakeVolume(name string, driverName string) volume.Volume {
+	return FakeVolume{name: name, driverName: driverName}
 }
 
 // Name is the name of the volume
 func (f FakeVolume) Name() string { return f.name }
 
 // DriverName is the name of the driver
-func (FakeVolume) DriverName() string { return "fake" }
+func (f FakeVolume) DriverName() string { return f.driverName }
 
 // Path is the filesystem path to the volume
 func (FakeVolume) Path() string { return "fake" }
@@ -72,7 +73,7 @@ func (d *FakeDriver) Create(name string, opts map[string]string) (volume.Volume,
 	if opts != nil && opts["error"] != "" {
 		return nil, fmt.Errorf(opts["error"])
 	}
-	v := NewFakeVolume(name)
+	v := NewFakeVolume(name, d.name)
 	d.vols[name] = v
 	return v, nil
 }


### PR DESCRIPTION
This PR supersedes #21405

fixes #21403 

**\- What I did**
Avoided having a race between volume List and Remove

**\- How I did it**
Made List not populate the volume names cache

**\- How to verify it**
Read the code. I don't have an easy way to reproduce the issue. It would be great if someone can come up with a test for this. Also see #21405 for an alternative solution.

**\- A picture of a cute animal (not mandatory but encouraged)**
![](http://www.portlandsocietypage.com/wp-content/uploads/2013/07/2013-06-27_Kitten-Derby-2_0895-e1372871493149.jpg)
