### PR TITLE
Add config parameter to change stop timeout during daemon shutdown

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -22,6 +22,10 @@ const (
 	disableNetworkBridge = "none"
 )
 
+const (
+	defaultShutdownTimeout = 10
+)
+
 // flatOptions contains configuration keys
 // that MUST NOT be parsed as deep structures.
 // Use this to differentiate these options
@@ -94,6 +98,10 @@ type CommonConfig struct {
 	// reachable by other hosts.
 	ClusterAdvertise string `json:"cluster-advertise,omitempty"`
 
+	// ShutdownTimeout is the timeout value (in seconds) the daemon will wait for the container
+	// to stop when daemon is being shutdown
+	ShutdownTimeout int `json:"shutdown-timeout,omitempty"`
+
 	Debug     bool     `json:"debug,omitempty"`
 	Hosts     []string `json:"hosts,omitempty"`
 	LogLevel  string   `json:"log-level,omitempty"`
@@ -138,6 +146,7 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.StringVar(&config.ClusterStore, []string{"-cluster-store"}, "", usageFn("Set the cluster store"))
 	cmd.Var(opts.NewNamedMapOpts("cluster-store-opts", config.ClusterOpts, nil), []string{"-cluster-store-opt"}, usageFn("Set cluster store options"))
 	cmd.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", usageFn("Set CORS headers in the remote API"))
+	cmd.IntVar(&config.ShutdownTimeout, []string{"-shutdown-timeout"}, defaultShutdownTimeout, usageFn("Set the default shutdown timeout"))
 }
 
 // IsValueSet returns true if a configuration value

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -812,7 +812,7 @@ func NewDaemon(config *Config, registryService *registry.Service, containerdRemo
 	return d, nil
 }
 
