### PR TITLE
Add load/save image event support

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -980,7 +980,7 @@ func isBrokenPipe(e error) bool {
 // the same tag are exported. names is the set of tags to export, and
 // outStream is the writer which the images are written to.
 func (daemon *Daemon) ExportImage(names []string, outStream io.Writer) error {
-	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore)
+	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon)
 	return imageExporter.Save(names, outStream)
 }
 
@@ -1059,7 +1059,7 @@ func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
 // complement of ImageExport.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 func (daemon *Daemon) LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
-	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore)
+	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon)
 	return imageExporter.Load(inTar, outStream, quiet)
 }
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2404,7 +2404,7 @@ Docker containers report the following events:
 
 Docker images report the following events:
 
-    delete, import, pull, push, tag, untag
+    delete, import, load, pull, push, save, tag, untag
 
 Docker volumes report the following events:
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -25,7 +25,7 @@ Docker containers report the following events:
 
 Docker images report the following events:
 
-    delete, import, pull, push, tag, untag
+    delete, import, load, pull, push, save, tag, untag
 
 Docker volumes report the following events:
 

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -122,6 +122,7 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		}
 
 		parentLinks = append(parentLinks, parentLink{imgID, m.Parent})
+		l.loggerImgEvent.LogImageEvent(imgID.String(), imgID.String(), "load")
 	}
 
 	for _, p := range validatedParentLinks(parentLinks) {

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -158,6 +158,7 @@ func (s *saveSession) save(outStream io.Writer) error {
 
 		parentID, _ := s.is.GetParent(id)
 		parentLinks = append(parentLinks, parentLink{id, parentID})
+		s.tarexporter.loggerImgEvent.LogImageEvent(id.String(), id.String(), "save")
 	}
 
 	for i, p := range validatedParentLinks(parentLinks) {

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -22,16 +22,24 @@ type manifestItem struct {
 }
 
 type tarexporter struct {
-	is image.Store
-	ls layer.Store
-	rs reference.Store
+	is             image.Store
+	ls             layer.Store
+	rs             reference.Store
+	loggerImgEvent LogImageEvent
+}
+
+// LogImageEvent defines interface for event generation related to image tar(load and save) operations
+type LogImageEvent interface {
+	//LogImageEvent generates an event related to an image operation
+	LogImageEvent(imageID, refName, action string)
 }
 
 // NewTarExporter returns new ImageExporter for tar packages
-func NewTarExporter(is image.Store, ls layer.Store, rs reference.Store) image.Exporter {
+func NewTarExporter(is image.Store, ls layer.Store, rs reference.Store, loggerImgEvent LogImageEvent) image.Exporter {
 	return &tarexporter{
-		is: is,
-		ls: ls,
-		rs: rs,
+		is:             is,
+		ls:             ls,
+		rs:             rs,
+		loggerImgEvent: loggerImgEvent,
 	}
 }

--- a/man/docker-events.1.md
+++ b/man/docker-events.1.md
@@ -18,11 +18,19 @@ information and real-time information.
 
 Docker containers will report the following events:
 
-    attach, commit, copy, create, destroy, die, exec_create, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause
+    attach, commit, copy, create, destroy, die, exec_create, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause, update
 
-and Docker images will report:
+Docker images report the following events:
 
-    delete, import, pull, push, tag, untag
+    delete, import, load, pull, push, save, tag, untag
+
+Docker volumes report the following events:
+
+    create, mount, unmount, destroy
+
+Docker networks report the following events:
+
+    create, connect, disconnect, destroy
 
 # OPTIONS
 **--help**


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
  make docker load/save emit events
**\- How I did it**
  move related logic to daemon directory(it follows other docker operation style)
**\- How to verify it**
 Have integration test for that

**\- A picture of a cute animal (not mandatory but encouraged)**

This change moves related load/save logic to daemon dir,
which keep same as other docker operations(import, export etc.)

For every docker load and save operations, it would log related
image events.

Closes: #21973

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
