### PR TITLE
Support unixgram syslog address

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -152,8 +152,8 @@ func parseAddress(address string) (string, string, error) {
 		return "", "", err
 	}
 
-	// unix socket validation
-	if url.Scheme == "unix" {
+	// unix and unixgram socket validation
+	if url.Scheme == "unix" || url.Scheme == "unixgram" {
 		if _, err := os.Stat(url.Path); err != nil {
 			return "", "", err
 		}

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -74,6 +74,7 @@ The following logging options are supported for the `syslog` logging driver:
 
     --log-opt syslog-address=[tcp|udp|tcp+tls]://host:port
     --log-opt syslog-address=unix://path
+    --log-opt syslog-address=unixgram://path
     --log-opt syslog-facility=daemon
     --log-opt syslog-tls-ca-cert=/etc/ca-certificates/custom/ca.pem
     --log-opt syslog-tls-cert=/etc/ca-certificates/custom/cert.pem

--- a/pkg/urlutil/urlutil.go
+++ b/pkg/urlutil/urlutil.go
@@ -11,7 +11,7 @@ var (
 	validPrefixes = map[string][]string{
 		"url":       {"http://", "https://"},
 		"git":       {"git://", "github.com/", "git@"},
-		"transport": {"tcp://", "tcp+tls://", "udp://", "unix://"},
+		"transport": {"tcp://", "tcp+tls://", "udp://", "unix://", "unixgram://"},
 	}
 	urlPathWithFragmentSuffix = regexp.MustCompile(".git(?:#.+)?$")
 )

--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -23,6 +23,7 @@ var (
 		"tcp+tls://example.com",
 		"udp://example.com",
 		"unix:///example",
+		"unixgram:///example",
 	}
 )
 


### PR DESCRIPTION
This tends to fix https://github.com/docker/docker/issues/18903.

The underlying syslog library (RackSec/srslog) supports both `unix://` and `unixgram://` socket protocols, the latter of which is used by systemd-journald and rsyslog. But Docker does not allow `unixgram://` as `syslog-address`, making users unable to specify alternative syslog socket.
