### PR TITLE
Add support for reloading daemon configuration through systemd

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,6 +10,7 @@ Type=notify
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
 ExecStart=/usr/bin/docker daemon -H fd://
+ExecReload=/bin/kill -s HUP $MAINPID
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Updated the systemd unit file to allow reloading the daemon configuration;

This adds support for reloading the docker daemon
(SIGHIUP) so that changes in '/etc/docker/daemon.json'
can be loaded at runtime by reloading the service
through systemd ('systemctl reload docker')

Before this change, systemd would output an error
that "reloading" is not supported for the docker
service;

```
systemctl reload docker
Failed to reload docker.service: Job type reload is not applicable for unit docker.service.
```

After this change, the docker daemon can be reloaded
through 'systemctl reload docker', which reloads
the configuration;

```
journalctl -f -u docker.service

May 02 03:49:20 testing systemd[1]: Reloading Docker Application Container Engine.
May 02 03:49:20 testing docker[28496]: time="2016-05-02T03:49:20.143964103-04:00" level=info msg="Got signal to reload configuration, reloading from: /etc/docker/daemon.json"
May 02 03:49:20 testing systemd[1]: Reloaded Docker Application Container Engine.
```

**\- How I did it**

By adding an `ExecReload` line to the unit file

**\- How to verify it**

on a host with docker installed and running systemd:
1. install docker on a system that uses systemd
2. update `/lib/systemd/system/docker.service` with the changes in this PR
3. reload the unit file; `systemctl daemon-reload`
4. check the output of `docker info`
   
   there should be no "labels" 
5. create `/etc/docker/daemon.json`, and edit it to look like this:
   
   ```
   {"labels":["foo=bar","bar=baz"]}
   ```
6. reload the daemon; `systemctl reload docker`
7. check the output of `docker info`
   
   the labels are set on the daemon, and visible as part of `docker info`;
   
   ```
   Labels:
    foo=bar
    bar=baz
   ```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add support for reloading the daemon configuration file (daemon.json) through systemd

**\- A picture of a cute animal (not mandatory but encouraged)**

![cute-little-fish](https://cloud.githubusercontent.com/assets/1804568/14950331/273e577c-1051-11e6-8639-1a7387278353.jpg)
