### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,6 @@ be found.
 - Fix an issue where registry service options in the daemon configuration file were not properly taken into account ([#21045](https://github.com/docker/docker/pull/21045))
 - Fix a race between the exec and resize operations ([#21022](https://github.com/docker/docker/pull/21022))
 - Fix an issue where nanoseconds were not correctly taken in account when filtering Docker events ([#21013](https://github.com/docker/docker/pull/21013))
-+ pkcs11 hardware signing is no longer an experimental feature  ([#21003](https://github.com/docker/docker/pull/21003))
 - Fix the handling of Docker command when passed a 64 bytes id ([#21002](https://github.com/docker/docker/pull/21002))
 * Docker will now return a `204` (i.e http.StatusNoContent) code when it successfully deleted a network ([#20977](https://github.com/docker/docker/pull/20977))
 - Fix a bug where the daemon would wait indefinitely in case the process it was about to killed had already exited on its own ([#20967](https://github.com/docker/docker/pull/20967)
@@ -119,6 +118,7 @@ be found.
 * `docker update` learned how to change a container restart policy ([#19116](https://github.com/docker/docker/pull/19116))
 * `docker inspect` now also returns a new `State` field containing the container state in a human readable way (i.e. one of `created`, `restarting`, `running`, `paused`, `exited` or `dead`)([#18966](https://github.com/docker/docker/pull/18966))
 + Docker learned to limit the number of active pids (i.e. processes) within the container via the `pids-limit` flags. NOTE: This requires `CGROUP_PIDS=y` to be in the kernel configuration. ([#18697](https://github.com/docker/docker/pull/18697))
+- `docker load` now has a `--quiet` option to suppress the load output ([#20078](https://github.com/docker/docker/pull/20078))
 
 ### Security
 


### PR DESCRIPTION
- hardware signing was put back to experimental due to packaging issues
  (https://github.com/docker/docker/pull/21499)
- add missing "--quiet" option for docker load
