### PR TITLE
Added a better message for when we build an unsupported Docker version

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -81,6 +81,14 @@ if command -v git &> /dev/null && git rev-parse &> /dev/null; then
 	GITCOMMIT=$(git rev-parse --short HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-unsupported"
+		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+		echo "# GITCOMMIT = $GITCOMMIT"
+		echo "# The version you are building is listed as unsupported because"
+		echo "# there are some files in the git repository that are in an uncommited state."
+		echo "# Commit these changes, or add to .gitignore to remove the -unsupported from the version."
+		echo "# Here is the current list:"
+		git status --porcelain --untracked-files=no
+		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	fi
 	! BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
 	if [ -z $BUILDTIME ]; then


### PR DESCRIPTION
Right now when we build an unsupported version, it doesn't tell us why it is being marked as unsupported, this PR improves the messaging around building unsupported versions and makes it easier to figure out what is causing it, and how to fix.

A follow up feature would be to have an ENV variable that if set, would fail if the version is unsupported, which would be good when cutting releases and we don't want unsupported versions.

Example output:

```
#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# GITCOMMIT = 04e7428-unsupported
# The version you are building is listed as unsupported because
# there are some files in the git repository that are in an uncommited state.
# Commit these changes, or add to .gitignore to remove the -unsupported from the version.
# Here is the current list:
 M hack/make.sh
#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

/cc @tiborvass 

Signed-off-by: Ken Cochrane kencochrane@gmail.com
