### PR TITLE
Add support for volume scopes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -745,7 +745,9 @@ func configureVolumes(config *Config, rootUID, rootGID int) (*store.VolumeStore,
 		return nil, err
 	}
 
-	volumedrivers.Register(volumesDriver, volumesDriver.Name())
+	if !volumedrivers.Register(volumesDriver, volumesDriver.Name()) {
+		return nil, fmt.Errorf("local volume driver could not be registered")
+	}
 	return store.New(config.Root)
 }
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -27,10 +27,12 @@ func volumeToAPIType(v volume.Volume) *types.Volume {
 		Name:   v.Name(),
 		Driver: v.DriverName(),
 	}
-	if v, ok := v.(interface {
-		Labels() map[string]string
-	}); ok {
+	if v, ok := v.(volume.LabeledVolume); ok {
 		tv.Labels = v.Labels()
+	}
+
+	if v, ok := v.(volume.ScopedVolume); ok {
+		tv.Scope = v.Scope()
 	}
 	return tv
 }

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -20,6 +20,7 @@ documentation](plugins.md) for more information.
 ### 1.12.0
 
 - Add `Status` field to `VolumeDriver.Get` response ([#21006](https://github.com/docker/docker/pull/21006#))
+- Add `VolumeDriver.Capabilities` to get capabilities of the volume driver([#22077](https://github.com/docker/docker/pull/22077))
 
 ### 1.10.0
 
@@ -236,3 +237,29 @@ Get the list of volumes registered with the plugin.
 ```
 
 Respond with a string error if an error occurred.
+
+### /VolumeDriver.Capabilities
+
+**Request**:
+```json
+{}
+```
+
+Get the list of capabilities the driver supports.
+The driver is not required to implement this endpoint, however in such cases
+the default values will be taken.
+
+**Response**:
+```json
+{
+  "Capabilities": {
+    "Scope": "global"
+  }
+}
+```
+
+Supported scopes are `global` and `local`. Any other value in `Scope` will be
+ignored and assumed to be `local`. Scope allows cluster managers to handle the
+volume differently, for instance with a scope of `global`, the cluster manager
+knows it only needs to create the volume once instead of on every engine. More
+capabilities may be added in the future.

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/docker/volume"
 	"github.com/docker/engine-api/types"
 	"github.com/go-check/check"
 )
@@ -35,6 +36,7 @@ type eventCounter struct {
 	paths       int
 	lists       int
 	gets        int
+	caps        int
 }
 
 type DockerExternalVolumeSuite struct {
@@ -223,6 +225,18 @@ func (s *DockerExternalVolumeSuite) SetUpSuite(c *check.C) {
 		}
 
 		send(w, nil)
+	})
+
+	mux.HandleFunc("/VolumeDriver.Capabilities", func(w http.ResponseWriter, r *http.Request) {
+		s.ec.caps++
+
+		_, err := read(r.Body)
+		if err != nil {
+			send(w, err)
+			return
+		}
+
+		send(w, `{"Capabilities": { "Scope": "global" }}`)
 	})
 
 	err := os.MkdirAll("/etc/docker/plugins", 0755)
@@ -490,4 +504,19 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverMountID(c *check.C) 
 	out, err := s.d.Cmd("run", "--rm", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", "test-external-volume-driver", "busybox:latest", "cat", "/tmp/external-volume-test/test")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+}
+
+// Check that VolumeDriver.Capabilities gets called, and only called once
+func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverCapabilities(c *check.C) {
+	c.Assert(s.d.Start(), checker.IsNil)
+	c.Assert(s.ec.caps, checker.Equals, 0)
+
+	for i := 0; i < 3; i++ {
+		out, err := s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "--name", fmt.Sprintf("test%d", i))
+		c.Assert(err, checker.IsNil, check.Commentf(out))
+		c.Assert(s.ec.caps, checker.Equals, 1)
+		out, err = s.d.Cmd("volume", "inspect", "--format={{.Scope}}", fmt.Sprintf("test%d", i))
+		c.Assert(err, checker.IsNil)
+		c.Assert(strings.TrimSpace(out), checker.Equals, volume.GlobalScope)
+	}
 }

--- a/pkg/plugins/pluginrpc-gen/README.md
+++ b/pkg/plugins/pluginrpc-gen/README.md
@@ -43,16 +43,6 @@ supplying `--tag`. This flag can be specified multiple times.
 
 ## Known issues
 
-The parser can currently only handle types which are not specifically a map or
-a slice.  
-You can, however, create a type that uses a map or a slice internally, for instance:
-
-```go
-type opts map[string]string
-```
-
-This `opts` type will work, whreas using a `map[string]string` directly will not.
-
 ## go-generate
 
 You can also use this with go-generate, which is pretty awesome.  

--- a/pkg/plugins/pluginrpc-gen/fixtures/foo.go
+++ b/pkg/plugins/pluginrpc-gen/fixtures/foo.go
@@ -1,5 +1,17 @@
 package foo
 
+import (
+	"fmt"
+
+	aliasedio "io"
+
+	"github.com/docker/docker/pkg/plugins/pluginrpc-gen/fixtures/otherfixture"
+)
+
+var (
+	errFakeImport = fmt.Errorf("just to import fmt for imports tests")
+)
+
 type wobble struct {
 	Some      string
 	Val       string
@@ -22,6 +34,7 @@ type Fooer3 interface {
 	Qux(a, b string) (val string, err error)
 	Wobble() (w *wobble)
 	Wiggle() (w wobble)
+	WiggleWobble(a []*wobble, b []wobble, c map[string]*wobble, d map[*wobble]wobble, e map[string][]wobble, f []*otherfixture.Spaceship) (g map[*wobble]wobble, h [][]*wobble, i otherfixture.Spaceship, j *otherfixture.Spaceship, k map[*otherfixture.Spaceship]otherfixture.Spaceship, l []otherfixture.Spaceship)
 }
 
 // Fooer4 is an interface used for tests.
@@ -38,4 +51,39 @@ type Bar interface {
 type Fooer5 interface {
 	Foo()
 	Bar
+}
+
+// Fooer6 is an interface used for tests.
+type Fooer6 interface {
+	Foo(a otherfixture.Spaceship)
+}
+
+// Fooer7 is an interface used for tests.
+type Fooer7 interface {
+	Foo(a *otherfixture.Spaceship)
+}
+
+// Fooer8 is an interface used for tests.
+type Fooer8 interface {
+	Foo(a map[string]otherfixture.Spaceship)
+}
+
+// Fooer9 is an interface used for tests.
+type Fooer9 interface {
+	Foo(a map[string]*otherfixture.Spaceship)
+}
+
+// Fooer10 is an interface used for tests.
+type Fooer10 interface {
+	Foo(a []otherfixture.Spaceship)
+}
+
+// Fooer11 is an interface used for tests.
+type Fooer11 interface {
+	Foo(a []*otherfixture.Spaceship)
+}
+
+// Fooer12 is an interface used for tests.
+type Fooer12 interface {
+	Foo(a aliasedio.Reader)
 }

--- a/pkg/plugins/pluginrpc-gen/fixtures/otherfixture/spaceship.go
+++ b/pkg/plugins/pluginrpc-gen/fixtures/otherfixture/spaceship.go
@@ -1,0 +1,4 @@
+package otherfixture
+
+// Spaceship is a fixture for tests
+type Spaceship struct{}

--- a/pkg/plugins/pluginrpc-gen/main.go
+++ b/pkg/plugins/pluginrpc-gen/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	errorOut("parser error", generatedTempl.Execute(&buf, analysis))
 	src, err := format.Source(buf.Bytes())
-	errorOut("error formating generated source", err)
+	errorOut("error formating generated source:\n"+buf.String(), err)
 	errorOut("error writing file", ioutil.WriteFile(*outputFile, src, 0644))
 }
 

--- a/pkg/plugins/pluginrpc-gen/main.go
+++ b/pkg/plugins/pluginrpc-gen/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	errorOut("parser error", generatedTempl.Execute(&buf, analysis))
 	src, err := format.Source(buf.Bytes())
-	errorOut("error formating generated source:\n"+buf.String(), err)
+	errorOut("error formatting generated source:\n"+buf.String(), err)
 	errorOut("error writing file", ioutil.WriteFile(*outputFile, src, 0644))
 }
 

--- a/pkg/plugins/pluginrpc-gen/template.go
+++ b/pkg/plugins/pluginrpc-gen/template.go
@@ -13,6 +13,19 @@ func printArgs(args []arg) string {
 	return strings.Join(argStr, ", ")
 }
 
+func buildImports(specs []importSpec) string {
+	if len(specs) == 0 {
+		return `import "errors"`
+	}
+	imports := "import(\n"
+	imports += "\t\"errors\"\n"
+	for _, i := range specs {
+		imports += "\t" + i.String() + "\n"
+	}
+	imports += ")"
+	return imports
+}
+
 func marshalType(t string) string {
 	switch t {
 	case "error":
@@ -44,6 +57,7 @@ var templFuncs = template.FuncMap{
 	"lower":       strings.ToLower,
 	"title":       title,
 	"tag":         buildTag,
+	"imports":     buildImports,
 }
 
 func title(s string) string {
@@ -60,7 +74,7 @@ var generatedTempl = template.Must(template.New("rpc_cient").Funcs(templFuncs).P
 
 package {{ .Name }}
 
-import "errors"
+{{ imports .Imports }}
 
 type client interface{
 	Call(string, interface{}, interface{}) error

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -24,15 +24,12 @@ func NewVolumeDriver(name string, c client) volume.Driver {
 	return &volumeDriverAdapter{name: name, proxy: proxy}
 }
 
-type opts map[string]string
-type list []*proxyVolume
-
 // volumeDriver defines the available functions that volume plugins must implement.
 // This interface is only defined to generate the proxy objects.
 // It's not intended to be public or reused.
 type volumeDriver interface {
 	// Create a volume with the given name
-	Create(name string, opts opts) (err error)
+	Create(name string, opts map[string]string) (err error)
 	// Remove the volume with the given name
 	Remove(name string) (err error)
 	// Get the mountpoint of the given volume
@@ -42,7 +39,7 @@ type volumeDriver interface {
 	// Unmount the given volume
 	Unmount(name, id string) (err error)
 	// List lists all the volumes known to the driver
-	List() (volumes list, err error)
+	List() (volumes []*proxyVolume, err error)
 	// Get retrieves the volume with the requested name
 	Get(name string) (volume *proxyVolume, err error)
 }

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -2,7 +2,10 @@
 
 package volumedrivers
 
-import "errors"
+import (
+	"errors"
+	"github.com/docker/docker/volume"
+)
 
 type client interface {
 	Call(string, interface{}, interface{}) error
@@ -202,6 +205,33 @@ func (pp *volumeDriverProxy) Get(name string) (volume *proxyVolume, err error) {
 	}
 
 	volume = ret.Volume
+
+	if ret.Err != "" {
+		err = errors.New(ret.Err)
+	}
+
+	return
+}
+
+type volumeDriverProxyCapabilitiesRequest struct {
+}
+
+type volumeDriverProxyCapabilitiesResponse struct {
+	Capabilities volume.Capability
+	Err          string
+}
+
+func (pp *volumeDriverProxy) Capabilities() (capabilities volume.Capability, err error) {
+	var (
+		req volumeDriverProxyCapabilitiesRequest
+		ret volumeDriverProxyCapabilitiesResponse
+	)
+
+	if err = pp.Call("VolumeDriver.Capabilities", req, &ret); err != nil {
+		return
+	}
+
+	capabilities = ret.Capabilities
 
 	if ret.Err != "" {
 		err = errors.New(ret.Err)

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -14,14 +14,14 @@ type volumeDriverProxy struct {
 
 type volumeDriverProxyCreateRequest struct {
 	Name string
-	Opts opts
+	Opts map[string]string
 }
 
 type volumeDriverProxyCreateResponse struct {
 	Err string
 }
 
-func (pp *volumeDriverProxy) Create(name string, opts opts) (err error) {
+func (pp *volumeDriverProxy) Create(name string, opts map[string]string) (err error) {
 	var (
 		req volumeDriverProxyCreateRequest
 		ret volumeDriverProxyCreateResponse
@@ -158,11 +158,11 @@ type volumeDriverProxyListRequest struct {
 }
 
 type volumeDriverProxyListResponse struct {
-	Volumes list
+	Volumes []*proxyVolume
 	Err     string
 }
 
-func (pp *volumeDriverProxy) List() (volumes list, err error) {
+func (pp *volumeDriverProxy) List() (volumes []*proxyVolume, err error) {
 	var (
 		req volumeDriverProxyListRequest
 		ret volumeDriverProxyListResponse

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -52,6 +52,11 @@ func TestVolumeRequestError(t *testing.T) {
 		fmt.Fprintln(w, `{"Err": "Cannot get volume"}`)
 	})
 
+	mux.HandleFunc("/VolumeDriver.Capabilities", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.docker.plugins.v1+json")
+		http.Error(w, "error", 500)
+	})
+
 	u, _ := url.Parse(server.URL)
 	client, err := plugins.NewClient("tcp://"+u.Host, tlsconfig.Options{InsecureSkipVerify: true})
 	if err != nil {
@@ -118,5 +123,10 @@ func TestVolumeRequestError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Cannot get volume") {
 		t.Fatalf("Unexpected error: %v\n", err)
+	}
+
+	_, err = driver.Capabilities()
+	if err == nil {
+		t.Fatal(err)
 	}
 }

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -248,6 +248,11 @@ func (r *Root) Get(name string) (volume.Volume, error) {
 	return v, nil
 }
 
+// Scope returns the local volume scope
+func (r *Root) Scope() string {
+	return volume.LocalScope
+}
+
 func (r *Root) validateName(name string) error {
 	if !volumeNameRegex.MatchString(name) {
 		return validationError{fmt.Errorf("%q includes invalid characters for a local volume name, only %q are allowed", name, utils.RestrictedNameChars)}

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -109,3 +109,8 @@ func (d *FakeDriver) Get(name string) (volume.Volume, error) {
 	}
 	return nil, fmt.Errorf("no such volume")
 }
+
+// Scope returns the local scope
+func (*FakeDriver) Scope() string {
+	return "local"
+}


### PR DESCRIPTION
Add support for volume scopes

This is similar to network scopes where a volume can either be `local` or `global`. 
A `global` volume is one that exists across the entire cluster where as a `local` volume exists on a single engine.

Includes fixes to the plugin RPC generator to support passing structs to the plugin which was required for this PR.
