### PR TITLE
Make zsh completion work when ps output is custom

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -57,7 +57,7 @@ __docker_get_containers() {
     type=$1; shift
     [[ $kind = (stopped|all) ]] && args=($args -a)
 
-    lines=(${(f)"$(_call_program commands docker $docker_options ps --no-trunc $args)"})
+    lines=(${(f)"$(_call_program commands docker $docker_options ps --format 'table' --no-trunc $args)"})
 
     # Parse header line to find columns
     local i=1 j=1 k header=${lines[1]}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Make zsh completion work when ps output is custom

When `psFormat` is used in the docker client config json, if the output
is non-standard it breaks some of the completion handling for
containers.

**\- How I did it**
This fixes that by ensuring that calls to `ps` use the default/standard
formatting by calling `docker ps --format 'table'`

**\- How to verify it**
Use a custom ps format in your `~/.docker/config.json`... here's mine:

``` json
{
    "psFormat": "table {{.Names}}\\t{{.Image}}\\t{{.RunningFor}} ago\\t{{.Status}}\\t{{.Command}}"
}
```

The error case with this format is specifically when you've got a partial name (e.g. `docker rm lo`) and try to complete it you'll get a bunch of math errors.
This is a particularly light error case, but also can imagine if I removed the names column all-togther.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

no changelog entry needed

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Brian Goff cpuguy83@gmail.com
