### PR TITLE
Windows: Terminate on failed shutdown, fixes dockerd deadlock

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -185,7 +185,12 @@ func (ctr *container) waitExit(pid uint32, processFriendlyName string, isFirstPr
 				(herr.Err != hcsshim.ERROR_SHUTDOWN_IN_PROGRESS &&
 					herr.Err != ErrorBadPathname &&
 					herr.Err != syscall.ERROR_PATH_NOT_FOUND) {
-				logrus.Warnf("Ignoring error from ShutdownComputeSystem %s", err)
+				logrus.Debugf("waitExit - error from ShutdownComputeSystem on %s %v. Calling TerminateComputeSystem", ctr.containerCommon, err)
+				if err := hcsshim.TerminateComputeSystem(ctr.containerID, shutdownTimeout, "waitExit"); err != nil {
+					logrus.Debugf("waitExit - ignoring error from TerminateComputeSystem %s %v", ctr.containerID, err)
+				} else {
+					logrus.Debugf("Successful TerminateComputeSystem after failed ShutdownComputeSystem on %s in waitExit", ctr.containerID)
+				}
 			}
 		} else {
 			logrus.Debugf("Completed shutting down container %s", ctr.containerID)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes #22543 

Found on an internal test run against Hyper-V containers. Dockerd can become unresponsive (deadlocked on a container lock) to any CLI call which needs to take the same individual container lock (eg `docker ps`, `docker stop` on the container) if Windows gets into a  situation where the it returns an unexpected failure from the vmcompute `ShutdownComputeSystem` call. This may happen for example if HCS become out of sync with GCS, or the utility VM crashes.

@swernli 
