### PR TITLE
Change the windows bundle from a .tgz to a .zip file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get update && apt-get install -y \
 	xfsprogs \
 	libzfs-dev \
 	tar \
+	zip \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15 \
 	&& ln -snf /usr/bin/clang-3.8 /usr/local/bin/clang \

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,11 @@ bundles:
 cross: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross
 
-
 win: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh win
 
+tgz: build
+	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz
 
 deb: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary build-deb

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -15,9 +15,17 @@ for d in "$CROSS/"*/*; do
 	export GOOS="$(basename "$(dirname "$d")")"
 	BINARY_NAME="docker-$VERSION"
 	BINARY_EXTENSION="$(export GOOS && binary_extension)"
+	if [ "$GOOS" = 'windows' ]; then
+		# if windows use a zip, not tgz
+		BUNDLE_EXTENSION=".zip"
+		IS_TAR="false"
+	else
+		BUNDLE_EXTENSION=".tgz"
+		IS_TAR="true"
+	fi
 	BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 	mkdir -p "$DEST/$GOOS/$GOARCH"
-	TGZ="$DEST/$GOOS/$GOARCH/$BINARY_NAME.tgz"
+	TGZ="$DEST/$GOOS/$GOARCH/$BINARY_NAME$BUNDLE_EXTENSION"
 
 	# The staging directory for the files in the tgz
 	BUILD_PATH="$DEST/build"
@@ -35,8 +43,21 @@ for d in "$CROSS/"*/*; do
 	# copy over all the containerd binaries
 	copy_containerd $TAR_PATH
 
-	echo "Creating tgz from $BUILD_PATH and naming it $TGZ"
-	tar --numeric-owner --owner 0 -C "$BUILD_PATH" -czf "$TGZ" $TAR_BASE_DIRECTORY
+	if [ "$IS_TAR" == "true" ]; then
+		echo "Creating tgz from $BUILD_PATH and naming it $TGZ"
+		tar --numeric-owner --owner 0 -C "$BUILD_PATH" -czf "$TGZ" $TAR_BASE_DIRECTORY
+	else
+		# ZIP needs to full absolute dir path, not the absolute path
+		ZIP=`pwd`"/$TGZ"
+		# keep track of where we are, for later.
+		pushd .
+		# go into the BUILD_PATH since zip does not have a -C equivalent.
+		cd $BUILD_PATH
+		echo "Creating zip from $BUILD_PATH and naming it $ZIP"
+		zip -q -r $ZIP $TAR_BASE_DIRECTORY
+		# go back to where we started
+		popd
+	fi
 
 	hash_files "$TGZ"
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -181,7 +181,9 @@ release_build() {
 	binDir=bundles/$VERSION/cross/$GOOS/$GOARCH
 	tgzDir=bundles/$VERSION/tgz/$GOOS/$GOARCH
 	binary=docker-$VERSION
-	tgz=docker-$VERSION.tgz
+	zipExt=".tgz"
+	binaryExt=""
+	tgz=$binary$zipExt
 
 	latestBase=
 	if [ -z "$NOLATEST" ]; then
@@ -204,11 +206,12 @@ release_build() {
 			s3Os=Linux
 			;;
 		windows)
+			# this is windows use the .zip and .exe extentions for the files.
 			s3Os=Windows
-			binary+='.exe'
-			if [ "$latestBase" ]; then
-				latestBase+='.exe'
-			fi
+			zipExt=".zip"
+			binaryExt=".exe"
+			tgz=$binary$zipExt
+			binary+=$binaryExt
 			;;
 		*)
 			echo >&2 "error: can't convert $s3Os to an appropriate value for 'uname -s'"
@@ -235,11 +238,13 @@ release_build() {
 	esac
 
 	s3Dir="s3://$BUCKET_PATH/builds/$s3Os/$s3Arch"
-	latest=
+	# latest=
 	latestTgz=
 	if [ "$latestBase" ]; then
-		latest="$s3Dir/$latestBase"
-		latestTgz="$s3Dir/$latestBase.tgz"
+		# commented out since we aren't uploading binaries right now.
+		# latest="$s3Dir/$latestBase$binaryExt"
+		# we don't include the $binaryExt because we don't want docker.exe.zip
+		latestTgz="$s3Dir/$latestBase$zipExt"
 	fi
 
 	if [ ! -f "$tgzDir/$tgz" ]; then
@@ -308,6 +313,6 @@ echo "We have just pushed $VERSION to $(s3_url). You can download it with the fo
 echo
 echo "Darwin/OSX 64bit client tgz: $(s3_url)/builds/Darwin/x86_64/docker-$VERSION.tgz"
 echo "Linux 64bit tgz: $(s3_url)/builds/Linux/x86_64/docker-$VERSION.tgz"
-echo "Windows 64bit client tgz: $(s3_url)/builds/Windows/x86_64/docker-$VERSION.tgz"
-echo "Windows 32bit client tgz: $(s3_url)/builds/Windows/i386/docker-$VERSION.tgz"
+echo "Windows 64bit client tgz: $(s3_url)/builds/Windows/x86_64/docker-$VERSION.zip"
+echo "Windows 32bit client tgz: $(s3_url)/builds/Windows/i386/docker-$VERSION.zip"
 echo


### PR DESCRIPTION
**\- What I did**
Currently the build process creates windows bundles as a `tgz` file. These files are hard to open on windows, so I changed them to a zip file, which is easier to open.

I also changed the `release.sh` script so that it handles the new extentions.

I also added a tgz target to the master Makefile so that it was easier to test, and create tgz bundles.

**\- How I did it**

I updated the `hack/make/tgz` and `hack/release.sh` files

**\- How to verify it**

run `make tgz` and make sure the bundles under windows are .zip and have the correct contents.
I haven't had a chance to verify that the zip files that are created can be opened on windows, due to not having a windows machine to test.

run the `release.sh` script and make sure it uploads the zip files into the s3 buckets.

I ran the `make tgz`, and that worked fine, I wasn't sure how to test the `release.sh` script.

Signed-off-by: Ken Cochrane kencochrane@gmail.com

/cc @tiborvass @mikedougherty @thaJeztah 
