### PR TITLE
Bump notary version to v0.3.0-RC1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION docker-v1.11-3
+ENV NOTARY_VERSION v0.3.0-RC1
 RUN set -x \
 	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -117,7 +117,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION docker-v1.11-3
+ENV NOTARY_VERSION v0.3.0-RC1
 RUN set -x \
 	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -128,7 +128,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION docker-v1.11-3
+ENV NOTARY_VERSION v0.3.0-RC1
 RUN set -x \
 	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -141,7 +141,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION docker-v1.11-3
+ENV NOTARY_VERSION v0.3.0-RC1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -158,7 +158,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV DOCKER_BUILDTAGS apparmor selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -130,7 +130,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
-ENV NOTARY_VERSION docker-v1.11-3
+ENV NOTARY_VERSION v0.3.0-RC1
 RUN set -x \
 	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/trustpinning"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/signed"
 	"github.com/docker/notary/tuf/store"
@@ -184,7 +185,9 @@ func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, aut
 	modifiers = append(modifiers, transport.RequestModifier(auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)))
 	tr := transport.NewTransport(base, modifiers...)
 
-	return client.NewNotaryRepository(cli.trustDirectory(), repoInfo.FullName(), server, tr, cli.getPassphraseRetriever())
+	return client.NewNotaryRepository(
+		cli.trustDirectory(), repoInfo.FullName(), server, tr, cli.getPassphraseRetriever(),
+		trustpinning.TrustPinConfig{})
 }
 
 func convertTarget(t client.Target) (target, error) {
@@ -474,7 +477,7 @@ func (cli *DockerCli) trustedPush(repoInfo *registry.RepositoryInfo, ref referen
 	}
 
 	// get the latest repository metadata so we can figure out which roles to sign
-	_, err = repo.Update(false)
+	err = repo.Update(false)
 
 	switch err.(type) {
 	case client.ErrRepoNotInitialized, client.ErrRepositoryNotExist:

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -53,7 +53,7 @@ clone git github.com/docker/distribution 9ec0d742d69f77caa4dd5f49ceb70c3067d39f3
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get desired notary commit, might also need to be updated in Dockerfile
-clone git github.com/docker/notary docker-v1.11-3
+clone git github.com/docker/notary v0.3.0-RC1
 
 clone git google.golang.org/grpc a22b6611561e9f0a3e0919690dd2caf48f14c517 https://github.com/grpc/grpc-go.git
 clone git github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f

--- a/vendor/src/github.com/docker/notary/Dockerfile
+++ b/vendor/src/github.com/docker/notary/Dockerfile
@@ -1,15 +1,35 @@
-FROM golang:1.6.0
+FROM golang:1.6.1
 
 RUN apt-get update && apt-get install -y \
+	curl \
+	clang \
 	libltdl-dev \
 	libsqlite3-dev \
+	patch \
+	tar \
+	xz-utils \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN go get golang.org/x/tools/cmd/vet \
-	&& go get golang.org/x/tools/cmd/cover \
-	&& go get github.com/tools/godep
+RUN go get golang.org/x/tools/cmd/cover
 
-COPY . /go/src/github.com/docker/notary
+# Configure the container for OSX cross compilation
+ENV OSX_SDK MacOSX10.11.sdk
+ENV OSX_CROSS_COMMIT 8aa9b71a394905e6c5f4b59e2b97b87a004658a4
+RUN set -x \
+	&& export OSXCROSS_PATH="/osxcross" \
+	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+	&& ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT) \
+	&& curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh > /dev/null
+ENV PATH /osxcross/target/bin:$PATH
 
-WORKDIR /go/src/github.com/docker/notary
+ENV NOTARYDIR /go/src/github.com/docker/notary
+
+COPY . ${NOTARYDIR}
+
+ENV GOPATH ${NOTARYDIR}/Godeps/_workspace:$GOPATH
+
+WORKDIR ${NOTARYDIR}
+
+# Note this cannot use alpine because of the MacOSX Cross SDK: the cctools there uses sys/cdefs.h and that cannot be used in alpine: http://wiki.musl-libc.org/wiki/FAQ#Q:_I.27m_trying_to_compile_something_against_musl_and_I_get_error_messages_about_sys.2Fcdefs.h

--- a/vendor/src/github.com/docker/notary/Makefile
+++ b/vendor/src/github.com/docker/notary/Makefile
@@ -13,14 +13,18 @@ endif
 CTIMEVAR=-X $(NOTARY_PKG)/version.GitCommit=$(GITCOMMIT) -X $(NOTARY_PKG)/version.NotaryVersion=$(NOTARY_VERSION)
 GO_LDFLAGS=-ldflags "-w $(CTIMEVAR)"
 GO_LDFLAGS_STATIC=-ldflags "-w $(CTIMEVAR) -extldflags -static"
-GOOSES = darwin freebsd linux
-GOARCHS = amd64
+GOOSES = darwin linux
 NOTARY_BUILDTAGS ?= pkcs11
-GO_EXC = go
 NOTARYDIR := /go/src/github.com/docker/notary
 
+GO_VERSION := $(shell go version | grep "1\.[6-9]\(\.[0-9]+\)*")
+# check to make sure we have the right version
+ifeq ($(strip $(GO_VERSION)),)
+$(error Bad Go version - please install Go >= 1.6)
+endif
+
 # check to be sure pkcs11 lib is always imported with a build tag
-GO_LIST_PKCS11 := $(shell go list -e -f '{{join .Deps "\n"}}' ./... | grep -v /vendor/ | xargs go list -e -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | grep -q pkcs11)
+GO_LIST_PKCS11 := $(shell go list -tags "${NOTARY_BUILDTAGS}" -e -f '{{join .Deps "\n"}}' ./... | grep -v /vendor/ | xargs go list -e -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | grep -q pkcs11)
 ifeq ($(GO_LIST_PKCS11),)
 $(info pkcs11 import was not found anywhere without a build tag, yay)
 else
@@ -34,7 +38,7 @@ _space := $(empty) $(empty)
 COVERDIR=.cover
 COVERPROFILE?=$(COVERDIR)/cover.out
 COVERMODE=count
-PKGS ?= $(shell go list ./... | grep -v /vendor/ | tr '\n' ' ')
+PKGS ?= $(shell go list -tags "${NOTARY_BUILDTAGS}" ./... | grep -v /vendor/ | tr '\n' ' ')
 
 GO_VERSION = $(shell go version | awk '{print $$3}')
 
@@ -53,15 +57,15 @@ version/version.go:
 
 ${PREFIX}/bin/notary-server: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@godep go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS} ./cmd/notary-server
+	@go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS} ./cmd/notary-server
 
 ${PREFIX}/bin/notary: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@godep go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS} ./cmd/notary
+	@go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS} ./cmd/notary
 
 ${PREFIX}/bin/notary-signer: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@godep go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS} ./cmd/notary-signer
+	@go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS} ./cmd/notary-signer
 
 ifeq ($(shell uname -s),Darwin)
 ${PREFIX}/bin/static/notary-server:
