### PR TITLE
Use 'null' instead of 'nil' for json

### DIFF
--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -196,8 +196,8 @@ should implement the following two methods:
    "Allow":              "Determined whether the user is allowed or not",
    "Msg":                "The authorization message",
    "Err":                "The error message if things go wrong",
-   "ModifiedBody":       "Byte array containing a modified body of the raw HTTP body (or nil if no changes required)",
-   "ModifiedHeader":     "Byte array containing a modified header of the HTTP response (or nil if no changes required)",
+   "ModifiedBody":       "Byte array containing a modified body of the raw HTTP body (or null if no changes required)",
+   "ModifiedHeader":     "Byte array containing a modified header of the HTTP response (or null if no changes required)",
    "ModifiedStatusCode": "int containing the modified version of the status code (or 0 if not change is required)"
 }
 ```


### PR DESCRIPTION
When describe json response, 'null' is better than 'nil' which is not in
json specification.

Signed-off-by: Yi EungJun eungjun.yi@navercorp.com
