### PR TITLE
Change volumes database name should not be fixed

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -45,15 +45,25 @@ func New(rootPath string) (*VolumeStore, error) {
 	}
 
 	if rootPath != "" {
+		var err error
+		var hostname string
+
 		// initialize metadata store
 		volPath := filepath.Join(rootPath, volumeDataDir)
 		if err := os.MkdirAll(volPath, 750); err != nil {
 			return nil, err
 		}
 
-		dbPath := filepath.Join(volPath, "metadata.db")
+		// initialize database name
+		hostname, err = os.Hostname()
+		if err != nil {
+			return nil, err
+		}
 
-		var err error
+		dbName := "metadata-"+hostname+".db"
+
+		dbPath := filepath.Join(volPath, dbName)
+
 		vs.db, err = bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**\- What I did**
Change the volumes database name from "metadata.db" to "metadata-[hostname].db",
So it can be use docker 1.11.x+ with GlusterFS brick that mount to /var/lib/docker/volumes

**\- How I did it**
I get a hostname from os.Hostname() then add as suffix of old name.

**\- How to verify it**
metadata.db in /var/lib/docker/volumes changed to metadata-[hostname].db

**\- Description for the changelog**
Change volumes database name should not be fixed.

**\- A picture of a cute animal (not mandatory but encouraged)**
Sadly, I don't have this.

Signed-off-by: Surachate Sangtongrum hildamerom@gmail.com
