### PR TITLE
pkg: authorization: cleanup tests

### DIFF
--- a/pkg/authorization/authz_unix_test.go
+++ b/pkg/authorization/authz_unix_test.go
@@ -8,7 +8,6 @@ package authorization
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -139,7 +138,6 @@ func TestResponseModifier(t *testing.T) {
 }
 
 func TestDrainBody(t *testing.T) {
-
 	tests := []struct {
 		length             int // length is the message length send to drainBody
 		expectedBodyLength int // expectedBodyLength is the expected body length after drainBody is called
@@ -151,17 +149,16 @@ func TestDrainBody(t *testing.T) {
 	}
 
 	for _, test := range tests {
-
 		msg := strings.Repeat("a", test.length)
 		body, closer, err := drainBody(ioutil.NopCloser(bytes.NewReader([]byte(msg))))
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(body) != test.expectedBodyLength {
 			t.Fatalf("Body must be copied, actual length: '%d'", len(body))
 		}
 		if closer == nil {
 			t.Fatalf("Closer must not be nil")
-		}
-		if err != nil {
-			t.Fatalf("Error must not be nil: '%v'", err)
 		}
 		modified, err := ioutil.ReadAll(closer)
 		if err != nil {
@@ -207,7 +204,7 @@ func createTestPlugin(t *testing.T) *authorizationPlugin {
 	plugin := &plugins.Plugin{Name: "authz"}
 	pwd, err := os.Getwd()
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	plugin.Client, err = plugins.NewClient("unix:///"+path.Join(pwd, pluginAddress), tlsconfig.Options{InsecureSkipVerify: true})
@@ -232,16 +229,11 @@ type authZPluginTestServer struct {
 func (t *authZPluginTestServer) start() {
 	r := mux.NewRouter()
 	os.Remove(pluginAddress)
-	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: pluginAddress, Net: "unix"})
-	if err != nil {
-		t.t.Fatalf("Failed to listen %v", err)
-	}
+	l, _ := net.ListenUnix("unix", &net.UnixAddr{Name: pluginAddress, Net: "unix"})
 	t.listener = l
-
 	r.HandleFunc("/Plugin.Activate", t.activate)
 	r.HandleFunc("/"+AuthZApiRequest, t.auth)
 	r.HandleFunc("/"+AuthZApiResponse, t.auth)
-	t.listener, _ = net.Listen("tcp", pluginAddress)
 	server := http.Server{Handler: r, Addr: pluginAddress}
 	server.Serve(l)
 }
@@ -257,20 +249,14 @@ func (t *authZPluginTestServer) stop() {
 // auth is a used to record/replay the authentication api messages
 func (t *authZPluginTestServer) auth(w http.ResponseWriter, r *http.Request) {
 	t.recordedRequest = Request{}
-	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, _ := ioutil.ReadAll(r.Body)
+	r.Body.Close()
 	json.Unmarshal(body, &t.recordedRequest)
-	b, err := json.Marshal(t.replayResponse)
-	if err != nil {
-		log.Fatal(err)
-	}
+	b, _ := json.Marshal(t.replayResponse)
 	w.Write(b)
 }
 
 func (t *authZPluginTestServer) activate(w http.ResponseWriter, r *http.Request) {
-	b, err := json.Marshal(plugins.Manifest{Implements: []string{AuthZApiImplements}})
-	if err != nil {
-		log.Fatal(err)
-	}
+	b, _ := json.Marshal(plugins.Manifest{Implements: []string{AuthZApiImplements}})
 	w.Write(b)
 }


### PR DESCRIPTION
- do use use `log` pkg
- do not `t.Fatal` in goroutine
- cleanups

Signed-off-by: Antonio Murdaca runcom@redhat.com
