### PR TITLE
Add container's short-id as default network alias

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -101,6 +101,9 @@ func (daemon *Daemon) getSize(container *container.Container) (int64, int64) {
 
 // ConnectToNetwork connects a container to a network
 func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings) error {
+	if endpointConfig == nil {
+		endpointConfig = &networktypes.EndpointSettings{}
+	}
 	if !container.Running {
 		if container.RemovalInProgress || container.Dead {
 			return errRemovalContainer(container.ID)
@@ -108,9 +111,7 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 		if _, err := daemon.updateNetworkConfig(container, idOrName, endpointConfig, true); err != nil {
 			return err
 		}
-		if endpointConfig != nil {
-			container.NetworkSettings.Networks[idOrName] = endpointConfig
-		}
+		container.NetworkSettings.Networks[idOrName] = endpointConfig
 	} else {
 		if err := daemon.connectToNetwork(container, idOrName, endpointConfig, true); err != nil {
 			return err


### PR DESCRIPTION
**\- What I did**
link feature in docker0 bridge by default provides short-id as a container alias. With built-in SD feature for user-defined networks, providing a container short-id as a network alias by default will fill that gap.

Without the short-id alias, compose like applications are forced to perform artificial steps such as -
- create a container in a network & get the container-id
- disconnect the container from the network
- connect the same container again to the same network and this time with `--alias={short-id}`

By providing the short-id as a default alias (similar to links), we can avoid such artificial steps

This also helps with https://github.com/docker/libnetwork/issues/996.

Not targeting this for 1.11 release

Signed-off-by: Madhu Venugopal madhu@docker.com
