### PR TITLE
Add support for repeating integration tests

### DIFF
--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -2,7 +2,7 @@
 set -e
 
 bundle_test_integration_cli() {
-	TESTFLAGS="$TESTFLAGS -check.v -check.timeout=${TIMEOUT} -timeout=360m"
+	TESTFLAGS="$TESTFLAGS -check.v -check.timeout=${TIMEOUT} -test.timeout=360m"
 	go_test_dir ./integration-cli
 }
 


### PR DESCRIPTION
`TEST_REPEAT=n` runs the test suite again `n` times or
until the first failure without doing building and
daemon setup. Useful for debugging flaky tests.

Example: `TEST_REPEAT=100 TESTFLAGS="-check.vv -check.f TestDockerNetworkHostModeUngracefulDaemonRestart" hack/make.sh binary test-integration-cli`

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
