### PR TITLE
Correct login debug log message

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -29,7 +29,7 @@ func loginV1(authConfig *types.AuthConfig, apiEndpoint APIEndpoint, userAgent st
 
 	serverAddress := registryEndpoint.String()
 
-	logrus.Debugf("attempting v1 login to registry endpoint %s", registryEndpoint)
+	logrus.Debugf("attempting v1 login to registry endpoint %s", serverAddress)
 
 	if serverAddress == "" {
 		return "", "", fmt.Errorf("Server Error: Server Address not set.")
@@ -103,7 +103,7 @@ func (err fallbackError) Error() string {
 // endpoint will be pinged to get authorization challenges. These challenges
 // will be used to authenticate against the registry to validate credentials.
 func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent string) (string, string, error) {
-	logrus.Debugf("attempting v2 login to registry endpoint %s", endpoint)
+	logrus.Debugf("attempting v2 login to registry endpoint %s", strings.TrimRight(endpoint.URL.String(), "/")+"/v2/")
 
 	modifiers := DockerHeaders(userAgent, nil)
 	authTransport := transport.NewTransport(NewTransport(endpoint.TLSConfig), modifiers...)


### PR DESCRIPTION
I noticed the following message in a daemon log:

```
attempting v2 login to registry endpoint {%!s(bool=false) https://registry:5000 v2 %!s(bool=false) %!s(bool=true) %!s(*tls.Config=&{<nil> <nil> [] map[] <nil> 0xc82075c030 []  0 <nil> false [49196 49200 49195 49199 49162 49161 49172 49171 53 47] true false [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] <nil> 769 0 [] {{0 0} 0} {{0 0} 0 0 0 0} []})}
```

`loginV2` tries to log an `APIEndpoint` as a string, but this struct does
not have a `String` method. Log the actual URL that will be used as the
endpoint, instead.
