### PR TITLE
Bump Go version to 1.6.2 from 1.6.1 where it was used

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -73,9 +73,9 @@ RUN cd /usr/local/lvm2 \
 
 ## BUILD GOLANG 1.6
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
-ENV GO_VERSION 1.6.1
+ENV GO_VERSION 1.6.2
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GO_DOWNLOAD_SHA256 1d4b53cdee51b2298afcf50926a7fa44b286f0bf24ff8323ce690a66daa7193f
+ENV GO_DOWNLOAD_SHA256 787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63f1bccc
 ENV GOROOT_BOOTSTRAP /usr/local
 
 RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \


### PR DESCRIPTION
Go 1.6.2 was [just released](https://groups.google.com/forum/?utm_source=golangweekly&utm_medium=email#!msg/golang-announce/8FwSHbMTEjQ/2-IAqgSbLgAJ) to fix some issues from 1.6.1, this bumps the Go version to 1.6.2 where 1.6.1 was used, to fix those issues.

Related: #22127

Signed-off-by: Ken Cochrane kencochrane@gmail.com
