### PR TITLE
Docker pull/push with max concurrency limits.

### DIFF
--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -25,6 +25,11 @@ type LayerDownloadManager struct {
 	tm         TransferManager
 }
 
+// SetConcurrency set the max concurrent downloads for each pull
+func (ldm *LayerDownloadManager) SetConcurrency(concurrency int) {
+	ldm.tm.SetConcurrency(concurrency)
+}
+
 // NewLayerDownloadManager returns a new LayerDownloadManager.
 func NewLayerDownloadManager(layerStore layer.Store, concurrencyLimit int) *LayerDownloadManager {
 	return &LayerDownloadManager{

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -279,6 +279,8 @@ type TransferManager interface {
 	// so, it returns progress and error output from that transfer.
 	// Otherwise, it will call xferFunc to initiate the transfer.
 	Transfer(key string, xferFunc DoFunc, progressOutput progress.Output) (Transfer, *Watcher)
+	// SetConcurrency set the concurrencyLimit so that it is adjustable daemon reload
+	SetConcurrency(concurrency int)
 }
 
 type transferManager struct {
@@ -296,6 +298,13 @@ func NewTransferManager(concurrencyLimit int) TransferManager {
 		concurrencyLimit: concurrencyLimit,
 		transfers:        make(map[string]Transfer),
 	}
+}
+
+// SetConcurrency set the concurrencyLimit
+func (tm *transferManager) SetConcurrency(concurrency int) {
+	tm.mu.Lock()
+	tm.concurrencyLimit = concurrency
+	tm.mu.Unlock()
 }
 
 // Transfer checks if a transfer matching the given key is in progress. If not,
@@ -337,7 +346,7 @@ func (tm *transferManager) Transfer(key string, xferFunc DoFunc, progressOutput 
 	start := make(chan struct{})
 	inactive := make(chan struct{})
 
-	if tm.activeTransfers < tm.concurrencyLimit {
+	if tm.concurrencyLimit == 0 || tm.activeTransfers < tm.concurrencyLimit {
 		close(start)
 		tm.activeTransfers++
 	} else {

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -19,6 +19,11 @@ type LayerUploadManager struct {
 	tm TransferManager
 }
 
+// SetConcurrency set the max concurrent uploads for each push
+func (lum *LayerUploadManager) SetConcurrency(concurrency int) {
+	lum.tm.SetConcurrency(concurrency)
+}
+
 // NewLayerUploadManager returns a new LayerUploadManager.
 func NewLayerUploadManager(concurrencyLimit int) *LayerUploadManager {
 	return &LayerUploadManager{

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -54,6 +54,8 @@ weight = -1
       --log-driver="json-file"               Default driver for container logs
       --log-opt=[]                           Log driver specific options
       --mtu=0                                Set the containers network MTU
+      --max-concurrent-downloads=3           Set the max concurrent downloads for each pull
+      --max-concurrent-uploads=5             Set the max concurrent uploads for each push
       --disable-legacy-registry              Do not contact legacy registries
       -p, --pidfile="/var/run/docker.pid"    Path to use for daemon PID file
       --raw-logs                             Full timestamps without ANSI coloring
@@ -913,6 +915,8 @@ This is a full example of the allowed configuration options in the file:
 	"cluster-store": "",
 	"cluster-store-opts": [],
 	"cluster-advertise": "",
+	"max-concurrent-downloads": 3,
+	"max-concurrent-uploads": 5,
 	"debug": true,
 	"hosts": [],
 	"log-level": "",
@@ -963,6 +967,8 @@ The list of currently supported options that can be reconfigured is this:
 - `cluster-store-opts`: it uses the new options to reload the discovery store.
 - `cluster-advertise`: it modifies the address advertised after reloading.
 - `labels`: it replaces the daemon labels with a new set of labels.
+- `max-concurrent-downloads`: it updates the max concurrent downloads for each pull.
+- `max-concurrent-uploads`: it updates the max concurrent uploads for each push.
 
 Updating and reloading the cluster configurations such as `--cluster-store`,
 `--cluster-advertise` and `--cluster-store-opts` will take effect only if

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -44,6 +44,8 @@ dockerd - Enable daemon mode
 [**--log-driver**[=*json-file*]]
 [**--log-opt**[=*map[]*]]
 [**--mtu**[=*0*]]
+[**--max-concurrent-downloads**[=*3*]]
+[**--max-concurrent-uploads**[=*5*]]
 [**-p**|**--pidfile**[=*/var/run/docker.pid*]]
 [**--raw-logs**]
 [**--registry-mirror**[=*[]*]]
@@ -196,6 +198,12 @@ unix://[/path/to/socket] to use.
 
 **--mtu**=*0*
   Set the containers network mtu. Default is `0`.
+
+**--max-concurrent-downloads**=*3*
+  Set the max concurrent downloads for each pull. Default is `3`.
+
+**--max-concurrent-uploads**=*5*
+  Set the max concurrent uploads for each push. Default is `5`.
 
 **-p**, **--pidfile**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`


### PR DESCRIPTION
**\- What I did**

This fix tries to address issues raised in #20936 and #22443 where `docker pull` or `docker push` fails because of the concurrent connection failing.
Currently, the number of maximum concurrent connections is controlled by `maxDownloadConcurrency` and `maxUploadConcurrency` which are set to 3 and 5 respectively. Therefore, in situations where network connections don't support multiple downloads/uploads, failures may encounter for `docker push` or `docker pull`.

**\- How I did it**

This fix changes `maxDownloadConcurrency` and `maxUploadConcurrency` to adjustable by passing `--max-concurrent-uploads` and `--max-concurrent-downloads` to `docker daemon` command.

The documentation related to docker daemon has been updated.

**\- How to verify it**

Additional test case have been added to cover the changes in this fix.

**\- Description for the changelog**

Add  `--max--concurrent-uploads` and `--max--concurrent-downloads` to `docker daemon` command so that `docker pull` and `docker push` could control the max number of concurrent connections during uploads or downloads.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #20936. This fix fixes #22443.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
