### PR TITLE
Remove builder dependency from the api.

### DIFF
--- a/api/server/router/build/backend.go
+++ b/api/server/router/build/backend.go
@@ -3,7 +3,7 @@ package build
 import (
 	"io"
 
-	"github.com/docker/docker/builder"
+	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
@@ -16,5 +16,5 @@ type Backend interface {
 	// by the caller.
 	//
 	// TODO: make this return a reference instead of string
-	Build(clientCtx context.Context, config *types.ImageBuildOptions, context builder.Context, stdout io.Writer, stderr io.Writer, out io.Writer) (string, error)
+	BuildFromContext(ctx context.Context, src io.ReadCloser, remote string, buildOptions *types.ImageBuildOptions, pg backend.ProgressWriter) (string, error)
 }

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -6,6 +6,7 @@ package backend
 import (
 	"io"
 
+	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/engine-api/types"
 )
 
@@ -72,4 +73,13 @@ type ExecProcessConfig struct {
 type ContainerCommitConfig struct {
 	types.ContainerCommitConfig
 	Changes []string
+}
+
+// ProgressWriter is an interface
+// to transport progress streams.
+type ProgressWriter struct {
+	Output             io.Writer
+	StdoutFormatter    *streamformatter.StdoutFormatter
+	StderrFormatter    *streamformatter.StderrFormatter
+	ProgressReaderFunc func(io.ReadCloser) io.ReadCloser
 }

--- a/daemon/builder.go
+++ b/daemon/builder.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"io"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/builder"
+	"github.com/docker/docker/builder/dockerfile"
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// BuildFromContext builds a new image from a given context.
+func (daemon *Daemon) BuildFromContext(ctx context.Context, src io.ReadCloser, remote string, buildOptions *types.ImageBuildOptions, pg backend.ProgressWriter) (string, error) {
+	buildContext, dockerfileName, err := builder.DetectContextFromRemoteURL(src, remote, pg.ProgressReaderFunc)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := buildContext.Close(); err != nil {
+			logrus.Debugf("[BUILDER] failed to remove temporary context: %v", err)
+		}
+	}()
+	if len(dockerfileName) > 0 {
+		buildOptions.Dockerfile = dockerfileName
+	}
+
+	m := dockerfile.NewBuildManager(daemon)
+	return m.Build(ctx, buildOptions,
+		builder.DockerIgnoreContext{ModifiableContext: buildContext},
+		pg.StdoutFormatter, pg.StderrFormatter, pg.Output)
+}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/api/server/router/network"
 	systemrouter "github.com/docker/docker/api/server/router/system"
 	"github.com/docker/docker/api/server/router/volume"
-	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon"
@@ -413,7 +412,7 @@ func initRouter(s *apiserver.Server, d *daemon.Daemon) {
 		image.NewRouter(d, decoder),
 		systemrouter.NewRouter(d),
 		volume.NewRouter(d),
-		build.NewRouter(dockerfile.NewBuildManager(d)),
+		build.NewRouter(d),
 	}
 	if d.NetworkControllerEnabled() {
 		routers = append(routers, network.NewRouter(d))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This change removes the builder dependency from the api.

I moved part of the build to the daemon and it's not responsible of creating the context and executing the build.

/cc @MHBauer, @icecrime 

Signed-off-by: David Calavera david.calavera@gmail.com
