### PR TITLE
bash completions: Improve consistency for boolean options with default=true

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -615,7 +615,7 @@ _docker_attach() {
 
  	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach-keys --help --no-stdin --sig-proxy" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach-keys --help --no-stdin --sig-proxy=false" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--detach-keys')
@@ -702,7 +702,7 @@ _docker_commit() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--author -a --change -c --help --message -m --pause -p" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--author -a --change -c --help --message -m --pause=false -p=false" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--author|-a|--change|-c|--message|-m')


### PR DESCRIPTION
**Background**
Boolean options with a default value of `true` should complete to the only value that makes sense.
Example: leaving `docker daemon --ip-forward` as such would not change the behavior in comparison to `docker daemon`. Thus, `docker daemon --ip-forward=false` is the best completion as it does not encourage the user to issue unexpected commands.

This kind of completion existed for several boolean options for quite a while. This PR applies this policy to the remaining options.
