### PR TITLE
HTTP 500 status code for commands denied by auth plugin

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -46,14 +46,15 @@ func GetHTTPErrorStatusCode(err error) int {
 		// we should create appropriate error types that implement the httpStatusError interface.
 		errStr := strings.ToLower(errMsg)
 		for keyword, status := range map[string]int{
-			"not found":             http.StatusNotFound,
-			"no such":               http.StatusNotFound,
-			"bad parameter":         http.StatusBadRequest,
-			"conflict":              http.StatusConflict,
-			"impossible":            http.StatusNotAcceptable,
-			"wrong login/password":  http.StatusUnauthorized,
-			"unauthorized":          http.StatusUnauthorized,
-			"hasn't been activated": http.StatusForbidden,
+			"not found":               http.StatusNotFound,
+			"no such":                 http.StatusNotFound,
+			"bad parameter":           http.StatusBadRequest,
+			"conflict":                http.StatusConflict,
+			"impossible":              http.StatusNotAcceptable,
+			"wrong login/password":    http.StatusUnauthorized,
+			"unauthorized":            http.StatusUnauthorized,
+			"authorization denied by": http.StatusForbidden,
+			"hasn't been activated":   http.StatusForbidden,
 		} {
 			if strings.Contains(errStr, keyword) {
 				statusCode = status


### PR DESCRIPTION
**\- What I did**

This fix tried to address the issue raised in #22428 where HTTP 500 status code would be returned for commands denied by auth plugin, instead of HTTP 403 (StatusForbidden). The reason for this issue is that the error message for commands denied by auth plugin was not captured properly.

**\- How I did it**

This fix updates the error message capturing to address the issue.

**\- How to verify it**

An additional test has been added to cover the changes.

**\- Description for the changelog**

Change the returned HTTP status code for commands denied by auth plugin from 500 (Internal Error) to 403 (Forbidden).

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22428.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
