### PR TITLE
When using systemd, pass expected cgroupsPath and cli options to runc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -243,7 +243,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -253,7 +253,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -181,7 +181,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -191,7 +191,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -198,7 +198,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -208,7 +208,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -74,7 +74,7 @@ WORKDIR /go/src/github.com/docker/docker
 ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -84,7 +84,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -199,7 +199,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -209,7 +209,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -178,7 +178,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -188,7 +188,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -57,7 +57,7 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 ENV CGO_LDFLAGS -L/lib
 
 # Install runc
-ENV RUNC_COMMIT d563bd134293c1026976a8f5764d5df5612f1dbf
+ENV RUNC_COMMIT 5439bd2d95229c4e213a219174c7b9da284e3487
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
@@ -67,7 +67,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT c761085e92be09df9d5298f852c328b538f5dc2f
+ENV CONTAINERD_COMMIT 471bb075214cf0ad85f74f003ca00c7651638c79
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/docker/daemon_unix.go
+++ b/docker/daemon_unix.go
@@ -75,6 +75,10 @@ func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 	} else {
 		opts = append(opts, libcontainerd.WithStartDaemon(true))
 	}
+	if daemon.UsingSystemd(cli.Config) {
+		args := []string{"--systemd-cgroup=true"}
+		opts = append(opts, libcontainerd.WithRuntimeArgs(args))
+	}
 	return opts
 }
 

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -490,12 +490,13 @@ with the `--exec-opt` flag. All the flag's options have the `native` prefix. A
 single `native.cgroupdriver` option is available.
 
 The `native.cgroupdriver` option specifies the management of the container's
-cgroups. You can specify only specify `cgroupfs` at the moment.  If you omit the
+cgroups. You can specify only specify `cgroupfs` or `systemd`. If you specify
+`systemd` and it is not available, the system errors out. If you omit the
 `native.cgroupdriver` option,` cgroupfs` is used.
 
-This example explicitely sets the `cgroupdriver` to `cgroupfs`:
+This example sets the `cgroupdriver` to `systemd`:
 
-    $ sudo docker daemon --exec-opt native.cgroupdriver=cgroupfs
+    $ sudo docker daemon --exec-opt native.cgroupdriver=systemd
 
 Setting this option applies to all containers the daemon launches.
 

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -230,8 +230,9 @@ Use the **--exec-opt** flags to specify options to the execution driver.
 The following options are available:
 
 #### native.cgroupdriver
-Specifies the management of the container's `cgroups`. Only `cgroupfs` can be specified
-`cgroupfs` at the moment.
+Specifies the management of the container's `cgroups`. You can specify `cgroupfs`
+or `systemd`. If you specify `systemd` and it is not available, the system errors
+out.
 
 #### Client
 For specific client examples please see the man page for the specific Docker


### PR DESCRIPTION
runc expects a systemd cgroupsPath to be in slice:scopePrefix:containerName
format and the "--systemd-cgroup" option to be set. Update docker accordingly.

Tested with daemon --exec-opt native.cgroupdriver=systemd in a systemd host. Started/stopped a few containers. Tested the same in non-systemd host and observed appropriate runc error.  

Fixes #21475.

Signed-off-by: Anusha Ragunathan anusha@docker.com
