### PR TITLE
Windows: bridgeConfig rework

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -39,6 +39,13 @@ type LogConfig struct {
 	Config map[string]string `json:"log-opts,omitempty"`
 }
 
+// commonBridgeConfig stores all the platform-common bridge driver specific
+// configuration.
+type commonBridgeConfig struct {
+	Iface     string `json:"bridge,omitempty"`
+	FixedCIDR string `json:"fixed-cidr,omitempty"`
+}
+
 // CommonTLSOptions defines TLS configuration for the daemon server.
 // It includes json tags to deserialize configuration from a file
 // using the same names that the flags in the command line uses.

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -38,15 +38,16 @@ type Config struct {
 // bridgeConfig stores all the bridge driver specific
 // configuration.
 type bridgeConfig struct {
+	commonBridgeConfig
+
+	// Fields below here are platform specific.
 	EnableIPv6                  bool   `json:"ipv6,omitempty"`
 	EnableIPTables              bool   `json:"iptables,omitempty"`
 	EnableIPForward             bool   `json:"ip-forward,omitempty"`
 	EnableIPMasq                bool   `json:"ip-mask,omitempty"`
 	EnableUserlandProxy         bool   `json:"userland-proxy,omitempty"`
 	DefaultIP                   net.IP `json:"ip,omitempty"`
-	Iface                       string `json:"bridge,omitempty"`
 	IP                          string `json:"bip,omitempty"`
-	FixedCIDR                   string `json:"fixed-cidr,omitempty"`
 	FixedCIDRv6                 string `json:"fixed-cidr-v6,omitempty"`
 	DefaultGatewayIPv4          net.IP `json:"default-gateway,omitempty"`
 	DefaultGatewayIPv6          net.IP `json:"default-gateway-v6,omitempty"`

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -14,9 +14,7 @@ var (
 // bridgeConfig stores all the bridge driver specific
 // configuration.
 type bridgeConfig struct {
-	FixedCIDR   string
-	NetworkMode string
-	Iface       string `json:"bridge,omitempty"`
+	commonBridgeConfig
 }
 
 // Config defines the configuration of a docker daemon.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

`NetworkMode` in bridgeConfig was not used on Windows, so removed. While there, the overall `bridgeConfig` structure was a prime one for splitting into common and platform specific parts to avoid duplication, so I did that too...
