### PR TITLE
Add ulimit support to libcontainerd addprocess

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -485,6 +485,17 @@ func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
 	dockerCmd(c, "exec", "parent", "true")
 }
 
+func (s *DockerSuite) TestExecUlimits(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	name := "testexeculimits"
+	runSleepingContainer(c, "-d", "--ulimit", "nproc=21", "--name", name)
+	c.Assert(waitRun(name), checker.IsNil)
+
+	out, _, err := dockerCmdWithError("exec", name, "sh", "-c", "ulimit -p")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "21")
+}
+
 // #15750
 func (s *DockerSuite) TestExecStartFails(c *check.C) {
 	// TODO Windows CI. This test should be portable. Figure out why it fails

--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -79,6 +79,7 @@ func (clnt *client) AddProcess(containerID, processFriendlyName string, specp Pr
 		ApparmorProfile: sp.ApparmorProfile,
 		SelinuxLabel:    sp.SelinuxLabel,
 		NoNewPrivileges: sp.NoNewPrivileges,
+		Rlimits:         convertRlimits(sp.Rlimits),
 	}
 
 	iopipe, err := p.openFifos(sp.Terminal)

--- a/libcontainerd/utils_linux.go
+++ b/libcontainerd/utils_linux.go
@@ -39,3 +39,14 @@ func systemPid(ctr *containerd.Container) uint32 {
 	}
 	return pid
 }
+
+func convertRlimits(sr []specs.Rlimit) (cr []*containerd.Rlimit) {
+	for _, r := range sr {
+		cr = append(cr, &containerd.Rlimit{
+			Type: r.Type,
+			Hard: r.Hard,
+			Soft: r.Soft,
+		})
+	}
+	return
+}


### PR DESCRIPTION
This was recently added to containerd and was not supported by docker yet.

@crosbymichael 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
