### PR TITLE
bash completion for `--log-opt syslog-format`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -415,7 +415,7 @@ __docker_complete_log_options() {
 	local gelf_options="env gelf-address gelf-compression-level gelf-compression-type labels tag"
 	local journald_options="env labels tag"
 	local json_file_options="env labels max-file max-size"
-	local syslog_options="syslog-address syslog-tls-ca-cert syslog-tls-cert syslog-tls-key syslog-tls-skip-verify syslog-facility tag"
+	local syslog_options="syslog-address syslog-format syslog-tls-ca-cert syslog-tls-cert syslog-tls-key syslog-tls-skip-verify syslog-facility tag"
 	local splunk_options="env labels splunk-caname splunk-capath splunk-index splunk-insecureskipverify splunk-source splunk-sourcetype splunk-token splunk-url tag"
 
 	local all_options="$fluentd_options $gcplogs_options $gelf_options $journald_options $json_file_options $syslog_options $splunk_options"
@@ -505,6 +505,10 @@ __docker_complete_log_driver_options() {
 				user
 				uucp
 			" -- "${cur##*=}" ) )
+			return
+			;;
+		syslog-format)
+			COMPREPLY=( $( compgen -W "rfc3164 rfc5424" -- "${cur##*=}" ) )
 			return
 			;;
 		syslog-tls-@(ca-cert|cert|key))


### PR DESCRIPTION
I hope this is not too confusing:
#20121 introduced support for two syslog formats and is part of 1.11.0.

This PR implements the bash completion part of just this feature.

It does **not** include the support for a third log format, that was added in #21844 (not part of 1.11.0).
bash completion in _master_ already supports all three log options because #21883 was merged.

Because of that, this PR is not based on _master_ but on _bump_v1.11.0_.
Please pull in so that it makes its way into 1.11.0 to match the CLI feature set.

ping @thaJeztah 
cc @sdurrheimer for zsh completion
