### PR TITLE
Documentation: docker volumes: remove trailing comma from top command

### DIFF
--- a/docs/userguide/containers/dockervolumes.md
+++ b/docs/userguide/containers/dockervolumes.md
@@ -345,7 +345,7 @@ source. When the container is deleted, you should instruction the Engine daemon
 to clean up anonymous volumes. To do this, use the `--rm` option, for example:
 
 ```bash
-$ docker run --rm -v /foo -v awesome:/bar busybox top,
+$ docker run --rm -v /foo -v awesome:/bar busybox top
 ```
 
 This command creates an anonymous `/foo` volume. When the container is removed,


### PR DESCRIPTION
Removed trailing comma after `top` command in the documentation for Docker Volumes in the User Guide. Fixes #22528 
