### PR TITLE
docs: note requirements for systemd drop-in filenames

### DIFF
--- a/docs/admin/systemd.md
+++ b/docs/admin/systemd.md
@@ -33,15 +33,19 @@ If you want Docker to start at boot, you should also:
 There are a number of ways to configure the daemon flags and environment variables
 for your Docker daemon.
 
-The recommended way is to use a systemd drop-in file. These are local files in
-the `/etc/systemd/system/docker.service.d` directory. This could also be
-`/etc/systemd/system/docker.service`, which also works for overriding the
-defaults from `/lib/systemd/system/docker.service`.
+The recommended way is to use a systemd drop-in file (as described in
+the <a target="_blank"
+href="https://www.freedesktop.org/software/systemd/man/systemd.unit.html">systemd.unit</a>
+documentation). These are local files named `<something>.conf` in the
+`/etc/systemd/system/docker.service.d` directory. This could also be
+`/etc/systemd/system/docker.service`, which also works for overriding
+the defaults from `/lib/systemd/system/docker.service`.
 
-However, if you had previously used a package which had an `EnvironmentFile`
-(often pointing to `/etc/sysconfig/docker`) then for backwards compatibility,
-you drop a file in the `/etc/systemd/system/docker.service.d`
-directory including the following:
+However, if you had previously used a package which had an
+`EnvironmentFile` (often pointing to `/etc/sysconfig/docker`) then for
+backwards compatibility, you drop a file with a `.conf` extension into
+the `/etc/systemd/system/docker.service.d` directory including the
+following:
 
     [Service]
     EnvironmentFile=-/etc/sysconfig/docker


### PR DESCRIPTION
the documentations says that you can drop "a file" into the
`docker.service.d` directory, but does not note that the file must end
with `.conf` in order to be recognized by systemd.  This can lead to
some [confusion](https://botbot.me/freenode/docker/2016-05-06/?msg=65605541&page=11) if readers are not previously familiar with
systemd.

Signed-off-by: Lars Kellogg-Stedman lars@redhat.com
