### PR TITLE
Vendor Libnetwork v0.7.0-rc.3

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -29,7 +29,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.7.0-rc.1
+clone git github.com/docker/libnetwork v0.7.0-rc.3
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.7.0-rc.3 (2016-04-05)
+- Revert fix for default gateway endoint join/leave. Needs to be reworked.
+- Persist the network internal mode for bridge networks
+
+## 0.7.0-rc.2 (2016-04-05)
+- Fixes https://github.com/docker/libnetwork/issues/1070
+- Move IPAM resource initialization out of init()
+- Initialize overlay driver before network delete 
+- Fix the handling for default gateway Endpoint join/lean 
+
 ## 0.7.0-rc.1 (2016-03-30)
 - Fixes https://github.com/docker/libnetwork/issues/985
 - Fixes https://github.com/docker/libnetwork/issues/945

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge_store.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge_store.go
@@ -95,6 +95,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["EnableIPMasquerade"] = ncfg.EnableIPMasquerade
 	nMap["EnableICC"] = ncfg.EnableICC
 	nMap["Mtu"] = ncfg.Mtu
+	nMap["Internal"] = ncfg.Internal
 	nMap["DefaultBridge"] = ncfg.DefaultBridge
 	nMap["DefaultBindingIP"] = ncfg.DefaultBindingIP.String()
 	nMap["DefaultGatewayIPv4"] = ncfg.DefaultGatewayIPv4.String()
@@ -143,6 +144,9 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 	ncfg.EnableIPMasquerade = nMap["EnableIPMasquerade"].(bool)
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
 	ncfg.Mtu = int(nMap["Mtu"].(float64))
+	if v, ok := nMap["Internal"]; ok {
+		ncfg.Internal = v.(bool)
+	}
 
 	return nil
 }

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -104,6 +104,11 @@ func (d *driver) DeleteNetwork(nid string) error {
 		return fmt.Errorf("invalid network id")
 	}
 
+	// Make sure driver resources are initialized before proceeding
+	if err := d.configure(); err != nil {
+		return err
+	}
+
 	n := d.network(nid)
 	if n == nil {
 		return fmt.Errorf("could not find network with id %s", nid)

--- a/vendor/src/github.com/docker/libnetwork/ipams/builtin/builtin_unix.go
+++ b/vendor/src/github.com/docker/libnetwork/ipams/builtin/builtin_unix.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/ipam"
 	"github.com/docker/libnetwork/ipamapi"
+	"github.com/docker/libnetwork/ipamutils"
 )
 
 // Init registers the built-in ipam service with libnetwork
@@ -28,6 +29,9 @@ func Init(ic ipamapi.Callback, l, g interface{}) error {
 			return fmt.Errorf("incorrect global datastore passed to built-in ipam init")
 		}
 	}
+
+	ipamutils.InitNetworks()
+
 	a, err := ipam.NewAllocator(localDs, globalDs)
 	if err != nil {
 		return err

--- a/vendor/src/github.com/docker/libnetwork/ipamutils/utils.go
+++ b/vendor/src/github.com/docker/libnetwork/ipamutils/utils.go
@@ -1,7 +1,10 @@
 // Package ipamutils provides utililty functions for ipam management
 package ipamutils
 
-import "net"
+import (
+	"net"
+	"sync"
+)
 
 var (
 	// PredefinedBroadNetworks contains a list of 31 IPv4 private networks with host size 16 and 12
@@ -10,11 +13,16 @@ var (
 	// PredefinedGranularNetworks contains a list of 64K IPv4 private networks with host size 8
 	// (10.x.x.x/24) which do not overlap with the networks in `PredefinedBroadNetworks`
 	PredefinedGranularNetworks []*net.IPNet
+
+	initNetworksOnce sync.Once
 )
 
-func init() {
-	PredefinedBroadNetworks = initBroadPredefinedNetworks()
-	PredefinedGranularNetworks = initGranularPredefinedNetworks()
+// InitNetworks initializes the pre-defined networks used by the  built-in IP allocator
+func InitNetworks() {
+	initNetworksOnce.Do(func() {
+		PredefinedBroadNetworks = initBroadPredefinedNetworks()
+		PredefinedGranularNetworks = initGranularPredefinedNetworks()
+	})
 }
 
 func initBroadPredefinedNetworks() []*net.IPNet {

--- a/vendor/src/github.com/docker/libnetwork/ipamutils/utils_linux.go
+++ b/vendor/src/github.com/docker/libnetwork/ipamutils/utils_linux.go
@@ -22,6 +22,8 @@ func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
 		err    error
 	)
 
+	InitNetworks()
+
 	defer osl.InitOSContext()()
 
 	link, _ := netlink.LinkByName(name)


### PR DESCRIPTION
- Reverted the fix for EP join/leave in default gateway network introduced in RC2. It needs some rework.
- Fix to persist the network internal flag for bridge networks
- Fixes https://github.com/docker/libnetwork/issues/1070
- Move IPAM resource initialization out of init()
- Initialize overlay driver before network delete 

Signed-off-by: Santhosh Manohar santhosh@docker.com
