### PR TITLE
[CI DEBUG: DO NOT MERGE] Print the daemon error message upon "generic" message

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -260,7 +260,11 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		// Autoremove: wait for the container to finish, retrieve
 		// the exit code and remove the container
 		if status, err = cli.client.ContainerWait(context.Background(), createResponse.ID); err != nil {
-			return runStartContainerErr(err)
+			tmpErr := runStartContainerErr(err)
+			if se, ok := tmpErr.(Cli.StatusError); ok && se.StatusCode == 125 {
+				fmt.Fprintf(cli.err, "Container did not execute successfully: %v\n", err)
+			}
+			return tmpErr
 		}
 		if _, status, err = getExitCode(cli, createResponse.ID); err != nil {
 			return err

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -102,10 +102,14 @@ func (s *DockerSuite) TestEventsLimit(c *check.C) {
 	args := []string{"run", "--rm", "busybox", "true"}
 	for i := 0; i < 17; i++ {
 		waitGroup.Add(1)
-		go func() {
+		go func(i int) {
 			defer waitGroup.Done()
-			errChan <- exec.Command(dockerBinary, args...).Run()
-		}()
+			out, err := exec.Command(dockerBinary, args...).CombinedOutput()
+			if err != nil {
+				fmt.Printf("Container %d failed: %v -- %s\n", i, err, string(out))
+			}
+			errChan <- err
+		}(i)
 	}
 
 	waitGroup.Wait()


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

Trying to get some more details from the win2lin failure  (see [#21473](https://github.com/docker/docker/issues/21473)) since we can't access the daemon log atm.

![aux armes!](https://s-media-cache-ak0.pinimg.com/736x/d6/ec/aa/d6ecaa9f56909a54349708e3d9c3c8d5.jpg)
