### PR TITLE
Add new `HostConfig` field, `Mounts`.

### DIFF
--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/volume"
 	volumestore "github.com/docker/docker/volume/store"
 )
 
@@ -24,10 +25,10 @@ func (daemon *Daemon) removeMountPoints(container *container.Container, rm bool)
 			continue
 		}
 		daemon.volumes.Dereference(m.Volume, container.ID)
-		if rm {
+		if rm || m.Type == volume.MountTypeEphemeral {
 			// Do not remove named mountpoints
 			// these are mountpoints specified like `docker run -v <name>:/foo`
-			if m.Named {
+			if m.Named || m.Type == volume.MountTypePersistent {
 				continue
 			}
 			err := daemon.volumes.Remove(m.Volume)

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -70,9 +70,8 @@ func sortMounts(m []container.Mount) []container.Mount {
 // setBindModeIfNull is platform specific processing to ensure the
 // shared mode is set to 'z' if it is null. This is called in the case
 // of processing a named volume and not a typical bind.
-func setBindModeIfNull(bind *volume.MountPoint) *volume.MountPoint {
+func setBindModeIfNull(bind *volume.MountPoint) {
 	if bind.Mode == "" {
 		bind.Mode = "z"
 	}
-	return bind
 }

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -46,6 +46,6 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 
 // setBindModeIfNull is platform specific processing which is a no-op on
 // Windows.
-func setBindModeIfNull(bind *volume.MountPoint) *volume.MountPoint {
-	return bind
+func setBindModeIfNull(bind *volume.MountPoint) {
+	return
 }

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -115,6 +115,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now takes `StorageOpt` field.
 * `GET /info` now returns `SecurityOptions` field, showing if `apparmor`, `seccomp`, or `selinux` is supported.
 * `GET /networks` now supports filtering by `label`.
+* `POST /containers/create` now takes a `Mounts` field in `HostConfig` which replaces `Binds` and `Volumes`. *note*: `Binds` and `Volumes` are still available but are exclussive with `Mounts`
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -319,7 +319,8 @@ Create a container
              "StorageOpt": {},
              "CgroupParent": "",
              "VolumeDriver": "",
-             "ShmSize": 67108864
+             "ShmSize": 67108864,
+             "Mounts": []
           },
           "NetworkingConfig": {
           "EndpointsConfig": {
@@ -457,6 +458,20 @@ Json Parameters:
     -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
     -   **VolumeDriver** - Driver that this container users to mount volumes.
     -   **ShmSize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
+    -   **Mounts** - List of mount configurations to create the container with. This replaces `Binds` and `Volumes`. If `Mounts` is specified along with either `Binds` or `Volumes`, the request will be rejected. Fields for a mount configuration:
+          + **Type** - String specifying the type of mount, e.g. `hostbind`, `ephemeral`, or `persistent` (required)
+          + **Source** - String specifying the host path to use for the mount. Path must exist. (required, `hostbind` only)
+          + **Destination** - String specifying the container destination path for the mount (required)
+          + **Driver** - String specifying the driver to use when creating a volume (required, `persistent` only)
+          + **Name** - String specifying the name of the volume to create (required, `persistent` only)
+          + **Mode** - comma sepparated list of mount modes, e.g. `ro`, `rw`, `nocopy`
+          + **CreateOpts** - A map of key/value pairs (strings) to use when creating the volume, passed directly to the volume driver. (`persistent only)
+
+          Mount types:
+            + **hostbind** - Mounts a file or directory from the host into the container. Must exist prior to creating the container.
+            + **ephemeral** - Creates a new volume with default options on the default driver. These volumes are removed when the container is removed
+            + **persistent** - Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are **not** removed when the container is removed.
+
 
 Query Parameters:
 
@@ -579,7 +594,8 @@ Return low-level information on the container `id`
 			"VolumesFrom": null,
 			"Ulimits": [{}],
 			"VolumeDriver": "",
-			"ShmSize": 67108864
+			"ShmSize": 67108864,
+      "Mounts": []
 		},
 		"HostnamePath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname",
 		"HostsPath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts",

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -68,6 +68,19 @@ func DecodeContainerConfig(src io.Reader) (*container.Config, *container.HostCon
 // validateVolumesAndBindSettings validates each of the volumes and bind settings
 // passed by the caller to ensure they are valid.
 func validateVolumesAndBindSettings(c *container.Config, hc *container.HostConfig) error {
+	if len(hc.Mounts) > 0 {
+		if len(hc.Binds) > 0 {
+			return fmt.Errorf("Must not specify both `Binds` and `Mounts`")
+		}
+
+		if len(c.Volumes) > 0 {
+			return fmt.Errorf("Must not specify both `Volumes` and `Mounts`")
+		}
+
+		if len(hc.VolumeDriver) > 0 {
+			return fmt.Errorf("Must not specify both `VolumeDriver` and `Mounts`")
+		}
+	}
 
 	// Ensure all volumes and binds are valid.
 	for spec := range c.Volumes {

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -253,6 +253,19 @@ type UpdateConfig struct {
 	RestartPolicy RestartPolicy
 }
 
+// MountConfig holds attributes for configuring a container mount
+// This replaces the `Binds` field (kept for back-compat)
+// Not all fields are used in all cases, and some fields conflict based on `Type`
+type MountConfig struct {
+	Type        string            // Type of mount, e.g. 'hostbind', 'ephemeral'
+	Source      string            `json:",omitempty"` // Path on the host to mount from
+	Destination string            // Path in the container to mount to
+	Driver      string            `json:",omitempty"` // Driver to use
+	Name        string            `json:",omitempty"` // Name of the volume to use
+	Mode        string            `json:",omitempty"` // ro,rw,nocopy, z, Z
+	CreateOpts  map[string]string `json:",omitempty"` // Options that get passed to the driver if the volume name is not found
+}
+
 // HostConfig the non-portable Config structure of a container.
 // Here, "non-portable" means "dependent of the host we are running on".
 // Portable information *should* appear in Config.
@@ -298,4 +311,5 @@ type HostConfig struct {
 
 	// Contains container's resources (cgroups, ulimits)
 	Resources
+	Mounts []MountConfig
 }

--- a/volume/validate.go
+++ b/volume/validate.go
@@ -1,0 +1,57 @@
+package volume
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/engine-api/types/container"
+)
+
+func validateMountConfig(mnt *container.MountConfig) error {
+	if len(mnt.Destination) == 0 {
+		return fmt.Errorf("Invalid mount spec: Destination must not be empty")
+	}
+
+	if len(mnt.Mode) > 0 {
+		if !ValidMountMode(mnt.Mode) {
+			return fmt.Errorf("Invalid mount spec: Mode %q is invalid", mnt.Mode)
+		}
+	}
+	switch mnt.Type {
+	case MountTypeEphemeral:
+		if len(mnt.Source) > 0 {
+			return fmt.Errorf("Invalid ephemeral mount spec: Source must not be specified")
+		}
+		if len(mnt.Name) > 0 {
+			return fmt.Errorf("Invalid ephemeral mount spec: Name must not be specified")
+		}
+	case MountTypeHostBind:
+		if len(mnt.Name) > 0 {
+			return fmt.Errorf("Invalid hostbind mount spec: Name must not be specified")
+		}
+		if len(mnt.Source) == 0 {
+			return fmt.Errorf("Invalid hostbind mount spec: Source must not be empty")
+		}
+
+		if len(mnt.Driver) > 0 {
+			return fmt.Errorf("Invalid hostbind mount spec: Driver must not be specified")
+		}
+		// Do not allow binding to non-existent path
+		if _, err := os.Stat(mnt.Source); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("Invalid hostbind mount spec for Source: path does not exist")
+			}
+			return fmt.Errorf("Invalid hostbind mount spec for Source %q: %v", mnt.Source, err)
+		}
+	case MountTypePersistent:
+		if len(mnt.Name) == 0 {
+			return fmt.Errorf("Invalid hostbind mount spec: Name must not be empty")
+		}
+		if len(mnt.Source) > 0 {
+			return fmt.Errorf("Invalid ephemeral mount spec: Source must not be specified")
+		}
+	default:
+		return fmt.Errorf("Invalid mount spec: mount type unknown: %q", mnt.Type)
+	}
+	return nil
+}

--- a/volume/validate_test.go
+++ b/volume/validate_test.go
@@ -1,0 +1,50 @@
+package volume
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/docker/engine-api/types/container"
+)
+
+func TestValidateMount(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "test-validate-mount")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testDir)
+
+	cases := []struct {
+		input    container.MountConfig
+		expected error
+	}{
+		{container.MountConfig{Type: MountTypeEphemeral}, fmt.Errorf("Invalid mount spec: Destination must not be empty")},
+		{container.MountConfig{Type: MountTypeEphemeral, Destination: "/foo", Source: "/foo"}, fmt.Errorf("Invalid ephemeral mount spec: Source must not be specified")},
+		{container.MountConfig{Type: MountTypeEphemeral, Name: "hello", Destination: "/foo"}, fmt.Errorf("Invalid ephemeral mount spec: Name must not be specified")},
+		{container.MountConfig{Type: MountTypeEphemeral, Destination: "/foo"}, nil},
+		{container.MountConfig{Type: MountTypeHostBind}, fmt.Errorf("Invalid mount spec: Destination must not be empty")},
+		{container.MountConfig{Type: MountTypeHostBind, Destination: "/foo", Name: "hello"}, fmt.Errorf("Invalid hostbind mount spec: Name must not be specified")},
+		{container.MountConfig{Type: MountTypeHostBind, Destination: "/foo"}, fmt.Errorf("Invalid hostbind mount spec: Source must not be empty")},
+		{container.MountConfig{Type: MountTypeHostBind, Source: "/foo", Destination: "/foo", Driver: "whatevs"}, fmt.Errorf("Invalid hostbind mount spec: Driver must not be specified")},
+		{container.MountConfig{Type: MountTypeHostBind, Source: "/non-existent", Destination: "/foo"}, fmt.Errorf("Invalid hostbind mount spec for Source: path does not exist")},
+		{container.MountConfig{Type: MountTypeHostBind, Source: testDir, Destination: "/foo"}, nil},
+		{container.MountConfig{Type: MountTypePersistent}, fmt.Errorf("Invalid mount spec: Destination must not be empty")},
+		{container.MountConfig{Type: MountTypePersistent, Destination: "/foo", Name: "hello"}, nil},
+		{container.MountConfig{Type: MountTypePersistent, Destination: "/foo", Source: "/foo", Name: "hello"}, fmt.Errorf("Invalid ephemeral mount spec: Source must not be specified")},
+		{container.MountConfig{Type: MountTypeEphemeral, Destination: "/foo", Mode: "not-real"}, fmt.Errorf("Invalid mount spec: Mode \"not-real\" is invalid")},
+		{container.MountConfig{Type: MountTypeEphemeral, Destination: "/foo", Mode: "rw"}, nil},
+		{container.MountConfig{Type: "invalid", Destination: "/foo", Mode: "rw"}, fmt.Errorf("Invalid mount spec: mount type unknown: \"invalid\"")},
+	}
+	for i, x := range cases {
+		err := validateMountConfig(&x.input)
+		if err == nil && x.expected == nil {
+			continue
+		}
+		if (err == nil && x.expected != nil) || (x.expected == nil && err != nil) || (err.Error() != x.expected.Error()) {
+			t.Fatalf("expected %q, got %q, case: %d", x.expected, err, i)
+		}
+	}
+
+}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -11,6 +11,15 @@ import (
 // implemented in the local package.
 const DefaultDriverName string = "local"
 
+const (
+	// MountTypeEphemeral is for volume mounts that will be removed when the container is removed.
+	MountTypeEphemeral = "ephemeral"
+	// MountTypePersistent is for volume mounts that stay around when the container is removed
+	MountTypePersistent = "persistent"
+	// MountTypeHostBind is for mounts from the host fs.
+	MountTypeHostBind = "hostbind"
+)
+
 // Driver is for creating and removing volumes.
 type Driver interface {
 	// Name returns the name of the volume driver.
@@ -51,6 +60,7 @@ type MountPoint struct {
 	RW          bool   // True if writable
 	Name        string // Name set by user
 	Driver      string // Volume driver to use
+	Type        string // Type of mount to use, see `MountType<foo>` definitions
 	Volume      Volume `json:"-"`
 
 	// Note Mode is not used on Windows
@@ -61,8 +71,6 @@ type MountPoint struct {
 	Named       bool   // specifies if the mountpoint was specified by name
 
 	// Specifies if data should be copied from the container before the first mount
-	// Use a pointer here so we can tell if the user set this value explicitly
-	// This allows us to error out when the user explicitly enabled copy but we can't copy due to the volume being populated
 	CopyData bool `json:"-"`
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

`Mounts` allows users to specify in a much safer way the volumes they
want to use in the container.
This replaces `Binds` and `Volumes`, which both still exist, but
`Mounts` and `Binds`/`Volumes` are exclussive.
The CLI will continue to use `Binds` and `Volumes` due to concerns with
parsing the volume specs on the client side and cross-platform support.

Example usage of `Mounts`:

```
$ curl -XPOST localhost:2375/containers/create -d '{
  "Image": "alpine:latest",
  "HostConfig": {
    "Mounts": [{
      "Type": "ephemeral",
      "Destination": "/foo"
      },{
      "Type": "hostbind",
      "Source": "/var/run/docker.sock",
      "Destination": "/var/run/docker.sock",
      },{
      "Type": "persistent",
      "Name": "important_data",
      "Target": "/var/data",
      "Mode": "ro"
      "Driver": "awesomeStorage",
      "CreateOpts": { "Size": "10G" }
      }]
    }
}'

There are currently 3 types of volumes:

  - **ephemeral**: Essentially scratch space on disk and are
    removed when the container is removed
  - **hostbind**: Paths on the host that get mounted into the
    container. Paths must exist prior to creating the container.
  - **persistent**: Volumes that have names and persist after the
    container is removed.

Not all fields are available in each type, and validation is done to
ensure these fields aren't mixed up between types.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
```
