### PR TITLE
Add the missing subtitle in deprecated docs for --security-opt

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -21,6 +21,11 @@ The following list of features are deprecated in Engine.
 
 The docker login command is removing the ability to automatically register for an account with the target registry if the given username doesn't exist. Due to this change, the email flag is no longer required, and will be deprecated.
 
+### Separator (`:`) of `--security-opt` flag on `docker run`
+**Deprecated In Release: v1.11**
+
+**Target For Removal In Release: v1.13**
+
 The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consinstency with other similar flags, like `--storage-opt`.
 
 ### Ambiguous event fields in API


### PR DESCRIPTION
The colon separator(`:`) of `--security-opt` flag was deprecated in 1.11.0. However, the subtitle in deprecated docs is missing so it is placed under the same subtitle as the deprecated `-e` and `--email` flags.

This fix adds the missing subtitle in deprecated docs.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
