### PR TITLE
Fix overlay test running on overlay

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -67,7 +67,7 @@ func getBaseLoopStats() (*syscall.Stat_t, error) {
 }
 
 func newDriver(t *testing.T, name string) *Driver {
-	root, err := ioutil.TempDir("/var/tmp", "docker-graphtest-")
+	root, err := ioutil.TempDir("", "docker-graphtest-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -120,7 +120,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		backingFs = fsName
 	}
 
-	// check if they are running over btrfs or aufs
+	// check if they are running over btrfs, aufs, zfs or overlay
 	switch fsMagic {
 	case graphdriver.FsMagicBtrfs:
 		logrus.Error("'overlay' is not supported over btrfs.")
@@ -130,6 +130,9 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, graphdriver.ErrIncompatibleFS
 	case graphdriver.FsMagicZfs:
 		logrus.Error("'overlay' is not supported over zfs.")
+		return nil, graphdriver.ErrIncompatibleFS
+	case graphdriver.FsMagicOverlay:
+		logrus.Error("'overlay' is not supported over overlay.")
 		return nil, graphdriver.ErrIncompatibleFS
 	}
 


### PR DESCRIPTION
Overlay tests were failing when /var/tmp was an overlay mount with a misleading message.
Now overlay tests will be skipped when attempting to be run on overlay.
Tests will now use the TMPDIR environment variable instead of only /var/tmp

Fixes #21686
