### PR TITLE
Update vendored engine-api to e37a82dfcea64559ca6a581776253c01d83357d9.

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api v0.3.1
+clone git github.com/docker/engine-api e37a82dfcea64559ca6a581776253c01d83357d9
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/container_copy.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_copy.go
@@ -53,7 +53,7 @@ func (cli *Client) CopyToContainer(ctx context.Context, options types.CopyToCont
 	return nil
 }
 
-// CopyFromContainer get the content from the container and return it as a Reader
+// CopyFromContainer gets the content from the container and returns it as a Reader
 // to manipulate it in the host. It's up to the caller to close the reader.
 func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
 	query := make(url.Values, 1)

--- a/vendor/src/github.com/docker/engine-api/client/container_exec.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_exec.go
@@ -19,7 +19,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, config types.ExecCon
 	return response, err
 }
 
-// ContainerExecStart starts an exec process already create in the docker host.
+// ContainerExecStart starts an exec process already created in the docker host.
 func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
 	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
 	ensureReaderClosed(resp)

--- a/vendor/src/github.com/docker/engine-api/client/container_export.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_export.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ContainerExport retrieves the raw contents of a container
-// and returns them as a io.ReadCloser. It's up to the caller
+// and returns them as an io.ReadCloser. It's up to the caller
 // to close the stream.
 func (cli *Client) ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error) {
 	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)

--- a/vendor/src/github.com/docker/engine-api/client/container_wait.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_wait.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
-// ContainerWait pauses execution util a container is exits.
+// ContainerWait pauses execution util a container exits.
 // It returns the API status code as response of its readiness.
 func (cli *Client) ContainerWait(ctx context.Context, containerID string) (int, error) {
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)

--- a/vendor/src/github.com/docker/engine-api/client/errors.go
+++ b/vendor/src/github.com/docker/engine-api/client/errors.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// ErrConnectionFailed is a error raised when the connection between the client and the server failed.
+// ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
 // imageNotFoundError implements an error returned when an image is not in the docker host.
@@ -30,7 +30,7 @@ type containerNotFoundError struct {
 	containerID string
 }
 
-// Error returns a string representation of an containerNotFoundError
+// Error returns a string representation of a containerNotFoundError
 func (e containerNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such container: %s", e.containerID)
 }
@@ -47,7 +47,7 @@ type networkNotFoundError struct {
 	networkID string
 }
 
-// Error returns a string representation of an networkNotFoundError
+// Error returns a string representation of a networkNotFoundError
 func (e networkNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such network: %s", e.networkID)
 }
@@ -64,7 +64,7 @@ type volumeNotFoundError struct {
 	volumeID string
 }
 
-// Error returns a string representation of an networkNotFoundError
+// Error returns a string representation of a networkNotFoundError
 func (e volumeNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such volume: %s", e.volumeID)
 }
@@ -87,7 +87,7 @@ func (u unauthorizedError) Error() string {
 }
 
 // IsErrUnauthorized returns true if the error is caused
