### PR TITLE
Windows: Fix deamon deadlock in docker stop

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1231,7 +1231,7 @@ func (s *DockerSuite) TestContainerApiPostContainerStop(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	// 204 No Content is expected, not 200
 	c.Assert(statusCode, checker.Equals, http.StatusNoContent)
-	c.Assert(waitInspect(containerID, "{{ .State.Running  }}", "false", 5*time.Second), checker.IsNil)
+	c.Assert(waitInspect(containerID, "{{ .State.Running  }}", "false", 60*time.Second), checker.IsNil)
 }
 
 // #14170


### PR DESCRIPTION
@tiborvass @icecrime @calavera 

Signed-off-by: John Howard jhoward@microsoft.com

Edit - see later comments. The actual fault was a deadlock in the daemon, not the test.

Timeout TestContainerApiPostContainerStop appears to be the infrequent (1 in 25 or 30 runs) cause of windowsTP5 failures now that private kernel binaries have been applied to the CI servers. I have not been able to get any repro outside of live CI, hence asking for Windows-specific debugging to be added temporarily to try and debug this when it happens again. It also increases the timeout in the test itself, but I'm fairly certain that is not the cause. I suspect it's either a locking issue, or a possible golang issue where the wait channel is never getting notified. Cannot see a reasonable code path from code inspection to explain why the hang is observed. Note these have been added as `.InfoLn`, not debug as when running the daemon under test in CI with full debug mode (`docker daemon -D ...`), the repro is far less frequent.

An example of a failure: https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP5/409/console.

```
01:43:43 PASS: docker_api_containers_test.go:1403: DockerSuite.TestContainerApiGetContainersJSONEmpty   0.003s
01:43:43 SKIP: docker_api_containers_test.go:121: DockerSuite.TestContainerApiGetExport (Test requires a Linux daemon)
01:43:47 PASS: docker_api_containers_test.go:51: DockerSuite.TestContainerApiGetJSONNoFieldsOmitted 3.361s
01:43:47 PASS: docker_api_containers_test.go:799: DockerSuite.TestContainerApiInvalidPortSyntax 0.003s
01:43:51 PASS: docker_api_containers_test.go:926: DockerSuite.TestContainerApiKill  3.332s
01:43:51 SKIP: docker_api_containers_test.go:466: DockerSuite.TestContainerApiPause (Test requires a Linux daemon)
04:48:47 Build timed out (after 200 minutes). Marking the build as failed.
04:48:47 Build was aborted
04:48:47 [PostBuildScript] - Execution post build scripts.
04:48:47 [docker] $ sh -xe C:\Users\jenkins\hudson8857524241740742705.sh
04:48:47 + set +e
04:48:47 + set +x
04:48:48 INFO: Non-base image count on control daemon to delete is 1
```
