### PR TITLE
Avoid Precision Loss in calculateCPUPercent

### DIFF
--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -45,3 +45,29 @@ func TestCalculBlockIO(t *testing.T) {
 		t.Fatalf("blkWrite = %d, want 579", blkWrite)
 	}
 }
+
+func TestCalculateCPUPercent(t *testing.T) {
+	var (
+		cpuPercent float64
+		cpuStats   = &types.StatsJSON{
+			Stats: types.Stats{
+				CPUStats: types.CPUStats{
+					CPUUsage: types.CPUUsage{
+						TotalUsage:  100,
+						PercpuUsage: []uint64{1, 2, 3},
+					},
+					SystemUsage: 200,
+				},
+			},
+		}
+	)
+	cpuPercent = calculateCPUPercent(50, 100, cpuStats)
+	if cpuPercent != 150.00 {
+		t.Fatalf("cpuPercent = %f, want 150.00", cpuPercent)
+	}
+
+	cpuPercent = calculateCPUPercent(100, 200, cpuStats)
+	if cpuPercent != 0.0 {
+		t.Fatalf("cpuPercent = %f, want 0.0", cpuPercent)
+	}
+}


### PR DESCRIPTION
**\- What I did**:  avoid loss of precision from converting uint64s to float64s in the `calculateCPUPercent` function

**\- How I did it**: used the math/big library for doing arbitrary-precision floating point division

**\- How to verify it**: I wrote some tests

**\- A picture of a cute animal (not mandatory but encouraged)**:

![tumblr_mbr8ilygne1qh92ooo1_1280](https://cloud.githubusercontent.com/assets/139214/14159924/92ac001c-f69e-11e5-843c-745945d5fe26.jpg)

Signed-off-by: Walt Askew waskew@civisanalytics.com
