### PR TITLE
Remove runconfig package dependency from the API.

### DIFF
--- a/api/server/httputils/decoder.go
+++ b/api/server/httputils/decoder.go
@@ -1,0 +1,16 @@
+package httputils
+
+import (
+	"io"
+
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
+)
+
+// ContainerDecoder specifies how
+// to translate an io.Reader into
+// container configuration.
+type ContainerDecoder interface {
+	DecodeConfig(src io.Reader) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error)
+	DecodeHostConfig(src io.Reader) (*container.HostConfig, error)
+}

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -1,17 +1,22 @@
 package container
 
-import "github.com/docker/docker/api/server/router"
+import (
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/api/server/router"
+)
 
 // containerRouter is a router to talk with the container controller
 type containerRouter struct {
 	backend Backend
+	decoder httputils.ContainerDecoder
 	routes  []router.Route
 }
 
 // NewRouter initializes a new container router
-func NewRouter(b Backend) router.Router {
+func NewRouter(b Backend, decoder httputils.ContainerDecoder) router.Router {
 	r := &containerRouter{
 		backend: b,
+		decoder: decoder,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/term"
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
@@ -149,7 +148,7 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 			return err
 		}
 
-		c, err := runconfig.DecodeHostConfig(r.Body)
+		c, err := s.decoder.DecodeHostConfig(r.Body)
 		if err != nil {
 			return err
 		}
@@ -350,7 +349,7 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 
 	name := r.Form.Get("name")
 
-	config, hostConfig, networkingConfig, err := runconfig.DecodeContainerConfig(r.Body)
+	config, hostConfig, networkingConfig, err := s.decoder.DecodeConfig(r.Body)
 	if err != nil {
 		return err
 	}

--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -1,17 +1,22 @@
 package image
 
-import "github.com/docker/docker/api/server/router"
+import (
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/api/server/router"
+)
 
 // imageRouter is a router to talk with the image controller
 type imageRouter struct {
 	backend Backend
+	decoder httputils.ContainerDecoder
 	routes  []router.Route
 }
 
 // NewRouter initializes a new image router
-func NewRouter(backend Backend) router.Router {
+func NewRouter(backend Backend, decoder httputils.ContainerDecoder) router.Router {
 	r := &imageRouter{
 		backend: backend,
+		decoder: decoder,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/reference"
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"golang.org/x/net/context"
@@ -40,7 +39,7 @@ func (s *imageRouter) postCommit(ctx context.Context, w http.ResponseWriter, r *
 		pause = true
 	}
 
-	c, _, _, err := runconfig.DecodeContainerConfig(r.Body)
+	c, _, _, err := s.decoder.DecodeConfig(r.Body)
 	if err != nil && err != io.EOF { //Do not fail if body is empty.
 		return err
 	}

--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/libnetwork"
 )
@@ -11,8 +13,8 @@ type Backend interface {
 	FindNetwork(idName string) (libnetwork.Network, error)
 	GetNetworkByName(idName string) (libnetwork.Network, error)
 	GetNetworksByID(partialID string) []libnetwork.Network
-	GetAllNetworks() []libnetwork.Network
-	CreateNetwork(name, driver string, ipam network.IPAM, options map[string]string, labels map[string]string, internal bool, enableIPv6 bool) (libnetwork.Network, error)
+	FilterNetworks(netFilters filters.Args) ([]libnetwork.Network, error)
+	CreateNetwork(types.NetworkCreate) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, network libnetwork.Network, force bool) error
 	DeleteNetwork(name string) error

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -231,6 +231,8 @@ func (daemon *Daemon) DeleteNetwork(networkID string) error {
 	return nil
 }
 
+// FilterNetworks returns a list of networks filtered by the given arguments.
+// It returns an error if the filters are not included in the list of accepted filters.
 func (daemon *Daemon) FilterNetworks(netFilters filters.Args) ([]libnetwork.Network, error) {
 	if netFilters.Len() != 0 {
 		if err := netFilters.Validate(netsettings.AcceptedFilters); err != nil {

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -20,7 +20,7 @@ var (
 		"id":   filterNetworkByID,
 	}
 
-	// acceptFilters is an acceptable filter flag list
+	// AcceptedFilters is an acceptable filter flag list
 	// generated for validation. e.g.
 	// acceptedFilters = map[string]bool{
 	//     "type": true,
@@ -84,7 +84,7 @@ func filterNetworkByID(nws []libnetwork.Network, id string) (retNws []libnetwork
 	return retNws, nil
 }
 
-// FilterAllNetworks filters network list according to user specified filter
+// FilterNetworks filters network list according to user specified filter
 // and returns user chosen networks
 func FilterNetworks(nws []libnetwork.Network, filter filters.Args) ([]libnetwork.Network, error) {
 	// if filter is empty, return original network list

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -27,7 +27,7 @@ var (
 	//     "name": true,
 	//     "id":   true,
 	// }
-	acceptedFilters = func() map[string]bool {
+	AcceptedFilters = func() map[string]bool {
 		ret := make(map[string]bool)
 		for k := range supportedFilters {
 			ret[k] = true
@@ -84,9 +84,9 @@ func filterNetworkByID(nws []libnetwork.Network, id string) (retNws []libnetwork
 	return retNws, nil
 }
 
-// filterAllNetworks filters network list according to user specified filter
+// FilterAllNetworks filters network list according to user specified filter
 // and returns user chosen networks
-func filterNetworks(nws []libnetwork.Network, filter filters.Args) ([]libnetwork.Network, error) {
+func FilterNetworks(nws []libnetwork.Network, filter filters.Args) ([]libnetwork.Network, error) {
 	// if filter is empty, return original network list
 	if filter.Len() == 0 {
 		return nws, nil

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -37,6 +37,7 @@ import (
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 	"github.com/docker/go-connections/tlsconfig"
 )
@@ -405,9 +406,11 @@ func loadDaemonCliConfig(config *daemon.Config, daemonFlags *flag.FlagSet, commo
 }
 
 func initRouter(s *apiserver.Server, d *daemon.Daemon) {
+	decoder := runconfig.ContainerDecoder{}
+
 	routers := []router.Router{
-		container.NewRouter(d),
-		image.NewRouter(d),
+		container.NewRouter(d, decoder),
+		image.NewRouter(d, decoder),
 		systemrouter.NewRouter(d),
 		volume.NewRouter(d),
 		build.NewRouter(dockerfile.NewBuildManager(d)),

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -296,8 +296,8 @@ func createNetwork(c *check.C, config types.NetworkCreate, shouldSucceed bool) s
 		return ""
 	}
 
-	c.Assert(status, checker.Equals, http.StatusCreated)
 	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusCreated)
 
 	var nr types.NetworkCreateResponse
 	err = json.Unmarshal(resp, &nr)

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -10,6 +10,20 @@ import (
 	networktypes "github.com/docker/engine-api/types/network"
 )
 
+// ContainerDecoder implements httputils.ContainerDecoder
+// calling DecodeContainerConfig.
+type ContainerDecoder struct{}
+
+// DecodeConfig makes ContainerDecoder to implement httputils.ContainerDecoder
+func (r ContainerDecoder) DecodeConfig(src io.Reader) (*container.Config, *container.HostConfig, *networktypes.NetworkingConfig, error) {
+	return DecodeContainerConfig(src)
+}
+
+// DecodeHostConfig makes ContainerDecoder to implement httputils.ContainerDecoder
+func (r ContainerDecoder) DecodeHostConfig(src io.Reader) (*container.HostConfig, error) {
+	return DecodeHostConfig(src)
+}
+
 // DecodeContainerConfig decodes a json encoded config into a ContainerConfigWrapper
 // struct and returns both a Config and an HostConfig struct
 // Be aware this function is not checking whether the resulted structs are nil,


### PR DESCRIPTION
This change makes the API to be free of `runconfig` references:
1. Move network validations to the backend.
2. Specify the configuration decoding behavior in an interface.

/cc @MHBauer, @icecrime
