### PR TITLE
Enabling specifying static ip for predefined network on windows

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -511,7 +511,7 @@ func (daemon *Daemon) updateNetworkConfig(container *container.Container, idOrNa
 	}
 
 	if !containertypes.NetworkMode(idOrName).IsUserDefined() {
-		if hasUserDefinedIPAddress(endpointConfig) {
+		if hasUserDefinedIPAddress(endpointConfig) && !enableIPOnPredefinedNetwork() {
 			return nil, runconfig.ErrUnsupportedNetworkAndIP
 		}
 		if endpointConfig != nil && len(endpointConfig.Aliases) > 0 {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -383,3 +383,7 @@ func isLinkable(child *container.Container) bool {
 func errRemovalContainer(containerID string) error {
 	return fmt.Errorf("Container %s is marked for removal and cannot be connected or disconnected to the network", containerID)
 }
+
+func enableIPOnPredefinedNetwork() bool {
+	return false
+}

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -55,3 +55,7 @@ func killProcessDirectly(container *container.Container) error {
 func isLinkable(child *container.Container) bool {
 	return false
 }
+
+func enableIPOnPredefinedNetwork() bool {
+	return true
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Windows only has ability for a single nat network. We want to allow specifying custom ip for the network. This is not allowed by docker. I have enabled that support for windows

**\- How I did it**
Added a function to enable ip configuration on predefined networks. The function returns true for windows and false on other platforms.

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: msabansal sabansal@microsoft.com
