### PR TITLE
[WIP] Windows: TestRestartContainerwithRestartPolicy

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -233,12 +233,12 @@ func (s *DockerSuite) TestRestartContainerwithRestartPolicy(c *check.C) {
 	// Error response from daemon: Cannot restart container 6655f620d90b390527db23c0a15b3e46d86a58ecec20a5697ab228d860174251: remove /var/run/docker/libcontainerd/6655f620d90b390527db23c0a15b3e46d86a58ecec20a5697ab228d860174251/rootfs: device or resource busy
 	if _, _, err := dockerCmdWithError("restart", id1); err != nil {
 		// if restart met racey problem, try again
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(3 * time.Second)
 		dockerCmd(c, "restart", id1)
 	}
 	if _, _, err := dockerCmdWithError("restart", id2); err != nil {
 		// if restart met racey problem, try again
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(3 * time.Second)
 		dockerCmd(c, "restart", id2)
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This already known flaky test (see commentary in it) is failing occasionally on windowsTP5 CI. Increasing the timeout to allow a much better chance of success. 500ms is certainly not long enough.

Example of failure:https://jenkins.dockerproject.org/job/Docker-PRs-WoW-TP5/418/console

```
03:27:05 PASS: docker_cli_restart_test.go:108: DockerSuite.TestRestartContainerwithGoodContainer    3.672s
03:27:42 
03:27:42 ----------------------------------------------------------------------
03:27:42 FAIL: docker_cli_restart_test.go:222: DockerSuite.TestRestartContainerwithRestartPolicy
03:27:42 
03:27:42 docker_cli_restart_test.go:229:
03:27:42     c.Assert(err, checker.IsNil)
03:27:42 ... value *errors.errorString = &errors.errorString{s:"condition \"\"false true\" == \"false false\"\" not true in time"} ("condition \"\"false true\" == \"false false\"\" not true in time")
03:27:42 
03:27:52 
03:27:52 ----------------------------------------------------------------------
03:27:52 PASS: docker_cli_restart_test.go:192: DockerSuite.TestRestartPolicyAfterRestart    8.905s
03:27:55 PASS: docker_cli_restart_test.go:84: DockerSuite.TestRestartPolicyAlways   2.977s
```
