### PR TITLE
v1.11.0: Bump containerd to enable docker run on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -191,7 +191,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -208,7 +208,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -84,7 +84,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -209,7 +209,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -188,7 +188,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -40,7 +40,7 @@ RUN set -x \
 	&& cp runc /usr/local/bin/docker-runc
 
 # Install containerd
-ENV CONTAINERD_COMMIT d2f03861c91edaafdcb3961461bf82ae83785ed7
+ENV CONTAINERD_COMMIT 10e3a6f9b5f0a15f45d2d44aa81f620fb59f0671
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone git://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
bump conainerd to enable docker run on arm64. we have already run docker-1.10 on arm64, if upgrade to 1.11, it failed to run because the containerd use `epoll` syscall which is not implement on
arm64. we work a workaround to enable containerd to rum on arm64 https://github.com/docker/containerd/pull/186

ping @tiborvass 

this include https://github.com/docker/containerd/commit/d2f03861c91edaafdcb3961461bf82ae83785ed7 to 
https://github.com/docker/containerd/commit/d34c458529afdbe0d85065d5d9b801ef5e9c94df

maybe it's too late since v1.11.0 is on the way.

**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Lei Jitang leijitang@huawei.com
