### PR TITLE
Move hardware signing back into experimental

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -151,7 +151,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -153,7 +153,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -154,7 +154,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV DOCKER_BUILDTAGS apparmor selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -133,7 +133,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV DOCKER_BUILDTAGS apparmor selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -113,7 +113,7 @@ fi
 if [ "$DOCKER_EXPERIMENTAL" ]; then
 	echo >&2 '# WARNING! DOCKER_EXPERIMENTAL is set: building experimental features'
 	echo >&2
-	DOCKER_BUILDTAGS+=" experimental"
+	DOCKER_BUILDTAGS+=" experimental pkcs11"
 fi
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -5,8 +5,8 @@ VERSION = $(shell cat VERSION)
 override_dh_gencontrol:
 	# if we're on Ubuntu, we need to Recommends: apparmor
 	echo 'apparmor:Recommends=$(shell dpkg-vendor --is Ubuntu && echo apparmor)' >> debian/docker-engine.substvars
-	# recommend yubico-piv-tool since we include pkcs11 by default
-	echo 'yubico:Recommends=yubico-piv-tool (>= 1.1.0~)' >> debian/docker-engine.substvars
+	# if we are building experimental we recommend yubico-piv-tool
+	echo 'yubico:Recommends=$(shell [ "$DOCKER_EXPERIMENTAL" ] && echo "yubico-piv-tool (>= 1.1.0~)")' >> debian/docker-engine.substvars
 	dh_gencontrol
 
 override_dh_auto_build:

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -60,9 +60,11 @@ Requires: device-mapper >= 1.02.90-2
 %global with_selinux 1
 %endif
 
-# yubico-piv-tool recommends
+%if 0%{?_experimental}
+# yubico-piv-tool conditional
 %if 0%{?fedora} >= 20 || 0%{?centos} >= 7 || 0%{?rhel} >= 7
 Requires: yubico-piv-tool >= 1.1.0
+%endif
 %endif
 
 # start if with_selinux

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -36,7 +36,7 @@ if [ "$(go env GOOS)" == "linux" ] ; then
 	esac
 fi
 
-if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ]; then
+if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ] && [ "$DOCKER_EXPERIMENTAL" ]; then
 	if  [ "${GOOS}/${GOARCH}" == "darwin/amd64" ]; then
 		export CGO_ENABLED=1
 		export CC=o64-clang

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -60,7 +60,7 @@ To build the Docker daemon, you will additionally need:
 * btrfs-progs version 3.16.1 or later (unless using an older version is
   absolutely necessary, in which case 3.8 is the minimum)
 * libseccomp version 2.2.1 or later (for build tag seccomp)
-* yubico-piv-tool version 1.1.0 or later
+* yubico-piv-tool version 1.1.0 or later (for experimental)
 
 Be sure to also check out Docker's Dockerfile for the most up-to-date list of
 these build-time dependencies.


### PR DESCRIPTION
So it doesn't block the RC release.

We need to address https://github.com/docker/docker/issues/21494 before moving this back into GA.
