### PR TITLE
Un-deprecated command line short variant options of `-c`

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -52,7 +52,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	flMemoryString := cmd.String([]string{"m", "-memory"}, "", "Memory limit")
 	flMemorySwap := cmd.String([]string{"-memory-swap"}, "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
 	flShmSize := cmd.String([]string{"-shm-size"}, "", "Size of /dev/shm, default value is 64MB")
-	flCPUShares := cmd.Int64([]string{"#c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
+	flCPUShares := cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 	flCPUPeriod := cmd.Int64([]string{"-cpu-period"}, 0, "Limit the CPU CFS (Completely Fair Scheduler) period")
 	flCPUQuota := cmd.Int64([]string{"-cpu-quota"}, 0, "Limit the CPU CFS (Completely Fair Scheduler) quota")
 	flCPUSetCpus := cmd.String([]string{"-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")

--- a/api/client/update.go
+++ b/api/client/update.go
@@ -23,7 +23,7 @@ func (cli *DockerCli) CmdUpdate(args ...string) error {
 	flCPUQuota := cmd.Int64([]string{"-cpu-quota"}, 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 	flCpusetCpus := cmd.String([]string{"-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 	flCpusetMems := cmd.String([]string{"-cpuset-mems"}, "", "MEMs in which to allow execution (0-3, 0,1)")
-	flCPUShares := cmd.Int64([]string{"#c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
+	flCPUShares := cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 	flMemoryString := cmd.String([]string{"m", "-memory"}, "", "Memory limit")
 	flMemoryReservation := cmd.String([]string{"-memory-reservation"}, "", "Memory soft limit")
 	flMemorySwap := cmd.String([]string{"-memory-swap"}, "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -67,18 +67,6 @@ Use `docker ps --filter=before=...` and `docker ps --filter=since=...` instead.
 The `docker search --automated` and `docker search --stars` options are deprecated.
 Use `docker search --filter=is-automated=...` and `docker search --filter=stars=...` instead.
 
-### Command line short variant options
-**Deprecated In Release: v1.9**
-
-**Target For Removal In Release: v1.11**
-
-The following short variant options are deprecated in favor of their long
-variants:
-
-    docker run -c (--cpu-shares)
-    docker build -c (--cpu-shares)
-    docker create -c (--cpu-shares)
-
 ### Driver Specific Log Tags
 **Deprecated In Release: v1.9**
 

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -76,7 +76,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		flKernelMemory      = cmd.String([]string{"-kernel-memory"}, "", "Kernel memory limit")
 		flUser              = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
 		flWorkingDir        = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
-		flCPUShares         = cmd.Int64([]string{"#c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
+		flCPUShares         = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCPUPercent        = cmd.Int64([]string{"-cpu-percent"}, 0, "CPU percent (Windows only)")
 		flCPUPeriod         = cmd.Int64([]string{"-cpu-period"}, 0, "Limit CPU CFS (Completely Fair Scheduler) period")
 		flCPUQuota          = cmd.Int64([]string{"-cpu-quota"}, 0, "Limit CPU CFS (Completely Fair Scheduler) quota")


### PR DESCRIPTION
Since 1.9, the following short variant options have been deprecated in favor of their long variants:
`docker run -c (--cpu-shares)`
`docker build -c (--cpu-shares)`
`docker create -c (--cpu-shares)`
`docker update -c (--cpu-shares)`

However, `-c` is still widely used and is considered as a convenient option for swarm (see #16271).

This fix undeprecated the command line short variant options of `-c` and updated the deprecated.md.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
