### PR TITLE
Additional syslog-format option to allow microsecond resolution in syslog timestamp.

### DIFF
--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -19,6 +19,12 @@ func TestParseLogFormat(t *testing.T) {
 		t.Fatal("Failed to parse rfc5424 format", err, formatter, framer)
 	}
 
+	formatter, framer, err = parseLogFormat("rfc5424micro")
+	if err != nil || !functionMatches(rfc5424microformatterWithAppNameAsTag, formatter) ||
+		!functionMatches(syslog.RFC5425MessageLengthFramer, framer) {
+		t.Fatal("Failed to parse rfc5424 (microsecond) format", err, formatter, framer)
+	}
+
 	formatter, framer, err = parseLogFormat("rfc3164")
 	if err != nil || !functionMatches(syslog.RFC3164Formatter, formatter) ||
 		!functionMatches(syslog.DefaultFramer, framer) {

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -80,7 +80,7 @@ The following logging options are supported for the `syslog` logging driver:
     --log-opt syslog-tls-key=/etc/ca-certificates/custom/key.pem
     --log-opt syslog-tls-skip-verify=true
     --log-opt tag="mailer"
-    --log-opt syslog-format=[rfc5424|rfc3164] 
+    --log-opt syslog-format=[rfc5424|rfc5424micro|rfc3164]
 
 `syslog-address` specifies the remote syslog server address where the driver connects to.
 If not specified it defaults to the local unix socket of the running system.
@@ -135,7 +135,8 @@ the log tag format.
 `syslog-format` specifies syslog message format to use when logging.
 If not specified it defaults to the local unix syslog format without hostname specification.
 Specify rfc3164 to perform logging in RFC-3164 compatible format. Specify rfc5424 to perform 
-logging in RFC-5424 compatible format
+logging in RFC-5424 compatible format. Specify rfc5424micro to perform logging in RFC-5424
+compatible format with microsecond timestamp resolution.
 
 
 ## journald options


### PR DESCRIPTION
This fix tries to add an additional syslog-format of `rfc5424micro` which follows the same as rfc5424 except that it use microsecond resolution for timestamp. The purpose is to solve the issue raised in #21793 where log events might lose its ordering if happens on the same second.

The timestamp field in rfc5424 is derived from rfc3339, though the maximum resolution is limited to "TIME-SECFRAC" which is 6 (microsecond resolution).

This fix adds a unit test to cover the newly introduced format.

This fix fixes #21793.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
