### PR TITLE
Fix critical bug: can't restart an restarting container

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -81,7 +82,14 @@ func (daemon *Daemon) killWithSignal(container *container.Container, sig int) er
 	}
 
 	if err := daemon.kill(container, sig); err != nil {
-		return fmt.Errorf("Cannot kill container %s: %s", container.ID, err)
+		err = fmt.Errorf("Cannot kill container %s: %s", container.ID, err)
+		// if container or process not exists, ignore the error
+		if strings.Contains(err.Error(), "container not found") ||
+			strings.Contains(err.Error(), "no such process") {
+			logrus.Warnf("%s", err.Error())
+		} else {
+			return err
+		}
 	}
 
 	attributes := map[string]string{

--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -134,7 +134,7 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 	defer clnt.unlock(containerID)
 
 	if ctr, err := clnt.getContainer(containerID); err == nil {
-		if ctr.restarting { // docker doesn't actually call start if restart is on atm, but probably should in the future
+		if ctr.restarting {
 			ctr.restartManager.Cancel()
 			ctr.clean()
 		} else {

--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -124,6 +124,7 @@ func (ctr *container) handleEvent(e *containerd.Event) error {
 			} else if restart {
 				st.State = StateRestart
 				ctr.restarting = true
+				ctr.client.deleteContainer(e.Id)
 				go func() {
 					err := <-wait
 					ctr.restarting = false

--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -51,7 +51,7 @@ func (rm *restartManager) ShouldRestart(exitCode uint32) (bool, chan error, erro
 	}()
 
 	if rm.canceled {
-		return false, nil, nil
+		return false, nil, fmt.Errorf("restartmanager canceled")
 	}
 
 	if rm.active {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

When user try to restart an restarting container, docker client report
error: "container is already active", and container will be stopped
instead be restarted which is seriously wrong.

What's more critical is that when user try to start this container
again, it will always fail.

This error can also be reproduced with a `docker stop`+`docker start`.

And this commit will fix the bug.

**\- How I did it**

**\- How to verify it**

```
$ docker run -tid --restart always --name test busybox sh -c "sleep 1; exit 88"
2675048b4ef84307f90e9bd1cac25059d432768d4e354c5a6e3e702749b24c09

$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                  PORTS               NAMES
2675048b4ef8        busybox             "sh -c 'sleep 1; exit"   3 seconds ago       Up Less than a second                       test

$ docker restart test
Error response from daemon: Cannot restart container test: Container 2675048b4ef84307f90e9bd1cac25059d432768d4e354c5a6e3e702749b24c09 is already active

$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES

$ docker start test
Error response from daemon: Container 2675048b4ef84307f90e9bd1cac25059d432768d4e354c5a6e3e702749b24c09 is already active
Error: failed to start containers: test

$ docker start test
Error response from daemon: Container 2675048b4ef84307f90e9bd1cac25059d432768d4e354c5a6e3e702749b24c09 is already active
Error: failed to start containers: test

$ docker version
Client:
 Version:      1.11.0-dev
 API version:  1.24
 Go version:   go1.5.3
 Git commit:   d5dfc4e
 Built:        Thu Apr  7 14:10:30 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.11.0-dev
 API version:  1.24
 Go version:   go1.5.3
 Git commit:   d5dfc4e
 Built:        Thu Apr  7 14:10:30 2016
 OS/Arch:      linux/amd64
```

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Zhang Wei zhangwei555@huawei.com
