### PR TITLE
show plugin details only if plugin is not empty

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -54,13 +54,15 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	ioutils.FprintfIfNotEmpty(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
 	ioutils.FprintfIfNotEmpty(cli.out, "Cgroup Driver: %s\n", info.CgroupDriver)
 
-	fmt.Fprintf(cli.out, "Plugins: \n")
-	fmt.Fprintf(cli.out, " Volume:")
-	fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Volume, " "))
-	fmt.Fprintf(cli.out, "\n")
-	fmt.Fprintf(cli.out, " Network:")
-	fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Network, " "))
-	fmt.Fprintf(cli.out, "\n")
+	if len(info.Plugins.Volume) != 0 || len(info.Plugins.Network) != 0 {
+		fmt.Fprintf(cli.out, "Plugins: \n")
+		fmt.Fprintf(cli.out, " Volume:")
+		fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Volume, " "))
+		fmt.Fprintf(cli.out, "\n")
+		fmt.Fprintf(cli.out, " Network:")
+		fmt.Fprintf(cli.out, " %s", strings.Join(info.Plugins.Network, " "))
+		fmt.Fprintf(cli.out, "\n")
+	}
 
 	if len(info.Plugins.Authorization) != 0 {
 		fmt.Fprintf(cli.out, " Authorization:")


### PR DESCRIPTION
show plugin details only if plugins are not empty
1.if volume plugin has details, print it in `docker info`
2.if network plugin has details, print it in `docker info`
3.if both volume plugin and network plugin have no details, do not print Plugins in `docker info`

It will make swarm `docker info` output better without outputting empty Plugins.

fix #22161 
