### PR TITLE
Enabling expose support for Windows TP5

### DIFF
--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -21,7 +21,6 @@ package dockerfile
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/docker/docker/builder/dockerfile/command"
@@ -199,17 +198,4 @@ func (b *Builder) dispatch(stepN int, ast *parser.Node) error {
 	}
 
 	return fmt.Errorf("Unknown instruction: %s", upperCasedCmd)
-}
-
-// platformSupports is a short-term function to give users a quality error
-// message if a Dockerfile uses a command not supported on the platform.
-func platformSupports(command string) error {
-	if runtime.GOOS != "windows" {
-		return nil
-	}
-	switch command {
-	case "expose", "user", "stopsignal", "arg":
-		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
-	}
-	return nil
 }

--- a/builder/dockerfile/evaluator_unix.go
+++ b/builder/dockerfile/evaluator_unix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package dockerfile
+
+// platformSupports is a short-term function to give users a quality error
+// message if a Dockerfile uses a command not supported on the platform.
+func platformSupports(command string) error {
+	return nil
+}

--- a/builder/dockerfile/evaluator_windows.go
+++ b/builder/dockerfile/evaluator_windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package dockerfile
+
+import (
+	"fmt"
+
+	"github.com/Microsoft/hcsshim"
+)
+
+// platformSupports is a short-term function to give users a quality error
+// message if a Dockerfile uses a command not supported on the platform.
+func platformSupports(command string) error {
+	switch command {
+	// TODO Windows TP5. Expose can be removed from here once TP4 is
+	// no longer supported.
+	case "expose":
+		if !hcsshim.IsTP4() {
+			break
+		}
+		fallthrough
+	case "user", "stopsignal", "arg":
+		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
+	}
+	return nil
+}


### PR DESCRIPTION
This can now be supported(only for the default nat network) with our libnetwork integration hence enabling it. We will document the expected behavior in our documentation.
