### PR TITLE
Windows: Fix failing unit tests

### DIFF
--- a/builder/context.go
+++ b/builder/context.go
@@ -174,7 +174,7 @@ func GetContextFromLocalDir(localDir, dockerfileName string) (absContextDir, rel
 // the dockerfile in that context directory, and a non-nil error on success.
 func getDockerfileRelPath(givenContextDir, givenDockerfile string) (absContextDir, relDockerfile string, err error) {
 	if absContextDir, err = filepath.Abs(givenContextDir); err != nil {
-		return "", "", fmt.Errorf("unable to get absolute context directory: %v", err)
+		return "", "", fmt.Errorf("unable to get absolute context directory of given context directory %q: %v", givenContextDir, err)
 	}
 
 	// The context dir might be a symbolic link, so follow it to the actual

--- a/builder/context_test.go
+++ b/builder/context_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -53,7 +54,6 @@ func testValidateContextDirectory(t *testing.T, prepare func(t *testing.T) strin
 	contextDir := prepare(t)
 
 	defer os.RemoveAll(contextDir)
-
 	err := ValidateContextDirectory(contextDir, excludes)
 
 	if err != nil {
@@ -166,8 +166,7 @@ func TestGetContextFromLocalDirWithNoDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when changing directory to %s: %s", contextDir, err)
 	}
-
-	absContextDir, relDockerfile, err := GetContextFromLocalDir("", "")
+	absContextDir, relDockerfile, err := GetContextFromLocalDir(contextDir, "")
 
 	if err != nil {
 		t.Fatalf("Error when getting context from local dir: %s", err)
@@ -400,6 +399,14 @@ func TestGetContextFromReaderTar(t *testing.T) {
 }
 
 func TestValidateContextDirectoryEmptyContext(t *testing.T) {
+	// This isn't a valid test on Windows. See https://play.golang.org/p/RR6z6jxR81.
+	// The test will ultimately end up calling filepath.Abs(""). On Windows,
+	// golang will error. On Linux, golang will return /. Due to there being
+	// drive letters on Windows, this is probably the correct behaviour for
+	// Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip("Invalid test on Windows")
+	}
 	testValidateContextDirectory(t, prepareEmpty, []string{})
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This fixes the two failing unit tests on Windows TP5 currently. @thaJeztah. One of the tests comes down to an (arguably correct) behavioural difference between Go on Linux and Windows which you can see from this sample code available at `https://play.golang.org/p/RR6z6jxR81`

```
package main

import (
    "path/filepath"
    "fmt"
)

func main () {
    s,e:=filepath.Abs("")
    fmt.Println(s,e)
    // Windows: The filename, directory name, or volume label syntax is incorrect.
    // Linux: / <nil>
}
```

Once merged, I'll turn off the "Ignore CI failures" flag on Windows.

```
19:28:04 --- FAIL: TestGetContextFromLocalDirWithNoDirectory (0.00s)
19:28:04    context_test.go:173: Error when getting context from local dir: unable to get absolute context directory: The filename, directory name, or volume label syntax is incorrect.
19:28:04 --- FAIL: TestValidateContextDirectoryEmptyContext (0.00s)
19:28:04    context_test.go:60: Error should be nil, got: The filename, directory name, or volume label syntax is incorrect.
19:28:04 FAIL
19:28:04 coverage: 46.3% of statements
```
