### PR TITLE
oci: default devices don't need to be listed explicitly

### DIFF
--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -99,43 +99,11 @@ func DefaultSpec() specs.Spec {
 			{Type: "pid"},
 			{Type: "ipc"},
 		},
+		// Devices implicitly contains the following devices:
+		// null, zero, full, random, urandom, tty, console, and ptmx.
+		// ptmx is a bind-mount or symlink of the container's ptmx.
+		// See also: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-devices
 		Devices: []specs.Device{
-			{
-				Type:     "c",
-				Path:     "/dev/zero",
-				Major:    1,
-				Minor:    5,
-				FileMode: fmPtr(0666),
-				UID:      u32Ptr(0),
-				GID:      u32Ptr(0),
-			},
-			{
-				Type:     "c",
-				Path:     "/dev/null",
-				Major:    1,
-				Minor:    3,
-				FileMode: fmPtr(0666),
-				UID:      u32Ptr(0),
-				GID:      u32Ptr(0),
-			},
-			{
-				Type:     "c",
-				Path:     "/dev/urandom",
-				Major:    1,
-				Minor:    9,
-				FileMode: fmPtr(0666),
-				UID:      u32Ptr(0),
-				GID:      u32Ptr(0),
-			},
-			{
-				Type:     "c",
-				Path:     "/dev/random",
-				Major:    1,
-				Minor:    8,
-				FileMode: fmPtr(0666),
-				UID:      u32Ptr(0),
-				GID:      u32Ptr(0),
-			},
 			{
 				Type:     "c",
 				Path:     "/dev/fuse",


### PR DESCRIPTION
**\- What I did**
Make the code understandable.

**\- How I did it**
Eliminate default device specs because runc automatically adds them.

**\- How to verify it**

```
$ docker run -it --rm busybox sh
# echo foo > /dev/null
# cat /dev/null
```

---

Eliminating these things make the code much more understandable.

See also https://github.com/opencontainers/runtime-spec/blob/adcbe530a9652b6f61c740b5c4feb1a6ee8c5918/config-linux.md#default-devices
https://github.com/opencontainers/runc/blob/df25eddce6dce1e1123372bc6ccf98d7b3acc0ce/libcontainer/specconv/spec_linux.go#L454

Signed-off-by: Akihiro Suda suda.kyoto@gmail.com
