### PR TITLE
ppc64le: remove seccomp from docker buildtags

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -168,7 +168,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc


### PR DESCRIPTION
Removes seccomp from ppc64le as a buildtag for now

@justincormack I'm going to take a more in depth look next week, but for now should fix the jenkins issues.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
