### PR TITLE
Do not return error on hijacked connection for docker exec

### DIFF
--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -112,7 +112,6 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		}
 		stdout.Write([]byte(err.Error()))
 		logrus.Errorf("Error running exec in container: %v\n", err)
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
remove the return error when it was on hijacked connection,  the return error
is useless when the connection is hijacked, it will generate log 

<pre><code>
ERRO[0091] Handler for POST /v1.24/exec/8d4c1a6551a3171ffc290b3017a96746989e3b9d0bb0930104560d31e63b424b/start returned error: rpc error: code = 2 desc = "exec failed: exec: \"aaaa\": executable file not found in $PATH"
2016/03/24 08:58:52 http: response.WriteHeader on hijacked connection
2016/03/24 08:58:52 http: response.Write on hijacked connection
ERRO[0091] Handler for POST /v1.24/exec/8d4c1a6551a3171ffc290b3017a96746989e3b9d0bb0930104560d31e63b424b/resize returned error: rpc error: code = 2 desc = "containerd: processs not found for container"</code></pre>

no daemon.
**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Lei Jitang leijitang@huawei.com
