### PR TITLE
Vendoring libnetwork v0.8.0-dev.1

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -30,7 +30,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.7.0-rc.6
+clone git github.com/docker/libnetwork v0.8.0-dev.1
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## 0.8.0-dev.1 (2016-04-16)
+- Fixes docker/docker#16964
+- Added maximum egress bandwidth qos for Windows
+
 ## 0.7.0-rc.6 (2016-04-10)
 - Flush cached resolver socket on default gateway change
 
 ## 0.7.0-rc.5 (2016-04-08)
 - Persist ipam driver options
 - Fixes https://github.com/docker/libnetwork/issues/1087
-- Use go vet from go tool 
+- Use go vet from go tool
 - Godep update to pick up latest docker/docker packages
 - Validate remote driver response using docker plugins package method.
 
@@ -20,8 +24,8 @@
 ## 0.7.0-rc.2 (2016-04-05)
 - Fixes https://github.com/docker/libnetwork/issues/1070
 - Move IPAM resource initialization out of init()
-- Initialize overlay driver before network delete 
-- Fix the handling for default gateway Endpoint join/lean 
+- Initialize overlay driver before network delete
+- Fix the handling for default gateway Endpoint join/lean
 
 ## 0.7.0-rc.1 (2016-03-30)
 - Fixes https://github.com/docker/libnetwork/issues/985

--- a/vendor/src/github.com/docker/libnetwork/drivers/windows/labels.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/windows/labels.go
@@ -12,4 +12,7 @@ const (
 
 	// Interface of the network
 	Interface = "com.docker.network.windowsshim.interface"
+
+	// QosPolicies of the endpoint
+	QosPolicies = "com.docker.endpoint.windowsshim.qospolicies"
 )

--- a/vendor/src/github.com/docker/libnetwork/types/types.go
+++ b/vendor/src/github.com/docker/libnetwork/types/types.go
@@ -12,6 +12,11 @@ import (
 // UUID represents a globally unique ID of various resources like network and endpoint
 type UUID string
 
+// QosPolicy represents a quality of service policy on an endpoint
+type QosPolicy struct {
+	MaxEgressBandwidth uint64
+}
+
 // TransportPort represent a local Layer 4 endpoint
 type TransportPort struct {
 	Proto Protocol


### PR DESCRIPTION
Vendoring libnetwork v0.8.0-dev.1 which carries the required windows fix that TP5 build is dependent on.

v0.8.0-dev.1 contains 
- Fixes docker/docker#16964
- Added maximum egress bandwidth qos for Windows
