### PR TITLE
Clean loopbacks in TestDaemonNoSpaceLeftOnDeviceError

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1922,16 +1922,24 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *check.C) {
 	defer os.RemoveAll(testDir)
 	c.Assert(mount.MakeRShared(testDir), checker.IsNil)
 	defer mount.Unmount(testDir)
-	defer mount.Unmount(filepath.Join(testDir, "test-mount"))
 
 	// create a 2MiB image and mount it as graph root
 	// Why in a container? Because `mount` sometimes behaves weirdly and often fails outright on this test in debian:jessie (which is what the test suite runs under if run from the Makefile)
 	dockerCmd(c, "run", "--rm", "-v", testDir+":/test", "busybox", "sh", "-c", "dd of=/test/testfs.img bs=1M seek=2 count=0")
 	out, _, err := runCommandWithOutput(exec.Command("mkfs.ext4", "-F", filepath.Join(testDir, "testfs.img"))) // `mkfs.ext4` is not in busybox
 	c.Assert(err, checker.IsNil, check.Commentf(out))
-	dockerCmd(c, "run", "--privileged", "--rm", "-v", testDir+":/test:shared", "busybox", "sh", "-c", "mkdir -p /test/test-mount && mount -t ext4 -no loop,rw /test/testfs.img /test/test-mount")
+
+	cmd := exec.Command("losetup", "-f", "--show", filepath.Join(testDir, "testfs.img"))
+	loout, err := cmd.CombinedOutput()
+	c.Assert(err, checker.IsNil)
+	loopname := strings.TrimSpace(string(loout))
+	defer exec.Command("losetup", "-d", loopname).Run()
+
+	dockerCmd(c, "run", "--privileged", "--rm", "-v", testDir+":/test:shared", "busybox", "sh", "-c", fmt.Sprintf("mkdir -p /test/test-mount && mount -t ext4 -no loop,rw %v /test/test-mount", loopname))
+	defer mount.Unmount(filepath.Join(testDir, "test-mount"))
 
 	err = s.d.Start("--graph", filepath.Join(testDir, "test-mount"))
+	defer s.d.Stop()
 	c.Assert(err, check.IsNil)
 
 	// pull a repository large enough to fill the mount point


### PR DESCRIPTION
After #22172 some machines do not seem to properly release the loopback devices used in `TestDaemonNoSpaceLeftOnDeviceError`. I could reproduce it in `trusty-3.13` and our arm ci also seems affected. https://jenkins.dockerproject.org/job/Docker%20Master%20(arm)/1679/console https://jenkins.dockerproject.org/job/Docker%20Master/label=centos%20&&%20devicemapper/5328/console

This version manually releases the loopbacks. I've confirmed it working locally and in an arm ci box.

We can also consider reverting #22172 and investigating what the original problem was that caused us to use containers for mount calls. 

cc @cpuguy83 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
