### PR TITLE
Fix memory update to -1

### DIFF
--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -76,9 +76,13 @@ func runUpdate(dockerCli *command.DockerCli, opts *updateOptions) error {
 
 	var memory int64
 	if opts.memoryString != "" {
-		memory, err = units.RAMInBytes(opts.memoryString)
-		if err != nil {
-			return err
+		if opts.memoryString == "-1" {
+			memory = -1
+		} else {
+			memory, err = units.RAMInBytes(opts.memoryString)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -64,7 +64,7 @@ const (
 func getMemoryResources(config containertypes.Resources) *specs.Memory {
 	memory := specs.Memory{}
 
-	if config.Memory > 0 {
+	if config.Memory != 0 {
 		limit := uint64(config.Memory)
 		memory.Limit = &limit
 	}
@@ -278,8 +278,10 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	warnings := []string{}
 
 	// memory subsystem checks and adjustments
-	if resources.Memory != 0 && resources.Memory < linuxMinMemory {
-		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
+	if resources.Memory != 0 {
+		if resources.Memory != -1 && resources.Memory < linuxMinMemory {
+			return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
+		}
 	}
 	if resources.Memory > 0 && !sysInfo.MemoryLimit {
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded.")

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -295,7 +295,7 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	var err error
 
 	var memory int64
-	if copts.memoryString != "" {
+	if copts.memoryString != "" && copts.memoryString != "-1" {
 		memory, err = units.RAMInBytes(copts.memoryString)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
**\- What I did**
Close  #22516

**\- How I did it**
If memory parameter is not changed by update command set is  as '-1'

**\- How to verify it**
    docker create --name test -m 50m busybox:latest
    docker inspect -f '{{.HostConfig.Memory}}' test
    #52428800
    docker update -m -1 test
    docker inspect -f '{{.HostConfig.Memory}}' test
    # -1

---

```
docker run -it -d --name test2 -m 50m busybox:latest
docker stats test2
# Shows 50m memory limit
docker update -m -1 test2
docker stats test2
# Shows no memory limits (host memory)
```

**\- Description for the changelog**
Remove memory constraints after creating/running container with update command

Possibility to set memory to '-1' which removes memory constraints

Signed-off-by: boynux boynux@gmail.com
