### PR TITLE
centos:7/oraclelinux:7 now includes libseccomp 2.2.1

### DIFF
--- a/contrib/builder/rpm/amd64/centos-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/centos-7/Dockerfile
@@ -6,7 +6,7 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git
+RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git
 
 ENV GO_VERSION 1.5.4
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -14,6 +14,6 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS pkcs11 selinux
-ENV RUNC_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
 

--- a/contrib/builder/rpm/amd64/generate.sh
+++ b/contrib/builder/rpm/amd64/generate.sh
@@ -96,9 +96,8 @@ for version in "${versions[@]}"; do
 	esac
 
 	# opensuse & oraclelinx:6 do not have the right libseccomp libs
-	# centos:7 and oraclelinux:7 have a libseccomp < 2.2.1 :(
 	case "$from" in
-		opensuse:*|oraclelinux:*|centos:7)
+		opensuse:*|oraclelinux:6)
 			packages=( "${packages[@]/libseccomp-devel}" )
 			runcBuildTags="selinux"
 			;;

--- a/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/amd64/oraclelinux-7/Dockerfile
@@ -5,7 +5,7 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git
+RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git
 
 ENV GO_VERSION 1.5.4
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
@@ -13,6 +13,6 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 
-ENV DOCKER_BUILDTAGS pkcs11 selinux
-ENV RUNC_BUILDTAGS selinux
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
 

--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -26,8 +26,8 @@ CONFIG_SECCOMP=y
 ```
 
 > **Note**: seccomp profiles require seccomp 2.2.1 and are only
-> available starting with Debian 9 "Stretch", Ubuntu 15.10 "Wily", and
-> Fedora 22. To use this feature on Ubuntu 14.04, Debian Wheezy, or
+> available starting with Debian 9 "Stretch", Ubuntu 15.10 "Wily",
+> Fedora 22, centos 7 and Oracle Linux 7. To use this feature on Ubuntu 14.04, Debian Wheezy, or
 > Debian Jessie, you must download the [latest static Docker Linux binary](../installation/binaries.md).
 > This feature is currently *not* available on other distributions.
 


### PR DESCRIPTION
**\- What I did**
Make centos/oraclelinux more secure
**\- How I did it**
disable centos filter in rpm builder
**\- How to verify it**
`make rpm` and install on centos
**\- Description for the changelog**
centos package now supports seccomp

Signed-off-by: Brian Goff cpuguy83@gmail.com
