### PR TITLE
Change name from docker-client to docker in dynbinary-client

### DIFF
--- a/hack/make/dynbinary-client
+++ b/hack/make/dynbinary-client
@@ -2,7 +2,7 @@
 set -e
 
 (
-    export BINARY_SHORT_NAME="docker-client"
+    export BINARY_SHORT_NAME="docker"
     export SOURCE_PATH="./client"
 	export IAMSTATIC="false"
 	export LDFLAGS_STATIC_DOCKER=''


### PR DESCRIPTION
Change name from `docker-client` to `docker` in `dynbinary-client` , this was breaking the unit tests since they were looking for a docker binary, and there wasn't one.

/cc @dnephin 

Signed-off-by: Ken Cochrane kencochrane@gmail.com
