### PR TITLE
Fix spelling error in names-generator.go

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -246,7 +246,7 @@ var (
 		// Dorothy Hodgkin was a British biochemist, credited with the development of protein crystallography. She was awarded the Nobel Prize in Chemistry in 1964. https://en.wikipedia.org/wiki/Dorothy_Hodgkin
 		"hodgkin",
 
-		// Erna Schneider Hoover revolutionized modern communication by inventing a computerized telephon switching method. https://en.wikipedia.org/wiki/Erna_Schneider_Hoover
+		// Erna Schneider Hoover revolutionized modern communication by inventing a computerized telephone switching method. https://en.wikipedia.org/wiki/Erna_Schneider_Hoover
 		"hoover",
 
 		// Grace Hopper developed the first compiler for a computer programming language and  is credited with popularizing the term "debugging" for fixing computer glitches. https://en.wikipedia.org/wiki/Grace_Hopper


### PR DESCRIPTION
Not much is required to reproduce the issue, since it's just a spelling error (and one in a comment, at that).

Here's a picture of my brother's new puppy:

![10370956_10154051156402990_4600322530034293477_n](https://cloud.githubusercontent.com/assets/464394/14279020/0f7fbf44-fb2b-11e5-904c-5472f3d4c90f.jpg)
