### PR TITLE
Labels set on the command line don't override labels in Dockerfile

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -40,19 +40,6 @@ import (
 	"github.com/docker/engine-api/types/strslice"
 )
 
-func (b *Builder) addLabels() {
-	// merge labels
-	if len(b.options.Labels) > 0 {
-		logrus.Debugf("[BUILDER] setting labels %v", b.options.Labels)
-		if b.runConfig.Labels == nil {
-			b.runConfig.Labels = make(map[string]string)
-		}
-		for kL, vL := range b.options.Labels {
-			b.runConfig.Labels[kL] = vL
-		}
-	}
-}
-
 func (b *Builder) commit(id string, autoCmd strslice.StrSlice, comment string) error {
 	if b.disableCommit {
 		return nil
@@ -418,20 +405,7 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 		b.image = img.ImageID()
 
 		if img.RunConfig() != nil {
-			imgConfig := *img.RunConfig()
-			// inherit runConfig labels from the current
-			// state if they've been set already.
-			// Ensures that images with only a FROM
-			// get the labels populated properly.
-			if b.runConfig.Labels != nil {
-				if imgConfig.Labels == nil {
-					imgConfig.Labels = make(map[string]string)
-				}
-				for k, v := range b.runConfig.Labels {
-					imgConfig.Labels[k] = v
-				}
-			}
-			b.runConfig = &imgConfig
+			b.runConfig = img.RunConfig()
 		}
 	}
 

--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -34,7 +34,7 @@ func parseSubCommand(rest string) (*Node, map[string]bool, error) {
 		return nil, nil, nil
 	}
 
-	_, child, err := parseLine(rest)
+	_, child, err := ParseLine(rest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -68,8 +68,8 @@ func init() {
 	}
 }
 
-// parse a line and return the remainder.
-func parseLine(line string) (string, *Node, error) {
+// ParseLine parse a line and return the remainder.
+func ParseLine(line string) (string, *Node, error) {
 	if line = stripComments(line); line == "" {
 		return "", nil, nil
 	}
@@ -111,7 +111,7 @@ func Parse(rwc io.Reader) (*Node, error) {
 	for scanner.Scan() {
 		scannedLine := strings.TrimLeftFunc(scanner.Text(), unicode.IsSpace)
 		currentLine++
-		line, child, err := parseLine(scannedLine)
+		line, child, err := ParseLine(scannedLine)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +126,7 @@ func Parse(rwc io.Reader) (*Node, error) {
 					continue
 				}
 
-				line, child, err = parseLine(line + newline)
+				line, child, err = ParseLine(line + newline)
 				if err != nil {
 					return nil, err
 				}
@@ -136,7 +136,7 @@ func Parse(rwc io.Reader) (*Node, error) {
 				}
 			}
 			if child == nil && line != "" {
-				_, child, err = parseLine(line)
+				_, child, err = ParseLine(line)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the inconsistency in #22036 where labels set on the command line will not override labels specified in Dockerfile, but will override labels inherited from `FROM` images.

**\- How I did it**

The fix add a LABEL with command line options at the end of the processed Dockerfile so that command line options labels always override the LABEL in Dockerfiles (or through `FROM`).

**\- How to verify it**

An integration test has been added for test cases specified in #22036.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22036.

NOTE: Some changes are from #22266 (@tiborvass).

Signed-off-by: Yong Tang yong.tang.github@outlook.com
