### PR TITLE
ppc64le: bump golang back to 1.6

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -71,11 +71,9 @@ RUN cd /usr/local/lvm2 \
 	&& make install_device-mapper
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
-# TODO install Go, using gccgo as GOROOT_BOOTSTRAP (Go 1.5+ supports ppc64le properly)
-# possibly a ppc64le/golang image?
-
-## BUILD GOLANG 1.5.3
-ENV GO_VERSION 1.5.3
+## BUILD GOLANG 1.6
+# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
+ENV GO_VERSION 1.6
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 ENV GO_DOWNLOAD_SHA256 a96cce8ce43a9bf9b2a4c7d470bc7ee0cb00410da815980681c8353218dcf146
 ENV GOROOT_BOOTSTRAP /usr/local
@@ -129,13 +127,12 @@ RUN set -x \
 # Install notary and notary-server
 ENV NOTARY_VERSION docker-v1.11-3
 RUN set -x \
-	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
-	&& GOPATH="$GOPATH/src/github.com/docker/notary/vendor:$GOPATH" \
+	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
 		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
-	&& GOPATH="$GOPATH/src/github.com/docker/notary/vendor:$GOPATH" \
+	&& GOPATH="$GOPATH/src/github.com/docker/notary/Godeps/_workspace:$GOPATH" \
 		go build -o /usr/local/bin/notary github.com/docker/notary/cmd/notary \
 	&& rm -rf "$GOPATH"
 


### PR DESCRIPTION
Despite the current issue with unix sockets and golang, I'm bumping this back up to 1.6.
Go <1.6 has major compatibility issues on ppc64\* including not supporting dynamic binding,
so we would have to go back to gccgo, which is worse in a lot of other categories. Ultimately for us,
the amount of people affected by this issue isn't worth switching compilers.

ping @duglin @calavera 

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
