### PR TITLE
Always disable containerd metrics when started by docker

### DIFF
--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -349,9 +349,9 @@ func (r *remote) runContainerdDaemon() error {
 	}
 
 	// Start a new instance
-	args := []string{"-l", r.rpcAddr, "--runtime", "docker-runc"}
+	args := []string{"-l", r.rpcAddr, "--runtime", "docker-runc", "--metrics-interval=0"}
 	if r.debugLog {
-		args = append(args, "--debug", "--metrics-interval=0")
+		args = append(args, "--debug")
 	}
 	if len(r.runtimeArgs) > 0 {
 		for _, v := range r.runtimeArgs {


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com

---

Since no-one will see them. 

![snakes](http://www.magazinetimepass.com/wp-content/uploads/2014/03/cartoon-cute-snakes-hat-10.jpeg)
