### PR TITLE
Fix container mount cleanup issues

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -720,7 +720,7 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 
 	sb, err := daemon.netController.SandboxByID(sid)
 	if err != nil {
-		logrus.Errorf("error locating sandbox id %s: %v", sid, err)
+		logrus.Warnf("error locating sandbox id %s: %v", sid, err)
 		return
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -304,10 +304,6 @@ func (daemon *Daemon) restore() error {
 				mapLock.Lock()
 				restartContainers[c] = make(chan struct{})
 				mapLock.Unlock()
-			} else if !c.IsRunning() && !c.IsPaused() {
-				if mountid, err := daemon.layerStore.GetMountID(c.ID); err == nil {
-					daemon.cleanupMountsByID(mountid)
-				}
 			}
 
 			// if c.hostConfig.Links is nil (not just empty), then it is using the old sqlite links and needs to be migrated

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -59,7 +59,7 @@ func TestCleanupMounts(t *testing.T) {
 		return nil
 	}
 
-	d.cleanupMountsFromReader(strings.NewReader(mountsFixture), unmount)
+	d.cleanupMountsFromReaderByID(strings.NewReader(mountsFixture), "", unmount)
 
 	if unmounted != 1 {
 		t.Fatalf("Expected to unmount the shm (and the shm only)")
@@ -97,7 +97,7 @@ func TestNotCleanupMounts(t *testing.T) {
 		return nil
 	}
 	mountInfo := `234 232 0:59 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k`
-	d.cleanupMountsFromReader(strings.NewReader(mountInfo), unmount)
+	d.cleanupMountsFromReaderByID(strings.NewReader(mountInfo), "", unmount)
 	if unmounted {
 		t.Fatalf("Expected not to clean up /dev/shm")
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -174,8 +174,10 @@ func (daemon *Daemon) Cleanup(container *container.Container) {
 		daemon.unregisterExecCommand(container, eConfig)
 	}
 
-	if err := container.UnmountVolumes(false, daemon.LogVolumeEvent); err != nil {
-		logrus.Warnf("%s cleanup: Failed to umount volumes: %v", container.ID, err)
+	if container.BaseFS != "" {
+		if err := container.UnmountVolumes(false, daemon.LogVolumeEvent); err != nil {
+			logrus.Warnf("%s cleanup: Failed to umount volumes: %v", container.ID, err)
+		}
 	}
 	container.CancelAttachContext()
 }

--- a/libcontainerd/client_shutdownrestore_linux.go
+++ b/libcontainerd/client_shutdownrestore_linux.go
@@ -31,8 +31,10 @@ func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 			select {
 			case <-time.After(2 * time.Second):
 			case <-w.wait():
+				return nil
 			}
 		case <-w.wait():
+			return nil
 		}
 	}
 	return clnt.setExited(containerID)


### PR DESCRIPTION
- Refactor generic and path based cleanup functions into a single function.
- Include aufs and zfs mounts in the mounts cleanup.
- Containers that receive exit event on restore don't require manual cleanup
- Make "missing sandbox id" message a warning because currently sandboxes are always cleared on startup. libnetwork#975
- Don't unmount volumes for containers that don't have base path. Shouldn't be needed after #21372

fixes #21618

@mlaventure 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
