### PR TITLE
Remove deprecated daemon --restart flag

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -61,7 +61,6 @@ type CommonTLSOptions struct {
 // using the same names that the flags in the command line uses.
 type CommonConfig struct {
 	AuthorizationPlugins []string            `json:"authorization-plugins,omitempty"` // AuthorizationPlugins holds list of authorization plugins
-	AutoRestart          bool                `json:"-"`
 	Context              map[string][]string `json:"-"`
 	DisableBridge        bool                `json:"-"`
 	DNS                  []string            `json:"dns,omitempty"`
@@ -121,7 +120,6 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.Var(opts.NewNamedListOptsRef("exec-opts", &config.ExecOptions, nil), []string{"-exec-opt"}, usageFn("Set runtime execution options"))
 	cmd.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, defaultPidFile, usageFn("Path to use for daemon PID file"))
 	cmd.StringVar(&config.Root, []string{"g", "-graph"}, defaultGraph, usageFn("Root of the Docker runtime"))
-	cmd.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, usageFn("--restart on the daemon has been deprecated in favor of --restart policies on docker run"))
 	cmd.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", usageFn("Storage driver to use"))
 	cmd.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, usageFn("Set the containers network MTU"))
 	cmd.BoolVar(&config.RawLogs, []string{"-raw-logs"}, false, usageFn("Full timestamps without ANSI coloring"))

--- a/daemon/config_test.go
+++ b/daemon/config_test.go
@@ -22,7 +22,6 @@ func TestDaemonConfigurationMerge(t *testing.T) {
 
 	c := &Config{
 		CommonConfig: CommonConfig{
-			AutoRestart: true,
 			LogConfig: LogConfig{
 				Type:   "syslog",
 				Config: map[string]string{"tag": "test"},
@@ -36,9 +35,6 @@ func TestDaemonConfigurationMerge(t *testing.T) {
 	}
 	if !cc.Debug {
 		t.Fatalf("expected %v, got %v\n", true, cc.Debug)
-	}
-	if !cc.AutoRestart {
-		t.Fatalf("expected %v, got %v\n", true, cc.AutoRestart)
 	}
 	if cc.LogConfig.Type != "syslog" {
 		t.Fatalf("expected syslog config, got %q\n", cc.LogConfig)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -300,13 +300,15 @@ func (daemon *Daemon) restore() error {
 			}
 			// fixme: only if not running
 			// get list of containers we need to restart
-			if daemon.configStore.AutoRestart && !c.IsRunning() && !c.IsPaused() && c.ShouldRestart() {
-				mapLock.Lock()
-				restartContainers[c] = make(chan struct{})
-				mapLock.Unlock()
-			} else if !c.IsRunning() && !c.IsPaused() {
-				if mountid, err := daemon.layerStore.GetMountID(c.ID); err == nil {
-					daemon.cleanupMountsByID(mountid)
+			if !c.IsRunning() && !c.IsPaused() {
+				if c.ShouldRestart() {
+					mapLock.Lock()
+					restartContainers[c] = make(chan struct{})
+					mapLock.Unlock()
+				} else {
+					if mountid, err := daemon.layerStore.GetMountID(c.ID); err == nil {
+						daemon.cleanupMountsByID(mountid)
+					}
 				}
 			}
 


### PR DESCRIPTION
"--restart" flag on daemon is declared deprecated since 1.8.0,  I think docker promised to keep deprecated features for two releases, so apparently it's ready to be removed now.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
