### PR TITLE
Windows: Remove --exec-root

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -61,7 +61,6 @@ type CommonConfig struct {
 	DNSOptions           []string            `json:"dns-opts,omitempty"`
 	DNSSearch            []string            `json:"dns-search,omitempty"`
 	ExecOptions          []string            `json:"exec-opts,omitempty"`
-	ExecRoot             string              `json:"exec-root,omitempty"`
 	GraphDriver          string              `json:"storage-driver,omitempty"`
 	GraphOptions         []string            `json:"storage-opts,omitempty"`
 	Labels               []string            `json:"labels,omitempty"`
@@ -115,7 +114,6 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.Var(opts.NewNamedListOptsRef("exec-opts", &config.ExecOptions, nil), []string{"-exec-opt"}, usageFn("Set runtime execution options"))
 	cmd.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, defaultPidFile, usageFn("Path to use for daemon PID file"))
 	cmd.StringVar(&config.Root, []string{"g", "-graph"}, defaultGraph, usageFn("Root of the Docker runtime"))
-	cmd.StringVar(&config.ExecRoot, []string{"-exec-root"}, defaultExecRoot, usageFn("Root directory for execution state files"))
 	cmd.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, usageFn("--restart on the daemon has been deprecated in favor of --restart policies on docker run"))
 	cmd.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", usageFn("Storage driver to use"))
 	cmd.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, usageFn("Set the containers network MTU"))

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -25,13 +25,14 @@ type Config struct {
 
 	// Fields below here are platform specific.
 
+	CgroupParent         string                   `json:"cgroup-parent,omitempty"`
+	ContainerdAddr       string                   `json:"containerd,omitempty"`
 	CorsHeaders          string                   `json:"api-cors-headers,omitempty"`
 	EnableCors           bool                     `json:"api-enable-cors,omitempty"`
 	EnableSelinuxSupport bool                     `json:"selinux-enabled,omitempty"`
+	ExecRoot             string                   `json:"exec-root,omitempty"`
 	RemappedRoot         string                   `json:"userns-remap,omitempty"`
-	CgroupParent         string                   `json:"cgroup-parent,omitempty"`
 	Ulimits              map[string]*units.Ulimit `json:"default-ulimits,omitempty"`
-	ContainerdAddr       string                   `json:"containerd,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -69,6 +70,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.BoolVar(&config.bridgeConfig.EnableIPForward, []string{"#ip-forward", "-ip-forward"}, true, usageFn("Enable net.ipv4.ip_forward"))
 	cmd.BoolVar(&config.bridgeConfig.EnableIPMasq, []string{"-ip-masq"}, true, usageFn("Enable IP masquerading"))
 	cmd.BoolVar(&config.bridgeConfig.EnableIPv6, []string{"-ipv6"}, false, usageFn("Enable IPv6 networking"))
+	cmd.StringVar(&config.ExecRoot, []string{"-exec-root"}, defaultExecRoot, usageFn("Root directory for execution state files"))
 	cmd.StringVar(&config.bridgeConfig.IP, []string{"#bip", "-bip"}, "", usageFn("Specify network bridge IP"))
 	cmd.StringVar(&config.bridgeConfig.Iface, []string{"b", "-bridge"}, "", usageFn("Attach containers to a network bridge"))
 	cmd.StringVar(&config.bridgeConfig.FixedCIDR, []string{"-fixed-cidr"}, "", usageFn("IPv4 subnet for fixed IPs"))

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -7,9 +7,8 @@ import (
 )
 
 var (
-	defaultPidFile  = os.Getenv("programdata") + string(os.PathSeparator) + "docker.pid"
-	defaultGraph    = os.Getenv("programdata") + string(os.PathSeparator) + "docker"
-	defaultExecRoot = defaultGraph
+	defaultPidFile = os.Getenv("programdata") + string(os.PathSeparator) + "docker.pid"
+	defaultGraph   = os.Getenv("programdata") + string(os.PathSeparator) + "docker"
 )
 
 // bridgeConfig stores all the bridge driver specific

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -265,8 +265,7 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 	cli.TrustKeyPath = commonFlags.TrustKey
 
 	registryService := registry.NewService(cli.Config.ServiceOptions)
-
-	containerdRemote, err := libcontainerd.New(filepath.Join(cli.Config.ExecRoot, "libcontainerd"), cli.getPlatformRemoteOptions()...)
+	containerdRemote, err := libcontainerd.New(cli.getLibcontainerdRoot(), cli.getPlatformRemoteOptions()...)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/docker/daemon_unix.go
+++ b/docker/daemon_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
@@ -75,4 +76,10 @@ func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 		opts = append(opts, libcontainerd.WithStartDaemon(true))
 	}
 	return opts
+}
+
+// getLibcontainerdRoot gets the root directory for libcontainerd/containerd to
+// store their state.
+func (cli *DaemonCli) getLibcontainerdRoot() string {
+	return filepath.Join(cli.Config.ExecRoot, "libcontainerd")
 }

--- a/docker/daemon_windows.go
+++ b/docker/daemon_windows.go
@@ -62,3 +62,10 @@ func setupConfigReloadTrap(configFile string, flags *mflag.FlagSet, reload func(
 func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 	return nil
 }
+
+// getLibcontainerdRoot gets the root directory for libcontainerd to store its
+// state. The Windows libcontainerd implementation does not need to write a spec
+// or state to disk, so this is a no-op.
+func (cli *DaemonCli) getLibcontainerdRoot() string {
+	return ""
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This removes the `--exec-root` daemon option from Windows where it is unused. Been meaning to do this for the longest time. 

![image](https://cloud.githubusercontent.com/assets/10522484/14027662/0753a1f6-f1b6-11e5-836c-d106264b524a.png)
(Practicing food distraction...)
