### PR TITLE
More descriptive error when running a container with a too long hostname (#21445)

### DIFF
--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -244,8 +244,9 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 	// Validate if the given hostname is RFC 1123 (https://tools.ietf.org/html/rfc1123) compliant.
 	hostname := *flHostname
 	if hostname != "" {
+		// Linux hostname is limited to HOST_NAME_MAX=64, not not including the terminating null byte.
 		matched, _ := regexp.MatchString("^(([[:alnum:]]|[[:alnum:]][[:alnum:]\\-]*[[:alnum:]])\\.)*([[:alnum:]]|[[:alnum:]][[:alnum:]\\-]*[[:alnum:]])$", hostname)
-		if !matched {
+		if len(hostname) > 64 || !matched {
 			return nil, nil, nil, cmd, fmt.Errorf("invalid hostname format for --hostname: %s", hostname)
 		}
 	}

--- a/runconfig/opts/parse_test.go
+++ b/runconfig/opts/parse_test.go
@@ -390,6 +390,7 @@ func TestParseHostname(t *testing.T) {
 		"host-name":   "host-name",
 		"hostname123": "hostname123",
 		"123hostname": "123hostname",
+		"hostname-of-64-bytes-long-should-be-valid-and-without-any-errors": "hostname-of-64-bytes-long-should-be-valid-and-without-any-errors",
 	}
 	invalidHostnames := map[string]string{
 		"^hostname": "invalid hostname format for --hostname: ^hostname",
@@ -397,6 +398,7 @@ func TestParseHostname(t *testing.T) {
 		"host&name": "invalid hostname format for --hostname: host&name",
 		"-hostname": "invalid hostname format for --hostname: -hostname",
 		"host_name": "invalid hostname format for --hostname: host_name",
+		"hostname-of-65-bytes-long-should-be-invalid-and-be-given-an-error": "invalid hostname format for --hostname: hostname-of-65-bytes-long-should-be-invalid-and-be-given-an-error",
 	}
 	hostnameWithDomain := "--hostname=hostname.domainname"
 	hostnameWithDomainTld := "--hostname=hostname.domainname.tld"


### PR DESCRIPTION
This fix tries to fix issues encountered when running a container with a hostname that is longer than HOST_NAME_MAX(64).

Previously, `could not synchronise with container process` was generated as the length of the regex check was missing.

This fix covers the length check so that a hostname that is longer than HOST_NAME_MAX(64) will be given a correct error message.

Several unit tests cases and additional integration test cases are added as well.

This fix closes #21445.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
