### PR TITLE
Don't perform external setkey when net==host

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -48,10 +48,11 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container, n libn
 		sboxOptions = append(sboxOptions, libnetwork.OptionUseDefaultSandbox())
 		sboxOptions = append(sboxOptions, libnetwork.OptionOriginHostsPath("/etc/hosts"))
 		sboxOptions = append(sboxOptions, libnetwork.OptionOriginResolvConfPath("/etc/resolv.conf"))
+	} else {
+		// OptionUseExternalKey is mandatory for userns support.
+		// But optional for non-userns support
+		sboxOptions = append(sboxOptions, libnetwork.OptionUseExternalKey())
 	}
-	// OptionUseExternalKey is mandatory for userns support.
-	// But optional for non-userns support
-	sboxOptions = append(sboxOptions, libnetwork.OptionUseExternalKey())
 
 	container.HostsPath, err = container.GetRootResourcePath("hosts")
 	if err != nil {


### PR DESCRIPTION
This else case was lost in the migration from native execdriver to OCI
implementation via runc. There is no need to have external setkey when
--net=host.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com
