### PR TITLE
Align default seccomp profile with selected capabilities

### DIFF
--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -35,7 +35,7 @@ func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
 			return err
 		}
 	} else {
-		profile, err = seccomp.GetDefaultProfile()
+		profile, err = seccomp.GetDefaultProfile(rs)
 		if err != nil {
 			return err
 		}

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1071,14 +1071,6 @@ one can use this flag:
     --privileged=false: Give extended privileges to this container
     --device=[]: Allows you to run devices inside the container without the --privileged flag.
 
-> **Note:**
-> With Docker 1.10 and greater, the default seccomp profile will also block
-> syscalls, regardless of `--cap-add` passed to the container. We recommend in
-> these cases to create your own custom seccomp profile based off our
-> [default](https://github.com/docker/docker/blob/master/profiles/seccomp/default.json).
-> Or if you don't want to run with the default seccomp profile, you can pass
-> `--security-opt=seccomp=unconfined` on run.
-
 By default, Docker containers are "unprivileged" and cannot, for
 example, run a Docker daemon inside a Docker container. This is because
 by default a container is not allowed to access any devices, but a
@@ -1196,6 +1188,11 @@ To mount a FUSE based filesystem, you need to combine both `--cap-add` and
     -rw-rw-r-- 1 1000 1000    461 Dec  4 06:08 .gitignore
     ....
 
+The default seccomp profile will adjust to the selected capabilities, in order to allow
+use of facilities allowed by the capabilities, so you should not have to adjust this,
+since Docker 1.12. In Docker 1.10 and 1.11 this did not happen and it may be necessary
+to use a custom seccomp profile or use `--security-opt seccomp=unconfined` when adding
+capabilities.
 
 ## Logging drivers (--log-driver)
 

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -27,11 +27,6 @@
 			"args": []
 		},
 		{
-			"name": "arch_prctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
 			"name": "bind",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -62,21 +57,6 @@
 			"args": []
 		},
 		{
-			"name": "chown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chroot",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
 			"name": "clock_getres",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -90,18 +70,6 @@
 			"name": "clock_nanosleep",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
-		},
-		{
-			"name": "clone",
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 2080505856,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_MASKED_EQ"
-				}
-			]
 		},
 		{
 			"name": "close",
@@ -224,11 +192,6 @@
 			"args": []
 		},
 		{
-			"name": "fanotify_init",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
 			"name": "fanotify_mark",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -245,21 +208,6 @@
 		},
 		{
 			"name": "fchmodat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchownat",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
@@ -605,16 +553,6 @@
 		},
 		{
 			"name": "kill",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lchown32",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
@@ -1165,11 +1103,6 @@
 			"args": []
 		},
 		{
-			"name": "setdomainname",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
 			"name": "setfsgid",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -1206,11 +1139,6 @@
 		},
 		{
 			"name": "setgroups32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sethostname",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
@@ -1580,22 +1508,69 @@
 			"args": []
 		},
 		{
+			"name": "arch_prctl",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
 			"name": "modify_ldt",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
 		{
-			"name": "breakpoint",
+			"name": "chown",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
 		{
-			"name": "cacheflush",
+			"name": "chown32",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
 		{
-			"name": "set_tls",
+			"name": "fchown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "fchown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "fchownat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "lchown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "lchown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "chroot",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "clone",
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			]
+		},
+		{
+			"name": "fchown",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		}

--- a/profiles/seccomp/generate.go
+++ b/profiles/seccomp/generate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/oci"
 	"github.com/docker/docker/profiles/seccomp"
 )
 
@@ -20,8 +21,10 @@ func main() {
 	}
 	f := filepath.Join(wd, "default.json")
 
+	rs := oci.DefaultSpec()
+
 	// write the default profile to the file
-	b, err := json.MarshalIndent(seccomp.DefaultProfile, "", "\t")
+	b, err := json.MarshalIndent(seccomp.DefaultProfile(&rs), "", "\t")
 	if err != nil {
 		panic(err)
 	}

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -13,8 +13,8 @@ import (
 //go:generate go run -tags 'seccomp' generate.go
 
 // GetDefaultProfile returns the default seccomp profile.
-func GetDefaultProfile() (*specs.Seccomp, error) {
-	return setupSeccomp(DefaultProfile)
+func GetDefaultProfile(rs *specs.Spec) (*specs.Seccomp, error) {
+	return setupSeccomp(DefaultProfile(rs))
 }
 
 // LoadProfile takes a file path and decodes the seccomp profile.

--- a/profiles/seccomp/seccomp_unsupported.go
+++ b/profiles/seccomp/seccomp_unsupported.go
@@ -2,9 +2,12 @@
 
 package seccomp
 
-import "github.com/docker/engine-api/types"
-
-var (
-	// DefaultProfile is a nil pointer on unsupported systems.
-	DefaultProfile *types.Seccomp
+import (
+	"github.com/docker/engine-api/types"
+	"github.com/opencontainers/specs/specs-go"
 )
+
+// DefaultProfile returns a nil pointer on unsupported systems.
+func DefaultProfile(rs *specs.Spec) *types.Seccomp {
+	return nil
+}


### PR DESCRIPTION
Currently the default seccomp profile is fixed. This changes it
so that it varies depending on the Linux capabilities selected with
the --cap-add and --cap-drop options. Without this, if a user adds
privileges, eg to allow ptrace with --cap-add sys_ptrace then still
cannot actually use ptrace as it is still blocked by seccomp, so
they will probably disable seccomp or use --privileged. With this
change the syscalls that are needed for the capability are also
allowed by the seccomp profile based on the selected capabilities.

While this patch makes it easier to do things with for example
cap_sys_admin enabled, as it will now allow creating new namespaces
and use of mount, it still allows less than --cap-add cap_sys_admin
--security-opt seccomp:unconfined would have previously. It is not
recommended that users run containers with cap_sys_admin as this does
give full access to the host machine.

It also cleans up some architecture specific system calls to be
only selected when needed.

Signed-off-by: Justin Cormack justin.cormack@docker.com

Note this patch is currently missing the needed documentation changes,
but I thought I would put it out for review first.

cc @jfrazelle 

![goatymcgoatface](https://cloud.githubusercontent.com/assets/482364/15075938/017104b2-139f-11e6-910b-c816c0ed78f1.jpg)
