### PR TITLE
Adds a correct error string for network validation

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4233,7 +4233,8 @@ func (s *DockerSuite) TestRunAttachFailedNoLeak(c *check.C) {
 	// TODO Windows Post TP5. Fix the error message string
 	c.Assert(strings.Contains(string(out), "port is already allocated") ||
 		strings.Contains(string(out), "were not connected because a duplicate name exists") ||
-		strings.Contains(string(out), "HNS failed with error : Failed to create endpoint"), checker.Equals, true, check.Commentf("Output: %s", out))
+		strings.Contains(string(out), "HNS failed with error : Failed to create endpoint") ||
+		strings.Contains(string(out), "HNS failed with error : The object already exists"), checker.Equals, true, check.Commentf("Output: %s", out))
 	dockerCmd(c, "rm", "-f", "test")
 
 	// NGoroutines is not updated right away, so we need to wait before failing


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Updated the test to pass with recent Windows error strings.
**\- How I did it**
Wrote some Go code.
**\- How to verify it**
Docker CI will run this test.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Adds a correct error string for network validation

**\- A picture of a cute animal (not mandatory but encouraged)**
[Pygmy Seahorse](https://www.google.com/url?sa=i&rct=j&q=&esrc=s&source=images&cd=&cad=rja&uact=8&ved=0ahUKEwi_i-K4lc7MAhVC_mMKHcGHD3cQjRwIBw&url=http%3A%2F%2Fmission-blue.org%2F2012%2F12%2Fphoto-of-the-day-pygmy-seahorse%2F&psig=AFQjCNE8-_IelLbmPk_8t5bWFZS0nOT0Bw&ust=1462923654019401)

Fixes the negative networking test to include the new error string
from recent Windows builds.

Signed-off-by: Justin Terry juterry@microsoft.com
