### PR TITLE
Remove deprecated driver specific log tags

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -57,8 +57,8 @@ func init() {
 }
 
 // New creates a fluentd logger using the configuration passed in on
-// the context. Supported context configuration variables are
-// fluentd-address & fluentd-tag.
+// the context. The supported context configuration variable is
+// fluentd-address.
 func New(ctx logger.Context) (logger.Logger, error) {
 	host, port, err := parseAddress(ctx.Config[addressKey])
 	if err != nil {
@@ -154,12 +154,11 @@ func (f *fluentd) Name() string {
 	return name
 }
 
-// ValidateLogOpt looks for fluentd specific log options fluentd-address & fluentd-tag.
+// ValidateLogOpt looks for fluentd specific log option fluentd-address.
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {
 		case "env":
-		case "fluentd-tag":
 		case "labels":
 		case "tag":
 		case addressKey:

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -40,8 +40,7 @@ func init() {
 }
 
 // New creates a gelf logger using the configuration passed in on the
-// context. Supported context configuration variables are
-// gelf-address, & gelf-tag.
+// context. The supported context configuration variable is gelf-address.
 func New(ctx logger.Context) (logger.Logger, error) {
 	// parse gelf address
 	address, err := parseAddress(ctx.Config["gelf-address"])
@@ -153,13 +152,11 @@ func (s *gelfLogger) Name() string {
 	return name
 }
 
-// ValidateLogOpt looks for gelf specific log options gelf-address, &
-// gelf-tag.
+// ValidateLogOpt looks for gelf specific log option gelf-address.
 func ValidateLogOpt(cfg map[string]string) error {
 	for key, val := range cfg {
 		switch key {
 		case "gelf-address":
-		case "gelf-tag":
 		case "tag":
 		case "labels":
 		case "env":

--- a/daemon/logger/loggerutils/log_tag_test.go
+++ b/daemon/logger/loggerutils/log_tag_test.go
@@ -18,24 +18,6 @@ func TestParseLogTag(t *testing.T) {
 	assertTag(t, e, tag, "test-image/test-container/container-ab")
 }
 
-func TestParseLogTagSyslogTag(t *testing.T) {
-	ctx := buildContext(map[string]string{"syslog-tag": "{{.ImageName}}/{{.Name}}/{{.ID}}"})
-	tag, e := ParseLogTag(ctx, "{{.ID}}")
-	assertTag(t, e, tag, "test-image/test-container/container-ab")
-}
-
-func TestParseLogTagGelfTag(t *testing.T) {
-	ctx := buildContext(map[string]string{"gelf-tag": "{{.ImageName}}/{{.Name}}/{{.ID}}"})
-	tag, e := ParseLogTag(ctx, "{{.ID}}")
-	assertTag(t, e, tag, "test-image/test-container/container-ab")
-}
-
-func TestParseLogTagFluentdTag(t *testing.T) {
-	ctx := buildContext(map[string]string{"fluentd-tag": "{{.ImageName}}/{{.Name}}/{{.ID}}"})
-	tag, e := ParseLogTag(ctx, "{{.ID}}")
-	assertTag(t, e, tag, "test-image/test-container/container-ab")
-}
-
 // Helpers
 
 func buildContext(cfg map[string]string) logger.Context {

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -89,7 +89,7 @@ func rfc5424microformatterWithAppNameAsTag(p syslog.Priority, hostname, tag, con
 
 // New creates a syslog logger using the configuration passed in on
 // the context. Supported context configuration variables are
-// syslog-address, syslog-facility, syslog-format,  syslog-tag.
+// syslog-address, syslog-facility, syslog-format.
 func New(ctx logger.Context) (logger.Logger, error) {
 	tag, err := loggerutils.ParseLogTag(ctx, "{{.ID}}")
 	if err != nil {
@@ -184,7 +184,7 @@ func parseAddress(address string) (string, string, error) {
 }
 
 // ValidateLogOpt looks for syslog specific log options
-// syslog-address, syslog-facility, & syslog-tag.
+// syslog-address, syslog-facility.
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {
@@ -192,7 +192,6 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case "labels":
 		case "syslog-address":
 		case "syslog-facility":
-		case "syslog-tag":
 		case "syslog-tls-ca-cert":
 		case "syslog-tls-cert":
 		case "syslog-tls-key":

--- a/docs/admin/logging/log_tags.md
+++ b/docs/admin/logging/log_tags.md
@@ -64,8 +64,3 @@ Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: + exec app
 Apr  1 15:22:17 ip-10-27-39-73 docker/logtester.1234[45499]: 2016-04-01 15:22:17.075416751 +0000 UTC stderr msg: 1
 ```
 
-
-
->**Note**:The driver specific log options `syslog-tag`, `fluentd-tag` and
->`gelf-tag` still work for backwards compatibility. However, going forward you
->should standardize on using the generic `tag` log option instead.

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -73,7 +73,7 @@ variants:
 ### Driver Specific Log Tags
 **Deprecated In Release: v1.9**
 
-**Target For Removal In Release: v1.11**
+**Removed In Release: v1.12**
 
 Log tags are now generated in a standard way across different logging drivers.
 Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` and


### PR DESCRIPTION
Since 1.9, driver specific log tag options
`syslog-tag`
`gelf-tag`
`fluentd-tag`
have been deprecated in favor of the generic tag option which is standard across different logging drivers.

This fix removed the deprecated driver specific log tag options of `syslog-tag`, `gelf-tag`, `fluentd-tag` for 1.12 and updated the docs.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
