### PR TITLE
docs for `docker daemon --containerd`

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -21,13 +21,14 @@ weight = -1
       -b, --bridge=""                        Attach containers to a network bridge
       --bip=""                               Specify network bridge IP
       --cgroup-parent=                       Set parent cgroup for all containers
-      -D, --debug                            Enable debug mode
-      --default-gateway=""                   Container default gateway IPv4 address
-      --default-gateway-v6=""                Container default gateway IPv6 address
       --cluster-store=""                     URL of the distributed storage backend
       --cluster-advertise=""                 Address of the daemon instance on the cluster
       --cluster-store-opt=map[]              Set cluster options
       --config-file=/etc/docker/daemon.json  Daemon configuration file
+      --containerd                           Path to containerd socket
+      -D, --debug                            Enable debug mode
+      --default-gateway=""                   Container default gateway IPv4 address
+      --default-gateway-v6=""                Container default gateway IPv6 address
       --dns=[]                               DNS server to use
       --dns-opt=[]                           DNS options to use
       --dns-search=[]                        DNS search domains to use

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -15,6 +15,7 @@ docker-daemon - Enable daemon mode
 [**--cluster-advertise**[=*[]*]]
 [**--cluster-store-opt**[=*map[]*]]
 [**--config-file**[=*/etc/docker/daemon.json*]]
+[**--containerd**[=*SOCKET-PATH*]]
 [**-D**|**--debug**]
 [**--default-gateway**[=*DEFAULT-GATEWAY*]]
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
@@ -100,6 +101,9 @@ format.
 
 **--config-file**="/etc/docker/daemon.json"
   Specifies the JSON file path to load the configuration from.
+
+**--containerd**=""
+  Path to containerd socket.
 
 **-D**, **--debug**=*true*|*false*
   Enable debug mode. Default is false.


### PR DESCRIPTION
When adding bash completion for this option (Ref. #21573), I noticed that there were no docs as well.

https://github.com/docker/docker/blob/master/daemon/config_unix.go#L87 suggests that there is no default. I think there must be a default, though, which should be documented. Can anybody help?
