### PR TITLE
Request pull credentials when using trusted reference

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -252,7 +252,7 @@ func (cli *DockerCli) trustedReference(ref reference.NamedTagged) (reference.Can
 	// Resolve the Auth config relevant for this server
 	authConfig := cli.resolveAuthConfig(repoInfo.Index)
 
-	notaryRepo, err := cli.getNotaryRepository(repoInfo, authConfig)
+	notaryRepo, err := cli.getNotaryRepository(repoInfo, authConfig, "pull")
 	if err != nil {
 		fmt.Fprintf(cli.out, "Error establishing connection to trust repository: %s\n", err)
 		return nil, err


### PR DESCRIPTION
https://github.com/docker/docker/commit/6b8a2a0fe47b218aaba3050c1f376941e4773313 didn't pass read/write permissions to `getNotaryRepository` from `trustedReference`.  This adds the `"pull"` permission to `getNotaryRepository` from `trustedReference`. 

Previously:

```
$ DOCKER_CONTENT_TRUST=1 bundles/latest/dynbinary/docker -D build -f Dockerfile.test .
Sending build context to Docker daemon 137.9 MB
An error occurred trying to connect: Post https://192.168.99.100:2376/v1.23/build?buildargs=%7B%7D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile.test&memory=0&memswap=0&rm=1&shmsize=0&ulimits=null: unable to 
reach trust server at this time: 401.

$ docker run --rm -it --privileged --name dct docker:dind docker daemon -D -s overlay
docker: you are not authorized to perform this operation: server returned 401..
See 'docker run --help'.
```

(as @jfrazelle notes in https://github.com/docker/docker/pull/20844)

This PR fixes the permissions.

Cute puppy:
![cute](http://persephonemagazine.com/wp-content/uploads/2012/06/www.petflow.comcutest.jpg)