-func (daemon *Daemon) shutdownContainer(c *container.Container) error {
+func (daemon *Daemon) shutdownContainer(c *container.Container, shutdownTimeout int) error {
 	// TODO(windows): Handle docker restart with paused containers
 	if c.IsPaused() {
 		// To terminate a process in freezer cgroup, we should send
@@ -829,8 +829,8 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 		if err := daemon.containerUnpause(c); err != nil {
 			return fmt.Errorf("Failed to unpause container %s with error: %v", c.ID, err)
 		}
-		if _, err := c.WaitStop(10 * time.Second); err != nil {
-			logrus.Debugf("container %s failed to exit in 10 second of SIGTERM, sending SIGKILL to force", c.ID)
+		if _, err := c.WaitStop(time.Duration(shutdownTimeout) * time.Second); err != nil {
+			logrus.Debugf("container %s failed to exit in %s second of SIGTERM, sending SIGKILL to force", c.ID, shutdownTimeout)
 			sig, ok := signal.SignalMap["KILL"]
 			if !ok {
 				return fmt.Errorf("System does not support SIGKILL")
@@ -842,8 +842,8 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 			return err
 		}
 	}
-	// If container failed to exit in 10 seconds of SIGTERM, then using the force
-	if err := daemon.containerStop(c, 10); err != nil {
+	// If container failed to exit in shutdownTimeout seconds of SIGTERM, then using the force
+	if err := daemon.containerStop(c, shutdownTimeout); err != nil {
 		return fmt.Errorf("Stop container %s with error: %v", c.ID, err)
 	}
 
@@ -855,13 +855,14 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 func (daemon *Daemon) Shutdown() error {
 	daemon.shutdown = true
 	if daemon.containers != nil {
-		logrus.Debug("starting clean shutdown of all containers...")
+		shutdownTimeout := daemon.configStore.ShutdownTimeout
+		logrus.Debugf("starting clean shutdown of all containers in %d seconds...", shutdownTimeout)
 		daemon.containers.ApplyAll(func(c *container.Container) {
 			if !c.IsRunning() {
 				return
 			}
 			logrus.Debugf("stopping %s", c.ID)
-			if err := daemon.shutdownContainer(c); err != nil {
+			if err := daemon.shutdownContainer(c, shutdownTimeout); err != nil {
 				logrus.Errorf("Stop container error: %v", err)
 				return
 			}
@@ -1496,6 +1497,7 @@ func (daemon *Daemon) initDiscovery(config *Config) error {
 // - Daemon labels.
 // - Daemon debug log level.
 // - Cluster discovery (reconfigure and restart).
+// - Daemon shutdown timeout (in seconds).
 func (daemon *Daemon) Reload(config *Config) error {
 	daemon.configStore.reloadLock.Lock()
 	defer daemon.configStore.reloadLock.Unlock()
@@ -1504,6 +1506,10 @@ func (daemon *Daemon) Reload(config *Config) error {
 	}
 	if config.IsValueSet("debug") {
 		daemon.configStore.Debug = config.Debug
+	}
+	if config.IsValueSet("shutdown-timeout") {
+		daemon.configStore.ShutdownTimeout = config.ShutdownTimeout
+		logrus.Debugf("Reset Shutdown Timeout: %d", daemon.configStore.ShutdownTimeout)
 	}
 	return daemon.reloadClusterDiscovery(config)
 }

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -54,6 +54,7 @@ weight = -1
       --log-driver="json-file"               Default driver for container logs
       --log-opt=[]                           Log driver specific options
       --mtu=0                                Set the containers network MTU
+      --shutdown-timeout=10                  Set the shutdown timeout value in seconds
       --disable-legacy-registry              Do not contact legacy registries
       -p, --pidfile="/var/run/docker.pid"    Path to use for daemon PID file
       --raw-logs                             Full timestamps without ANSI coloring
@@ -894,6 +895,7 @@ This is a full example of the allowed configuration options in the file:
 	"log-driver": "",
 	"log-opts": [],
 	"mtu": 0,
+	"shutdown-timeout": 10,
 	"pidfile": "",
 	"graph": "",
 	"cluster-store": "",

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2224,3 +2224,51 @@ func (s *DockerSuite) TestDaemonDiscoveryBackendConfigReload(c *check.C) {
 	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Store: consul://consuladdr:consulport/some/path"))
 	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Advertise: 192.168.56.100:0"))
 }
+
+// Test case for #22471
+func (s *DockerDaemonSuite) TestDaemonShutdownTimeout(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	c.Assert(s.d.Start("--shutdown-timeout=3"), check.IsNil)
+
+	_, err := s.d.Cmd("run", "-d", "busybox", "top")
+	c.Assert(err, check.IsNil)
+
+	syscall.Kill(s.d.cmd.Process.Pid, syscall.SIGINT)
+
+	time.Sleep(5 * time.Second)
+
+	expectedMessage := `level=debug msg="starting clean shutdown of all containers in 3 seconds..."`
+	content, _ := ioutil.ReadFile(s.d.logFile.Name())
+	c.Assert(string(content), checker.Contains, expectedMessage)
+}
+
+// Test case for #22471
+func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	// daemon config file
+	configFilePath := "test.json"
+	configFile, err := os.Create(configFilePath)
+	c.Assert(err, checker.IsNil)
+	defer os.Remove(configFilePath)
+
+	daemonConfig := `{ "shutdown-timeout" : 8 }`
+	fmt.Fprintf(configFile, "%s", daemonConfig)
+	configFile.Close()
+	c.Assert(s.d.Start(fmt.Sprintf("--config-file=%s", configFilePath)), check.IsNil)
+
+	configFile, err = os.Create(configFilePath)
+	c.Assert(err, checker.IsNil)
+	daemonConfig = `{ "shutdown-timeout" : 5 }`
+	fmt.Fprintf(configFile, "%s", daemonConfig)
+	configFile.Close()
+
+	syscall.Kill(s.d.cmd.Process.Pid, syscall.SIGHUP)
+
+	time.Sleep(3 * time.Second)
+
+	expectedMessage := `level=debug msg="Reset Shutdown Timeout: 5"`
+	content, _ := ioutil.ReadFile(s.d.logFile.Name())
+	c.Assert(string(content), checker.Contains, expectedMessage)
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to add a daemon config parameter `--shutdown-timeout` that specifies the timeout value to stop containers gracefully (before SIGKILL). This fix is related to #22471.

**\- How I did it**

The `--shutdown-timeout` parameter is added to daemon options and config file. It will also be updated during daemon reload.

**\- How to verify it**

Additional test cases have been added to cover the change.

**\- Description for the changelog**

Add `--shutdown-timeout` to daemon config for the timeout value to stop containers (before SIGKILL) during daemon shutdown.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22471.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
