### PR TITLE
Add "driver" filter for network ls

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1378,6 +1378,11 @@ _docker_network_inspect() {
 _docker_network_ls() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
+		driver)
+			local plugins=" $(__docker_plugins Network) "
+			COMPREPLY=( $(compgen -W "$plugins" -- "${cur##*=}") )
+			return
+			;;
 		id)
 			cur="${cur##*=}"
 			__docker_complete_network_ids
@@ -1396,7 +1401,7 @@ _docker_network_ls() {
 
 	case "$prev" in
 		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "id name type" -- "$cur" ) )
+			COMPREPLY=( $( compgen -S = -W "driver id label name type" -- "$cur" ) )
 			__docker_nospace
 			return
 			;;

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -13,10 +13,11 @@ type filterHandler func([]libnetwork.Network, string) ([]libnetwork.Network, err
 var (
 	// AcceptedFilters is an acceptable filters for validation
 	AcceptedFilters = map[string]bool{
-		"type":  true,
-		"name":  true,
-		"id":    true,
-		"label": true,
+		"driver": true,
+		"type":   true,
+		"name":   true,
+		"id":     true,
+		"label":  true,
 	}
 )
 
@@ -50,6 +51,11 @@ func FilterNetworks(nws []libnetwork.Network, filter filters.Args) ([]libnetwork
 
 	var displayNet []libnetwork.Network
 	for _, nw := range nws {
+		if filter.Include("driver") {
+			if !filter.ExactMatch("driver", nw.Type()) {
+				continue
+			}
+		}
 		if filter.Include("name") {
 			if !filter.Match("name", nw.Name()) {
 				continue

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -114,7 +114,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 * `POST /containers/create` now takes `StorageOpt` field.
 * `GET /info` now returns `SecurityOptions` field, showing if `apparmor`, `seccomp`, or `selinux` is supported.
-* `GET /networks` now supports filtering by `label`.
+* `GET /networks` now supports filtering by `label` and `driver`.
 * `POST /containers/create` now takes `MaximumIOps` and `MaximumIOBps` fields. Windows daemon only.
 
 ### v1.23 API changes

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2967,6 +2967,7 @@ Content-Type: application/json
 Query Parameters:
 
 - **filters** - JSON encoded network list filter. The filter value is one of:
+  -   `driver=<driver-name>` Matches a network's driver.
   -   `id=<network-id>` Matches all or part of a network id.
   -   `label=<key>` or `label=<key>=<value>` of a network label.
   -   `name=<network-name>` Matches all or part of a network name.

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -51,10 +51,24 @@ Multiple filter flags are combined as an `OR` filter. For example,
 
 The currently supported filters are:
 
+* driver
 * id (network's id)
 * label (`label=<key>` or `label=<key>=<value>`)
 * name (network's name)
 * type (custom|builtin)
+
+#### Driver
+
+The `driver` filter matches networks based on their driver.
+
+The following example matches networks with the `bridge` driver:
+
+```bash
+$ docker network ls --filter driver=bridge
+NETWORK ID          NAME                DRIVER
+db9db329f835        test1               bridge
+f6e212da9dfd        test2               bridge
+```
 
 #### ID
 
@@ -83,7 +97,7 @@ NETWORK ID          NAME                DRIVER
 
 #### Label
 
-The `label` filter matches containers based on the presence of a `label` alone or a `label` and a
+The `label` filter matches networks based on the presence of a `label` alone or a `label` and a
 value.
 
 The following filter matches networks with the `usage` label regardless of its value.
@@ -95,7 +109,7 @@ db9db329f835        test1               bridge
 f6e212da9dfd        test2               bridge
 ```
 
-The following filter matches containers with the `usage` label with the `prod` value.
+The following filter matches networks with the `usage` label with the `prod` value.
 
 ```bash
 $ docker network ls -f "label=usage=prod"

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -352,6 +352,15 @@ func (s *DockerNetworkSuite) TestDockerNetworkLsFilter(c *check.C) {
 	out, _ = dockerCmd(c, "network", "ls", "-f", "label=nonexistent")
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("%s\n", out))
+
+	out, _ = dockerCmd(c, "network", "ls", "-f", "driver=null")
+	assertNwList(c, out, []string{"none"})
+
+	out, _ = dockerCmd(c, "network", "ls", "-f", "driver=host")
+	assertNwList(c, out, []string{"host"})
+
+	out, _ = dockerCmd(c, "network", "ls", "-f", "driver=bridge")
+	assertNwList(c, out, []string{"bridge", "dev", testNet})
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkCreateDelete(c *check.C) {

--- a/man/docker-network-ls.1.md
+++ b/man/docker-network-ls.1.md
@@ -46,10 +46,24 @@ Multiple filter flags are combined as an `OR` filter. For example,
 
 The currently supported filters are:
 
+* driver
 * id (network's id)
 * label (`label=<key>` or `label=<key>=<value>`)
 * name (network's name)
 * type (custom|builtin)
+
+#### Driver
+
+The `driver` filter matches networks based on their driver.
+
+The following example matches networks with the `bridge` driver:
+
+```bash
+$ docker network ls --filter driver=bridge
+NETWORK ID          NAME                DRIVER
+db9db329f835        test1               bridge
+f6e212da9dfd        test2               bridge
+```
 
 #### ID
 
@@ -78,7 +92,7 @@ NETWORK ID          NAME                DRIVER
 
 #### Label
 
-The `label` filter matches containers based on the presence of a `label` alone or a `label` and a
+The `label` filter matches networks based on the presence of a `label` alone or a `label` and a
 value.
 
 The following filter matches networks with the `usage` label regardless of its value.
@@ -90,7 +104,7 @@ db9db329f835        test1               bridge
 f6e212da9dfd        test2               bridge
 ```
 
-The following filter matches containers with the `usage` label with the `prod` value.
+The following filter matches networks with the `usage` label with the `prod` value.
 
 ```bash
 $ docker network ls -f "label=usage=prod"


### PR DESCRIPTION
This add a new filter to `docker network ls` to allow filtering by driver-name.

Contrary to "ID" and "name" filters, this filter only supports an _exact_ match.

fixes https://github.com/docker/docker/issues/22315
