### PR TITLE
Use separate exec-root for test daemons

### DIFF
--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -144,6 +144,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		d.Command,
 		"--containerd", "/var/run/docker/libcontainerd/docker-containerd.sock",
 		"--graph", d.root,
+		"--exec-root", filepath.Join(d.folder, "exec-root"),
 		"--pidfile", fmt.Sprintf("%s/docker.pid", d.folder),
 		fmt.Sprintf("--userland-proxy=%t", d.userlandProxy),
 	)

--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -210,7 +210,7 @@ func (r *remote) getLastEventTimestamp() int64 {
 	t := time.Now()
 
 	fi, err := os.Stat(r.eventTsPath)
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) || fi.Size() == 0 {
 		return t.Unix()
 	}
 


### PR DESCRIPTION
Fixes #21545

Secondary daemons used the same exec-root meaning the events timestamp file collided. If one process was writing the same time other daemon could read empty file and skip the events liveness indicator.

@mlaventure 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
