### PR TITLE
integration-cli: fix wrong test and add log

### DIFF
--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestDiffEnsureInitLayerFilesAreIgnored(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
+func (s *DockerSuite) TestDiffEnsureDefaultDevs(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sleep", "0")
 
@@ -75,7 +75,7 @@ func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
 	}
 
 	for _, line := range strings.Split(out, "\n") {
-		c.Assert(line == "" || expected[line], checker.True)
+		c.Assert(line == "" || expected[line], checker.True, check.Commentf(line))
 	}
 }
 


### PR DESCRIPTION
This test is failing but I'm not sure why also, (it's failing on my host not in the PR which is a lot weird):

```
INFO: Testing against a local daemon

----------------------------------------------------------------------
FAIL: docker_cli_diff_test.go:50: DockerSuite.TestDiffEnsureOnlyKmsgAndPtmx

docker_cli_diff_test.go:78:
    c.Assert(line == "" || expected[line], checker.True, check.Commentf(line))
... obtained bool = false
... A /run

OOPS: 0 passed, 1 FAILED
```

I have `/run/systemd/notify` in my host.

This test seems totally wrong btw, cause any /dev is shown in docker diff, i.e.

$ docker diff 7238ea8f10d5f3034204666941dee436c63b3b8ddb3d0408bd95f1822ba0551e
A /run
A /run/systemd
A /run/systemd/notify

Signed-off-by: Antonio Murdaca runcom@redhat.com
