### PR TITLE
Windows: Remove TP4 support from test code

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -908,7 +908,7 @@ func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiRename(c *check.C) {
-	// TODO Windows: Enable for TP5. Fails on TP4.
+	// TODO Windows: Debug why this sometimes fails on TP5. For now, leave disabled
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--name", "TestContainerApiRename", "-d", "busybox", "sh")
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -91,11 +91,6 @@ func (s *DockerSuite) TestEventsContainerFailStartDie(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsLimit(c *check.C) {
-	// TODO Windows CI: This test is not reliable enough on Windows TP4. Reports
-	// multiple errors in the analytic log sometimes.
-	// [NetSetupHelper::InstallVirtualMiniport()@2153] NetSetup install of ROOT\VMS_MP\0001 failed with error 0x80070002
-	// This should be able to be enabled on TP5.
-	testRequires(c, DaemonIsLinux)
 	var waitGroup sync.WaitGroup
 	errChan := make(chan error, 17)
 
@@ -460,7 +455,7 @@ func (s *DockerSuite) TestEventsResize(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsAttach(c *check.C) {
-	// TODO Windows CI: Figure out why this test fails intermittently (TP4 and TP5).
+	// TODO Windows CI: Figure out why this test fails intermittently (TP5).
 	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
@@ -527,8 +522,8 @@ func (s *DockerSuite) TestEventsDefaultEmpty(c *check.C) {
 
 // #14316
 func (s *DockerRegistrySuite) TestEventsImageFilterPush(c *check.C) {
-	// Problematic to port for Windows CI during TP4/TP5 timeframe while
-	// not supporting push
+	// Problematic to port for Windows CI during TP5 timeframe until
+	// supporting push
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, Network)
 	since := daemonTime(c).Unix()

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -194,8 +194,6 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
-	// TODO Windows: Flakey on TP4. Enable for next technical preview.
-	testRequires(c, DaemonIsLinux)
 	name := "testlogssincefuturefollow"
 	out, _ := dockerCmd(c, "run", "-d", "--name", name, "busybox", "/bin/sh", "-c", `for i in $(seq 1 5); do echo log$i; sleep 1; done`)
 
@@ -228,7 +226,7 @@ func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
 
 // Regression test for #8832
 func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
-	// TODO Windows: Consider enabling post-TP4. Too expensive to run on TP4
+	// TODO Windows: Fix this test for TP5.
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 600000;yes X | head -c 200000`)
 

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -324,10 +324,6 @@ func (*DockerSuite) TestRmiParentImageFail(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiWithParentInUse(c *check.C) {
-	// TODO Windows. There is a bug either in Windows TP4, or the TP4 compatible
-	// docker which means this test fails. It has been verified to have been fixed
-	// in TP5 and docker/master, hence enable it once CI switch to TP5.
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "busybox")
 	cID := strings.TrimSpace(out)
 
@@ -345,10 +341,6 @@ func (s *DockerSuite) TestRmiWithParentInUse(c *check.C) {
 
 // #18873
 func (s *DockerSuite) TestRmiByIDHardConflict(c *check.C) {
-	// TODO Windows CI. This will work on a TP5 compatible docker which
-	// has content addressibility fixes. Do not run this on TP4 as it
-	// will end up deleting the busybox image causing subsequent tests to fail.
-	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "create", "busybox")
 
 	imgID := inspectField(c, "busybox:latest", "Id")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -424,7 +424,7 @@ func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir2(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunVolumesMountedAsReadonly(c *check.C) {
-	// TODO Windows (Post TP4): This test cannot run on a Windows daemon as
+	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
 	// Windows does not support read-only bind mounts.
 	testRequires(c, DaemonIsLinux)
 	if _, code, err := dockerCmdWithError("run", "-v", "/test:/test:ro", "busybox", "touch", "/test/somefile"); err == nil || code == 0 {
@@ -433,7 +433,7 @@ func (s *DockerSuite) TestRunVolumesMountedAsReadonly(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunVolumesFromInReadonlyModeFails(c *check.C) {
-	// TODO Windows (Post TP4): This test cannot run on a Windows daemon as
+	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
 	// Windows does not support read-only bind mounts. Modified for when ro is supported.
 	testRequires(c, DaemonIsLinux)
 	var (
@@ -481,7 +481,7 @@ func (s *DockerSuite) TestRunVolumesFromInReadWriteMode(c *check.C) {
 
 func (s *DockerSuite) TestVolumesFromGetsProperMode(c *check.C) {
 	// TODO Windows: This test cannot yet run on a Windows daemon as Windows does
-	// not support read-only bind mounts as at TP4
+	// not support read-only bind mounts as at TP5
 	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test:/test:ro", "busybox", "true")
 
@@ -667,12 +667,7 @@ func (s *DockerSuite) TestRunExitCode(c *check.C) {
 func (s *DockerSuite) TestRunUserDefaults(c *check.C) {
 	expected := "uid=0(root) gid=0(root)"
 	if daemonPlatform == "windows" {
-		// TODO Windows: Remove this check once TP4 is no longer supported.
-		if windowsDaemonKV < 14250 {
-			expected = "uid=1000(SYSTEM) gid=1000(SYSTEM)"
-		} else {
-			expected = "uid=1000(ContainerAdministrator) gid=1000(ContainerAdministrator)"
-		}
+		expected = "uid=1000(ContainerAdministrator) gid=1000(ContainerAdministrator)"
 	}
 	out, _ := dockerCmd(c, "run", "busybox", "id")
 	if !strings.Contains(out, expected) {
@@ -750,18 +745,9 @@ func (s *DockerSuite) TestRunUserNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunTwoConcurrentContainers(c *check.C) {
-	// TODO Windows. There are two bugs in TP4 which means this test cannot
-	// be reliably enabled. The first is a race condition where sometimes
-	// HCS CreateComputeSystem() will fail "Invalid class string". #4985252 and
-	// #4493430.
-	//
-	// The second, which is seen more readily by increasing the number of concurrent
-	// containers to 5 or more, is that CSRSS hangs. This may fixed in the TP4 ZDP.
-	// #4898773.
-	testRequires(c, DaemonIsLinux)
 	sleepTime := "2"
 	if daemonPlatform == "windows" {
-		sleepTime = "5" // Make more reliable on Windows
+		sleepTime = "20" // Make more reliable on Windows
 	}
 	group := sync.WaitGroup{}
 	group.Add(2)
@@ -1688,7 +1674,7 @@ func (s *DockerSuite) TestRunCopyVolumeUidGid(c *check.C) {
 
 // Test for #1582
 func (s *DockerSuite) TestRunCopyVolumeContent(c *check.C) {
-	// TODO Windows, post TP4. Windows does not yet support volume functionality
+	// TODO Windows, post TP5. Windows does not yet support volume functionality
 	// that copies from the image to the volume.
 	testRequires(c, DaemonIsLinux)
 	name := "testruncopyvolumecontent"
@@ -1724,12 +1710,7 @@ func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 	out = strings.TrimSpace(out)
 	expected := "root"
 	if daemonPlatform == "windows" {
-		// TODO Windows: Remove this check once TP4 is no longer supported.
-		if windowsDaemonKV < 14250 {
-			expected = `nt authority\system`
-		} else {
-			expected = `user manager\containeradministrator`
-		}
+		expected = `user manager\containeradministrator`
 	}
 	if out != expected {
 		c.Fatalf("Expected output %s, got %q", expected, out)
@@ -1924,7 +1905,7 @@ func (s *DockerSuite) TestRunBindMounts(c *check.C) {
 	defer os.RemoveAll(tmpDir)
 	writeFile(path.Join(tmpDir, "touch-me"), "", c)
 
-	// TODO Windows Post TP4. Windows does not yet support :ro binds
+	// TODO Windows Post TP5. Windows does not yet support :ro binds
 	if daemonPlatform != "windows" {
 		// Test reading from a read-only bind mount
 		out, _ := dockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:ro", tmpDir), "busybox", "ls", "/tmp")
@@ -2114,7 +2095,7 @@ func (s *DockerSuite) TestRunAllocatePortInReservedRange(c *check.C) {
 
 // Regression test for #7792
 func (s *DockerSuite) TestRunMountOrdering(c *check.C) {
-	// TODO Windows: Post TP4. Updated, but Windows does not support nested mounts currently.
+	// TODO Windows: Post TP5. Updated, but Windows does not support nested mounts currently.
 	testRequires(c, SameHostDaemon, DaemonIsLinux, NotUserNamespace)
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
@@ -2206,7 +2187,7 @@ func (s *DockerSuite) TestRunCreateVolumeEtc(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
-	// TODO Windows (Post TP4). Windows does not support volumes which
+	// TODO Windows (Post TP5). Windows does not support volumes which
 	// are pre-populated such as is built in the dockerfile used in this test.
 	testRequires(c, DaemonIsLinux)
 	if _, err := buildImage("dataimage",
@@ -3077,7 +3058,7 @@ func (s *DockerSuite) TestRunCapAddCHOWN(c *check.C) {
 
 // https://github.com/docker/docker/pull/14498
 func (s *DockerSuite) TestVolumeFromMixedRWOptions(c *check.C) {
-	// TODO Windows post TP4. Enable the read-only bits once they are
+	// TODO Windows post TP5. Enable the read-only bits once they are
 	// supported on the platform.
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -690,7 +690,7 @@ func (s *DockerSuite) TestRunWithShmSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunTmpfsMounts(c *check.C) {
-	// TODO Windows (Post TP4): This test cannot run on a Windows daemon as
+	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
 	// Windows does not support tmpfs mounts.
 	testRequires(c, DaemonIsLinux)
 	if out, _, err := dockerCmdWithError("run", "--tmpfs", "/run", "busybox", "touch", "/run/somefile"); err != nil {

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -100,9 +100,6 @@ func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
 }
 
 func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
-	// TODO Windows CI. This fails on TP4 docker, but has since been fixed.
-	// Enable these tests for TP5.
-	testRequires(c, DaemonIsLinux)
 	// Don't attempt to pull on Windows as not in hub. It's installed
 	// as an image through .ensure-frozen-images-windows
 	if daemonPlatform != "windows" {
@@ -129,9 +126,6 @@ func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 // ensure tagging using official names works
 // ensure all tags result in the same name
 func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
-	// TODO Windows CI. This fails on TP4 docker, but has since been fixed.
-	// Enable these tests for TP5.
-	testRequires(c, DaemonIsLinux)
 	names := []string{
 		"docker.io/busybox",
 		"index.docker.io/busybox",
@@ -169,10 +163,6 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 
 // ensure tags can not match digests
 func (s *DockerSuite) TestTagMatchesDigest(c *check.C) {
-	// TODO Windows CI. This can be enabled for TP5, but will fail on TP4.
-	// This is due to the content addressibility changes which are not
-	// in the TP4 version of Docker.
-	testRequires(c, DaemonIsLinux)
 	// Don't attempt to pull on Windows as not in hub. It's installed
 	// as an image through .ensure-frozen-images-windows
 	if daemonPlatform != "windows" {
@@ -194,9 +184,6 @@ func (s *DockerSuite) TestTagMatchesDigest(c *check.C) {
 }
 
 func (s *DockerSuite) TestTagInvalidRepoName(c *check.C) {
-	// TODO Windows CI. This can be enabled for TP5, but will fail on the
-	// TP4 version of docker.
-	testRequires(c, DaemonIsLinux)
 	// Don't attempt to pull on Windows as not in hub. It's installed
 	// as an image through .ensure-frozen-images-windows
 	if daemonPlatform != "windows" {

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -40,8 +40,8 @@ var (
 
 	// windowsDaemonKV is used on Windows to distinguish between different
 	// versions. This is necessary to enable certain tests based on whether
-	// the platform supports it. For example, Windows Server 2016 TP3 does
-	// not support volumes, but TP4 does.
+	// the platform supports it. For example, Windows Server 2016 TP3 did
+	// not support volumes, but TP4 did.
 	windowsDaemonKV int
 
 	// daemonDefaultImage is the name of the default image to use when running

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -18,7 +18,7 @@ func TestParseMountSpec(t *testing.T) {
 			`d:`,
 			`d:\path`,
 			`d:\path with space`,
-			// TODO Windows post TP4 - readonly support `d:\pathandmode:ro`,
+			// TODO Windows post TP5 - readonly support `d:\pathandmode:ro`,
 			`c:\:d:\`,
 			`c:\windows\:d:`,
 			`c:\windows:d:\s p a c e`,
@@ -29,9 +29,9 @@ func TestParseMountSpec(t *testing.T) {
 			`name:D:`,
 			`name:D::rW`,
 			`name:D::RW`,
-			// TODO Windows post TP4 - readonly support `name:D::RO`,
+			// TODO Windows post TP5 - readonly support `name:D::RO`,
 			`c:/:d:/forward/slashes/are/good/too`,
-			// TODO Windows post TP4 - readonly support `c:/:d:/including with/spaces:ro`,
+			// TODO Windows post TP5 - readonly support `c:/:d:/including with/spaces:ro`,
 			`c:\Windows`,             // With capital
 			`c:\Program Files (x86)`, // With capitals and brackets
 		}
@@ -152,12 +152,12 @@ func TestParseMountSpecSplit(t *testing.T) {
 		cases = []testParseMountSpec{
 			{`c:\:d:`, "local", `d:`, `c:\`, ``, "", true, false},
 			{`c:\:d:\`, "local", `d:\`, `c:\`, ``, "", true, false},
-			// TODO Windows post TP4 - Add readonly support {`c:\:d:\:ro`, "local", `d:\`, `c:\`, ``, "", false, false},
+			// TODO Windows post TP5 - Add readonly support {`c:\:d:\:ro`, "local", `d:\`, `c:\`, ``, "", false, false},
 			{`c:\:d:\:rw`, "local", `d:\`, `c:\`, ``, "", true, false},
 			{`c:\:d:\:foo`, "local", `d:\`, `c:\`, ``, "", false, true},
 			{`name:d::rw`, "local", `d:`, ``, `name`, "local", true, false},
 			{`name:d:`, "local", `d:`, ``, `name`, "local", true, false},
-			// TODO Windows post TP4 - Add readonly support {`name:d::ro`, "local", `d:`, ``, `name`, "local", false, false},
+			// TODO Windows post TP5 - Add readonly support {`name:d::ro`, "local", `d:`, ``, `name`, "local", false, false},
 			{`name:c:`, "", ``, ``, ``, "", true, true},
 			{`driver/name:c:`, "", ``, ``, ``, "", true, true},
 		}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Removes the TP4 hacks from test code (both unit and integration-cli). Bumps some comments to TP5 where platform support still doesn't exist, such as testing read-only volumes.
