### PR TITLE
Windows: docker cp platform semantically consistent paths

### DIFF
--- a/container/archive.go
+++ b/container/archive.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/engine-api/types"
 )
 
@@ -13,6 +14,12 @@ import (
 // the absolute path to the resource relative to the container's rootfs, and
 // an error if the path points to outside the container's rootfs.
 func (container *Container) ResolvePath(path string) (resolvedPath, absPath string, err error) {
+	// Check if a drive letter supplied, it must be the system drive. No-op except on Windows
+	path, err = system.CheckSystemDriveAndRemoveDriveLetter(path)
+	if err != nil {
+		return "", "", err
+	}
+
 	// Consider the given path as an absolute path in the container.
 	absPath = archive.PreserveTrailingDotOrSeparator(filepath.Join(string(filepath.Separator), path), path)
 

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/engine-api/types"
 )
 
@@ -184,6 +185,12 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 
 	err = daemon.mountVolumes(container)
 	defer container.UnmountVolumes(true, daemon.LogVolumeEvent)
+	if err != nil {
+		return err
+	}
+
+	// Check if a drive letter supplied, it must be the system drive. No-op except on Windows
+	path, err = system.CheckSystemDriveAndRemoveDriveLetter(path)
 	if err != nil {
 		return err
 	}

--- a/daemon/archive_unix.go
+++ b/daemon/archive_unix.go
@@ -3,9 +3,10 @@
 package daemon
 
 import (
-	"github.com/docker/docker/container"
 	"os"
 	"path/filepath"
+
+	"github.com/docker/docker/container"
 )
 
 // checkIfPathIsInAVolume checks if the path is in a volume. If it is, it

--- a/pkg/system/path_unix.go
+++ b/pkg/system/path_unix.go
@@ -6,3 +6,9 @@ package system
 // executables. Each directory is separated from the next by a colon
 // ':' character .
 const DefaultPathEnv = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+// CheckSystemDriveAndRemoveDriveLetter verifies that a path, if it includes a drive letter,
+// is the system drive. This is a no-op on Linux.
+func CheckSystemDriveAndRemoveDriveLetter(path string) (string, error) {
+	return path, nil
+}

--- a/pkg/system/path_windows.go
+++ b/pkg/system/path_windows.go
@@ -2,6 +2,36 @@
 
 package system
 
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
 // DefaultPathEnv is deliberately empty on Windows as the default path will be set by
 // the container. Docker has no context of what the default path should be.
 const DefaultPathEnv = ""
+
+// CheckSystemDriveAndRemoveDriveLetter verifies and manipulates a Windows path.
+// This is used, for example, when validating a user provided path in docker cp.
+// If a drive letter is supplied, it must be the system drive. The drive letter
+// is always removed. Also, it translates it to OS semantics (IOW / to \). We
+// need the path in this syntax so that it can ultimately be contatenated with
+// a Windows long-path which doesn't support drive-letters. Examples:
+// C:			--> Fail
+// C:\			--> \
+// a			--> a
+// /a			--> \a
+// d:\			--> Fail
+func CheckSystemDriveAndRemoveDriveLetter(path string) (string, error) {
+	if len(path) == 2 && string(path[1]) == ":" {
+		return "", fmt.Errorf("No relative path specified in %q", path)
+	}
+	if !filepath.IsAbs(path) || len(path) < 2 {
+		return filepath.FromSlash(path), nil
+	}
+	if string(path[1]) == ":" && !strings.EqualFold(string(path[0]), "c") {
+		return "", fmt.Errorf("The specified path is not on the system drive (C:)")
+	}
+	return filepath.FromSlash(path[2:]), nil
+}

--- a/pkg/system/path_windows_test.go
+++ b/pkg/system/path_windows_test.go
@@ -1,0 +1,78 @@
+// +build windows
+
+package system
+
+import "testing"
+
+// TestCheckSystemDriveAndRemoveDriveLetter tests CheckSystemDriveAndRemoveDriveLetter
+func TestCheckSystemDriveAndRemoveDriveLetter(t *testing.T) {
+	// Fails if not C drive.
+	path, err := CheckSystemDriveAndRemoveDriveLetter(`d:\`)
+	if err == nil || (err != nil && err.Error() != "The specified path is not on the system drive (C:)") {
+		t.Fatalf("Expected error for d:")
+	}
+
+	// Single character is unchanged
+	if path, err = CheckSystemDriveAndRemoveDriveLetter("z"); err != nil {
+		t.Fatalf("Single character should pass")
+	}
+	if path != "z" {
+		t.Fatalf("Single character should be unchanged")
+	}
+
+	// Two characters without colon is unchanged
+	if path, err = CheckSystemDriveAndRemoveDriveLetter("AB"); err != nil {
+		t.Fatalf("2 characters without colon should pass")
+	}
+	if path != "AB" {
+		t.Fatalf("2 characters without colon should be unchanged")
+	}
+
+	// Abs path without drive letter
+	if path, err = CheckSystemDriveAndRemoveDriveLetter(`\l`); err != nil {
+		t.Fatalf("abs path no drive letter should pass")
+	}
+	if path != `\l` {
+		t.Fatalf("abs path without drive letter should be unchanged")
+	}
+
+	// Abs path without drive letter, linux style
+	if path, err = CheckSystemDriveAndRemoveDriveLetter(`/l`); err != nil {
+		t.Fatalf("abs path no drive letter linux style should pass")
+	}
+	if path != `\l` {
+		t.Fatalf("abs path without drive letter linux failed %s", path)
+	}
+
+	// Drive-colon should be stripped
+	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:\`); err != nil {
+		t.Fatalf("An absolute path should pass")
+	}
+	if path != `\` {
+		t.Fatalf(`An absolute path should have been shortened to \ %s`, path)
+	}
+
+	// Verify with a linux-style path
+	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:/`); err != nil {
+		t.Fatalf("An absolute path should pass")
+	}
+	if path != `\` {
+		t.Fatalf(`A linux style absolute path should have been shortened to \ %s`, path)
+	}
+
+	// Failure on c:
+	if path, err = CheckSystemDriveAndRemoveDriveLetter(`c:`); err == nil {
+		t.Fatalf("c: should fail")
+	}
+	if err.Error() != `No relative path specified in "c:"` {
+		t.Fatalf(path, err)
+	}
+
+	// Failure on d:
+	if path, err = CheckSystemDriveAndRemoveDriveLetter(`d:`); err == nil {
+		t.Fatalf("c: should fail")
+	}
+	if err.Error() != `No relative path specified in "d:"` {
+		t.Fatalf(path, err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This makes docker cp work with full Windows-semantics paths (both `\` and `/` were previously supported, but not `drive:\path`). This relates to https://github.com/docker/docker/pull/22181 which did make it in for TP5. If this too could be added, we would have consistency :smile:

@tiborvass @icecrime @friism @taylorb-microsoft

Example of copying in/out of a container below:

```
C:\John>docker ps -a
CONTAINER ID        IMAGE               COMMAND              CREATED             STATUS                     PORTS               NAMES
cc0cdaeb3ace        windowsservercore   "cmd /s /c dir \\"   12 seconds ago      Exited (0) 7 seconds ago                       naughty_tesla

C:\John>docker cp testfile.txt cc:c:\

C:\John>docker cp cc:c:\windows\system32\ntdll.dll .

C:\John>dir ntdll.dll
 Volume in drive C has no label.
 Volume Serial Number is B41F-6F9B

 Directory of C:\John

03/25/2016  04:12 AM         1,866,808 ntdll.dll
               1 File(s)      1,866,808 bytes
               0 Dir(s)  110,190,714,880 bytes free

C:\John>docker commit cc
sha256:f22ebb561ab6ea059ab4e9d80e7ef48a052fc751a43b3717ec60f77163b19c55

C:\John>docker run f2 cmd /s /c dir c:\
 Volume in drive C has no label.
 Volume Serial Number is 1440-27FA

 Directory of c:\

03/25/2016  05:28 AM    <DIR>          inetpub
03/25/2016  04:22 AM    <DIR>          PerfLogs
04/26/2016  08:55 PM    <DIR>          Program Files
03/25/2016  04:22 AM    <DIR>          Program Files (x86)
04/18/2016  09:26 AM                 4 testfile.txt
04/26/2016  08:55 PM    <DIR>          Users
04/26/2016  08:55 PM    <DIR>          Windows
               1 File(s)              4 bytes
               6 Dir(s)  21,242,904,576 bytes free

C:\John>
```
