### PR TITLE
Move libcontainerd root inside /var/lib/docker

### DIFF
--- a/docker/daemon_unix.go
+++ b/docker/daemon_unix.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -88,7 +89,11 @@ func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 // getLibcontainerdRoot gets the root directory for libcontainerd/containerd to
 // store their state.
 func (cli *DaemonCli) getLibcontainerdRoot() string {
-	return filepath.Join(cli.Config.ExecRoot, "libcontainerd")
+	execRootPath := filepath.Join(cli.Config.ExecRoot, "libcontainerd")
+	if infos, _ := ioutil.ReadDir(execRootPath); len(infos) > 0 {
+		return execRootPath
+	}
+	return filepath.Join(cli.Config.Root, "libcontainerd")
 }
 
 // allocateDaemonPort ensures that there are no containers


### PR DESCRIPTION
Because libcontainerd mounts the container rootfs to
`/var/run/libcontainerd`, and some people mount `/var/run` into the
container. This causes mounts used by other containers to leak into
containers that do mount `/var/run`.

This is really just moving the problem, but since
mounting `/var/lib/docker` into a container is already problematic
(for the same reasons) at least we can fix issues of people being able
to mount `/var/run`

I chose not to change the default exec root path since this also contains other items.
We may want to change this all anyway... and do so before container re-attach is stable, which would complicate this since we couldn't really clean up the old files at that point.

This is a work-around for #21969
