### PR TITLE
Add short description about default authentication method in authorization docs

### DIFF
--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -49,6 +49,11 @@ Each plugin must reside within directories described under the
 **Note**: the abbreviations `AuthZ` and `AuthN` mean authorization and authentication
 respectively.
 
+## Default user authorization mechanism
+
+If TLS is enabled in the [Docker daemon](https://docs.docker.com/engine/security/https/), the default user authorization flow extracts the user details from the certificate subject name.
+That is, the `User` field is set to the client certificate subject common name, and the `AuthenticationMethod` field is set to `TLS`.
+
 ## Basic architecture
 
 You are responsible for registering your plugin as part of the Docker daemon


### PR DESCRIPTION
Following the discussion in #21556, adding a short description of the
default user authentication mechanism (without requiring authentication
plugins)
Signed-off-by: Liron Levin liron@twistlock.com
