### PR TITLE
Add maximum egress bandwidth option for Windows containers

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -802,6 +802,9 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 		}
 	}
 
+	// Platform specific generic options
+	createOptions = append(createOptions, container.buildGenericEndpointOptions(n)...)
+
 	// Port-mapping rules belong to the container & applicable only to non-internal networks
 	portmaps := getSandboxPortMapInfo(sb)
 	if n.Info().Internal() || len(portmaps) > 0 {

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/utils"
 	"github.com/docker/docker/volume"
 	containertypes "github.com/docker/engine-api/types/container"
+	"github.com/docker/libnetwork"
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
@@ -402,4 +403,10 @@ func cleanResourcePath(path string) string {
 // can be mounted locally. A no-op on non-Windows platforms
 func (container *Container) canMountFS() bool {
 	return true
+}
+
+// buildGenericEndpointOptions builds the platform specific generic endpoint options.
+// There are currently no platform specific endpoint options on Unix.
+func (container *Container) buildGenericEndpointOptions(n libnetwork.Network) []libnetwork.EndpointOption {
+	return []libnetwork.EndpointOption{}
 }

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -275,6 +275,7 @@ Create a container
                    "22/tcp": {}
            },
            "StopSignal": "SIGTERM",
+           "MaxBandwidth": 1000,
            "HostConfig": {
              "Binds": ["/tmp:/tmp"],
              "Links": ["redis3:redis"],
@@ -398,6 +399,7 @@ Json Parameters:
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
 -   **StopSignal** - Signal to stop a container as a string or unsigned integer. `SIGTERM` by default.
+-   **MaxBandwidth** - Maximum network egress bandwidth of the container in bytes per second (Windows daemon only).
 -   **HostConfig**
     -   **Binds** – A list of volume bindings for this container. Each volume binding is a string in one of these forms:
            + `host_path:container_path` to bind-mount a host path into the container
@@ -525,7 +527,8 @@ Return low-level information on the container `id`
 				"/volumes/data": {}
 			},
 			"WorkingDir": "",
-			"StopSignal": "SIGTERM"
+			"StopSignal": "SIGTERM",
+			"MaxBandwidth": 1000,
 		},
 		"Created": "2015-01-06T15:47:31.485331387Z",
 		"Driver": "devicemapper",

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -69,6 +69,7 @@ parent = "smn_cli"
                                     'container:<name|id>': reuse another container's network stack
                                     'host': use the Docker host network stack
                                     '<network-name>|<network-id>': connect to a user-defined network
+      --net-maxbandwidth=0          Maximum network egress bandwidth in bytes per second
       --net-alias=[]                Add network-scoped alias for the container
       --oom-kill-disable            Whether to disable OOM Killer for the container or not
       --oom-score-adj=0             Tune the host's OOM preferences for containers (accepts -1000 to 1000)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Added network maximum egress bandwidth control for Windows containers via a new CLI flag `--net-maxbandwidth`, which sets a generic option added to the Windows libnetwork driver with https://github.com/docker/libnetwork/pull/1061

![Corgi!](https://i.ytimg.com/vi/To8oesttqc4/hqdefault.jpg)

**TODO**
- [x] engine-api changes in https://github.com/docker/engine-api/pull/180 merged and re-vendored
- [x] libnetwork changes in https://github.com/docker/libnetwork/pull/1061 merged and re-vendored

Signed-off-by: Darren Stahl darst@microsoft.com
