### PR TITLE
Remove restart canceled error

### DIFF
--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	containerd "github.com/docker/containerd/api/grpc/types"
+	"github.com/docker/docker/restartmanager"
 	"github.com/opencontainers/specs/specs-go"
 	"golang.org/x/net/context"
 )
@@ -135,7 +136,9 @@ func (ctr *container) handleEvent(e *containerd.Event) error {
 								logrus.Error(err)
 							}
 						})
-						logrus.Error(err)
+						if err != restartmanager.ErrRestartCanceled {
+							logrus.Error(err)
+						}
 					} else {
 						ctr.start()
 					}


### PR DESCRIPTION
It should not be an error to call a common option to cancel restarts.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
