### PR TITLE
Fix incorrect docs in remote API for the option of `SecurityOpt`

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.15.md
+++ b/docs/reference/api/docker_remote_api_v1.15.md
@@ -151,7 +151,7 @@ Create a container
              "ExposedPorts": {
                      "22/tcp": {}
              },
-             "SecurityOpts": [],
+             "SecurityOpt": [],
              "HostConfig": {
                "Binds": ["/tmp:/tmp"],
                "Links": ["redis3:redis"],
@@ -212,7 +212,7 @@ Json Parameters:
       container
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
--   **SecurityOpts**: A list of string values to customize labels for MLS
+-   **SecurityOpt**: A list of string values to customize labels for MLS
       systems, such as SELinux.
 -   **HostConfig**
   -   **Binds** – A list of volume bindings for this container.  Each volume

--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -151,7 +151,7 @@ Create a container
              "ExposedPorts": {
                      "22/tcp": {}
              },
-             "SecurityOpts": [],
+             "SecurityOpt": [],
              "HostConfig": {
                "Binds": ["/tmp:/tmp"],
                "Links": ["redis3:redis"],
@@ -212,7 +212,7 @@ Json Parameters:
       container
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
--   **SecurityOpts**: A list of string values to customize labels for MLS
+-   **SecurityOpt**: A list of string values to customize labels for MLS
       systems, such as SELinux.
 -   **HostConfig**
   -   **Binds** – A list of volume bindings for this container.  Each volume


### PR DESCRIPTION
This fix tries to fix the issue in remote API docs for v1.15 (Docker 1.3.x) and v1.16 (Docker 1.4.x) where `SecurityOpts` was used but the actual field should be `SecurityOpt`.

This `SecurityOpt` field is verified through the source code in v1.3.0 and v1.4.0:
https://github.com/docker/docker/blob/v1.3.0/runconfig/config.go#L35
https://github.com/docker/docker/blob/v1.4.0/runconfig/hostconfig.go#L98

Signed-off-by: Yong Tang yong.tang.github@outlook.com
