### PR TITLE
systemctl show, no need to sudo

### DIFF
--- a/docs/admin/systemd.md
+++ b/docs/admin/systemd.md
@@ -56,14 +56,14 @@ directory including the following:
 
 To check if the `docker.service` uses an `EnvironmentFile`:
 
-    $ sudo systemctl show docker | grep EnvironmentFile
+    $ systemctl show docker | grep EnvironmentFile
     EnvironmentFile=-/etc/sysconfig/docker (ignore_errors=yes)
 
 Alternatively, find out where the service file is located:
 
-    $ sudo systemctl status docker | grep Loaded
-       Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled)
-    $ sudo grep EnvironmentFile /usr/lib/systemd/system/docker.service
+    $ systemctl show --property=FragmentPath docker
+    FragmentPath=/usr/lib/systemd/system/docker.service
+    $ grep EnvironmentFile /usr/lib/systemd/system/docker.service
     EnvironmentFile=-/etc/sysconfig/docker
 
 You can customize the Docker daemon options using override files as explained in the
@@ -143,7 +143,7 @@ Flush changes:
 
 Verify that the configuration has been loaded:
 
-    $ sudo systemctl show docker --property Environment
+    $ systemctl show --property=Environment docker
     Environment=HTTP_PROXY=http://proxy.example.com:80/
 
 Restart Docker:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Use `systemctl show` consistently instead of using grep.
There's also no need to be using `sudo`

**\- How I did it**
Updated the .md

**\- How to verify it**

```
$ systemctl show docker | grep EnvironmentFile
EnvironmentFile=/etc/sysconfig/docker (ignore_errors=yes)
$ systemctl show --property=FragmentPath docker
FragmentPath=/etc/systemd/system/docker.service
$ systemctl show --property=Environment docker
Environment=
```

**\- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/7956715/14076979/00b32270-f4e7-11e5-9ecc-353302b439c9.png)

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
