### PR TITLE
Fix closing attach streams on lost tcp connection

### DIFF
--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -51,6 +51,7 @@ func (bp *BytesPipe) Write(p []byte) (int, error) {
 	bp.mu.Lock()
 
 	written := 0
+loop0:
 	for {
 		if bp.closeErr != nil {
 			bp.mu.Unlock()
@@ -85,6 +86,9 @@ func (bp *BytesPipe) Write(p []byte) (int, error) {
 		// make sure the buffer doesn't grow too big from this write
 		for bp.bufLen >= blockThreshold {
 			bp.wait.Wait()
+			if bp.closeErr != nil {
+				continue loop0
+			}
 		}
 
 		// add new byte slice to the buffers slice and continue writing


### PR DESCRIPTION
**\- What I did**

Fixed issue where if attach stream went away while it was blocked on allocation buffering limit, all container output streams would block. As a related issue this caused containerd to not stop containers correctly because the stdio was not being fully read.

**\- How I did it**

Check is added to see if `Close` has set up an error before unlocking the waiters.

**\- How to verify it**

Run `docker run -it busybox yes`, let it run a bit and close the terminal. Previously this would stop output generation from container after it detects that connection went away. Now the container output is still written to the logs.

fixes #21782

cc @vikstrous @aaronlehmann @crosbymichael 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
