### PR TITLE
Reduce time for TestRunTwoConcurrentContainers

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -770,9 +770,6 @@ func (s *DockerSuite) TestRunUserNotFound(c *check.C) {
 
 func (s *DockerSuite) TestRunTwoConcurrentContainers(c *check.C) {
 	sleepTime := "2"
-	if daemonPlatform == "windows" {
-		sleepTime = "20" // Make more reliable on Windows
-	}
 	group := sync.WaitGroup{}
 	group.Add(2)
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Cuts another 20+ seconds off the windowsTP5 CI runtime, and 2 seconds off the Linux CI runtime. No need for the container to sleep. Just exit immediately.
