### PR TITLE
Use dockerd instead of docker daemon in integration-cli

### DIFF
--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -23,9 +23,6 @@ import (
 
 // Daemon represents a Docker daemon for the testing framework.
 type Daemon struct {
-	// Defaults to "daemon"
-	// Useful to set to --daemon or -d for checking backwards compatibility
-	Command     string
 	GlobalFlags []string
 
 	id                string
@@ -72,7 +69,6 @@ func NewDaemon(c *check.C) *Daemon {
 	}
 
 	return &Daemon{
-		Command:       "daemon",
 		id:            id,
 		c:             c,
 		folder:        daemonFolder,
@@ -137,11 +133,10 @@ func (d *Daemon) Start(args ...string) error {
 
 // StartWithLogFile will start the daemon and attach its streams to a given file.
 func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
-	dockerBinary, err := exec.LookPath(dockerBinary)
+	dockerdBinary, err := exec.LookPath(dockerdBinary)
 	d.c.Assert(err, check.IsNil, check.Commentf("[%s] could not find docker binary in $PATH", d.id))
 
 	args := append(d.GlobalFlags,
-		d.Command,
 		"--containerd", "/var/run/docker/libcontainerd/docker-containerd.sock",
 		"--graph", d.root,
 		"--exec-root", filepath.Join(d.folder, "exec-root"),
@@ -175,7 +170,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	}
 
 	args = append(args, providedArgs...)
-	d.cmd = exec.Command(dockerBinary, args...)
+	d.cmd = exec.Command(dockerdBinary, args...)
 
 	d.cmd.Stdout = out
 	d.cmd.Stderr = out

--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -327,7 +327,7 @@ func (s *DockerAuthzSuite) TestAuthZPluginAllowEventStream(c *check.C) {
 
 	startTime := strconv.FormatInt(daemonTime(c).Unix(), 10)
 	// Add another command to to enable event pipelining
-	eventsCmd := exec.Command(s.d.cmd.Path, "--host", s.d.sock(), "events", "--since", startTime)
+	eventsCmd := exec.Command(dockerBinary, "--host", s.d.sock(), "events", "--since", startTime)
 	stdout, err := eventsCmd.StdoutPipe()
 	if err != nil {
 		c.Assert(err, check.IsNil)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -29,6 +29,16 @@ import (
 	"github.com/kr/pty"
 )
 
+// TestLegacyDaemonCommand test starting docker daemon using "deprecated" docker daemon
+// command. Remove this test when we remove this.
+func (s *DockerDaemonSuite) TestLegacyDaemonCommand(c *check.C) {
+	cmd := exec.Command(dockerBinary, "daemon", "--storage-driver=vfs", "--debug")
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil, check.Commentf("could not start daemon using 'docker daemon'"))
+
+	c.Assert(cmd.Process.Kill(), checker.IsNil)
+}
+
 func (s *DockerDaemonSuite) TestDaemonRestartWithRunningContainersPorts(c *check.C) {
 	if err := s.d.StartWithBusybox(); err != nil {
 		c.Fatalf("Could not start daemon with busybox: %v", err)
@@ -1454,7 +1464,7 @@ func (s *DockerDaemonSuite) TestHttpsRun(c *check.C) {
 
 // TestTlsVerify verifies that --tlsverify=false turns on tls
 func (s *DockerDaemonSuite) TestTlsVerify(c *check.C) {
-	out, err := exec.Command(dockerBinary, "daemon", "--tlsverify=false").CombinedOutput()
+	out, err := exec.Command(dockerdBinary, "--tlsverify=false").CombinedOutput()
 	if err == nil || !strings.Contains(string(out), "Could not load X509 key pair") {
 		c.Fatalf("Daemon should not have started due to missing certs: %v\n%s", err, string(out))
 	}

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -10,8 +10,10 @@ import (
 )
 
 var (
-	// the docker binary to use
+	// the docker client binary to use
 	dockerBinary = "docker"
+	// the docker daemon binary to use
+	dockerdBinary = "dockerd"
 
 	// path to containerd's ctr binary
 	ctrBinary = "docker-containerd-ctr"


### PR DESCRIPTION
Updating `integration-cli/daemon.go` to use `dockerd` instead of `docker daemon` to start up the daemon 🐳.

<del>Maybe we should add a test for making sure `docker daemon` for the time being ?</del> done :)

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
