### PR TITLE
fix reloading of daemon labels from config

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1498,7 +1498,7 @@ func (daemon *Daemon) initDiscovery(config *Config) error {
 func (daemon *Daemon) Reload(config *Config) error {
 	daemon.configStore.reloadLock.Lock()
 	defer daemon.configStore.reloadLock.Unlock()
-	if config.IsValueSet("label") {
+	if config.IsValueSet("labels") {
 		daemon.configStore.Labels = config.Labels
 	}
 	if config.IsValueSet("debug") {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -320,7 +320,7 @@ func TestDaemonReloadLabels(t *testing.T) {
 	}
 
 	valuesSets := make(map[string]interface{})
-	valuesSets["label"] = "foo:baz"
+	valuesSets["labels"] = "foo:baz"
 	newConfig := &Config{
 		CommonConfig: CommonConfig{
 			Labels:    []string{"foo:baz"},
@@ -345,7 +345,7 @@ func TestDaemonReloadNotAffectOthers(t *testing.T) {
 	}
 
 	valuesSets := make(map[string]interface{})
-	valuesSets["label"] = "foo:baz"
+	valuesSets["labels"] = "foo:baz"
 	newConfig := &Config{
 		CommonConfig: CommonConfig{
 			Labels:    []string{"foo:baz"},


### PR DESCRIPTION
commit 20a038eca68e4188e1cd812293aea8cb220cf08f changed daemon configuration reloading to check if a value was actually set, however, it checked for the wrong property ("label" instead of "labels"), which resulted in the labels only to be loaded from daemon.json if both a "label" -and- a "labels" property was present.

This change makes it work again

fixes https://github.com/docker/docker/issues/22293
