### PR TITLE
docs: add Ubuntu 16.04 "xenial"

### DIFF
--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -14,6 +14,7 @@ weight = -6
 
 Docker is supported on these Ubuntu operating systems:
 
+- Ubuntu Xenial 16.04 (LTS)
 - Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 - Ubuntu Precise 12.04 (LTS)
@@ -85,6 +86,10 @@ packages from the new repository:
 
             deb https://apt.dockerproject.org/repo ubuntu-wily main
 
+    - Ubuntu Xenial 16.04 (LTS)
+
+            deb https://apt.dockerproject.org/repo ubuntu-xenial main
+
     > **Note**: Docker does not provide packages for all architectures. You can find
 	> nightly built binaries in https://master.dockerproject.org. To install docker on
     > a multi-architecture system, add an `[arch=...]` clause to the entry. Refer to the
@@ -109,10 +114,11 @@ packages from the new repository:
 
 ### Prerequisites by Ubuntu Version
 
+- Ubuntu Xenial 16.04 (LTS)
 - Ubuntu Wily 15.10
 - Ubuntu Trusty 14.04 (LTS)
 
-For Ubuntu Trusty and Wily, it's recommended to install the
+For Ubuntu Trusty, Wily, and Xenial, it's recommended to install the
 `linux-image-extra` kernel package. The `linux-image-extra` package
 allows you use the `aufs` storage driver.
 


### PR DESCRIPTION
Ubuntu 16.04 "xenial" is not yet released (currently scheduled around april 21st https://wiki.ubuntu.com/XenialXerus/ReleaseSchedule), but we should start building for 16.04

fixes https://github.com/docker/docker/issues/20192 (once it's used for the releases)

Should we include this for the 1.11 release, or wait until it's actually released?
