### PR TITLE
[WIP] Changing docker event message attributes to official ones

### DIFF
--- a/daemon/events.go
+++ b/daemon/events.go
@@ -20,9 +20,9 @@ func (daemon *Daemon) LogContainerEvent(container *container.Container, action s
 func (daemon *Daemon) LogContainerEventWithAttributes(container *container.Container, action string, attributes map[string]string) {
 	copyAttributes(attributes, container.Config.Labels)
 	if container.Config.Image != "" {
-		attributes["image"] = container.Config.Image
+		attributes[events.ContainerImageEventKey] = container.Config.Image
 	}
-	attributes["name"] = strings.TrimLeft(container.Name, "/")
+	attributes[events.ContainerEventKey] = strings.TrimLeft(container.Name, "/")
 
 	actor := events.Actor{
 		ID:         container.ID,
@@ -45,7 +45,7 @@ func (daemon *Daemon) LogImageEventWithAttributes(imageID, refName, action strin
 		copyAttributes(attributes, img.Config.Labels)
 	}
 	if refName != "" {
-		attributes["name"] = refName
+		attributes[events.ImageEventKey] = refName
 	}
 	actor := events.Actor{
 		ID:         imageID,
@@ -71,8 +71,8 @@ func (daemon *Daemon) LogNetworkEvent(nw libnetwork.Network, action string) {
 
 // LogNetworkEventWithAttributes generates an event related to a network with specific given attributes.
 func (daemon *Daemon) LogNetworkEventWithAttributes(nw libnetwork.Network, action string, attributes map[string]string) {
-	attributes["name"] = nw.Name()
-	attributes["type"] = nw.Type()
+	attributes[events.NetworkEventKey] = nw.Name()
+	attributes[events.NetworkEventTypeKey] = nw.Type()
 	actor := events.Actor{
 		ID:         nw.ID(),
 		Attributes: attributes,

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -92,7 +92,7 @@ func (e *Events) Log(action, eventType string, actor eventtypes.Actor) {
 	case eventtypes.ContainerEventType:
 		jm.ID = actor.ID
 		jm.Status = action
-		jm.From = actor.Attributes["image"]
+		jm.From = actor.Attributes[eventtypes.ContainerImageEventKey]
 	case eventtypes.ImageEventType:
 		jm.ID = actor.ID
 		jm.Status = action

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -22,7 +22,7 @@ func TestEventsLog(t *testing.T) {
 	}
 	actor := events.Actor{
 		ID:         "cont",
-		Attributes: map[string]string{"image": "image"},
+		Attributes: map[string]string{events.ContainerImageEventKey: "image"},
 	}
 	e.Log("test", events.ContainerEventType, actor)
 	select {

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -18,59 +18,59 @@ func NewFilter(filter filters.Args) *Filter {
 
 // Include returns true when the event ev is included by the filters
 func (ef *Filter) Include(ev events.Message) bool {
-	return ef.filter.ExactMatch("event", ev.Action) &&
-		ef.filter.ExactMatch("type", ev.Type) &&
-		ef.matchContainer(ev) &&
-		ef.matchVolume(ev) &&
-		ef.matchNetwork(ev) &&
-		ef.matchImage(ev) &&
+	return ef.filter.ExactMatch("event", ev.Action) ||
+		ef.filter.ExactMatch("type", ev.Type) ||
+		ef.matchContainer(ev) ||
+		ef.matchVolume(ev) ||
+		ef.matchNetwork(ev) ||
+		ef.matchImage(ev) ||
 		ef.matchLabels(ev.Actor.Attributes)
 }
 
 func (ef *Filter) matchLabels(attributes map[string]string) bool {
 	if !ef.filter.Include("label") {
-		return true
+		return false
 	}
 	return ef.filter.MatchKVList("label", attributes)
 }
 
 func (ef *Filter) matchContainer(ev events.Message) bool {
-	return ef.fuzzyMatchName(ev, events.ContainerEventType)
+	return ef.fuzzyMatchName(ev, events.ContainerEventKey)
 }
 
 func (ef *Filter) matchVolume(ev events.Message) bool {
-	return ef.fuzzyMatchName(ev, events.VolumeEventType)
+	return ef.fuzzyMatchName(ev, events.VolumeEventKey)
 }
 
 func (ef *Filter) matchNetwork(ev events.Message) bool {
-	return ef.fuzzyMatchName(ev, events.NetworkEventType)
+	return ef.fuzzyMatchName(ev, events.NetworkEventKey)
 }
 
 func (ef *Filter) fuzzyMatchName(ev events.Message, eventType string) bool {
 	return ef.filter.FuzzyMatch(eventType, ev.Actor.ID) ||
-		ef.filter.FuzzyMatch(eventType, ev.Actor.Attributes["name"])
+		ef.filter.FuzzyMatch(eventType, ev.Actor.Attributes[eventType])
 }
 
 // matchImage matches against both event.Actor.ID (for image events)
-// and event.Actor.Attributes["image"] (for container events), so that any container that was created
-// from an image will be included in the image events. Also compare both
-// against the stripped repo name without any tags.
+// and event.Actor.Attributes[events.ContainerImageEventKey] (for container events),
+// so that any container that was created from an image will be included in the image
+// events. Also compare both against the stripped repo name without any tags.
 func (ef *Filter) matchImage(ev events.Message) bool {
 	id := ev.Actor.ID
-	nameAttr := "image"
+	nameAttr := events.ContainerImageEventKey
 	var imageName string
 
 	if ev.Type == events.ImageEventType {
-		nameAttr = "name"
+		nameAttr = events.ImageEventKey
 	}
 
 	if n, ok := ev.Actor.Attributes[nameAttr]; ok {
 		imageName = n
 	}
-	return ef.filter.ExactMatch("image", id) ||
-		ef.filter.ExactMatch("image", imageName) ||
-		ef.filter.ExactMatch("image", stripTag(id)) ||
-		ef.filter.ExactMatch("image", stripTag(imageName))
+	return ef.filter.ExactMatch(nameAttr, id) ||
+		ef.filter.ExactMatch(nameAttr, imageName) ||
+		ef.filter.ExactMatch(nameAttr, stripTag(id)) ||
+		ef.filter.ExactMatch(nameAttr, stripTag(imageName))
 }
 
 func stripTag(image string) string {

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -82,9 +82,9 @@ func (s *DockerSuite) TestApiNetworkInspect(c *check.C) {
 	c.Assert(nr.Name, checker.Equals, "bridge")
 
 	// run a container and attach it to the default bridge network
-	out, _ := dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
+	out, _ := dockerCmd(c, "run", "-d", "--name", "test-2", "busybox", "top")
 	containerID := strings.TrimSpace(out)
-	containerIP := findContainerIP(c, "test", "bridge")
+	containerIP := findContainerIP(c, "test-2", "bridge")
 
 	// inspect default bridge network again and make sure the container is connected
 	nr = getNetworkResource(c, nr.ID)

--- a/vendor/src/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/src/github.com/docker/engine-api/types/events/events.go
@@ -9,6 +9,21 @@ const (
 	VolumeEventType = "volume"
 	// NetworkEventType is the event type that networks generate
 	NetworkEventType = "network"
+
+	// Key attributes for used for the events above.
+
+	// ContainerEventKey is the key used for container event attributes
+	ContainerEventKey = "com.docker.container.name"
+	// ContainerImageEventKey is the key used for container images event attributes
+	ContainerImageEventKey = "com.docker.container.image"
+	// ImageEventKey is the key used for image event attributes
+	ImageEventKey = "com.docker.image.name"
+	// VolumeEventKey is the key used for volume event attributes
+	VolumeEventKey = "com.docker.volume.name"
+	// NetworkEventKey is the key used for network event attributes
+	NetworkEventKey = "com.docker.network.name"
+	// NetworkEventTypeKey is the key used for network event attributes
+	NetworkEventTypeKey = "com.docker.network.type"
 )
 
 // Actor describes something that generates events,

--- a/vendor/src/github.com/docker/engine-api/types/filters/parse.go
+++ b/vendor/src/github.com/docker/engine-api/types/filters/parse.go
@@ -211,7 +211,7 @@ func (filters Args) ExactMatch(field, source string) bool {
 	fieldValues, ok := filters.fields[field]
 	//do not filter if there is no filter set or cannot determine filter
 	if !ok || len(fieldValues) == 0 {
-		return true
+		return false
 	}
 
 	// try to match full name value to avoid O(N) regular expression matching


### PR DESCRIPTION
**\- What I did**
Fixed https://github.com/docker/docker/issues/20879

**\- How I did it**
Change the attribute keys of events to have the official docker prefixes.

**\- How to verify it**
$ docker events --since=0
Then on a different terminal run
$ docker run hello-world

**\- A picture of a cute animal (not mandatory but encouraged)**
![Docker in defense mode](https://d2a2wjuuf1c30f.cloudfront.net/product_photos/1030667/il_570xN.357079674_2u7r_original.jpeg)

Signed-off-by: André Martins aanm90@gmail.com
