### PR TITLE
Add default `serveraddress` value in remote API `/auth`

### DIFF
--- a/integration-cli/docker_api_auth_test.go
+++ b/integration-cli/docker_api_auth_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/engine-api/types"
+	"github.com/go-check/check"
+)
+
+// Test case for #22244
+func (s *DockerSuite) TestAuthApi(c *check.C) {
+	config := types.AuthConfig{
+		Username: "no-user",
+		Password: "no-password",
+	}
+
+	expected := "Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password\n"
+	status, body, err := sockRequest("POST", "/auth", config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusUnauthorized)
+	c.Assert(string(body), checker.Contains, expected, check.Commentf("Expected: %v, got: %v", expected, string(body)))
+}

--- a/registry/service.go
+++ b/registry/service.go
@@ -37,6 +37,9 @@ func (s *Service) ServiceConfig() *registrytypes.ServiceConfig {
 // It can be used to verify the validity of a client's credentials.
 func (s *Service) Auth(authConfig *types.AuthConfig, userAgent string) (status, token string, err error) {
 	serverAddress := authConfig.ServerAddress
+	if serverAddress == "" {
+		serverAddress = IndexServer
+	}
 	if !strings.HasPrefix(serverAddress, "https://") && !strings.HasPrefix(serverAddress, "http://") {
 		serverAddress = "https://" + serverAddress
 	}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue in #22244 where the remote API `/auth` will not set the default value of `serveraddress` if not provided. This behavior happens only after 1.11.0 and is a regression as in 1.10.3, `serveraddress` will be assigned with `IndexServer` if no value is provided.

**\- How I did it**

The default value `IndexServer` is assigned to `serveraddress` if no value provided in this fix.

**\- How to verify it**

An integration test `TestAuthApi` has been added to cover this change

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22244.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
