### PR TITLE
[1.11-rc3] contrib: init: systemd: remove incorrect systemd options

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,7 +10,6 @@ Type=notify
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
 ExecStart=/usr/bin/docker daemon -H fd://
-MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity


### PR DESCRIPTION
MountFlags=slave causes Docker to not operate with containerd if it was
started as a service, separately from Docker. Since containerd as a
service is in a separate mount namepsace from Docker (in contrast with
when Docker starts containerd by itself) this results in containerd not
being able to use the rootfs mounted by Docker.

Remove this outdated option from the service file.

Since Docker no longer manages any containers (it's all done by
containerd), Delegate=yes no longer makes any sense. Remove it because
it's just clutter.

![lazer kitteh](https://c3.staticflickr.com/3/2455/3566421306_edb4ec86d3_n.jpg)

Signed-off-by: Aleksa Sarai asarai@suse.de

This **must** be merged for 1.11, because it affects how distributions will package containerd with Docker. At SUSE, we're planning on packaging containerd as a separate service so this is a real issue for us.

/cc @lsm5 @philips @jfrazelle
