### PR TITLE
docker bash completions fails when failglob is enabled

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -606,7 +606,7 @@ _docker_docker() {
 			COMPREPLY=( $( compgen -W "$boolean_options $global_options_with_args" -- "$cur" ) )
 			;;
 		*)
-			local counter=$( __docker_pos_first_nonflag $(__docker_to_extglob "$global_options_with_args") )
+			local counter=$( __docker_pos_first_nonflag "$(__docker_to_extglob "$global_options_with_args")" )
 			if [ $cword -eq $counter ]; then
 				COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
 			fi


### PR DESCRIPTION
When failglob is enabled, bash triggers an error everytime an unquoted pattern does not any file. Enabling failglob can help troubleshot badly quoted functions/scripts and avoir surprises but that's another debate. 

When failglob is enabled (with `shopt -s failglob`), docker bash completions fails with errors and does complete anything anymore. By quoting the result of __docker_to_extglob, failglob cannot interfer anymore.

A a generic rule, if not used in a case or [[ ]] construction, __docker_to_extglob should **always** be quoted to avoid such interference.

[cute animal here](https://i.ytimg.com/vi/g4xLVP_eFec/maxresdefault.jpg)

Signed-off-by: Damien Nadé github@livna.org
