### PR TITLE
Always unset the value for daemon reload for predictable behaviors

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -997,11 +997,19 @@ func (daemon *Daemon) Reload(config *Config) error {
 		return err
 	}
 
+	// We always unset the value if not specified so that
+	// users know what to expect based on the config file
+	// to be loaded, instead of the previous state of the
+	// daemon (before reload).
 	if config.IsValueSet("labels") {
 		daemon.configStore.Labels = config.Labels
+	} else {
+		daemon.configStore.Labels = []string{}
 	}
 	if config.IsValueSet("debug") {
 		daemon.configStore.Debug = config.Debug
+	} else {
+		daemon.configStore.Debug = false
 	}
 
 	// If no value is set for max-concurrent-downloads we assume it is the default value

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -335,7 +335,7 @@ func TestDaemonReloadLabels(t *testing.T) {
 	}
 }
 
-func TestDaemonReloadNotAffectOthers(t *testing.T) {
+func TestDaemonReloadUnset(t *testing.T) {
 	daemon := &Daemon{}
 	daemon.configStore = &Config{
 		CommonConfig: CommonConfig{
@@ -359,8 +359,8 @@ func TestDaemonReloadNotAffectOthers(t *testing.T) {
 		t.Fatalf("Expected daemon label `foo:baz`, got %s", label)
 	}
 	debug := daemon.configStore.Debug
-	if !debug {
-		t.Fatalf("Expected debug 'enabled', got 'disabled'")
+	if debug {
+		t.Fatalf("Expected debug 'disabled', got 'enabled'")
 	}
 }
 


### PR DESCRIPTION
**\- What I did**

This fix tries to address a separate issue raised during the review of another PR #22445. The issue was raised because currently, daemon reload will skip the action if the field (e.g., `debug`, `labels`, etc) is not specified.

This potentially could cause some confusion:
1. Users will need to explicitly set the field if they want to unset and they cannot assume `default` value any more
2. Users have to check the previous state of the daemon in order to figure out the expected behavior of a reload, instead of relying on the config file they intend to reload. Without knowing the previous state of the daemon the behavior will be unpredictable.

**\- How I did it**

In this fix, we always unset the value if not specified so that
users know what to expect based on the config file to be loaded,
instead of the previous state of the daemon (before reload).

**\- How to verify it**

Additional test has been added to cover the changes in this fix.

**\- Description for the changelog**

Always unset the value for daemon reload in case the options is not present for predictable behaviors of daemon reloading.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix is related to #22445.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
