### PR TITLE
Fix panic on winsize syscall

### DIFF
--- a/pkg/term/term.go
+++ b/pkg/term/term.go
@@ -27,6 +27,8 @@ type State struct {
 type Winsize struct {
 	Height uint16
 	Width  uint16
+	x      uint16
+	y      uint16
 }
 
 // StdStreams returns the standard streams (stdin, stdout, stedrr).


### PR DESCRIPTION
This code was removed in https://github.com/docker/docker/pull/21694 but it's not really unused as this struct is passed to the syscall.

I noticed it because when building with go1.6 this caused a panic on `docker pull`.

cc @LK4D4 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
