### PR TITLE
Add a check for size field in custom format string

### DIFF
--- a/api/client/formatter/formatter.go
+++ b/api/client/formatter/formatter.go
@@ -98,7 +98,8 @@ func (c *Context) contextFormat(tmpl *template.Template, subContext subContext) 
 type ContainerContext struct {
 	Context
 	// Size when set to true will display the size of the output.
-	Size bool
+	Size            bool
+	SizeSetByFormat bool
 	// Containers
 	Containers []types.Container
 }
@@ -129,19 +130,19 @@ created_at: {{.CreatedAt}}
 status: {{.Status}}
 names: {{.Names}}
 labels: {{.Labels}}
-ports: {{.Ports}}
-`
-			if ctx.Size {
-				ctx.Format += `size: {{.Size}}
-`
-			}
+ports: {{.Ports}}`
 		}
 	}
 
 	ctx.buffer = bytes.NewBufferString("")
 	ctx.preformat()
-	if ctx.table && ctx.Size {
-		ctx.finalFormat += "\t{{.Size}}"
+	if ctx.Size && !ctx.SizeSetByFormat {
+		if ctx.table {
+			ctx.finalFormat += "\t{{.Size}}"
+		} else {
+			ctx.finalFormat += `
+size: {{.Size}}`
+		}
 	}
 
 	tmpl, err := ctx.parseFormat()

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -787,3 +787,20 @@ func (s *DockerSuite) TestPsShowMounts(c *check.C) {
 	out, _ = dockerCmd(c, "ps", "--format", "{{.Names}} {{.Mounts}}", "--filter", "volume="+prefix+slash+"this-path-was-never-mounted")
 	c.Assert(strings.TrimSpace(string(out)), checker.HasLen, 0)
 }
+
+func (s *DockerSuite) TestPsFormatSize(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	runSleepingContainer(c)
+
+	out, _ := dockerCmd(c, "ps", "--format", "table {{.Size}}")
+	lines := strings.Split(out, "\n")
+	c.Assert(lines[1], checker.Not(checker.Equals), "0 B", check.Commentf("Should not display a size of 0 B"))
+
+	out, _ = dockerCmd(c, "ps", "--size", "--format", "table {{.Size}}")
+	lines = strings.Split(out, "\n")
+	c.Assert(lines[0], checker.Equals, "SIZE", check.Commentf("Should only have one size column"))
+
+	out, _ = dockerCmd(c, "ps", "--size", "--format", " ")
+	lines = strings.Split(out, "\n")
+	c.Assert(lines[1], checker.HasPrefix, "size:", check.Commentf("Size should be appended on a newline"))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
This fix addresses an issue where including the `{{.Size}}` format
field in conjunction with `docker ps --format`, without the `--size`
flag, would not correctly display the size of containers.

**\- How I did it**
This is done by doing a check on the custom format string, and setting
the size flag on the options struct if the field is found. This struct
gets passed to the engine API which then generates the correct query.

**\- How to verify it**
An integration test is included which runs `docker ps --format table`
`{{.Size}}` without `--size`, and checks that the returned output is
not `0 B`.

**\- A picture of a cute animal (not mandatory but encouraged)**
![Baby penguin](https://s-media-cache-ak0.pinimg.com/236x/ce/eb/92/ceeb92ff02869506c45878d00f8f651a.jpg)

Fixes #21991

As suggested by @cpuguy83, a parser is implemented to process the format
string as a template, and then traverses the template tree to determine
if `.Size` was called.

This was then reworked by making use of template execution with a
pre-processor struct that will set the `--size` option if the template
calls for the field.

The pre-processor now also sets a boolean in the context passed to the
writer. There is an integration test for this that calls `docker ps`
`--size --format "{{.Size}}"` and then checks that `size: {{.Size}}` is
not appended, as it would with previous behavior.

Signed-off-by: Paulo Ribeiro paigr.io@gmail.com
