### PR TITLE
exited=0 in filter shouldn't show "Created" ones

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -312,7 +312,7 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 	if len(ctx.exitAllowed) > 0 {
 		shouldSkip := true
 		for _, code := range ctx.exitAllowed {
-			if code == container.ExitCode && !container.Running {
+			if code == container.ExitCode && !container.Running && !container.StartedAt.IsZero() {
 				shouldSkip = false
 				break
 			}


### PR DESCRIPTION
Newly created containers which are not started yet should not list
when "exited=0" filter is used with "ps -a"

fixes #21186

**\- What I did**
Fix exited=0 filter to skip containers with "Created" status

**\- How I did it**
Check for StartedAt time to be zero when checking for ExitCode

**\- How to verify it**

```
docker create --name test busybox
docker ps -a --filter exited=0
```

Should not list "test" container
