### PR TITLE
api: server: check for unauthorized error

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -52,6 +52,7 @@ func GetHTTPErrorStatusCode(err error) int {
 			"conflict":              http.StatusConflict,
 			"impossible":            http.StatusNotAcceptable,
 			"wrong login/password":  http.StatusUnauthorized,
+			"unauthorized":          http.StatusUnauthorized,
 			"hasn't been activated": http.StatusForbidden,
 		} {
 			if strings.Contains(errStr, keyword) {


### PR DESCRIPTION
Fixes something about #21054, though there are still missing points but at least this fixes the regression we saw.

ping @calavera @aaronlehmann 

This functionality has been fixed by
7bca93218291767c5dd8782de0ad630dbcda9995 but then it has been broken
again by a793564b2591035aec5412fbcbcccf220c773a4c and finally refixed
here.

Basically the functionality was to prompt for login when trying to pull
from the official docker hub.

Signed-off-by: Antonio Murdaca runcom@redhat.com
