### PR TITLE
Cleanup: remove redundant period

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	errCmdNotFound          = "not found or does not exist."
-	errCmdCouldNotBeInvoked = "could not be invoked."
+	errCmdNotFound          = "not found or does not exist"
+	errCmdCouldNotBeInvoked = "could not be invoked"
 )
 
 func (cid *cidFile) Close() error {
@@ -48,9 +48,8 @@ func (cid *cidFile) Write(id string) error {
 // if container start fails with 'command cannot be invoked' error, return 126
 // return 125 for generic docker daemon failures
 func runStartContainerErr(err error) error {
-	trimmedErr := strings.Trim(err.Error(), "Error response from daemon: ")
+	trimmedErr := strings.TrimPrefix(err.Error(), "Error response from daemon: ")
 	statusError := Cli.StatusError{StatusCode: 125}
-
 	if strings.HasPrefix(trimmedErr, "Container command") {
 		if strings.Contains(trimmedErr, errCmdNotFound) {
 			statusError = Cli.StatusError{StatusCode: 127}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -140,12 +140,12 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 			strings.Contains(err.Error(), "no such file or directory") ||
 			strings.Contains(err.Error(), "system cannot find the file specified") {
 			container.ExitCode = 127
-			err = fmt.Errorf("Container command '%s' not found or does not exist.", container.Path)
+			err = fmt.Errorf("Container command '%s' not found or does not exist", container.Path)
 		}
 		// set to 126 for container cmd can't be invoked errors
 		if strings.Contains(err.Error(), syscall.EACCES.Error()) {
 			container.ExitCode = 126
-			err = fmt.Errorf("Container command '%s' could not be invoked.", container.Path)
+			err = fmt.Errorf("Container command '%s' could not be invoked", container.Path)
 		}
 
 		container.Reset(false)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
clean up redundant period of error message.
**\- How I did it**

**\- How to verify it**

<pre><code>$ docker run -ti --rm busybox aaaa
docker: Error response from daemon: Container command 'aaaa' not found or does not exist..</code></pre>

There are two period at the end of the error message
**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Lei Jitang leijitang@huawei.com
