### PR TITLE
Remove the tryit tutotial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,6 @@ on servers for running them. To get started, [check out the installation
 instructions in the
 documentation](https://docs.docker.com/engine/installation/).
 
-We also offer an [interactive tutorial](https://www.docker.com/tryit/)
-for quickly learning the basics of using Docker.
-
 Usage examples
 ==============
 


### PR DESCRIPTION
It's no longer there.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com

This online demo is really cool, I hope it's just moved to somewhere else, we can't access it from https://www.docker.com/tryit/ 

Any information so I can change the web site instead of removing it from README?
