### PR TITLE
Remove deprecation warning

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/pkg/system"
 )
 
 // DefaultDriverName is the driver name used for the driver
@@ -79,8 +76,7 @@ func (m *MountPoint) Setup() (string, error) {
 				return "", err
 			}
 			if runtime.GOOS != "windows" { // Windows does not have deprecation issues here
-				logrus.Warnf("Auto-creating non-existent volume host path %s, this is deprecated and will be removed soon", m.Source)
-				if err := system.MkdirAll(m.Source, 0755); err != nil {
+				if err := os.MkdirAll(m.Source, 0755); err != nil {
 					return "", err
 				}
 			}


### PR DESCRIPTION
Auto-creation of non-existing host directories is no longer deprecated (see https://github.com/docker/docker/pull/21666), so this warning is no longer relevant.

This removes the deprecation warning.

Thanks @csandanov for noticing https://github.com/docker/docker/issues/16072#issuecomment-210306750 :smile:
