### PR TITLE
Allow specifying apt mirror in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 608
 	|| apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
 RUN echo deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main > /etc/apt/sources.list.d/llvm.list
 
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
 	apparmor \


### PR DESCRIPTION
Fixes #21512

This is so that we can set another mirror for the CI.

Example: `make shell DOCKER_BUILD_ARGS="--build-arg APT_MIRROR=cdn-fastly.deb.debian.org"`

@icecrime @tianon 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
