### PR TITLE
Stop running symlink-volume tests on Windows

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -359,7 +359,9 @@ func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir(c *check.C) {
 		containerPath string
 		cmd           string
 	)
-	testRequires(c, SameHostDaemon)
+	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
+	// Windows does not support symlinks inside a volume path
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 	name := "test-volume-symlink"
 
 	dir, err := ioutil.TempDir("", name)
@@ -404,7 +406,9 @@ func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir2(c *check.C) {
 		containerPath string
 		cmd           string
 	)
-	testRequires(c, SameHostDaemon)
+	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
+	// Windows does not support symlinks inside a volume path
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 	name := "test-volume-symlink2"
 
 	if daemonPlatform == "windows" {
@@ -614,6 +618,9 @@ func (s *DockerSuite) TestRunCreateVolumeWithSymlink(c *check.C) {
 
 // Tests that a volume path that has a symlink exists in a container mounting it with `--volumes-from`.
 func (s *DockerSuite) TestRunVolumesFromSymlinkPath(c *check.C) {
+	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
+	// Windows does not support symlinks inside a volume path
+	testRequires(c, DaemonIsLinux)
 	name := "docker-test-volumesfromsymlinkpath"
 	prefix := ""
 	dfContents := `FROM busybox


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This stops running tests that create a volume with a symlink in the container path on Windows, as the tests were never correctly working, and will fail in future releases of Windows.

![Sticks!](http://i.imgur.com/n3HwT1E.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
