### PR TITLE
Windows: integration-cli don't delete nat

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -283,6 +283,10 @@ func deleteAllNetworks() error {
 		if n.Name == "bridge" || n.Name == "none" || n.Name == "host" {
 			continue
 		}
+		if daemonPlatform == "windows" && strings.ToLower(n.Name) == "nat" {
+			// nat is a pre-defined network on Windows and cannot be removed
+			continue
+		}
 		status, b, err := sockRequest("DELETE", "/networks/"+n.Name, nil)
 		if err != nil {
 			errors = append(errors, err.Error())


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@msabansal On Windows, the nat network is pre-defined and shouldn't be deleted. Avoids a bunch of errors in the daemon-under-test log when running integration-cli on Windows, such as shown below:

```
ime="2016-04-06T02:20:50.525332500Z" level=error msg="Handler for DELETE /networks/nat returned error: nat is a pre-defined network and cannot be removed"
time="2016-04-06T02:20:50.686339600Z" level=error msg="Handler for DELETE /networks/nat returned error: nat is a pre-defined network and cannot be removed"
time="2016-04-06T02:20:51.472345800Z" level=error msg="Handler for DELETE /networks/nat returned error: nat is a pre-defined network and cannot be removed"
time="2016-04-06T02:20:51.680334800Z" level=error msg="Handler for DELETE /networks/nat returned error: nat is a pre-defined network and cannot be removed"
time="2016-04-06T02:20:52.430353900Z" level=error msg="Handler for GET /v1.24/containers/testbuildentrypoint/json returned error: No such container: testbuildentrypoint"
time="2016-04-06T02:20:52.473379600Z" level=error msg="Handler for GET /v1.24/containers/testbuildentrypoint/json returned error: No such container: testbuildentrypoint"
time="2016-04-06T02:20:52.701366800Z" level=error msg="Handler for DELETE /networks/nat returned error: nat is a pre-defined network and cannot be removed"
time="2016-04-06T02:20:53.324742700Z" level=error msg="Handler for GET /v1.24/containers/parent/json returned error: No such container: parent"
time="2016-04-06T02:20:56.551664900Z" level=error msg="Handler for GET /v1.24/containers/child/json returned error: No such container: child"
```
