### PR TITLE
set the default storage driver as the users current default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: all binary build cross default docs docs-build docs-shell shell test test-docker-py test-integration-cli test-unit validate
 
+# set the graph driver as the current graphdriver if not set
+DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info | grep "Storage Driver" | sed 's/.*: //'))
+
 # get OS/Arch of docker engine
 DOCKER_OSARCH := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKER_ENGINE_OSARCH:-$$DOCKER_CLIENT_OSARCH}')
 DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKERFILE}')
@@ -15,7 +18,7 @@ DOCKER_ENVS := \
 	-e DOCKER_CLIENTONLY \
 	-e DOCKER_DEBUG \
 	-e DOCKER_EXPERIMENTAL \
-	-e DOCKER_GRAPHDRIVER \
+	-e DOCKER_GRAPHDRIVER=$(DOCKER_GRAPHDRIVER) \
 	-e DOCKER_INCREMENTAL_BINARY \
 	-e DOCKER_REMAP_ROOT \
 	-e DOCKER_STORAGE_OPTS \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Made it so if you dont specify `DOCKER_GRAPHDRIVER` on make it will use your current, so say overlay in overlay or aufs in aufs, zfs in zfs, and if you are running anything else you are effed already :P

**\- How I did it**

Makefile rule

**\- How to verify it**

`make`

or override the default

`DOCKER_GRAPHDRIVER=vfs make`

**\- A picture of a cute animal (not mandatory but encouraged)**

![c732z](https://cloud.githubusercontent.com/assets/1445228/14023258/e9992d3a-f1a0-11e5-8342-f536d6b6ac4b.gif)

Signed-off-by: Jess Frazelle jess@mesosphere.com
