### PR TITLE
bash completion for `dm.min_free_space`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -887,6 +887,7 @@ _docker_daemon() {
 				dm.fs
 				dm.loopdatasize
 				dm.loopmetadatasize
+				dm.min_free_space
 				dm.mkfsarg
 				dm.mountopt
 				dm.override_udev_sync_check

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -462,7 +462,7 @@ options for `zfs` start with `zfs`.
 
     Example use:
 
-        $ docker daemon --storage-opt dm.min_free_space_percent=10%
+        $ docker daemon --storage-opt dm.min_free_space=10%
 
 Currently supported options of `zfs`:
 

--- a/man/docker-daemon.8.md
+++ b/man/docker-daemon.8.md
@@ -487,7 +487,7 @@ pool and that should automatically resolve it. If loop devices are being
 used, then stop docker, grow the size of loop files and restart docker and
 that should resolve the issue.
 
-Example use: `docker daemon --storage-opt dm.min_free_space_percent=10%`
+Example use: `docker daemon --storage-opt dm.min_free_space=10%`
 
 ## ZFS options
 


### PR DESCRIPTION
Ref: #20786

Also fixes two broken examples in the docs.

ping @sdurrheimer for zsh completion
