### PR TITLE
Adds ability to flatten image after build

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -54,6 +54,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options.NetworkMode = r.FormValue("networkmode")
 	options.Tags = r.Form["t"]
 	options.SecurityOpt = r.Form["securityopt"]
+	options.Squash = httputils.BoolValue(r, "squash")
 
 	if r.Form.Get("shmsize") != "" {
 		shmSize, err := strconv.ParseInt(r.Form.Get("shmsize"), 10, 64)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -135,9 +135,15 @@ type Backend interface {
 	// TODO: make an Extract method instead of passing `decompress`
 	// TODO: do not pass a FileInfo, instead refactor the archive package to export a Walk function that can be used
 	// with Context.Walk
-	//ContainerCopy(name string, res string) (io.ReadCloser, error)
+	// ContainerCopy(name string, res string) (io.ReadCloser, error)
 	// TODO: use copyBackend api
 	CopyOnBuild(containerID string, destPath string, src FileInfo, decompress bool) error
+
+	// HasExperimental checks if the backend supports experimental features
+	HasExperimental() bool
+
+	// SquashImage squashes the fs layers from the provided image down to the specified `to` image
+	SquashImage(from string, to string) (string, error)
 }
 
 // Image represents a Docker image used by the builder.

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	apierrors "github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
@@ -18,6 +19,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/reference"
+	perrors "github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -77,6 +79,7 @@ type Builder struct {
 	id string
 
 	imageCache builder.ImageCache
+	from       builder.Image
 }
 
 // BuildManager implements builder.Backend and is shared across all Builder objects.
@@ -91,6 +94,9 @@ func NewBuildManager(b builder.Backend) (bm *BuildManager) {
 
 // BuildFromContext builds a new image from a given context.
 func (bm *BuildManager) BuildFromContext(ctx context.Context, src io.ReadCloser, remote string, buildOptions *types.ImageBuildOptions, pg backend.ProgressWriter) (string, error) {
+	if buildOptions.Squash && !bm.backend.HasExperimental() {
+		return "", apierrors.NewBadRequestError(errors.New("squash is only supported with experimental mode"))
+	}
 	buildContext, dockerfileName, err := builder.DetectContextFromRemoteURL(src, remote, pg.ProgressReaderFunc)
 	if err != nil {
 		return "", err
@@ -100,6 +106,7 @@ func (bm *BuildManager) BuildFromContext(ctx context.Context, src io.ReadCloser,
 			logrus.Debugf("[BUILDER] failed to remove temporary context: %v", err)
 		}
 	}()
+
 	if len(dockerfileName) > 0 {
 		buildOptions.Dockerfile = dockerfileName
 	}
@@ -284,6 +291,17 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 
 	if b.image == "" {
 		return "", fmt.Errorf("No image was generated. Is your Dockerfile empty?")
+	}
+
+	if b.options.Squash {
+		var fromID string
+		if b.from != nil {
+			fromID = b.from.ImageID()
+		}
+		b.image, err = b.docker.SquashImage(b.image, fromID)
+		if err != nil {
+			return "", perrors.Wrap(err, "error squashing image")
+		}
 	}
 
 	imageID := image.ID(b.image)

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -221,6 +221,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 			}
 		}
 	}
+	b.from = image
 
 	return b.processImageFrom(image)
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -59,6 +59,7 @@ type buildOptions struct {
 	compress       bool
 	securityOpt    []string
 	networkMode    string
+	squash         bool
 }
 
 // NewBuildCommand creates a new `docker build` command
@@ -109,6 +110,10 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&options.networkMode, "network", "default", "Connect a container to a network")
 
 	command.AddTrustedFlags(flags, true)
+
+	if dockerCli.HasExperimental() {
+		flags.BoolVar(&options.squash, "squash", false, "Squash newly built layers into a single new layer")
+	}
 
 	return cmd
 }
@@ -305,6 +310,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		CacheFrom:      options.cacheFrom,
 		SecurityOpt:    options.securityOpt,
 		NetworkMode:    options.networkMode,
