### PR TITLE
Windows: escape entrypoint before passing to libcontainerd

### DIFF
--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -8,7 +8,6 @@ import (
 
 func execSetPlatformOpt(c *container.Container, ec *exec.Config, p *libcontainerd.Process) error {
 	// Process arguments need to be escaped before sending to OCI.
-	// TODO (jstarks): escape the entrypoint too once the tests are fixed to not rely on this behavior
-	p.Args = append([]string{p.Args[0]}, escapeArgs(p.Args[1:])...)
+	p.Args = escapeArgs(p.Args)
 	return nil
 }

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -63,11 +63,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	}
 
 	// In s.Process
-	if c.Config.ArgsEscaped {
-		s.Process.Args = append([]string{c.Path}, c.Args...)
-	} else {
-		// TODO (jstarks): escape the entrypoint too once the tests are fixed to not rely on this behavior
-		s.Process.Args = append([]string{c.Path}, escapeArgs(c.Args)...)
+	s.Process.Args = append([]string{c.Path}, c.Args...)
+	if !c.Config.ArgsEscaped {
+		s.Process.Args = escapeArgs(s.Process.Args)
 	}
 	s.Process.Cwd = c.Config.WorkingDir
 	s.Process.Env = c.CreateDaemonEnvironment(linkedEnv)


### PR DESCRIPTION
This fixes a TODO that I introduced in the 1.11 release. Windows has always been incorrectly breaking the entry point into separate arguments (e.g. "echo hello" becomes "echo" "hello" before the process is launched), which is inconsistent with Linux behavior. This set of changes fixes a few tests that were depending on this behavior and then fixes the behavior itself.

cc/@jhowardmsft, @darrenstahlmsft 
