### PR TITLE
libcontainerd: reuse our pkg/locker

### DIFF
--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
+	"github.com/docker/docker/pkg/locker"
 	sysinfo "github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/utils"
 	"golang.org/x/net/context"
@@ -169,9 +170,9 @@ func (r *remote) Cleanup() {
 func (r *remote) Client(b Backend) (Client, error) {
 	c := &client{
 		clientCommon: clientCommon{
-			backend:          b,
-			containerMutexes: make(map[string]*sync.Mutex),
-			containers:       make(map[string]*container),
+			backend:    b,
+			containers: make(map[string]*container),
+			locker:     locker.New(),
 		},
 		remote:        r,
 		exitNotifiers: make(map[string]*exitNotifier),

--- a/libcontainerd/remote_windows.go
+++ b/libcontainerd/remote_windows.go
@@ -1,6 +1,6 @@
 package libcontainerd
 
-import "sync"
+import "github.com/docker/docker/pkg/locker"
 
 type remote struct {
 }
@@ -8,9 +8,9 @@ type remote struct {
 func (r *remote) Client(b Backend) (Client, error) {
 	c := &client{
 		clientCommon: clientCommon{
-			backend:          b,
-			containerMutexes: make(map[string]*sync.Mutex),
-			containers:       make(map[string]*container),
+			backend:    b,
+			containers: make(map[string]*container),
+			locker:     locker.New(),
 		},
 	}
 	return c, nil


### PR DESCRIPTION
**\- What I did**
Fixed race in libcontainer in access to mutexes map
**\- How I did it**
Replaced self-written lock-by-string stuff with pkg/locker
**\- How to verify it**
Build docker with `-race` and spawn many containers
**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](http://s00.yaplakal.com/pics/pics_original/0/3/4/5459430.jpg)
