### PR TITLE
daemon: graphdriver: btrfs: use kernel structures

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -5,8 +5,14 @@ package btrfs
 /*
 #include <stdlib.h>
 #include <dirent.h>
-#include <btrfs/ioctl.h>
-#include <btrfs/ctree.h>
+#include <linux/btrfs.h>
+#include <btrfs/version.h>
+
+// Values taken from <btrfs/ctree.h>
+// We can't use that header because it redefines everything in <linux/btrfs.h>.
+#define BTRFS_FIRST_FREE_OBJECTID 256ULL
+#define BTRFS_LAST_FREE_OBJECTID -256ULL
+#define BTRFS_FIRST_CHUNK_TREE_OBJECTID 256ULL
 */
 import "C"
 


### PR DESCRIPTION
In an update for libbtrfs-devel, the ioctl structure
C.struct_btrfs_ioctl_vol_args_v2 was changed such that one of the fields
used in the Go code were in a union. Since Go doesn't support unions,
this caused Docker to not compile.

By using the kernel definition (which is guaranteed to never change,
thanks to Linus' fanatical obsession to backwards compatibility) we can
ensure that Docker will build no matter what changes are made to other
headers.

![penguin omg](https://c8.staticflickr.com/7/6020/5877251295_45b810e599.jpg)

Signed-off-by: Aleksa Sarai asarai@suse.de

Image source: https://www.flickr.com/photos/wwarby/5877251295/in/pool-creative_commons-_free_pictures/
