### PR TITLE
Workaround Windows bug discovered with Go security fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,16 @@ RUN set -x \
 ENV GO_VERSION 1.5.4
 RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
+
+# !!! TEMPORARY HACK !!!
+# Because of https://github.com/golang/go/issues/15286 we have to revert to Go 1.5.3 for windows/amd64 in master
+# To change which version of Go to compile with, simply prepend PATH with /usr/local/go1.5.3/bin
+# and set GOROOT to /usr/local/go1.5.3
+ENV HACK_GO_VERSION 1.5.3
+RUN curl -fsSL "https://storage.googleapis.com/golang/go${HACK_GO_VERSION}.linux-amd64.tar.gz" \
+	| tar -xzC /tmp \
+	&& mv /tmp/go "/usr/local/go${HACK_GO_VERSION}"
+
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -29,6 +29,12 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 			export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
 			export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
 		fi
+		# !!! TEMPORARY HACK !!!
+		# See Dockerfile
+		if [ "$platform" == "windows/amd64" ]; then
+			export GOROOT="/usr/local/go${HACK_GO_VERSION}"
+			export PATH=$(echo "$PATH" | sed "s,:/usr/local/go/bin:,:/usr/local/go${HACK_GO_VERSION}/bin:,")
+		fi
 		source "${MAKEDIR}/binary"
 	)
 done


### PR DESCRIPTION
For context: https://github.com/golang/go/issues/15286

This commit downloads go1.5.3 in addition to go1.5.4 in order to
workaround the issue.

It is not expected to do a Docker release without a proper fix, however
this should help unblock Docker development on Windows TP5.

Signed-off-by: Tibor Vass tibor@docker.com
