### PR TITLE
Fix race with event timer stopping early

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -55,11 +55,10 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 
-	timer := time.NewTimer(0)
-	timer.Stop()
+	var timeout <-chan time.Time
 	if until > 0 || untilNano > 0 {
 		dur := time.Unix(until, untilNano).Sub(time.Now())
-		timer = time.NewTimer(dur)
+		timeout = time.NewTimer(dur).C
 	}
 
 	ef, err := filters.FromParam(r.Form.Get("filters"))
@@ -94,7 +93,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 			if err := enc.Encode(jev); err != nil {
 				return err
 			}
-		case <-timer.C:
+		case <-timeout:
 			return nil
 		case <-ctx.Done():
 			logrus.Debug("Client context cancelled, stop sending events")


### PR DESCRIPTION
Fixes #18672

There seems to be a race between `NewTimer(0)` sending on the channel and `Stop()` closing it. Easy way to check it is to add `runtime.Gosched()` between these calls and after that the events stop working.  Confirmed by running `TestStatsAllNewContainersAdded` with `TEST_REPEAT=1000`.

@calavera 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
