### PR TITLE
docs: remove unused "registry" parameter

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.14.md
+++ b/docs/reference/api/docker_remote_api_v1.14.md
@@ -844,7 +844,6 @@ Query Parameters:
 -   **fromSrc** – source to import, - means stdin
 -   **repo** – repository
 -   **tag** – tag
--   **registry** – the registry to pull from
 
 Request Headers:
 

--- a/docs/reference/api/docker_remote_api_v1.15.md
+++ b/docs/reference/api/docker_remote_api_v1.15.md
@@ -994,7 +994,6 @@ Query Parameters:
         can be retrieved or `-` to read the image from the request body.
 -   **repo** – repository
 -   **tag** – tag
--   **registry** – the registry to pull from
 
     Request Headers:
 

--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -942,7 +942,6 @@ Query Parameters:
         can be retrieved or `-` to read the image from the request body.
 -   **repo** – repository
 -   **tag** – tag
--   **registry** – the registry to pull from
 
     Request Headers:
 

--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -1155,7 +1155,6 @@ Query Parameters:
         can be retrieved or `-` to read the image from the request body.
 -   **repo** – repository
 -   **tag** – tag
--   **registry** – the registry to pull from
 
     Request Headers:
 

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1252,7 +1252,6 @@ Query Parameters:
         can be retrieved or `-` to read the image from the request body.
 -   **repo** – repository
 -   **tag** – tag
--   **registry** – the registry to pull from
 
     Request Headers:
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1301,7 +1301,6 @@ Query Parameters:
         can be retrieved or `-` to read the image from the request body.
 -   **repo** – Repository name.
 -   **tag** – Tag.
--   **registry** – The registry to pull from.
 
     Request Headers:
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1443,7 +1443,6 @@ Query Parameters:
         can be retrieved or `-` to read the image from the request body.
 -   **repo** – Repository name.
 -   **tag** – Tag.
--   **registry** – The registry to pull from.
 
     Request Headers:
 


### PR DESCRIPTION
The "registry" query-param was in added 10c0e990371e065d4fc1c9b680f03a46e5bacc5e,
and removed in docker 0.5.0 via 66a9d06d9fa7a382c6852cf047e1448e0d3e1782.

Aparently, it was never removed from the documentation, and included in all versions of the API docs.

This removes it from the documentation.

closes https://github.com/docker/docker/issues/22061
