### PR TITLE
Allow changing wheezy deb builder backport mirror

### DIFF
--- a/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
@@ -7,6 +7,7 @@ FROM debian:wheezy-backports
 # allow replacing httpredir mirror
 ARG APT_MIRROR=httpredir.debian.org
 RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config --no-install-recommends && rm -rf /var/lib/apt/lists/*

--- a/contrib/builder/deb/amd64/generate.sh
+++ b/contrib/builder/deb/amd64/generate.sh
@@ -46,8 +46,15 @@ for version in "${versions[@]}"; do
 			# allow replacing httpredir mirror
 			ARG APT_MIRROR=httpredir.debian.org
 			RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
-
 		EOF
+
+		if [ "$suite" = "wheezy" ]; then
+			cat >> "$version/Dockerfile" <<-'EOF'
+				RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list.d/backports.list
+			EOF
+		fi
+
+		echo "" >> "$version/Dockerfile"
 	fi
 
 	extraBuildTags='pkcs11'


### PR DESCRIPTION
So it turns out, there is one more source-list file to be changed in our debian-wheezy deb-builder image
