### PR TITLE
[v1.11.1] Wait for the reader fifo opening to block

### DIFF
--- a/libcontainerd/process_linux.go
+++ b/libcontainerd/process_linux.go
@@ -79,7 +79,9 @@ func (r emptyReader) Read(b []byte) (int, error) {
 
 func openReaderFromFifo(fn string) io.Reader {
 	r, w := io.Pipe()
+	c := make(chan struct{})
 	go func() {
+		close(c)
 		stdoutf, err := os.OpenFile(fn, syscall.O_RDONLY, 0)
 		if err != nil {
 			r.CloseWithError(err)
@@ -90,6 +92,7 @@ func openReaderFromFifo(fn string) io.Reader {
 		w.Close()
 		stdoutf.Close()
 	}()
+	<-c // wait for the goroutine to get scheduled and syscall to block
 	return r
 }
 


### PR DESCRIPTION
fixes #22124

Looking more closely on the deadlock trace from #22124 there is a goroutine (https://gist.github.com/tonistiigi/9d79de62b2f7919f33a9e987619b9de8#file-container-deadlock-patch-L385) that is not waiting on container lock but the exec io to return. My best guess is that this can happen when the whole exec process exits before the goroutine that calls open on a fifo gets scheduled. If this happens then the open will just block because the other side of the fifo is already gone. That makes the `io.Copy` block and exec io to never return.

This can be reproduced in `v1.11.0` by adding a sleep before the `Open` call. Reproducing in master/v1.11.1 is much harder because of the fifo cleanup fix #22121 . This means that fifos are deleted after process exits and if open happens after that there is no fifo and open will not block(it will still show wrong output).

A better way how to solve this could be by opening the fifo write-only in containerd and only after this returns open the same fifo readonly as well. We already use a similar trick for the stdin.

Another way to make this safer would be to add some timeout that would cancel the open call when it takes too long.

@mlaventure @crosbymichael

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
