### PR TITLE
strip cariage-returns in log-entries (added by TTY)

### DIFF
--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -33,15 +34,35 @@ func (l *TestLoggerJSON) Name() string { return "json" }
 func TestCopier(t *testing.T) {
 	stdoutLine := "Line that thinks that it is log line from docker stdout"
 	stderrLine := "Line that thinks that it is log line from docker stderr"
+	stdoutTrailingLine := "stdout trailing line"
+	stderrTrailingLine := "stderr trailing line"
+
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 15; i++ {
 		if _, err := stdout.WriteString(stdoutLine + "\n"); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := stderr.WriteString(stderrLine + "\n"); err != nil {
 			t.Fatal(err)
 		}
+
+		// Containers with -t / --tty use CRLF as line-ending. Test that
+		// Copier strips those as well.
+		if _, err := stdout.WriteString(stdoutLine + "\r\n"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := stderr.WriteString(stderrLine + "\r\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Test remaining lines without line-endings
+	if _, err := stdout.WriteString(stdoutTrailingLine); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stderr.WriteString(stderrTrailingLine); err != nil {
+		t.Fatal(err)
 	}
 
 	var jsonBuf bytes.Buffer
@@ -78,13 +99,87 @@ func TestCopier(t *testing.T) {
 			t.Fatalf("Wrong Source: %q, should be %q or %q", msg.Source, "stdout", "stderr")
 		}
 		if msg.Source == "stdout" {
-			if string(msg.Line) != stdoutLine {
-				t.Fatalf("Wrong Line: %q, expected %q", msg.Line, stdoutLine)
+			if string(msg.Line) != stdoutLine && string(msg.Line) != stdoutTrailingLine {
+				t.Fatalf("Wrong Line: %q, expected %q or %q", msg.Line, stdoutLine, stdoutTrailingLine)
 			}
 		}
 		if msg.Source == "stderr" {
-			if string(msg.Line) != stderrLine {
-				t.Fatalf("Wrong Line: %q, expected %q", msg.Line, stderrLine)
+			if string(msg.Line) != stderrLine && string(msg.Line) != stderrTrailingLine {
+				t.Fatalf("Wrong Line: %q, expected %q or %q", msg.Line, stderrLine, stderrTrailingLine)
+			}
+		}
+	}
+}
+
+// TestCopierLongLines tests long lines without line breaks
+func TestCopierLongLines(t *testing.T) {
+	// Long lines (should be split at "bufSize")
+	const bufSize = 16 * 1024
+	stdoutLongLine := strings.Repeat("a", bufSize)
+	stderrLongLine := strings.Repeat("b", bufSize)
+	stdoutTrailingLine := "stdout trailing line"
+	stderrTrailingLine := "stderr trailing line"
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	for i := 0; i < 3; i++ {
+		if _, err := stdout.WriteString(stdoutLongLine); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := stderr.WriteString(stderrLongLine); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := stdout.WriteString(stdoutTrailingLine); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stderr.WriteString(stderrTrailingLine); err != nil {
+		t.Fatal(err)
+	}
+
+	var jsonBuf bytes.Buffer
+
+	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf)}
+
+	c := NewCopier(
+		map[string]io.Reader{
+			"stdout": &stdout,
+			"stderr": &stderr,
+		},
+		jsonLog)
+	c.Run()
+	wait := make(chan struct{})
+	go func() {
+		c.Wait()
+		close(wait)
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatal("Copier failed to do its work in 1 second")
+	case <-wait:
+	}
+	dec := json.NewDecoder(&jsonBuf)
+	for {
+		var msg Message
+		if err := dec.Decode(&msg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if msg.Source != "stdout" && msg.Source != "stderr" {
+			t.Fatalf("Wrong Source: %q, should be %q or %q", msg.Source, "stdout", "stderr")
+		}
+		if msg.Source == "stdout" {
+			if string(msg.Line) != stdoutLongLine && string(msg.Line) != stdoutTrailingLine {
+				t.Fatalf("Wrong Line: %q, expected 'stdoutLongLine' or 'stdoutTrailingLine'", msg.Line)
+			}
+		}
+		if msg.Source == "stderr" {
+			if string(msg.Line) != stderrLongLine && string(msg.Line) != stderrTrailingLine {
+				t.Fatalf("Wrong Line: %q, expected 'stderrLongLine' or 'stderrTrailingLine'", msg.Line)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Updated daemon/logger/copier.go to remove trailing CR's (`\r`).

fixes https://github.com/docker/docker/issues/15722

**\- How to verify it**

When running a container with a tty (`-t` / `-tty`), the TTY automatically converts LF to CRLF.
Strip those trailing CR's as they are not part of the original output.

This also prevents the systemd journal from treating those log-entries as "blob data":

```
  docker run -it --rm --log-driver=journald --name=tester hello-world

  journalctl CONTAINER_NAME=tester
  -- Logs begin at Wed 2016-04-27 18:40:30 EDT, end at Mon 2016-05-02 07:45:16 EDT. --
  May 02 07:39:05 ubuntu-2gb-ams3-01 docker[27908]: [1B blob data]
  May 02 07:39:05 ubuntu-2gb-ams3-01 docker[27908]: [19B blob data]
  ...
  ...
```

After this change is applied;

```
  docker run -it --rm --log-driver=journald --name=tester hello-world

  journalctl CONTAINER_NAME=tester
  -- Logs begin at Wed 2016-04-27 18:40:30 EDT, end at Mon 2016-05-02 07:45:16 EDT. --
  May 02 07:40:55 ubuntu-2gb-ams3-01 dockerd[28324]:
  May 02 07:40:55 ubuntu-2gb-ams3-01 dockerd[28324]: Hello from Docker.
  May 02 07:40:55 ubuntu-2gb-ams3-01 dockerd[28324]: This message shows that your installation appears to be working correctly.
  ...
  ...
```

Finally, this upates unit tests, to check if trailing CR's are stripped, and adds new tests to test logging of long log-lines (without newlines), and trailing log- lines.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed systemd journal treating container log entries as "blob data" if the container is started with a TTY (`-t`)

**\- A picture of a cute animal (not mandatory but encouraged)**

![sleeping-baby-turtle-cute-animal-pictures](https://cloud.githubusercontent.com/assets/1804568/14954822/a5fff34e-1075-11e6-991a-db953b07bc81.jpg)
