### PR TITLE
Initialize activateWait for plugins activated by json spec

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 var (
@@ -118,6 +119,7 @@ func readPluginJSONInfo(name, path string) (*Plugin, error) {
 	if len(p.TLSConfig.CAFile) == 0 {
 		p.TLSConfig.InsecureSkipVerify = true
 	}
+	p.activateWait = sync.NewCond(&sync.Mutex{})
 
 	return &p, nil
 }


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/22175
This is a regression introduced by the well-intended fix : https://github.com/docker/docker/pull/21446.

The fix is straight-forward. most of the changes in this PR is to add an IT to test the case of plugins loaded via the json spec file format.
