### PR TITLE
Also generate "InRelease" files for newer APT clients

### DIFF
--- a/hack/make/sign-repos
+++ b/hack/make/sign-repos
@@ -32,6 +32,13 @@ sign_packages(){
 					--batch --yes \
 					--output "$F.gpg" "$F"
 			fi
+			inRelease="$(dirname "$F")/InRelease"
+			if test "$F" -nt "$inRelease" ; then
+				gpg -u "$GPG_KEYID" --passphrase "$GPG_PASSPHRASE" \
+					--clearsign \
+					--batch --yes \
+					--output "$inRelease" "$F"
+			fi
 		done
 	fi
 


### PR DESCRIPTION
Fixes #21707

cc @jfrazelle @kencochrane

I don't have an easy setup ATM to test this, but this should do the trick for generating the newer `InRelease` files. :smile:
