### PR TITLE
Windows: Support ARG in builder

### DIFF
--- a/builder/dockerfile/evaluator_windows.go
+++ b/builder/dockerfile/evaluator_windows.go
@@ -6,7 +6,7 @@ import "fmt"
 // a command not supported on the platform.
 func platformSupports(command string) error {
 	switch command {
-	case "user", "stopsignal", "arg":
+	case "user", "stopsignal":
 		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
 	}
 	return nil

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/utils"
 	"github.com/docker/docker/volume"
 	containertypes "github.com/docker/engine-api/types/container"
 )
@@ -30,8 +31,10 @@ type ExitStatus struct {
 
 // CreateDaemonEnvironment creates a new environment variable slice for this container.
 func (container *Container) CreateDaemonEnvironment(linkedEnv []string) []string {
-	// On Windows, nothing to link. Just return the container environment.
-	return container.Config.Env
+	// because the env on the container can override certain default values
+	// we need to replace the 'env' keys where they match and append anything
+	// else.
+	return utils.ReplaceOrAppendEnvValues(linkedEnv, container.Config.Env)
 }
 
 // UnmountIpcMounts unmount Ipc related mounts.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This turned out to be WAY simpler than I thought. Very small change to enable `ARG` in a dockerfile and --build-arg= in `docker build` to work on Windows.

```
PS E:\docker\build\arg> docker build --build-arg user1=john -t arg --no-cache=true .
Sending build context to Docker daemon 2.048 kB
Step 1 : FROM windowsservercore
 ---> dbfee88ee9fd
Step 2 : ARG user1
 ---> Running in ddc1c39b4d6e
 ---> bb917e5f0e81
Removing intermediate container ddc1c39b4d6e
Step 3 : RUN cmd /s /c echo %user1%
 ---> Running in 81a5aa1ce690
john
 ---> 73b8ee90deee
Removing intermediate container 81a5aa1ce690
Step 4 : RUN powershell -command echo $env:user1
 ---> Running in 21116ddc265e
john
 ---> ae57c550b6a2
Removing intermediate container 21116ddc265e
Successfully built ae57c550b6a2
PS E:\docker\build\arg>
```
