### PR TITLE
`docker version` supports `--json` and returns version info in JSON

### DIFF
--- a/api/client/version.go
+++ b/api/client/version.go
@@ -43,7 +43,7 @@ Server:
 func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	cmd := Cli.Subcmd("version", nil, Cli.DockerCommands["version"].Description, true)
 	tmplStr := cmd.String([]string{"f", "#format", "-format"}, "", "Format the output using the given go template")
-	isJson := cmd.Bool([]string{"j", "#json", "-json"}, false, "Output in JSON format")
+	isJSON := cmd.Bool([]string{"j", "#json", "-json"}, false, "Output in JSON format")
 
 	cmd.Require(flag.Exact, 0)
 
@@ -82,8 +82,8 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 
 	var err2 error
 
-	if *isJson {
-		err2 = renderJson(cli.out, vd)
+	if *isJSON {
+		err2 = renderJSON(cli.out, vd)
 	} else {
 		err2 = renderTemplate(cli.out, *tmplStr, vd)
 	}
@@ -96,7 +96,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	return err
 }
 
-func renderJson(out io.Writer, vd types.VersionResponse) error {
+func renderJSON(out io.Writer, vd types.VersionResponse) error {
 	output, err := json.MarshalIndent(vd, "", "    ")
 	out.Write(output)
 	return err

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -42,6 +42,8 @@ Server:
 func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	cmd := Cli.Subcmd("version", nil, Cli.DockerCommands["version"].Description, true)
 	tmplStr := cmd.String([]string{"f", "#format", "-format"}, "", "Format the output using the given go template")
+	isJson := cmd.Bool([]string{"j", "#json", "-json"}, false, "Output in JSON format")
+
 	cmd.Require(flag.Exact, 0)
 
 	cmd.ParseFlags(args, true)
@@ -88,9 +90,15 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 		}
 	}
 
-	if err2 := tmpl.Execute(cli.out, vd); err2 != nil && err == nil {
-		err = err2
+	if *isJson {
+		output, _ := json.MarshalIndent(vd, "", "    ");
+		cli.out.Write(output)
+	} else {
+		if err2 := tmpl.Execute(cli.out, vd); err2 != nil && err == nil {
+			err = err2
+		}
 	}
+
 	cli.out.Write([]byte{'\n'})
 	return err
 }

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"text/template"
 	"time"
+	"encoding/json"
 
 	"golang.org/x/net/context"
 

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -85,20 +85,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	if *isJson {
 		err2 = renderJson(cli.out, vd)
 	} else {
-		templateFormat := versionTemplate
-		if *tmplStr != "" {
-			templateFormat = *tmplStr
-		}
-
-		var tmpl *template.Template
-		if tmpl, err = templates.Parse(templateFormat); err != nil {
-			return Cli.StatusError{StatusCode: 64,
-				Status: "Template parsing error: " + err.Error()}
-		}
-
-		if err2 := tmpl.Execute(cli.out, vd); err2 != nil && err == nil {
-			err = err2
-		}
+		err2 = renderTemplate(cli.out, *tmplStr, vd)
 	}
 
 	if err2 != nil && err == nil {
@@ -115,5 +102,20 @@ func renderJson(out io.Writer, vd types.VersionResponse) error {
 	return err
 }
 
-//func renderTemplate(out io.Writer, templateFormat string, vd types.VersionResponse) error {
-//}
+func renderTemplate(out io.Writer, templateString string, vd types.VersionResponse) error {
+	templateFormat := versionTemplate
+	if templateString != "" {
+		templateFormat = templateString
+	}
+
+	var (
+		tmpl *template.Template
+		err  error
+	)
+	if tmpl, err = templates.Parse(templateFormat); err != nil {
+		return Cli.StatusError{StatusCode: 64,
+			Status: "Template parsing error: " + err.Error()}
+	}
+
+	return tmpl.Execute(out, vd)
+}

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 
+	"encoding/json"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -24,6 +25,14 @@ func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
 	for k, v := range stringsToCheck {
 		c.Assert(strings.Count(out, k), checker.Equals, v, check.Commentf("The count of %v in %s does not match excepted", k, out))
 	}
+}
+
+func (s *DockerSuite) TestVersionJsonEnsureSucceeds(c *check.C) {
+	out, _ := dockerCmd(c, "version --json")
+	var version map[string]interface{}
+	json.Unmarshal([]byte(out), &version)
+	c.Assert(version["Client"], checker.NotNil)
+	c.Assert(version["Server"], checker.NotNil)
 }
 
 // ensure the Windows daemon return the correct platform string


### PR DESCRIPTION
**\- What I did**
Make `docker version` accept `--json` flag and when specified, returns the version information in JSON.

**\- How I did it**
Add a `json` flag in `api/client/version.go` and use `encoding/json.Marshal` to output the version response in JSON format.

**\- How to verify it**
- Build the binaries
- run `docker version --json` or `docker version -j`

**\- A picture of a cute animal (not mandatory but encouraged)**

![qzmn9ogm](https://cloud.githubusercontent.com/assets/84321/14563167/8d9504c8-02ee-11e6-9cf9-c91c8b8452b9.jpg)
