### PR TITLE
bump engine-api to v0.3.3 for 1.11.0-rc4

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api v0.3.2
+clone git github.com/docker/engine-api v0.3.3
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/request.go
+++ b/vendor/src/github.com/docker/engine-api/client/request.go
@@ -56,12 +56,14 @@ func (cli *Client) delete(ctx context.Context, path string, query url.Values, he
 }
 
 func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
-	body, err := encodeData(obj)
-	if err != nil {
-		return nil, err
-	}
+	var body io.Reader
 
-	if body != nil {
+	if obj != nil {
+		var err error
+		body, err = encodeData(obj)
+		if err != nil {
+			return nil, err
+		}
 		if headers == nil {
 			headers = make(map[string][]string)
 		}


### PR DESCRIPTION
bumps engine API to include https://github.com/docker/engine-api/pull/193

we may want to create a new tag of engine-api before 1.11.0 GA
