### PR TITLE
Improve error reporting with --insecure-registry if https registry connection fails (#20286)

### DIFF
--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -1,7 +1,9 @@
 package distribution
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
@@ -94,7 +96,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 	}
 
 	var (
-		lastErr error
+		fullErr []string
 
 		// discardNoSupportErrors is used to track whether an endpoint encountered an error of type registry.ErrNoSupport
 		// By default it is false, which means that if a ErrNoSupport error is encountered, it will be saved in lastErr.
@@ -132,7 +134,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 
 		puller, err := newPuller(endpoint, repoInfo, imagePullConfig)
 		if err != nil {
-			lastErr = err
+			fullErr = append(fullErr, err.Error())
 			continue
 		}
 		if err := puller.Pull(ctx, ref); err != nil {
@@ -156,29 +158,30 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 					// Because we found an error that's not ErrNoSupport, discard all subsequent ErrNoSupport errors.
 					discardNoSupportErrors = true
 					// append subsequent errors
-					lastErr = err
+					fullErr = append(fullErr, err.Error())
 				} else if !discardNoSupportErrors {
 					// Save the ErrNoSupport error, because it's either the first error or all encountered errors
 					// were also ErrNoSupport errors.
 					// append subsequent errors
-					lastErr = err
+					fullErr = append(fullErr, err.Error())
 				}
 				logrus.Errorf("Attempting next endpoint for pull after error: %v", err)
 				continue
 			}
 			logrus.Errorf("Not continuing with pull after error: %v", err)
-			return err
+			fullErr = append(fullErr, err.Error())
+			return errors.New(strings.Join(fullErr, "\n"))
 		}
 
 		imagePullConfig.ImageEventLogger(ref.String(), repoInfo.Name(), "pull")
 		return nil
 	}
 
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", ref.String())
+	if len(fullErr) == 0 {
+		fullErr = append(fullErr, fmt.Sprintf("no endpoints found for %s", ref.String()))
 	}
 
-	return lastErr
+	return errors.New(strings.Join(fullErr, "\n"))
 }
 
 // writeStatus writes a status message to out. If layersDownloaded is true, the

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -3,8 +3,10 @@ package distribution
 import (
 	"bufio"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/distribution/metadata"
@@ -113,7 +115,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 	}
 
 	var (
-		lastErr error
+		fullErr []string
 
 		// confirmedV2 is set to true if a push attempt managed to
 		// confirm that it was talking to a v2 registry. This will
@@ -143,7 +145,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 
 		pusher, err := NewPusher(ref, endpoint, repoInfo, imagePushConfig)
 		if err != nil {
-			lastErr = err
+			fullErr = append(fullErr, err.Error())
 			continue
 		}
 		if err := pusher.Push(ctx); err != nil {
@@ -158,24 +160,25 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 						confirmedTLSRegistries[endpoint.URL.Host] = struct{}{}
 					}
 					err = fallbackErr.err
-					lastErr = err
+					fullErr = append(fullErr, err.Error())
 					logrus.Errorf("Attempting next endpoint for push after error: %v", err)
 					continue
 				}
 			}
 
 			logrus.Errorf("Not continuing with push after error: %v", err)
-			return err
+			fullErr = append(fullErr, err.Error())
+			return errors.New(strings.Join(fullErr, "\n"))
 		}
 
 		imagePushConfig.ImageEventLogger(ref.String(), repoInfo.Name(), "push")
 		return nil
 	}
 
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", repoInfo.FullName())
+	if len(fullErr) == 0 {
+		fullErr = append(fullErr, fmt.Sprintf("no endpoints found for %s", repoInfo.FullName()))
 	}
-	return lastErr
+	return errors.New(strings.Join(fullErr, "\n"))
 }
 
 // compress returns an io.ReadCloser which will supply a compressed version of


### PR DESCRIPTION
This fix tries to fix issues in `docker push` and `docker pull` where only the last error would be reported if https registry connection fails.

In the implementation of `push` and `pull`, docker client may try to connect to multiple endpoints though only the last error would be reported. As is described in #20286, this causes confusion for end users.

This fix tries to address this issue by combining multiple endpoint errors into one error and return back. The end user would be able to see a series of end point attampts and error messages.

This fix has been tested manually.

This fix fixes #20286.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
