### PR TITLE
Fix network path issue

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api v0.3.0
+clone git github.com/docker/engine-api v0.3.1
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1452,3 +1452,16 @@ func (s *DockerSuite) TestDockerNetworkInternalMode(c *check.C) {
 	_, _, err = dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
 	c.Assert(err, check.IsNil)
 }
+
+// Test for #21401
+func (s *DockerNetworkSuite) TestDockerNetworkCreateDeleteSpecialCharacters(c *check.C) {
+	dockerCmd(c, "network", "create", "test@#$")
+	assertNwIsAvailable(c, "test@#$")
+	dockerCmd(c, "network", "rm", "test@#$")
+	assertNwNotAvailable(c, "test@#$")
+
+	dockerCmd(c, "network", "create", "kiwl$%^")
+	assertNwIsAvailable(c, "kiwl$%^")
+	dockerCmd(c, "network", "rm", "kiwl$%^")
+	assertNwNotAvailable(c, "kiwl$%^")
+}

--- a/vendor/src/github.com/docker/engine-api/client/client.go
+++ b/vendor/src/github.com/docker/engine-api/client/client.go
@@ -97,10 +97,14 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	} else {
 		apiPath = fmt.Sprintf("%s%s", cli.basePath, p)
 	}
-	if len(query) > 0 {
-		apiPath += "?" + query.Encode()
+
+	u := &url.URL{
+		Path: apiPath,
 	}
-	return apiPath
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
 }
 
 // ClientVersion returns the version string associated with this


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

I fixed an issue that caused docker to raise an error when network names included especial characters.

I also carried #21421.

**\- How I did it**

I made all the API calls to escape the request path.

**\- How to verify it**

There is a test included to verify that this behavior is correct.

**\- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/1050/13997599/1f62dae4-f0f0-11e5-937c-1482881b18cb.png)
