### PR TITLE
Persist a container's mount-path to disk.

### DIFF
--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -54,7 +54,6 @@ func (daemon *Daemon) cleanupMountsFromReaderByID(reader io.Reader, id string, u
 		return fmt.Errorf("Error cleaning up mounts:\n%v", strings.Join(errors, "\n"))
 	}
 
-	logrus.Debugf("Cleaning up old mountid %v: done.", id)
 	return nil
 }
 

--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -90,7 +90,15 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *check.C) {
 		c.Fatalf("Container %s expected to stay alive after daemon restart", id)
 	}
 
-	// 'docker stop' should work.
+	// 'docker cp', which mounts paths should work.
+	tmpFile, err := ioutil.TempFile("", "copy-file")
+	c.Assert(err, check.IsNil, check.Commentf("failed to create tmpFile"))
+	defer os.Remove(tmpFile.Name())
+
+	out, err = s.d.Cmd("cp", tmpFile.Name(), containerCpPath(id, "/tmp"))
+	c.Assert(err, check.IsNil, check.Commentf("docker cp error %s", err))
+
+	// 'docker stop', which unmounts paths should work.
 	out, err = s.d.Cmd("stop", id)
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 

--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -214,6 +214,13 @@ func (fms *fileMetadataStore) SetMountID(mount string, mountID string) error {
 	return ioutil.WriteFile(fms.getMountFilename(mount, "mount-id"), []byte(mountID), 0644)
 }
 
+func (fms *fileMetadataStore) SetMountPath(mount string, mountPath string) error {
+	if err := os.MkdirAll(fms.getMountDirectory(mount), 0755); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(fms.getMountFilename(mount, "mount-path"), []byte(mountPath), 0644)
+}
+
 func (fms *fileMetadataStore) SetInitID(mount string, init string) error {
 	if err := os.MkdirAll(fms.getMountDirectory(mount), 0755); err != nil {
 		return err
@@ -226,6 +233,20 @@ func (fms *fileMetadataStore) SetMountParent(mount string, parent ChainID) error
 		return err
 	}
 	return ioutil.WriteFile(fms.getMountFilename(mount, "parent"), []byte(digest.Digest(parent).String()), 0644)
+}
+
+func (fms *fileMetadataStore) GetMountPath(mount string) (string, error) {
+	contentBytes, err := ioutil.ReadFile(fms.getMountFilename(mount, "mount-path"))
+	if err != nil {
+		return "", err
+	}
+
+	mountPath := strings.TrimSpace(string(contentBytes))
+	if _, err := os.Stat(mountPath); err != nil {
+		return "", err
+	}
+
+	return mountPath, nil
 }
 
 func (fms *fileMetadataStore) GetMountID(mount string) (string, error) {

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -210,10 +210,12 @@ type MetadataStore interface {
 	GetCacheID(ChainID) (string, error)
 	TarSplitReader(ChainID) (io.ReadCloser, error)
 
+	SetMountPath(string, string) error
 	SetMountID(string, string) error
 	SetInitID(string, string) error
 	SetMountParent(string, ChainID) error
 
+	GetMountPath(string) (string, error)
 	GetMountID(string) (string, error)
 	GetInitID(string) (string, error)
 	GetMountParent(string) (ChainID, error)

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -490,7 +490,6 @@ func (ls *layerStore) GetMountID(id string) (string, error) {
 	if !ok {
 		return "", ErrMountDoesNotExist
 	}
-	logrus.Debugf("GetMountID id: %s -> mountID: %s", id, mount.mountID)
 
 	return mount.mountID, nil
 }


### PR DESCRIPTION
For live containers after a daemon restart, activity count for
the mounted layers is > 0. As a result, there's no need to mount
again. We simply increment the activity count and return the path.
However, the path is not initialized.

With this change, start writing mount paths to disks. Read it back
in the above case.

Updated test to include docker cp, which tests the graph mounts.

Signed-off-by: Anusha Ragunathan anusha@docker.com
