### PR TITLE
When container had no layer data, cleanupContainer crashed

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -123,10 +123,14 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
 	}
 
-	metadata, err := daemon.layerStore.ReleaseRWLayer(container.RWLayer)
-	layer.LogReleaseMetadata(metadata)
-	if err != nil && err != layer.ErrMountDoesNotExist {
-		return fmt.Errorf("Driver %s failed to remove root filesystem %s: %s", daemon.GraphDriverName(), container.ID, err)
+	// When container creation fails and `RWLayer` has not been created yet, we
+	// do not call `ReleaseRWLayer`
+	if container.RWLayer != nil {
+		metadata, err := daemon.layerStore.ReleaseRWLayer(container.RWLayer)
+		layer.LogReleaseMetadata(metadata)
+		if err != nil && err != layer.ErrMountDoesNotExist {
+			return fmt.Errorf("Driver %s failed to remove root filesystem %s: %s", daemon.GraphDriverName(), container.ID, err)
+		}
 	}
 
 	return nil

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -68,15 +68,15 @@ func (s *DockerSuite) TestCreateGrowRootfs(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectOut := inspectField(c, cleanedContainerID, "HostConfig.StorageOpt")
-	c.Assert(inspectOut, checker.Equals, "[size=120G]")
+	c.Assert(inspectOut, checker.Equals, "map[size:120G]")
 }
 
 // Make sure we cannot shrink the container's rootfs at creation time.
 func (s *DockerSuite) TestCreateShrinkRootfs(c *check.C) {
 	testRequires(c, Devicemapper)
 
-	// Ensure this fails
-	out, _, err := dockerCmdWithError("create", "--storage-opt", "size=80G", "busybox")
+	// Ensure this fails because of the defaultBaseFsSize is 10G
+	out, _, err := dockerCmdWithError("create", "--storage-opt", "size=5G", "busybox")
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "Container size cannot be smaller than")
 }

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -54,6 +54,11 @@ var (
 	dockerBasePath       string
 	volumesConfigPath    string
 	containerStoragePath string
+
+	// daemonStorageDriver is held globally so that tests can know the storage
+	// driver of the daemon. This is initialized in docker_utils by sending
+	// a version call to the daemon and examining the response header.
+	daemonStorageDriver string
 )
 
 const (

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -86,6 +86,7 @@ func init() {
 
 	var info types.Info
 	err = json.Unmarshal(body, &info)
+	daemonStorageDriver = info.Driver
 	dockerBasePath = info.DockerRootDir
 	volumesConfigPath = filepath.Join(dockerBasePath, "volumes")
 	containerStoragePath = filepath.Join(dockerBasePath, "containers")

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -109,22 +109,14 @@ var (
 	}
 	NotOverlay = testRequirement{
 		func() bool {
-			cmd := exec.Command("grep", "^overlay / overlay", "/proc/mounts")
-			if err := cmd.Run(); err != nil {
-				return true
-			}
-			return false
+			return !strings.HasPrefix(daemonStorageDriver, "overlay")
 		},
 		"Test requires underlying root filesystem not be backed by overlay.",
 	}
 
 	Devicemapper = testRequirement{
 		func() bool {
-			cmd := exec.Command("grep", "^devicemapper / devicemapper", "/proc/mounts")
-			if err := cmd.Run(); err != nil {
-				return false
-			}
-			return true
+			return strings.HasPrefix(daemonStorageDriver, "devicemapper")
 		},
 		"Test requires underlying root filesystem to be backed by devicemapper.",
 	}


### PR DESCRIPTION
### Background

When I tried to test `TestCreateGrowRootfs` and `TestCreateShrinkRootfs` with the following command
`DOCKER_STORAGE_OPTS="dm.override_udev_sync_check=true,dm.basesize=10G,dm.loopdatasize=40G" DOCKER_GRAPHDRIVER="devicemapper" TESTFLAGS="-check.f DockerSuite.TestCreate*" make test-integration-cli`. I found the above two test were always skipped, but it should not be. Then I change some code to make the two test able to run, and the `TestCreateShrinkRootfs` crash the daemon with the following log

```
1062 time="2016-04-01T06:25:08.009764500Z" level=debug msg="devmapper: AddDevice(hash=7dc4c61b0cb29d5698ce16faca46feaa42d5937cfd5f850     e953938b18e231432-init basehash=7a5b71596cd0bc77f6c5b6c051f6005a14bce55cfe69ce59d780df1b5c1fc8e6)"
1063 time="2016-04-01T06:25:08.009795514Z" level=debug msg="devmapper: AddDevice(hash=7dc4c61b0cb29d5698ce16faca46feaa42d5937cfd5f850     e953938b18e231432-init basehash=7a5b71596cd0bc77f6c5b6c051f6005a14bce55cfe69ce59d780df1b5c1fc8e6) END"
1064 time="2016-04-01T06:25:08.009826278Z" level=error msg="Error saving dying container to disk: open /var/lib/docker/containers/d38     7c8c947c5cb2813421e6f9376cc50d3115058aba5cd27132ee000c29adb66/config.v2.json: no such file or directory"
1065 2016/04/01 06:25:08 http: panic serving @: runtime error: invalid memory address or nil pointer dereference
1066 goroutine 283 [running]:
1067 net/http.(*conn).serve.func1(0xc8216faa50, 0x7fdef83b9088, 0xc821854ce8)
1068   /usr/local/go/src/net/http/server.go:1287 +0xb5
1069 github.com/docker/docker/layer.(*layerStore).ReleaseRWLayer(0xc82093f700, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
1070   /go/src/github.com/docker/docker/layer/layer_store.go:520 +0xc3
1071 github.com/docker/docker/daemon.(*Daemon).cleanupContainer(0xc820503080, 0xc820018380, 0xc82032b901, 0x0, 0x0)
1072   /go/src/github.com/docker/docker/daemon/delete.go:126 +0x918
```

Because the `RWLayer` field is nil
### Solution

Before `ReleaseRWLayer` of a container, check validation of the `RWLayer` field to prevent daemon crash
