### PR TITLE
Fix mount label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -181,7 +181,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -200,7 +200,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -74,7 +74,7 @@ WORKDIR /go/src/github.com/docker/docker
 ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -196,7 +196,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -178,7 +178,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -57,7 +57,7 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 ENV CGO_LDFLAGS -L/lib
 
 # Install runc
-ENV RUNC_COMMIT e87436998478d222be209707503c27f6f91be0c5
+ENV RUNC_COMMIT baf6536d6259209c3edfa2b22237af82942d3dfa
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -672,6 +672,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	}
 	s.Process.SelinuxLabel = c.GetProcessLabel()
 	s.Process.NoNewPrivileges = c.NoNewPrivileges
+	s.Linux.MountLabel = c.MountLabel
 
 	return (*libcontainerd.Spec)(&s), nil
 }

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -61,7 +61,7 @@ clone git github.com/docker/go v1.5.1-1-1-gbaf439e
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
 clone git github.com/opencontainers/runc 2441732d6fcc0fb0a542671a4372e0c7bc99c19e # libcontainer
-clone git github.com/opencontainers/specs 93ca97e83ca7fb4fba6d9e30d5470f99ddc02d11 # specs
+clone git github.com/opencontainers/specs f955d90e70a98ddfb886bd930ffd076da9b67998 # specs
 clone git github.com/seccomp/libseccomp-golang 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
 clone git github.com/coreos/go-systemd v4

--- a/vendor/src/github.com/opencontainers/specs/specs-go/config.go
+++ b/vendor/src/github.com/opencontainers/specs/specs-go/config.go
@@ -49,7 +49,7 @@ type Process struct {
 
 	// ApparmorProfile specified the apparmor profile for the container. (this field is platform dependent)
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
-	// SelinuxProcessLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
+	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
@@ -140,6 +140,8 @@ type Linux struct {
 	MaskedPaths []string `json:"maskedPaths,omitempty"`
 	// ReadonlyPaths sets the provided paths as RO inside the container.
 	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
+	// MountLabel specifies the selinux context for the mounts in the container.
+	MountLabel string `json:"mountLabel,omitempty"`
 }
 
 // Namespace is the configuration for a Linux namespace

--- a/vendor/src/github.com/opencontainers/specs/specs-go/version.go
+++ b/vendor/src/github.com/opencontainers/specs/specs-go/version.go
@@ -6,7 +6,7 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 0
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 5
+	VersionMinor = 6
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 


### PR DESCRIPTION
This PR fixes up Selinux mount labels in the container.
You can verify it by building with selinux and starting a container:

```
[root@dhcp-16-129 runtime-spec]# /root/gosrc/src/github.com/docker/docker/bundles/latest/dynbinary-client/docker run -it --rm fedora bash                                                                                                                                                 
[root@0273c3fa88de /]# mount | grep context
/dev/mapper/docker-253:0-1853944-cd843944a958326d73308f55600f462fd92260b2ced6d6d357b36e6d71a7d7fb on / type xfs (rw,relatime,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",nouuid,attr2,inode64,logbsize=64k,sunit=128,swidth=128,noquota)
tmpfs on /dev type tmpfs (rw,nosuid,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",mode=755)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",gid=5,mode=620,ptmxmode=666)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,relatime,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",mode=755)
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",size=65536k)
tmpfs on /proc/kcore type tmpfs (rw,nosuid,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",mode=755)
tmpfs on /proc/latency_stats type tmpfs (rw,nosuid,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",mode=755)
tmpfs on /proc/timer_stats type tmpfs (rw,nosuid,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",mode=755)
tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,context="system_u:object_r:svirt_sandbox_file_t:s0:c165,c267",mode=755)
```
