### PR TITLE
Create a copy of stats value before modifications

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -43,11 +43,11 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 
 	var preCPUStats types.CPUStats
 	getStatJSON := func(v interface{}) *types.StatsJSON {
-		ss := v.(*types.StatsJSON)
+		ss := v.(types.StatsJSON)
 		ss.PreCPUStats = preCPUStats
 		// ss.MemoryStats.Limit = uint64(update.MemoryLimit)
 		preCPUStats = ss.CPUStats
-		return ss
+		return &ss
 	}
 
 	enc := json.NewEncoder(outStream)

--- a/daemon/stats_collector_unix.go
+++ b/daemon/stats_collector_unix.go
@@ -135,7 +135,7 @@ func (s *statsCollector) run() {
 			// FIXME: move to containerd
 			stats.CPUStats.SystemUsage = systemUsage
 
-			pair.publisher.Publish(stats)
+			pair.publisher.Publish(*stats)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #22030

Because the publisher uses this same value to all the
stats endpoints we need to make a copy of this as soon as we get it so
that we can make our modifications without it affecting others.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
