### PR TITLE
documentation: adding gce-docker plugin to plugins.md

### DIFF
--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -68,6 +68,8 @@ The following plugins exist:
 * The [Netshare plugin](https://github.com/gondor/docker-volume-netshare) is a volume plugin
   that provides volume management for NFS 3/4, AWS EFS and CIFS file systems.
 
+* The [gce-docker plugin](https://github.com/mcuadros/gce-docker) is a volume plugin able to attach, format and mount Google Compute [persistent-disks](https://cloud.google.com/compute/docs/disks/persistent-disks).
+
 * The [OpenStorage Plugin](https://github.com/libopenstorage/openstorage) is a cluster aware volume plugin that provides volume management for file and block storage solutions.  It implements a vendor neutral specification for implementing extensions such as CoS, encryption, and snapshots.   It has example drivers based on FUSE, NFS, NBD and EBS to name a few.
 
 * The [Quobyte Volume Plugin](https://github.com/quobyte/docker-volume) connects Docker to [Quobyte](http://www.quobyte.com/containers)'s data center file system, a general-purpose scalable and fault-tolerant storage platform.


### PR DESCRIPTION
Just adding https://github.com/mcuadros/gce-docker to documentation
