### PR TITLE
Remove deprecated Docker Content Trust ENV passphrase variables

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -217,22 +217,6 @@ func (cli *DockerCli) getPassphraseRetriever() passphrase.Retriever {
 		"default":  os.Getenv("DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE"),
 	}
 
-	// Backwards compatibility with old env names. We should remove this in 1.10
-	if env["root"] == "" {
-		if passphrase := os.Getenv("DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE"); passphrase != "" {
-			env["root"] = passphrase
-			fmt.Fprintf(cli.err, "[DEPRECATED] The environment variable DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE has been deprecated and will be removed in v1.10. Please use DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE\n")
-		}
-	}
-	if env["snapshot"] == "" || env["targets"] == "" || env["default"] == "" {
-		if passphrase := os.Getenv("DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE"); passphrase != "" {
-			env["snapshot"] = passphrase
-			env["targets"] = passphrase
-			env["default"] = passphrase
-			fmt.Fprintf(cli.err, "[DEPRECATED] The environment variable DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE has been deprecated and will be removed in v1.10. Please use DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE\n")
-		}
-	}
-
 	return func(keyName string, alias string, createNew bool, numAttempts int) (string, bool, error) {
 		if v := env[alias]; v != "" {
 			return v, numAttempts > 1, nil

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -140,9 +140,9 @@ Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the d
 ### Docker Content Trust ENV passphrase variables name change
 **Deprecated In Release: v1.9**
 
-**Target For Removal In Release: v1.10**
+**Removed In Release: v1.12**
 
-As of 1.9, Docker Content Trust Offline key will be renamed to Root key and the Tagging key will be renamed to Repository key. Due to this renaming, we're also changing the corresponding environment variables
+Since 1.9, Docker Content Trust Offline key has been renamed to Root key and the Tagging key has been renamed to Repository key. Due to this renaming, we're also changing the corresponding environment variables
 
-- DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE will now be named DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE
-- DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE will now be named DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE
+- DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE is named DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE
+- DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE is named DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -315,20 +315,6 @@ func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {
 	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
 }
 
-// This test ensures backwards compatibility with old ENV variables. Should be
-// deprecated by 1.10
-func (s *DockerTrustSuite) TestTrustedPushWithDeprecatedEnvPasswords(c *check.C) {
-	repoName := fmt.Sprintf("%v/dockercli/trusteddeprecated:latest", privateRegistryURL)
-	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmdWithDeprecatedEnvPassphrases(pushCmd, "12345678", "12345678")
-	out, _, err := runCommandWithOutput(pushCmd)
-	c.Assert(err, check.IsNil, check.Commentf("Error running trusted push: %s\n%s", err, out))
-	c.Assert(out, checker.Contains, "Signing and pushing trust metadata", check.Commentf("Missing expected output on trusted push"))
-}
-
 func (s *DockerTrustSuite) TestTrustedPushWithFailingServer(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockerclitrusted/failingserver:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
@@ -418,28 +404,6 @@ func (s *DockerTrustSuite) TestTrustedPushWithIncorrectPassphraseForNonRoot(c *c
 	// Push with wrong passphrases
 	pushCmd = exec.Command(dockerBinary, "push", repoName)
 	s.trustedCmdWithPassphrases(pushCmd, "12345678", "87654321")
-	out, _, err = runCommandWithOutput(pushCmd)
-	c.Assert(err, check.NotNil, check.Commentf("Error missing from trusted push with short targets passphrase: \n%s", out))
-	c.Assert(out, checker.Contains, "could not find necessary signing keys", check.Commentf("Missing expected output on trusted push with short targets/snapsnot passphrase"))
-}
-
-// This test ensures backwards compatibility with old ENV variables. Should be
-// deprecated by 1.10
-func (s *DockerTrustSuite) TestTrustedPushWithIncorrectDeprecatedPassphraseForNonRoot(c *check.C) {
-	repoName := fmt.Sprintf("%v/dockercliincorretdeprecatedpwd/trusted:latest", privateRegistryURL)
-	// tag the image and upload it to the private registry
-	dockerCmd(c, "tag", "busybox", repoName)
-
-	// Push with default passphrases
-	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmd(pushCmd)
-	out, _, err := runCommandWithOutput(pushCmd)
-	c.Assert(err, check.IsNil, check.Commentf("trusted push failed: %s\n%s", err, out))
-	c.Assert(out, checker.Contains, "Signing and pushing trust metadata", check.Commentf("Missing expected output on trusted push"))
-
-	// Push with wrong passphrases
-	pushCmd = exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmdWithDeprecatedEnvPassphrases(pushCmd, "12345678", "87654321")
 	out, _, err = runCommandWithOutput(pushCmd)
 	c.Assert(err, check.NotNil, check.Commentf("Error missing from trusted push with short targets passphrase: \n%s", out))
 	c.Assert(out, checker.Contains, "could not find necessary signing keys", check.Commentf("Missing expected output on trusted push with short targets/snapsnot passphrase"))

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -177,28 +177,12 @@ func (s *DockerTrustSuite) trustedCmdWithPassphrases(cmd *exec.Cmd, rootPwd, rep
 	trustCmdEnv(cmd, notaryURL, rootPwd, repositoryPwd)
 }
 
-func (s *DockerTrustSuite) trustedCmdWithDeprecatedEnvPassphrases(cmd *exec.Cmd, offlinePwd, taggingPwd string) {
-	trustCmdDeprecatedEnv(cmd, notaryURL, offlinePwd, taggingPwd)
-}
-
 func trustCmdEnv(cmd *exec.Cmd, server, rootPwd, repositoryPwd string) {
 	env := []string{
 		"DOCKER_CONTENT_TRUST=1",
 		fmt.Sprintf("DOCKER_CONTENT_TRUST_SERVER=%s", server),
 		fmt.Sprintf("DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE=%s", rootPwd),
 		fmt.Sprintf("DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=%s", repositoryPwd),
-	}
-	cmd.Env = append(os.Environ(), env...)
-}
-
-// Helper method to test the old env variables OFFLINE and TAGGING that will
-// be deprecated by 1.10
-func trustCmdDeprecatedEnv(cmd *exec.Cmd, server, offlinePwd, taggingPwd string) {
-	env := []string{
-		"DOCKER_CONTENT_TRUST=1",
-		fmt.Sprintf("DOCKER_CONTENT_TRUST_SERVER=%s", server),
-		fmt.Sprintf("DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE=%s", offlinePwd),
-		fmt.Sprintf("DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE=%s", taggingPwd),
 	}
 	cmd.Env = append(os.Environ(), env...)
 }


### PR DESCRIPTION
Since 1.9, Docker Content Trust Offline key has been renamed to Root key and the Tagging key has been renamed to Repository key.

The corresponding environment variables
`DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE`
`DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE`

have also been deprecated and renamed to

`DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE` 
`DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE`

This fix removed the deprecated ENV passphrase variables for 1.12 and updated the docs.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
