### PR TITLE
Remove the verbosity of copy_containerd

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -290,23 +290,21 @@ bundle() {
 }
 
 copy_containerd() {
-    dir="$1"
-    # Add nested executables to bundle dir so we have complete set of
-    # them available, but only if the native OS/ARCH is the same as the
-    # OS/ARCH of the build target
-    if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
-        (set -x
-        if [ -x /usr/local/bin/docker-runc ]; then
-            echo "Copying nested executables into $dir"
-	    for file in containerd containerd-shim containerd-ctr runc; do
-                cp "/usr/local/bin/docker-$file" "$dir/"
-                if [ "$2" == "hash" ]; then
-                    hash_files "$dir/docker-$file"
+	dir="$1"
+	# Add nested executables to bundle dir so we have complete set of
+	# them available, but only if the native OS/ARCH is the same as the
+	# OS/ARCH of the build target
+	if [ "$(go env GOOS)/$(go env GOARCH)" == "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+		if [ -x /usr/local/bin/docker-runc ]; then
+			echo "Copying nested executables into $dir"
+			for file in containerd containerd-shim containerd-ctr runc; do
+				cp "/usr/local/bin/docker-$file" "$dir/"
+				if [ "$2" == "hash" ]; then
+					hash_files "$dir/docker-$file"
+				fi
+			done
 		fi
-            done
-        fi
-        )
-    fi
+	fi
 }
 
 main() {


### PR DESCRIPTION
`make binary` is quit verbose, removed the `set -x` 🐼.

``` bash
# […]

bundles/1.12.0-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.12.0-dev/binary)
Building: bundles/1.12.0-dev/binary/docker-1.12.0-dev
Created binary: bundles/1.12.0-dev/binary/docker-1.12.0-dev
Copying nested executables into bundles/1.12.0-dev/binary
```

_Also, used `<tab>` instead of spaces to be the same as the rest of the file_.

/cc @tiborvass @kencochrane @tianon @jfrazelle 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
