### PR TITLE
Define readonly/mask paths in spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,7 +248,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -181,7 +181,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -198,7 +198,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -74,13 +74,12 @@ WORKDIR /go/src/github.com/docker/docker
 ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
 	&& git checkout -q "$RUNC_COMMIT" \
-	&& (find . -name "*_ffjson.go" | xargs rm) \
 	&& make static BUILDTAGS="seccomp apparmor selinux" \
 	&& cp runc /usr/local/bin/docker-runc
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -196,7 +196,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -178,7 +178,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -57,7 +57,7 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 ENV CGO_LDFLAGS -L/lib
 
 # Install runc
-ENV RUNC_COMMIT 0c1c615ebd6a15545b6a82ead01d2745ea49b242
+ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -536,6 +536,8 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 				}
 			}
 		}
+		s.Linux.ReadonlyPaths = nil
+		s.Linux.MaskedPaths = nil
 	}
 
 	// TODO: until a kernel/mount solution exists for handling remount in a user namespace,
@@ -660,10 +662,10 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 
 	if apparmor.IsEnabled() {
 		appArmorProfile := "docker-default"
-		if c.HostConfig.Privileged {
-			appArmorProfile = "unconfined"
-		} else if len(c.AppArmorProfile) > 0 {
+		if len(c.AppArmorProfile) > 0 {
 			appArmorProfile = c.AppArmorProfile
+		} else if c.HostConfig.Privileged {
+			appArmorProfile = "unconfined"
 		}
 		s.Process.ApparmorProfile = appArmorProfile
 	}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git github.com/docker/go v1.5.1-1-1-gbaf439e
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
 clone git github.com/opencontainers/runc 2441732d6fcc0fb0a542671a4372e0c7bc99c19e # libcontainer
-clone git github.com/opencontainers/specs 3ce138b1934bf227a418e241ead496c383eaba1c # specs
+clone git github.com/opencontainers/specs 93ca97e83ca7fb4fba6d9e30d5470f99ddc02d11 # specs
 clone git github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v4

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1106,7 +1106,7 @@ func (s *DockerSuite) TestRunProcNotWritableInNonPrivilegedContainers(c *check.C
 func (s *DockerSuite) TestRunProcWritableInPrivilegedContainers(c *check.C) {
 	// Not applicable for Windows as there is no concept of --privileged
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
-	if _, code := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "umount /proc/sysrq-trigger && touch /proc/sysrq-trigger"); code != 0 {
+	if _, code := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "touch /proc/sysrq-trigger"); code != 0 {
 		c.Fatalf("proc should be writable in privileged container")
 	}
 }

--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -79,6 +79,20 @@ func DefaultSpec() specs.Spec {
 	}
 
 	s.Linux = specs.Linux{
+		MaskedPaths: []string{
+			"/proc/kcore",
+			"/proc/latency_stats",
+			"/proc/timer_stats",
+			"/proc/sched_debug",
+		},
+		ReadonlyPaths: []string{
+			"/proc/asound",
+			"/proc/bus",
+			"/proc/fs",
+			"/proc/irq",
+			"/proc/sys",
+			"/proc/sysrq-trigger",
+		},
 		Namespaces: []specs.Namespace{
 			{Type: "mount"},
 			{Type: "network"},

--- a/vendor/src/github.com/opencontainers/specs/specs-go/config.go
+++ b/vendor/src/github.com/opencontainers/specs/specs-go/config.go
@@ -96,9 +96,10 @@ type Mount struct {
 
 // Hook specifies a command that is run at a particular event in the lifecycle of a container
 type Hook struct {
-	Path string   `json:"path"`
-	Args []string `json:"args,omitempty"`
-	Env  []string `json:"env,omitempty"`
+	Path    string   `json:"path"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	Timeout *int     `json:"timeout,omitempty"`
 }
 
 // Hooks for container setup and teardown
@@ -128,13 +129,17 @@ type Linux struct {
 	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
 	CgroupsPath *string `json:"cgroupsPath,omitempty"`
 	// Namespaces contains the namespaces that are created and/or joined by the container
-	Namespaces []Namespace `json:"namespaces"`
+	Namespaces []Namespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
-	Devices []Device `json:"devices"`
+	Devices []Device `json:"devices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
 	Seccomp *Seccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
+	// MaskedPaths masks over the provided paths inside the container.
+	MaskedPaths []string `json:"maskedPaths,omitempty"`
+	// ReadonlyPaths sets the provided paths as RO inside the container.
+	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
 }
 
 // Namespace is the configuration for a Linux namespace

--- a/vendor/src/github.com/opencontainers/specs/specs-go/version.go
+++ b/vendor/src/github.com/opencontainers/specs/specs-go/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 0
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 4
+	VersionMinor = 5
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This vendors in new spec/runc that supports
setting readonly and masked paths in the 
configuration. Using this allows us to make an
exception for `—-privileged`.

Fixes #21649

Runc changes: https://github.com/opencontainers/runc/compare/0c1c615ebd6a15545b6a82ead01d2745ea49b242...6c88a526cdd74aab90cc88018368c452c7294a06

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
