### PR TITLE
move hardware signing out of experimental, remove yubico-piv-tool deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN set -x \
 	&& export OSXCROSS_PATH="/osxcross" \
 	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
 	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
-	&& curl -sSL https://s3.dockerproject.org/darwin/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
 	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
 ENV PATH /osxcross/target/bin:$PATH
 
@@ -198,7 +198,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -145,7 +145,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -154,7 +154,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -155,7 +155,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -134,7 +134,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -121,7 +121,7 @@ fi
 if [ "$DOCKER_EXPERIMENTAL" ]; then
 	echo >&2 '# WARNING! DOCKER_EXPERIMENTAL is set: building experimental features'
 	echo >&2
-	DOCKER_BUILDTAGS+=" experimental pkcs11"
+	DOCKER_BUILDTAGS+=" experimental"
 fi
 
 if [ -z "$DOCKER_CLIENTONLY" ]; then

--- a/hack/make/.build-deb/control
+++ b/hack/make/.build-deb/control
@@ -15,8 +15,7 @@ Recommends: aufs-tools,
             cgroupfs-mount | cgroup-lite,
             git,
             xz-utils,
-            ${apparmor:Recommends},
-            ${yubico:Recommends}
+            ${apparmor:Recommends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine-cs
 Description: Docker: the open-source application container engine
  Docker is an open source project to build, ship and run any application as a

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -5,8 +5,6 @@ VERSION = $(shell cat VERSION)
 override_dh_gencontrol:
 	# if we're on Ubuntu, we need to Recommends: apparmor
 	echo 'apparmor:Recommends=$(shell dpkg-vendor --is Ubuntu && echo apparmor)' >> debian/docker-engine.substvars
-	# if we are building experimental we recommend yubico-piv-tool
-	echo 'yubico:Recommends=$(shell [ "$DOCKER_EXPERIMENTAL" ] && echo "yubico-piv-tool (>= 1.1.0~)")' >> debian/docker-engine.substvars
 	dh_gencontrol
 
 override_dh_auto_build:

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -60,13 +60,6 @@ Requires: device-mapper >= 1.02.90-2
 %global with_selinux 1
 %endif
 
-%if 0%{?_experimental}
-# yubico-piv-tool conditional
-%if 0%{?fedora} >= 20 || 0%{?centos} >= 7 || 0%{?rhel} >= 7
-Requires: yubico-piv-tool >= 1.1.0
-%endif
-%endif
-
 # start if with_selinux
 %if 0%{?with_selinux}
 # Version of SELinux we were using

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -36,7 +36,7 @@ if [ "$(go env GOOS)" == "linux" ] ; then
 	esac
 fi
 
-if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ] && [ "$DOCKER_EXPERIMENTAL" ]; then
+if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ]; then
 	if  [ "${GOOS}/${GOARCH}" == "darwin/amd64" ]; then
 		export CGO_ENABLED=1
 		export CC=o64-clang

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -60,7 +60,6 @@ To build the Docker daemon, you will additionally need:
 * btrfs-progs version 3.16.1 or later (unless using an older version is
   absolutely necessary, in which case 3.8 is the minimum)
 * libseccomp version 2.2.1 or later (for build tag seccomp)
-* yubico-piv-tool version 1.1.0 or later (for experimental)
 
 Be sure to also check out Docker's Dockerfile for the most up-to-date list of
 these build-time dependencies.


### PR DESCRIPTION
Moves hardware signing back out of experimental.  The main difference from this PR and https://github.com/docker/docker/pull/21003 is that we statically link `libltdl` for OS X (there's a new s3 link that bundles a `.a` file).  cc @endophage @cyli 

We also remove dependencies on `yubico-piv-tool`, since there is additional setup anyway to correctly configure hardware signing.  We'll follow up with in-depth documentation for this process.

Manually checked by building binaries for Windows and OSX, please let us know how we can help with other targets.
Closes https://github.com/docker/docker/issues/21494.

<img src="http://buzzlefeed.com/wp-content/uploads/2016/02/600x315-1424793516.jpg" width=400/>
