### PR TITLE
Fix incorrect markdown rendering

### DIFF
--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -169,9 +169,10 @@ Responds with a list of Docker subsystems which this plugin implements.
 After activation, the plugin will then be sent events from this subsystem.
 
 Possible values are:
- - [`authz`](plugins_authorization.md)
- - [`NetworkDriver`](plugins_network.md)
- - [`VolumeDriver`](plugins_volume.md)
+
+* [`authz`](plugins_authorization.md)
+* [`NetworkDriver`](plugins_network.md)
+* [`VolumeDriver`](plugins_volume.md)
 
 
 ## Plugin retries


### PR DESCRIPTION
The docker document site [1](https://docs.docker.com/engine/extend/plugin_api) rendered the list of plugin implements
incorrectly.

Signed-off-by: Yi EungJun eungjun.yi@navercorp.com
