### PR TITLE
docs: update compatibility matrix

### DIFF
--- a/docs/userguide/storagedriver/selectadriver.md
+++ b/docs/userguide/storagedriver/selectadriver.md
@@ -71,14 +71,14 @@ For example, the `btrfs` storage driver on a Btrfs backing filesystem. The
 following table lists each storage driver and whether it must match the host's
 backing file system:
 
-|Storage driver |Must match backing filesystem |Incompatible with   |
-|---------------|------------------------------|--------------------|
-|`overlay`      |No                            |`btrfs` `aufs` `zfs`|
-|`aufs`         |No                            |`btrfs` `aufs`      |
-|`btrfs`        |Yes                           |   N/A              |
-|`devicemapper` |No                            |   N/A              |
-|`vfs`          |No                            |   N/A              |
-|`zfs`          |Yes                           |   N/A              |
+| Storage driver | Must match backing filesystem | Incompatible with              |
+|----------------|-------------------------------|--------------------------------|
+| `overlay`      | No                            | `aufs` `btrfs` `overlay` `zfs` |
+| `aufs`         | No                            | `aufs` `btrfs`                 |
+| `btrfs`        | Yes                           | N/A                            |
+| `devicemapper` | No                            | N/A                            |
+| `vfs`          | No                            | N/A                            |
+| `zfs`          | Yes                           | N/A                            |
 
 
 > **Note**


### PR DESCRIPTION
Commit 824c72f4727504e3a8d37f87ce88733c560d4129 marked
overlay as "not compatible" with overlay.

This updates the compatibility matrix in the documentation
to match that.

Also see the discussion in https://github.com/docker/docker/issues/22624
