### PR TITLE
Fix create container with wrong storage-opt, fixes #21753

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -515,6 +515,9 @@ func (ls *layerStore) ReinitRWLayer(l RWLayer) error {
 }
 
 func (ls *layerStore) ReleaseRWLayer(l RWLayer) ([]Metadata, error) {
+	if l == nil {
+		return []Metadata{}, nil
+	}
 	ls.mountL.Lock()
 	defer ls.mountL.Unlock()
 	m, ok := ls.mounts[l.Name()]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fix create container with wrong storage-opt. closes #21753 
**\- How I did it**
Check if `l` is nil at the beginning of `ReleaseRWLayer`. If create a container with wrong `--storage-opt`
it will failed to create a `RWLayer`, but `cleanupContainer` will try to call `ReleaseRWLayer` which will cause daemon panic.
**\- How to verify it**
Start daemon with `devicemapper` graphdriver and set the base size to 10G,
`docker run -ti --storage-opt size=5G busybox` will cause daemon panic
And after the fix, it will return `docker: Error response from daemon: devmapper: Container size cannot be smaller than 10.74 GB.`
**\- A picture of a cute animal (not mandatory but encouraged)**

/cc @shishir-a412ed 
Signed-off-by: Lei Jitang leijitang@huawei.com
