### PR TITLE
skip TestAuthApi if no network is available

### DIFF
--- a/integration-cli/docker_api_auth_test.go
+++ b/integration-cli/docker_api_auth_test.go
@@ -10,6 +10,7 @@ import (
 
 // Test case for #22244
 func (s *DockerSuite) TestAuthApi(c *check.C) {
+	testRequires(c, Network)
 	config := types.AuthConfig{
 		Username: "no-user",
 		Password: "no-password",


### PR DESCRIPTION
addresses https://github.com/docker/docker/pull/22254#discussion_r60947097

only run this integration test if we have networking, to allow running the tests off-line if needed
