### PR TITLE
Windows: don't overwrite PID file if process exists

### DIFF
--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -21,7 +20,7 @@ func checkPIDFileAlreadyExists(path string) error {
 	if pidByte, err := ioutil.ReadFile(path); err == nil {
 		pidString := strings.TrimSpace(string(pidByte))
 		if pid, err := strconv.Atoi(pidString); err == nil {
-			if _, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid))); err == nil {
+			if processExists(pid) {
 				return fmt.Errorf("pid file found, ensure docker is not running or delete %s", path)
 			}
 		}

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -13,9 +13,15 @@ func TestNewAndRemove(t *testing.T) {
 		t.Fatal("Could not create test directory")
 	}
 
-	file, err := New(filepath.Join(dir, "testfile"))
+	path := filepath.Join(dir, "testfile")
+	file, err := New(path)
 	if err != nil {
 		t.Fatal("Could not create test file", err)
+	}
+
+	_, err = New(path)
+	if err == nil {
+		t.Fatal("Test file creation not blocked")
 	}
 
 	if err := file.Remove(); err != nil {

--- a/pkg/pidfile/pidfile_unix.go
+++ b/pkg/pidfile/pidfile_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package pidfile
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+func processExists(pid int) bool {
+	if _, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid))); err == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -1,0 +1,23 @@
+package pidfile
+
+import "syscall"
+
+const (
+	processQueryLimitedInformation = 0x1000
+
+	stillActive = 259
+)
+
+func processExists(pid int) bool {
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	var c uint32
+	err = syscall.GetExitCodeProcess(h, &c)
+	syscall.Close(h)
+	if err != nil {
+		return c == stillActive
+	}
+	return true
+}


### PR DESCRIPTION
pidfile.New() was opening a file in /proc to determine if the owning process still exists. As a result, you would get a confusing error when trying to start two instances of the daemon.

Use syscall.OpenProcess() on Windows instead.

Other OSes may also need to be updated here.

cc @jhowardmsft 
