### PR TITLE
Docker stats is not working when a container is using another container's network.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1421,8 +1421,27 @@ func (daemon *Daemon) GetContainerStats(container *container.Container) (*types.
 	return stats, nil
 }
 
+// Resolve Network SandboxID in case the container reuse another container's network stack
+func (daemon *Daemon) getNetworkSandboxID(c *container.Container) (string, error) {
+	curr := c
+	for curr.HostConfig.NetworkMode.IsContainer() {
+		containerID := curr.HostConfig.NetworkMode.ConnectedContainer()
+		connected, err := daemon.GetContainer(containerID)
+		if err != nil {
+			return "", fmt.Errorf("Could not get container for %s", containerID)
+		}
+		curr = connected
+	}
+	return curr.NetworkSettings.SandboxID, nil
+}
+
 func (daemon *Daemon) getNetworkStats(c *container.Container) (map[string]types.NetworkStats, error) {
-	sb, err := daemon.netController.SandboxByID(c.NetworkSettings.SandboxID)
+	sandboxID, err := daemon.getNetworkSandboxID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	sb, err := daemon.netController.SandboxByID(sandboxID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fix tries to fix the issue in #21848 where `docker stats` will not correctly display the container stats in case the container reuse another container's network stack.

The issue is that when `stats` is performed, the daemon will check for container network setting's `SandboxID`. Unfortunately, for containers that reuse another container's network stack (`NetworkMode.IsContainer()`), SandboxID is not assigned. Therefore, the daemon thinks the id is invalid and remote API will never return.

This fix tries to resolve the SandboxID by iterating through connected containers and identify the appropriate SandboxID.

A test case for `stats` remote API has been added to check if `stats` will return within the timeout.

This fix fixes #21848.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