@@ -72,11 +76,11 @@ ${PREFIX}/bin/static/notary-signer:
 else
 ${PREFIX}/bin/static/notary-server: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@godep go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-server
+	@go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-server
 
 ${PREFIX}/bin/static/notary-signer: NOTARY_VERSION $(shell find . -type f -name '*.go')
 	@echo "+ $@"
-	@godep go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-signer
+	@go build -tags ${NOTARY_BUILDTAGS} -o $@ ${GO_LDFLAGS_STATIC} ./cmd/notary-signer
 endif
 
 vet:
@@ -94,7 +98,7 @@ fmt:
 
 lint:
 	@echo "+ $@"
-	@test -z "$$(golint ./... | grep -v .pb. | grep -v vendor/ | tee /dev/stderr)"
+	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)"
 
 # Requires that the following:
 # go get -u github.com/client9/misspell/cmd/misspell
@@ -126,6 +130,9 @@ test-full: vet lint
 	@echo
 	go test -tags "${NOTARY_BUILDTAGS}" $(TESTOPTS) -v $(PKGS)
 
+integration:
+	buildscripts/integrationtest.sh development.yml
+
 protos:
 	@protoc --go_out=plugins=grpc:. proto/*.proto
 
@@ -136,7 +143,7 @@ protos:
 # be run first
 
 define gocover
-$(GO_EXC) test $(OPTS) $(TESTOPTS) -covermode="$(COVERMODE)" -coverprofile="$(COVERDIR)/$(subst /,-,$(1)).$(subst $(_space),.,$(NOTARY_BUILDTAGS)).coverage.txt" "$(1)" || exit 1;
+go test $(OPTS) $(TESTOPTS) -covermode="$(COVERMODE)" -coverprofile="$(COVERDIR)/$(subst /,-,$(1)).$(subst $(_space),.,$(NOTARY_BUILDTAGS)).coverage.txt" "$(1)" || exit 1;
 endef
 
 gen-cover:
@@ -146,15 +153,13 @@ gen-cover:
 
 # Generates the cover binaries and runs them all in serial, so this can be used
 # run all tests with a yubikey without any problems
-cover: GO_EXC := go
-       OPTS = -tags "${NOTARY_BUILDTAGS}" -coverpkg "$(shell ./coverpkg.sh $(1) $(NOTARY_PKG))"
+cover: OPTS = -tags "${NOTARY_BUILDTAGS}" -coverpkg "$(shell ./coverpkg.sh $(1) $(NOTARY_PKG))"
 cover: gen-cover covmerge
 	@go tool cover -html="$(COVERPROFILE)"
 
 # Generates the cover binaries and runs them all in serial, so this can be used
 # run all tests with a yubikey without any problems
 ci: OPTS = -tags "${NOTARY_BUILDTAGS}" -race -coverpkg "$(shell ./coverpkg.sh $(1) $(NOTARY_PKG))"
-    GO_EXC := godep go
 # Codecov knows how to merge multiple coverage files, so covmerge is not needed
 ci: gen-cover
 
@@ -168,20 +173,14 @@ covmerge:
 clean-protos:
 	@rm proto/*.pb.go
 
+client: ${PREFIX}/bin/notary
+	@echo "+ $@"
+
 binaries: ${PREFIX}/bin/notary-server ${PREFIX}/bin/notary ${PREFIX}/bin/notary-signer
 	@echo "+ $@"
 
 static: ${PREFIX}/bin/static/notary-server ${PREFIX}/bin/static/notary-signer
 	@echo "+ $@"
-
-define template
-mkdir -p ${PREFIX}/cross/$(1)/$(2);
-GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -o ${PREFIX}/cross/$(1)/$(2)/notary -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} ./cmd/notary;
-endef
-
-cross:
-	$(foreach GOARCH,$(GOARCHS),$(foreach GOOS,$(GOOSES),$(call template,$(GOOS),$(GOARCH))))
-
 
 notary-dockerfile:
 	@docker build --rm --force-rm -t notary .
@@ -196,6 +195,10 @@ docker-images: notary-dockerfile server-dockerfile signer-dockerfile
 
 shell: notary-dockerfile
 	docker run --rm -it -v $(CURDIR)/cross:$(NOTARYDIR)/cross -v $(CURDIR)/bin:$(NOTARYDIR)/bin notary bash
+
+cross: notary-dockerfile
+	@rm -rf $(CURDIR)/cross
+	docker run --rm -v $(CURDIR)/cross:$(NOTARYDIR)/cross -e NOTARY_BUILDTAGS=$(NOTARY_BUILDTAGS) notary buildscripts/cross.sh $(GOOSES)
 
 
 clean:

--- a/vendor/src/github.com/docker/notary/circle.yml
+++ b/vendor/src/github.com/docker/notary/circle.yml
@@ -3,10 +3,18 @@ machine:
   pre:
   # Install gvm
     - bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/1.0.22/binscripts/gvm-installer)
+  # Upgrade docker
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
+    - sudo chmod 0755 /usr/bin/docker
 
   post:
   # Install many go versions
-    - gvm install go1.6 -B --name=stable
+    - gvm install go1.6.1 -B --name=stable
+  # upgrade compose
+    - sudo pip install --upgrade docker-compose
+
+  services:
+    - docker
 
   environment:
   # Convenient shortcuts to "common" locations
@@ -32,16 +40,13 @@ dependencies:
       cp -R "$CHECKOUT" "$BASE_STABLE"
 
   override:
-  # Install dependencies for every copied clone/go version
-    - gvm use stable && go get github.com/tools/godep:
-        pwd: $BASE_STABLE
-
-  post:
-  # For the stable go version, additionally install linting and misspell tools
+   # don't use circleci's default dependency installation step of `go get -d -u ./...`
+   # since we already vendor everything; additionally install linting and misspell tools
     - >
       gvm use stable &&
       go get github.com/golang/lint/golint &&
       go get -u github.com/client9/misspell/cmd/misspell
+
 test:
   pre:
   # Output the go versions we are going to test
@@ -70,13 +75,13 @@ test:
   override:
   # Test stable, and report
   # hacking this to be parallel
-    - case $CIRCLE_NODE_INDEX in 0) gvm use stable && NOTARY_BUILDTAGS=pkcs11 make ci ;; 1) gvm use stable && NOTARY_BUILDTAGS=none make ci ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) gvm use stable && NOTARY_BUILDTAGS=pkcs11 make ci ;; 1) gvm use stable && NOTARY_BUILDTAGS=none make ci ;; 2) gvm use stable && make integration ;; esac:
         parallel: true
         timeout: 600
         pwd: $BASE_STABLE
 
   post:
   # Report to codecov.io
-    - bash <(curl -s https://codecov.io/bash):
+    - case $CIRCLE_NODE_INDEX in 0) bash <(curl -s https://codecov.io/bash) ;; 1) bash <(curl -s https://codecov.io/bash) ;; esac:
         parallel: true
         pwd: $BASE_STABLE

--- a/vendor/src/github.com/docker/notary/client/delegations.go
+++ b/vendor/src/github.com/docker/notary/client/delegations.go
@@ -240,7 +240,7 @@ func newDeleteDelegationChange(name string, content []byte) *changelist.TufChang
 // Also converts key IDs to canonical key IDs to keep consistent with signing prompts
 func (r *NotaryRepository) GetDelegationRoles() ([]*data.Role, error) {
 	// Update state of the repo to latest
-	if _, err := r.Update(false); err != nil {
+	if err := r.Update(false); err != nil {
 		return nil, err
 	}
 

--- a/vendor/src/github.com/docker/notary/client/repo.go
+++ b/vendor/src/github.com/docker/notary/client/repo.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/trustpinning"
 )
 
 // NewNotaryRepository is a helper method that returns a new notary repository.
 // It takes the base directory under where all the trust files will be stored
 // (usually ~/.docker/trust/).
 func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
-	retriever passphrase.Retriever) (
+	retriever passphrase.Retriever, trustPinning trustpinning.TrustPinConfig) (
 	*NotaryRepository, error) {
 
 	fileKeyStore, err := trustmanager.NewKeyFileStore(baseDir, retriever)
@@ -23,5 +24,5 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 	}
 
 	return repositoryFromKeystores(baseDir, gun, baseURL, rt,
-		[]trustmanager.KeyStore{fileKeyStore})
+		[]trustmanager.KeyStore{fileKeyStore}, trustPinning)
 }

--- a/vendor/src/github.com/docker/notary/client/repo_pkcs11.go
+++ b/vendor/src/github.com/docker/notary/client/repo_pkcs11.go
@@ -9,13 +9,14 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/trustmanager/yubikey"
+	"github.com/docker/notary/trustpinning"
 )
 
 // NewNotaryRepository is a helper method that returns a new notary repository.
 // It takes the base directory under where all the trust files will be stored
 // (usually ~/.docker/trust/).
 func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
-	retriever passphrase.Retriever) (
+	retriever passphrase.Retriever, trustPinning trustpinning.TrustPinConfig) (
 	*NotaryRepository, error) {
 
 	fileKeyStore, err := trustmanager.NewKeyFileStore(baseDir, retriever)
@@ -24,10 +25,10 @@ func NewNotaryRepository(baseDir, gun, baseURL string, rt http.RoundTripper,
 	}
 
 	keyStores := []trustmanager.KeyStore{fileKeyStore}
-	yubiKeyStore, _ := yubikey.NewYubiKeyStore(fileKeyStore, retriever)
+	yubiKeyStore, _ := yubikey.NewYubiStore(fileKeyStore, retriever)
 	if yubiKeyStore != nil {
 		keyStores = []trustmanager.KeyStore{yubiKeyStore, fileKeyStore}
 	}
 
-	return repositoryFromKeystores(baseDir, gun, baseURL, rt, keyStores)
+	return repositoryFromKeystores(baseDir, gun, baseURL, rt, keyStores, trustPinning)
 }

--- a/vendor/src/github.com/docker/notary/const.go
+++ b/vendor/src/github.com/docker/notary/const.go
@@ -20,6 +20,8 @@ const (
 	PubCertPerms = 0755
 	// Sha256HexSize is how big a Sha256 hex is in number of characters
 	Sha256HexSize = 64
+	// Sha512HexSize is how big a Sha512 hex is in number of characters
+	Sha512HexSize = 128
 	// SHA256 is the name of SHA256 hash algorithm
 	SHA256 = "sha256"
 	// SHA512 is the name of SHA512 hash algorithm
@@ -49,6 +51,11 @@ const (
 	// (one year, in seconds, since one year is forever in terms of internet
 	// content)
 	CacheMaxAgeLimit = 1 * Year
+
+	MySQLBackend     = "mysql"
+	MemoryBackend    = "memory"
+	SQLiteBackend    = "sqlite3"
+	RethinkDBBackend = "rethinkdb"
 )
 
 // NotaryDefaultExpiries is the construct used to configure the default expiry times of

--- a/vendor/src/github.com/docker/notary/cryptoservice/certificate.go
+++ b/vendor/src/github.com/docker/notary/cryptoservice/certificate.go
@@ -21,13 +21,6 @@ func GenerateCertificate(rootKey data.PrivateKey, gun string, startTime, endTime
 	return generateCertificate(signer, gun, startTime, endTime)
 }
 
-// GenerateTestingCertificate generates a non-expired X509 Certificate from a template, given a GUN.
-// Good enough for tests where expiration does not really matter; do not use if you care about the policy.
-func GenerateTestingCertificate(signer crypto.Signer, gun string) (*x509.Certificate, error) {
-	startTime := time.Now()
-	return generateCertificate(signer, gun, startTime, startTime.AddDate(10, 0, 0))
-}
-
 func generateCertificate(signer crypto.Signer, gun string, startTime, endTime time.Time) (*x509.Certificate, error) {
 	template, err := trustmanager.NewCertificate(gun, startTime, endTime)
 	if err != nil {

--- a/vendor/src/github.com/docker/notary/development.rethink.yml
+++ b/vendor/src/github.com/docker/notary/development.rethink.yml
@@ -1,0 +1,113 @@
+version: "2"
+services:
+    server:
+      build:
+        context: .
+        dockerfile: server.Dockerfile
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+      networks:
+        - rdb
+      links:
+        - rdb-proxy:rdb-proxy.rdb
+        - signer
+      environment:
+        - SERVICE_NAME=notary_server
+      ports:
+        - "8080"
+        - "4443:4443"
+      entrypoint: /usr/bin/env sh
+      command: -c "sh migrations/rethink_migrate.sh && notary-server -config=fixtures/server-config.rethink.json"
+      depends_on:
+        - rdb-proxy
+    signer:
+      build:
+        context: .
+        dockerfile: signer.Dockerfile
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+      networks:
+        rdb:
+            aliases:
+                - notarysigner
+      links:
+        - rdb-proxy:rdb-proxy.rdb
+      environment:
+        - SERVICE_NAME=notary_signer
+      entrypoint: /usr/bin/env sh
+      command: -c "sh migrations/rethink_migrate.sh && notary-signer -config=fixtures/signer-config.rethink.json"
+      depends_on:
+        - rdb-proxy
+    rdb-01:
+      image: jlhawn/rethinkdb-tls
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+        - rdb-01-data:/var/data
+      networks:
+        rdb:
+          aliases:
+            - rdb
+            - rdb.rdb
+            - rdb-01.rdb
+      command: "--bind all --no-http-admin --server-name rdb_01 --canonical-address rdb-01.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+    rdb-02:
+      image: jlhawn/rethinkdb-tls
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+        - rdb-02-data:/var/data
+      networks:
+        rdb:
+          aliases:
+            - rdb
+            - rdb.rdb
+            - rdb-02.rdb
+      command: "--bind all --no-http-admin --server-name rdb_02 --canonical-address rdb-02.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+    rdb-03:
+      image: jlhawn/rethinkdb-tls
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+        - rdb-03-data:/var/data
+      networks:
+        rdb:
+          aliases:
+            - rdb
+            - rdb.rdb
+            - rdb-03.rdb
+      command: "--bind all --no-http-admin --server-name rdb_03 --canonical-address rdb-03.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+    rdb-proxy:
+      image: jlhawn/rethinkdb-tls
+      ports:
+        - "8080:8080"
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+      networks:
+        rdb:
+          aliases:
+            - rdb-proxy
+            - rdb-proxy.rdp
+      command: "proxy --bind all --join rdb.rdb --web-tls --web-tls-key /tls/key.pem --web-tls-cert /tls/cert.pem --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      depends_on:
+        - rdb-01
+        - rdb-02
+        - rdb-03
+    client:
+      volumes:
+        - ./test_output:/test_output
+      networks:
+        - rdb
+      build:
+        context: .
+        dockerfile: Dockerfile
+      links:
+        - server:notary-server
+      command: buildscripts/testclient.sh
+volumes:
+    rdb-01-data:
+        external: false
+    rdb-02-data:
+        external: false
+    rdb-03-data:
+        external: false
+networks:
+    rdb:
+        external: false

--- a/vendor/src/github.com/docker/notary/development.yml
+++ b/vendor/src/github.com/docker/notary/development.yml
@@ -7,9 +7,6 @@ server:
     - signer:notarysigner
   environment:
     - SERVICE_NAME=notary_server
-  ports:
-    - "8080"
-    - "4443:4443"
   entrypoint: /usr/bin/env sh
   command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
 signer:
@@ -24,11 +21,16 @@ signer:
 mysql:
   volumes:
     - ./notarymysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-    - notary_data:/var/lib/mysql
   image: mariadb:10.1.10
-  ports:
-    - "3306:3306"
   environment:
     - TERM=dumb
     - MYSQL_ALLOW_EMPTY_PASSWORD="true"
   command: mysqld --innodb_file_per_table
+client:
+  volumes:
+    - ./test_output:/test_output
+  build: .
+  dockerfile: Dockerfile
+  links:
+    - server:notary-server
+  command: buildscripts/testclient.sh

--- a/vendor/src/github.com/docker/notary/docker-compose.rethink.yml
+++ b/vendor/src/github.com/docker/notary/docker-compose.rethink.yml
@@ -1,0 +1,102 @@
+version: "2"
+services:
+    server:
+      build: 
+        context: .
+        dockerfile: server.Dockerfile
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+      networks:
+        - rdb
+      links:
+        - rdb-proxy:rdb-proxy.rdb
+        - signer
+      environment:
+        - SERVICE_NAME=notary_server
+      ports:
+        - "8080"
+        - "4443:4443"
+      entrypoint: /usr/bin/env sh
+      command: -c "sh migrations/rethink_migrate.sh && notary-server -config=fixtures/server-config.rethink.json"
+      depends_on:
+        - rdb-proxy
+    signer:
+      build: 
+        context: .
+        dockerfile: signer.Dockerfile
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+      networks:
+        rdb:
+            aliases:
+                - notarysigner
+      links:
+        - rdb-proxy:rdb-proxy.rdb
+      environment:
+        - SERVICE_NAME=notary_signer
+      entrypoint: /usr/bin/env sh
+      command: -c "sh migrations/rethink_migrate.sh && notary-signer -config=fixtures/signer-config.rethink.json"
+      depends_on:
+        - rdb-proxy
+    rdb-01:
+      image: jlhawn/rethinkdb-tls
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+        - rdb-01-data:/var/data
+      networks:
+        rdb:
+          aliases:
+            - rdb
+            - rdb.rdb
+            - rdb-01.rdb
+      command: "--bind all --no-http-admin --server-name rdb_01 --canonical-address rdb-01.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+    rdb-02:
+      image: jlhawn/rethinkdb-tls
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+        - rdb-02-data:/var/data
+      networks:
+        rdb:
+          aliases:
+            - rdb
+            - rdb.rdb
+            - rdb-02.rdb
+      command: "--bind all --no-http-admin --server-name rdb_02 --canonical-address rdb-02.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+    rdb-03:
+      image: jlhawn/rethinkdb-tls
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+        - rdb-03-data:/var/data
+      networks:
+        rdb:
+          aliases:
+            - rdb
+            - rdb.rdb
+            - rdb-03.rdb
+      command: "--bind all --no-http-admin --server-name rdb_03 --canonical-address rdb-03.rdb --directory /var/data/rethinkdb --join rdb.rdb --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+    rdb-proxy:
+      image: jlhawn/rethinkdb-tls
+      ports:
+        - "8080:8080"
+      volumes:
+        - ./fixtures/rethinkdb:/tls
+      networks:
+        rdb:
+          aliases:
+            - rdb-proxy
+            - rdb-proxy.rdp
+      command: "proxy --bind all --join rdb.rdb --web-tls --web-tls-key /tls/key.pem --web-tls-cert /tls/cert.pem --driver-tls --driver-tls-key /tls/key.pem --driver-tls-cert /tls/cert.pem --cluster-tls --cluster-tls-key /tls/key.pem --cluster-tls-cert /tls/cert.pem --cluster-tls-ca /tls/ca.pem"
+      depends_on:
+        - rdb-01
+        - rdb-02
+        - rdb-03
+volumes:
+    rdb-01-data:
+        external: false
+    rdb-02-data:
+        external: false
+    rdb-03-data:
+        external: false
+networks:
+    rdb:
+        external: false

--- a/vendor/src/github.com/docker/notary/server.Dockerfile
+++ b/vendor/src/github.com/docker/notary/server.Dockerfile
@@ -1,28 +1,25 @@
-FROM golang:1.6.0
+FROM golang:1.6.1-alpine
 MAINTAINER David Lawrence "david.lawrence@docker.com"
 
-RUN apt-get update && apt-get install -y \
-    libltdl-dev \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --update git gcc libc-dev && rm -rf /var/cache/apk/*
 
-EXPOSE 4443
-
-# Install DB migration tool
+# Install SQL DB migration tool
 RUN go get github.com/mattes/migrate
 
 ENV NOTARYPKG github.com/docker/notary
 
 # Copy the local repo to the expected go path
-COPY . /go/src/github.com/docker/notary
+COPY . /go/src/${NOTARYPKG}
 
 WORKDIR /go/src/${NOTARYPKG}
+
+EXPOSE 4443
 
 # Install notary-server
 RUN go install \
     -tags pkcs11 \
     -ldflags "-w -X ${NOTARYPKG}/version.GitCommit=`git rev-parse --short HEAD` -X ${NOTARYPKG}/version.NotaryVersion=`cat NOTARY_VERSION`" \
-    ${NOTARYPKG}/cmd/notary-server
+    ${NOTARYPKG}/cmd/notary-server && apk del git gcc libc-dev
 
 ENTRYPOINT [ "notary-server" ]
 CMD [ "-config=fixtures/server-config-local.json" ]

--- a/vendor/src/github.com/docker/notary/trustmanager/keystore.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/keystore.go
@@ -43,6 +43,8 @@ type KeyStore interface {
 	// AddKey adds a key to the KeyStore, and if the key already exists,
 	// succeeds.  Otherwise, returns an error if it cannot add.
 	AddKey(keyInfo KeyInfo, privKey data.PrivateKey) error
+	// Should fail with ErrKeyNotFound if the keystore is operating normally
+	// and knows that it does not store the requested key.
 	GetKey(keyID string) (data.PrivateKey, string, error)
 	GetKeyInfo(keyID string) (KeyInfo, error)
 	ListKeys() map[string]KeyInfo

--- a/vendor/src/github.com/docker/notary/trustmanager/memorystore.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/memorystore.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// MemoryFileStore is an implementation of LimitedFileStore that keeps
+// MemoryFileStore is an implementation of Storage that keeps
 // the contents in memory.
 type MemoryFileStore struct {
 	sync.Mutex

--- a/vendor/src/github.com/docker/notary/trustmanager/store.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/store.go
@@ -17,8 +17,8 @@ var (
 	ErrPathOutsideStore = errors.New("path outside file store")
 )
 
-// LimitedFileStore implements the bare bones primitives (no hierarchy)
-type LimitedFileStore interface {
+// Storage implements the bare bones primitives (no hierarchy)
+type Storage interface {
 	// Add writes a file to the specified location, returning an error if this
 	// is not possible (reasons may include permissions errors). The path is cleaned
 	// before being made absolute against the store's base dir.
@@ -37,16 +37,6 @@ type LimitedFileStore interface {
 
 	// ListFiles returns a list of paths relative to the base directory of the
 	// filestore. Any of these paths must be retrievable via the
-	// LimitedFileStore.Get method.
+	// Storage.Get method.
 	ListFiles() []string
-}
-
-// FileStore is the interface for full-featured FileStores
-type FileStore interface {
-	LimitedFileStore
-
-	RemoveDir(directoryName string) error
-	GetPath(fileName string) (string, error)
-	ListDir(directoryName string) []string
-	BaseDir() string
 }

--- a/vendor/src/github.com/docker/notary/trustmanager/x509memstore.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/x509memstore.go
@@ -188,7 +188,7 @@ func (s *X509MemStore) GetCertificatesByCN(cn string) ([]*x509.Certificate, erro
 // as part of the roots list. This never allows the use of system roots, returning
 // an error if there are no root CAs.
 func (s *X509MemStore) GetVerifyOptions(dnsName string) (x509.VerifyOptions, error) {
-	// If we have no Certificates loaded return error (we don't want to rever to using
+	// If we have no Certificates loaded return error (we don't want to revert to using
 	// system CAs).
 	if len(s.fingerprintMap) == 0 {
 		return x509.VerifyOptions{}, errors.New("no root CAs available")

--- a/vendor/src/github.com/docker/notary/trustmanager/x509utils.go
+++ b/vendor/src/github.com/docker/notary/trustmanager/x509utils.go
@@ -1,6 +1,7 @@
 package trustmanager
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -57,11 +58,22 @@ func GetCertFromURL(urlStr string) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-// CertToPEM is an utility function returns a PEM encoded x509 Certificate
+// CertToPEM is a utility function returns a PEM encoded x509 Certificate
 func CertToPEM(cert *x509.Certificate) []byte {
 	pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 
 	return pemCert
+}
+
+// CertChainToPEM is a utility function returns a PEM encoded chain of x509 Certificates, in the order they are passed
+func CertChainToPEM(certChain []*x509.Certificate) ([]byte, error) {
+	var pemBytes bytes.Buffer
+	for _, cert := range certChain {
+		if err := pem.Encode(&pemBytes, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return nil, err
+		}
+	}
+	return pemBytes.Bytes(), nil
 }
 
 // LoadCertFromPEM returns the first certificate found in a bunch of bytes or error
@@ -224,20 +236,19 @@ func ParsePEMPrivateKey(pemBytes []byte, passphrase string) (data.PrivateKey, er
 		return nil, errors.New("no valid private key found")
 	}
 
+	var privKeyBytes []byte
+	var err error
+	if x509.IsEncryptedPEMBlock(block) {
+		privKeyBytes, err = x509.DecryptPEMBlock(block, []byte(passphrase))
+		if err != nil {
+			return nil, errors.New("could not decrypt private key")
+		}
+	} else {
+		privKeyBytes = block.Bytes
+	}
+
 	switch block.Type {
 	case "RSA PRIVATE KEY":
-		var privKeyBytes []byte
-		var err error
-
-		if x509.IsEncryptedPEMBlock(block) {
-			privKeyBytes, err = x509.DecryptPEMBlock(block, []byte(passphrase))
-			if err != nil {
-				return nil, errors.New("could not decrypt private key")
-			}
-		} else {
-			privKeyBytes = block.Bytes
-		}
-
 		rsaPrivKey, err := x509.ParsePKCS1PrivateKey(privKeyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse DER encoded key: %v", err)
@@ -250,18 +261,6 @@ func ParsePEMPrivateKey(pemBytes []byte, passphrase string) (data.PrivateKey, er
 
 		return tufRSAPrivateKey, nil
 	case "EC PRIVATE KEY":
-		var privKeyBytes []byte
-		var err error
-
-		if x509.IsEncryptedPEMBlock(block) {
-			privKeyBytes, err = x509.DecryptPEMBlock(block, []byte(passphrase))
-			if err != nil {
-				return nil, errors.New("could not decrypt private key")
-			}
-		} else {
-			privKeyBytes = block.Bytes
-		}
-
 		ecdsaPrivKey, err := x509.ParseECPrivateKey(privKeyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse DER encoded private key: %v", err)
@@ -277,18 +276,6 @@ func ParsePEMPrivateKey(pemBytes []byte, passphrase string) (data.PrivateKey, er
 		// We serialize ED25519 keys by concatenating the private key
 		// to the public key and encoding with PEM. See the
 		// ED25519ToPrivateKey function.
-		var privKeyBytes []byte
-		var err error
-
-		if x509.IsEncryptedPEMBlock(block) {
-			privKeyBytes, err = x509.DecryptPEMBlock(block, []byte(passphrase))
-			if err != nil {
-				return nil, errors.New("could not decrypt private key")
-			}
-		} else {
-			privKeyBytes = block.Bytes
-		}
-
 		tufECDSAPrivateKey, err := ED25519ToPrivateKey(privKeyBytes)
 		if err != nil {
 			return nil, fmt.Errorf("could not convert ecdsa.PrivateKey to data.PrivateKey: %v", err)
@@ -544,12 +531,34 @@ func CertToKey(cert *x509.Certificate) data.PublicKey {
 	}
 }
 
-// CertsToKeys transforms each of the input certificates into it's corresponding
+// CertsToKeys transforms each of the input certificate chains into its corresponding
 // PublicKey
-func CertsToKeys(certs []*x509.Certificate) map[string]data.PublicKey {
+func CertsToKeys(leafCerts []*x509.Certificate, intCerts map[string][]*x509.Certificate) map[string]data.PublicKey {
 	keys := make(map[string]data.PublicKey)
-	for _, cert := range certs {
-		newKey := CertToKey(cert)
+	for _, leafCert := range leafCerts {
+		certBundle := []*x509.Certificate{leafCert}
+		certID, err := FingerprintCert(leafCert)
+		if err != nil {
+			continue
+		}
+		if intCertsForLeafs, ok := intCerts[certID]; ok {
+			certBundle = append(certBundle, intCertsForLeafs...)
+		}
+		certChainPEM, err := CertChainToPEM(certBundle)
+		if err != nil {
+			continue
+		}
+		var newKey data.PublicKey
+		// Use the leaf cert's public key algorithm for typing
+		switch leafCert.PublicKeyAlgorithm {
+		case x509.RSA:
+			newKey = data.NewRSAx509PublicKey(certChainPEM)
+		case x509.ECDSA:
+			newKey = data.NewECDSAx509PublicKey(certChainPEM)
+		default:
+			logrus.Debugf("Unknown key type parsed from certificate: %v", leafCert.PublicKeyAlgorithm)
+			continue
+		}
 		keys[newKey.ID()] = newKey
 	}
 	return keys
@@ -581,6 +590,7 @@ func NewCertificate(gun string, startTime, endTime time.Time) (*x509.Certificate
 // X509PublicKeyID returns a public key ID as a string, given a
 // data.PublicKey that contains an X509 Certificate
 func X509PublicKeyID(certPubKey data.PublicKey) (string, error) {
+	// Note that this only loads the first certificate from the public key
 	cert, err := LoadCertFromPEM(certPubKey.Public())
 	if err != nil {
 		return "", err

--- a/vendor/src/github.com/docker/notary/trustpinning/trustpin.go
+++ b/vendor/src/github.com/docker/notary/trustpinning/trustpin.go
@@ -1,0 +1,118 @@
+package trustpinning
+
+import (
+	"crypto/x509"
+	"fmt"
+	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/utils"
+	"strings"
+)
+
+// TrustPinConfig represents the configuration under the trust_pinning section of the config file
+// This struct represents the preferred way to bootstrap trust for this repository
+type TrustPinConfig struct {
+	CA          map[string]string
+	Certs       map[string][]string
+	DisableTOFU bool
+}
+
+type trustPinChecker struct {
+	gun           string
+	config        TrustPinConfig
+	pinnedCAPool  *x509.CertPool
+	pinnedCertIDs []string
+}
+
+// CertChecker is a function type that will be used to check leaf certs against pinned trust
+type CertChecker func(leafCert *x509.Certificate, intCerts []*x509.Certificate) bool
+
+// NewTrustPinChecker returns a new certChecker function from a TrustPinConfig for a GUN
+func NewTrustPinChecker(trustPinConfig TrustPinConfig, gun string) (CertChecker, error) {
+	t := trustPinChecker{gun: gun, config: trustPinConfig}
+	// Determine the mode, and if it's even valid
+	if pinnedCerts, ok := trustPinConfig.Certs[gun]; ok {
+		t.pinnedCertIDs = pinnedCerts
+		return t.certsCheck, nil
+	}
+
+	if caFilepath, err := getPinnedCAFilepathByPrefix(gun, trustPinConfig); err == nil {
+		// Try to add the CA certs from its bundle file to our certificate store,
+		// and use it to validate certs in the root.json later
+		caCerts, err := trustmanager.LoadCertBundleFromFile(caFilepath)
+		if err != nil {
+			return nil, fmt.Errorf("could not load root cert from CA path")
+		}
+		// Now only consider certificates that are direct children from this CA cert chain
+		caRootPool := x509.NewCertPool()
+		for _, caCert := range caCerts {
+			if err = trustmanager.ValidateCertificate(caCert); err != nil {
+				continue
+			}
+			caRootPool.AddCert(caCert)
+		}
+		// If we didn't have any valid CA certs, error out
+		if len(caRootPool.Subjects()) == 0 {
+			return nil, fmt.Errorf("invalid CA certs provided")
+		}
+		t.pinnedCAPool = caRootPool
+		return t.caCheck, nil
+	}
+
+	if !trustPinConfig.DisableTOFU {
+		return t.tofusCheck, nil
+	}
+	return nil, fmt.Errorf("invalid trust pinning specified")
+}
+
+func (t trustPinChecker) certsCheck(leafCert *x509.Certificate, intCerts []*x509.Certificate) bool {
+	// reconstruct the leaf + intermediate cert chain, which is bundled as {leaf, intermediates...},
+	// in order to get the matching id in the root file
+	leafCertID, err := trustmanager.FingerprintCert(leafCert)
+	if err != nil {
+		return false
+	}
+	rootKeys := trustmanager.CertsToKeys([]*x509.Certificate{leafCert}, map[string][]*x509.Certificate{leafCertID: intCerts})
+	for keyID := range rootKeys {
+		if utils.StrSliceContains(t.pinnedCertIDs, keyID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t trustPinChecker) caCheck(leafCert *x509.Certificate, intCerts []*x509.Certificate) bool {
+	// Use intermediate certificates included in the root TUF metadata for our validation
+	caIntPool := x509.NewCertPool()
+	for _, intCert := range intCerts {
+		caIntPool.AddCert(intCert)
+	}
+	// Attempt to find a valid certificate chain from the leaf cert to CA root
+	// Use this certificate if such a valid chain exists (possibly using intermediates)
+	if _, err := leafCert.Verify(x509.VerifyOptions{Roots: t.pinnedCAPool, Intermediates: caIntPool}); err == nil {
+		return true
+	}
+	return false
+}
+
+func (t trustPinChecker) tofusCheck(leafCert *x509.Certificate, intCerts []*x509.Certificate) bool {
+	return true
+}
+
+// Will return the CA filepath corresponding to the most specific (longest) entry in the map that is still a prefix
+// of the provided gun.  Returns an error if no entry matches this GUN as a prefix.
+func getPinnedCAFilepathByPrefix(gun string, t TrustPinConfig) (string, error) {
+	specificGUN := ""
+	specificCAFilepath := ""
+	foundCA := false
+	for gunPrefix, caFilepath := range t.CA {
+		if strings.HasPrefix(gun, gunPrefix) && len(gunPrefix) >= len(specificGUN) {
+			specificGUN = gunPrefix
+			specificCAFilepath = caFilepath
+			foundCA = true
+		}
+	}
+	if !foundCA {
+		return "", fmt.Errorf("could not find pinned CA for GUN: %s\n", gun)
+	}
+	return specificCAFilepath, nil
+}

--- a/vendor/src/github.com/docker/notary/tuf/client/client.go
+++ b/vendor/src/github.com/docker/notary/tuf/client/client.go
@@ -75,7 +75,7 @@ func (c *Client) update() error {
 		return err
 	}
 	// will always need top level targets at a minimum
-	err = c.downloadTargets("targets")
+	err = c.downloadTargets(data.CanonicalTargetsRole)
 	if err != nil {
 		logrus.Debugf("Client Update (Targets): %s", err.Error())
 		return err
@@ -93,7 +93,7 @@ func (c Client) checkRoot() error {
 
 	expectedHashes := c.local.Snapshot.Signed.Meta[role].Hashes
 
-	raw, err := c.cache.GetMeta("root", size)
+	raw, err := c.cache.GetMeta(data.CanonicalRootRole, size)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func (c *Client) downloadSnapshot() error {
 	size := c.local.Timestamp.Signed.Meta[role].Length
 	expectedHashes := c.local.Timestamp.Signed.Meta[role].Hashes
 	if len(expectedHashes) == 0 {
-		return data.ErrMissingMeta{Role: "snapshot"}
+		return data.ErrMissingMeta{Role: data.CanonicalSnapshotRole}
 	}
 
 	var download bool

--- a/vendor/src/github.com/docker/notary/tuf/data/errors.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/errors.go
@@ -20,3 +20,21 @@ type ErrMissingMeta struct {
 func (e ErrMissingMeta) Error() string {
 	return fmt.Sprintf("tuf: sha256 checksum required for %s", e.Role)
 }
+
+// ErrInvalidChecksum is the error to be returned when checksum is invalid
+type ErrInvalidChecksum struct {
+	alg string
+}
+
+func (e ErrInvalidChecksum) Error() string {
+	return fmt.Sprintf("%s checksum invalid", e.alg)
+}
+
+// ErrMismatchedChecksum is the error to be returned when checksum is mismatched
+type ErrMismatchedChecksum struct {
+	alg string
+}
+
+func (e ErrMismatchedChecksum) Error() string {
+	return fmt.Sprintf("%s checksum mismatched", e.alg)
+}

--- a/vendor/src/github.com/docker/notary/tuf/data/roles.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/roles.go
@@ -116,6 +116,22 @@ func (b BaseRole) ListKeyIDs() []string {
 	return listKeyIDs(b.Keys)
 }
 
+// Equals returns whether this BaseRole equals another BaseRole
+func (b BaseRole) Equals(o BaseRole) bool {
+	if b.Threshold != o.Threshold || b.Name != o.Name || len(b.Keys) != len(o.Keys) {
+		return false
+	}
+
+	for keyID, key := range b.Keys {
+		oKey, ok := o.Keys[keyID]
+		if !ok || key.ID() != oKey.ID() {
+			return false
+		}
+	}
+
+	return true
+}
+
 // DelegationRole is an internal representation of a delegation role, with its public keys included
 type DelegationRole struct {
 	BaseRole

--- a/vendor/src/github.com/docker/notary/tuf/data/snapshot.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/snapshot.go
@@ -3,7 +3,6 @@ package data
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/go/canonical/json"
@@ -19,10 +18,8 @@ type SignedSnapshot struct {
 
 // Snapshot is the Signed component of a snapshot.json
 type Snapshot struct {
-	Type    string    `json:"_type"`
-	Version int       `json:"version"`
-	Expires time.Time `json:"expires"`
-	Meta    Files     `json:"meta"`
+	SignedCommon
+	Meta Files `json:"meta"`
 }
 
 // isValidSnapshotStructure returns an error, or nil, depending on whether the content of the
@@ -33,6 +30,11 @@ func isValidSnapshotStructure(s Snapshot) error {
 	if s.Type != expectedType {
 		return ErrInvalidMetadata{
 			role: CanonicalSnapshotRole, msg: fmt.Sprintf("expected type %s, not %s", expectedType, s.Type)}
+	}
+
+	if s.Version < 0 {
+		return ErrInvalidMetadata{
+			role: CanonicalSnapshotRole, msg: "version cannot be negative"}
 	}
 
 	for _, role := range []string{CanonicalRootRole, CanonicalTargetsRole} {
@@ -82,9 +84,11 @@ func NewSnapshot(root *Signed, targets *Signed) (*SignedSnapshot, error) {
 	return &SignedSnapshot{
 		Signatures: make([]Signature, 0),
 		Signed: Snapshot{
-			Type:    TUFTypes["snapshot"],
-			Version: 0,
-			Expires: DefaultExpires("snapshot"),
+			SignedCommon: SignedCommon{
+				Type:    TUFTypes[CanonicalSnapshotRole],
+				Version: 0,
+				Expires: DefaultExpires(CanonicalSnapshotRole),
+			},
 			Meta: Files{
 				CanonicalRootRole:    rootMeta,
 				CanonicalTargetsRole: targetsMeta,

--- a/vendor/src/github.com/docker/notary/tuf/data/targets.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/targets.go
@@ -38,6 +38,10 @@ func isValidTargetsStructure(t Targets, roleName string) error {
 			role: roleName, msg: fmt.Sprintf("expected type %s, not %s", expectedType, t.Type)}
 	}
 
+	if t.Version < 0 {
+		return ErrInvalidMetadata{role: roleName, msg: "version cannot be negative"}
+	}
+
 	for _, roleObj := range t.Delegations.Roles {
 		if !IsDelegation(roleObj.Name) || path.Dir(roleObj.Name) != roleName {
 			return ErrInvalidMetadata{

--- a/vendor/src/github.com/docker/notary/tuf/data/types.go
+++ b/vendor/src/github.com/docker/notary/tuf/data/types.go
@@ -141,13 +141,13 @@ func CheckHashes(payload []byte, hashes Hashes) error {
 		case notary.SHA256:
 			checksum := sha256.Sum256(payload)
 			if subtle.ConstantTimeCompare(checksum[:], v) == 0 {
-				return fmt.Errorf("%s checksum mismatched", k)
+				return ErrMismatchedChecksum{alg: notary.SHA256}
 			}
 			cnt++
 		case notary.SHA512:
 			checksum := sha512.Sum512(payload)
 			if subtle.ConstantTimeCompare(checksum[:], v) == 0 {
-				return fmt.Errorf("%s checksum mismatched", k)
+				return ErrMismatchedChecksum{alg: notary.SHA512}
 			}
 			cnt++
 		}
@@ -169,12 +169,12 @@ func CheckValidHashStructures(hashes Hashes) error {
 		switch k {
 		case notary.SHA256:
 			if len(v) != sha256.Size {
-				return fmt.Errorf("invalid %s checksum", notary.SHA256)
+				return ErrInvalidChecksum{alg: notary.SHA256}
 			}
 			cnt++
 		case notary.SHA512:
 			if len(v) != sha512.Size {
-				return fmt.Errorf("invalid %s checksum", notary.SHA512)
+				return ErrInvalidChecksum{alg: notary.SHA512}
 			}
 			cnt++
 		}

--- a/vendor/src/github.com/docker/notary/tuf/signed/errors.go
+++ b/vendor/src/github.com/docker/notary/tuf/signed/errors.go
@@ -5,14 +5,21 @@ import (
 	"strings"
 )
 
-// ErrInsufficientSignatures - do not have enough signatures on a piece of
+// ErrInsufficientSignatures - can not create enough signatures on a piece of
 // metadata
 type ErrInsufficientSignatures struct {
-	Name string
+	FoundKeys     int
+	NeededKeys    int
+	MissingKeyIDs []string
 }
 
 func (e ErrInsufficientSignatures) Error() string {
-	return fmt.Sprintf("tuf: insufficient signatures: %s", e.Name)
+	candidates := strings.Join(e.MissingKeyIDs, ", ")
+	if e.FoundKeys == 0 {
+		return fmt.Sprintf("signing keys not available, need %d keys out of: %s", e.NeededKeys, candidates)
+	}
+	return fmt.Sprintf("not enough signing keys: got %d of %d needed keys, other candidates: %s",
+		e.FoundKeys, e.NeededKeys, candidates)
 }
 
 // ErrExpired indicates a piece of metadata has expired
@@ -49,6 +56,13 @@ type ErrInvalidKeyType struct{}
 
 func (e ErrInvalidKeyType) Error() string {
 	return "key type is not valid for signature"
+}
+
+// ErrInvalidKeyID indicates the specified key ID was incorrect for its associated data
+type ErrInvalidKeyID struct{}
+
+func (e ErrInvalidKeyID) Error() string {
+	return "key ID is not valid for key content"
 }
 
 // ErrInvalidKeyLength indicates that while we may support the cipher, the provided

--- a/vendor/src/github.com/docker/notary/tuf/signed/sign.go
+++ b/vendor/src/github.com/docker/notary/tuf/signed/sign.go
@@ -13,68 +13,78 @@ package signed
 
 import (
 	"crypto/rand"
-	"fmt"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/notary/trustmanager"
 	"github.com/docker/notary/tuf/data"
 	"github.com/docker/notary/tuf/utils"
 )
 
-// Sign takes a data.Signed and a key, calculated and adds the signature
-// to the data.Signed
-// N.B. All public keys for a role should be passed so that this function
-//      can correctly clean up signatures that are no longer valid.
-func Sign(service CryptoService, s *data.Signed, keys ...data.PublicKey) error {
-	logrus.Debugf("sign called with %d keys", len(keys))
+// Sign takes a data.Signed and a cryptoservice containing private keys,
+// calculates and adds at least minSignature signatures using signingKeys the
+// data.Signed.  It will also clean up any signatures that are not in produced
+// by either a signingKey or an otherWhitelistedKey.
+// Note that in most cases, otherWhitelistedKeys should probably be null. They
+// are for keys you don't want to sign with, but you also don't want to remove
+// existing signatures by those keys.  For instance, if you want to call Sign
+// multiple times with different sets of signing keys without undoing removing
+// signatures produced by the previous call to Sign.
+func Sign(service CryptoService, s *data.Signed, signingKeys []data.PublicKey,
+	minSignatures int, otherWhitelistedKeys []data.PublicKey) error {
+
+	logrus.Debugf("sign called with %d/%d required keys", minSignatures, len(signingKeys))
 	signatures := make([]data.Signature, 0, len(s.Signatures)+1)
 	signingKeyIDs := make(map[string]struct{})
 	tufIDs := make(map[string]data.PublicKey)
-	ids := make([]string, 0, len(keys))
 
 	privKeys := make(map[string]data.PrivateKey)
 
 	// Get all the private key objects related to the public keys
-	for _, key := range keys {
+	missingKeyIDs := []string{}
+	for _, key := range signingKeys {
 		canonicalID, err := utils.CanonicalKeyID(key)
-		ids = append(ids, canonicalID)
 		tufIDs[key.ID()] = key
 		if err != nil {
-			continue
+			return err
 		}
 		k, _, err := service.GetPrivateKey(canonicalID)
 		if err != nil {
-			continue
+			if _, ok := err.(trustmanager.ErrKeyNotFound); ok {
+				missingKeyIDs = append(missingKeyIDs, canonicalID)
+				continue
+			}
+			return err
 		}
 		privKeys[key.ID()] = k
 	}
 
-	// Check to ensure we have at least one signing key
-	if len(privKeys) == 0 {
-		return ErrNoKeys{KeyIDs: ids}
+	// include the list of otherWhitelistedKeys
+	for _, key := range otherWhitelistedKeys {
+		if _, ok := tufIDs[key.ID()]; !ok {
+			tufIDs[key.ID()] = key
+		}
 	}
 
+	// Check to ensure we have enough signing keys
+	if len(privKeys) < minSignatures {
+		return ErrInsufficientSignatures{FoundKeys: len(privKeys),
+			NeededKeys: minSignatures, MissingKeyIDs: missingKeyIDs}
+	}
+
+	emptyStruct := struct{}{}
 	// Do signing and generate list of signatures
 	for keyID, pk := range privKeys {
 		sig, err := pk.Sign(rand.Reader, *s.Signed, nil)
 		if err != nil {
 			logrus.Debugf("Failed to sign with key: %s. Reason: %v", keyID, err)
-			continue
+			return err
 		}
-		signingKeyIDs[keyID] = struct{}{}
+		signingKeyIDs[keyID] = emptyStruct
 		signatures = append(signatures, data.Signature{
 			KeyID:     keyID,
 			Method:    pk.SignatureAlgorithm(),
 			Signature: sig[:],
 		})
-	}
-
-	// Check we produced at least on signature
-	if len(signatures) < 1 {
-		return ErrInsufficientSignatures{
-			Name: fmt.Sprintf(
-				"cryptoservice failed to produce any signatures for keys with IDs: %v",
-				ids),
-		}
 	}
 
 	for _, sig := range s.Signatures {

--- a/vendor/src/github.com/docker/notary/tuf/store/filestore.go
+++ b/vendor/src/github.com/docker/notary/tuf/store/filestore.go
@@ -39,7 +39,8 @@ func (f *FilesystemStore) getPath(name string) string {
 }
 
 // GetMeta returns the meta for the given name (a role) up to size bytes
-// If size is -1, this corresponds to "infinite," but we cut off at 100MB
+// If size is -1, this corresponds to "infinite," but we cut off at the
+// predefined threshold "notary.MaxDownloadSize".
 func (f *FilesystemStore) GetMeta(name string, size int64) ([]byte, error) {
 	meta, err := ioutil.ReadFile(f.getPath(name))
 	if err != nil {

--- a/vendor/src/github.com/docker/notary/tuf/utils/util.go
+++ b/vendor/src/github.com/docker/notary/tuf/utils/util.go
@@ -98,7 +98,7 @@ func HashedPaths(path string, hashes data.Hashes) []string {
 
 // CanonicalKeyID returns the ID of the public bytes version of a TUF key.
 // On regular RSA/ECDSA TUF keys, this is just the key ID.  On X509 RSA/ECDSA
-// TUF keys, this is the key ID of the public key part of the key.
+// TUF keys, this is the key ID of the public key part of the key in the leaf cert
 func CanonicalKeyID(k data.PublicKey) (string, error) {
 	switch k.Algorithm() {
 	case data.ECDSAx509Key, data.RSAx509Key:


### PR DESCRIPTION
This PR mainly bumps the notary version up to v0.3.0-RC1.

There are 2 Notary API changes relevant to Docker in this change:
- `NotaryRepository.Update` now returns just an error
- `NewNotaryRepository` now takes a trust pinning configuration - we are just providing an empty one here, so that behavior does not change (TOFU is enabled), but a future PR should probably add trust pinning configuration to Docker itself (to only trust roots signed by a particular CA, or to otherwise disable TOFU)

This PR also removes the pkcs11 tag for Dockerfile.s390x as per #22007, since that depends upon GCCGo 5.3, which supports the Go 1.4 standard library.  Notary + pkcs11 (the yubikey support) requires an interface that was added in Go 1.5.

![cute bunny](https://pbs.twimg.com/media/A7hdDEnCYAA8oky.jpg)
