### PR TITLE
Fixing nanoserver image load bug.

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -402,7 +402,9 @@ func restoreCustomImage(is image.Store, ls layer.Store, rs reference.Store) erro
 
 		id, err := is.Create(config)
 		if err != nil {
-			return err
+			logrus.Warnf("Failed to restore custom image %s with error: %s.", name, err.Error)
+			logrus.Warnf("Skipping image %s...", name)
+			continue
 		}
 
 		if err := rs.AddTag(ref, id, true); err != nil {

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -449,7 +449,7 @@ func (d *Driver) GetCustomImageInfos() ([]CustomImageInfo, error) {
 		imageData.ID = id
 
 		// For now, hard code that all base images except nanoserver depend on win32k support
-		if imageData.Name != "nanoserver" {
+		if imageData.Name != "NanoServer" {
 			imageData.OSFeatures = append(imageData.OSFeatures, "win32k")
 		}
 


### PR DESCRIPTION
@jstarks @jhowardmsft 

Fixes an issue that prevents nano server images from loading properly.  Also updates logic for custom image loading to avoid preventing daemon start because an image failed to load.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
