### PR TITLE
Improved message when pushing a non-existant image

### DIFF
--- a/distribution/push.go
+++ b/distribution/push.go
@@ -109,7 +109,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
 
 	associations := imagePushConfig.ReferenceStore.ReferencesByName(repoInfo)
 	if len(associations) == 0 {
-		return fmt.Errorf("Repository does not exist: %s", repoInfo.Name())
+		return fmt.Errorf("An image does not exist locally with the tag: %s", repoInfo.Name())
 	}
 
 	var (

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -43,7 +43,7 @@ func (s *DockerSuite) TestPushUnprefixedRepo(c *check.C) {
 
 func testPushUntagged(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
-	expected := "Repository does not exist"
+	expected := "An image does not exist locally with the tag"
 
 	out, _, err := dockerCmdWithError("push", repoName)
 	c.Assert(err, check.NotNil, check.Commentf("pushing the image to the private registry should have failed: output %q", out))


### PR DESCRIPTION
**\- Intro**
If a user forgot to tag their image prior to pushing it to a remote registry, or possibly misspelled their tag, they would see the message 'Repository does not exist', which is not very clear and causes some to think that there might be a problem with the registry or connectivity to it, when the problem was simply just that docker doesn't have any image with that tag to push.

**\- What I did**
Changed the error message from "Repository does not exist: %s" to "An image does not exist locally with the tag: %s", so that the user would have a better understanding of what went wrong.

**\- How I did it**
By updating the error message text and a corresponding test expectation.

**\- How to verify it**
'docker login' to a registry (e.g. the docker hub), and then issue a 'docker push' command for an image that does not exist.

Signed-off-by: Dave MacDonald mindlapse@gmail.com
