### PR TITLE
Fix error message in running container

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -41,7 +41,9 @@ func (cli *DockerCli) holdHijackedConnection(ctx context.Context, tty bool, inpu
 					})
 				}
 			} else {
-				_, err = stdcopy.StdCopy(outputStream, errorStream, resp.Reader)
+				if _, err = stdcopy.StdCopy(outputStream, errorStream, resp.Reader); err != nil {
+					_, err = io.Copy(errorStream, resp.Reader)
+				}
 			}
 
 			logrus.Debugf("[hijack] End of stdout")


### PR DESCRIPTION
Docker client displayed "Unrecognized input header: 99" error when
running a container if the client communicates to swarm cluster which
consists of docker daemons whose API version is lower than the client.

This fixes #21902.

Signed-off-by: Yi EungJun eungjun.yi@navercorp.com
