### PR TITLE
Changelog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,6 @@ be found.
 
 - Fix panic if a node is forcibly removed from the cluster ([#21671](https://github.com/docker/docker/pull/21671))
 - Fix "error creating vxlan interface" when starting a container in a Swarm cluster ([#21671](https://github.com/docker/docker/pull/21671))
-- Fix `host` and `none` networks to disappear until restart when SIGHUP is used to reload cluster configuration ([#21671](https://github.com/docker/docker/pull/21671))
 - Fix a bug where IPv6 addresses were not properly handled ([#20842](https://github.com/docker/docker/pull/20842))
 * `docker network inspect` will now report all endpoints whether they have an active container or not ([#21160](https://github.com/docker/docker/pull/21160))
 + Experimental support for the MacVlan and IPVlan network drivers have been added ([#21122](https://github.com/docker/docker/pull/21122))
@@ -102,7 +101,6 @@ be found.
 - Fix race conditions in the layer store, potentially corrupting the map and crashing the process ([#21677](https://github.com/docker/docker/pull/21677))
 - Un-deprecate auto-creation of host directories for mounts. This feature was marked deprecated in ([#21666](https://github.com/docker/docker/pull/21666))  
   Docker 1.9, but was decided to be too much of an backward-incompatible change, so it was decided to keep the feature.
-- Fix an issue where parallel aufs mount calls produce invalid argument error ([#21552](https://github.com/docker/docker/pull/21552))
 + It is now possible for containers to share the NET and IPC namespaces when `userns` is enabled ([#21383](https://github.com/docker/docker/pull/21383))
 + `docker inspect <image-id>` will now expose the rootfs layers ([#21370](https://github.com/docker/docker/pull/21370))
 + Docker Windows gained a minimal `top` implementation ([#21354](https://github.com/docker/docker/pull/21354))


### PR DESCRIPTION
Some fixes in the changelog were not regressions since 1.10.x, but only present in 1.11 release candidates so don't need to be mentioned for the release.

see https://github.com/docker/docker/pull/21827#discussion_r58807270

ping @cpuguy83 ptal :+1: 
