### PR TITLE
Tweak hack/make/*-{client,daemon} to be consistent

### DIFF
--- a/hack/make/binary-client
+++ b/hack/make/binary-client
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-BINARY_SHORT_NAME="docker"
-SOURCE_PATH="./client"
-
-source "${MAKEDIR}/.binary"
+(
+	export BINARY_SHORT_NAME='docker'
+	export SOURCE_PATH='./client'
+	source "${MAKEDIR}/.binary"
+)

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-BINARY_SHORT_NAME="dockerd"
-SOURCE_PATH="./docker"
-
-source "${MAKEDIR}/.binary"
-copy_containerd "$DEST" "hash"
+(
+	export BINARY_SHORT_NAME='dockerd'
+	export SOURCE_PATH='./docker'
+	source "${MAKEDIR}/.binary"
+	copy_containerd "$DEST" 'hash'
+)

--- a/hack/make/dynbinary-client
+++ b/hack/make/dynbinary-client
@@ -2,9 +2,9 @@
 set -e
 
 (
-    export BINARY_SHORT_NAME="docker"
-    export SOURCE_PATH="./client"
-	export IAMSTATIC="false"
+	export BINARY_SHORT_NAME='docker'
+	export SOURCE_PATH='./client'
+	export IAMSTATIC='false'
 	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here

--- a/hack/make/dynbinary-daemon
+++ b/hack/make/dynbinary-daemon
@@ -2,9 +2,9 @@
 set -e
 
 (
-    export BINARY_SHORT_NAME="dockerd"
-    export SOURCE_PATH="./docker"
-	export IAMSTATIC="false"
+	export BINARY_SHORT_NAME='dockerd'
+	export SOURCE_PATH='./docker'
+	export IAMSTATIC='false'
 	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here


### PR DESCRIPTION
Without this, `dynbinary` creates `docker-client`, but `binary` creates `docker`.
