### PR TITLE
Remove `docker/` prefix from log messages tag.

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -315,6 +315,7 @@ func (container *Container) StartLogger(cfg containertypes.LogConfig) (logger.Lo
 		ContainerCreated:    container.Created,
 		ContainerEnv:        container.Config.Env,
 		ContainerLabels:     container.Config.Labels,
+		DaemonName:          "docker",
 	}
 
 	// Set logging file for "json-logger"

--- a/daemon/logger/context.go
+++ b/daemon/logger/context.go
@@ -20,6 +20,7 @@ type Context struct {
 	ContainerEnv        []string
 	ContainerLabels     map[string]string
 	LogPath             string
+	DaemonName          string
 }
 
 // ExtraAttributes returns the user-defined extra attributes (labels,

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -65,7 +65,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, err
 	}
 
-	tag, err := loggerutils.ParseLogTag(ctx, "docker.{{.ID}}")
+	tag, err := loggerutils.ParseLogTag(ctx, "{{.DaemonName}}.{{.ID}}")
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/logger/loggerutils/log_tag_test.go
+++ b/daemon/logger/loggerutils/log_tag_test.go
@@ -18,6 +18,12 @@ func TestParseLogTag(t *testing.T) {
 	assertTag(t, e, tag, "test-image/test-container/container-ab")
 }
 
+func TestParseLogTagEmptyTag(t *testing.T) {
+	ctx := buildContext(map[string]string{})
+	tag, e := ParseLogTag(ctx, "{{.DaemonName}}/{{.ID}}")
+	assertTag(t, e, tag, "test-dockerd/container-ab")
+}
+
 // Helpers
 
 func buildContext(cfg map[string]string) logger.Context {
@@ -27,6 +33,7 @@ func buildContext(cfg map[string]string) logger.Context {
 		ContainerImageID:   "image-abcdefghijklmnopqrstuvwxyz01234567890",
 		ContainerImageName: "test-image",
 		Config:             cfg,
+		DaemonName:         "test-dockerd",
 	}
 }
 

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -91,7 +90,7 @@ func rfc5424microformatterWithAppNameAsTag(p syslog.Priority, hostname, tag, con
 // the context. Supported context configuration variables are
 // syslog-address, syslog-facility, syslog-format.
 func New(ctx logger.Context) (logger.Logger, error) {
-	tag, err := loggerutils.ParseLogTag(ctx, "{{.ID}}")
+	tag, err := loggerutils.ParseLogTag(ctx, "{{.DaemonName}}/{{.ID}}")
 	if err != nil {
 		return nil, err
 	}
@@ -111,17 +110,15 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, err
 	}
 
-	logTag := path.Base(os.Args[0]) + "/" + tag
-
 	var log *syslog.Writer
 	if proto == secureProto {
 		tlsConfig, tlsErr := parseTLSConfig(ctx.Config)
 		if tlsErr != nil {
 			return nil, tlsErr
 		}
-		log, err = syslog.DialWithTLSConfig(proto, address, facility, logTag, tlsConfig)
+		log, err = syslog.DialWithTLSConfig(proto, address, facility, tag, tlsConfig)
 	} else {
-		log, err = syslog.Dial(proto, address, facility, logTag)
+		log, err = syslog.Dial(proto, address, facility, tag)
 	}
 
 	if err != nil {

--- a/docs/admin/logging/log_tags.md
+++ b/docs/admin/logging/log_tags.md
@@ -30,6 +30,7 @@ Docker supports some special template markup you can use when specifying a tag's
 | `{{.ImageID}}`     | The first 12 characters of the container's image id. |
 | `{{.ImageFullID}}` | The container's full image identifier.               |
 | `{{.ImageName}}`   | The name of the image used by the container.         |
+| `{{.DaemonName}}`  | The name of the docker program (`docker`).           |
 
 For example, specifying a `--log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}"` value yields `syslog` log lines like:
 


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #22358 where syslog's message tag always starts with `docker/` and can not be removed by changing the log tag templates.

**\- How I did it**

The issue is that syslog driver hardcodes `path.Base(os.Args[0])` as the prefix, which is the binary file name of the daemon (`dockerd`). This could be an issue for certain situations (e.g., #22358) where
user may prefer not to have a dedicated prefix in syslog messages. There is no way to override this behavior in the current version of the docker.

This fix tries to address this issue without making changes in the default behavior of the syslog driver. An additional template markup `{{.DaemonName}}` has been introduced in the syslog tag. This is assigned as the `path.Base(os.Args[0])` when daemon (`docker`) starts.

The default log tag template has also been changed from `path.Base(os.Args[0]) + "/{{.ID}}"` to `{{.DaemonName}}/{{.ID}}`. Therefore, there is no behavior changes when log-tag is not provided.

In order to be consistent, the default log tag for fluentd has been changed from `docker.{{.ID}}` to `{{DaemonName}}.{{.ID}}` as well.

The documentation for log-tag has been updated to reflect this change.

**\- How to verify it**

Additional test cases have been added to cover changes in this fix.

**\- Description for the changelog**

Remove `docker/` prefix from log messages tag and replace with `{{.DaemonName}}` so that users could have the option of changing prefix. 

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22358.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
