### PR TITLE
DWZ problem with multiple golang binary caused OL7 RPM build to fail

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -60,6 +60,12 @@ Requires: device-mapper >= 1.02.90-2
 %global with_selinux 1
 %endif
 
+# DWZ problem with multiple golang binary, see bug
+# https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12
+%if 0%{?fedora} >= 20 || 0%{?rhel} >= 7 || 0%{?oraclelinux} >= 7
+%global _dwz_low_mem_die_limit 0
+%endif
+
 # start if with_selinux
 %if 0%{?with_selinux}
 # Version of SELinux we were using


### PR DESCRIPTION
Refering to this: https://fedoraproject.org/wiki/PackagingDrafts/Go
this could be due to the following bug:
https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12

This fixes #22051

Signed-off-by: Thomas Tanaka thomas.tanaka@oracle.com
