### PR TITLE
Build deb package for all Raspberry Pi's / raspbian-jessie

### DIFF
--- a/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -1,0 +1,11 @@
+FROM resin/rpi-raspbian:jessie
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.4.3
+ENV GOARM 6
+RUN curl -fSL "https://github.com/hypriot/golang-armbuilds/releases/download/v${GO_VERSION}/go${GO_VERSION}.linux-armv6.tar.gz" | tar xzC /usr/local
+ENV PATH $PATH:/usr/local/go/bin
+
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -1,10 +1,13 @@
 FROM resin/rpi-raspbian:jessie
 
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.4.3
-ENV GOARM 6
-RUN curl -fSL "https://github.com/hypriot/golang-armbuilds/releases/download/v${GO_VERSION}/go${GO_VERSION}.linux-armv6.tar.gz" | tar xzC /usr/local
+ENV GO_VERSION 1.6.2
+RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1


### PR DESCRIPTION
**\- What I did**

Compile the Docker Engine 1.11 and build a deb package for Raspbian that is working for all eight million Raspberry Pi's, beginning with RPi 1, RPi 2, RPi 3 and should also work with RPi zero.

**\- How I did it**

Take the `contrib/builder/armhf/debian-jessie/Dockerfile` for ARMv7 and use a Raspbian Docker image and set GOARM to 6 instead of 7 to build ARMv6 compatible binaries.

**\- How to verify it**

Run `make deb` on an ARM machine, this can be ARMv6 or ARMv7. This build works eg. on Scaleway C1 servers.

Install it on a Raspbian LITE image:

```
$ echo "overlay" | sudo tee -a /etc/modules
$ sudo modprobe overlay
$ sudo apt-get install -y libapparmor1
$ sudo raspi-config
# reboot required for resizing SD card
$ sudo dpkg -i docker-engine_1.11*jessie_armhf.deb
```

Install it on HypriotOS for Raspberry Pi:

```
$ sudo apt-get remove -y docker-hypriot
$ sudo dpkg -i docker-engine_1.11*jessie_armhf.deb
```

**\- A picture of a cute animal (not mandatory but encouraged)**

Successful installation on a Raspberry Pi (1) Model B with Raspbian LITE SD card image from the Raspberry Pi Foundation.

<img width="834" alt="bildschirmfoto 2016-04-09 um 00 25 22" src="https://cloud.githubusercontent.com/assets/207759/14399047/9669a590-fde9-11e5-972a-18c56865fadb.png">

Would be great if we can add this Dockerfile to the 1.11 release so we can get rid of our proprietary build steps and start using docker-engine package instead of docker-hypriot package :-)

Signed-off-by: Stefan Scherer scherer_stefan@icloud.com
