### PR TITLE
Adding postRunProcessing infrastructure for handling Windows Update.

### DIFF
--- a/daemon/monitor_linux.go
+++ b/daemon/monitor_linux.go
@@ -12,3 +12,8 @@ func platformConstructExitStatus(e libcontainerd.StateInfo) *container.ExitStatu
 		OOMKilled: e.OOMKilled,
 	}
 }
+
+// postRunProcessing perfoms any processing needed on the container after it has stopped.
+func (daemon *Daemon) postRunProcessing(container *container.Container, e libcontainerd.StateInfo) error {
+	return nil
+}

--- a/daemon/monitor_windows.go
+++ b/daemon/monitor_windows.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/libcontainerd"
 )
@@ -10,4 +12,13 @@ func platformConstructExitStatus(e libcontainerd.StateInfo) *container.ExitStatu
 	return &container.ExitStatus{
 		ExitCode: int(e.ExitCode),
 	}
+}
+
+// postRunProcessing perfoms any processing needed on the container after it has stopped.
+func (daemon *Daemon) postRunProcessing(container *container.Container, e libcontainerd.StateInfo) error {
+	//TODO Windows - handle update processing here...
+	if e.UpdatePending {
+		return fmt.Errorf("Windows: Update handling not implemented.")
+	}
+	return nil
 }

--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -269,9 +269,10 @@ func (clnt *client) setExited(containerID string) error {
 	}
 
 	err := clnt.backend.StateChanged(containerID, StateInfo{
-		State:    StateExit,
-		ExitCode: exitCode,
-	})
+		CommonStateInfo: CommonStateInfo{
+			State:    StateExit,
+			ExitCode: exitCode,
+		}})
 
 	// Unmount and delete the bundle folder
 	if mts, err := mount.GetMounts(); err == nil {

--- a/libcontainerd/client_liverestore_linux.go
+++ b/libcontainerd/client_liverestore_linux.go
@@ -48,9 +48,10 @@ func (clnt *client) restore(cont *containerd.Container, options ...CreateOption)
 	clnt.appendContainer(container)
 
 	err = clnt.backend.StateChanged(containerID, StateInfo{
-		State: StateRestore,
-		Pid:   container.systemPid,
-	})
+		CommonStateInfo: CommonStateInfo{
+			State: StateRestore,
+			Pid:   container.systemPid,
+		}})
 
 	if err != nil {
 		return err
@@ -60,9 +61,10 @@ func (clnt *client) restore(cont *containerd.Container, options ...CreateOption)
 		// This should only be a pause or resume event
 		if event.Type == StatePause || event.Type == StateResume {
 			return clnt.backend.StateChanged(containerID, StateInfo{
-				State: event.Type,
-				Pid:   container.systemPid,
-			})
+				CommonStateInfo: CommonStateInfo{
+					State: event.Type,
+					Pid:   container.systemPid,
+				}})
 		}
 
 		logrus.Warnf("unexpected backlog event: %#v", event)

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -505,9 +505,10 @@ func (clnt *client) Restore(containerID string, unusedOnWindows ...CreateOption)
 	// TODO Windows: Implement this. For now, just tell the backend the container exited.
 	logrus.Debugf("lcd Restore %s", containerID)
 	return clnt.backend.StateChanged(containerID, StateInfo{
-		State:    StateExit,
-		ExitCode: 1 << 31,
-	})
+		CommonStateInfo: CommonStateInfo{
+			State:    StateExit,
+			ExitCode: 1 << 31,
+		}})
 }
 
 // GetPidsForContainer returns a list of process IDs running in a container.

--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -81,9 +81,10 @@ func (ctr *container) start() error {
 	ctr.systemPid = systemPid(resp.Container)
 
 	return ctr.client.backend.StateChanged(ctr.containerID, StateInfo{
-		State: StateStart,
-		Pid:   ctr.systemPid,
-	})
+		CommonStateInfo: CommonStateInfo{
+			State: StateStart,
+			Pid:   ctr.systemPid,
+		}})
 }
 
 func (ctr *container) newProcess(friendlyName string) *process {
@@ -103,8 +104,10 @@ func (ctr *container) handleEvent(e *containerd.Event) error {
 	switch e.Type {
 	case StateExit, StatePause, StateResume, StateOOM:
 		st := StateInfo{
-			State:     e.Type,
-			ExitCode:  e.Status,
+			CommonStateInfo: CommonStateInfo{
+				State:    e.Type,
+				ExitCode: e.Status,
+			},
 			OOMKilled: e.Type == StateExit && ctr.oom,
 		}
 		if e.Type == StateOOM {

--- a/libcontainerd/types.go
+++ b/libcontainerd/types.go
@@ -16,13 +16,12 @@ const (
 	stateLive         = "live"
 )
 
-// StateInfo contains description about the new state container has entered.
-type StateInfo struct { // FIXME: event?
+// CommonStateInfo contains the state info common to all platforms.
+type CommonStateInfo struct { // FIXME: event?
 	State     string
 	Pid       uint32
 	ExitCode  uint32
 	ProcessID string
-	OOMKilled bool // TODO Windows containerd factor out
 }
 
 // Backend defines callbacks that the client of the library needs to implement.

--- a/libcontainerd/types_linux.go
+++ b/libcontainerd/types_linux.go
@@ -33,6 +33,14 @@ type Process struct {
 	SelinuxLabel *string `json:"selinuxLabel,omitempty"`
 }
 
+// StateInfo contains description about the new state container has entered.
+type StateInfo struct {
+	CommonStateInfo
+
+	// Platform specific StateInfo
+	OOMKilled bool
+}
+
 // Stats contains a stats properties from containerd.
 type Stats containerd.StatsResponse
 

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -17,6 +17,14 @@ type Summary struct {
 	Command string
 }
 
+// StateInfo contains description about the new state container has entered.
+type StateInfo struct {
+	CommonStateInfo
+
+	// Platform specific StateInfo
+	UpdatePending bool
+}
+
 // Stats contains a stats properties from containerd.
 type Stats struct{}
 


### PR DESCRIPTION
@jhowardmsft @jstarks 
This change introduces the infrastructure that we will use to trigger the necessary update steps on an offline container when hcsshim reports there are pending updates.  This will enable running customized Windows Update code inside the container, with the host finishing the update processing (offline DISM calls and reboots if needed) after the container has shut down.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
