### PR TITLE
Fix #22240 do not pull all the tags implicitely

### DIFF
--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -63,10 +63,10 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 		return cli.trustedPull(repoInfo, registryRef, authConfig, requestPrivilege)
 	}
 
-	return cli.imagePullPrivileged(authConfig, distributionRef.String(), requestPrivilege)
+	return cli.imagePullPrivileged(authConfig, distributionRef.String(), requestPrivilege, *allTags)
 }
 
-func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc) error {
+func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc, all bool) error {
 
 	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
@@ -75,6 +75,7 @@ func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, ref strin
 	options := types.ImagePullOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,
+		All:           all,
 	}
 
 	responseBody, err := cli.client.ImagePull(context.Background(), ref, options)

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -377,7 +377,7 @@ func (cli *DockerCli) trustedPull(repoInfo *registry.RepositoryInfo, ref registr
 		if err != nil {
 			return err
 		}
-		if err := cli.imagePullPrivileged(authConfig, ref.String(), requestPrivilege); err != nil {
+		if err := cli.imagePullPrivileged(authConfig, ref.String(), requestPrivilege, false); err != nil {
 			return err
 		}
 

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -25,7 +25,7 @@ clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api a2999dbd3471ffe167f2aec7dccb9fa9b016dcbc
+clone git github.com/docker/engine-api b7e5e1ecd6121d7b643d607f20ced0cb5c93739c
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -237,6 +237,20 @@ func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
 	c.Assert(splitLatest, checker.DeepEquals, splitCurrent, check.Commentf("busybox:latest was changed after pulling all tags"))
 }
 
+// TestRunImplicitPullWithNoTagOnlyPullDefaultTag should pull implicitely only the default tag (latest)
+func (s *DockerHubPullSuite) TestRunImplicitPullWithNoTagOnlyPullDefaultTag(c *check.C) {
+	// run with an image we don't have
+	testRequires(c, DaemonIsLinux)
+	out := s.Cmd(c, "run", "busybox")
+
+	c.Assert(out, checker.Contains, "Unable to find image 'busybox:latest' locally")
+
+	// There should be only one line for busybox, the one with busybox:latest
+	outImageCmd := s.Cmd(c, "images", "busybox")
+	splitOutImageCmd := strings.Split(strings.TrimSpace(outImageCmd), "\n")
+	c.Assert(splitOutImageCmd, checker.HasLen, 2)
+}
+
 // TestPullClientDisconnect kills the client during a pull operation and verifies that the operation
 // gets cancelled.
 //

--- a/vendor/src/github.com/docker/engine-api/client/client.go
+++ b/vendor/src/github.com/docker/engine-api/client/client.go
@@ -21,7 +21,7 @@ type Client struct {
 	addr string
 	// basePath holds the path to prepend to the requests.
 	basePath string
-	// transport is the interface to sends request with, it implements transport.Client.
+	// transport is the interface to send request with, it implements transport.Client.
 	transport transport.Client
 	// version of the server to talk to.
 	version string

--- a/vendor/src/github.com/docker/engine-api/client/image_pull.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_pull.go
@@ -27,7 +27,7 @@ func (cli *Client) ImagePull(ctx context.Context, ref string, options types.Imag
 
 	query := url.Values{}
 	query.Set("fromImage", repository)
-	if tag != "" {
+	if tag != "" && !options.All {
 		query.Set("tag", tag)
 	}
 

--- a/vendor/src/github.com/docker/engine-api/client/image_push.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_push.go
@@ -10,7 +10,6 @@ import (
 
 	distreference "github.com/docker/distribution/reference"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/reference"
 )
 
 // ImagePush requests the docker host to push an image to a remote registry.
@@ -27,7 +26,10 @@ func (cli *Client) ImagePush(ctx context.Context, ref string, options types.Imag
 		return nil, errors.New("cannot push a digest reference")
 	}
 
-	tag := reference.GetTagFromNamedRef(distributionRef)
+	var tag = ""
+	if nameTaggedRef, isNamedTagged := distributionRef.(distreference.NamedTagged); isNamedTagged {
+		tag = nameTaggedRef.Tag()
+	}
 
 	query := url.Values{}
 	query.Set("tag", tag)

--- a/vendor/src/github.com/docker/engine-api/client/request.go
+++ b/vendor/src/github.com/docker/engine-api/client/request.go
@@ -85,6 +85,11 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 	}
 
 	req, err := cli.newRequest(method, path, query, body, headers)
+	if cli.proto == "unix" || cli.proto == "npipe" {
+		// For local communications, it doesn't matter what the host is. We just
+		// need a valid and meaningful host name. (See #189)
+		req.Host = "docker"
+	}
 	req.URL.Host = cli.addr
 	req.URL.Scheme = cli.transport.Scheme()
 

--- a/vendor/src/github.com/docker/engine-api/client/transport/cancellable/LICENSE
+++ b/vendor/src/github.com/docker/engine-api/client/transport/cancellable/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -178,6 +178,7 @@ type ImageLoadResponse struct {
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {
+	All           bool
 	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
 	PrivilegeFunc RequestPrivilegeFunc
 }

--- a/vendor/src/github.com/docker/engine-api/types/configs.go
+++ b/vendor/src/github.com/docker/engine-api/types/configs.go
@@ -38,7 +38,7 @@ type ContainerCommitConfig struct {
 	Config       *container.Config
 }
 
-// ExecConfig is a small subset of the Config struct that hold the configuration
+// ExecConfig is a small subset of the Config struct that holds the configuration
 // for the exec feature of docker.
 type ExecConfig struct {
 	User         string   // User that will run the command

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -25,7 +25,7 @@ func (i Isolation) IsDefault() bool {
 // IpcMode represents the container ipc stack.
 type IpcMode string
 
-// IsPrivate indicates whether the container uses it's private ipc stack.
+// IsPrivate indicates whether the container uses its private ipc stack.
 func (n IpcMode) IsPrivate() bool {
 	return !(n.IsHost() || n.IsContainer())
 }
@@ -186,7 +186,7 @@ func (rp *RestartPolicy) IsAlways() bool {
 }
 
 // IsOnFailure indicates whether the container has the "on-failure" restart policy.
-// This means the contain will automatically restart of exiting with a non-zero exit status.
+// This means the container will automatically restart of exiting with a non-zero exit status.
 func (rp *RestartPolicy) IsOnFailure() bool {
 	return rp.Name == "on-failure"
 }

--- a/vendor/src/github.com/docker/engine-api/types/reference/image_reference.go
+++ b/vendor/src/github.com/docker/engine-api/types/reference/image_reference.go
@@ -4,7 +4,7 @@ import (
 	distreference "github.com/docker/distribution/reference"
 )
 
-// Parse parses the given references and return the repository and
+// Parse parses the given references and returns the repository and
 // tag (if present) from it. If there is an error during parsing, it will
 // return an error.
 func Parse(ref string) (string, string, error) {
@@ -18,7 +18,7 @@ func Parse(ref string) (string, string, error) {
 }
 
 // GetTagFromNamedRef returns a tag from the specified reference.
-// This function is necessary as long as the docker "server" api make the distinction between repository
+// This function is necessary as long as the docker "server" api makes the distinction between repository
 // and tags.
 func GetTagFromNamedRef(ref distreference.Named) string {
 	var tag string
@@ -27,6 +27,8 @@ func GetTagFromNamedRef(ref distreference.Named) string {
 		tag = x.Digest().String()
 	case distreference.NamedTagged:
 		tag = x.Tag()
+	default:
+		tag = "latest"
 	}
 	return tag
 }

--- a/vendor/src/github.com/docker/engine-api/types/registry/registry.go
+++ b/vendor/src/github.com/docker/engine-api/types/registry/registry.go
@@ -82,7 +82,7 @@ type SearchResult struct {
 	IsOfficial bool `json:"is_official"`
 	// Name is the name of the repository
 	Name string `json:"name"`
-	// IsOfficial indicates whether the result is trusted
+	// IsTrusted indicates whether the result is trusted
 	IsTrusted bool `json:"is_trusted"`
 	// IsAutomated indicates whether the result is automated
 	IsAutomated bool `json:"is_automated"`

--- a/vendor/src/github.com/docker/engine-api/types/versions/v1p20/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/versions/v1p20/types.go
@@ -27,7 +27,7 @@ type ContainerConfig struct {
 	VolumeDriver string
 }
 
-// StatsJSON is a backcompatibility struct used in Stats for API prior to 1.21
+// StatsJSON is a backcompatibility struct used in Stats for APIs prior to 1.21
 type StatsJSON struct {
 	types.Stats
 	Network types.NetworkStats `json:"network,omitempty"`


### PR DESCRIPTION
This fixes #22240 (`docker run -it busybox /bin/sh` will, on master, pull any tag if `busybox:latest` was not present) <del>in a weird and quick way. I would really prefer the fix in docker/engine-api#205 (in one of the _option_)</del> — it is now cleaner and uses engine-api.

Depends on docker/engine-api#205 :angel: 

/cc @stevvooe @calavera @tonistiigi 

Signed-off-by: Vincent Demeester vincent@sbr.pm
