### PR TITLE
Pass labels to containerd

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -130,7 +130,11 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 		return err
 	}
 
-	if err := daemon.containerd.Create(container.ID, *spec, libcontainerd.WithRestartManager(container.RestartManager(true))); err != nil {
+	options := []libcontainerd.CreateOption{
+		libcontainerd.WithRestartManager(container.RestartManager(true)),
+		libcontainerd.WithLabels(container.Config.Labels)}
+
+	if err := daemon.containerd.Create(container.ID, *spec, options...); err != nil {
 		// if we receive an internal error from the initial start of a container then lets
 		// return it instead of entering the restart loop
 		// set to 127 for container cmd not found/does not exist)

--- a/libcontainerd/container.go
+++ b/libcontainerd/container.go
@@ -19,6 +19,7 @@ type containerCommon struct {
 	restartManager restartmanager.RestartManager
 	restarting     bool
 	processes      map[string]*process
+	labels         map[string]string
 	startedAt      time.Time
 }
 
@@ -37,4 +38,21 @@ func (rm restartManager) Apply(p interface{}) error {
 		return nil
 	}
 	return fmt.Errorf("WithRestartManager option not supported for this client")
+}
+
+// WithLabels sets labels of the container.
+func WithLabels(l map[string]string) CreateOption {
+	return labels{l}
+}
+
+type labels struct {
+	labels map[string]string
+}
+
+func (l labels) Apply(p interface{}) error {
+	if pr, ok := p.(*container); ok {
+		pr.labels = l.labels
+		return nil
+	}
+	return fmt.Errorf("WithLabels option not supported for this client")
 }

--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -2,6 +2,7 @@ package libcontainerd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -75,6 +76,11 @@ func (ctr *container) start() error {
 		return err
 	}
 
+	var labels []string
+	for k, v := range ctr.labels {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	r := &containerd.CreateContainerRequest{
 		Id:         ctr.containerID,
 		BundlePath: ctr.dir,
@@ -82,6 +88,7 @@ func (ctr *container) start() error {
 		Stdout:     ctr.fifo(syscall.Stdout),
 		Stderr:     ctr.fifo(syscall.Stderr),
 		// check to see if we are running in ramdisk to disable pivot root
+		Labels:      labels,
 		NoPivotRoot: os.Getenv("DOCKER_RAMDISK") != "",
 	}
 	ctr.client.appendContainer(ctr)


### PR DESCRIPTION
CreateContainerRequest contains labels field but docker never passes
labels to containerd, which makes it impossible to set labels for
containerd.

This commit will add label support for containerd.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
