### PR TITLE
Fix deprecated format for security-opt

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -608,8 +608,8 @@ with the same logic -- if the original volume was specified with a name it will 
                                          to the container
     --security-opt="no-new-privileges" : Disable container processes from gaining
                                          new privileges
-    --security-opt="seccomp:unconfined": Turn off seccomp confinement for the container
-    --security-opt="seccomp:profile.json: White listed syscalls seccomp Json file to be used as a seccomp filter
+    --security-opt="seccomp=unconfined": Turn off seccomp confinement for the container
+    --security-opt="seccomp=profile.json: White listed syscalls seccomp Json file to be used as a seccomp filter
 
 
 You can override the default labeling scheme for each container by specifying


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
