### PR TITLE
Fix build cache false positives when build context tar contains unnormalized paths

### DIFF
--- a/builder/tarsum.go
+++ b/builder/tarsum.go
@@ -138,7 +138,7 @@ func (c *tarSumContext) Walk(root string, walkFn WalkFunc) error {
 		}
 
 		sum := rel
-		if tsInfo := c.sums.GetFile(rel); tsInfo != nil {
+		if tsInfo := c.sums.GetFile(filepath.ToSlash(rel)); tsInfo != nil {
 			sum = tsInfo.Sum()
 		}
 		fi := &HashedFileInfo{PathFileInfo{FileInfo: info, FilePath: fullpath}, sum}

--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"path"
 	"strings"
 )
 
@@ -235,7 +236,7 @@ func (ts *tarSum) Read(buf []byte) (int, error) {
 				}
 				return n, err
 			}
-			ts.currentFile = strings.TrimSuffix(strings.TrimPrefix(currentHeader.Name, "./"), "/")
+			ts.currentFile = path.Clean(currentHeader.Name)
 			if err := ts.encodeHeader(currentHeader); err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
If a build context tar has path names of the form 'x/./y', they will be
stored in this unnormalized form internally by tarsum. When the builder
walks the untarred directory tree and queries hashes for each relative
path, it will query paths of the form 'x/y', and they will not be found.

To correct this, have tarsum normalize path names by calling Clean.

Add a test to detect this caching false positive.

Fixes #21715

cc @rhuss @thaJeztah 
