### PR TITLE
refactor overlay storage driver compatibility check

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -53,12 +53,8 @@ var (
 	// ErrAufsNotSupported is returned if aufs is not supported by the host.
 	ErrAufsNotSupported = fmt.Errorf("AUFS was not found in /proc/filesystems")
 	// ErrAufsNested means aufs cannot be used bc we are in a user namespace
-	ErrAufsNested       = fmt.Errorf("AUFS cannot be used in non-init user namespace")
-	incompatibleFsMagic = []graphdriver.FsMagic{
-		graphdriver.FsMagicBtrfs,
-		graphdriver.FsMagicAufs,
-	}
-	backingFs = "<unknown>"
+	ErrAufsNested = fmt.Errorf("AUFS cannot be used in non-init user namespace")
+	backingFs     = "<unknown>"
 
 	enableDirpermLock sync.Once
 	enableDirperm     bool
@@ -95,10 +91,10 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		backingFs = fsName
 	}
 
-	for _, magic := range incompatibleFsMagic {
-		if fsMagic == magic {
-			return nil, graphdriver.ErrIncompatibleFS
-		}
+	switch fsMagic {
+	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs:
+		logrus.Errorf("AUFS is not supported over %s", backingFs)
+		return nil, graphdriver.ErrIncompatibleFS
 	}
 
 	paths := []string{

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -29,6 +29,7 @@ import (
 var (
 	// ErrApplyDiffFallback is returned to indicate that a normal ApplyDiff is applied as a fallback from Naive diff writer.
 	ErrApplyDiffFallback = fmt.Errorf("Fall back to normal ApplyDiff")
+	backingFs            = "<unknown>"
 )
 
 // ApplyDiffProtoDriver wraps the ProtoDriver by extending the interface with ApplyDiff method.
@@ -99,8 +100,6 @@ type Driver struct {
 	ctr           *graphdriver.RefCounter
 }
 
-var backingFs = "<unknown>"
-
 func init() {
 	graphdriver.Register("overlay", Init)
 }
@@ -122,19 +121,9 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		backingFs = fsName
 	}
 
-	// check if they are running over btrfs, aufs, zfs or overlay
 	switch fsMagic {
-	case graphdriver.FsMagicBtrfs:
-		logrus.Error("'overlay' is not supported over btrfs.")
-		return nil, graphdriver.ErrIncompatibleFS
-	case graphdriver.FsMagicAufs:
-		logrus.Error("'overlay' is not supported over aufs.")
-		return nil, graphdriver.ErrIncompatibleFS
-	case graphdriver.FsMagicZfs:
-		logrus.Error("'overlay' is not supported over zfs.")
-		return nil, graphdriver.ErrIncompatibleFS
-	case graphdriver.FsMagicOverlay:
-		logrus.Error("'overlay' is not supported over overlay.")
+	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicZfs:
+		logrus.Errorf("'overlay' is not supported over %s", backingFs)
 		return nil, graphdriver.ErrIncompatibleFS
 	}
 


### PR DESCRIPTION
use the same approach as is used in the AUFS driver,
to be less DRY.

also add an error-message for the AUFS driver if
an incompatible combination is found.