-// when an the remote registry authentication fails
+// when a remote registry authentication fails
 func IsErrUnauthorized(err error) bool {
 	_, ok := err.(unauthorizedError)
 	return ok

--- a/vendor/src/github.com/docker/engine-api/client/image_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_inspect.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ImageInspectWithRaw returns the image information and it's raw representation.
+// ImageInspectWithRaw returns the image information and its raw representation.
 func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (types.ImageInspect, []byte, error) {
 	query := url.Values{}
 	if getSize {

--- a/vendor/src/github.com/docker/engine-api/client/image_pull.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_pull.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
-// ImagePull request the docker host to pull an image from a remote registry.
+// ImagePull requests the docker host to pull an image from a remote registry.
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
 // It's up to the caller to handle the io.ReadCloser and close it properly.

--- a/vendor/src/github.com/docker/engine-api/client/image_push.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_push.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
-// ImagePush request the docker host to push an image to a remote registry.
+// ImagePush requests the docker host to push an image to a remote registry.
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
 // It's up to the caller to handle the io.ReadCloser and close it properly.

--- a/vendor/src/github.com/docker/engine-api/client/image_save.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_save.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ImageSave retrieves one or more images from the docker host as a io.ReadCloser.
+// ImageSave retrieves one or more images from the docker host as an io.ReadCloser.
 // It's up to the caller to store the images and close the stream.
 func (cli *Client) ImageSave(ctx context.Context, imageIDs []string) (io.ReadCloser, error) {
 	query := url.Values{

--- a/vendor/src/github.com/docker/engine-api/types/blkiodev/blkio.go
+++ b/vendor/src/github.com/docker/engine-api/types/blkiodev/blkio.go
@@ -2,7 +2,7 @@ package blkiodev
 
 import "fmt"
 
-// WeightDevice is a structure that hold device:weight pair
+// WeightDevice is a structure that holds device:weight pair
 type WeightDevice struct {
 	Path   string
 	Weight uint16
@@ -12,7 +12,7 @@ func (w *WeightDevice) String() string {
 	return fmt.Sprintf("%s:%d", w.Path, w.Weight)
 }
 
-// ThrottleDevice is a structure that hold device:rate_per_second pair
+// ThrottleDevice is a structure that holds device:rate_per_second pair
 type ThrottleDevice struct {
 	Path string
 	Rate uint64

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -229,7 +229,7 @@ type VersionResponse struct {
 	Server *Version
 }
 
-// ServerOK return true when the client could connect to the docker server
+// ServerOK returns true when the client could connect to the docker server
 // and parse the information received. It returns false otherwise.
 func (v VersionResponse) ServerOK() bool {
 	return v.Server != nil

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -89,7 +89,7 @@ func (n UsernsMode) Valid() bool {
 	return true
 }
 
-// Cgroup Spec represents the cgroup to use for the container.
+// CgroupSpec represents the cgroup to use for the container.
 type CgroupSpec string
 
 func (c CgroupSpec) IsContainer() bool {
@@ -113,7 +113,7 @@ func (c CgroupSpec) Container() string {
 // UTSMode represents the UTS namespace of the container.
 type UTSMode string
 
-// IsPrivate indicates whether the container uses it's private UTS namespace.
+// IsPrivate indicates whether the container uses its private UTS namespace.
 func (n UTSMode) IsPrivate() bool {
 	return !(n.IsHost())
 }
@@ -137,7 +137,7 @@ func (n UTSMode) Valid() bool {
 // PidMode represents the pid stack of the container.
 type PidMode string
 
-// IsPrivate indicates whether the container uses it's private pid stack.
+// IsPrivate indicates whether the container uses its private pid stack.
 func (n PidMode) IsPrivate() bool {
 	return !(n.IsHost())
 }
@@ -236,11 +236,10 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount    int64  `json:"CpuCount"`   // CPU count
-	CPUPercent  int64  `json:"CpuPercent"` // CPU percent
-	BlkioIOps   uint64 // Maximum IOps for the container system drive
-	BlkioBps    uint64 // Maximum Bytes per second for the container system drive
-	SandboxSize uint64 // System drive will be expanded to at least this size (in bytes)
+	CPUCount     int64  `json:"CpuCount"`   // CPU count
+	CPUPercent   int64  `json:"CpuPercent"` // CPU percent
+	MaximumIOps  uint64 // Maximum IOps for the container system drive
+	MaximumIOBps uint64 // Maximum IO in bytes per second for the container system drive
 }
 
 // UpdateConfig holds the mutable attributes of a Container.

--- a/vendor/src/github.com/docker/engine-api/types/container/hostconfig_windows.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/hostconfig_windows.go
@@ -32,7 +32,7 @@ func (n NetworkMode) IsHost() bool {
 	return false
 }
 
-// IsPrivate indicates whether container uses it's private network stack.
+// IsPrivate indicates whether container uses its private network stack.
 func (n NetworkMode) IsPrivate() bool {
 	return !(n.IsHost() || n.IsContainer())
 }

--- a/vendor/src/github.com/docker/engine-api/types/filters/parse.go
+++ b/vendor/src/github.com/docker/engine-api/types/filters/parse.go
@@ -11,9 +11,9 @@ import (
 )
 
 // Args stores filter arguments as map key:{map key: bool}.
-// It contains a aggregation of the map of arguments (which are in the form
-// of -f 'key=value') based on the key, and store values for the same key
-// in an map with string keys and boolean values.
+// It contains an aggregation of the map of arguments (which are in the form
+// of -f 'key=value') based on the key, and stores values for the same key
+// in a map with string keys and boolean values.
 // e.g given -f 'label=label1=1' -f 'label=label2=2' -f 'image.name=ubuntu'
 // the args will be {"image.name":{"ubuntu":true},"label":{"label1=1":true,"label2=2":true}}
 type Args struct {
@@ -54,7 +54,7 @@ func ParseFlag(arg string, prev Args) (Args, error) {
 // ErrBadFormat is an error returned in case of bad format for a filter.
 var ErrBadFormat = errors.New("bad format of filter (expected name=value)")
 
-// ToParam packs the Args into an string for easy transport from client to server.
+// ToParam packs the Args into a string for easy transport from client to server.
 func ToParam(a Args) (string, error) {
 	// this way we don't URL encode {}, just empty space
 	if a.Len() == 0 {
@@ -190,7 +190,7 @@ func (filters Args) ExactMatch(field, source string) bool {
 		return true
 	}
 
-	// try to march full name value to avoid O(N) regular expression matching
+	// try to match full name value to avoid O(N) regular expression matching
 	if fieldValues[source] {
 		return true
 	}

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -251,6 +251,7 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
+	SecurityOptions    []string
 }
 
 // PluginsInfo is a temp struct holding Plugins name
@@ -289,6 +290,18 @@ type ContainerState struct {
 	FinishedAt string
 }
 
+// NodeData stores information about the node that a container
+// is running on.  It's only available in Docker Swarm
+type ContainerNode struct {
+	ID        string
+	IPAddress string `json:"IP"`
+	Addr      string
+	Name      string
+	Cpus      int
+	Memory    int
+	Labels    map[string]string
+}
+
 // ContainerJSONBase contains response of Remote API:
 // GET "/containers/{name:.*}/json"
 type ContainerJSONBase struct {
@@ -302,6 +315,7 @@ type ContainerJSONBase struct {
 	HostnamePath    string
 	HostsPath       string
 	LogPath         string
+	Node            *ContainerNode `json:",omitempty"`
 	Name            string
 	RestartCount    int
 	Driver          string


### PR DESCRIPTION
This PR updates vendored engine-api to e37a82dfcea64559ca6a581776253c01d83357d9 in order to support `SecurityOptions` in `Info`.

See #20909, #21172 for details related to `SecurityOptions`.

`SecurityOptions` was added in `Info` through pull request https://github.com/docker/engine-api/pull/157 in engine-api.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
