### PR TITLE
Update documentations for `Warnings` fields in `GET /volumes` API

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -2789,7 +2789,8 @@ Status Codes:
           "Driver": "local",
           "Mountpoint": "/var/lib/docker/volumes/tardis"
         }
-      ]
+      ],
+      "Warnings": []
     }
 
 Query Parameters:

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -2832,7 +2832,8 @@ Status Codes:
           "Driver": "local",
           "Mountpoint": "/var/lib/docker/volumes/tardis"
         }
-      ]
+      ],
+      "Warnings": []
     }
 
 Query Parameters:

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2836,7 +2836,8 @@ Status Codes:
           "Driver": "local",
           "Mountpoint": "/var/lib/docker/volumes/tardis"
         }
-      ]
+      ],
+      "Warnings": []
     }
 
 Query Parameters:


### PR DESCRIPTION
This fix updated documentations to add the `Warnings` fields in `GET /volumes` API.

The `Warnings` has been part of the `GET /volumes` API response since Docker 1.10 (v1.22). However, the `Warnings` field is not in the documentation so there are some confusions (See #21606).

This fix updated the related documentations in v1.22, v1.23, and v1.24 and added this field to the API.

This fix is related to #21605.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
