### PR TITLE
Windows: Native console disableNewlineAutoReturn

### DIFF
--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -31,6 +31,7 @@ const (
 	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms683167(v=vs.85).aspx
 	enableVirtualTerminalInput      = 0x0200
 	enableVirtualTerminalProcessing = 0x0004
+	disableNewlineAutoReturn        = 0x0008
 )
 
 // usingNativeConsole is true if we are using the Windows native console
@@ -146,8 +147,14 @@ func probeNativeConsole(state State) error {
 
 // enableNativeConsole turns on native console mode
 func enableNativeConsole(state State) error {
-	if err := winterm.SetConsoleMode(uintptr(state.outHandle), state.outMode|enableVirtualTerminalProcessing); err != nil {
-		return err
+	// First attempt both enableVirtualTerminalProcessing and disableNewlineAutoReturn
+	if err := winterm.SetConsoleMode(uintptr(state.outHandle),
+		state.outMode|(enableVirtualTerminalProcessing|disableNewlineAutoReturn)); err != nil {
+
+		// That may fail, so fallback to trying just enableVirtualTerminalProcessing
+		if err := winterm.SetConsoleMode(uintptr(state.outHandle), state.outMode|enableVirtualTerminalProcessing); err != nil {
+			return err
+		}
 	}
 
 	if err := winterm.SetConsoleMode(uintptr(state.inHandle), state.inMode|enableVirtualTerminalInput); err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Adds disableNewlineAutoReturn handling to the Windows native console support. Has been verified internally to work by our console team.
