### PR TITLE
Remove reference package dependency from the api.

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -4,7 +4,6 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types/backend"
-	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/registry"
 	"golang.org/x/net/context"
@@ -28,17 +27,17 @@ type imageBackend interface {
 	ImageHistory(imageName string) ([]*types.ImageHistory, error)
 	Images(filterArgs string, filter string, all bool) ([]*types.Image, error)
 	LookupImage(name string) (*types.ImageInspect, error)
-	TagImage(newTag reference.Named, imageName string) error
+	TagImage(imageName, repository, tag string) error
 }
 
 type importExportBackend interface {
 	LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error
-	ImportImage(src string, newRef reference.Named, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error
+	ImportImage(src string, repository, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error
 	ExportImage(names []string, outStream io.Writer) error
 }
 
 type registryBackend interface {
-	PullImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
-	PushImage(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
 	SearchRegistryForImages(ctx context.Context, term string, authConfig *types.AuthConfig, metaHeaders map[string][]string) (*registry.SearchResults, error)
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
@@ -109,7 +110,7 @@ type Backend interface {
 	// GetImageOnBuild looks up a Docker image referenced by `name`.
 	GetImageOnBuild(name string) (Image, error)
 	// TagImage tags an image with newTag
-	TagImage(newTag reference.Named, imageName string) error
+	TagImageWithReference(image.ID, reference.Named) error
 	// PullOnBuild tells Docker to pull image referenced by `name`.
 	PullOnBuild(ctx context.Context, name string, authConfigs map[string]types.AuthConfig, output io.Writer) (Image, error)
 	// ContainerAttachRaw attaches to container.

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerfile/parser"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
@@ -256,8 +257,9 @@ func (b *Builder) build(config *types.ImageBuildOptions, context builder.Context
 		return "", fmt.Errorf("No image was generated. Is your Dockerfile empty?")
 	}
 
+	imageID := image.ID(b.image)
 	for _, rt := range repoAndTags {
-		if err := b.docker.TagImage(rt, b.image); err != nil {
+		if err := b.docker.TagImageWithReference(imageID, rt); err != nil {
 			return "", err
 		}
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -215,7 +215,7 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 				return "", err
 			}
 		}
-		if err := daemon.TagImage(newTag, id.String()); err != nil {
+		if err := daemon.TagImageWithReference(id, newTag); err != nil {
 			return "", err
 		}
 	}

--- a/daemon/image_pull.go
+++ b/daemon/image_pull.go
@@ -1,0 +1,106 @@
+package daemon
+
+import (
+	"io"
+	"strings"
+
+	"github.com/docker/distribution/digest"
+	"github.com/docker/docker/builder"
+	"github.com/docker/docker/distribution"
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PullImage initiates a pull operation. image is the repository name to pull, and
+// tag may be either empty, or indicate a specific tag to pull.
+func (daemon *Daemon) PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+	// Special case: "pull -a" may send an image name with a
+	// trailing :. This is ugly, but let's not break API
+	// compatibility.
+	image = strings.TrimSuffix(image, ":")
+
+	ref, err := reference.ParseNamed(image)
+	if err != nil {
+		return err
+	}
+
+	if tag != "" {
+		// The "tag" could actually be a digest.
+		var dgst digest.Digest
+		dgst, err = digest.ParseDigest(tag)
+		if err == nil {
+			ref, err = reference.WithDigest(ref, dgst)
+		} else {
+			ref, err = reference.WithTag(ref, tag)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return daemon.pullImageWithReference(ctx, ref, metaHeaders, authConfig, outStream)
+}
+
+// PullOnBuild tells Docker to pull image referenced by `name`.
+func (daemon *Daemon) PullOnBuild(ctx context.Context, name string, authConfigs map[string]types.AuthConfig, output io.Writer) (builder.Image, error) {
+	ref, err := reference.ParseNamed(name)
+	if err != nil {
+		return nil, err
+	}
+	ref = reference.WithDefaultTag(ref)
+
+	pullRegistryAuth := &types.AuthConfig{}
+	if len(authConfigs) > 0 {
+		// The request came with a full auth config file, we prefer to use that
+		repoInfo, err := daemon.RegistryService.ResolveRepository(ref)
+		if err != nil {
+			return nil, err
+		}
+
+		resolvedConfig := registry.ResolveAuthConfig(
+			authConfigs,
+			repoInfo.Index,
+		)
+		pullRegistryAuth = &resolvedConfig
+	}
+
+	if err := daemon.pullImageWithReference(ctx, ref, nil, pullRegistryAuth, output); err != nil {
+		return nil, err
+	}
+	return daemon.GetImage(name)
+}
+
+func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+	// Include a buffer so that slow client connections don't affect
+	// transfer performance.
+	progressChan := make(chan progress.Progress, 100)
+
+	writesDone := make(chan struct{})
+
+	ctx, cancelFunc := context.WithCancel(ctx)
+
+	go func() {
+		writeDistributionProgress(cancelFunc, outStream, progressChan)
+		close(writesDone)
+	}()
+
+	imagePullConfig := &distribution.ImagePullConfig{
+		MetaHeaders:      metaHeaders,
+		AuthConfig:       authConfig,
+		ProgressOutput:   progress.ChanOutput(progressChan),
+		RegistryService:  daemon.RegistryService,
+		ImageEventLogger: daemon.LogImageEvent,
+		MetadataStore:    daemon.distributionMetadataStore,
+		ImageStore:       daemon.imageStore,
+		ReferenceStore:   daemon.referenceStore,
+		DownloadManager:  daemon.downloadManager,
+	}
+
+	err := distribution.Pull(ctx, ref, imagePullConfig)
+	close(progressChan)
+	<-writesDone
+	return err
+}

--- a/daemon/image_push.go
+++ b/daemon/image_push.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"io"
+
+	"github.com/docker/docker/distribution"
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/reference"
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PushImage initiates a push operation on the repository named localName.
+func (daemon *Daemon) PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+	ref, err := reference.ParseNamed(image)
+	if err != nil {
+		return err
+	}
+	if tag != "" {
+		// Push by digest is not supported, so only tags are supported.
+		ref, err = reference.WithTag(ref, tag)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Include a buffer so that slow client connections don't affect
+	// transfer performance.
+	progressChan := make(chan progress.Progress, 100)
+
+	writesDone := make(chan struct{})
+
+	ctx, cancelFunc := context.WithCancel(ctx)
+
+	go func() {
+		writeDistributionProgress(cancelFunc, outStream, progressChan)
+		close(writesDone)
+	}()
+
+	imagePushConfig := &distribution.ImagePushConfig{
+		MetaHeaders:      metaHeaders,
+		AuthConfig:       authConfig,
+		ProgressOutput:   progress.ChanOutput(progressChan),
+		RegistryService:  daemon.RegistryService,
+		ImageEventLogger: daemon.LogImageEvent,
+		MetadataStore:    daemon.distributionMetadataStore,
+		LayerStore:       daemon.layerStore,
+		ImageStore:       daemon.imageStore,
+		ReferenceStore:   daemon.referenceStore,
+		TrustKey:         daemon.trustKey,
+		UploadManager:    daemon.uploadManager,
+	}
+
+	err = distribution.Push(ctx, ref, imagePushConfig)
+	close(progressChan)
+	<-writesDone
+	return err
+}

--- a/daemon/image_tag.go
+++ b/daemon/image_tag.go
@@ -1,0 +1,37 @@
+package daemon
+
+import (
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/reference"
+)
+
+// TagImage creates the tag specified by newTag, pointing to the image named
+// imageName (alternatively, imageName can also be an image ID).
+func (daemon *Daemon) TagImage(imageName, repository, tag string) error {
+	imageID, err := daemon.GetImageID(imageName)
+	if err != nil {
+		return err
+	}
+
+	newTag, err := reference.WithName(repository)
+	if err != nil {
+		return err
+	}
+	if tag != "" {
+		if newTag, err = reference.WithTag(newTag, tag); err != nil {
+			return err
+		}
+	}
+
+	return daemon.TagImageWithReference(imageID, newTag)
+}
+
+// TagImageWithReference adds the given reference to the image ID provided.
+func (daemon *Daemon) TagImageWithReference(imageID image.ID, newTag reference.Named) error {
+	if err := daemon.referenceStore.AddTag(newTag, imageID, true); err != nil {
+		return err
+	}
+
+	daemon.LogImageEvent(imageID.String(), newTag.String(), "tag")
+	return nil
+}


### PR DESCRIPTION
This change removes the dependency from the reference package by delegating the reference resolution to the daemon. The behavior is exactly the same.

![](http://www.shpquad.org/wp-content/uploads/2015/11/o-OHARE-GOATS-CHICAGO-AIRPORT-facebook.jpg)

Signed-off-by: David Calavera david.calavera@gmail.com
