### PR TITLE
Add support for setting storage size on ZFS containers

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -250,11 +250,7 @@ func (d *Driver) CreateReadWrite(id, parent, mountLabel string, storageOpt map[s
 
 // Create prepares the dataset and filesystem for the ZFS driver for the given id under the parent.
 func (d *Driver) Create(id string, parent string, mountLabel string, storageOpt map[string]string) error {
-	if len(storageOpt) != 0 {
-		return fmt.Errorf("--storage-opt is not supported for zfs")
-	}
-
-	err := d.create(id, parent)
+	err := d.create(id, parent, storageOpt)
 	if err == nil {
 		return nil
 	}
@@ -273,22 +269,55 @@ func (d *Driver) Create(id string, parent string, mountLabel string, storageOpt 
 	}
 
 	// retry
-	return d.create(id, parent)
+	return d.create(id, parent, storageOpt)
 }
 
-func (d *Driver) create(id, parent string) error {
+func (d *Driver) create(id, parent string, storageOpt map[string]string) error {
 	name := d.zfsPath(id)
+	quota, err := parseStorageOpt(storageOpt)
 	if parent == "" {
 		mountoptions := map[string]string{"mountpoint": "legacy"}
 		fs, err := zfs.CreateFilesystem(name, mountoptions)
 		if err == nil {
-			d.Lock()
-			d.filesystemsCache[fs.Name] = true
-			d.Unlock()
+			err = setQuota(name, quota)
+			if err == nil {
+				d.Lock()
+				d.filesystemsCache[fs.Name] = true
+				d.Unlock()
+			}
 		}
 		return err
 	}
-	return d.cloneFilesystem(name, d.zfsPath(parent))
+	err = d.cloneFilesystem(name, d.zfsPath(parent))
+	if err == nil {
+		err = setQuota(name, quota)
+	}
+	return err
+}
+
+func parseStorageOpt(storageOpt map[string]string) (string, error) {
+	// Read size to change the disk quota per container
+	for k, v := range storageOpt {
+		key := strings.ToLower(k)
+		switch key {
+		case "size":
+			return v, nil
+		default:
+			return "0", fmt.Errorf("Unknown option %s", key)
+		}
+	}
+	return "0", nil
+}
+
+func setQuota(name string, quota string) error {
+	if quota == "0" {
+		return nil
+	}
+	fs, err := zfs.GetDataset(name)
+	if err != nil {
+		return err
+	}
+	return fs.SetProperty("quota", quota)
 }
 
 // Remove deletes the dataset, filesystem and the cache for the given id.

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -275,6 +275,9 @@ func (d *Driver) Create(id string, parent string, mountLabel string, storageOpt 
 func (d *Driver) create(id, parent string, storageOpt map[string]string) error {
 	name := d.zfsPath(id)
 	quota, err := parseStorageOpt(storageOpt)
+	if err != nil {
+		return err
+	}
 	if parent == "" {
 		mountoptions := map[string]string{"mountpoint": "legacy"}
 		fs, err := zfs.CreateFilesystem(name, mountoptions)

--- a/daemon/graphdriver/zfs/zfs_test.go
+++ b/daemon/graphdriver/zfs/zfs_test.go
@@ -26,6 +26,10 @@ func TestZfsCreateSnap(t *testing.T) {
 	graphtest.DriverTestCreateSnap(t, "zfs")
 }
 
+func TestZfsSetQuota(t *testing.T) {
+	graphtest.DriverTestSetQuota(t, "zfs")
+}
+
 func TestZfsTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }


### PR DESCRIPTION
**\- What I did**
Added support for for the `--storage-opt` CLI flag to ZFS.  Users can specify a container's block device size by passing size (`--storage-opt size=2G`).  Built off of pull request https://github.com/docker/docker/pull/19367

**\- How I did it**
When creating or cloning a ZFS volume, check storage options for the key `size`.  If it is provided, set the ZFS property `quota` to the given value on the new ZFS filesystem.  If size is not specified, do not set `quota`.

**\- How to verify it**
Have docker engine setup with ZFS as the storage driver.  Pull an image and run it with the `--storage-opts size=<size>` flag.  Run `df -h` to view attached volumes sizes.  The `Avail` space on the root device should be the size specified.

```
root@dockerzfs:~# docker run -it --rm --storage-opt size=2G ubuntu bash
root@217c5a71c117:/# df -h
Filesystem                                                                            Size  Used Avail Use% Mounted on
zpool-docker/docker/a9897bab72a60873898191704eb0dfff96aa4efdb0a2676d9e8a74ad20b265a7  2.2G  198M  2.0G   9% /
tmpfs                                                                                1001M     0 1001M   0% /dev
tmpfs                                                                                1001M     0 1001M   0% /sys/fs/cgroup
zpool-docker/docker                                                                    48G  3.2M   48G   1% /etc/hosts
shm                                                                                    64M     0   64M   0% /dev/shm
```

Note:  Due to the way docker utilizes ZFS, the newly created ZFS volume will be from a read-only snapshot of the docker image.  Therefore setting the `quota` on the new volume will make the available space the size of the quota as it is applied to the new volume and not parent volumes.

**\- A picture of a cute animal**
![Westies at the Cincinnati Reds Parade](http://i.imgur.com/yVKcATw.jpg)

This is my first pull request to Docker, and I welcome all comments and suggestions!

Signed-off-by: Ken Herner kherner@progress.com
