### PR TITLE
Fix incorrect request json body for `/containers/create` in remote API docs.

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.15.md
+++ b/docs/reference/api/docker_remote_api_v1.15.md
@@ -151,7 +151,7 @@ Create a container
              "ExposedPorts": {
                      "22/tcp": {}
              },
-             "SecurityOpts": [""],
+             "SecurityOpts": [],
              "HostConfig": {
                "Binds": ["/tmp:/tmp"],
                "Links": ["redis3:redis"],

--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -151,7 +151,7 @@ Create a container
              "ExposedPorts": {
                      "22/tcp": {}
              },
-             "SecurityOpts": [""],
+             "SecurityOpts": [],
              "HostConfig": {
                "Binds": ["/tmp:/tmp"],
                "Links": ["redis3:redis"],

--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -168,7 +168,7 @@ Create a container
                "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
                "NetworkMode": "bridge",
                "Devices": [],
-               "SecurityOpt": [""]
+               "SecurityOpt": []
             }
         }
 

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -184,7 +184,7 @@ Create a container
                "Devices": [],
                "Ulimits": [{}],
                "LogConfig": { "Type": "json-file", Config: {} },
-               "SecurityOpt": [""],
+               "SecurityOpt": [],
                "CgroupParent": ""
             }
         }

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -191,7 +191,7 @@ Create a container
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
-             "SecurityOpt": [""],
+             "SecurityOpt": [],
              "CgroupParent": ""
           }
       }

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -156,7 +156,7 @@ Create a container
            },
            "Volumes": {
              "/volumes/data": {}
-           }
+           },
            "WorkingDir": "",
            "NetworkDisabled": false,
            "MacAddress": "12:34:56:78:9a:bc",
@@ -193,7 +193,7 @@ Create a container
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
-             "SecurityOpt": [""],
+             "SecurityOpt": [],
              "CgroupParent": ""
           }
       }

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -160,7 +160,7 @@ Create a container
            },
            "Volumes": {
              "/volumes/data": {}
-           }
+           },
            "WorkingDir": "",
            "NetworkDisabled": false,
            "MacAddress": "12:34:56:78:9a:bc",
@@ -201,7 +201,7 @@ Create a container
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
-             "SecurityOpt": [""],
+             "SecurityOpt": [],
              "CgroupParent": "",
              "VolumeDriver": ""
           }

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -248,7 +248,7 @@ Create a container
            },
            "Volumes": {
              "/volumes/data": {}
-           }
+           },
            "WorkingDir": "",
            "NetworkDisabled": false,
            "MacAddress": "12:34:56:78:9a:bc",
@@ -294,7 +294,7 @@ Create a container
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
-             "SecurityOpt": [""],
+             "SecurityOpt": [],
              "CgroupParent": "",
              "VolumeDriver": "",
              "ShmSize": 67108864

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -267,7 +267,7 @@ Create a container
            },
            "Volumes": {
              "/volumes/data": {}
-           }
+           },
            "WorkingDir": "",
            "NetworkDisabled": false,
            "MacAddress": "12:34:56:78:9a:bc",
@@ -313,7 +313,7 @@ Create a container
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
-             "SecurityOpt": [""],
+             "SecurityOpt": [],
              "CgroupParent": "",
              "VolumeDriver": "",
              "ShmSize": 67108864

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -267,7 +267,7 @@ Create a container
            },
            "Volumes": {
              "/volumes/data": {}
-           }
+           },
            "WorkingDir": "",
            "NetworkDisabled": false,
            "MacAddress": "12:34:56:78:9a:bc",
@@ -313,7 +313,7 @@ Create a container
              "Devices": [],
              "Ulimits": [{}],
              "LogConfig": { "Type": "json-file", "Config": {} },
-             "SecurityOpt": [""],
+             "SecurityOpt": [],
              "StorageOpt": {},
              "CgroupParent": "",
              "VolumeDriver": "",


### PR DESCRIPTION
This fix tries to fix the incorrect request json body for `/containers/create` in remote API docs.

When using the example json request for `/containers/create`, there are two errors:
(1). `invalid character '"' after object key:value pair`
(2).  `Invalid --security-opt: ""`

Issue (1) exists in v1.20-v1.24. It is because a `,` is missing after `"Volumes": {}`

Issue (2) exists in v1.15-v1.24. It is because in `"SecurityOpt": [""]` line, an empty string  `""` is passed yet `""` is not a valid `SecurityOpt`. Either no string `[]`, or a valid string (e.g., `["no-new-privileges"]`) could be used.

This fix updates the docs and correct the above two issues.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
