### PR TITLE
re-add .bashrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.test
 .*.swp
 .DS_Store
+# a .bashrc may be added to customize the build environment
+.bashrc
 .gopath/
 autogen/
 bundles/


### PR DESCRIPTION
.bashrc was removed in 29fbc9cc1d67759974ec4cb746840ae160d842bc but it is still needed. 
It serves as a hook to customize the build environment.

ping @tianon iirc, you added this some time ago.
