### PR TITLE
Fix lookup of dockerd when called from outside of $PATH

### DIFF
--- a/cmd/docker/daemon_none.go
+++ b/cmd/docker/daemon_none.go
@@ -1,11 +1,16 @@
+// +build !daemon
+
 package main
 
 import (
 	"fmt"
+	"runtime"
+	"strings"
 )
 
 // CmdDaemon reports on an error on windows, because there is no exec
 func (p DaemonProxy) CmdDaemon(args ...string) error {
 	return fmt.Errorf(
-		"`docker daemon` does not exist on windows. Please run `dockerd` directly")
+		"`docker daemon` is not supported on %s. Please run `dockerd` directly",
+		strings.Title(runtime.GOOS))
 }

--- a/cmd/docker/daemon_none_test.go
+++ b/cmd/docker/daemon_none_test.go
@@ -1,3 +1,5 @@
+// +build !daemon
+
 package main
 
 import (
@@ -9,7 +11,7 @@ func TestCmdDaemon(t *testing.T) {
 	proxy := NewDaemonProxy()
 	err := proxy.CmdDaemon("--help")
 	if err == nil {
-		t.Fatal("Expected CmdDaemon to fail in Windows.")
+		t.Fatal("Expected CmdDaemon to fail on Windows.")
 	}
 
 	if !strings.Contains(err.Error(), "Please run `dockerd`") {

--- a/cmd/docker/daemon_unix.go
+++ b/cmd/docker/daemon_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build daemon
 
 package main
 

--- a/cmd/docker/daemon_unix.go
+++ b/cmd/docker/daemon_unix.go
@@ -5,25 +5,38 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 )
 
 // CmdDaemon execs dockerd with the same flags
-// TODO: add a deprecation warning?
 func (p DaemonProxy) CmdDaemon(args ...string) error {
 	// Use os.Args[1:] so that "global" args are passed to dockerd
 	args = stripDaemonArg(os.Args[1:])
 
-	// TODO: check dirname args[0] first
-	binaryAbsPath, err := exec.LookPath(daemonBinary)
+	binaryPath, err := findDaemonBinary()
 	if err != nil {
 		return err
 	}
 
 	return syscall.Exec(
-		binaryAbsPath,
+		binaryPath,
 		append([]string{daemonBinary}, args...),
 		os.Environ())
+}
+
+// findDaemonBinary looks for the path to the dockerd binary starting with
+// the directory of the current executable (if one exists) and followed by $PATH
+func findDaemonBinary() (string, error) {
+	execDirname := filepath.Dir(os.Args[0])
+	if execDirname != "" {
+		binaryPath := filepath.Join(execDirname, daemonBinary)
+		if _, err := os.Stat(binaryPath); err == nil {
+			return binaryPath, nil
+		}
+	}
+
+	return exec.LookPath(daemonBinary)
 }
 
 // stripDaemonArg removes the `daemon` argument from the list

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -127,6 +127,7 @@ if [ "$DOCKER_EXPERIMENTAL" ]; then
 	DOCKER_BUILDTAGS+=" experimental"
 fi
 
+DOCKER_BUILDTAGS+=" daemon"
 if pkg-config 'libsystemd >= 209' 2> /dev/null ; then
 	DOCKER_BUILDTAGS+=" journald"
 elif pkg-config 'libsystemd-journal' 2> /dev/null ; then

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -35,7 +35,10 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 		fi
 
 		if [ -z "${daemonSupporting[$platform]}" ]; then
-			export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
+            # we just need a simple client for these platforms
+			export LDFLAGS_STATIC_DOCKER=""
+            # remove the "daemon" build tag from platforms that aren't supported
+            export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" )
 		    source "${MAKEDIR}/binary-client"
         else
 		    source "${MAKEDIR}/binary-client"


### PR DESCRIPTION
ac84063 - fixes a bug where running `/opt/docker daemon` (or really any path that isn't in $PATH) would either cause the wrong dockerd to be executed, or would error out with an `exec` error. 

aa733bf - provides a better error message for platforms that don't have a `dockerd` (osx)
