### PR TITLE
Graceful msg to provide when removing containers and networks

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -110,6 +110,8 @@ func (cli *DockerCli) CmdNetworkRm(args ...string) error {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			status = 1
 			continue
+		} else {
+			fmt.Fprintf(cli.out, "Deleted: %s\n", net)
 		}
 	}
 	if status != 0 {

--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -33,7 +33,7 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 		if err := cli.removeContainer(name, *v, *link, *force); err != nil {
 			errs = append(errs, err.Error())
 		} else {
-			fmt.Fprintf(cli.out, "%s\n", name)
+			fmt.Fprintf(cli.out, "Deleted: %s\n", name)
 		}
 	}
 	if len(errs) > 0 {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -114,10 +114,7 @@ func (s *DockerSuite) TestRunDetachedContainerIDPrinting(c *check.C) {
 
 	rmOut, _ := dockerCmd(c, "rm", out)
 
-	rmOut = strings.TrimSpace(rmOut)
-	if rmOut != out {
-		c.Errorf("rm didn't print the container ID %s %s", out, rmOut)
-	}
+	c.Assert(strings.TrimSpace(rmOut), checker.Contains, out, check.Commentf("rm didn't print the container ID %s", out))
 }
 
 // the working directory should be set correctly


### PR DESCRIPTION
For better user experience, removing containers and networks should be as follows:

```
root@5a7c129937a0:/go/src/github.com/docker/docker# docker rm -f drunk_wozniak
Deleted: drunk_wozniak
root@5a7c129937a0:/go/src/github.com/docker/docker# docker network rm test
Deleted: test
```

Signed-off-by: Wen Cheng Ma wenchma@cn.ibm.com
