### PR TITLE
docs: update graphdriver compatibility matrix

### DIFF
--- a/docs/userguide/storagedriver/selectadriver.md
+++ b/docs/userguide/storagedriver/selectadriver.md
@@ -40,10 +40,10 @@ driver names:
 |AUFS          |`aufs`               |
 |Btrfs         |`btrfs`              |
 |Device Mapper |`devicemapper`       |
-|VFS*          |`vfs`                |
+|VFS           |`vfs`                |
 |ZFS           |`zfs`                |
 
-To find out which storage driver is set on the daemon , you use the
+To find out which storage driver is set on the daemon, you use the
 `docker info` command:
 
     $ docker info
@@ -71,18 +71,18 @@ For example, the `btrfs` storage driver on a Btrfs backing filesystem. The
 following table lists each storage driver and whether it must match the host's
 backing file system:
 
-|Storage driver |Must match backing filesystem |Incompatible with   |
-|---------------|------------------------------|--------------------|
-|`overlay`      |No                            |`btrfs` `aufs` `zfs`|
-|`aufs`         |No                            |`btrfs` `aufs`      |
-|`btrfs`        |Yes                           |   N/A              |
-|`devicemapper` |No                            |   N/A              |
-|`vfs`          |No                            |   N/A              |
-|`zfs`          |Yes                           |   N/A              |
+|Storage driver |Commonly used on |Disabled on                   |
+|---------------|-----------------|------------------------------|
+|`overlay`      |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `zfs`|
+|`aufs`         |`ext4` `xfs`     |`btrfs` `aufs`                |
+|`btrfs`        |`btrfs` _only_   |   N/A                        |
+|`devicemapper` |`direct-lvm`     |   N/A                        |
+|`vfs`          |debugging only   |   N/A                        |
+|`zfs`          |`zfs` _only_     |   N/A                        |
 
 
 > **Note**
-> Incompatible with means some storage drivers can not run over certain backing
+> "Disabled on" means some storage drivers can not run over certain backing
 > filesystem.
 
 You can set the storage driver by passing the `--storage-driver=<name>` option


### PR DESCRIPTION
alternative to #22628

Commit 824c72f marked
overlay as "not compatible" with overlay.

This updates the compatibility matrix in the documentation
to match that.

Also see the discussion in #22624
