### PR TITLE
Add missing "start" event back for auto-restart container

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -77,6 +77,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 			c.Reset(false)
 			return err
 		}
+		daemon.LogContainerEvent(c, "start")
 	case libcontainerd.StatePause:
 		c.Paused = true
 		daemon.LogContainerEvent(c, "pause")

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -131,7 +131,6 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 		return err
 	}
 
-	defer daemon.LogContainerEvent(container, "start") // this is logged even on error
 	if err := daemon.containerd.Create(container.ID, *spec, libcontainerd.WithRestartManager(container.RestartManager(true))); err != nil {
 		// if we receive an internal error from the initial start of a container then lets
 		// return it instead of entering the restart loop
@@ -149,6 +148,9 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 		}
 
 		container.Reset(false)
+
+		// start event is logged even on error
+		daemon.LogContainerEvent(container, "start")
 		return err
 	}
 


### PR DESCRIPTION
When container is automatically restarted based on restart policy,
docker events can't get "start" event but only get "die" event, this is
not consistent with previous behavior. This commit will add "start"
event back.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
