### PR TITLE
Fixing help text of "docker network --help" to be consistent

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -372,19 +372,19 @@ func subnetMatches(subnet, data string) (bool, error) {
 }
 
 func networkUsage() string {
-	networkCommands := map[string]string{
-		"create":     "Create a network",
-		"connect":    "Connect container to a network",
-		"disconnect": "Disconnect container from a network",
-		"inspect":    "Display detailed network information",
-		"ls":         "List all networks",
-		"rm":         "Remove a network",
+	networkCommands := [][]string{
+		{"create", "Create a network"},
+		{"connect", "Connect container to a network"},
+		{"disconnect", "Disconnect container from a network"},
+		{"inspect", "Display detailed network information"},
+		{"ls", "List all networks"},
+		{"rm", "Remove a network"},
 	}
 
 	help := "Commands:\n"
 
-	for cmd, description := range networkCommands {
-		help += fmt.Sprintf("  %-25.25s%s\n", cmd, description)
+	for _, cmd := range networkCommands {
+		help += fmt.Sprintf("  %-25.25s%s\n", cmd[0], cmd[1])
 	}
 
 	help += fmt.Sprintf("\nRun 'docker network COMMAND --help' for more information on a command.")


### PR DESCRIPTION
**\- What I did**
changed networkUsage from hash table to multidimensional array because hash tables are not considered to be ordered (exact problem description in #21710 )
**\- How I did it**
oriented on implementation of `docker volume --help`
**\- How to verify it**
run `docker network --help` multiple times. output is now the same every time

Changed from hashmap to multidimensional array as in `docker volume --help`
closes #21710

Signed-off-by: Robin Naundorf r.naundorf@fh-muenster.de
