### PR TITLE
We should always return the MountLabel

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -340,9 +340,6 @@ func (container *Container) GetProcessLabel() string {
 // GetMountLabel returns the mounting label for the container.
 // This label is empty if the container is privileged.
 func (container *Container) GetMountLabel() string {
-	if container.HostConfig.Privileged {
-		return ""
-	}
 	return container.MountLabel
 }
 


### PR DESCRIPTION
We need to have labels applied even if a container is running in privileged
mode.  On an tightly locked down SELinux system, this will cause running
without labels will cause SELinux to block privileged mode containers.

Signed-off-by: Dan Walsh dwalsh@redhat.com
