### PR TITLE
minor contributing.md cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Want to hack on Docker? Awesome!  We have a contributor's guide that explains
 [setting up a Docker development environment and the contribution
 process](https://docs.docker.com/opensource/project/who-written-for/). 
 
-![Contributors guide](docs/static_files/contributors.png)
+[![Contributors guide](docs/static_files/contributors.png)](https://docs.docker.com/opensource/project/who-written-for/)
 
 This page contains information about reporting issues as well as some tips and
 guidelines useful to experienced open source contributors. Finally, make sure
@@ -58,51 +58,11 @@ When sending lengthy log-files, consider posting them as a gist (https://gist.gi
 Don't forget to remove sensitive data from your logfiles before posting (you can
 replace those parts with "REDACTED").
 
-**Issue Report Template**:
-
-```
-Description of problem:
-
-
-`docker version`:
-
-
-`docker info`:
-
-
-`uname -a`:
-
-
-Environment details (AWS, VirtualBox, physical, etc.):
-
-
-How reproducible:
-
-
-Steps to Reproduce:
-1.
-2.
-3.
-
-
-Actual Results:
-
-
-Expected Results:
-
-
-Additional info:
-
-
-
-```
-
-
-##Quick contribution tips and guidelines
+## Quick contribution tips and guidelines
 
 This section gives the experienced contributor some tips and guidelines.
 
-###Pull requests are always welcome
+### Pull requests are always welcome
 
 Not sure if that typo is worth a pull request? Found a bug and know how to fix
 it? Do it! We will appreciate it. Any significant improvement should be
@@ -133,6 +93,14 @@ However, there might be a way to implement that feature *on top of* Docker.
   <col width="45%">
   <col width="65%">
   <tr>
+    <td>Forums</td>
+    <td>
+      A public forum for users to discuss questions and explore current design patterns and
+      best practices about Docker and related projects in the Docker Ecosystem. To participate,
+      just log in with your Docker Hub account on <a href="https://forums.docker.com" target="_blank">https://forums.docker.com</a>.
+    </td>
+  </tr>
+  <tr>
     <td>Internet&nbsp;Relay&nbsp;Chat&nbsp;(IRC)</td>
     <td>
       <p>
@@ -142,19 +110,19 @@ However, there might be a way to implement that feature *on top of* Docker.
         IRC is a rich chat protocol but it can overwhelm new users. You can search
         <a href="https://botbot.me/freenode/docker/#" target="_blank">our chat archives</a>.
       </p>
-      Read our <a href="https://docs.docker.com/opensource/get-help/#irc-quickstart" target="_blank">IRC quickstart guide</a> for an easy way to get started.
+      <p>
+        Read our <a href="https://docs.docker.com/opensource/get-help/#irc-quickstart" target="_blank">IRC quickstart guide</a>
+        for an easy way to get started.
+      </p>
     </td>
   </tr>
   <tr>
-    <td>Google Groups</td>
+    <td>Google Group</td>
     <td>
-      There are two groups.
-      <a href="https://groups.google.com/forum/#!forum/docker-user" target="_blank">Docker-user</a>
-      is for people using Docker containers.
       The <a href="https://groups.google.com/forum/#!forum/docker-dev" target="_blank">docker-dev</a>
-      group is for contributors and other people contributing to the Docker
-      project.
-      You can join them without an google account by sending an email to e.g. "docker-user+subscribe@googlegroups.com".
+      group is for contributors and other people contributing to the Docker project.
+      You can join them without an google account by sending an email to 
+      <a href="mailto:docker-dev+subscribe@googlegroups.com">docker-dev+subscribe@googlegroups.com</a>.
       After receiving the join-request message, you can simply reply to that to confirm the subscribtion.
     </td>
   </tr>
@@ -308,10 +276,6 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
 
-Note that the old-style `Docker-DCO-1.1-Signed-off-by: ...` format is still
-accepted, so there is no need to update outstanding pull requests to the new
-format right away, but please do adjust your processes for future contributions.
-
 ### How can I become a maintainer?
 
 The procedures for adding new maintainers are explained in the 
@@ -431,6 +395,6 @@ The rules:
     guidelines. Since you've read all the rules, you now know that.
 
 If you are having trouble getting into the mood of idiomatic Go, we recommend
-reading through [Effective Go](http://golang.org/doc/effective_go.html). The
-[Go Blog](http://blog.golang.org/) is also a great resource. Drinking the
+reading through [Effective Go](https://golang.org/doc/effective_go.html). The
+[Go Blog](https://blog.golang.org) is also a great resource. Drinking the
 kool-aid is a lot easier than going thirsty.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
- added an  image-link to the contributors guide
- added a link to forums.docker.com
- removed link to the docker-user Google Group, which is no longer in use
- remove the "Issue Report Template", because we now have a template for this on GitHub
- remove reference to the old "Docker-DCO-1.1-Signed-off-by" sign-off
- changed some none-https links to https

**\- A picture of a cute animal (not mandatory but encouraged)**

![emperor-penguin-chick-snow-hill-island-antarctica](https://cloud.githubusercontent.com/assets/1804568/14943389/1c7c80b2-0fd8-11e6-9373-58a68b9be6ac.jpg)
