### PR TITLE
Emit events for docker daemon

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1393,6 +1393,8 @@ func (daemon *Daemon) Reload(config *Config) error {
 	} else {
 		attributes["labels"] = "[]"
 	}
+	attributes["max-concurrent-downloads"] = fmt.Sprintf("%d", *daemon.configStore.MaxConcurrentDownloads)
+	attributes["max-concurrent-uploads"] = fmt.Sprintf("%d", *daemon.configStore.MaxConcurrentUploads)
 	daemon.LogDaemonEventWithAttributes("reload", attributes)
 
 	return nil

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -83,6 +83,9 @@ func (daemon *Daemon) LogNetworkEventWithAttributes(nw libnetwork.Network, actio
 // LogDaemonEventWithAttributes generates an event related to the daemon itself with specific given attributes.
 func (daemon *Daemon) LogDaemonEventWithAttributes(action string, attributes map[string]string) {
 	if daemon.EventsService != nil {
+		if info, err := daemon.SystemInfo(); err == nil && info.Name != "" {
+			attributes["name"] = info.Name
+		}
 		actor := events.Actor{
 			ID:         daemon.ID,
 			Attributes: attributes,

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -80,6 +80,17 @@ func (daemon *Daemon) LogNetworkEventWithAttributes(nw libnetwork.Network, actio
 	daemon.EventsService.Log(action, events.NetworkEventType, actor)
 }
 
+// LogDaemonEventWithAttributes generates an event related to the daemon itself with specific given attributes.
+func (daemon *Daemon) LogDaemonEventWithAttributes(action string, attributes map[string]string) {
+	if daemon.EventsService != nil {
+		actor := events.Actor{
+			ID:         daemon.ID,
+			Attributes: attributes,
+		}
+		daemon.EventsService.Log(action, events.DaemonEventType, actor)
+	}
+}
+
 // SubscribeToEvents returns the currently record of events, a channel to stream new events from, and a function to cancel the stream of events.
 func (daemon *Daemon) SubscribeToEvents(since, until time.Time, filter filters.Args) ([]events.Message, chan interface{}) {
 	ef := daemonevents.NewFilter(filter)

--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -20,6 +20,7 @@ func NewFilter(filter filters.Args) *Filter {
 func (ef *Filter) Include(ev events.Message) bool {
 	return ef.filter.ExactMatch("event", ev.Action) &&
 		ef.filter.ExactMatch("type", ev.Type) &&
+		ef.matchDaemon(ev) &&
 		ef.matchContainer(ev) &&
 		ef.matchVolume(ev) &&
 		ef.matchNetwork(ev) &&
@@ -32,6 +33,10 @@ func (ef *Filter) matchLabels(attributes map[string]string) bool {
 		return true
 	}
 	return ef.filter.MatchKVList("label", attributes)
+}
+
+func (ef *Filter) matchDaemon(ev events.Message) bool {
+	return ef.fuzzyMatchName(ev, events.DaemonEventType)
 }
 
 func (ef *Filter) matchContainer(ev events.Message) bool {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -119,6 +119,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now returns a HTTP 400 "bad parameter" message
   if no command is specified (instead of a HTTP 500 "server error")
 * `GET /images/search` now takes a `filters` query parameter.
+* `GET /events` now supports daemon events of `reload`.
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -119,7 +119,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now returns a HTTP 400 "bad parameter" message
   if no command is specified (instead of a HTTP 500 "server error")
 * `GET /images/search` now takes a `filters` query parameter.
-* `GET /events` now supports daemon events of `reload`.
+* `GET /events` now supports a `reload` event that is emitted when the daemon configuration is reloaded.
+* `GET /events` now supports filtering by daemon name or ID.
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2593,9 +2593,10 @@ Query Parameters:
   -   `event=<string>`; -- event to filter
   -   `image=<string>`; -- image to filter
   -   `label=<string>`; -- image and container label to filter
-  -   `type=<string>`; -- either `container` or `image` or `volume` or `network`
+  -   `type=<string>`; -- either `container` or `image` or `volume` or `network` or `daemon`
   -   `volume=<string>`; -- volume to filter
   -   `network=<string>`; -- network to filter
+  -   `daemon=<string>`; -- daemon name or id to filter
 
 Status Codes:
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2420,6 +2420,10 @@ Docker networks report the following events:
 
     create, connect, disconnect, destroy
 
+Docker daemon report the following event:
+
+    reload
+
 **Example request**:
 
     GET /events?since=1374067924

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -72,9 +72,10 @@ The currently supported filters are:
 * event (`event=<event action>`)
 * image (`image=<tag or id>`)
 * label (`label=<key>` or `label=<key>=<value>`)
-* type (`type=<container or image or volume or network>`)
+* type (`type=<container or image or volume or network or daemon>`)
 * volume (`volume=<name or id>`)
 * network (`network=<name or id>`)
+* daemon (`daemon=<name or id>`)
 
 ## Examples
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -35,6 +35,10 @@ Docker networks report the following events:
 
     create, connect, disconnect, destroy
 
+Docker daemon report the following events:
+
+    reload
+
 The `--since` and `--until` parameters can be Unix timestamps, date formatted
 timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
 relative to the client machine’s time. If you do not provide the `--since` option,

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -386,17 +386,19 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err := s.d.Cmd("info")
 	c.Assert(err, checker.IsNil)
 	daemonID := ""
+	daemonName := ""
 	for _, line := range strings.Split(out, "\n") {
 		if strings.HasPrefix(line, "ID: ") {
 			daemonID = strings.TrimPrefix(line, "ID: ")
-			break
+		} else if strings.HasPrefix(line, "Name: ") {
+			daemonName = strings.TrimPrefix(line, "Name: ")
 		}
 	}
 	c.Assert(daemonID, checker.Not(checker.Equals), "")
 
 	configFile, err = os.Create(configFilePath)
 	c.Assert(err, checker.IsNil)
-	daemonConfig = `{"labels":["bar=foo"]}`
+	daemonConfig = `{"max-concurrent-downloads":1,"labels":["bar=foo"]}`
 	fmt.Fprintf(configFile, "%s", daemonConfig)
 	configFile.Close()
 
@@ -406,5 +408,58 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, labels=[\"bar=foo\"])", daemonID))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, labels=[\"bar=foo\"], max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s)", daemonID, daemonName))
+}
+
+func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	// daemon config file
+	configFilePath := "test.json"
+	configFile, err := os.Create(configFilePath)
+	c.Assert(err, checker.IsNil)
+	defer os.Remove(configFilePath)
+
+	daemonConfig := `{"labels":["foo=bar"]}`
+	fmt.Fprintf(configFile, "%s", daemonConfig)
+	configFile.Close()
+	c.Assert(s.d.Start(fmt.Sprintf("--config-file=%s", configFilePath)), check.IsNil)
+
+	// Get daemon ID
+	out, err := s.d.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	daemonID := ""
+	daemonName := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "ID: ") {
+			daemonID = strings.TrimPrefix(line, "ID: ")
+		} else if strings.HasPrefix(line, "Name: ") {
+			daemonName = strings.TrimPrefix(line, "Name: ")
+		}
+	}
+	c.Assert(daemonID, checker.Not(checker.Equals), "")
+
+	syscall.Kill(s.d.cmd.Process.Pid, syscall.SIGHUP)
+
+	time.Sleep(3 * time.Second)
+
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", daemonID))
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s", daemonID))
+
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", daemonName))
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s", daemonID))
+
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "daemon=foo")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), fmt.Sprintf("daemon reload %s", daemonID))
+
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=daemon")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s", daemonID))
+
+	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=container")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), fmt.Sprintf("daemon reload %s", daemonID))
 }


### PR DESCRIPTION
**\- What I did**

This fix tries to cover the issue raised in #22463 by emitting events for docker daemon so that user could be notified by scenarios like config reload, etc.

**\- How I did it**

This fix adds the  `daemon reload` event for docker daemon. An additional filter type `daemon` has been added.

Related documentations have been updated as well.

**\- How to verify it**

Additional tests have been added to cover the changes in this fix.

**\- Description for the changelog**

Emit   `daemon reload` event for docker daemon.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22463.

Signed-off-by: Yong Tang yong.tang.github@outlook.com

**NOTE: This fix changes `vendor/src/github.com/docker/engine-api/types/events/events.go` for now but a different PR in engine-api will be created.**
