### PR TITLE
Relative symlinks don't work with --device argument

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -311,7 +311,7 @@ func getDevicesFromPath(deviceMapping containertypes.DeviceMapping) (devs []spec
 
 	// check if it is a symbolic link
 	if src, e := os.Lstat(deviceMapping.PathOnHost); e == nil && src.Mode()&os.ModeSymlink == os.ModeSymlink {
-		if linkedPathOnHost, e := os.Readlink(deviceMapping.PathOnHost); e == nil {
+		if linkedPathOnHost, e := filepath.EvalSymlinks(deviceMapping.PathOnHost); e == nil {
 			resolvedPathOnHost = linkedPathOnHost
 		}
 	}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #22271 where relative symlinks don't work with --device argument.

**\- How I did it**

Previously, the symlinks in --device was implemneted (#20684) with `os.Readlink()` which does not resolve if the linked target is a relative path. In this fix, `filepath.EvalSymlinks()` has been used which will reolve correctly with relative paths.

**\- How to verify it**

An additional test case has been added to the existing `TestRunDeviceSymlink` to cover changes in this fix.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix is related to #13840 and #20684, #22271.
This fix fixes #22271.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
