### PR TITLE
pkg/archive: use more narrow interface for CompressStream

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -193,7 +193,7 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 }
 
 // CompressStream compresses the dest with specified compression algorithm.
-func CompressStream(dest io.WriteCloser, compression Compression) (io.WriteCloser, error) {
+func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, error) {
 	p := pools.BufioWriter32KPool
 	buf := p.Get(dest)
 	switch compression {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Used io.Writer interface instead of io.WriterCloser, because WriteCloser is too broad for CompressStream
**\- How I did it**
just changed a type of a function argument
**\- How to verify it**
compile docker
**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](http://www.fonstola.ru/pic/201312/1366x768/fonstola.ru-138586.jpg)
