### PR TITLE
Update the binary name in docker-engine-selinux/docker.fc

### DIFF
--- a/contrib/docker-engine-selinux/docker.fc
+++ b/contrib/docker-engine-selinux/docker.fc
@@ -1,6 +1,6 @@
 /root/\.docker	gen_context(system_u:object_r:docker_home_t,s0)
 
-/usr/bin/docker			--	gen_context(system_u:object_r:docker_exec_t,s0)
+/usr/bin/dockerd			--	gen_context(system_u:object_r:docker_exec_t,s0)
 
 /usr/lib/systemd/system/docker.service		--	gen_context(system_u:object_r:docker_unit_file_t,s0)
 


### PR DESCRIPTION
The daemon binary name is now `dockerd` so I'm guessing this needs to be updated.

Anything else that needs to be changed for selinux?
