### PR TITLE
Fix layer store Get locking

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -334,7 +334,10 @@ func (ls *layerStore) get(l ChainID) *roLayer {
 }
 
 func (ls *layerStore) Get(l ChainID) (Layer, error) {
-	layer := ls.get(l)
+	ls.layerL.Lock()
+	defer ls.layerL.Unlock()
+
+	layer := ls.getWithoutLock(l)
 	if layer == nil {
 		return nil, ErrLayerDoesNotExist
 	}


### PR DESCRIPTION
Get was calling getReference without layerL held. This meant writes to
the references map could race. Such races are dangerous because they can
corrupt the map and crash the process.

Fixes #21616
Fixes #21674

cc @dmcgowan @tonistiigi @ibuildthecloud
