### PR TITLE
Remove mlock and vhangup from the default seccomp profile

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -714,21 +714,6 @@
 			"args": []
 		},
 		{
-			"name": "mlock",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mlock2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mlockall",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
 			"name": "mmap",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -1561,11 +1546,6 @@
 		},
 		{
 			"name": "vfork",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "vhangup",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -746,21 +746,6 @@ var DefaultProfile = &types.Seccomp{
 			Args:   []*types.Arg{},
 		},
 		{
-			Name:   "mlock",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mlock2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mlockall",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
 			Name:   "mmap",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
@@ -1590,11 +1575,6 @@ var DefaultProfile = &types.Seccomp{
 		},
 		{
 			Name:   "vfork",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "vhangup",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 		},


### PR DESCRIPTION
These syscalls are already blocked by the default capabilities:
mlock mlock2 mlockall require CAP_IPC_LOCK
vhangup requires CAP_SYS_TTY_CONFIG

There is therefore no reason to allow them in the default profile
as they cannot be used anyway.

Signed-off-by: Justin Cormack justin.cormack@docker.com

Note I am planning to align the default seccomp filter with the capabilities the user selects and I found these during the audit for this.

// cc @jfrazelle 

![goat](https://cloud.githubusercontent.com/assets/482364/14718613/9f2a8194-07ef-11e6-926b-744566c3795d.jpg)
