### PR TITLE
Don't throw "restartmanager canceled" error for no restart policy container

### DIFF
--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -120,7 +120,7 @@ func (ctr *container) handleEvent(e *containerd.Event) error {
 		if st.State == StateExit && ctr.restartManager != nil {
 			restart, wait, err := ctr.restartManager.ShouldRestart(e.Status, false)
 			if err != nil {
-				logrus.Error(err)
+				logrus.Warnf("container %s %v", ctr.containerID, err)
 			} else if restart {
 				st.State = StateRestart
 				ctr.restarting = true

--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -42,6 +42,9 @@ func (rm *restartManager) SetPolicy(policy container.RestartPolicy) {
 }
 
 func (rm *restartManager) ShouldRestart(exitCode uint32, hasBeenManuallyStopped bool) (bool, chan error, error) {
+	if rm.policy.IsNone() {
+		return false, nil, nil
+	}
 	rm.Lock()
 	unlockOnExit := true
 	defer func() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Don't throw "restartmanager canceled" error for no restart policy container
or else if kill a no restart policy container, there is a error log 
`ERRO[0024] restartmanager canceled`

and add the container id to the warning message if a container has restart policy
and make error log to warn log

ping @tonistiigi 
**\- How I did it**

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Lei Jitang leijitang@huawei.com
