### PR TITLE
Improve source for containerd/runc copy

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -319,7 +319,7 @@ copy_containerd() {
 		if [ -x /usr/local/bin/docker-runc ]; then
 			echo "Copying nested executables into $dir"
 			for file in containerd containerd-shim containerd-ctr runc; do
-				cp "/usr/local/bin/docker-$file" "$dir/"
+				cp `which "docker-$file"` "$dir/"
 				if [ "$2" == "hash" ]; then
 					hash_files "$dir/docker-$file"
 				fi


### PR DESCRIPTION
This improves getting the source for the binaries that are compiled on
the system so that they can be copied into the bundles output.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
