### PR TITLE
Create "src" symlink for building notary with gcc 5

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -113,7 +113,7 @@ RUN set -x \
 	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
-	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \
+	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION" && ln -s . vendor/src) \
 	&& GOPATH="$GOPATH/src/github.com/docker/notary/vendor:$GOPATH" \
 		go build -o /usr/local/bin/notary-server github.com/docker/notary/cmd/notary-server \
 	&& rm -rf "$GOPATH"


### PR DESCRIPTION
With gcc 5 version 1.4.2 of go is included. This version does not support
go's "native vendoring" which is needed to build notary since git commit
51dc1747e4ab5 ("Move the godeps workspace to the vendor directory to be
compliant with Go 1.6").

As a workaround create a symlink "vendor/src" that points to "vendor/".
This allows to compile notary with gcc 5.

closes #22007
Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
