### PR TITLE
Fix flaky test TestTransfer (take 2)

### DIFF
--- a/distribution/xfer/transfer_test.go
+++ b/distribution/xfer/transfer_test.go
@@ -37,11 +37,7 @@ func TestTransfer(t *testing.T) {
 	go func() {
 		for p := range progressChan {
 			val, present := receivedProgress[p.ID]
-			if !present {
-				if p.Current != 0 {
-					t.Fatalf("got unexpected progress value: %d (expected 0)", p.Current)
-				}
-			} else if p.Current <= val {
+			if present && p.Current <= val {
 				t.Fatalf("got unexpected progress value: %d (expected %d)", p.Current, val+1)
 			}
 			receivedProgress[p.ID] = p.Current


### PR DESCRIPTION
TestTransfer failed in CI: https://jenkins.dockerproject.org/job/Docker-PRs-experimental/17103/console

This is the same issue as https://github.com/docker/docker/pull/21233, but only one of the code paths was fixed in that PR. The one which handles the first progress update was not - it still assumed that the progress indication should be 0/10.
