### PR TITLE
Fix a link to the deprecated docs from the volume docs.

### DIFF
--- a/docs/userguide/containers/dockervolumes.md
+++ b/docs/userguide/containers/dockervolumes.md
@@ -144,7 +144,7 @@ Mounting a host directory can be useful for testing. For example, you can mount
 source code inside a container. Then, change the source code and see its effect
 on the application in real time. The directory on the host must be specified as
 an absolute path and if the directory doesn't exist the Engine daemon automatically
-creates it for you. This auto-creation of the host path has been [*deprecated*](../../../deprecated/#auto-creating-missing-host-paths-for-bind-mounts).
+creates it for you. This auto-creation of the host path has been [*deprecated*](../../deprecated.md/#auto-creating-missing-host-paths-for-bind-mounts).
 
 Docker volumes default to mount in read-write mode, but you can also set it to
 be mounted read-only.

--- a/docs/userguide/containers/dockervolumes.md
+++ b/docs/userguide/containers/dockervolumes.md
@@ -144,7 +144,7 @@ Mounting a host directory can be useful for testing. For example, you can mount
 source code inside a container. Then, change the source code and see its effect
 on the application in real time. The directory on the host must be specified as
 an absolute path and if the directory doesn't exist the Engine daemon automatically
-creates it for you.  This auto-creation of the host path has been [*deprecated*](#auto-creating-missing-host-paths-for-bind-mounts).
+creates it for you. This auto-creation of the host path has been [*deprecated*](../../../deprecated/#auto-creating-missing-host-paths-for-bind-mounts).
 
 Docker volumes default to mount in read-write mode, but you can also set it to
 be mounted read-only.

--- a/docs/userguide/containers/dockervolumes.md
+++ b/docs/userguide/containers/dockervolumes.md
@@ -144,7 +144,7 @@ Mounting a host directory can be useful for testing. For example, you can mount
 source code inside a container. Then, change the source code and see its effect
 on the application in real time. The directory on the host must be specified as
 an absolute path and if the directory doesn't exist the Engine daemon automatically
-creates it for you. This auto-creation of the host path has been [*deprecated*](../../deprecated.md/#auto-creating-missing-host-paths-for-bind-mounts).
+creates it for you. This auto-creation of the host path has been [*deprecated*](../../deprecated.md#auto-creating-missing-host-paths-for-bind-mounts).
 
 Docker volumes default to mount in read-write mode, but you can also set it to
 be mounted read-only.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixed a broken link in the docs.

**\- How I did it**
Vim and perseverance.

**\- How to verify it**
Clone my code, build the documentation, run locally and follow the newly fixed link.

**\- A picture of a cute animal (not mandatory but encouraged)**
Here's a stylized picture of a dog eating an ethernet cord: http://i.imgur.com/ODtAMIX.png

Signed-off-by: Brian Trump brian@opselite.org
