### PR TITLE
Fixes #21660: Augment load API to return imported images 

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -209,7 +209,8 @@ func (s *imageRouter) postImagesLoad(ctx context.Context, w http.ResponseWriter,
 		}
 		return nil
 	}
-	return s.backend.LoadImage(r.Body, w, quiet)
+	err := s.backend.LoadImage(r.Body, w, quiet)
+	return err
 }
 
 func (s *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1062,7 +1062,8 @@ func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
 // ball containing images and metadata.
 func (daemon *Daemon) LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
 	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon)
-	return imageExporter.Load(inTar, outStream, quiet)
+	_, err := imageExporter.Load(inTar, outStream, quiet)
+	return err
 }
 
 // ImageHistory returns a slice of ImageHistory structures for the specified image

--- a/image/image.go
+++ b/image/image.go
@@ -118,7 +118,7 @@ type History struct {
 
 // Exporter provides interface for exporting and importing images
 type Exporter interface {
-	Load(io.ReadCloser, io.Writer, bool) error
+	Load(io.ReadCloser, io.Writer, bool) ([]ID, error)
 	// TODO: Load(net.Context, io.ReadCloser, <- chan StatusMessage) error
 	Save([]string, io.Writer) error
 }


### PR DESCRIPTION
This is a WIP branch. I'm looking for input on what the http response should be when loading a tar file containing docker images.

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

When importing a TAR file of container images, the Docker API should return the list of images that were successfully imported. This commit tracks the changes made, but breaks the current docker client, which expects a streaming HTTP response containing a sequence of status messages.

With a bit of `io.Copy(response, stdout)`, the current (broken) responses look as follows when importing the `hello-world` image contained in a tar file produced by `docker save`:

```
&{0xc820652780 map[Content-Type:[application/json] Server:[Docker/1.11.0-dev (linux)] Date:[Fri, 01 Apr 2016 18:55:29 GMT] Content-Length:[1733]] 200}
{"status":"Loading layer","progressDetail":{"current":512,"total":2560},"progress":"[==========\u003e                                        ]    512 B/2.56 kB","id":"b652ec3a27e7"}
{"status":"Loading layer","progressDetail":{"current":1472,"total":2560},"progress":"[============================\u003e                      ] 1.472 kB/2.56 kB","id":"b652ec3a27e7"}
{"status":"Loading layer","progressDetail":{"current":1536,"total":2560},"progress":"[==============================\u003e                    ] 1.536 kB/2.56 kB","id":"b652ec3a27e7"}
{"status":"Loading layer","progressDetail":{"current":2048,"total":2560},"progress":"[========================================\u003e          ] 2.048 kB/2.56 kB","id":"b652ec3a27e7"}
{"status":"Loading layer","progressDetail":{"current":2560,"total":2560},"progress":"[==================================================\u003e]  2.56 kB/2.56 kB","id":"b652ec3a27e7"}
{"status":"Loading layer","progressDetail":{"current":2560,"total":2560},"progress":"[==================================================\u003e]  2.56 kB/2.56 kB","id":"b652ec3a27e7"}
{"status":"Loading layer","progressDetail":{"current":512,"total":1024},"progress":"[=========================\u003e                         ]    512 B/1.024 kB","id":"5f70bf18a086"}
{"status":"Loading layer","progressDetail":{"current":1024,"total":1024},"progress":"[==================================================\u003e] 1.024 kB/1.024 kB","id":"5f70bf18a086"}
{"status":"Loading layer","progressDetail":{"current":1024,"total":1024},"progress":"[==================================================\u003e] 1.024 kB/1.024 kB","id":"5f70bf18a086"}
["sha256:690ed74de00f99a7d00a98a5ad855ac4febd66412be132438f9b8dbd300a937d"]
```
