### PR TITLE
Fix insecure registries upppercase in docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -153,7 +153,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	}
 
 	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
-		fmt.Fprintln(cli.out, "Insecure registries:")
+		fmt.Fprintln(cli.out, "Insecure Registries:")
 		for _, registry := range info.RegistryConfig.IndexConfigs {
 			if registry.Secure == false {
 				fmt.Fprintf(cli.out, " %s\n", registry.Name)

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -178,7 +178,7 @@ func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
 
 	out, err := d.Cmd("info")
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, "Insecure registries:\n")
+	c.Assert(out, checker.Contains, "Insecure Registries:\n")
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s\n", registryHost))
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s\n", registryCIDR))
 }


### PR DESCRIPTION
make Insecure registries uppercase like other keys in docker info
