### PR TITLE
Manually do recursive bind mount instead of rbind one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,7 +248,8 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT 6c88a526cdd74aab90cc88018368c452c7294a06
+# WIP: Modified RUNC_COMMIT to latest version, do not merge this (blocked by #21942)
+ENV RUNC_COMMIT 445d184c81685337fd640fc3da930244ae3c8e95
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -238,12 +238,7 @@ func (daemon *Daemon) mountVolumes(container *container.Container) error {
 			return err
 		}
 
-		opts := "rbind,ro"
-		if m.Writable {
-			opts = "rbind,rw"
-		}
-
-		if err := mount.Mount(m.Source, dest, "bind", opts); err != nil {
+		if err := mount.BindTree(m.Source, dest, m.Writable); err != nil {
 			return err
 		}
 	}
@@ -342,7 +337,7 @@ func getDevicesFromPath(deviceMapping containertypes.DeviceMapping) (devs []spec
 }
 
 func detachMounted(path string) error {
-	return syscall.Unmount(path, syscall.MNT_DETACH)
+	return mount.UnbindTree(path)
 }
 
 func isLinkable(child *container.Container) bool {

--- a/pkg/mount/bindtree_linux.go
+++ b/pkg/mount/bindtree_linux.go
@@ -1,0 +1,116 @@
+// +build linux
+
+package mount
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+)
+
+// BindTree bind-mounts the tree recursively.
+// See also docker/docker#20670.
+func BindTree(source, dest string, rw bool) error {
+	mounts, err := GetMounts()
+	if err != nil {
+		return err
+	}
+	opts := "bind,ro"
+	if rw {
+		opts = "bind,rw"
+	}
+	f := func(source, dest string) error {
+		return Mount(source, dest, "bind", opts)
+	}
+	// the function is split for ease of mocking.
+	return bindTree(mounts, source, dest, f)
+}
+
+func bindTree(mounts []*Info, source, dest string,
+	f func(source, dest string) error) error {
+	// sort the mounts in top-down order, using the number of '/' in m.Mountpoint
+	sort.Sort(mountsByNumSep(mounts))
+	hitSource := false
+	for _, m := range mounts {
+		if m.Mountpoint == source {
+			hitSource = true
+		}
+		// typically m.Mountpoint="/dev/pts" (or just match the source),
+		// source="/dev", dest="/var/lib/docker/overlay/foobar/merged/dev"
+		if !strings.HasPrefix(m.Mountpoint, source) {
+			continue
+		}
+		childSource := m.Mountpoint
+		childDest := filepath.Join(filepath.Dir(dest), m.Mountpoint)
+		if err := f(childSource, childDest); err != nil {
+			return err
+		}
+
+	}
+	if !hitSource {
+		if err := f(source, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnbindTree unmounts the bind-mounted tree recursively.
+func UnbindTree(dest string) error {
+	mounts, err := GetMounts()
+	if err != nil {
+		return err
+	}
+	f := func(dest string) error {
+		// should we move MNT_DETACH to elsewhere?
+		return syscall.Unmount(dest, syscall.MNT_DETACH)
+	}
+	// the function is split for ease of mocking,
+	return unbindTree(mounts, dest, f)
+}
+
+func unbindTree(mounts []*Info, dest string,
+	f func(dest string) error) error {
+	// sort the mounts in bottom-up order, using the number of '/' in m.Mountpoint
+	sort.Sort(sort.Reverse(mountsByNumSep(mounts)))
+	hitDest := false
+	for _, m := range mounts {
+		if m.Mountpoint == dest {
+			hitDest = true
+		}
+		// typically dest="/var/lib/docker/overlay/foobar/merged/dev"
+		// m.Mountpoint="/var/lib/docker/overlay/foobar/merged/dev/pts"
+		// (or just match the dest)
+		if !strings.HasPrefix(m.Mountpoint, dest) {
+			continue
+		}
+
+		if err := f(m.Mountpoint); err != nil {
+			return err
+		}
+	}
+	if !hitDest {
+		if err := f(dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type mountsByNumSep []*Info
+
+func (mounts mountsByNumSep) Len() int {
+	return len(mounts)
+}
+
+func (mounts mountsByNumSep) Swap(i, j int) {
+	mounts[i], mounts[j] = mounts[j], mounts[i]
+}
+
+func (mounts mountsByNumSep) Less(i, j int) bool {
+	sep := "/"
+	c := strings.Count(mounts[i].Mountpoint, sep)
+	d := strings.Count(mounts[j].Mountpoint, sep)
+	return c < d
+}


### PR DESCRIPTION
**\- What I did**

Fixed #20670 

**\- How I did it**

Use `bind` instead of `rbind` as the mount option.

**\- How to verify it**

Start the daemon _without_ the systemd option `MountFlags=slave`, and verifies that `/dev/pts` is kept.

```
$ docker run -it --name test_container -v /dev/:/dev/ busybox
$ docker cp test_container:/bin/sh /tmp
$ mount |grep pts
```

**\- Notes**
- Dockerfile is unmergeable, should be replaced by (#21942)
- Perhaps the content of `bindtree_linux.go` should be moved to `daemon/container_operations_unix.go`

Signed-off-by: Akihiro Suda suda.kyoto@gmail.com
