### PR TITLE
Fixing Windows update logic.

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -54,10 +54,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 			"exitCode": strconv.Itoa(int(e.ExitCode)),
 		}
 		daemon.LogContainerEventWithAttributes(c, "die", attributes)
-		if err := c.ToDisk(); err != nil {
-			return err
-		}
-		return daemon.postRunProcessing(c, e)
+		return c.ToDisk()
 	case libcontainerd.StateExitProcess:
 		c.Lock()
 		defer c.Unlock()

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -352,7 +352,6 @@ func (clnt *client) Signal(containerID string, sig int) error {
 		if err := hcsshim.TerminateComputeSystem(containerID, hcsshim.TimeoutInfinite, context); err != nil {
 			logrus.Errorf("Failed to terminate %s - %q", containerID, err)
 		}
-
 	} else {
 		// Terminate Process
 		if err = hcsshim.TerminateProcessInComputeSystem(containerID, cont.systemPid); err != nil {
@@ -360,12 +359,10 @@ func (clnt *client) Signal(containerID string, sig int) error {
 			// Ignore errors
 			err = nil
 		}
-
-		// Shutdown the compute system
-		if err := hcsshim.ShutdownComputeSystem(containerID, hcsshim.TimeoutInfinite, context); err != nil {
-			logrus.Errorf("Failed to shutdown %s - %q", containerID, err)
-		}
 	}
+
+	cont.stopped.Wait()
+
 	return nil
 }
 


### PR DESCRIPTION
@jhowardmsft @brian-young
Removing the call to Shutdown from within Signal in order to rely on waitExit handling the exit of the process. Also added a WaitGroup to make sure `docker stop` waits until the container is really done processing the stop and postRunProcessing before returning to cmdline.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
