### PR TITLE
add .gitattributes to set default line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto-detect text files, ensure they use LF.
+* text=auto eol=lf


### PR DESCRIPTION
Set some defaults for line-endings for text-files
to assist (docs)contributors on Windows that don't
have a global configuration present to end up with
errors if they try to build/run the documentation.

This is just a quick draft; should we enforce `LF` for all files? Use different settings? I'm always a bit confused by these settings myself, and I'm not on Windows, so input is welcome :smile:
