### PR TITLE
Produce fatal error when running on kernel < 3.10.0

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -267,10 +267,12 @@ func checkKernel() error {
 	// without actually causing a kernel panic, so we need this workaround until
 	// the circumstances of pre-3.10 crashes are clearer.
 	// For details see https://github.com/docker/docker/issues/407
+	// Docker 1.11 and above doesn't actually run on kernels older than 3.4,
+	// due to containerd-shim usage of PR_SET_CHILD_SUBREAPER (introduced in 3.4).
 	if !checkKernelVersion(3, 10, 0) {
 		v, _ := kernel.GetKernelVersion()
 		if os.Getenv("DOCKER_NOWARN_KERNEL_VERSION") == "" {
-			logrus.Warnf("Your Linux kernel version %s can be unstable running docker. Please upgrade your kernel to 3.10.0.", v.String())
+			logrus.Fatalf("Your Linux kernel version %s is not supported for running docker. Please upgrade your kernel to 3.10.0 or newer.", v.String())
 		}
 	}
 	return nil


### PR DESCRIPTION
Running on kernel versions older than 3.10 has not been supported for a while (as it's known to be unstable).

With the containerd integration, this has become more apparent, because kernels < 3.4 don't support PR_SET_CHILD_SUBREAPER, which is required for containerd-shim to run (see https://github.com/docker/docker/issues/22037#issuecomment-210098974)

Change the previous "warning" to a "fatal" error, so that we refuse to start.

There's still an escape-hatch for users by setting "DOCKER_NOWARN_KERNEL_VERSION=1" so that they can run "at their own risk".
