### PR TITLE
call growFS when size is a mismatch

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1880,7 +1880,7 @@ func (devices *DeviceSet) AddDevice(hash, baseHash string, storageOpt map[string
 	}
 
 	// Grow the container rootfs.
-	if size > 0 {
+	if size > baseInfo.Size {
 		info, err := devices.lookupDevice(hash)
 		if err != nil {
 			return err


### PR DESCRIPTION
When calling `AddDevice`, the procedure is described as follows

```
    devinfo := &devInfo{}

    if err := devices.parseStorageOpt(storageOpt, devinfo); err != nil {
        return err
    }

    if devinfo.Size == 0 {
        devinfo.Size = baseInfo.Size
    }

    if devinfo.Size < baseInfo.Size {
        return fmt.Errorf("devmapper: Container size cannot be smaller than %s", units.HumanSize(float64(baseInfo.Size)))
    }

    if err := devices.createRegisterSnapDevice(hash, baseInfo, devinfo.Size); err != nil {
        return err
    }

    // Grow the container rootfs.
    if devinfo.Size > 0 {
        info, err := devices.lookupDevice(hash)
        if err != nil {
            return err
        }

        if err := devices.growFS(info); err != nil {
            return err
        }
    }
```
1. parse the `--storage-opt` to get the target size related to `hash`, if no value is set, treat the size the same as `baseHash`
2. create snap device according to the `devinfo`
3. grow the container rootfs according to the information related to `hash`

The 3rd step, I think it can be skipped when `--storage-opt` is empty, because the size related to `hash` is the same as `baseHash`, it is not necessary to grow the container rootfs.So I add the code to optimize the procedure.

Signed-off-by: mYmNeo mymneo@163.com
