### PR TITLE
distribution: errors: do not retry if too many login attempts

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -89,7 +89,7 @@ func retryOnError(err error) error {
 		}
 	case errcode.Error:
 		switch v.Code {
-		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied:
+		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied, errcode.ErrorCodeTooManyRequests:
 			return xfer.DoNotRetry{Err: err}
 		}
 	case *url.Error:

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -49,7 +49,7 @@ clone git github.com/boltdb/bolt v1.2.0
 clone git github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-clone git github.com/docker/distribution 467fc068d88aa6610691b7f1a677271a3fac4aac
+clone git github.com/docker/distribution 9ec0d742d69f77caa4dd5f49ceb70c3067d39f30
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile

--- a/vendor/src/github.com/docker/distribution/manifest/schema1/config_builder.go
+++ b/vendor/src/github.com/docker/distribution/manifest/schema1/config_builder.go
@@ -110,7 +110,8 @@ func (mb *configManifestBuilder) Build(ctx context.Context) (m distribution.Mani
 		ContainerConfig struct {
 			Cmd []string
 		} `json:"container_config,omitempty"`
-		ThrowAway bool `json:"throwaway,omitempty"`
+		Author    string `json:"author,omitempty"`
+		ThrowAway bool   `json:"throwaway,omitempty"`
 	}
 
 	fsLayerList := make([]FSLayer, len(img.History))
@@ -145,6 +146,7 @@ func (mb *configManifestBuilder) Build(ctx context.Context) (m distribution.Mani
 			Parent:  parent,
 			Comment: h.Comment,
 			Created: h.Created,
+			Author:  h.Author,
 		}
 		v1Compatibility.ContainerConfig.Cmd = []string{img.History[i].CreatedBy}
 		if h.EmptyLayer {

--- a/vendor/src/github.com/docker/distribution/registry/api/errcode/register.go
+++ b/vendor/src/github.com/docker/distribution/registry/api/errcode/register.go
@@ -63,6 +63,19 @@ var (
 		Description:    "Returned when a service is not available",
 		HTTPStatusCode: http.StatusServiceUnavailable,
 	})
+
+	// ErrorCodeTooManyRequests is returned if a client attempts too many
+	// times to contact a service endpoint.
+	ErrorCodeTooManyRequests = Register("errcode", ErrorDescriptor{
+		Value:   "TOOMANYREQUESTS",
+		Message: "too many requests",
+		Description: `Returned when a client attempts to contact a
+		service too many times`,
+		// FIXME: go1.5 doesn't export http.StatusTooManyRequests while
+		// go1.6 does. Update the hardcoded value to the constant once
+		// Docker updates golang version to 1.6.
+		HTTPStatusCode: 429,
+	})
 )
 
 var nextCode = 1000


### PR DESCRIPTION
Hit this while looking for other stuff in the push code. Basically this stops retrying if that too many login attempts error is encountered (I don't see why keep trying to login, you'll wait more and more.). I believe this happens only against the official docker hub though. The check isn't perfect, if you have suggestions, welcome. I thought this string check could be avoided by placing this error in `errcode` pkg in distribution, again, not sure.

ping @aaronlehmann 

(to @aaronlehmann as a side note, the client doesn't receive the error, as the push with unauthorized case from https://github.com/docker/docker/pull/22253#issuecomment-213470857, the client just gets 200 because I think the status code is written before to allow streaming of chars, not sure)

Signed-off-by: Antonio Murdaca runcom@redhat.com
