### PR TITLE
Build-deb hack for systemd tasksmax

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -86,6 +86,16 @@ set -e
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN cp -aL hack/make/.build-deb debian
 			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
+		EOF
+		# Remove the following case-based substitution when none of these are supported, and the TasksMax value is uncommented in docker.service
+		case "$version" in
+		debian-jessie|debian-wheezy|ubuntu-precise|ubuntu-trusty|ubuntu-wily)
+			;;
+		*)
+			echo "RUN sed -i -- 's/#TasksMax=infinity/TasksMax=infinity/' contrib/init/systemd/docker.service" >> "$DEST/$version/Dockerfile.build"
+			;;
+		esac
+		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN dpkg-buildpackage -uc -us
 		EOF
 		tempImage="docker-temp/build-deb:$version"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This uncomments the TasksMax line in the docker.service file _if_ it's a known release that uses a systemd that supports it.

Verify by:
1. docker run --rm -it --privileged -v `pwd`:/go/src/github.com/docker/docker docker ./hack/make.sh dynbinary build-deb
2. cd bundles/latest/build-deb/
3. cd into one of the distros that built
4. untar the docker bundle
5. check that the TasksMax value is either commented or uncommented in the docker.service file under bundles/latest/build-deb/<release-name>/docker/contrib/init/systemd/

Verify more quickly by deleting some of the releases under contrib/builder/deb/amd64/ (e.g. all but ubuntu-wily and ubuntu-xenial, so you can check that wily is still commented out but xenial isn't).

![hedgehog](https://cloud.githubusercontent.com/assets/4493281/14122501/babef70e-f5c1-11e5-8f90-1a0d24c52f6d.jpg)

Since we can't just add the TasksMax value into the docker.service
file, we can add it in at buildtime.

See docker/docker/pull/21491 for some background.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
