### PR TITLE
[DON'T MERGE] verify existing racey problem on docker CI platform. 

### DIFF
--- a/integration-cli/docker_cli_stop_test.go
+++ b/integration-cli/docker_cli_stop_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestStopContainerWithRestartAlways(c *check.C) {
+	dockerCmd(c, "run", "--name", "verifyRestart1", "-d", "--restart=always", "busybox", "false")
+	dockerCmd(c, "run", "--name", "verifyRestart2", "-d", "--restart=always", "busybox", "false")
+	dockerCmd(c, "run", "--name", "verifyRestart3", "-d", "--restart=always", "busybox", "false")
+
+	c.Assert(waitRun("verifyRestart1"), checker.IsNil)
+	c.Assert(waitRun("verifyRestart2"), checker.IsNil)
+	c.Assert(waitRun("verifyRestart3"), checker.IsNil)
+
+	dockerCmd(c, "stop", "verifyRestart1")
+	dockerCmd(c, "stop", "verifyRestart2")
+	dockerCmd(c, "stop", "verifyRestart3")
+}


### PR DESCRIPTION
!!![DON'T MERGE]!!!

Suspecting that stop a restarting container will have great possibility
to fail, Use this test case to verify.

The racey problem is hard to reproduce, I want to make use of docker's CI platform to check master code. Sorry if this bothers someone. 

Seen here:  https://jenkins.dockerproject.org/job/Docker-PRs-gccgo/4245/console and https://jenkins.dockerproject.org/job/Docker-PRs-userns/8449/console

```
03:50:39 ----------------------------------------------------------------------
03:50:39 FAIL: docker_cli_restart_test.go:222: TestRestartContainerwithRestartPolicy.pN52_github_com_docker_docker_integration_cli.DockerSuite
03:50:39 
03:50:39 /go/src/github.com/docker/docker/pkg/integration/dockerCmd_utils.go:42:
03:50:39     c.Assert(err, check.IsNil, check.Commentf(quote+"%v"+quote+" failed with errors: %s, %v", strings.Join(args, " "), out, err))
03:50:39 ... value *exec.ExitError = &exec.ExitError{ProcessState:(*os.ProcessState)(0xc208aa3120)} ("exit status 1")
03:50:39 ... "restart 6b6e562a08364d6908ce1b0f80ee6d3047943f70038d170b7278f749a6db5778" failed with errors: Error response from daemon: Cannot restart container 6b6e562a08364d6908ce1b0f80ee6d3047943f70038d170b7278f749a6db5778: Cannot kill container 6b6e562a08364d6908ce1b0f80ee6d3047943f70038d170b7278f749a6db5778: rpc error: code = 2 desc = "containerd: container not found"
03:50:39 , exit status 1
03:50:39 
03:50:44 
03:50:44 ----------------------------------------------------------------------
```

Will close this if Janky is always green, maybe I'm just a little bit too suspicious :smile:  

Signed-off-by: Zhang Wei zhangwei555@huawei.com
