### PR TITLE
Windows: Remove TP4 support from main codebase

### DIFF
--- a/builder/dockerfile/evaluator_windows.go
+++ b/builder/dockerfile/evaluator_windows.go
@@ -1,24 +1,11 @@
-// +build windows
-
 package dockerfile
 
-import (
-	"fmt"
+import "fmt"
 
-	"github.com/Microsoft/hcsshim"
-)
-
-// platformSupports is a short-term function to give users a quality error
-// message if a Dockerfile uses a command not supported on the platform.
+// platformSupports is gives users a quality error message if a Dockerfile uses
+// a command not supported on the platform.
 func platformSupports(command string) error {
 	switch command {
-	// TODO Windows TP5. Expose can be removed from here once TP4 is
-	// no longer supported.
-	case "expose":
-		if !hcsshim.IsTP4() {
-			break
-		}
-		fallthrough
 	case "user", "stopsignal", "arg":
 		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
 	}

--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -7,7 +7,7 @@ import "github.com/docker/docker/container"
 // cannot be configured with a read-only rootfs.
 //
 // This is a no-op on Windows which does not support read-only volumes, or
-// extracting to a mount point inside a volume. TODO Windows: FIXME Post-TP4
+// extracting to a mount point inside a volume. TODO Windows: FIXME Post-TP5
 func checkIfPathIsInAVolume(container *container.Container, absPath string) (bool, error) {
 	return false, nil
 }

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -322,13 +322,6 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 		err error
 	)
 
