### PR TITLE
Mention "docker login" in push/pull documentation

### DIFF
--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -165,6 +165,8 @@ listening on port 5000 (`myregistry.local:5000`):
 $ docker pull myregistry.local:5000/testing/test-image
 ```
 
+Registry credentials are managed by [docker login](login.md).
+
 Docker uses the `https://` protocol to communicate with a registry, unless the
 registry is allowed to be accessed over an insecure connection. Refer to the
 [insecure registries](daemon.md#insecure-registries) section for more information.

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -22,3 +22,5 @@ registry or to a self-hosted one.
 
 Killing the `docker push` process, for example by pressing `CTRL-c` while it is
 running in a terminal, will terminate the push operation.
+
+Registry credentials are managed by [docker login](login.md).

--- a/man/docker-pull.1.md
+++ b/man/docker-pull.1.md
@@ -151,6 +151,8 @@ listening on port 5000 (`myregistry.local:5000`):
 
     $ docker pull myregistry.local:5000/testing/test-image
 
+Registry credentials are managed by **docker-login(1)**.
+
 Docker uses the `https://` protocol to communicate with a registry, unless the
 registry is allowed to be accessed over an insecure connection. Refer to the
 [insecure registries](https://docs.docker.com/engine/reference/commandline/daemon/#insecure-registries)

--- a/man/docker-push.1.md
+++ b/man/docker-push.1.md
@@ -44,6 +44,8 @@ Check that this worked by running:
 You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
 listed.
 
+Registry credentials are managed by **docker-login(1)**.
+
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.


### PR DESCRIPTION
It was suggested to me that documentation for "docker pull" and "docker
push" should reference "docker login", to make clearer how to specify
credentials for a push or pull operation. Add a note to the manual pages
and reference documentation explaining how registry credentials are
managed.
