### PR TITLE
Carry 21716: When container had no layer data, cleanupContainer crashed

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -123,10 +123,14 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
 	}
 
-	metadata, err := daemon.layerStore.ReleaseRWLayer(container.RWLayer)
-	layer.LogReleaseMetadata(metadata)
-	if err != nil && err != layer.ErrMountDoesNotExist {
-		return fmt.Errorf("Driver %s failed to remove root filesystem %s: %s", daemon.GraphDriverName(), container.ID, err)
+	// When container creation fails and `RWLayer` has not been created yet, we
+	// do not call `ReleaseRWLayer`
+	if container.RWLayer != nil {
+		metadata, err := daemon.layerStore.ReleaseRWLayer(container.RWLayer)
+		layer.LogReleaseMetadata(metadata)
+		if err != nil && err != layer.ErrMountDoesNotExist {
+			return fmt.Errorf("Driver %s failed to remove root filesystem %s: %s", daemon.GraphDriverName(), container.ID, err)
+		}
 	}
 
 	return nil

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -68,15 +68,15 @@ func (s *DockerSuite) TestCreateGrowRootfs(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectOut := inspectField(c, cleanedContainerID, "HostConfig.StorageOpt")
-	c.Assert(inspectOut, checker.Equals, "[size=120G]")
+	c.Assert(inspectOut, checker.Equals, "map[size:120G]")
 }
 
 // Make sure we cannot shrink the container's rootfs at creation time.
 func (s *DockerSuite) TestCreateShrinkRootfs(c *check.C) {
 	testRequires(c, Devicemapper)
 
-	// Ensure this fails
-	out, _, err := dockerCmdWithError("create", "--storage-opt", "size=80G", "busybox")
+	// Ensure this fails because of the defaultBaseFsSize is 10G
+	out, _, err := dockerCmdWithError("create", "--storage-opt", "size=5G", "busybox")
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "Container size cannot be smaller than")
 }

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -54,6 +54,11 @@ var (
 	dockerBasePath       string
 	volumesConfigPath    string
 	containerStoragePath string
+
+	// daemonStorageDriver is held globally so that tests can know the storage
+	// driver of the daemon. This is initialized in docker_utils by sending
+	// a version call to the daemon and examining the response header.
+	daemonStorageDriver string
 )
 
 const (

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -67,6 +67,7 @@ func init() {
 		panic(fmt.Errorf("Init failed to unmarshal docker info: %v", err))
 	}
 
+	daemonStorageDriver = info.Driver
 	dockerBasePath = info.DockerRootDir
 	volumesConfigPath = filepath.Join(dockerBasePath, "volumes")
 	containerStoragePath = filepath.Join(dockerBasePath, "containers")

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -109,22 +109,14 @@ var (
 	}
 	NotOverlay = testRequirement{
 		func() bool {
-			cmd := exec.Command("grep", "^overlay / overlay", "/proc/mounts")
-			if err := cmd.Run(); err != nil {
-				return true
-			}
-			return false
+			return !strings.HasPrefix(daemonStorageDriver, "overlay")
 		},
 		"Test requires underlying root filesystem not be backed by overlay.",
 	}
 
 	Devicemapper = testRequirement{
 		func() bool {
-			cmd := exec.Command("grep", "^devicemapper / devicemapper", "/proc/mounts")
-			if err := cmd.Run(); err != nil {
-				return false
-			}
-			return true
+			return strings.HasPrefix(daemonStorageDriver, "devicemapper")
 		},
 		"Test requires underlying root filesystem to be backed by devicemapper.",
 	}


### PR DESCRIPTION
Carry of #21716
Closes #21716
