### PR TITLE
Un-deprecate auto-creation of host directories for mounts

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -133,17 +133,6 @@ The following double-dash options are deprecated and have no replacement:
     docker ps --before-id
     docker search --trusted
 
-### Auto-creating missing host paths for bind mounts
-**Deprecated in Release: v1.9**
-
-**Target for Removal in Release: 1.11**
-
-When creating a container with a bind-mounted volume-- `docker run -v /host/path:/container/path` --
-docker was automatically creating the `/host/path` if it didn't already exist.
-
-This auto-creation of the host path is deprecated and docker will error out if
-the path does not exist.
-
 ### Interacting with V1 registries
 
 Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the docker daemon from `pull`, `push`, and `login` operations against v1 registries.  Though disabled by default, this signals the intent to deprecate the v1 protocol.

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1415,9 +1415,6 @@ The example below mounts an empty tmpfs into the container with the `rw`,
     --volumes-from="": Mount all volumes from the given container(s)
 
 > **Note**:
-> The auto-creation of the host path has been [*deprecated*](../deprecated.md#auto-creating-missing-host-paths-for-bind-mounts).
-
-> **Note**:
 > When using systemd to manage the Docker daemon's start and stop, in the systemd
 > unit file there is an option to control mount propagation for the Docker daemon
 > itself, called `MountFlags`. The value of this setting may cause Docker to not

--- a/docs/userguide/containers/dockervolumes.md
+++ b/docs/userguide/containers/dockervolumes.md
@@ -144,7 +144,7 @@ Mounting a host directory can be useful for testing. For example, you can mount
 source code inside a container. Then, change the source code and see its effect
 on the application in real time. The directory on the host must be specified as
 an absolute path and if the directory doesn't exist the Engine daemon automatically
-creates it for you.  This auto-creation of the host path has been [*deprecated*](../../deprecated.md#auto-creating-missing-host-paths-for-bind-mounts).
+creates it for you.
 
 Docker volumes default to mount in read-write mode, but you can also set it to
 be mounted read-only.


### PR DESCRIPTION
Auto-creation of host-directories was marked deprecated in
Docker 1.9, but was decided to be too much of an backward-incompatible
change, so it was decided to keep the feature.

fixes https://github.com/docker/docker/issues/21652, refs https://github.com/docker/docker/pull/19953#issuecomment-198024624)
