### PR TITLE
add `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all binary build build-gccgo cross default docs docs-build docs-shell shell gccgo test test-docker-py test-integration-cli test-unit validate help
 
 # set the graph driver as the current graphdriver if not set
-DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info | grep "Storage Driver" | sed 's/.*: //'))
+DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info 2>&1 | grep "Storage Driver" | sed 's/.*: //'))
 
 # get OS/Arch of docker engine
 DOCKER_OSARCH := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKER_ENGINE_OSARCH:-$$DOCKER_CLIENT_OSARCH}')


### PR DESCRIPTION
Sometimes it's hard to figure out what makefile rule does what.
How about we add a `make test` rule ?

```
$ make help
all                            validate all checks, build linux binaries, run all tests, cross build non-linux binariesand generate archives
binary                         build the linux binaries
cross                          cross build the binaries for darwin, freebsd and windows
win                            cross build the binary for windows
tgz                            build the archives (.zip on windows and .tgz otherwise) containing the binaries
deb                            build the deb packages
docs                           build the docs
gccgo                          build the gcc-go linux binaries
rpm                            build the rpm packages
shell                          start a shell inside the build env
test                           un the unit, integration and docker-py tests
test-docker-py                 run the docker-py tests
test-integration-cli           run the integration tests
test-unit                      run the unit tests
validate                       validate DCO, Seccomp profile generation, gofmt, ./pkg/ isolation, golint, tests, tomls, go vet and vendor
help                           this help
```

ping @tianon 
