### PR TITLE
Allow specifying the apt mirror to use when generating deb packages

### DIFF
--- a/contrib/builder/deb/amd64/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-jessie/Dockerfile
@@ -4,6 +4,10 @@
 
 FROM debian:jessie
 
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.4

--- a/contrib/builder/deb/amd64/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-stretch/Dockerfile
@@ -4,6 +4,10 @@
 
 FROM debian:stretch
 
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.5.4

--- a/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
@@ -4,6 +4,10 @@
 
 FROM debian:wheezy-backports
 
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/contrib/builder/deb/amd64/generate.sh
+++ b/contrib/builder/deb/amd64/generate.sh
@@ -41,6 +41,15 @@ for version in "${versions[@]}"; do
 
 	echo >> "$version/Dockerfile"
 
+	if [ "$distro" = "debian" ]; then
+		cat >> "$version/Dockerfile" <<-'EOF'
+			# allow replacing httpredir mirror
+			ARG APT_MIRROR=httpredir.debian.org
+			RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
+		EOF
+	fi
+
 	extraBuildTags='pkcs11'
 	runcBuildTags=
 

--- a/contrib/builder/deb/armhf/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/debian-jessie/Dockerfile
@@ -1,5 +1,9 @@
 FROM armhf/debian:jessie
 
+# allow replacing httpredir mirror
+ARG APT_MIRROR=httpredir.debian.org
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.4.3


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

This seem to have been the main reason of failure for the automatic experimental build generator

![Tassie](https://cdn.thinglink.me/api/image/639312589112737793/1240/10/scaletowidth)
