### PR TITLE
[WIP] add network restore to experimental

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/kernel"
@@ -654,9 +655,11 @@ func (daemon *Daemon) initNetworkController(config *Config) (libnetwork.NetworkC
 	}
 
 	if !config.DisableBridge {
-		// Initialize default driver "bridge"
-		if err := initBridgeDriver(controller, config); err != nil {
-			return nil, err
+		if !libcontainerd.EnableLiveRestore() {
+			// Initialize default driver "bridge"
+			if err := initBridgeDriver(controller, config); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -193,3 +193,67 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *che
 		t.Fatalf("Expected exit code '%s' got '%s' for container '%s'\n", "running", out, cid)
 	}
 }
+
+func (s *DockerDaemonSuite) TestDaemonRestartRestoreBridgeNetwork(t *check.C) {
+	testRequires(t, DaemonIsLinux)
+	if err := s.d.StartWithBusybox(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.d.Stop()
+	oldCon := "old"
+
+	_, err := s.d.Cmd("run", "-d", "--name", oldCon, "-p", "80:80", "busybox", "top")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldContainerIP, err := s.d.Cmd("inspect", "-f", "{{ .NetworkSettings.Networks.bridge.IPAddress }}", oldCon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Kill the daemon
+	if err := s.d.Kill(); err != nil {
+		t.Fatal(err)
+	}
+
+	// restart the daemon
+	if err := s.d.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// start a new container, the new container's ip should not be the same with
+	// old running container.
+	newCon := "new"
+	_, err = s.d.Cmd("run", "-d", "--name", newCon, "busybox", "top")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newContainerIP, err := s.d.Cmd("inspect", "-f", "{{ .NetworkSettings.Networks.bridge.IPAddress }}", newCon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Compare(strings.TrimSpace(oldContainerIP), strings.TrimSpace(newContainerIP)) == 0 {
+		t.Fatalf("new container ip should not equal to old running container  ip")
+	}
+
+	// start a new container, the new container should ping old running container
+	_, err = s.d.Cmd("run", "-t", "busybox", "ping", "-c", "1", oldContainerIP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// start a new container try to publist port 80:80 will failed
+	out, err := s.d.Cmd("run", "-p", "80:80", "-d", "busybox", "top")
+	if err == nil || !strings.Contains(out, "Bind for 0.0.0.0:80 failed: port is already allocated") {
+		t.Fatalf("80 port is allocated to old running container, it should failed on allocating to new container")
+	}
+
+	// kill old running container and try to allocate again
+	_, err = s.d.Cmd("kill", oldCon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.d.Cmd("run", "-p", "80:80", "-d", "busybox", "top")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -891,7 +891,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkOverlayPortMapping(c *check.C) {
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkDriverUngracefulRestart(c *check.C) {
-	testRequires(c, DaemonIsLinux, NotUserNamespace)
+	testRequires(c, DaemonIsLinux, NotUserNamespace, NotExperimentalDaemon)
 	dnd := "dnd"
 	did := "did"
 

--- a/libcontainerd/client_liverestore_linux.go
+++ b/libcontainerd/client_liverestore_linux.go
@@ -9,6 +9,11 @@ import (
 	containerd "github.com/docker/containerd/api/grpc/types"
 )
 
+// EnableLiveRestore return true for experimental
+func EnableLiveRestore() bool {
+	return true
+}
+
 func (clnt *client) restore(cont *containerd.Container, options ...CreateOption) (err error) {
 	clnt.lock(cont.Id)
 	defer clnt.unlock(cont.Id)

--- a/libcontainerd/client_shutdownrestore_linux.go
+++ b/libcontainerd/client_shutdownrestore_linux.go
@@ -9,6 +9,11 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+// EnableLiveRestore return false for non-experimental
+func EnableLiveRestore() bool {
+	return false
+}
+
 func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 	w := clnt.getOrCreateExitNotifier(containerID)
 	defer w.close()

--- a/vendor/src/github.com/docker/libnetwork/config/config.go
+++ b/vendor/src/github.com/docker/libnetwork/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Daemon  DaemonCfg
 	Cluster ClusterCfg
 	Scopes  map[string]*datastore.ScopeCfg
+	Restore bool
 }
 
 // DaemonCfg represents libnetwork core configuration
@@ -182,6 +183,13 @@ func OptionDiscoveryWatcher(watcher discovery.Watcher) Option {
 func OptionDiscoveryAddress(address string) Option {
 	return func(c *Config) {
 		c.Cluster.Address = address
+	}
+}
+
+// OptionRestoreNetwork function returns an option setter for restore network
+func OptionRestoreNetwork(restore bool) Option {
+	return func(c *Config) {
+		c.Restore = restore
 	}
 }
 

--- a/vendor/src/github.com/docker/libnetwork/driverapi/driverapi.go
+++ b/vendor/src/github.com/docker/libnetwork/driverapi/driverapi.go
@@ -74,6 +74,9 @@ type InterfaceInfo interface {
 
 	// AddressIPv6 returns the IPv6 address.
 	AddressIPv6() *net.IPNet
+
+	// SrcName return the srcName
+	SrcName() string
 }
 
 // InterfaceNameInfo provides a go interface for the drivers to assign names

--- a/vendor/src/github.com/docker/libnetwork/drivers.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers.go
@@ -42,6 +42,9 @@ func makeDriverConfig(c *controller, ntype string) map[string]interface{} {
 
 		config[netlabel.Key(label)] = netlabel.Value(label)
 	}
+	if c.cfg.Restore {
+		config["restore"] = true
+	}
 
 	drvCfg, ok := c.cfg.Daemon.DriverCfg[ntype]
 	if ok {

--- a/vendor/src/github.com/docker/libnetwork/endpoint_info.go
+++ b/vendor/src/github.com/docker/libnetwork/endpoint_info.go
@@ -56,6 +56,10 @@ type endpointInterface struct {
 	v6PoolID  string
 }
 
+func (epi *endpointInterface) SrcName() string {
+	return epi.srcName
+}
+
 func (epi *endpointInterface) MarshalJSON() ([]byte, error) {
 	epMap := make(map[string]interface{})
 	if epi.mac != nil {
@@ -144,6 +148,59 @@ type endpointJoinInfo struct {
 	gw6                   net.IP
 	StaticRoutes          []*types.StaticRoute
 	disableGatewayService bool
+}
+
+func (epj *endpointJoinInfo) MarshalJSON() ([]byte, error) {
+	epMap := make(map[string]interface{})
+	if epj.gw != nil {
+		epMap["gw"] = epj.gw.String()
+	}
+	if epj.gw6 != nil {
+		epMap["gw6"] = epj.gw6.String()
+	}
+	epMap["disableGatewayService"] = epj.disableGatewayService
+	epMap["StaticRoutes"] = epj.StaticRoutes
+	return json.Marshal(epMap)
+}
+
+func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
+	var (
+		err   error
+		epMap map[string]interface{}
+	)
+	if err = json.Unmarshal(b, &epMap); err != nil {
+		return err
+	}
+	if v, ok := epMap["gw"]; ok {
+		epj.gw6 = net.ParseIP(v.(string))
+	}
+	if v, ok := epMap["gw6"]; ok {
+		epj.gw6 = net.ParseIP(v.(string))
+	}
+	epj.disableGatewayService = epMap["disableGatewayService"].(bool)
+
+	var tStaticRoute []types.StaticRoute
+	if v, ok := epMap["StaticRoutes"]; ok {
+		tb, _ := json.Marshal(v)
+		var tStaticRoute []types.StaticRoute
+		json.Unmarshal(tb, &tStaticRoute)
+	}
+	var StaticRoutes []*types.StaticRoute
+	for _, r := range tStaticRoute {
+		StaticRoutes = append(StaticRoutes, &r)
+	}
+	epj.StaticRoutes = StaticRoutes
+
+	return nil
+}
+
+func (epj *endpointJoinInfo) CopyTo(dstEpj *endpointJoinInfo) error {
+	dstEpj.disableGatewayService = epj.disableGatewayService
+	dstEpj.StaticRoutes = make([]*types.StaticRoute, len(epj.StaticRoutes))
+	copy(dstEpj.StaticRoutes, epj.StaticRoutes)
+	dstEpj.gw = types.GetIPCopy(epj.gw)
+	dstEpj.gw = types.GetIPCopy(epj.gw6)
+	return nil
 }
 
 func (ep *endpoint) Info() EndpointInfo {

--- a/vendor/src/github.com/docker/libnetwork/osl/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/osl/sandbox.go
@@ -4,6 +4,7 @@ package osl
 import (
 	"net"
 
+	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/types"
 )
 
@@ -11,7 +12,7 @@ import (
 // holds a list of Interfaces, routes etc, and more can be added dynamically.
 type Sandbox interface {
 	// The path where the network namespace is mounted.
-	Key() string
+	GetKey() string
 
 	// Add an existing Interface to this sandbox. The operation will rename
 	// from the Interface SrcName to DstName as it moves, and reconfigure the
@@ -58,6 +59,23 @@ type Sandbox interface {
 
 	// Destroy the sandbox
 	Destroy() error
+
+	// UpdateToStore update the sandbox to store
+	UpdateToStore(store UpdateToStore) error
+
+	// Get sandbox from store
+	GetFromStore(datastore.DataStore) error
+
+	// Delete from store
+	DeleteFromStore(store DeleteFromStore) error
+}
+
+type UpdateToStore interface {
+	UpdateToStore(kvObject datastore.KVObject) error
+}
+
+type DeleteFromStore interface {
+	DeleteFromStore(kvObject datastore.KVObject) error
 }
 
 // NeighborOptionSetter interfaces defines the option setter methods for interface options

--- a/vendor/src/github.com/docker/libnetwork/sandbox_dns_unix.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox_dns_unix.go
@@ -275,7 +275,11 @@ func (sb *sandbox) rebuildDNS() error {
 
 	// localhost entries have already been filtered out from the list
 	// retain only the v4 servers in sb for forwarding the DNS queries
-	sb.extDNS = resolvconf.GetNameservers(currRC.Content, netutils.IPv4)
+	if len(sb.extDNS) == 0 {
+		// if sb.extDNS > 0, it means the sandbox is restored from old running container
+		// and the dns has been rebuild
+		sb.extDNS = resolvconf.GetNameservers(currRC.Content, netutils.IPv4)
+	}
 
 	var (
 		dnsList        = []string{sb.resolver.NameServer()}

--- a/vendor/src/github.com/docker/libnetwork/store.go
+++ b/vendor/src/github.com/docker/libnetwork/store.go
@@ -205,6 +205,10 @@ func (n *network) getEndpointsFromStore() ([]*endpoint, error) {
 	return epl, nil
 }
 
+func (c *controller) UpdateToStore(kvObject datastore.KVObject) error {
+	return c.updateToStore(kvObject)
+}
+
 func (c *controller) updateToStore(kvObject datastore.KVObject) error {
 	cs := c.getStore(kvObject.DataScope())
 	if cs == nil {
@@ -220,6 +224,10 @@ func (c *controller) updateToStore(kvObject datastore.KVObject) error {
 	}
 
 	return nil
+}
+
+func (c *controller) DeleteFromStore(kvObject datastore.KVObject) error {
+	return c.deleteFromStore(kvObject)
 }
 
 func (c *controller) deleteFromStore(kvObject datastore.KVObject) error {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
add network restore to experimental https://github.com/docker/libnetwork/pull/1135
it's work for `bridge` driver network for now. 
TODO: add more driver support and more test cases
**\- How I did it**

**\- How to verify it**
run several containers with network which driver is `bridge` and then
kill daemon and then restart daemon.  the daemon should 
restore the network of old running container, any network operation
should work.

```
[lei@fedora docker]$ docker network create foo
a1ffe54e22b228e20d8da498eacc8dc63c40585ea42930755762350cffeb6892
[lei@fedora docker]$ docker run -tid busybox
4a8ea9718ca5ee6b43d70109e786624588cc99299eaacf030cbf9635b3d3ce44
[lei@fedora docker]$ docker run -tid --net foo --name foo busybox
381457006cac4c42aacdb38a67b603325f4a2ed47fa53f697b764908d5546b49
[lei@fedora docker]$ docker run -tid --net foo --name bar busybox
8b2dedf3c001121f92200929cb557476d4e15bcb7ae1bf1330bff7a9303c5a7b

sudo kill -9 $(cat /var/run/docker.pid)

restart daemon

INFO[0001] restore sandbox 027daaca9a9685668965b29748930b7c6e404e3a95a1434af65242d1c63c5f53 of container 381457006cac4c42aacdb38a67b603325f4a2ed47fa53f697b764908d5546b49
INFO[0001] restore sandbox 742210ad286666d0937d7f05aca0b408d0e9aa3d9d0f4a33f4d449a5fa354e4e of container 8b2dedf3c001121f92200929cb557476d4e15bcb7ae1bf1330bff7a9303c5a7b
INFO[0001] restore sandbox e309bcd536677034efa63412e36ec23b81b32b51030e5ffbd18c2c5298e23278 of container 4a8ea9718ca5ee6b43d70109e786624588cc99299eaacf030cbf9635b3d3ce44

[lei@fedora docker]$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
8b2dedf3c001        busybox             "sh"                2 minutes ago       Up 2 minutes                            bar
381457006cac        busybox             "sh"                2 minutes ago       Up 2 minutes                            foo
4a8ea9718ca5        busybox             "sh"                4 minutes ago       Up 4 minutes                            big_leakey

[lei@fedora docker]$ docker exec -ti bar sh -c 'ping foo -c 4'
PING foo (172.19.0.2): 56 data bytes
64 bytes from 172.19.0.2: seq=0 ttl=64 time=0.146 ms
64 bytes from 172.19.0.2: seq=1 ttl=64 time=0.100 ms
64 bytes from 172.19.0.2: seq=2 ttl=64 time=0.080 ms
64 bytes from 172.19.0.2: seq=3 ttl=64 time=0.133 ms

--- foo ping statistics ---
4 packets transmitted, 4 packets received, 0% packet loss
round-trip min/avg/max = 0.080/0.114/0.146 ms

[lei@fedora docker]$ docker network disconnect foo bar
[lei@fedora docker]$ docker exec -ti bar ifconfig
lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:12 errors:0 dropped:0 overruns:0 frame:0
          TX packets:12 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1
          RX bytes:887 (887.0 B)  TX bytes:887 (887.0 B)

[lei@fedora docker]$ docker network create test
66f352d41ec8b02463c6d2c2f2c34a564421b61044cd12a8554b13aa2b511245
[lei@fedora docker]$ docker network connect test bar
[lei@fedora docker]$ docker run -tid --name abcd --net test busybox
bdf2389c2484ac7ff36a5e70ebebf64bc4fbc34d9cb5c453b1ea9b1b09266144
[lei@fedora docker]$ docker exec -ti bar sh -c "ping abcd -c 4"
PING abcd (172.23.0.3): 56 data bytes
64 bytes from 172.23.0.3: seq=0 ttl=64 time=0.111 ms
64 bytes from 172.23.0.3: seq=1 ttl=64 time=0.087 ms
64 bytes from 172.23.0.3: seq=2 ttl=64 time=0.075 ms
64 bytes from 172.23.0.3: seq=3 ttl=64 time=0.078 ms

--- abcd ping statistics ---
4 packets transmitted, 4 packets received, 0% packet loss
round-trip min/avg/max = 0.075/0.087/0.111 ms
```

**\- A picture of a cute animal (not mandatory but encouraged)**
