### PR TITLE
TestApiStatsContainerGetMemoryLimit: Add cgroup memory test

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -228,34 +228,6 @@ func (s *DockerSuite) TestApiStatsContainerNotFound(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 }
 
-func (s *DockerSuite) TestApiStatsContainerGetMemoryLimit(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-
-	resp, body, err := sockRequestRaw("GET", "/info", nil, "application/json")
-	c.Assert(err, checker.IsNil)
-	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
-	var info types.Info
-	err = json.NewDecoder(body).Decode(&info)
-	c.Assert(err, checker.IsNil)
-	body.Close()
-
-	// don't set a memory limit, the memory limit should be system memory
-	conName := "foo"
-	dockerCmd(c, "run", "-d", "--name", conName, "busybox", "top")
-	c.Assert(waitRun(conName), checker.IsNil)
-
-	resp, body, err = sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", conName), nil, "")
-	c.Assert(err, checker.IsNil)
-	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
-	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
-
-	var v *types.Stats
-	err = json.NewDecoder(body).Decode(&v)
-	c.Assert(err, checker.IsNil)
-	body.Close()
-	c.Assert(fmt.Sprintf("%d", v.MemoryStats.Limit), checker.Equals, fmt.Sprintf("%d", info.MemTotal))
-}
-
 func (s *DockerSuite) TestApiStatsNoStreamConnectedContainers(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 

--- a/integration-cli/docker_api_stats_unix_test.go
+++ b/integration-cli/docker_api_stats_unix_test.go
@@ -1,0 +1,41 @@
+// +build !windows
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/engine-api/types"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestApiStatsContainerGetMemoryLimit(c *check.C) {
+	testRequires(c, DaemonIsLinux, memoryLimitSupport)
+
+	resp, body, err := sockRequestRaw("GET", "/info", nil, "application/json")
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
+	var info types.Info
+	err = json.NewDecoder(body).Decode(&info)
+	c.Assert(err, checker.IsNil)
+	body.Close()
+
+	// don't set a memory limit, the memory limit should be system memory
+	conName := "foo"
+	dockerCmd(c, "run", "-d", "--name", conName, "busybox", "top")
+	c.Assert(waitRun(conName), checker.IsNil)
+
+	resp, body, err = sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", conName), nil, "")
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
+	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
+
+	var v *types.Stats
+	err = json.NewDecoder(body).Decode(&v)
+	c.Assert(err, checker.IsNil)
+	body.Close()
+	c.Assert(fmt.Sprintf("%d", v.MemoryStats.Limit), checker.Equals, fmt.Sprintf("%d", info.MemTotal))
+}


### PR DESCRIPTION
Currently on kernels booted without the "cgroup_enable=memory" kernel
parameter the testcase TestApiStatsContainerGetMemoryLimit fails with:

FAIL: docker_api_stats_test.go:231: TestApiStatsContainerGetMemoryLimit.pN52_github_com_docker_docker_integration_cli.DockerSuite

docker_api_stats_test.go:256:
    c.Assert(fmt.Sprintf("%d", v.MemoryStats.Limit), checker.Equals, fmt.Sprintf("%d", info.MemTotal))
... obtained string = "0"
... expected string = "33759145984"

Fix this and skip the testcase if the kernel does not support cgroup memory
limit. In that case the output would be:

SKIP: docker_api_stats_test.go:231:
TestApiStatsContainerGetMemoryLimit.pN52_github_com_docker_docker_integration_cli.DockerSuite
(kernel does not support cgroup memory limit)

Fixes #22477

Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
