### PR TITLE
removing $version, as its nice to be able to pass custom tags rather …

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -113,22 +113,8 @@ rm -rf "$target"/sbin/sln
 rm -rf "$target"/etc/ld.so.cache "$target"/var/cache/ldconfig
 mkdir -p --mode=0755 "$target"/var/cache/ldconfig
 
-version=
-for file in "$target"/etc/{redhat,system}-release
-do
-    if [ -r "$file" ]; then
-        version="$(sed 's/^[^0-9\]*\([0-9.]\+\).*$/\1/' "$file")"
-        break
-    fi
-done
+tar --numeric-owner -c -C "$target" . | docker import - $name
 
-if [ -z "$version" ]; then
-    echo >&2 "warning: cannot autodetect OS version, using '$name' as tag"
-    version=$name
-fi
-
-tar --numeric-owner -c -C "$target" . | docker import - $name:$version
-
-docker run -i -t --rm $name:$version /bin/bash -c 'echo success'
+docker run -i -t --rm $name /bin/bash -c 'echo success'
 
 rm -rf "$target"


### PR DESCRIPTION
**\- What I did**

Removed $version from the mkimage-yum.sh script, so you can pass your own tag instead of the os version. 

e.g. 

$ ./mkimage-yum.sh -p "ca-certificates" -g "Core" -y /etc/yum.conf centos:minimal
$ ./mkimage-yum.sh -p "nano htop screen" -g "Development Tools" -y /etc/yum.conf centos:devtools

**\- How I did it**

Using vim... :)

**\- How to verify it**

Check the diff.

**\- Description for the changelog**

Removed $version to allow for custom image tags. 

**\- A picture of a cute animal (not mandatory but encouraged)**

🐈 
