### PR TITLE
fixes-#21581-no--subnetwork-option-as-specified-in-docs

### DIFF
--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -87,7 +87,7 @@ specify a single subnet. An `overlay` network supports multiple subnets.
 > in your infrastructure that is not managed by docker. Such overlaps can cause
 > connectivity issues or failures when containers are connected to that network.
 
-In addition to the `--subnetwork` option, you also specify the `--gateway` `--ip-range` and `--aux-address` options.
+In addition to the `--subnet` option, you also specify the `--gateway` `--ip-range` and `--aux-address` options.
 
 ```bash
 $ docker network create -d overlay


### PR DESCRIPTION
fixes-#21581-no--subnetwork-option-as-specified-in-docs-for-work-with-networks.md: fixed typo in docs
