### PR TITLE
Add the swapMemorySupport requirement to OOM tests

### DIFF
--- a/integration-cli/docker_cli_oom_killed_test.go
+++ b/integration-cli/docker_cli_oom_killed_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
-	testRequires(c, DaemonIsLinux, memoryLimitSupport)
+	testRequires(c, DaemonIsLinux, memoryLimitSupport, swapMemorySupport)
 
 	name := "testoomkilled"
 	_, exitCode, _ := dockerCmdWithError("run", "--name", name, "--memory", "32MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
@@ -20,7 +20,7 @@ func (s *DockerSuite) TestInspectOomKilledTrue(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectOomKilledFalse(c *check.C) {
-	testRequires(c, DaemonIsLinux, memoryLimitSupport)
+	testRequires(c, DaemonIsLinux, memoryLimitSupport, swapMemorySupport)
 
 	name := "testoomkilled"
 	dockerCmd(c, "run", "--name", name, "--memory", "32MB", "busybox", "sh", "-c", "echo hello world")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -554,7 +554,7 @@ func (s *DockerSuite) TestRunWithInvalidPathforBlkioDeviceWriteIOps(c *check.C) 
 }
 
 func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
-	testRequires(c, oomControl)
+	testRequires(c, memoryLimitSupport, swapMemorySupport)
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -353,7 +353,8 @@ as memory limit.
 **--memory-swap**="LIMIT"
    A limit value equal to memory plus swap. Must be used with the  **-m**
 (**--memory**) flag. The swap `LIMIT` should always be larger than **-m**
-(**--memory**) value.
+(**--memory**) value.  By default, the swap `LIMIT` will be set to double
+the value of --memory.
 
    The format of `LIMIT` is `<number>[<unit>]`. Unit can be `b` (bytes),
 `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you don't specify a


### PR DESCRIPTION
Add the swapMemorySupport requirement to all tests related to the OOM killer.  The --memory option has the subtle side effect of defaulting --memory-swap to double the value of --memory.  The OOM killer doesn't kick in until the container exhausts memory+swap, and so without the memory swap cgroup the tests will timeout due to swap being effectively unlimited.

Document the default behavior of --memory-swap in the docker run man page.

Signed-off-by: Sean Christopherson sean.j.christopherson@intel.com

Related to #17215 and #20627.
