### PR TITLE
Windows CI: Eliminate use of DOCKER_TEST_HOST

### DIFF
--- a/hack/Jenkins/W2L/setup.sh
+++ b/hack/Jenkins/W2L/setup.sh
@@ -198,7 +198,6 @@ if [ $ec -eq 0 ]; then
 	set -x
 	export TIMEOUT="5m"
 	export DOCKER_HOST="tcp://$ip:$port_inner"
-	export DOCKER_TEST_HOST="tcp://$ip:$port_inner"
 	unset DOCKER_CLIENTONLY
 	export DOCKER_REMOTE_DAEMON=1
 	hack/make.sh binary 

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -2,6 +2,13 @@
 
 # see test-integration-cli for example usage of this script
 
+# Both Windows to Linux and Windows to Windows CIs start/stop the daemon
+# through their CI script. Hence this is a no-op on Windows.
+if [ "$(go env GOOS)" = 'windows' ]; then
+	return
+fi
+ 
+
 export PATH="$ABS_DEST/../binary:$ABS_DEST/../dynbinary:$ABS_DEST/../gccgo:$ABS_DEST/../dyngccgo:$PATH"
 
 if ! command -v docker &> /dev/null; then

--- a/hack/make/.integration-daemon-stop
+++ b/hack/make/.integration-daemon-stop
@@ -1,27 +1,27 @@
 #!/bin/bash
 
-if [ ! "$(go env GOOS)" = 'windows' ]; then
-	trap - EXIT # reset EXIT trap applied in .integration-daemon-start
+# Both Windows to Linux and Windows to Windows CIs start/stop the daemon
+# through their CI script. Hence this is a no-op on Windows.
+if [ "$(go env GOOS)" = 'windows' ]; then
+	return
+fi
 
-	for pidFile in $(find "$DEST" -name docker.pid); do
-		pid=$(set -x; cat "$pidFile")
-		( set -x; kill "$pid" )
-		if ! wait "$pid"; then
-			echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
-		fi
-	done
+trap - EXIT # reset EXIT trap applied in .integration-daemon-start
 
-	if [ -z "$DOCKER_TEST_HOST" ]; then
-		# Stop apparmor if it is enabled
-		if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
-			(
-				set -x
-				/etc/init.d/apparmor stop
-			)
-		fi
+for pidFile in $(find "$DEST" -name docker.pid); do
+	pid=$(set -x; cat "$pidFile")
+	( set -x; kill "$pid" )
+	if ! wait "$pid"; then
+		echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
 	fi
-else
-	# Note this script is not actionable on Windows to Linux CI. Instead the 
-	# DIND daemon under test is torn down by the Jenkins tear-down script
-	echo "INFO: Not stopping daemon on Windows CI"
+done
+
+if [ -z "$DOCKER_TEST_HOST" ]; then
+	# Stop apparmor if it is enabled
+	if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
+		(
+			set -x
+			/etc/init.d/apparmor stop
+		)
+	fi
 fi


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

When perusing the split binary PR (@dnephin, @tiborvass), and some of the issues getting it to pass CI, it became obvious that on Windows, DOCKER_TEST_HOST variable is pointless, not to mention very misleading as a name!!. It was being used to stop `.integration-daemon-start` and `.integration-daemon-stop` from doing anything. This is a better solution which doesn't rely on a variable being set, and doesn't regress the real use of DOCKER_TEST_HOST on Linux platforms.

This should hopefully also make the split binary PR slightly easier.
