### PR TITLE
Fix N+1 calling `Path()` on `volume ls`

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -183,5 +183,7 @@ func (daemon *Daemon) VolumeCreate(name, driverName string, opts, labels map[str
 	}
 
 	daemon.LogVolumeEvent(v.Name(), "create", map[string]string{"driver": v.DriverName()})
-	return volumeToAPIType(v), nil
+	apiV := volumeToAPIType(v)
+	apiV.Mountpoint = v.Path()
+	return apiV, nil
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -204,7 +204,9 @@ func (daemon *Daemon) VolumeInspect(name string) (*types.Volume, error) {
 	if err != nil {
 		return nil, err
 	}
-	return volumeToAPIType(v), nil
+	apiV := volumeToAPIType(v)
+	apiV.Mountpoint = v.Path()
+	return apiV, nil
 }
 
 func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Settings) *v1p20.NetworkSettings {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -491,7 +491,15 @@ func (daemon *Daemon) Volumes(filter string) ([]*types.Volume, []string, error) 
 		return nil, nil, err
 	}
 	for _, v := range filterVolumes {
-		volumesOut = append(volumesOut, volumeToAPIType(v))
+		apiV := volumeToAPIType(v)
+		if vv, ok := v.(interface {
+			CachedPath() string
+		}); ok {
+			apiV.Mountpoint = vv.CachedPath()
+		} else {
+			apiV.Mountpoint = v.Path()
+		}
+		volumesOut = append(volumesOut, apiV)
 	}
 	return volumesOut, warnings, nil
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -25,9 +25,8 @@ type mounts []container.Mount
 // volumeToAPIType converts a volume.Volume to the type used by the remote API
 func volumeToAPIType(v volume.Volume) *types.Volume {
 	tv := &types.Volume{
-		Name:       v.Name(),
-		Driver:     v.DriverName(),
-		Mountpoint: v.Path(),
+		Name:   v.Name(),
+		Driver: v.DriverName(),
 	}
 	if v, ok := v.(interface {
 		Labels() map[string]string

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -88,11 +88,14 @@ func (a *volumeAdapter) DriverName() string {
 }
 
 func (a *volumeAdapter) Path() string {
-	if len(a.eMount) > 0 {
-		return a.eMount
+	if len(a.eMount) == 0 {
+		a.eMount, _ = a.proxy.Path(a.name)
 	}
-	m, _ := a.proxy.Path(a.name)
-	return m
+	return a.eMount
+}
+
+func (a *volumeAdapter) CachedPath() string {
+	return a.eMount
 }
 
 func (a *volumeAdapter) Mount() (string, error) {
@@ -102,5 +105,9 @@ func (a *volumeAdapter) Mount() (string, error) {
 }
 
 func (a *volumeAdapter) Unmount() error {
-	return a.proxy.Unmount(a.name)
+	err := a.proxy.Unmount(a.name)
+	if err == nil {
+		a.eMount = ""
+	}
+	return err
 }


### PR DESCRIPTION
Implements a `CachedPath` function on the volume plugin adapter that we
call from the volume list function instead of `Path`.
If a driver does not implement `CachedPath` it will just call `Path`.

Also makes sure we store the path on Mount and remove the path on
Unmount.

Closes #20062
