### PR TITLE
Update changelog in master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,15 +79,29 @@ be found.
 
 - Fix panic if a node is forcibly removed from the cluster ([#21671](https://github.com/docker/docker/pull/21671))
 - Fix "error creating vxlan interface" when starting a container in a Swarm cluster ([#21671](https://github.com/docker/docker/pull/21671))
-- Fix a bug where IPv6 addresses were not properly handled ([#20842](https://github.com/docker/docker/pull/20842))
 * `docker network inspect` will now report all endpoints whether they have an active container or not ([#21160](https://github.com/docker/docker/pull/21160))
 + Experimental support for the MacVlan and IPVlan network drivers have been added ([#21122](https://github.com/docker/docker/pull/21122))
 * Output of `docker network ls` is now sorted by network name ([#20383](https://github.com/docker/docker/pull/20383))
 - Fix a bug where Docker would allow a network to be created with the reserved `default` name ([#19431](https://github.com/docker/docker/pull/19431))
-* `docker network inspect` now returns whether a network is internal or not ([#19357](https://github.com/docker/docker/pull/19357))
+* `docker network inspect` returns whether a network is internal or not ([#19357](https://github.com/docker/docker/pull/19357))
 + Control IPv6 via explicit option when creating a network (`docker network create --ipv6`). This shows up as a new `EnableIPv6` field in `docker network inspect` ([#17513](https://github.com/docker/docker/pull/17513))
-* Support for AAAA Records (aka IPv6 Service Discovery) in embedded DNS Server [#21396](https://github.com/docker/docker/pull/21396)
-* Multiple A/AAAA records from embedded DNS Server for DNS Round robin [#21019](https://github.com/docker/docker/pull/21019)
+* Support for AAAA Records (aka IPv6 Service Discovery) in embedded DNS Server ([#21396](https://github.com/docker/docker/pull/21396))
+- Fix to not forward docker domain IPv6 queries to external servers ([#21396](https://github.com/docker/docker/pull/21396))
+* Multiple A/AAAA records from embedded DNS Server for DNS Round robin ([#21019](https://github.com/docker/docker/pull/21019))
+- Fix endpoint count inconsistency after an ungraceful dameon restart ([#21261](https://github.com/docker/docker/pull/21261))
+- Move the ownership of exposed ports and port-mapping options from Endpoint to Sandbox ([#21019](https://github.com/docker/docker/pull/21019))
+- Fixed a bug which prevents docker reload when host is configured with ipv6.disable=1 ([#21019](https://github.com/docker/docker/pull/21019))
+- Added inbuilt nil IPAM driver ([#21019](https://github.com/docker/docker/pull/21019))
+- Fixed bug in iptables.Exists() logic [#21019](https://github.com/docker/docker/pull/21019)
+- Fixed a Veth interface leak when using overlay network ([#21019](https://github.com/docker/docker/pull/21019))
+- Fixed a bug which prevents docker reload after a network delete during shutdown ([#20214](https://github.com/docker/docker/pull/20214))
+- Make sure iptables chains are recreated on firewalld reload ([#20419](https://github.com/docker/docker/pull/20419))
+- Allow to pass global datastore during config reload ([#20419](https://github.com/docker/docker/pull/20419))
+- For anonymous containers use the alias name for IP to name mapping, ie:DNS PTR record ([#21019](https://github.com/docker/docker/pull/21019))
+- Fix a panic when deleting an entry from /etc/hosts file  ([#21019](https://github.com/docker/docker/pull/21019))
+- Source the forwarded DNS queries from the container net namespace  ([#21019](https://github.com/docker/docker/pull/21019))
+- Fix to retain the network internal mode config for bridge networks on daemon reload ([#21780] (https://github.com/docker/docker/pull/21780))
+- Fix to retain ipam driver option configs on daemon reload ([#21914] (https://github.com/docker/docker/pull/21914))
 
 ### Plugins
 
@@ -128,6 +142,7 @@ be found.
 * `docker inspect` now also returns a new `State` field containing the container state in a human readable way (i.e. one of `created`, `restarting`, `running`, `paused`, `exited` or `dead`)([#18966](https://github.com/docker/docker/pull/18966))
 + Docker learned to limit the number of active pids (i.e. processes) within the container via the `pids-limit` flags. NOTE: This requires `CGROUP_PIDS=y` to be in the kernel configuration. ([#18697](https://github.com/docker/docker/pull/18697))
 - `docker load` now has a `--quiet` option to suppress the load output ([#20078](https://github.com/docker/docker/pull/20078))
+- Fix a bug in neighbor discovery for IPv6 peers ([#20842](https://github.com/docker/docker/pull/20842))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,6 @@ be found.
 
 - Fix panic if a node is forcibly removed from the cluster ([#21671](https://github.com/docker/docker/pull/21671))
 - Fix "error creating vxlan interface" when starting a container in a Swarm cluster ([#21671](https://github.com/docker/docker/pull/21671))
-- Fix `host` and `none` networks to disappear until restart when SIGHUP is used to reload cluster configuration ([#21671](https://github.com/docker/docker/pull/21671))
 - Fix a bug where IPv6 addresses were not properly handled ([#20842](https://github.com/docker/docker/pull/20842))
 * `docker network inspect` will now report all endpoints whether they have an active container or not ([#21160](https://github.com/docker/docker/pull/21160))
 + Experimental support for the MacVlan and IPVlan network drivers have been added ([#21122](https://github.com/docker/docker/pull/21122))
@@ -102,7 +101,6 @@ be found.
 - Fix race conditions in the layer store, potentially corrupting the map and crashing the process ([#21677](https://github.com/docker/docker/pull/21677))
 - Un-deprecate auto-creation of host directories for mounts. This feature was marked deprecated in ([#21666](https://github.com/docker/docker/pull/21666))  
   Docker 1.9, but was decided to be too much of an backward-incompatible change, so it was decided to keep the feature.
-- Fix an issue where parallel aufs mount calls produce invalid argument error ([#21552](https://github.com/docker/docker/pull/21552))
 + It is now possible for containers to share the NET and IPC namespaces when `userns` is enabled ([#21383](https://github.com/docker/docker/pull/21383))
 + `docker inspect <image-id>` will now expose the rootfs layers ([#21370](https://github.com/docker/docker/pull/21370))
 + Docker Windows gained a minimal `top` implementation ([#21354](https://github.com/docker/docker/pull/21354))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
 
-## 1.11.0 (2016-04-12)
+## 1.11.0 (2016-04-13)
 
 **IMPORTANT**: With Docker 1.11, a Linux docker installation is now made of 4 binaries (`docker`, [`docker-containerd`](https://github.com/docker/containerd), [`docker-containerd-shim`](https://github.com/docker/containerd) and [`docker-runc`](https://github.com/opencontainers/runc)). If you have scripts relying on docker being a single static binaries, please make sure to update them. Interaction with the daemon stay the same otherwise, the usage of the other binaries should be transparent. A Windows docker installation remains a single binary, `docker.exe`.
 
 ### Builder
 
-- Fix docker not sending credentials during build if content trust is enabled ([#21693](https://github.com/docker/docker/pull/21693))
 - Fix a bug where Docker would not used the correct uid/gid when processing the `WORKDIR` command ([#21033](https://github.com/docker/docker/pull/21033))
 - Fix a bug where copy operations with userns would not use the proper uid/gid ([#20782](https://github.com/docker/docker/pull/20782), [#21162](https://github.com/docker/docker/pull/21162))
 
@@ -37,7 +36,6 @@ be found.
 
 ### Distribution
 
-- Fix the download manager closing the tempfile twice ([#21676](https://github.com/docker/docker/pull/21676))
 - Fix a panic that occurred when pulling an images with 0 layers ([#21222](https://github.com/docker/docker/pull/21222))
 - Fix a panic that could occur on error while pushing to a registry with a misconfigured token service ([#21212](https://github.com/docker/docker/pull/21212))
 + All first-level delegation roles are now signed when doing a trusted push ([#21046](https://github.com/docker/docker/pull/21046))
@@ -47,6 +45,7 @@ be found.
 * Docker will now fallback to registry V1 if no basic auth credentials are available ([#20241](https://github.com/docker/docker/pull/20241))
 * Docker will now try to resume layer download where it left off after a network error/timeout ([#19840](https://github.com/docker/docker/pull/19840))
 - Fix generated manifest mediaType when pushing cross-repository ([#19509](https://github.com/docker/docker/pull/19509))
+- Fix docker requesting additional push credentials when pulling an image if Content Trust is enabled ([#20382](https://github.com/docker/docker/pull/20382))
 
 ### Logging
 
@@ -101,7 +100,7 @@ be found.
 - Fix a panic when deleting an entry from /etc/hosts file  ([#21019](https://github.com/docker/docker/pull/21019))
 - Source the forwarded DNS queries from the container net namespace  ([#21019](https://github.com/docker/docker/pull/21019))
 - Fix to retain the network internal mode config for bridge networks on daemon reload ([#21780] (https://github.com/docker/docker/pull/21780))
-- Fix to retain ipam driver option configs on daemon reload ([#21914] (https://github.com/docker/docker/pull/21914))
+- Fix to retain IPAM driver option configs on daemon reload ([#21914] (https://github.com/docker/docker/pull/21914))
 
 ### Plugins
 
@@ -143,12 +142,16 @@ be found.
 + Docker learned to limit the number of active pids (i.e. processes) within the container via the `pids-limit` flags. NOTE: This requires `CGROUP_PIDS=y` to be in the kernel configuration. ([#18697](https://github.com/docker/docker/pull/18697))
 - `docker load` now has a `--quiet` option to suppress the load output ([#20078](https://github.com/docker/docker/pull/20078))
 - Fix a bug in neighbor discovery for IPv6 peers ([#20842](https://github.com/docker/docker/pull/20842))
+- Fix a panic during cleanup if a container was started with invalid options ([#21802](https://github.com/docker/docker/pull/21802))
+- Fix a situation where a container cannot be stopped if the terminal is closed ([#21840](https://github.com/docker/docker/pull/21840))
 
 ### Security
 
 * Object with the `pcp_pmcd_t` selinux type were given management access to `/var/lib/docker(/.*)?` ([#21370](https://github.com/docker/docker/pull/21370))
 * `restart_syscall`, `copy_file_range`, `mlock2` joined the list of allowed calls in the default seccomp profile ([#21117](https://github.com/docker/docker/pull/21117), [#21262](https://github.com/docker/docker/pull/21262))
 * `send`, `recv` and `x32` were added to the list of allowed syscalls and arch in the default seccomp profile ([#19432](https://github.com/docker/docker/pull/19432))
+* Docker Content Trust now requests the server to perform snapshot signing ([#21046](https://github.com/docker/docker/pull/21046))
+* Support for using YubiKeys for Content Trust signing has been moved out of experimental ([#21591](https://github.com/docker/docker/pull/21591))
 
 ### Volumes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,6 @@ be found.
 - Fix an issue where registry service options in the daemon configuration file were not properly taken into account ([#21045](https://github.com/docker/docker/pull/21045))
 - Fix a race between the exec and resize operations ([#21022](https://github.com/docker/docker/pull/21022))
 - Fix an issue where nanoseconds were not correctly taken in account when filtering Docker events ([#21013](https://github.com/docker/docker/pull/21013))
-+ pkcs11 hardware signing is no longer an experimental feature  ([#21003](https://github.com/docker/docker/pull/21003))
 - Fix the handling of Docker command when passed a 64 bytes id ([#21002](https://github.com/docker/docker/pull/21002))
 * Docker will now return a `204` (i.e http.StatusNoContent) code when it successfully deleted a network ([#20977](https://github.com/docker/docker/pull/20977))
 - Fix a bug where the daemon would wait indefinitely in case the process it was about to killed had already exited on its own ([#20967](https://github.com/docker/docker/pull/20967)
@@ -119,6 +118,7 @@ be found.
 * `docker update` learned how to change a container restart policy ([#19116](https://github.com/docker/docker/pull/19116))
 * `docker inspect` now also returns a new `State` field containing the container state in a human readable way (i.e. one of `created`, `restarting`, `running`, `paused`, `exited` or `dead`)([#18966](https://github.com/docker/docker/pull/18966))
 + Docker learned to limit the number of active pids (i.e. processes) within the container via the `pids-limit` flags. NOTE: This requires `CGROUP_PIDS=y` to be in the kernel configuration. ([#18697](https://github.com/docker/docker/pull/18697))
+- `docker load` now has a `--quiet` option to suppress the load output ([#20078](https://github.com/docker/docker/pull/20078))
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ be found.
 
 ### Builder
 
+- Fix docker not sending credentials during build if content trust is enabled ([#21693](https://github.com/docker/docker/pull/21693))
 - Fix a bug where Docker would not used the correct uid/gid when processing the `WORKDIR` command ([#21033](https://github.com/docker/docker/pull/21033))
 - Fix a bug where copy operations with userns would not use the proper uid/gid ([#20782](https://github.com/docker/docker/pull/20782), [#21162](https://github.com/docker/docker/pull/21162))
 
@@ -36,6 +37,7 @@ be found.
 
 ### Distribution
 
+- Fix the download manager closing the tempfile twice ([#21676](https://github.com/docker/docker/pull/21676))
 - Fix a panic that occurred when pulling an images with 0 layers ([#21222](https://github.com/docker/docker/pull/21222))
 - Fix a panic that could occur on error while pushing to a registry with a misconfigured token service ([#21212](https://github.com/docker/docker/pull/21212))
 + All first-level delegation roles are now signed when doing a trusted push ([#21046](https://github.com/docker/docker/pull/21046))
@@ -75,6 +77,9 @@ be found.
 
 ### Networking
 
+- Fix panic if a node is forcibly removed from the cluster ([#21671](https://github.com/docker/docker/pull/21671))
+- Fix "error creating vxlan interface" when starting a container in a Swarm cluster ([#21671](https://github.com/docker/docker/pull/21671))
+- Fix `host` and `none` networks to disappear until restart when SIGHUP is used to reload cluster configuration ([#21671](https://github.com/docker/docker/pull/21671))
 - Fix a bug where IPv6 addresses were not properly handled ([#20842](https://github.com/docker/docker/pull/20842))
 * `docker network inspect` will now report all endpoints whether they have an active container or not ([#21160](https://github.com/docker/docker/pull/21160))
 + Experimental support for the MacVlan and IPVlan network drivers have been added ([#21122](https://github.com/docker/docker/pull/21122))
@@ -92,6 +97,12 @@ be found.
 
 ### Runtime
 
+- Fix a panic that could occur when cleanup after a container started with invalid parameters ([#21716](https://github.com/docker/docker/pull/21716))
+- Fix a race with event timers stopping early ([#21692](https://github.com/docker/docker/pull/21692))
+- Fix race conditions in the layer store, potentially corrupting the map and crashing the process ([#21677](https://github.com/docker/docker/pull/21677))
+- Un-deprecate auto-creation of host directories for mounts. This feature was marked deprecated in ([#21666](https://github.com/docker/docker/pull/21666))  
+  Docker 1.9, but was decided to be too much of an backward-incompatible change, so it was decided to keep the feature.
+- Fix an issue where parallel aufs mount calls produce invalid argument error ([#21552](https://github.com/docker/docker/pull/21552))
 + It is now possible for containers to share the NET and IPC namespaces when `userns` is enabled ([#21383](https://github.com/docker/docker/pull/21383))
 + `docker inspect <image-id>` will now expose the rootfs layers ([#21370](https://github.com/docker/docker/pull/21370))
 + Docker Windows gained a minimal `top` implementation ([#21354](https://github.com/docker/docker/pull/21354))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ be found.
 
 ## 1.11.0 (2016-04-12)
 
-**IMPORTANT**: With Docker 1.11, a docker installation is now made of 4 binaries (`docker`, [`docker-containerd`](https://github.com/docker/containerd), [`docker-containerd-shim`](https://github.com/docker/containerd) and [`docker-runc`](https://github.com/opencontainers/runc)). If you have scripts relying on docker being a single static binaries, please make sure to update them. Interaction with the daemon stay the same otherwise, the usage of the other binaries should be transparent.
+**IMPORTANT**: With Docker 1.11, a Linux docker installation is now made of 4 binaries (`docker`, [`docker-containerd`](https://github.com/docker/containerd), [`docker-containerd-shim`](https://github.com/docker/containerd) and [`docker-runc`](https://github.com/opencontainers/runc)). If you have scripts relying on docker being a single static binaries, please make sure to update them. Interaction with the daemon stay the same otherwise, the usage of the other binaries should be transparent. A Windows docker installation remains a single binary, `docker.exe`.
 
 ### Builder
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,136 @@
 
 Items starting with `DEPRECATE` are important deprecation notices. For more
 information on the list of deprecated flags and APIs please have a look at
-https://docs.docker.com/misc/deprecated/ where target removal dates can also
+https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
+
+## 1.11.0 (2016-04-12)
+
+**IMPORTANT**: With Docker 1.11, a docker installation is now made of 4 binaries (`docker`, [`docker-containerd`](https://github.com/docker/containerd), [`docker-containerd-shim`](https://github.com/docker/containerd) and [`docker-runc`](https://github.com/opencontainers/runc)). If you have scripts relying on docker being a single static binaries, please make sure to update them. Interaction with the daemon stay the same otherwise, the usage of the other binaries should be transparent.
+
+### Builder
+
+- Fix a bug where Docker would not used the correct uid/gid when processing the `WORKDIR` command ([#21033](https://github.com/docker/docker/pull/21033))
+- Fix a bug where copy operations with userns would not use the proper uid/gid ([#20782](https://github.com/docker/docker/pull/20782), [#21162](https://github.com/docker/docker/pull/21162))
+
+### Client
+
+* Usage of the `:` separator for security option has been deprecated. `=` should be used instead ([#21232](https://github.com/docker/docker/pull/21232))
++ The client user agent is now passed to the registry on `pull`, `build`, `push`, `login` and `search` operations ([#21306](https://github.com/docker/docker/pull/21306), [#21373](https://github.com/docker/docker/pull/21373))
+* Allow setting the Domainname and Hostname separately through the API ([#20200](https://github.com/docker/docker/pull/20200))
+* Docker info will now warn users if it can not detect the kernel version or the operating system ([#21128](https://github.com/docker/docker/pull/21128))
+- Fix an issue where `docker stats --no-stream` output could be all 0s ([#20803](https://github.com/docker/docker/pull/20803))
+- Fix a bug where some newly started container would not appear in a running `docker stats` command ([#20792](https://github.com/docker/docker/pull/20792))
+* Post processing is no longer enabled for linux-cgo terminals ([#20587](https://github.com/docker/docker/pull/20587))
+- Values to `--hostname` are now refused if they do not comply with [RFC1123](https://tools.ietf.org/html/rfc1123) ([#20566](https://github.com/docker/docker/pull/20566))
++ Docker learned how to use a SOCKS proxy ([#20366](https://github.com/docker/docker/pull/20366), [#18373](https://github.com/docker/docker/pull/18373))
++ Docker now supports external credential stores ([#20107](https://github.com/docker/docker/pull/20107))
+* `docker ps` now supports displaying the list of volumes mounted inside a container ([#20017](https://github.com/docker/docker/pull/20017))
+* `docker info` now also report Docker's root directory location ([#19986](https://github.com/docker/docker/pull/19986))
+- Docker now prohibits login in with an empty username (spaces are trimmed) ([#19806](https://github.com/docker/docker/pull/19806))
+* Docker events attributes are now sorted by key ([#19761](https://github.com/docker/docker/pull/19761))
+* `docker ps` no longer show exported port for stopped containers ([#19483](https://github.com/docker/docker/pull/19483))
+- Docker now cleans after itself if a save/export command fails ([#17849](https://github.com/docker/docker/pull/17849))
+* Docker load learned how to display a progress bar ([#17329](https://github.com/docker/docker/pull/17329), [#120078](https://github.com/docker/docker/pull/20078))
+
+### Distribution
+
+- Fix a panic that occurred when pulling an images with 0 layers ([#21222](https://github.com/docker/docker/pull/21222))
+- Fix a panic that could occur on error while pushing to a registry with a misconfigured token service ([#21212](https://github.com/docker/docker/pull/21212))
++ All first-level delegation roles are now signed when doing a trusted push ([#21046](https://github.com/docker/docker/pull/21046))
++ OAuth support for registries was added ([#20970](https://github.com/docker/docker/pull/20970))
+* `docker login` now handles token using the implementation found in [docker/distribution](https://github.com/docker/distribution) ([#20832](https://github.com/docker/docker/pull/20832))
+* `docker login` will no longer prompt for an email ([#20565](https://github.com/docker/docker/pull/20565))
+* Docker will now fallback to registry V1 if no basic auth credentials are available ([#20241](https://github.com/docker/docker/pull/20241))
+* Docker will now try to resume layer download where it left off after a network error/timeout ([#19840](https://github.com/docker/docker/pull/19840))
+- Fix generated manifest mediaType when pushing cross-repository ([#19509](https://github.com/docker/docker/pull/19509))
+
+### Logging
+
+- Fix a race in the journald log driver ([#21311](https://github.com/docker/docker/pull/21311))
+* Docker syslog driver now uses the RFC-5424 format when emitting logs ([#20121](https://github.com/docker/docker/pull/20121))
+* Docker GELF log driver now allows to specify the compression algorithm and level via the `gelf-compression-type` and `gelf-compression-level` options ([#19831](https://github.com/docker/docker/pull/19831))
+* Docker daemon learned to output uncolorized logs via the `--raw-logs` options ([#19794](https://github.com/docker/docker/pull/19794))
++ Docker, on Windows platform, now includes an ETW (Event Tracing in Windows) logging driver named `etwlogs` ([#19689](https://github.com/docker/docker/pull/19689))
+* Journald log driver learned how to handle tags ([#19564](https://github.com/docker/docker/pull/19564))
++ The fluentd log driver learned the following options: `fluentd-address`, `fluentd-buffer-limit`, `fluentd-retry-wait`, `fluentd-max-retries` and `fluentd-async-connect` ([#19439](https://github.com/docker/docker/pull/19439))
++ Docker learned to send log to Google Cloud via the new `gcplogs` logging driver. ([#18766](https://github.com/docker/docker/pull/18766))
+
+
+### Misc
+
++ When saving linked images together with `docker save` a subsequent `docker load` will correctly restore their parent/child relationship ([#21385](https://github.com/docker/docker/pull/c))
++ Support for building the Docker cli for OpenBSD was added ([#21325](https://github.com/docker/docker/pull/21325))
++ Labels can now be applied at network, volume and image creation ([#21270](https://github.com/docker/docker/pull/21270))
+* The `dockremap` is now created as a system user ([#21266](https://github.com/docker/docker/pull/21266))
+- Fix a few response body leaks ([#21258](https://github.com/docker/docker/pull/21258))
+- Docker, when run as a service with systemd, will now properly manage its processes cgroups ([#20633](https://github.com/docker/docker/pull/20633))
+* Docker info now reports the value of cgroup KernelMemory or emits a warning if it is not supported ([#20863](https://github.com/docker/docker/pull/20863))
+* Docker info now also reports the cgroup driver in use ([#20388](https://github.com/docker/docker/pull/20388))
+* Docker completion is now available on PowerShell ([#19894](https://github.com/docker/docker/pull/19894))
+* `dockerinit` is no more ([#19490](https://github.com/docker/docker/pull/19490),[#19851](https://github.com/docker/docker/pull/19851))
++ Support for building Docker on arm64 was added ([#19013](https://github.com/docker/docker/pull/19013))
++ Experimental support for building docker.exe in a native Windows Docker installation ([#18348](https://github.com/docker/docker/pull/18348))
+
+### Networking
+
+- Fix a bug where IPv6 addresses were not properly handled ([#20842](https://github.com/docker/docker/pull/20842))
+* `docker network inspect` will now report all endpoints whether they have an active container or not ([#21160](https://github.com/docker/docker/pull/21160))
++ Experimental support for the MacVlan and IPVlan network drivers have been added ([#21122](https://github.com/docker/docker/pull/21122))
+* Output of `docker network ls` is now sorted by network name ([#20383](https://github.com/docker/docker/pull/20383))
+- Fix a bug where Docker would allow a network to be created with the reserved `default` name ([#19431](https://github.com/docker/docker/pull/19431))
+* `docker network inspect` now returns whether a network is internal or not ([#19357](https://github.com/docker/docker/pull/19357))
++ Control IPv6 via explicit option when creating a network (`docker network create --ipv6`). This shows up as a new `EnableIPv6` field in `docker network inspect` ([#17513](https://github.com/docker/docker/pull/17513))
+* Support for AAAA Records (aka IPv6 Service Discovery) in embedded DNS Server [#21396](https://github.com/docker/docker/pull/21396)
+* Multiple A/AAAA records from embedded DNS Server for DNS Round robin [#21019](https://github.com/docker/docker/pull/21019)
+
+### Plugins
+
+- Fix a file descriptor leak that would occur every time plugins were enumerated ([#20686](https://github.com/docker/docker/pull/20686))
+- Fix an issue where Authz plugin would corrupt the payload body when faced with a large amount of data ([#20602](https://github.com/docker/docker/pull/20602))
+
+### Runtime
+
++ It is now possible for containers to share the NET and IPC namespaces when `userns` is enabled ([#21383](https://github.com/docker/docker/pull/21383))
++ `docker inspect <image-id>` will now expose the rootfs layers ([#21370](https://github.com/docker/docker/pull/21370))
++ Docker Windows gained a minimal `top` implementation ([#21354](https://github.com/docker/docker/pull/21354))
+* Docker learned to report the faulty exe when a container cannot be started due to its condition ([#21345](https://github.com/docker/docker/pull/21345))
+* Docker with device mapper will now refuse to run if `udev sync` is not available ([#21097](https://github.com/docker/docker/pull/21097))
+- Fix a bug where Docker would not validate the config file upon configuration reload ([#21089](https://github.com/docker/docker/pull/21089))
+- Fix a hang that would happen on attach if initial start was to fail ([#21048](https://github.com/docker/docker/pull/21048))
+- Fix an issue where registry service options in the daemon configuration file were not properly taken into account ([#21045](https://github.com/docker/docker/pull/21045))
+- Fix a race between the exec and resize operations ([#21022](https://github.com/docker/docker/pull/21022))
+- Fix an issue where nanoseconds were not correctly taken in account when filtering Docker events ([#21013](https://github.com/docker/docker/pull/21013))
++ pkcs11 hardware signing is no longer an experimental feature  ([#21003](https://github.com/docker/docker/pull/21003))
+- Fix the handling of Docker command when passed a 64 bytes id ([#21002](https://github.com/docker/docker/pull/21002))
+* Docker will now return a `204` (i.e http.StatusNoContent) code when it successfully deleted a network ([#20977](https://github.com/docker/docker/pull/20977))
+- Fix a bug where the daemon would wait indefinitely in case the process it was about to killed had already exited on its own ([#20967](https://github.com/docker/docker/pull/20967)
+* The devmapper driver learned the `dm.min_free_space` option. If the mapped device free space reaches the passed value, new device creation will be prohibited. ([#20786](https://github.com/docker/docker/pull/20786))
++ Docker can now prevent processes in container to gain new privileges via the `--security-opt=no-new-privileges` flag ([#20727](https://github.com/docker/docker/pull/20727))
+- Starting a container with the `--device` option will now correctly resolves symlinks ([#20684](https://github.com/docker/docker/pull/20684))
++ Docker now relies on [`containerd`](https://github.com/docker/containerd) and [`runc`](https://github.com/opencontainers/runc) to spawn containers. ([#20662](https://github.com/docker/docker/pull/20662))
+- Fix docker configuration reloading to only alter value present in the given config file ([#20604](https://github.com/docker/docker/pull/20604))
++ Docker now allows setting a container hostname via the `--hostname` flag when `--net=host` ([#20177](https://github.com/docker/docker/pull/20177))
++ Docker now allows executing privileged container while running with `--userns-remap` if both `--privileged` and the new `--userns=host` flag are specified ([#20111](https://github.com/docker/docker/pull/20111))
+- Fix Docker not cleaning up correctly old containers upon restarting after a crash ([#19679](https://github.com/docker/docker/pull/19679))
+* Docker will now error out if it doesn't recognize a configuration key within the config file ([#19517](https://github.com/docker/docker/pull/19517))
+- Fix container loading, on daemon startup, when they depends on a plugin running within a container ([#19500](https://github.com/docker/docker/pull/19500))
+* `docker update` learned how to change a container restart policy ([#19116](https://github.com/docker/docker/pull/19116))
+* `docker inspect` now also returns a new `State` field containing the container state in a human readable way (i.e. one of `created`, `restarting`, `running`, `paused`, `exited` or `dead`)([#18966](https://github.com/docker/docker/pull/18966))
++ Docker learned to limit the number of active pids (i.e. processes) within the container via the `pids-limit` flags. NOTE: This requires `CGROUP_PIDS=y` to be in the kernel configuration. ([#18697](https://github.com/docker/docker/pull/18697))
+
+### Security
+
+* Object with the `pcp_pmcd_t` selinux type were given management access to `/var/lib/docker(/.*)?` ([#21370](https://github.com/docker/docker/pull/21370))
+* `restart_syscall`, `copy_file_range`, `mlock2` joined the list of allowed calls in the default seccomp profile ([#21117](https://github.com/docker/docker/pull/21117), [#21262](https://github.com/docker/docker/pull/21262))
+* `send`, `recv` and `x32` were added to the list of allowed syscalls and arch in the default seccomp profile ([#19432](https://github.com/docker/docker/pull/19432))
+
+### Volumes
+
+* Output of `docker volume ls` is now sorted by volume name ([#20389](https://github.com/docker/docker/pull/20389))
+* Local volumes can now accepts options similar to the unix `mount` tool ([#20262](https://github.com/docker/docker/pull/20262))
+- Fix an issue where one letter directory name could not be used as source for volumes ([#21106](https://github.com/docker/docker/pull/21106))
++ `docker run -v` now accepts a new flag `nocopy`. This tell the runtime not to copy the container path content into the volume (which is the default behavior) ([#21223](https://github.com/docker/docker/pull/21223))
 
 ## 1.10.3 (2016-03-10)
 
@@ -25,9 +153,9 @@ be found.
 
 ### Security
 
-- Fix linux32 emulation to fail during docker build [#20672](https://github.com/docker/docker/pull/20672)  
+- Fix linux32 emulation to fail during docker build [#20672](https://github.com/docker/docker/pull/20672)
   It was due to the `personality` syscall being blocked by the default seccomp profile.
-- Fix Oracle XE 10g failing to start in a container [#20981](https://github.com/docker/docker/pull/20981)  
+- Fix Oracle XE 10g failing to start in a container [#20981](https://github.com/docker/docker/pull/20981)
   It was due to the `ipc` syscall being blocked by the default seccomp profile.
 - Fix user namespaces not working on Linux From Scratch [#20685](https://github.com/docker/docker/pull/20685)
 - Fix issue preventing daemon to start if userns is enabled and the `subuid` or `subgid` files contain comments [#20725](https://github.com/docker/docker/pull/20725)
@@ -113,7 +241,7 @@ Engine 1.10 migrator can be found on Docker Hub: https://hub.docker.com/r/docker
 + Add `--tmpfs` flag to `docker run` to create a tmpfs mount in a container [#13587](https://github.com/docker/docker/pull/13587)
 + Add `--format` flag to `docker images` command [#17692](https://github.com/docker/docker/pull/17692)
 + Allow to set daemon configuration in a file and hot-reload it with the `SIGHUP` signal [#18587](https://github.com/docker/docker/pull/18587)
-+ Updated docker events to include more meta-data and event types [#18888](https://github.com/docker/docker/pull/18888)  
++ Updated docker events to include more meta-data and event types [#18888](https://github.com/docker/docker/pull/18888)
   This change is backward compatible in the API, but not on the CLI.
 + Add `--blkio-weight-device` flag to `docker run` [#13959](https://github.com/docker/docker/pull/13959)
 + Add `--device-read-bps` and `--device-write-bps` flags to `docker run` [#14466](https://github.com/docker/docker/pull/14466)
@@ -148,18 +276,18 @@ Engine 1.10 migrator can be found on Docker Hub: https://hub.docker.com/r/docker
 + Add support for custom seccomp profiles in `--security-opt` [#17989](https://github.com/docker/docker/pull/17989)
 + Add default seccomp profile [#18780](https://github.com/docker/docker/pull/18780)
 + Add `--authorization-plugin` flag to `daemon` to customize ACLs [#15365](https://github.com/docker/docker/pull/15365)
-+ Docker Content Trust now supports the ability to read and write user delegations [#18887](https://github.com/docker/docker/pull/18887)  
-  This is an optional, opt-in feature that requires the explicit use of the Notary command-line utility in order to be enabled.  
++ Docker Content Trust now supports the ability to read and write user delegations [#18887](https://github.com/docker/docker/pull/18887)
+  This is an optional, opt-in feature that requires the explicit use of the Notary command-line utility in order to be enabled.
   Enabling delegation support in a specific repository will break the ability of Docker 1.9 and 1.8 to pull from that repository, if content trust is enabled.
 * Allow SELinux to run in a container when using the BTRFS storage driver [#16452](https://github.com/docker/docker/pull/16452)
 
 ### Distribution
 
-* Use content-addressable storage for images and layers [#17924](https://github.com/docker/docker/pull/17924)  
-  Note that a migration is performed the first time docker is run; it can take a significant amount of time depending on the number of images and containers present.  
-  Images no longer depend on the parent chain but contain a list of layer references.  
+* Use content-addressable storage for images and layers [#17924](https://github.com/docker/docker/pull/17924)
+  Note that a migration is performed the first time docker is run; it can take a significant amount of time depending on the number of images and containers present.
+  Images no longer depend on the parent chain but contain a list of layer references.
   `docker load`/`docker save` tarballs now also contain content-addressable image configurations.
-  For more information: https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration  
+  For more information: https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration
 * Add support for the new [manifest format ("schema2")](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md) [#18785](https://github.com/docker/docker/pull/18785)
 * Lots of improvements for push and pull: performance++, retries on failed downloads, cancelling on client disconnect [#18353](https://github.com/docker/docker/pull/18353), [#18418](https://github.com/docker/docker/pull/18418), [#19109](https://github.com/docker/docker/pull/19109), [#18353](https://github.com/docker/docker/pull/18353)
 * Limit v1 protocol fallbacks [#18590](https://github.com/docker/docker/pull/18590)
@@ -201,8 +329,8 @@ Engine 1.10 migrator can be found on Docker Hub: https://hub.docker.com/r/docker
 ### Volumes
 
 + Add support to set the mount propagation mode for a volume [#17034](https://github.com/docker/docker/pull/17034)
-* Add `ls` and `inspect` endpoints to volume plugin API [#16534](https://github.com/docker/docker/pull/16534)  
-  Existing plugins need to make use of these new APIs to satisfy users' expectation  
+* Add `ls` and `inspect` endpoints to volume plugin API [#16534](https://github.com/docker/docker/pull/16534)
+  Existing plugins need to make use of these new APIs to satisfy users' expectation
   For that, please use the new MIME type `application/vnd.docker.plugins.v1.2+json` [#19549](https://github.com/docker/docker/pull/19549)
 - Fix data not being copied to named volumes [#19175](https://github.com/docker/docker/pull/19175)
 - Fix issues preventing volume drivers from being containerized [#19500](https://github.com/docker/docker/pull/19500)


### PR DESCRIPTION
This updates the changelog in master with the changes from the 1.11 bump branch;

https://github.com/docker/docker/pull/21434 (https://github.com/docker/docker/commit/e651c1b2b92ccfcf3b075999e2427773a9b3dbdf)
https://github.com/docker/docker/pull/21450 (https://github.com/docker/docker/commit/76489af40f40385b3fd9f0a669fdc8cf3640e188)
https://github.com/docker/docker/pull/21500 (https://github.com/docker/docker/commit/32a5308237858cc5b7bcac16cc16286fc7996a9b)
https://github.com/docker/docker/pull/21827 (https://github.com/docker/docker/commit/c774c390b199ef59079cd1dc95260d1672625e50)
https://github.com/docker/docker/pull/21832 (https://github.com/docker/docker/commit/99589731ac1e5d901436e6d0d8c03e9eddb5cccc)
https://github.com/docker/docker/pull/21936 (https://github.com/docker/docker/commit/2153d9ec9d32b882be929a79997c326d516fc44a)
https://github.com/docker/docker/pull/22006 (https://github.com/docker/docker/commit/2535db86781f2731024c945ecabd59199de0c727)
