### PR TITLE
Windows: support embedded utility VM images

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -7,7 +7,7 @@ source 'hack/.vendor-helpers.sh'
 
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 70b2c90b260171e829f1ebd7c17f600c11858dbe
-clone git github.com/Microsoft/hcsshim v0.2.0
+clone git github.com/Microsoft/hcsshim v0.2.1
 clone git github.com/Microsoft/go-winio v0.3.0
 clone git github.com/Sirupsen/logrus v0.9.0 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a


### PR DESCRIPTION
For Hyper-V containers, a utility VM image is necessary to start the VM that hosts the container. In TP5, this is distributed with the base layer.

With this change, when launching a container that uses a Docker-managed base layer, the utility VM is provided if it is present. Without this, Hyper-V containers cannot work with Docker-managed base layers.

For Windows-managed base layers (currently the expected user workflow), nothing changes -- the utility VM image is automatically found by Windows.

The details of this will probably change post-TP5.

cc/@jhowardmsft 
