### PR TITLE
Fix restart monitor stopping on manual restart

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -909,6 +909,7 @@ func (container *Container) FullHostname() string {
 func (container *Container) RestartManager(reset bool) restartmanager.RestartManager {
 	if reset {
 		container.RestartCount = 0
+		container.restartManager = nil
 	}
 	if container.restartManager == nil {
 		container.restartManager = restartmanager.New(container.HostConfig.RestartPolicy)


### PR DESCRIPTION
fixes #21869

Always initializes fresh `restartManager` when container is manually started so that previous cancelled `restartManager` gets abandoned. 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
