### PR TITLE
Get pkg/term to build for Solaris

### DIFF
--- a/pkg/term/tc_other.go
+++ b/pkg/term/tc_other.go
@@ -1,5 +1,6 @@
 // +build !windows
 // +build !linux !cgo
+// +build !solaris !cgo
 
 package term
 

--- a/pkg/term/term.go
+++ b/pkg/term/term.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"unsafe"
 )
 
 var (
@@ -45,27 +44,6 @@ func GetFdInfo(in interface{}) (uintptr, bool) {
 		isTerminalIn = IsTerminal(inFd)
 	}
 	return inFd, isTerminalIn
-}
-
-// GetWinsize returns the window size based on the specified file descriptor.
-func GetWinsize(fd uintptr) (*Winsize, error) {
-	ws := &Winsize{}
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
-	// Skip errno = 0
-	if err == 0 {
-		return ws, nil
-	}
-	return ws, err
-}
-
-// SetWinsize tries to set the specified window size for the specified file descriptor.
-func SetWinsize(fd uintptr, ws *Winsize) error {
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
-	// Skip errno = 0
-	if err == 0 {
-		return nil
-	}
-	return err
 }
 
 // IsTerminal returns true if the given file descriptor is a terminal.

--- a/pkg/term/term_solaris.go
+++ b/pkg/term/term_solaris.go
@@ -1,0 +1,41 @@
+// +build solaris
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+/*
+#include <unistd.h>
+#include <stropts.h>
+#include <termios.h>
+
+// Small wrapper to get rid of variadic args of ioctl()
+int my_ioctl(int fd, int cmd, struct winsize *ws) {
+	return ioctl(fd, cmd, ws);
+}
+*/
+import "C"
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	ws := &Winsize{}
+	ret, err := C.my_ioctl(C.int(fd), C.int(syscall.TIOCGWINSZ), (*C.struct_winsize)(unsafe.Pointer(ws)))
+	// Skip retval = 0
+	if ret == 0 {
+		return ws, nil
+	}
+	return ws, err
+}
+
+// SetWinsize tries to set the specified window size for the specified file descriptor.
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	ret, err := C.my_ioctl(C.int(fd), C.int(syscall.TIOCSWINSZ), (*C.struct_winsize)(unsafe.Pointer(ws)))
+	// Skip retval = 0
+	if ret == 0 {
+		return nil
+	}
+	return err
+}

--- a/pkg/term/term_unix.go
+++ b/pkg/term/term_unix.go
@@ -1,0 +1,29 @@
+// +build !solaris,!windows
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	ws := &Winsize{}
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
+	// Skipp errno = 0
+	if err == 0 {
+		return ws, nil
+	}
+	return ws, err
+}
+
+// SetWinsize tries to set the specified window size for the specified file descriptor.
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
+	// Skipp errno = 0
+	if err == 0 {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
This changeset builds pkg/term on Solaris. 
This is a part of a larger effort towards a native Docker port for Solaris.
This is being done separately as pkg/term is a dependency for both libnetwork and containerd.
We will be submitting an Engine build clean PR shortly.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Got the pkg/term package to build on Solaris.
**\- How I did it**
Added new files : 
/pkg/term/tc_solaris_cgo.go
/pkg/term/term_solaris.go

and moved two functions GetWinsize and SetWinsize from term.go to term_unix.go and term_solaris,go, keeping the current implementation in term_unix.go and adding a Solaris specific one in term_solaris.go
**\- How to verify it**
No new code has been added for any platform other than Solaris (except two functions being moved). CI for Solaris has not been set up yet, we are working on it with the core team but this builds clean on Solaris and was also tested on Ubuntu.
**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Amit Krishnan krish.amit@gmail.com
