### PR TITLE
Vendor Libnetwork v0.7.0-rc.6

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -30,7 +30,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.7.0-rc.4
+clone git github.com/docker/libnetwork v0.7.0-rc.6
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.7.0-rc.6 (2016-04-10)
+- Flush cached resolver socket on default gateway change
+
+## 0.7.0-rc.5 (2016-04-08)
+- Persist ipam driver options
+- Fixes https://github.com/docker/libnetwork/issues/1087
+- Use go vet from go tool 
+- Godep update to pick up latest docker/docker packages
+- Validate remote driver response using docker plugins package method.
+
 ## 0.7.0-rc.4 (2016-04-06)
 - Fix the handling for default gateway Endpoint join/leave.
 

--- a/vendor/src/github.com/docker/libnetwork/Dockerfile.build
+++ b/vendor/src/github.com/docker/libnetwork/Dockerfile.build
@@ -3,6 +3,5 @@ RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \
 		github.com/golang/lint/golint \
-		golang.org/x/tools/cmd/vet \
 		golang.org/x/tools/cmd/cover\
 		github.com/mattn/goveralls

--- a/vendor/src/github.com/docker/libnetwork/drivers/remote/driver.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/remote/driver.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/plugins"
@@ -12,10 +11,6 @@ import (
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	"github.com/docker/libnetwork/types"
-)
-
-const (
-	missingMethod = "404 page not found"
 )
 
 type driver struct {
@@ -260,7 +255,7 @@ func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string
 		Options:    options,
 	}
 	err := d.call("ProgramExternalConnectivity", data, &api.ProgramExternalConnectivityResponse{})
-	if err != nil && strings.Contains(err.Error(), missingMethod) {
+	if err != nil && plugins.IsNotFound(err) {
 		// It is not mandatory yet to support this method
 		return nil
 	}
@@ -274,7 +269,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 		EndpointID: eid,
 	}
 	err := d.call("RevokeExternalConnectivity", data, &api.RevokeExternalConnectivityResponse{})
-	if err != nil && strings.Contains(err.Error(), missingMethod) {
+	if err != nil && plugins.IsNotFound(err) {
 		// It is not mandatory yet to support this method
 		return nil
 	}

--- a/vendor/src/github.com/docker/libnetwork/endpoint.go
+++ b/vendor/src/github.com/docker/libnetwork/endpoint.go
@@ -477,6 +477,10 @@ func (ep *endpoint) sbJoin(sb *sandbox, options ...EndpointOption) error {
 					ep.Name(), ep.ID(), err)
 			}
 		}
+
+		if sb.resolver != nil {
+			sb.resolver.FlushExtServers()
+		}
 	}
 
 	if !sb.needDefaultGW() {

--- a/vendor/src/github.com/docker/libnetwork/network.go
+++ b/vendor/src/github.com/docker/libnetwork/network.go
@@ -320,6 +320,13 @@ func (n *network) CopyTo(o datastore.KVObject) error {
 		dstN.labels[k] = v
 	}
 
+	if n.ipamOptions != nil {
+		dstN.ipamOptions = make(map[string]string, len(n.ipamOptions))
+		for k, v := range n.ipamOptions {
+			dstN.ipamOptions[k] = v
+		}
+	}
+
 	for _, v4conf := range n.ipamV4Config {
 		dstV4Conf := &IpamConf{}
 		v4conf.CopyTo(dstV4Conf)
@@ -372,6 +379,7 @@ func (n *network) MarshalJSON() ([]byte, error) {
 	netMap["scope"] = n.scope
 	netMap["labels"] = n.labels
 	netMap["ipamType"] = n.ipamType
+	netMap["ipamOptions"] = n.ipamOptions
 	netMap["addrSpace"] = n.addrSpace
 	netMap["enableIPv6"] = n.enableIPv6
 	if n.generic != nil {
@@ -429,6 +437,15 @@ func (n *network) UnmarshalJSON(b []byte) (err error) {
 		n.labels = make(map[string]string, len(labels))
 		for label, value := range labels {
 			n.labels[label] = value.(string)
+		}
+	}
+
+	if v, ok := netMap["ipamOptions"]; ok {
+		if iOpts, ok := v.(map[string]interface{}); ok {
+			n.ipamOptions = make(map[string]string, len(iOpts))
+			for k, v := range iOpts {
+				n.ipamOptions[k] = v.(string)
+			}
 		}
 	}
 


### PR DESCRIPTION
v0.7.0-rc.6
- Flush cached resolver socket on default gateway change

v0.7.0-rc.5
- Fixes #21849 
- Fixes https://github.com/docker/libnetwork/issues/1087
- Validate remote driver response using docker plugins package method.

Signed-off-by: Santhosh Manohar santhosh@docker.com
