### PR TITLE
Respect ALL_PROXY during registry operations

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/registry"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/go-connections/sockets"
 	"golang.org/x/net/context"
 )
 
@@ -43,18 +44,25 @@ func NewV2Repository(ctx context.Context, repoInfo *registry.RepositoryInfo, end
 		repoName = repoInfo.RemoteName()
 	}
 
+	direct := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
+
 	// TODO(dmcgowan): Call close idle connections when complete, use keep alive
 	base := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).Dial,
+		Proxy:               http.ProxyFromEnvironment,
+		Dial:                direct.Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     endpoint.TLSConfig,
 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
 		DisableKeepAlives: true,
+	}
+
+	proxyDialer, err := sockets.DialerFromEnvironment(direct)
+	if err == nil {
+		base.Dial = proxyDialer.Dial
 	}
 
 	modifiers := registry.DockerHeaders(dockerversion.DockerUserAgent(ctx), metaHeaders)


### PR DESCRIPTION
Use sockets.DialerFromEnvironment, as is done in other places,
to transparently support SOCKS proxy config from ALL_PROXY
environment variable.

Requires the _engine_ have the ALL_PROXY env var set, which
doesn't seem ideal. Maybe it should be a CLI option somehow?

Only tested with push and a v2 registry so far. I'm happy to look
further into testing more broadly, but I wanted to get feedback on
the general idea first.
