### PR TITLE
Docker http panics caused by container deletion with empty names.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -137,6 +137,10 @@ type Daemon struct {
 //    unique enough to only return a single container object
 //  If none of these searches succeed, an error is returned
 func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, error) {
+	if len(prefixOrName) == 0 {
+		return nil, errors.NewBadRequestError(fmt.Errorf("No container name or ID supplied"))
+	}
+
 	if containerByID := daemon.containers.Get(prefixOrName); containerByID != nil {
 		// prefix is an exact match to a full container ID
 		return containerByID, nil
@@ -530,6 +534,9 @@ func (daemon *Daemon) newContainer(name string, config *containertypes.Config, i
 
 // GetByName returns a container given a name.
 func (daemon *Daemon) GetByName(name string) (*container.Container, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("No container name supplied")
+	}
 	fullName := name
 	if name[0] != '/' {
 		fullName = "/" + name

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1616,3 +1616,11 @@ func (s *DockerSuite) TestPostContainersCreateWithOomScoreAdjInvalidRange(c *che
 		c.Fatalf("Expected output to contain %q, got %q", expected, string(b))
 	}
 }
+
+// test case for #22210 where an emtpy container name caused panic.
+func (s *DockerSuite) TestContainerApiDeleteWithEmptyName(c *check.C) {
+	status, out, err := sockRequest("DELETE", "/containers/", nil)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusBadRequest)
+	c.Assert(string(out), checker.Contains, "No container name or ID supplied")
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to fix the http panics caused by container deletion with empty names in #22210.

**\- How I did it**

The issue was because when an empty string was passed, `GetByName()` tried to access the first element of the name string without checking the length. A length check has been added.

**\- How to verify it**

A test case for #22210 has been added.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22210.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
