### PR TITLE
Fix bug: exec non-exist command miss a "\n"

### DIFF
--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -110,8 +110,8 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		if execStartCheck.Detach {
 			return err
 		}
-		stdout.Write([]byte(err.Error()))
-		logrus.Errorf("Error running exec in container: %v\n", err)
+		stdout.Write([]byte(err.Error() + "\r\n"))
+		logrus.Errorf("Error running exec in container: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
When exec a non-exist command, it should print a newline at last.

Currently:

```
$ docker exec -ti f5f703ea2c0a144 bash
rpc error: code = 2 desc = "oci runtime error: exec failed: exec:
\"bash\": executable file not found in $PATH"$
```

Signed-off-by: Feng Yan fy2462@gmail.com
