### PR TITLE
Allow granular vendoring

### DIFF
--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# vendor.sh can now accept command line arguments
+#
+# Usage:
+# vendor.sh github.com/docker/engine-api will revendor only the engine-api dependency.
+# vendor.sh github.com/docker/engine-api v0.3.3 will vendor only engine-api at the specified tag/commit.
+# vendor.sh git github.com/docker/engine-api v0.3.3 is the same but specifies the VCS for cases where the VCS is something else than git
+# vendor.sh git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git will vendor only golang.org/x/sys downloading from the specified URL
+
+
 PROJECT=github.com/docker/docker
 
 # Downloads dependencies into vendor/ directory

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -2,8 +2,35 @@
 set -e
 
 cd "$(dirname "$BASH_SOURCE")/.."
-rm -rf vendor/
 source 'hack/.vendor-helpers.sh'
+
+case $# in
+0)
+	rm -rf vendor/
+	;;
+# If user passed arguments to the script
+1)
+	eval "$(grep -E "^clone [^ ]+ $1" "$0")"
+	clean
+	exit 0
+	;;
+2)
+	rm -rf "vendor/src/$1"
+	clone git "$1" "$2"
+	clean
+	exit 0
+	;;
+[34])
+	rm -rf "vendor/src/$2"
+	clone "$@"
+	clean
+	exit 0
+	;;
+*)
+	>&2 echo "error: unexpected parameters"
+	exit 1
+	;;
+esac
 
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 70b2c90b260171e829f1ebd7c17f600c11858dbe


### PR DESCRIPTION
**\- What I did**

Allow vendoring only one dependency.

**\- How I did it**

Passing command line parameters to hack/vendor.sh

**\- How to verify it**

Run examples below

**\- A picture of a cute animal (not mandatory but encouraged)**

![cute insect](http://petslady.com/files/images/Incredible-Eye-Macros-caterpillar1-490x367.img_assist_custom.jpg)

hack/vendor.sh can now accept command line arguments

`./hack/vendor.sh github.com/docker/engine-api` will revendor only the
engine-api dependency.

`./hack/vendor.sh github.com/docker/engine-api v0.3.3` will vendor only
engine-api at the specified tag/commit.

`./hack/vendor.sh git github.com/docker/engine-api v0.3.3` is the same
but specifies the VCS for cases where the VCS is something else than git

`./hack/vendor.sh git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git` will vendor only golang.org/x/sys
downloading from the specified URL

Signed-off-by: Tibor Vass tibor@docker.com
