### PR TITLE
Fix flaky test TestRunExitOnStdinClose

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1743,10 +1743,9 @@ func (s *DockerSuite) TestRunExitOnStdinClose(c *check.C) {
 	name := "testrunexitonstdinclose"
 
 	meow := "/bin/cat"
-	delay := 1
+	delay := 60
 	if daemonPlatform == "windows" {
 		meow = "cat"
-		delay = 60
 	}
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "-i", "busybox", meow)
 


### PR DESCRIPTION
This test was flaky on ppc64le, where the average time to close was
around 1 second. This bumps that timeout to 3 seconds which should be
plenty.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

Here's a picture of a blue crab
![bluecrab](http://chesapeakebaystory.umces.edu/site/assets/files/1048/blue-crab-dfodge-maryland_cbf.jpg)
