### PR TITLE
Give better error message if applying apparmor profile fails

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -145,6 +145,15 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
 			container.ExitCode = 126
 			err = fmt.Errorf("Container command '%s' could not be invoked", container.Path)
 		}
+		// set to 126 for apparmor errors
+		if strings.Contains(err.Error(), "apparmor failed to apply profile") {
+			container.ExitCode = 126
+			if strings.Contains(err.Error(), "no such file or directory") {
+				err = fmt.Errorf("Apparmor profile not found")
+			} else {
+				err = fmt.Errorf("Apparmor profile could not be applied")
+			}
+		}
 
 		container.Reset(false)
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1017,6 +1017,15 @@ func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 	}
 }
 
+// test that non existent apparmor profile gives helpful error
+func (s *DockerSuite) TestRunApparmorProfileNotFound(c *check.C) {
+	testRequires(c, SameHostDaemon, Apparmor)
+
+	out, _, err := dockerCmdWithError("run", "--security-opt", "apparmor=thisapparmorprofiledoesnotexistonthismachine", "busybox", "ls")
+	c.Assert(err, checker.NotNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "Error response from daemon: Apparmor profile not found.")
+}
+
 // make sure the default profile can be successfully parsed (using unshare as it is
 // something which we know is blocked in the default profile)
 func (s *DockerSuite) TestRunSeccompWithDefaultProfile(c *check.C) {


### PR DESCRIPTION
If the error came from apparmor give a more helpful error message
than just "Container command not found".

Fixes #22560

Signed-off-by: Justin Cormack justin.cormack@docker.com

![nautilus](https://cloud.githubusercontent.com/assets/482364/15178622/888a37ac-176e-11e6-8e1c-c04b88c41a27.jpg)
