### PR TITLE
do not trim one char from {{.Names}} each time it is used in --format

### DIFF
--- a/api/client/formatter/custom.go
+++ b/api/client/formatter/custom.go
@@ -234,9 +234,10 @@ func (c *baseSubContext) addHeader(header string) {
 }
 
 func stripNamePrefix(ss []string) []string {
+	sss := make([]string, len(ss))
 	for i, s := range ss {
-		ss[i] = s[1:]
+		sss[i] = s[1:]
 	}
 
-	return ss
+	return sss
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -653,7 +653,22 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 		truncNames = append(truncNames, l)
 	}
 	c.Assert(expected, checker.DeepEquals, truncNames, check.Commentf("Expected array with truncated names: %v, got: %v", expected, truncNames))
+}
 
+// Test for GitHub issue #21772
+func (s *DockerSuite) TestPsNamesMultipleTime(c *check.C) {
+	runSleepingContainer(c, "--name=test1")
+	runSleepingContainer(c, "--name=test2")
+
+	//use the new format capabilities to list the names twice
+	out, _ := dockerCmd(c, "ps", "--format", "{{.Names}} {{.Names}}")
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	expected := []string{"test2 test2", "test1 test1"}
+	var names []string
+	for _, l := range lines {
+		names = append(names, l)
+	}
+	c.Assert(expected, checker.DeepEquals, names, check.Commentf("Expected array with names displayed twice: %v, got: %v", expected, names))
 }
 
 func (s *DockerSuite) TestPsFormatHeaders(c *check.C) {


### PR DESCRIPTION
fix #21772

ping @danielhoherd  @thaJeztah @calavera 
