### PR TITLE
Fix detection of git commit during build from tarball

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -79,7 +79,7 @@ DEFAULT_BUNDLES=(
 )
 
 VERSION=$(< ./VERSION)
-if command -v git &> /dev/null && git rev-parse &> /dev/null; then
+if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; then
 	GITCOMMIT=$(git rev-parse --short HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-unsupported"


### PR DESCRIPTION
Distro packagers will often use the tarball to build a package and have
the build script for the package in git. To avoid that the docker build
script picks up the git commit from the distro repo we also check for a
directory named .git before check for -unsupported builds.

Signed-off-by: Natanael Copa natanael.copa@docker.com
