### PR TITLE
Change the directory inside of tgz files.

### DIFF
--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -19,15 +19,29 @@ for d in "$CROSS/"*/*; do
 	mkdir -p "$DEST/$GOOS/$GOARCH"
 	TGZ="$DEST/$GOOS/$GOARCH/$BINARY_NAME.tgz"
 
-	mkdir -p "$DEST/build/usr/local/bin"
-	cp -L "$d/$BINARY_FULLNAME" "$DEST/build/usr/local/bin/docker$BINARY_EXTENSION"
-	copy_containerd "$DEST/build/usr/local/bin/"
+	# The staging directory for the files in the tgz
+	BUILD_PATH="$DEST/build"
 
-	tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
+	# The directory that is at the root of the tar file
+	TAR_BASE_DIRECTORY="docker"
+
+	# $DEST/build/docker
+	TAR_PATH="$BUILD_PATH/$TAR_BASE_DIRECTORY"
+
+	# Copy the correct docker binary
+	mkdir -p $TAR_PATH
+	cp -L "$d/$BINARY_FULLNAME" "$TAR_PATH/docker$BINARY_EXTENSION"
+
+	# copy over all the containerd binaries
+	copy_containerd $TAR_PATH
+
+	echo "Creating tgz from $BUILD_PATH and naming it $TGZ"
+	tar --numeric-owner --owner 0 -C "$BUILD_PATH" -czf "$TGZ" $TAR_BASE_DIRECTORY
 
 	hash_files "$TGZ"
 
-	rm -rf "$DEST/build"
+	# cleanup after ourselves
+	rm -rf "$BUILD_PATH"
 
 	echo "Created tgz: $TGZ"
 done


### PR DESCRIPTION
**\- What I did**

Currently the directory inside of the tgz files is /usr/local/bin
and this is causing some confusion, and problems with people who already
have stuff in those directories. This commit changes the directory
to /docker to help remove the confusion.

**\- How I did it**

I changed the hack/make/tgz file so that the directory was /docker instead of /usr/local/bin under the tgz file.

**\- How to verify it**

I ran it locally and the output looks correct. To do the same, run the following command.

`$ hack/make.sh binary cross tgz`

Signed-off-by: Ken Cochrane kencochrane@gmail.com

Closes: #21530

/cc @icecrime @thaJeztah @tiborvass 
