### PR TITLE
Windows: Fix Hyper-V container ACLs for TP5

### DIFF
--- a/daemon/graphdriver/windows/windows_windows_test.go
+++ b/daemon/graphdriver/windows/windows_windows_test.go
@@ -1,0 +1,18 @@
+package windows
+
+import "testing"
+
+func TestAddAceToSddlDacl(t *testing.T) {
+	cases := [][3]string{
+		{"D:", "(A;;;)", "D:(A;;;)"},
+		{"D:(A;;;)", "(A;;;)", "D:(A;;;)"},
+		{"O:D:(A;;;stuff)", "(A;;;new)", "O:D:(A;;;new)(A;;;stuff)"},
+		{"O:D:(D;;;no)(A;;;stuff)", "(A;;;new)", "O:D:(D;;;no)(A;;;new)(A;;;stuff)"},
+	}
+
+	for _, c := range cases {
+		if newSddl, worked := addAceToSddlDacl(c[0], c[1]); !worked || newSddl != c[2] {
+			t.Errorf("%s + %s == %s, expected %s (%v)", c[0], c[1], newSddl, c[2], worked)
+		}
+	}
+}


### PR DESCRIPTION
In TP5, Hyper-V containers need all image files ACLed so that the virtual machine process can access them. This was fixed post-TP5 in Windows, but for TP5 we need to explicitly add these ACLs.

This change sets the ACLs appropriately. These changes can be removed once a build after TP5 is available.

Signed-off-by: John Starks jostarks@microsoft.com

@jhowardmsft @swernli 
