### PR TITLE
Standardize the container json log name.

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -311,7 +311,7 @@ func (container *Container) StartLogger(cfg containertypes.LogConfig) (logger.Lo
 
 	// Set logging file for "json-logger"
 	if cfg.Type == jsonfilelog.Name {
-		ctx.LogPath, err = container.GetRootResourcePath(fmt.Sprintf("%s-json.log", container.ID))
+		ctx.LogPath, err = container.GetRootResourcePath("container-json.log")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Currently the json log includes the UUID of the container, even though
the log file is already stored in a RootResource Directory with is UUID based.
All of the other content in the RootResource Directory is not UUID based so
using a standard name does not seem to be a problem.  Changing it to a standard
name will allow us to label it correctly on creation using SELinux.  This will
allow other logging tools to be able to access just the log files but none of
the other data related to the container.

Signed-off-by: Dan Walsh dwalsh@redhat.com
