### PR TITLE
Docs: Email address can be passed as a flag too

### DIFF
--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -18,6 +18,7 @@ parent = "smn_cli"
       --help               Print usage
       -p, --password=""    Password
       -u, --username=""    Username
+      -e, --email=""       Email
 
 If you want to login to a self-hosted registry you can specify this by
 adding the server name.


### PR DESCRIPTION
Whist writing an unattended installation script I needed to do a docker login and it looks like the --email flag was undocumented.
