### PR TITLE
Add dockerd daemon binary to tgz and zip archives

### DIFF
--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -14,6 +14,7 @@ for d in "$CROSS/"*/*; do
 	export GOARCH="$(basename "$d")"
 	export GOOS="$(basename "$(dirname "$d")")"
 	BINARY_NAME="docker-$VERSION"
+	DAEMON_BINARY_NAME="dockerd-$VERSION"
 	BINARY_EXTENSION="$(export GOOS && binary_extension)"
 	if [ "$GOOS" = 'windows' ]; then
 		# if windows use a zip, not tgz
@@ -24,6 +25,7 @@ for d in "$CROSS/"*/*; do
 		IS_TAR="true"
 	fi
 	BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
+	DAEMON_BINARY_FULLNAME="$DAEMON_BINARY_NAME$BINARY_EXTENSION"
 	mkdir -p "$DEST/$GOOS/$GOARCH"
 	TGZ="$DEST/$GOOS/$GOARCH/$BINARY_NAME$BUNDLE_EXTENSION"
 
@@ -39,6 +41,9 @@ for d in "$CROSS/"*/*; do
 	# Copy the correct docker binary
 	mkdir -p $TAR_PATH
 	cp -L "$d/$BINARY_FULLNAME" "$TAR_PATH/docker$BINARY_EXTENSION"
+	if [ -f "$d/$DAEMON_BINARY_FULLNAME" ]; then
+		cp -L "$d/$DAEMON_BINARY_FULLNAME" "$TAR_PATH/dockerd$BINARY_EXTENSION"
+	fi
 
 	# copy over all the containerd binaries
 	copy_containerd $TAR_PATH


### PR DESCRIPTION
This is a small fix that adds the daemon binary in the tgz and zip archives.

Related to #20639

Ping @jhowardmsft @kencochrane 
