### PR TITLE
Move implicit pull test to use local registry

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -237,20 +237,6 @@ func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
 	c.Assert(splitLatest, checker.DeepEquals, splitCurrent, check.Commentf("busybox:latest was changed after pulling all tags"))
 }
 
-// TestRunImplicitPullWithNoTagOnlyPullDefaultTag should pull implicitely only the default tag (latest)
-func (s *DockerHubPullSuite) TestRunImplicitPullWithNoTagOnlyPullDefaultTag(c *check.C) {
-	// run with an image we don't have
-	testRequires(c, DaemonIsLinux)
-	out := s.Cmd(c, "run", "busybox")
-
-	c.Assert(out, checker.Contains, "Unable to find image 'busybox:latest' locally")
-
-	// There should be only one line for busybox, the one with busybox:latest
-	outImageCmd := s.Cmd(c, "images", "busybox")
-	splitOutImageCmd := strings.Split(strings.TrimSpace(outImageCmd), "\n")
-	c.Assert(splitOutImageCmd, checker.HasLen, 2)
-}
-
 // TestPullClientDisconnect kills the client during a pull operation and verifies that the operation
 // gets cancelled.
 //


### PR DESCRIPTION
The test added in #22247 is failing in the arm test suite https://jenkins.dockerproject.org/job/Docker%20Master%20(arm)/1620/console because it pulls and tries to run amd64 image. This moves the test to a local registry.

@vdemeester 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
