### PR TITLE
vendor: patch template init in trace pkg for performance

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -20,7 +20,8 @@ clone git github.com/mattn/go-sqlite3 v1.1.0
 clone git github.com/mistifyio/go-zfs v2.1.1
 clone git github.com/tchap/go-patricia v2.1.0
 clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
-clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
+# forked golang.org/x/net package includes a patch for lazy loading trace templates
+clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0

--- a/vendor/src/golang.org/x/net/trace/events.go
+++ b/vendor/src/golang.org/x/net/trace/events.go
@@ -21,11 +21,6 @@ import (
 	"time"
 )
 
-var eventsTmpl = template.Must(template.New("events").Funcs(template.FuncMap{
-	"elapsed":   elapsed,
-	"trimSpace": strings.TrimSpace,
-}).Parse(eventsHTML))
-
 const maxEventsPerLog = 100
 
 type bucket struct {
@@ -101,7 +96,7 @@ func RenderEvents(w http.ResponseWriter, req *http.Request, sensitive bool) {
 
 	famMu.RLock()
 	defer famMu.RUnlock()
-	if err := eventsTmpl.Execute(w, data); err != nil {
+	if err := eventsTmpl().Execute(w, data); err != nil {
 		log.Printf("net/trace: Failed executing template: %v", err)
 	}
 }
@@ -419,6 +414,19 @@ func freeEventLog(el *eventLog) {
 	case freeEventLogs <- el:
 	default:
 	}
+}
+
+var eventsTmplCache *template.Template
+var eventsTmplOnce sync.Once
+
+func eventsTmpl() *template.Template {
+	eventsTmplOnce.Do(func() {
+		eventsTmplCache = template.Must(template.New("events").Funcs(template.FuncMap{
+			"elapsed":   elapsed,
+			"trimSpace": strings.TrimSpace,
+		}).Parse(eventsHTML))
+	})
+	return eventsTmplCache
 }
 
 const eventsHTML = `

--- a/vendor/src/golang.org/x/net/trace/histogram.go
+++ b/vendor/src/golang.org/x/net/trace/histogram.go
@@ -12,6 +12,7 @@ import (
 	"html/template"
 	"log"
 	"math"
+	"sync"
 
 	"golang.org/x/net/internal/timeseries"
 )
@@ -320,15 +321,20 @@ func (h *histogram) newData() *data {
 
 func (h *histogram) html() template.HTML {
 	buf := new(bytes.Buffer)
-	if err := distTmpl.Execute(buf, h.newData()); err != nil {
+	if err := distTmpl().Execute(buf, h.newData()); err != nil {
 		buf.Reset()
 		log.Printf("net/trace: couldn't execute template: %v", err)
 	}
 	return template.HTML(buf.String())
 }
 
-// Input: data
-var distTmpl = template.Must(template.New("distTmpl").Parse(`
+var distTmplCache *template.Template
+var distTmplOnce sync.Once
+
+func distTmpl() *template.Template {
+	distTmplOnce.Do(func() {
+		// Input: data
+		distTmplCache = template.Must(template.New("distTmpl").Parse(`
 <table>
 <tr>
     <td style="padding:0.25em">Count: {{.Count}}</td>
@@ -354,3 +360,6 @@ var distTmpl = template.Must(template.New("distTmpl").Parse(`
 {{end}}
 </table>
 `))
+	})
+	return distTmplCache
+}

--- a/vendor/src/golang.org/x/net/trace/trace.go
+++ b/vendor/src/golang.org/x/net/trace/trace.go
@@ -232,7 +232,7 @@ func Render(w io.Writer, req *http.Request, sensitive bool) {
 
 	completedMu.RLock()
 	defer completedMu.RUnlock()
-	if err := pageTmpl.ExecuteTemplate(w, "Page", data); err != nil {
+	if err := pageTmpl().ExecuteTemplate(w, "Page", data); err != nil {
 		log.Printf("net/trace: Failed executing template: %v", err)
 	}
 }
@@ -888,10 +888,18 @@ func elapsed(d time.Duration) string {
 	return string(b)
 }
 
-var pageTmpl = template.Must(template.New("Page").Funcs(template.FuncMap{
-	"elapsed": elapsed,
-	"add":     func(a, b int) int { return a + b },
-}).Parse(pageHTML))
+var pageTmplCache *template.Template
+var pageTmplOnce sync.Once
+
+func pageTmpl() *template.Template {
+	pageTmplOnce.Do(func() {
+		pageTmplCache = template.Must(template.New("Page").Funcs(template.FuncMap{
+			"elapsed": elapsed,
+			"add":     func(a, b int) int { return a + b },
+		}).Parse(pageHTML))
+	})
+	return pageTmplCache
+}
 
 const pageHTML = `
 {{template "Prolog" .}}


### PR DESCRIPTION
**\- What I did**

Forked `golang.org/x/net` so that includes a fix for lazy loading trace templates. We don't usually do this but performance gain seems to be quite significant because we use reexec. In my test it makes every `docker run` command 60-70ms faster. Changes have been submitted to upstream at https://go-review.googlesource.com/#/c/21654/ 

https://bl.ocks.org/tonistiigi/7e182f627e4809addd5e690e159cf0fb has graphs of running `docker run busybox ls /` before and after this change.

cc @icecrime @cpuguy83 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
