### PR TITLE
Fix bug that can't kill an restarting container

### DIFF
--- a/integration-cli/docker_cli_stop_test.go
+++ b/integration-cli/docker_cli_stop_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestStopContainerWithRestartPolicyAlways(c *check.C) {
+	dockerCmd(c, "run", "--name", "verifyRestart1", "-d", "--restart=always", "busybox", "false")
+	dockerCmd(c, "run", "--name", "verifyRestart2", "-d", "--restart=always", "busybox", "false")
+
+	c.Assert(waitRun("verifyRestart1"), checker.IsNil)
+	c.Assert(waitRun("verifyRestart2"), checker.IsNil)
+
+	dockerCmd(c, "stop", "verifyRestart1")
+	dockerCmd(c, "stop", "verifyRestart2")
+}


### PR DESCRIPTION
This bug is confirmed on master branch: https://github.com/docker/docker/pull/21876

Sometime when we try to kill an restarting container, containerd will
report "container not found" or "no such process", if we can't find
container process, we can regard it as already dead and no need to kill
it anymore.
We can return immediately and ignore these kinds of errors.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
