### PR TITLE
build armhf deb for ubuntu-trusty

### DIFF
--- a/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
@@ -1,0 +1,10 @@
+FROM armhf/ubuntu:trusty
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.6.2
+RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV PATH $PATH:/usr/local/go/bin
+
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS apparmor selinux


### PR DESCRIPTION
**\- What I did**

Enable building of armhf Debian packages for Ubuntu trusty (14.04).
This is for armv7l machines like Odroid, BeagleBoneBlack, etc...

**\- How I did it**

Copied the `contrib/builder/deb/armhf/debian-jessie/Dockerfile` and adapted it for Ubuntu trusty (only changed to `FROM armhf/ubuntu:trusty`)

**\- How to verify it**

Build it with `make deb` on a ARMv7 machine then install it one one with Ubuntu trusty.

Tested on a odroid-XU3.

Signed-off-by: Felix Ruess felix.ruess@roboception.de
