### PR TITLE
daemon: reorder mounts before setting them

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -635,13 +636,14 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		return nil, err
 	}
 
-	mounts, err := daemon.setupMounts(c)
+	ms, err := daemon.setupMounts(c)
 	if err != nil {
 		return nil, err
 	}
-	mounts = append(mounts, c.IpcMounts()...)
-	mounts = append(mounts, c.TmpfsMounts()...)
-	if err := setMounts(daemon, &s, c, mounts); err != nil {
+	ms = append(ms, c.IpcMounts()...)
+	ms = append(ms, c.TmpfsMounts()...)
+	sort.Sort(mounts(ms))
+	if err := setMounts(daemon, &s, c, ms); err != nil {
 		return nil, fmt.Errorf("linux mounts: %v", err)
 	}
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -746,6 +746,14 @@ func (s *DockerSuite) TestRunWithShmSize(c *check.C) {
 	c.Assert(shmSize, check.Equals, "1073741824")
 }
 
+func (s *DockerSuite) TestRunTmpfsMountsEnsureOrdered(c *check.C) {
+	tmpFile, err := ioutil.TempFile("", "test")
+	c.Assert(err, check.IsNil)
+	defer tmpFile.Close()
+	out, _ := dockerCmd(c, "run", "--tmpfs", "/run", "-v", tmpFile.Name()+":/run/test", "busybox", "ls", "/run")
+	c.Assert(out, checker.Contains, "test")
+}
+
 func (s *DockerSuite) TestRunTmpfsMounts(c *check.C) {
 	// TODO Windows (Post TP5): This test cannot run on a Windows daemon as
 	// Windows does not support tmpfs mounts.
@@ -839,10 +847,8 @@ func (s *DockerSuite) TestRunSeccompProfileDenyChmod(c *check.C) {
 	]
 }`
 	tmpFile, err := ioutil.TempFile("", "profile.json")
+	c.Assert(err, check.IsNil)
 	defer tmpFile.Close()
-	if err != nil {
-		c.Fatal(err)
-	}
 
 	if _, err := tmpFile.Write([]byte(jsonData)); err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
Fix #21916
Fix #22327

Do another pass of sorting after applying tmpfs mounts

ping @cpuguy83 @calavera not sure the sort should go there, another options would be to pass ipc and tmpfs mounts to `setupMounts` and be ordered there but then ipc and tmpfs mounts would be considered in `daemon/archive.go` which isn't desiderable I guess. On the other side, ordering after applying the network mounts (done in `setupMounts`) could cause other issues.
I'm not sure either mounts should be applied _after_ a tmpfs mount - maybe the issue here is just to order just the tmpfs mounts (enforced in https://github.com/docker/docker/issues/22327) :)

seems like tests run fine though.

/cc @rhatdan 

Signed-off-by: Antonio Murdaca runcom@redhat.com
