### PR TITLE
Remove unnecessary hardcoded version.

### DIFF
--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -5,7 +5,6 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/authorization"
 )
 
@@ -15,7 +14,7 @@ import (
 func (s *Server) handleWithGlobalMiddlewares(handler httputils.APIFunc) httputils.APIFunc {
 	next := handler
 
-	handleVersion := middleware.NewVersionMiddleware(dockerversion.Version, api.DefaultVersion, api.MinVersion)
+	handleVersion := middleware.NewVersionMiddleware(s.cfg.Version, api.DefaultVersion, api.MinVersion)
 	next = handleVersion(next)
 
 	if s.cfg.EnableCors {

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/server/httputils"
@@ -11,7 +12,9 @@ import (
 )
 
 func TestMiddlewares(t *testing.T) {
-	cfg := &Config{}
+	cfg := &Config{
+		Version: "0.1omega2",
+	}
 	srv := &Server{
 		cfg: cfg,
 	}
@@ -24,6 +27,11 @@ func TestMiddlewares(t *testing.T) {
 		if httputils.VersionFromContext(ctx) == "" {
 			t.Fatalf("Expected version, got empty string")
 		}
+
+		if sv := w.Header().Get("Server"); !strings.Contains(sv, "Docker/0.1omega2") {
+			t.Fatalf("Expected server version in the header `Docker/0.1omega2`, got %s", sv)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
The server configuration already keeps the current version
if the daemon. This patch changes the middleware logic
to use it rather than using the global value.

This removes the dockerversion package dependency from the api.

/cc @MHBauer, @icecrime

Signed-off-by: David Calavera david.calavera@gmail.com
