### PR TITLE
Protect aufs mounts with locks

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -67,6 +67,7 @@ func init() {
 
 // Driver contains information about the filesystem mounted.
 type Driver struct {
+	sync.Mutex
 	root          string
 	uidMaps       []idtools.IDMap
 	gidMaps       []idtools.IDMap
@@ -418,6 +419,9 @@ func (a *Driver) getParentLayerPaths(id string) ([]string, error) {
 }
 
 func (a *Driver) mount(id string, target string, mountLabel string, layers []string) error {
+	a.Lock()
+	defer a.Unlock()
+
 	// If the id is mounted or we get an error return
 	if mounted, err := a.mounted(target); err != nil || mounted {
 		return err
@@ -432,6 +436,9 @@ func (a *Driver) mount(id string, target string, mountLabel string, layers []str
 }
 
 func (a *Driver) unmount(mountPath string) error {
+	a.Lock()
+	defer a.Unlock()
+
 	if mounted, err := a.mounted(mountPath); err != nil || !mounted {
 		return err
 	}


### PR DESCRIPTION
Parallel aufs mount calls produce `invalid argument` error.

Fixes #21545

This is causing the `TestDockerNetworkHostModeUngracefulDaemonRestart` failures in ci. @mlaventure also debugged #21473 to `invalid argument` so likely the same cause.

cc @cpuguy83 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
