### PR TITLE
Remove start/die event when fail to start container

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -107,10 +107,6 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 			}
 			container.ToDisk()
 			daemon.Cleanup(container)
-			attributes := map[string]string{
-				"exitCode": fmt.Sprintf("%d", container.ExitCode),
-			}
-			daemon.LogContainerEventWithAttributes(container, "die", attributes)
 		}
 	}()
 
@@ -149,8 +145,6 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 
 		container.Reset(false)
 
-		// start event is logged even on error
-		daemon.LogContainerEvent(container, "start")
 		return err
 	}
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -95,8 +95,16 @@ func (s *DockerSuite) TestEventsContainerFailStartDie(c *check.C) {
 			dieEvent = true
 		}
 	}
-	c.Assert(startEvent, checker.True, check.Commentf("Start event not found: %v\n%v", actions, events))
-	c.Assert(dieEvent, checker.True, check.Commentf("Die event not found: %v\n%v", actions, events))
+
+	// Windows platform is different from Linux, it will start container whatever
+	// so Windows can get start/die event but Linux can't
+	if daemonPlatform == "windows" {
+		c.Assert(startEvent, checker.True, check.Commentf("Start event not found: %v\n%v", actions, events))
+		c.Assert(dieEvent, checker.True, check.Commentf("Die event not found: %v\n%v", actions, events))
+	} else {
+		c.Assert(startEvent, checker.False, check.Commentf("Start event not expected: %v\n%v", actions, events))
+		c.Assert(dieEvent, checker.False, check.Commentf("Die event not expected: %v\n%v", actions, events))
+	}
 }
 
 func (s *DockerSuite) TestEventsLimit(c *check.C) {


### PR DESCRIPTION
If contaner start fail of (say) "command not found", the container
actually didn't start at all, we shouldn't log start and die event for
it, because that doesnt actually happen.

This is discussed previously in https://github.com/docker/docker/pull/21839#issuecomment-206711436, I'm not sure if anyone will rely on the previous events behavior, just bring this in case forgotten,  I'd like to hear more feedbacks.

/cc @tonistiigi 

Signed-off-by: Zhang Wei zhangwei555@huawei.com
