### PR TITLE
Output a bit more info during make binary

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -298,12 +298,13 @@ copy_containerd() {
         (set -x
         if [ -x /usr/local/bin/docker-runc ]; then
             echo "Copying nested executables into $dir"
-	    for file in containerd containerd-shim containerd-ctr runc; do
+    	    for file in containerd containerd-shim containerd-ctr runc; do
                 cp "/usr/local/bin/docker-$file" "$dir/"
                 if [ "$2" == "hash" ]; then
                     hash_files "$dir/docker-$file"
-		fi
+                fi
             done
+            echo "Finished copying containerd execs into $dir"
         fi
         )
     fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Added an echo to indicate the end of the copy to make it more clear that that's what all the new output was doing.

**\- How I did it**
Typed.

**\- How to verify it**
make binary, or ./hack/make.sh binary, and then you'll see a new message at the end, instead of just script commands.

If you're not working with a full screen, you might
be a little confused about all the new info spit out
by the containerd copy bits that recently went in.

Also, tidy up the spacing.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
