### PR TITLE
Vendoring libnetwork v0.7.0-rc.4

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -29,7 +29,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.7.0-rc.3
+clone git github.com/docker/libnetwork v0.7.0-rc.4
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.0-rc.4 (2016-04-06)
+- Fix the handling for default gateway Endpoint join/leave.
+
 ## 0.7.0-rc.3 (2016-04-05)
 - Revert fix for default gateway endoint join/leave. Needs to be reworked.
 - Persist the network internal mode for bridge networks

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -197,6 +197,10 @@ func (sb *sandbox) delete(force bool) error {
 	// Detach from all endpoints
 	retain := false
 	for _, ep := range sb.getConnectedEndpoints() {
+		// gw network endpoint detach and removal are automatic
+		if ep.endpointInGWNetwork() {
+			continue
+		}
 		// Retain the sanbdox if we can't obtain the network from store.
 		if _, err := c.getNetworkFromStore(ep.getNetwork().ID()); err != nil {
 			retain = true


### PR DESCRIPTION
- Restore original behavior where auxiliary connection to `docker_gwbridge` network goes hand in hand with connection to a network which does not provide a default gateway
- Skip double delete of default gw endpoint during sandbox cleanup after ungraceful daemon shutdown
- Protects against a npe which may happen during sandbox cleanup
- Fix connection to default gw network logic when container is connected to an internal network, among others

Signed-off-by: Alessandro Boch aboch@docker.com
