### PR TITLE
enable syslog logger to have access to env and labels

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -188,6 +188,8 @@ func parseAddress(address string) (string, string, error) {
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {
+		case "env":
+		case "labels":
 		case "syslog-address":
 		case "syslog-facility":
 		case "syslog-tag":

--- a/docs/admin/logging/log_tags.md
+++ b/docs/admin/logging/log_tags.md
@@ -46,6 +46,26 @@ For advanced usage, the generated tag's use [go
 templates](http://golang.org/pkg/text/template/) and the container's [logging
 context](https://github.com/docker/docker/blob/master/daemon/logger/context.go).
 
+As an example of what is possible with the syslog logger:
+
+```
+$ docker run -it --rm \
+    --log-driver syslog \
+    --log-opt tag="{{ (.ExtraAttributes nil).SOME_ENV_VAR }}" \
+    --log-opt env=SOME_ENV_VAR \
+    -e SOME_ENV_VAR=logtester.1234 \
+    flyinprogrammer/logtester
+```
+
+Results in logs like this:
+
+```
+Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: + exec app
+Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: 2016-04-01 15:22:17.075416751 +0000 UTC stderr msg: 1
+```
+
+
+
 >**Note**:The driver specific log options `syslog-tag`, `fluentd-tag` and
 >`gelf-tag` still work for backwards compatibility. However, going forward you
 >should standardize on using the generic `tag` log option instead.

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -81,6 +81,8 @@ The following logging options are supported for the `syslog` logging driver:
     --log-opt syslog-tls-skip-verify=true
     --log-opt tag="mailer"
     --log-opt syslog-format=[rfc5424|rfc5424micro|rfc3164]
+    --log-opt env=ENV1,ENV2,ENV3
+    --log-opt labels=label1,label2,label3
 
 `syslog-address` specifies the remote syslog server address where the driver connects to.
 If not specified it defaults to the local unix socket of the running system.
@@ -128,6 +130,7 @@ This option is ignored if the address protocol is not `tcp+tls`.
 This verification is enabled by default, but it can be overriden by setting
 this option to `true`. This option is ignored if the address protocol is not `tcp+tls`.
 
+`tag` configures a string that is appended to the APP-NAME in the syslog message.
 By default, Docker uses the first 12 characters of the container ID to tag log messages.
 Refer to the [log tag option documentation](log_tags.md) for customizing
 the log tag format.
@@ -138,6 +141,11 @@ Specify rfc3164 to perform logging in RFC-3164 compatible format. Specify rfc542
 logging in RFC-5424 compatible format. Specify rfc5424micro to perform logging in RFC-5424
 compatible format with microsecond timestamp resolution.
 
+`env` should be a comma-separated list of keys of environment variables. Used for
+advanced [log tag options](log_tags.md).
+
+`labels` should be a comma-separated list of keys of labels. Used for advanced
+[log tag options](log_tags.md).
 
 ## journald options
 


### PR DESCRIPTION
**\- What I did**
I added `env` and `labels` as valid log options for the syslog logger.

**\- How I did it**
Well... there's only 1 commit, I reckon you can figure that out.

**\- How to verify it**
You know I probably could write a test like this one:  https://github.com/docker/docker/blob/master/daemon/logger/syslog/syslog_test.go#L40-L45

Or...

I could show you this:

Shell:

```
$ docker run -it --rm --log-driver syslog --log-opt tag="{{ (.ExtraAttributes nil).MESOS_TASK_ID }}" --log-opt env=MESOS_TASK_ID -e MESOS_TASK_ID=logtester.1234 flyinprogrammer/logtester
+ exec app
2016-04-01 15:22:17.075416751 +0000 UTC stderr msg: 1
2016-04-01 15:22:17.075416751 +0000 UTC stdout msg: 1
2016-04-01 15:22:22.075767762 +0000 UTC stderr msg: 2
2016-04-01 15:22:22.075767762 +0000 UTC stdout msg: 2
```

`/var/log/syslog`:

```
Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: + exec app
Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: 2016-04-01 15:22:17.075416751 +0000 UTC stderr msg: 1
Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: 2016-04-01 15:22:17.075416751 +0000 UTC stdout msg: 1
Apr  1 15:22:22 ip-10-27-39-73 docker/logtester.1234[45499]: 2016-04-01 15:22:22.075767762 +0000 UTC stderr msg: 2
Apr  1 15:22:22 ip-10-27-39-73 docker/logtester.1234[45499]: 2016-04-01 15:22:22.075767762 +0000 UTC stdout msg: 2
```

So this is pretty cool huh because it starts to address issues like this one: 
https://github.com/mesosphere/marathon/issues/717

So that's nifty huh :smile_cat:.

**\- A picture of a cute animal (not mandatory but encouraged)**

![Alan](http://i.imgur.com/HDQdWkE.jpg)
**Steve!**

Signed-off-by: Alan Scherger flyinprogrammer@gmail.com
