### PR TITLE
Set containerd pdeathsig

### DIFF
--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -357,7 +357,7 @@ func (r *remote) runContainerdDaemon() error {
 	// redirect containerd logs to docker logs
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Pdeathsig: syscall.SIGKILL}
 	cmd.Env = nil
 	// clear the NOTIFY_SOCKET from the env when starting containerd
 	for _, e := range os.Environ() {


### PR DESCRIPTION
Currently when starting containerd, docker just sets containerd's stdio
to docker's stdio.
If the docker daemon is restarted there is no way to re-attach and we
lose containerd's logs.

This change sets up fifo's for containerd's stdio so docker can
re-attach to containerd's stdio and not lose logs.

This doesn't seem like a perfect solution.
One caveat of this is that logrus (which containerd uses) will not use pretty mode for the log output since it will never be a terminal out with this method.
