### PR TITLE
Mark Docker log files as docker_log_t

### DIFF
--- a/contrib/docker-engine-selinux/docker.fc
+++ b/contrib/docker-engine-selinux/docker.fc
@@ -17,4 +17,5 @@
 /var/lib/docker/init(/.*)?		gen_context(system_u:object_r:docker_share_t,s0)
 /var/lib/docker/containers/.*/hosts		gen_context(system_u:object_r:docker_share_t,s0)
 /var/lib/docker/containers/.*/hostname		gen_context(system_u:object_r:docker_share_t,s0)
+/var/lib/docker/containers/.*/.*\.log	--	gen_context(system_u:object_r:docker_log_t,s0)
 /var/lib/docker/.*/config\.env	gen_context(system_u:object_r:docker_share_t,s0)


### PR DESCRIPTION
**What I did**
As documented in #21672, log files are currently created with the wrong SELinux type. This pull request ensures that log files have the correct type.

**How I did it**
I added the log file path to the SELinux file context list so that `restorecon`, if run on Docker log files, would correctly assign them the `docker_log_t` type instead of `docker_var_lib_t`. I also made Docker assign the correct type to log files immediately after creation. My rationale for assigning the type in Docker rather than in an SELinux policy is that it is impossible to do so in a policy because:
1. The log files are created by a `docker_t` executable in a `docker_var_lib_t` directory, but
2. They are the only files with those properties that also need to be tagged as `docker_log_t` (preventing the use of a standard file transition), and
3. They do not have a standard filename (preventing the use of a file name transition).

I experimented with standardizing the filename as `json.log`, but that caused some issues, specifically:
1. Running `docker log` on containers that existed before the change resulted in Docker not reading from the existing logfiles, despite the fact that `docker inspect` showed the correct (i.e. old) value for `LogPath`.
2. Some downstream projects (e.g. [Kubernetes](https://github.com/kubernetes/kubernetes/blob/v1.2.0/pkg/kubelet/dockertools/manager.go#L1537)) use the log files but, rather than querying Docker for the location, basically replicate [the logic used to construct the `LogPath`](https://github.com/docker/docker/blob/v1.10.3/container/container.go#L301).

Ultimately, this appeared to be the best way forward.

**How to verify it**
1. On a system with SELinux, run something in a container: `docker run busybox echo hi`
2. Find the container ID: `CID="$(docker ps -ql)" ; echo $CID`
3. Find the container's log path: `LOGPATH="$(docker inspect --format '{{ .LogPath }}' $CID)" ; echo $LOGPATH`
4. View the SELinux context of the log file: `ls -Z $LOGPATH`

The output should be something like this:

``` shellsession
$ docker run busybox echo hi
hi
$ CID="$(docker ps -ql)" ; echo $CID
266767c59143
$ LOGPATH="$(docker inspect --format '{{ .LogPath }}' $CID)" ; echo $LOGPATH
/var/lib/docker/containers/266767c59143a16761a4a7cb06d8f35604a1b7facb30bb020219fe2c29b32913/266767c59143a16761a4a7cb06d8f35604a1b7facb30bb020219fe2c29b32913-json.log
$ ls -Z $LOGPATH
-rw-------. root root system_u:object_r:docker_log_t:s0 /var/lib/docker/containers/266767c59143a16761a4a7cb06d8f35604a1b7facb30bb020219fe2c29b32913/266767c59143a16761a4a7cb06d8f35604a1b7facb30bb020219fe2c29b32913-json.log
```

That is to say, the log file should have type `docker_log_t`.

**A picture of a cute animal (not mandatory but encouraged)**
![Tweetie and Blue](http://itburns.net/brokenforum/tweetie-and-blue.jpg)

Fixes #21672.

Signed-off-by: Eli Young elyscape@gmail.com
