### PR TITLE
Change HumanSize to BytesSize for memory output in `docker stats`.

### DIFF
--- a/api/client/stats_helpers.go
+++ b/api/client/stats_helpers.go
@@ -173,7 +173,7 @@ func (s *containerStats) Display(w io.Writer) error {
 	fmt.Fprintf(w, "%s\t%.2f%%\t%s / %s\t%.2f%%\t%s / %s\t%s / %s\t%d\n",
 		s.Name,
 		s.CPUPercentage,
-		units.HumanSize(s.Memory), units.HumanSize(s.MemoryLimit),
+		units.BytesSize(s.Memory), units.BytesSize(s.MemoryLimit),
 		s.MemoryPercentage,
 		units.HumanSize(s.NetworkRx), units.HumanSize(s.NetworkTx),
 		units.HumanSize(s.BlockRead), units.HumanSize(s.BlockWrite),

--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -27,7 +27,7 @@ func TestDisplay(t *testing.T) {
 		t.Fatalf("c.Display() gave error: %s", err)
 	}
 	got := b.String()
-	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\n"
+	want := "app\t30.00%\t100 MiB / 2 GiB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\n"
 	if got != want {
 		t.Fatalf("c.Display() = %q, want %q", got, want)
 	}

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -28,13 +28,13 @@ Running `docker stats` on all running containers
 
     $ docker stats
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    1285939c1fd3        0.07%               796 KiB / 64 MiB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    9c76f7834ae2        0.07%               2.746 MiB / 64 MiB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    d1ea048f04e4        0.03%               4.583 MiB / 64 MiB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
 
 Running `docker stats` on multiple containers by name and id.
 
     $ docker stats fervent_panini 5acfcb1b4fd1
     CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
-    5acfcb1b4fd1        0.00%               115.2 MB/1.045 GB   11.03%              1.422 kB/648 B
-    fervent_panini      0.02%               11.08 MB/1.045 GB   1.06%               648 B/648 B
+    5acfcb1b4fd1        0.00%               115.2 MiB/1.045 GiB   11.03%              1.422 kB/648 B
+    fervent_panini      0.02%               11.08 MiB/1.045 GiB   1.06%               648 B/648 B

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -31,13 +31,13 @@ Running `docker stats` on all running containers
 
     $ docker stats
     CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-    1285939c1fd3        0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-    9c76f7834ae2        0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-    d1ea048f04e4        0.03%               4.583 MB / 64 MB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+    1285939c1fd3        0.07%               796 KiB / 64 MiB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    9c76f7834ae2        0.07%               2.746 MiB / 64 MiB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
+    d1ea048f04e4        0.03%               4.583 MiB / 64 MiB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
 
 Running `docker stats` on multiple containers by name and id.
 
     $ docker stats fervent_panini 5acfcb1b4fd1
     CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
-    5acfcb1b4fd1        0.00%               115.2 MB/1.045 GB   11.03%              1.422 kB/648 B
-    fervent_panini      0.02%               11.08 MB/1.045 GB   1.06%               648 B/648 B
+    5acfcb1b4fd1        0.00%               115.2 MiB/1.045 GiB   11.03%              1.422 kB/648 B
+    fervent_panini      0.02%               11.08 MiB/1.045 GiB   1.06%               648 B/648 B


### PR DESCRIPTION
This fix tries to fix the discrepancy between `docker stats` and `docker run` where `docker run` uses RAMInBytes for all memory related inputs but `docker stats` uses HumanSize for all memory related outputs.

To be consistent, `docker stats` needs to use BytesSize for all memory related outputs to conform to RAMInBytes in `docker run`. (Otherwise we could equally change the input of `docker run` to use `FromHumanSize`).

This fix addresses this issue by changing HumanSize in stats_helper.go to BytesSize for memory related output. As BytesSize is used, the test cases needs to be adjusted to match `KiB/MiB/GiB` instead of `KB/MB/GB`.

This fix is related to #21765.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
