### PR TITLE
Dockerfile.s390x: Add upstream libseccomp to compile runc

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -48,6 +48,21 @@ RUN apt-get update && apt-get install -y \
 	tar \
 	--no-install-recommends
 
+# install seccomp: the version shipped in jessie is too old
+ENV SECCOMP_VERSION 2.3.0
+RUN set -x \
+	&& export SECCOMP_PATH="$(mktemp -d)" \
+	&& curl -fsSL "https://github.com/seccomp/libseccomp/releases/download/v${SECCOMP_VERSION}/libseccomp-${SECCOMP_VERSION}.tar.gz" \
+		| tar -xzC "$SECCOMP_PATH" --strip-components=1 \
+	&& ( \
+		cd "$SECCOMP_PATH" \
+		&& ./configure --prefix=/usr/local \
+		&& make \
+		&& make install \
+		&& ldconfig \
+	) \
+	&& rm -rf "$SECCOMP_PATH"
+
 # Get lvm2 source for compiling statically
 ENV LVM2_VERSION 2.02.103
 RUN mkdir -p /usr/local/lvm2 \


### PR DESCRIPTION
The runc compile currently fails on s390x:

 Step 35 : RUN set -x    && export GOPATH="$(mktemp -d)" && git clone
 https://github.com/opencontainers/runc.git
 "$GOPATH/src/github.com/opencontainers/runc"       && cd
 "$GOPATH/src/github.com/opencontainers/runc"      && git checkout -q
 "$RUNC_COMMIT"  && make static BUILDTAGS="seccomp apparmor selinux"     &&
 cp runc /usr/local/bin/docker-runc

 [snip]

 # github.com/seccomp/libseccomp-golang
  Godeps/_workspace/src/github.com/seccomp/libseccomp-golang/seccomp.go:25:22:
  fatal error: seccomp.h: No such file or directory
   // #include <seccomp.h>

The problem is that the installed libseccomp version in trusty is too old.

Fix this and install version 2.3.0 of libseccomp like it is done in the
x86 Dockerfile.

Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
