### PR TITLE
Fix flaky TestSaveLoadParents

### DIFF
--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -325,7 +325,7 @@ func (s *DockerSuite) TestSaveLoadParents(c *check.C) {
 		out, _ = dockerCmd(c, "commit", cleanedContainerID)
 		imageID := strings.TrimSpace(out)
 
-		dockerCmd(c, "rm", cleanedContainerID)
+		dockerCmd(c, "rm", "-f", cleanedContainerID)
 		return imageID
 	}
 


### PR DESCRIPTION
Although unlikely, it is possible that the container used in the test has not been marked as stopped yet.

Fixes #21824
