### PR TITLE
Use absolute path for rootfs in OCI config.json

### DIFF
--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -30,7 +30,6 @@ func (ctr *container) clean() error {
 		return err
 	}
 
-	syscall.Unmount(filepath.Join(ctr.dir, "rootfs"), syscall.MNT_DETACH) // ignore error
 	if err := os.RemoveAll(ctr.dir); err != nil {
 		return err
 	}


### PR DESCRIPTION
This avoid an extra bind mount within `/var/run/docker/libcontainerd`

This should resolve situations where a container having the host
`/var/run` bound prevents other containers from being cleanly removed
(e.g. #21969).

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com

---

~~This is technically making docker non `OCI` compliant, but then again `runc` allows it currently :).~~

There's an open issue for fixing the spec at opencontainers/runtime-spec/issues/389 with an associated PR for fixing the spec at opencontainers/runtime-spec/pull/394

![](https://s-media-cache-ak0.pinimg.com/564x/3b/93/99/3b93993ec76e1ff0975840199eb64202.jpg)
