### PR TITLE
Fix symlink copying for deb init scripts

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -84,7 +84,7 @@ set -e
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
 		fi
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			RUN mv -v hack/make/.build-deb debian
+			RUN cp -aL hack/make/.build-deb debian
 			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
 			RUN dpkg-buildpackage -uc -us
 		EOF


### PR DESCRIPTION
After 027f4fdca678ae955db6f115d6af15d532f6cf4b the paths to the symlinks under `hack/make/.build-deb` were broken.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
