### PR TITLE
remove deprecated feature of passing HostConfig at API container start

### DIFF
--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -5,6 +5,14 @@ import (
 	"github.com/docker/docker/api/server/router"
 )
 
+type validationError struct {
+	error
+}
+
+func (validationError) IsValidationError() bool {
+	return true
+}
+
 // containerRouter is a router to talk with the container controller
 type containerRouter struct {
 	backend Backend

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -122,6 +122,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /events` now supports a `reload` event that is emitted when the daemon configuration is reloaded.
 * `GET /events` now supports filtering by daemon name or ID.
 * `GET /images/json` now supports filters `since` and `before`.
+* `POST /containers/(id or name)/start` no longer accepts a `HostConfig`.
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -1010,10 +1010,6 @@ Status Codes:
 
 Start the container `id`
 
-> **Note**:
-> For backwards compatibility, this endpoint accepts a `HostConfig` as JSON-encoded request body.
-> See [create a container](#create-a-container) for details.
-
 **Example request**:
 
     POST /containers/e90e34656806/start HTTP/1.1

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1366,26 +1366,6 @@ func (s *DockerSuite) TestUserDefinedNetworkConnectDisconnectLink(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-// #19100 This is a deprecated feature test, it should be removed in Docker 1.12
-func (s *DockerNetworkSuite) TestDockerNetworkStartAPIWithHostconfig(c *check.C) {
-	netName := "test"
-	conName := "foo"
-	dockerCmd(c, "network", "create", netName)
-	dockerCmd(c, "create", "--name", conName, "busybox", "top")
-
-	config := map[string]interface{}{
-		"HostConfig": map[string]interface{}{
-			"NetworkMode": netName,
-		},
-	}
-	_, _, err := sockRequest("POST", "/containers/"+conName+"/start", config)
-	c.Assert(err, checker.IsNil)
-	c.Assert(waitRun(conName), checker.IsNil)
-	networks := inspectField(c, conName, "NetworkSettings.Networks")
-	c.Assert(networks, checker.Contains, netName, check.Commentf(fmt.Sprintf("Should contain '%s' network", netName)))
-	c.Assert(networks, checker.Not(checker.Contains), "bridge", check.Commentf("Should not contain 'bridge' network"))
-}
-
 func (s *DockerNetworkSuite) TestDockerNetworkDisconnectDefault(c *check.C) {
 	netWorkName1 := "test1"
 	netWorkName2 := "test2"

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -1,0 +1,227 @@
+// This file will be removed when we completely drop support for
+// passing HostConfig to container start API.
+
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func formatV123StartAPIURL(url string) string {
+	return "/v1.23" + url
+}
+
+func (s *DockerSuite) TestDeprecatedContainerApiStartHostConfig(c *check.C) {
+	name := "test-deprecated-api-124"
+	dockerCmd(c, "create", "--name", name, "busybox")
+	config := map[string]interface{}{
+		"Binds": []string{"/aa:/bb"},
+	}
+	status, body, err := sockRequest("POST", "/containers/"+name+"/start", config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusBadRequest)
+	c.Assert(string(body), checker.Contains, "was deprecated since v1.10")
+}
+
+func (s *DockerSuite) TestDeprecatedContainerApiStartVolumeBinds(c *check.C) {
+	// TODO Windows CI: Investigate further why this fails on Windows to Windows CI.
+	testRequires(c, DaemonIsLinux)
+	path := "/foo"
+	if daemonPlatform == "windows" {
+		path = `c:\foo`
+	}
+	name := "testing"
+	config := map[string]interface{}{
+		"Image":   "busybox",
+		"Volumes": map[string]struct{}{path: {}},
+	}
+
+	status, _, err := sockRequest("POST", formatV123StartAPIURL("/containers/create?name="+name), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusCreated)
+
+	bindPath := randomTmpDirPath("test", daemonPlatform)
+	config = map[string]interface{}{
+		"Binds": []string{bindPath + ":" + path},
+	}
+	status, _, err = sockRequest("POST", formatV123StartAPIURL("/containers/"+name+"/start"), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusNoContent)
+
+	pth, err := inspectMountSourceField(name, path)
+	c.Assert(err, checker.IsNil)
+	c.Assert(pth, checker.Equals, bindPath, check.Commentf("expected volume host path to be %s, got %s", bindPath, pth))
+}
+
+// Test for GH#10618
+func (s *DockerSuite) TestDeprecatedContainerApiStartDupVolumeBinds(c *check.C) {
+	// TODO Windows to Windows CI - Port this
+	testRequires(c, DaemonIsLinux)
+	name := "testdups"
+	config := map[string]interface{}{
+		"Image":   "busybox",
+		"Volumes": map[string]struct{}{"/tmp": {}},
+	}
+
+	status, _, err := sockRequest("POST", formatV123StartAPIURL("/containers/create?name="+name), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusCreated)
+
+	bindPath1 := randomTmpDirPath("test1", daemonPlatform)
+	bindPath2 := randomTmpDirPath("test2", daemonPlatform)
+
+	config = map[string]interface{}{
+		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},
+	}
+	status, body, err := sockRequest("POST", formatV123StartAPIURL("/containers/"+name+"/start"), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusInternalServerError)
+	c.Assert(string(body), checker.Contains, "Duplicate mount point", check.Commentf("Expected failure due to duplicate bind mounts to same path, instead got: %q with error: %v", string(body), err))
+}
+
+func (s *DockerSuite) TestDeprecatedContainerApiStartVolumesFrom(c *check.C) {
+	// TODO Windows to Windows CI - Port this
+	testRequires(c, DaemonIsLinux)
+	volName := "voltst"
+	volPath := "/tmp"
+
+	dockerCmd(c, "run", "--name", volName, "-v", volPath, "busybox")
+
+	name := "TestContainerApiStartVolumesFrom"
+	config := map[string]interface{}{
+		"Image":   "busybox",
+		"Volumes": map[string]struct{}{volPath: {}},
+	}
+
+	status, _, err := sockRequest("POST", formatV123StartAPIURL("/containers/create?name="+name), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusCreated)
+
+	config = map[string]interface{}{
+		"VolumesFrom": []string{volName},
+	}
+	status, _, err = sockRequest("POST", formatV123StartAPIURL("/containers/"+name+"/start"), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusNoContent)
+
+	pth, err := inspectMountSourceField(name, volPath)
+	c.Assert(err, checker.IsNil)
+	pth2, err := inspectMountSourceField(volName, volPath)
+	c.Assert(err, checker.IsNil)
+	c.Assert(pth, checker.Equals, pth2, check.Commentf("expected volume host path to be %s, got %s", pth, pth2))
+}
+
+// #9981 - Allow a docker created volume (ie, one in /var/lib/docker/volumes) to be used to overwrite (via passing in Binds on api start) an existing volume
+func (s *DockerSuite) TestDeprecatedPostContainerBindNormalVolume(c *check.C) {
+	// TODO Windows to Windows CI - Port this
+	testRequires(c, DaemonIsLinux)
+	dockerCmd(c, "create", "-v", "/foo", "--name=one", "busybox")
+
+	fooDir, err := inspectMountSourceField("one", "/foo")
+	c.Assert(err, checker.IsNil)
+
+	dockerCmd(c, "create", "-v", "/foo", "--name=two", "busybox")
+
+	bindSpec := map[string][]string{"Binds": {fooDir + ":/foo"}}
+	status, _, err := sockRequest("POST", formatV123StartAPIURL("/containers/two/start"), bindSpec)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusNoContent)
+
+	fooDir2, err := inspectMountSourceField("two", "/foo")
+	c.Assert(err, checker.IsNil)
+	c.Assert(fooDir2, checker.Equals, fooDir, check.Commentf("expected volume path to be %s, got: %s", fooDir, fooDir2))
+}
+
+func (s *DockerSuite) TestDeprecatedStartWithTooLowMemoryLimit(c *check.C) {
+	// TODO Windows: Port once memory is supported
+	testRequires(c, DaemonIsLinux)
+	out, _ := dockerCmd(c, "create", "busybox")
+
+	containerID := strings.TrimSpace(out)
+
+	config := `{
+                "CpuShares": 100,
+                "Memory":    524287
+        }`
+
+	res, body, err := sockRequestRaw("POST", formatV123StartAPIURL("/containers/"+containerID+"/start"), strings.NewReader(config), "application/json")
+	c.Assert(err, checker.IsNil)
+	b, err2 := readBody(body)
+	c.Assert(err2, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
+	c.Assert(string(b), checker.Contains, "Minimum memory limit allowed is 4MB")
+}
+
+// #14640
+func (s *DockerSuite) TestDeprecatedPostContainersStartWithoutLinksInHostConfig(c *check.C) {
+	// TODO Windows: Windows doesn't support supplying a hostconfig on start.
+	// An alternate test could be written to validate the negative testing aspect of this
+	testRequires(c, DaemonIsLinux)
+	name := "test-host-config-links"
+	dockerCmd(c, append([]string{"create", "--name", name, "busybox"}, defaultSleepCommand...)...)
+
+	hc := inspectFieldJSON(c, name, "HostConfig")
+	config := `{"HostConfig":` + hc + `}`
+
+	res, b, err := sockRequestRaw("POST", formatV123StartAPIURL("/containers/"+name+"/start"), strings.NewReader(config), "application/json")
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
+	b.Close()
+}
+
+// #14640
+func (s *DockerSuite) TestDeprecatedPostContainersStartWithLinksInHostConfig(c *check.C) {
+	// TODO Windows: Windows doesn't support supplying a hostconfig on start.
+	// An alternate test could be written to validate the negative testing aspect of this
+	testRequires(c, DaemonIsLinux)
+	name := "test-host-config-links"
+	dockerCmd(c, "run", "--name", "foo", "-d", "busybox", "top")
+	dockerCmd(c, "create", "--name", name, "--link", "foo:bar", "busybox", "top")
+
+	hc := inspectFieldJSON(c, name, "HostConfig")
+	config := `{"HostConfig":` + hc + `}`
+
+	res, b, err := sockRequestRaw("POST", formatV123StartAPIURL("/containers/"+name+"/start"), strings.NewReader(config), "application/json")
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
+	b.Close()
+}
+
+// #14640
+func (s *DockerSuite) TestDeprecatedPostContainersStartWithLinksInHostConfigIdLinked(c *check.C) {
+	// Windows does not support links
+	testRequires(c, DaemonIsLinux)
+	name := "test-host-config-links"
+	out, _ := dockerCmd(c, "run", "--name", "link0", "-d", "busybox", "top")
+	id := strings.TrimSpace(out)
+	dockerCmd(c, "create", "--name", name, "--link", id, "busybox", "top")
+
+	hc := inspectFieldJSON(c, name, "HostConfig")
+	config := `{"HostConfig":` + hc + `}`
+
+	res, b, err := sockRequestRaw("POST", formatV123StartAPIURL("/containers/"+name+"/start"), strings.NewReader(config), "application/json")
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
+	b.Close()
+}
+
+func (s *DockerSuite) TestDeprecatedStartWithNilDNS(c *check.C) {
+	// TODO Windows: Add once DNS is supported
+	testRequires(c, DaemonIsLinux)
+	out, _ := dockerCmd(c, "create", "busybox")
+	containerID := strings.TrimSpace(out)
+
+	config := `{"HostConfig": {"Dns": null}}`
+
+	res, b, err := sockRequestRaw("POST", formatV123StartAPIURL("/containers/"+containerID+"/start"), strings.NewReader(config), "application/json")
+	c.Assert(err, checker.IsNil)
+	c.Assert(res.StatusCode, checker.Equals, http.StatusNoContent)
+	b.Close()
+
+	dns := inspectFieldJSON(c, containerID, "HostConfig.Dns")
+	c.Assert(dns, checker.Equals, "[]")
+}

--- a/integration-cli/docker_deprecated_api_v124_unix_test.go
+++ b/integration-cli/docker_deprecated_api_v124_unix_test.go
@@ -1,0 +1,30 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+// #19100 This is a deprecated feature test, it should be removed in Docker 1.12
+func (s *DockerNetworkSuite) TestDeprecatedDockerNetworkStartAPIWithHostconfig(c *check.C) {
+	netName := "test"
+	conName := "foo"
+	dockerCmd(c, "network", "create", netName)
+	dockerCmd(c, "create", "--name", conName, "busybox", "top")
+
+	config := map[string]interface{}{
+		"HostConfig": map[string]interface{}{
+			"NetworkMode": netName,
+		},
+	}
+	_, _, err := sockRequest("POST", formatV123StartAPIURL("/containers/"+conName+"/start"), config)
+	c.Assert(err, checker.IsNil)
+	c.Assert(waitRun(conName), checker.IsNil)
+	networks := inspectField(c, conName, "NetworkSettings.Networks")
+	c.Assert(networks, checker.Contains, netName, check.Commentf(fmt.Sprintf("Should contain '%s' network", netName)))
+	c.Assert(networks, checker.Not(checker.Contains), "bridge", check.Commentf("Should not contain 'bridge' network"))
+}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/17799
- relates to https://github.com/moby/moby/issues/14777

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
According to https://docs.docker.com/engine/deprecated/#hostconfig-at-api-container-start passing `HostConfig` to the container start API will be removed in 1.12.
This PR removed the deprecated feature and the related test cases.
**\- How I did it**
Remove the related code.
Raise an error when the user tries to pass HostConfig when calling `POST /containers/xxx/start` API.
**\- How to verify it**
Call the container start API with HostConfig and check the error message.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Shijiang Wei mountkin@gmail.com
