### PR TITLE
Fixed a typo in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -313,6 +313,6 @@ echo "We have just pushed $VERSION to $(s3_url). You can download it with the fo
 echo
 echo "Darwin/OSX 64bit client tgz: $(s3_url)/builds/Darwin/x86_64/docker-$VERSION.tgz"
 echo "Linux 64bit tgz: $(s3_url)/builds/Linux/x86_64/docker-$VERSION.tgz"
-echo "Windows 64bit client tgz: $(s3_url)/builds/Windows/x86_64/docker-$VERSION.zip"
-echo "Windows 32bit client tgz: $(s3_url)/builds/Windows/i386/docker-$VERSION.zip"
+echo "Windows 64bit client zip: $(s3_url)/builds/Windows/x86_64/docker-$VERSION.zip"
+echo "Windows 32bit client zip: $(s3_url)/builds/Windows/i386/docker-$VERSION.zip"
 echo


### PR DESCRIPTION
**\- What I did**

Fixed a typo in the release.sh script. It was saying `tgz` for windows bundles when it should have been `zip`

**\- How I did it**

edited the release.sh script to remove the typo.

**\- How to verify it**

Look at the diff and see that the typo is no longer there.

Signed-off-by: Ken Cochrane kencochrane@gmail.com