-	// TODO Windows: Remove this once TP4 builds are not supported
-	// Windows TP4 build don't support libnetwork and in that case
-	// daemon.netController will be nil
-	if daemon.netController == nil {
-		return nil
-	}
-
 	mode := container.HostConfig.NetworkMode
 	if container.Config.NetworkDisabled || mode.IsContainer() {
 		return nil
@@ -511,13 +504,6 @@ func (daemon *Daemon) updateNetworkConfig(container *container.Container, idOrNa
 }
 
 func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings, updateSettings bool) (err error) {
-	// TODO Windows: Remove this once TP4 builds are not supported
-	// Windows TP4 build don't support libnetwork and in that case
-	// daemon.netController will be nil
-	if daemon.netController == nil {
-		return nil
-	}
-
 	n, err := daemon.updateNetworkConfig(container, idOrName, endpointConfig, updateSettings)
 	if err != nil {
 		return err
@@ -643,13 +629,6 @@ func disconnectFromNetwork(container *container.Container, n libnetwork.Network,
 
 func (daemon *Daemon) initializeNetworking(container *container.Container) error {
 	var err error
-
-	// TODO Windows: Remove this once TP4 builds are not supported
-	// Windows TP4 build don't support libnetwork and in that case
-	// daemon.netController will be nil
-	if daemon.netController == nil {
-		return nil
-	}
 
 	if container.HostConfig.NetworkMode.IsContainer() {
 		// we need to get the hosts files from the container to join

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -39,7 +39,7 @@ func (daemon *Daemon) setupIpcDirs(container *container.Container) error {
 	return nil
 }
 
-// TODO Windows: Fix Post-TP4. This is a hack to allow docker cp to work
+// TODO Windows: Fix Post-TP5. This is a hack to allow docker cp to work
 // against containers which have volumes. You will still be able to cp
 // to somewhere on the container drive, but not to any mounted volumes
 // inside the container. Without this fix, docker cp is broken to any

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -46,7 +46,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 		// is deferred for now. A case where this would be useful is when
 		// a dockerfile includes a VOLUME statement, but something is created
 		// in that directory during the dockerfile processing. What this means
-		// on Windows for TP4 is that in that scenario, the contents will not
+		// on Windows for TP5 is that in that scenario, the contents will not
 		// copied, but that's (somewhat) OK as HCS will bomb out soon after
 		// at it doesn't support mapped directories which have contents in the
 		// destination path anyway.

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -4,11 +4,7 @@ package windowsoci
 // writing, Windows does not have a spec defined in opencontainers/specs,
 // hence this is an interim workaround. TODO Windows: FIXME @jhowardmsft
 
-import (
-	"fmt"
-
-	"github.com/docker/go-connections/nat"
-)
+import "fmt"
 
 // WindowsSpec is the full specification for Windows containers.
 type WindowsSpec struct {
@@ -113,15 +109,6 @@ type HvRuntime struct {
 
 // Networking contains the platform specific network settings for the container
 type Networking struct {
-	// TODO Windows TP5. The following three fields are for 'legacy' non-
-	// libnetwork networking through HCS. They can be removed once TP4 is
-	// no longer supported. Also remove in libcontainerd\client_windows.go,
-	// function Create(), and in daemon\oci_windows.go, function CreateSpec()
-	MacAddress   string      `json:"mac,omitempty"`
-	Bridge       string      `json:"bridge,omitempty"`
-	PortBindings nat.PortMap `json:"port_bindings,omitempty"`
-	// End of TODO Windows TP5.
-
 	// List of endpoints to be attached to the container
 	EndpointList []string `json:"endpoints,omitempty"`
 }

--- a/opts/opts_windows.go
+++ b/opts/opts_windows.go
@@ -1,10 +1,10 @@
 package opts
 
-// TODO Windows. Identify bug in GOLang 1.5.1 and/or Windows Server 2016 TP4.
+// TODO Windows. Identify bug in GOLang 1.5.1+ and/or Windows Server 2016 TP5.
 // @jhowardmsft, @swernli.
 //
 // On Windows, this mitigates a problem with the default options of running
-// a docker client against a local docker daemon on TP4.
+// a docker client against a local docker daemon on TP5.
 //
 // What was found that if the default host is "localhost", even if the client
 // (and daemon as this is local) is not physically on a network, and the DNS
@@ -35,7 +35,7 @@ package opts
 // time="2015-11-06T13:38:38.326882500-08:00" level=info msg="POST /v1.22/containers/984758282b842f779e805664b2c95d563adc9a979c8a3973e68c807843ee4757/attach?stderr=1&stdin=1&stdout=1&stream=1"
 //
 // We suspect this is either a bug introduced in GOLang 1.5.1, or that a change
-// in GOLang 1.5.1 (from 1.4.3) is exposing a bug in Windows TP4. In theory,
+// in GOLang 1.5.1 (from 1.4.3) is exposing a bug in Windows. In theory,
 // the Windows networking stack is supposed to resolve "localhost" internally,
 // without hitting DNS, or even reading the hosts file (which is why localhost
 // is commented out in the hosts file on Windows).
@@ -44,12 +44,12 @@ package opts
 // address does not cause the delay.
 //
 // This does not occur with the docker client built with 1.4.3 on the same
-// Windows TP4 build, regardless of whether the daemon is built using 1.5.1
+// Windows build, regardless of whether the daemon is built using 1.5.1
 // or 1.4.3. It does not occur on Linux. We also verified we see the same thing
 // on a cross-compiled Windows binary (from Linux).
 //
 // Final note: This is a mitigation, not a 'real' fix. It is still susceptible
-// to the delay in TP4 if a user were to do 'docker run -H=tcp://localhost:2375...'
+// to the delay if a user were to do 'docker run -H=tcp://localhost:2375...'
 // explicitly.
 
 // DefaultHTTPHost Default HTTP Host used if only port is provided to -H flag e.g. docker daemon -H tcp://:8080

--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -64,11 +64,6 @@ func useNativeConsole() bool {
 		return false
 	}
 
-	// Must have a late pre-release TP4 build of Windows Server 2016/Windows 10 TH2 or later
-	if osv.Build < 10578 {
-		return false
-	}
-
 	// Get the console modes. If this fails, we can't use the native console
 	state, err := getNativeConsole()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This is the next step to removing TP4 support from the docker master codebase. This updates the remainder of the main codebase (see #21777 also). There are more TP4 references still to work on in future PRs in test code and in vendor code (HCSShim).

![image](https://cloud.githubusercontent.com/assets/10522484/14329345/d2d2af64-fbef-11e5-84c3-3a32e185b45f.png)