+		Squash:         options.squash,
 	}
 
 	response, err := dockerCli.Client().ImageBuild(ctx, body, buildOptions)

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -424,7 +424,7 @@ func TestChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err = d.Changes("3", "")
+	changes, err = d.Changes("3", "2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -530,7 +530,7 @@ func TestChildDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err = d.DiffSize("2", "")
+	diffSize, err = d.DiffSize("2", "1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/graphdriver/aufs/dirs.go
+++ b/daemon/graphdriver/aufs/dirs.go
@@ -29,7 +29,7 @@ func loadIds(root string) ([]string, error) {
 //
 // If there are no lines in the file then the id has no parent
 // and an empty slice is returned.
-func getParentIds(root, id string) ([]string, error) {
+func getParentIDs(root, id string) ([]string, error) {
 	f, err := os.Open(path.Join(root, "layers", id))
 	if err != nil {
 		return nil, err

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -78,9 +78,8 @@ type ProtoDriver interface {
 	Cleanup() error
 }
 
-// Driver is the interface for layered/snapshot file system drivers.
-type Driver interface {
-	ProtoDriver
+// DiffDriver is the interface to use to implement graph diffs
+type DiffDriver interface {
 	// Diff produces an archive of the changes between the specified
 	// layer and its parent layer which may be "".
 	Diff(id, parent string) (io.ReadCloser, error)
@@ -96,6 +95,12 @@ type Driver interface {
 	// and its parent and returns the size in bytes of the changes
 	// relative to its base filesystem directory.
 	DiffSize(id, parent string) (size int64, err error)
+}
+
+// Driver is the interface for layered/snapshot file system drivers.
+type Driver interface {
+	ProtoDriver
+	DiffDriver
 }
 
 // DiffGetterDriver is the interface for layered file system drivers that

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -1,9 +1,13 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"path"
 	"sort"
+	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -239,6 +243,89 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool, withExtraAttrs
 	sort.Sort(sort.Reverse(byCreated(images)))
 
 	return images, nil
+}
+
+// SquashImage creates a new image with the diff of the specified image and the specified parent.
+// This new image contains only the layers from it's parent + 1 extra layer which contains the diff of all the layers in between.
+// The existing image(s) is not destroyed.
+// If no parent is specified, a new image with the diff of all the specified image's layers merged into a new layer that has no parents.
+func (daemon *Daemon) SquashImage(id, parent string) (string, error) {
+	img, err := daemon.imageStore.Get(image.ID(id))
+	if err != nil {
+		return "", err
+	}
+
+	var parentImg *image.Image
+	var parentChainID layer.ChainID
+	if len(parent) != 0 {
+		parentImg, err = daemon.imageStore.Get(image.ID(parent))
+		if err != nil {
+			return "", errors.Wrap(err, "error getting specified parent layer")
+		}
+		parentChainID = parentImg.RootFS.ChainID()
+	} else {
+		rootFS := image.NewRootFS()
+		parentImg = &image.Image{RootFS: rootFS}
+	}
+
+	l, err := daemon.layerStore.Get(img.RootFS.ChainID())
+	if err != nil {
+		return "", errors.Wrap(err, "error getting image layer")
+	}
+	defer daemon.layerStore.Release(l)
+
+	ts, err := l.TarStreamFrom(parentChainID)
+	if err != nil {
+		return "", errors.Wrapf(err, "error getting tar stream to parent")
+	}
+	defer ts.Close()
+
+	newL, err := daemon.layerStore.Register(ts, parentChainID)
+	if err != nil {
+		return "", errors.Wrap(err, "error registering layer")
+	}
+	defer daemon.layerStore.Release(newL)
+
+	var newImage image.Image
+	newImage = *img
+	newImage.RootFS = nil
+
+	var rootFS image.RootFS
+	rootFS = *parentImg.RootFS
+	rootFS.DiffIDs = append(rootFS.DiffIDs, newL.DiffID())
+	newImage.RootFS = &rootFS
+
+	for i, hi := range newImage.History {
+		if i >= len(parentImg.History) {
+			hi.EmptyLayer = true
+		}
+		newImage.History[i] = hi
+	}
+
+	now := time.Now()
+	var historyComment string
+	if len(parent) > 0 {
+		historyComment = fmt.Sprintf("merge %s to %s", id, parent)
+	} else {
+		historyComment = fmt.Sprintf("create new from %s", id)
+	}
+
+	newImage.History = append(newImage.History, image.History{
+		Created: now,
+		Comment: historyComment,
+	})
+	newImage.Created = now
+
+	b, err := json.Marshal(&newImage)
+	if err != nil {
+		return "", errors.Wrap(err, "error marshalling image config")
+	}
+
+	newImgID, err := daemon.imageStore.Create(b)
+	if err != nil {
+		return "", errors.Wrap(err, "error creating new image after squash")
+	}
+	return string(newImgID), nil
 }
 
 func newImage(image *image.Image, virtualSize int64) *types.ImageSummary {

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -3,6 +3,7 @@ package xfer
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"runtime"
@@ -29,6 +30,10 @@ type mockLayer struct {
 
 func (ml *mockLayer) TarStream() (io.ReadCloser, error) {
 	return ioutil.NopCloser(bytes.NewBuffer(ml.layerData.Bytes())), nil
+}
+
+func (ml *mockLayer) TarStreamFrom(layer.ChainID) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (ml *mockLayer) ChainID() layer.ChainID {

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1800,6 +1800,7 @@ or being killed.
         variable expansion in other Dockerfile instructions. This is not meant for
         passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
+-   **squash** - squash the resulting images layers into a single layer (boolean) **Experimental Only**
 -   **labels** – JSON map of string pairs for labels to set on the image.
 -   **networkmode** - Sets the networking mode for the run commands during
         build. Supported standard values are: `bridge`, `host`, `none`, and

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -54,6 +54,7 @@ Options:
                                 The format is `<number><unit>`. `number` must be greater than `0`.
                                 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                 or `g` (gigabytes). If you omit the unit, the system uses bytes.
+  --squash                      Squash newly built layers into a single new layer (**Experimental Only**) 
   -t, --tag value               Name and optionally a tag in the 'name:tag' format (default [])
       --ulimit value            Ulimit options (default [])
 ```
@@ -432,3 +433,20 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                 |
 
 Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
+
+
+### Squash an image's layers (--squash) **Experimental Only**
+
+Once the image is built, squash the new layers into a new image with a single
+new layer. Squashing does not destroy any existing image, rather it creates a new
+image with the content of the squshed layers. This effectively makes it look
+like all `Dockerfile` commands were created with a single layer. The build
+cache is preserved with this method.
+
+**Note**: using this option means the new image will not be able to take
+advantage of layer sharing with other images and may use significantly more
+space.
+
+**Note**: using this option you may see significantly more space used due to
+storing two copies of the image, one for the build cache with all the cache
+layers in tact, and one for the squashed version.

--- a/layer/empty.go
+++ b/layer/empty.go
@@ -3,6 +3,7 @@ package layer
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -21,6 +22,10 @@ func (el *emptyLayer) TarStream() (io.ReadCloser, error) {
 	tarWriter := tar.NewWriter(buf)
 	tarWriter.Close()
 	return ioutil.NopCloser(buf), nil
+}
+
+func (el *emptyLayer) TarStreamFrom(ChainID) (io.ReadCloser, error) {
+	return nil, fmt.Errorf("can't get parent tar stream of an empty layer")
 }
 
 func (el *emptyLayer) ChainID() ChainID {

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -78,6 +78,9 @@ type TarStreamer interface {
 	// TarStream returns a tar archive stream
 	// for the contents of a layer.
 	TarStream() (io.ReadCloser, error)
+	// TarStreamFrom returns a tar archive stream for all the layer chain with
+	// arbitrary depth.
+	TarStreamFrom(ChainID) (io.ReadCloser, error)
 }
 
 // Layer represents a read-only layer

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -1,6 +1,7 @@
 package layer
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/pkg/archive"
@@ -28,11 +29,14 @@ func (ml *mountedLayer) cacheParent() string {
 }
 
 func (ml *mountedLayer) TarStream() (io.ReadCloser, error) {
-	archiver, err := ml.layerStore.driver.Diff(ml.mountID, ml.cacheParent())
-	if err != nil {
-		return nil, err
-	}
-	return archiver, nil
+	return ml.layerStore.driver.Diff(ml.mountID, ml.cacheParent())
+}
+
+func (ml *mountedLayer) TarStreamFrom(parent ChainID) (io.ReadCloser, error) {
+	// Not supported since this will include the init layer as well
+	// This can already be acheived with mount + tar.
+	// Should probably never reach this point, but error out here.
+	return nil, fmt.Errorf("getting a layer diff from an arbitrary parent is not supported on mounted layer")
 }
 
 func (ml *mountedLayer) Name() string {

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -11,6 +11,7 @@ docker-build - Build a new image from the source code at PATH
 [**--cgroup-parent**[=*CGROUP-PARENT*]]
 [**--help**]
 [**-f**|**--file**[=*PATH/Dockerfile*]]
+[**-squash**] *Experimental*
 [**--force-rm**]
 [**--isolation**[=*default*]]
 [**--label**[=*[]*]]
@@ -56,6 +57,22 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
    tarball or a Git repository, then the path must be relative to the root of
    the remote context. In all cases, the file must be within the build context.
    The default is *Dockerfile*.
+
+**--squash**=*true*|*false*
+   **Experimental Only**
+   Once the image is built, squash the new layers into a new image with a single
+   new layer. Squashing does not destroy any existing image, rather it creates a new
+   image with the content of the squshed layers. This effectively makes it look
+   like all `Dockerfile` commands were created with a single layer. The build
+   cache is preserved with this method.
+
+   **Note**: using this option means the new image will not be able to take
+   advantage of layer sharing with other images and may use significantly more
+   space.
+
+   **Note**: using this option you may see significantly more space used due to
+   storing two copies of the image, one for the build cache with all the cache
+   layers in tact, and one for the squashed version.
 
 **--build-arg**=*variable*
    name and value of a **buildarg**.

--- a/migrate/v1/migratev1_test.go
+++ b/migrate/v1/migratev1_test.go
@@ -406,6 +406,9 @@ type mockLayer struct {
 func (l *mockLayer) TarStream() (io.ReadCloser, error) {
 	return nil, nil
 }
+func (l *mockLayer) TarStreamFrom(layer.ChainID) (io.ReadCloser, error) {
+	return nil, nil
+}
 
 func (l *mockLayer) ChainID() layer.ChainID {
 	return layer.CreateChainID(l.diffIDs)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Allow built images to be squashed to their parent.
Squashing does not destroy any images or layers, and preserves the build cache.

**\- How I did it**
Introduce a new CLI argument `--squash` to `docker build`.
Introduce a new param to the build API endpoint `squash`.

Once the build is complete, docker creates a new image loading the diffs from each layer into a single new layer and references all the parent's layers

**\- How to verify it**

``` Dockerfile
FROM busybox
RUN echo hello > /hello
RUN echo world >> /hello
RUN touch remove_me /remove_me
ENV HELLO world
RUN rm /remove_me
```

```
$ docker build -t test squash .
...
$ docker history test
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
4e10cb5b4cac        3 seconds ago                                                       12 B                merge sha256:88a7b0112a41826885df0e7072698006ee8f621c6ab99fca7fe9151d7b599702 to sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb
<missing>           5 minutes ago       /bin/sh -c rm /remove_me                        0 B
<missing>           5 minutes ago       /bin/sh -c #(nop) ENV HELLO=world               0 B
<missing>           5 minutes ago       /bin/sh -c touch remove_me /remove_me           0 B
<missing>           5 minutes ago       /bin/sh -c echo world >> /hello                 0 B
<missing>           6 minutes ago       /bin/sh -c echo hello > /hello                  0 B
<missing>           7 weeks ago         /bin/sh -c #(nop) CMD ["sh"]                    0 B
<missing>           7 weeks ago         /bin/sh -c #(nop) ADD file:47ca6e777c36a4cfff   1.113 MB
```

Test the image, check for `/remove_me` being gone, make sure `hello\nworld` is in `/hello`, make sure the `HELLO` envvar's value is `world`

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add option to squash image layers to the `FROM` image after successful builds

**\- A picture of a cute animal (not mandatory but encouraged)**
![](http://www.southernsavers.com/wp-content/uploads/2012/03/build-a-bear-coupon.jpg)

Some of the implementation is a little rough around the edges but wanted to get this out there.
I also really wanted to make sure that when using the `full` option the user is prompted to make sure they know what it's really doing.
