### PR TITLE
Exclude .git directories from the source RPMS and debian packages

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -58,6 +58,7 @@ set -e
 			FROM $image
 			WORKDIR /usr/src/docker
 			COPY . /usr/src/docker
+			ENV DOCKER_GITCOMMIT $GITCOMMIT
 			RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers \
 				&& ln -snf /usr/src/docker /go/src/github.com/docker/docker
 		EOF
@@ -96,7 +97,7 @@ set -e
 			;;
 		esac
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			RUN dpkg-buildpackage -uc -us
+			RUN dpkg-buildpackage -uc -us -I.git
 		EOF
 		tempImage="docker-temp/build-deb:$version"
 		( set -x && docker build -t "$tempImage" -f "$DEST/$version/Dockerfile.build" . )

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -117,9 +117,9 @@ set -e
 			WORKDIR /root/rpmbuild
 			RUN ln -sfv /usr/src/${rpmName}/hack/make/.build-rpm SPECS
 			WORKDIR /root/rpmbuild/SPECS
-			RUN tar -r -C /usr/src -f /root/rpmbuild/SOURCES/${rpmName}.tar ${rpmName}
-			RUN tar -r -C /go/src/github.com/docker -f /root/rpmbuild/SOURCES/${rpmName}.tar containerd
-			RUN tar -r -C /go/src/github.com/opencontainers -f /root/rpmbuild/SOURCES/${rpmName}.tar runc
+			RUN tar --exclude .git -r -C /usr/src -f /root/rpmbuild/SOURCES/${rpmName}.tar ${rpmName}
+			RUN tar --exclude .git -r -C /go/src/github.com/docker -f /root/rpmbuild/SOURCES/${rpmName}.tar containerd
+			RUN tar --exclude .git -r -C /go/src/github.com/opencontainers -f /root/rpmbuild/SOURCES/${rpmName}.tar runc
 			RUN gzip /root/rpmbuild/SOURCES/${rpmName}.tar
 			RUN { cat /usr/src/${rpmName}/contrib/builder/rpm/${PACKAGE_ARCH}/changelog; } >> ${rpmName}.spec && tail >&2 ${rpmName}.spec
 			RUN rpmbuild -ba \


### PR DESCRIPTION
Right now the Source RPMs are around 121MB's and this is because we were accidentally including the .git directories. By excluding those directories we were able to trim off about 100MB of size off the SRPMS, and they are now around 22MB. 

The same was done with debian packages.

I tested this by running them normally, seeing the size of the source RPMS and debian packages and then again after making my change in this PR. Comparing the difference in sizes.

Signed-off-by: Ken Cochrane kencochrane@gmail.com
