### PR TITLE
Docker inspect gave default log options even when the option is emtpy.

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -108,16 +108,6 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 		hostConfig.Links = append(hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
 	}
 
-	// we need this trick to preserve empty log driver, so
-	// container will use daemon defaults even if daemon changes them
-	if hostConfig.LogConfig.Type == "" {
-		hostConfig.LogConfig.Type = daemon.defaultLogConfig.Type
-	}
-
-	if len(hostConfig.LogConfig.Config) == 0 {
-		hostConfig.LogConfig.Config = daemon.defaultLogConfig.Config
-	}
-
 	containerState := &types.ContainerState{
 		Status:     container.State.StateString(),
 		Running:    container.State.Running,

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2224,3 +2224,17 @@ func (s *DockerSuite) TestDaemonDiscoveryBackendConfigReload(c *check.C) {
 	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Store: consul://consuladdr:consulport/some/path"))
 	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Advertise: 192.168.56.100:0"))
 }
+
+// Test for #21956
+func (s *DockerDaemonSuite) TestDaemonLogOptions(c *check.C) {
+	err := s.d.StartWithBusybox("--log-driver=syslog", "--log-opt=syslog-address=udp://127.0.0.1:514")
+	c.Assert(err, check.IsNil)
+
+	out, err := s.d.Cmd("run", "-d", "--log-driver=json-file", "busybox", "top")
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	id := strings.TrimSpace(out)
+
+	out, err = s.d.Cmd("inspect", "--format='{{.HostConfig.LogConfig}}'", id)
+	c.Assert(err, check.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "{json-file map[]}")
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to addess the issue in #21956 where `docker inspect` will overwrite the log config options with default option even when the `--log-driver` is not empty and `--log-opt` is empty. In this situation, `docker inspect` and `docker run` is different.

With the introduction of #21153, the `HostConfig` will always have the correct log-driver and log-opt values.

However, the previous processing of `docker inspect` was not updated after the change in #21153. This results in the incorrect behavior.

**\- How I did it**

This fix addresses this issue by updating `docker inspect` to conform to #21153 so the the behavior of `docker inspect` and `docker run` is consistent.

**\- How to verify it**

A integration test has been added to cover this fix.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #21956. This fix is related to #21153.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
