### PR TITLE
Fix authorization issue - when request is denied return forbbiden exist code (403).

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"fmt"
 	"net"
-	"net/http"
 	"strings"
 
 	netsettings "github.com/docker/docker/daemon/network"
@@ -97,7 +96,7 @@ func (daemon *Daemon) getAllNetworks() []libnetwork.Network {
 func (daemon *Daemon) CreateNetwork(create types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
 	if runconfig.IsPreDefinedNetwork(create.Name) {
 		err := fmt.Errorf("%s is a pre-defined network and cannot be created", create.Name)
-		return nil, errors.NewErrorWithStatusCode(err, http.StatusForbidden)
+		return nil, errors.NewRequestForbiddenError(err)
 	}
 
 	var warning string
@@ -221,7 +220,7 @@ func (daemon *Daemon) DeleteNetwork(networkID string) error {
 
 	if runconfig.IsPreDefinedNetwork(nw.Name()) {
 		err := fmt.Errorf("%s is a pre-defined network and cannot be removed", nw.Name())
-		return errors.NewErrorWithStatusCode(err, http.StatusForbidden)
+		return errors.NewRequestForbiddenError(err)
 	}
 
 	if err := nw.Delete(); err != nil {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -28,6 +28,12 @@ func NewBadRequestError(err error) error {
 	return NewErrorWithStatusCode(err, http.StatusBadRequest)
 }
 
+// NewRequestForbiddenError creates a new API error
+// that has the 403 HTTP status code associated to it.
+func NewRequestForbiddenError(err error) error {
+	return NewErrorWithStatusCode(err, http.StatusForbidden)
+}
+
 // NewRequestNotFoundError creates a new API error
 // that has the 404 HTTP status code associated to it.
 func NewRequestNotFoundError(err error) error {

--- a/pkg/authorization/authz.go
+++ b/pkg/authorization/authz.go
@@ -85,7 +85,7 @@ func (ctx *Ctx) AuthZRequest(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		if !authRes.Allow {
-			return fmt.Errorf("authorization denied by plugin %s: %s", plugin.Name(), authRes.Msg)
+			return newAuthorizationError(plugin.Name(), authRes.Msg)
 		}
 	}
 
@@ -110,7 +110,7 @@ func (ctx *Ctx) AuthZResponse(rm ResponseModifier, r *http.Request) error {
 		}
 
 		if !authRes.Allow {
-			return fmt.Errorf("authorization denied by plugin %s: %s", plugin.Name(), authRes.Msg)
+			return newAuthorizationError(plugin.Name(), authRes.Msg)
 		}
 	}
 
@@ -162,4 +162,18 @@ func headers(header http.Header) map[string]string {
 		}
 	}
 	return v
+}
+
+// authorizationError represents an authorization deny error
+type authorizationError struct {
+	error
+}
+
+// HTTPErrorStatusCode returns the authorization error status code (forbidden)
+func (e authorizationError) HTTPErrorStatusCode() int {
+	return http.StatusForbidden
+}
+
+func newAuthorizationError(plugin, msg string) authorizationError {
+	return authorizationError{error: fmt.Errorf("authorization denied by plugin %s: %s", plugin, msg)}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
When request is rejected by authorization plugin, replace status code 500 (internal server error) with 403 (forbidden). Based on discussion in #2242

**\- How I did it**
Used `errors.NewErrorWithStatusCode` when authorization plugin rejects requests

**\- How to verify it**
New integration test for API

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
- Fix outdated documentation on response modification in authorization
- Return 403 (forbidden) when request is denied in authorization flows
  (including integration test)
- Fix #22428

Signed-off-by: Liron Levin liron@twistlock.com
