### PR TITLE
Fixing warning to correctly output error string.

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -402,7 +402,7 @@ func restoreCustomImage(is image.Store, ls layer.Store, rs reference.Store) erro
 
 		id, err := is.Create(config)
 		if err != nil {
-			logrus.Warnf("Failed to restore custom image %s with error: %s.", name, err.Error)
+			logrus.Warnf("Failed to restore custom image %s with error: %s.", name, err)
 			logrus.Warnf("Skipping image %s...", name)
 			continue
 		}


### PR DESCRIPTION
@jhowardmsft 
I had incorrectly used <code>err.Error</code> instead of either <code>err</code> or <code>err.Error()</code>, so the message wasn't showing up properly.
Signed-off-by: Stefan J. Wernli swernli@microsoft.com
