### PR TITLE
Allow Docker daemon to bind to different IP than --cluster-advertise.

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -263,6 +263,7 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
+	ClusterListen      string
 	SecurityOptions    []string
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -234,6 +234,10 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 		fmt.Fprintf(dockerCli.Out(), "Cluster Advertise: %s\n", info.ClusterAdvertise)
 	}
 
+	if info.ClusterListen != "" {
+		fmt.Fprintf(dockerCli.Out(), "Cluster Listen Address: %s\n", info.ClusterListen)
+	}
+
 	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
 		fmt.Fprintln(dockerCli.Out(), "Insecure Registries:")
 		for _, registry := range info.RegistryConfig.IndexConfigs {

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -119,6 +119,10 @@ type CommonConfig struct {
 	// reachable by other hosts.
 	ClusterAdvertise string `json:"cluster-advertise,omitempty"`
 
+	// ClusterListen is the network endpoint that the Engine bind to.
+	// This should be a 'host:port' combination on which that daemon instance is able to listen.
+	ClusterListen string `json:"cluster-listen,omitempty"`
+
 	// MaxConcurrentDownloads is the maximum number of downloads that
 	// may take place at a time for each pull.
 	MaxConcurrentDownloads *int `json:"max-concurrent-downloads,omitempty"`
@@ -179,6 +183,7 @@ func (config *Config) InstallCommonFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&config.LogConfig.Type, "log-driver", "json-file", "Default driver for container logs")
 	flags.Var(opts.NewNamedMapOpts("log-opts", config.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")
 	flags.StringVar(&config.ClusterAdvertise, "cluster-advertise", "", "Address or interface name to advertise")
+	flags.StringVar(&config.ClusterListen, "cluster-listen", "", "Address or interface name to listen")
 	flags.StringVar(&config.ClusterStore, "cluster-store", "", "URL of the distributed storage backend")
 	flags.Var(opts.NewNamedMapOpts("cluster-store-opts", config.ClusterOpts, nil), "cluster-store-opt", "Set cluster store options")
 	flags.StringVar(&config.CorsHeaders, "api-cors-header", "", "Set CORS headers in the remote API")
@@ -214,19 +219,30 @@ func NewConfig() *Config {
 	return &config
 }
 
-func parseClusterAdvertiseSettings(clusterStore, clusterAdvertise string) (string, error) {
+func parseClusterAdvertiseAndListenSettings(clusterStore, clusterAdvertise, clusterListen string) (string, string, error) {
+	if clusterAdvertise == "" && clusterListen == "" {
+		return "", "", errDiscoveryDisabled
+	}
 	if clusterAdvertise == "" {
-		return "", errDiscoveryDisabled
+		return "", "", fmt.Errorf("invalid cluster configuration. --cluster-listen must be accompanied by --cluster-store and --cluster-advertise configurations")
 	}
 	if clusterStore == "" {
-		return "", fmt.Errorf("invalid cluster configuration. --cluster-advertise must be accompanied by --cluster-store configuration")
+		return "", "", fmt.Errorf("invalid cluster configuration. --cluster-advertise must be accompanied by --cluster-store configuration")
 	}
 
 	advertise, err := discovery.ParseAdvertise(clusterAdvertise)
 	if err != nil {
-		return "", fmt.Errorf("discovery advertise parsing failed (%v)", err)
+		return "", "", fmt.Errorf("discovery advertise parsing failed (%v)", err)
 	}
-	return advertise, nil
+
+	if clusterListen == "" {
+		return advertise, advertise, nil
+	}
+	listen, err := discovery.ParseAdvertise(clusterListen)
+	if err != nil {
+		return "", "", fmt.Errorf("discovery listen parsing failed (%v)", err)
+	}
+	return advertise, listen, nil
 }
 
 // ReloadConfiguration reads the configuration in the host and reloads the daemon and server.

--- a/daemon/config_test.go
+++ b/daemon/config_test.go
@@ -34,18 +34,33 @@ func TestDaemonBrokenConfiguration(t *testing.T) {
 	}
 }
 
-func TestParseClusterAdvertiseSettings(t *testing.T) {
-	_, err := parseClusterAdvertiseSettings("something", "")
+func TestParseClusterAdvertiseAndListenSettings(t *testing.T) {
+	_, _, err := parseClusterAdvertiseAndListenSettings("something", "", "")
 	if err != errDiscoveryDisabled {
 		t.Fatalf("expected discovery disabled error, got %v\n", err)
 	}
 
-	_, err = parseClusterAdvertiseSettings("", "something")
+	_, _, err = parseClusterAdvertiseAndListenSettings("", "something", "something2")
 	if err == nil {
 		t.Fatalf("expected discovery store error, got %v\n", err)
 	}
 
-	_, err = parseClusterAdvertiseSettings("etcd", "127.0.0.1:8080")
+	_, _, err = parseClusterAdvertiseAndListenSettings("", "", "something2")
+	if err == nil {
+		t.Fatalf("expected discovery store error, got %v\n", err)
+	}
+
+	_, _, err = parseClusterAdvertiseAndListenSettings("etcd", "", "something2")
+	if err == nil {
+		t.Fatalf("expected discovery store error, got %v\n", err)
+	}
+
+	_, _, err = parseClusterAdvertiseAndListenSettings("etcd", "127.0.0.1:8080", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = parseClusterAdvertiseAndListenSettings("etcd", "127.0.0.1:8080", "0.0.0.0:8080")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -969,7 +969,7 @@ func (daemon *Daemon) IsShuttingDown() bool {
 
 // initDiscovery initializes the discovery watcher for this daemon.
 func (daemon *Daemon) initDiscovery(config *Config) error {
-	advertise, err := parseClusterAdvertiseSettings(config.ClusterStore, config.ClusterAdvertise)
+	advertise, listen, err := parseClusterAdvertiseAndListenSettings(config.ClusterStore, config.ClusterAdvertise, config.ClusterListen)
 	if err != nil {
 		if err == errDiscoveryDisabled {
 			return nil
@@ -978,6 +978,8 @@ func (daemon *Daemon) initDiscovery(config *Config) error {
 	}
 
 	config.ClusterAdvertise = advertise
+	config.ClusterListen = listen
+
 	discoveryWatcher, err := initDiscovery(config.ClusterStore, config.ClusterAdvertise, config.ClusterOpts)
 	if err != nil {
 		return fmt.Errorf("discovery initialization failed (%v)", err)
@@ -1115,12 +1117,16 @@ func (daemon *Daemon) Reload(config *Config) (err error) {
 func (daemon *Daemon) reloadClusterDiscovery(config *Config) error {
 	var err error
 	newAdvertise := daemon.configStore.ClusterAdvertise
+	newListen := daemon.configStore.ClusterListen
 	newClusterStore := daemon.configStore.ClusterStore
 	if config.IsValueSet("cluster-advertise") {
 		if config.IsValueSet("cluster-store") {
 			newClusterStore = config.ClusterStore
 		}
-		newAdvertise, err = parseClusterAdvertiseSettings(newClusterStore, config.ClusterAdvertise)
+		if config.IsValueSet("cluster-listen") {
+			newListen = config.ClusterListen
+		}
+		newAdvertise, newListen, err = parseClusterAdvertiseAndListenSettings(newClusterStore, config.ClusterAdvertise, newListen)
 		if err != nil && err != errDiscoveryDisabled {
 			return err
 		}
@@ -1133,7 +1139,7 @@ func (daemon *Daemon) reloadClusterDiscovery(config *Config) error {
 	}
 
 	// check discovery modifications
-	if !modifiedDiscoverySettings(daemon.configStore, newAdvertise, newClusterStore, config.ClusterOpts) {
+	if !modifiedDiscoverySettings(daemon.configStore, newAdvertise, newListen, newClusterStore, config.ClusterOpts) {
 		return nil
 	}
 
@@ -1159,6 +1165,7 @@ func (daemon *Daemon) reloadClusterDiscovery(config *Config) error {
 	daemon.configStore.ClusterStore = newClusterStore
 	daemon.configStore.ClusterOpts = config.ClusterOpts
 	daemon.configStore.ClusterAdvertise = newAdvertise
+	daemon.configStore.ClusterListen = newListen
 
 	if daemon.netController == nil {
 		return nil
@@ -1212,6 +1219,12 @@ func (daemon *Daemon) networkOptions(dconfig *Config, pg plugingetter.PluginGett
 
 	if dconfig.ClusterAdvertise != "" {
 		options = append(options, nwconfig.OptionDiscoveryAddress(dconfig.ClusterAdvertise))
+	}
+
+	if dconfig.ClusterListen != "" {
+		options = append(options, nwconfig.OptionDiscoveryBindAddress(dconfig.ClusterListen))
+	} else {
+		options = append(options, nwconfig.OptionDiscoveryBindAddress(dconfig.ClusterAdvertise))
 	}
 
 	options = append(options, nwconfig.OptionLabels(dconfig.Labels))

--- a/daemon/discovery.go
+++ b/daemon/discovery.go
@@ -200,8 +200,8 @@ func parseDiscoveryOptions(backendAddress string, clusterOpts map[string]string)
 }
 
 // modifiedDiscoverySettings returns whether the discovery configuration has been modified or not.
-func modifiedDiscoverySettings(config *Config, backendType, advertise string, clusterOpts map[string]string) bool {
-	if config.ClusterStore != backendType || config.ClusterAdvertise != advertise {
+func modifiedDiscoverySettings(config *Config, backendType, advertise string, listen string, clusterOpts map[string]string) bool {
+	if config.ClusterStore != backendType || config.ClusterAdvertise != advertise || config.ClusterListen != listen {
 		return true
 	}
 

--- a/daemon/discovery_test.go
+++ b/daemon/discovery_test.go
@@ -109,55 +109,61 @@ func TestModifiedDiscoverySettings(t *testing.T) {
 		expected bool
 	}{
 		{
-			current:  discoveryConfig("foo", "bar", map[string]string{}),
-			modified: discoveryConfig("foo", "bar", map[string]string{}),
+			current:  discoveryConfig("foo", "bar", "foobar", map[string]string{}),
+			modified: discoveryConfig("foo", "bar", "foobar", map[string]string{}),
 			expected: false,
 		},
 		{
-			current:  discoveryConfig("foo", "bar", map[string]string{"foo": "bar"}),
-			modified: discoveryConfig("foo", "bar", map[string]string{"foo": "bar"}),
+			current:  discoveryConfig("foo", "bar", "foobar", map[string]string{"foo": "bar"}),
+			modified: discoveryConfig("foo", "bar", "foobar", map[string]string{"foo": "bar"}),
 			expected: false,
 		},
 		{
-			current:  discoveryConfig("foo", "bar", map[string]string{}),
-			modified: discoveryConfig("foo", "bar", nil),
+			current:  discoveryConfig("foo", "bar", "foobar", map[string]string{}),
+			modified: discoveryConfig("foo", "bar", "foobar", nil),
 			expected: false,
 		},
 		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("foo", "bar", map[string]string{}),
+			current:  discoveryConfig("foo", "bar", "foobar", nil),
+			modified: discoveryConfig("foo", "bar", "foobar", map[string]string{}),
 			expected: false,
 		},
 		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("baz", "bar", nil),
+			current:  discoveryConfig("foo", "bar", "foobar", nil),
+			modified: discoveryConfig("baz", "bar", "foobar", nil),
 			expected: true,
 		},
 		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("foo", "baz", nil),
+			current:  discoveryConfig("foo", "bar", "foobar", nil),
+			modified: discoveryConfig("foo", "baz", "foobar", nil),
 			expected: true,
 		},
 		{
-			current:  discoveryConfig("foo", "bar", nil),
-			modified: discoveryConfig("foo", "bar", map[string]string{"foo": "bar"}),
+			current:  discoveryConfig("foo", "bar", "foobar", nil),
+			modified: discoveryConfig("foo", "bar", "foobar", map[string]string{"foo": "bar"}),
+			expected: true,
+		},
+		{
+			current:  discoveryConfig("foo", "bar", "foobar", nil),
+			modified: discoveryConfig("foo", "bar", "foobaz", map[string]string{}),
 			expected: true,
 		},
 	}
 
 	for _, c := range cases {
-		got := modifiedDiscoverySettings(c.current, c.modified.ClusterStore, c.modified.ClusterAdvertise, c.modified.ClusterOpts)
+		got := modifiedDiscoverySettings(c.current, c.modified.ClusterStore, c.modified.ClusterAdvertise, c.modified.ClusterListen, c.modified.ClusterOpts)
 		if c.expected != got {
 			t.Fatalf("expected %v, got %v: current config %v, new config %v", c.expected, got, c.current, c.modified)
 		}
 	}
 }
 
-func discoveryConfig(backendAddr, advertiseAddr string, opts map[string]string) *Config {
+func discoveryConfig(backendAddr, advertiseAddr string, listenAddr string, opts map[string]string) *Config {
 	return &Config{
 		CommonConfig: CommonConfig{
 			ClusterStore:     backendAddr,
 			ClusterAdvertise: advertiseAddr,
+			ClusterListen:    listenAddr,
 			ClusterOpts:      opts,
 		},
 	}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -113,6 +113,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		ServerVersion:      dockerversion.Version,
 		ClusterStore:       daemon.configStore.ClusterStore,
 		ClusterAdvertise:   daemon.configStore.ClusterAdvertise,
+		ClusterListen:      daemon.configStore.ClusterListen,
 		HTTPProxy:          sockets.GetProxyEnv("http_proxy"),
 		HTTPSProxy:         sockets.GetProxyEnv("https_proxy"),
 		NoProxy:            sockets.GetProxyEnv("no_proxy"),

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2974,3 +2974,44 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *check.C) 
 	content, _ := ioutil.ReadFile(s.d.logFile.Name())
 	c.Assert(string(content), checker.Contains, expectedMessage)
 }
+
+func (s *DockerDaemonSuite) TestDaemonDiscoveryListenConfigReload(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	// daemon config file
+	configFilePath := "test.json"
+	configFile, err := os.Create(configFilePath)
+	c.Assert(err, checker.IsNil)
+	defer os.Remove(configFilePath)
+
+	daemonConfig := `{ }`
+	fmt.Fprintf(configFile, "%s", daemonConfig)
+	configFile.Close()
+	c.Assert(s.d.Start(fmt.Sprintf("--config-file=%s", configFilePath)), check.IsNil)
+	c.Assert(err, checker.IsNil)
+
+	// daemon config file
+	daemonConfig = `{
+              "cluster-store": "consul://consuladdr:consulport/some/path",
+              "cluster-advertise": "192.168.56.100:0",
+              "cluster-listen": "10.2.3.4:0"
+        }`
+
+	configFile.Close()
+	os.Remove(configFilePath)
+
+	configFile, err = os.Create(configFilePath)
+	c.Assert(err, checker.IsNil)
+	defer os.Remove(configFilePath)
+	fmt.Fprintf(configFile, "%s", daemonConfig)
+	configFile.Close()
+
+	err = syscall.Kill(s.d.cmd.Process.Pid, syscall.SIGHUP)
+	time.Sleep(3 * time.Second)
+
+	out, err := s.d.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Store: consul://consuladdr:consulport/some/path"))
+	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Advertise: 192.168.56.100:0"))
+	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster Listen Address: 10.2.3.4:0"))
+}

--- a/vendor/src/github.com/docker/libnetwork/config/config.go
+++ b/vendor/src/github.com/docker/libnetwork/config/config.go
@@ -38,10 +38,11 @@ type DaemonCfg struct {
 
 // ClusterCfg represents cluster configuration
 type ClusterCfg struct {
-	Watcher   discovery.Watcher
-	Address   string
-	Discovery string
-	Heartbeat uint64
+	Watcher     discovery.Watcher
+	Address     string
+	BindAddress string
+	Discovery   string
+	Heartbeat   uint64
 }
 
 // LoadDefaultScopes loads default scope configs for scopes which
@@ -190,6 +191,13 @@ func OptionDiscoveryWatcher(watcher discovery.Watcher) Option {
 func OptionDiscoveryAddress(address string) Option {
 	return func(c *Config) {
 		c.Cluster.Address = address
+	}
+}
+
+// OptionDiscoveryBindAddress function returns an option setter for self discovery bind address
+func OptionDiscoveryBindAddress(address string) Option {
+	return func(c *Config) {
+		c.Cluster.BindAddress = address
 	}
 }
 

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_serf.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_serf.go
@@ -40,7 +40,8 @@ func (d *driver) serfInit() error {
 
 	config := serf.DefaultConfig()
 	config.Init()
-	config.MemberlistConfig.BindAddr = d.advertiseAddress
+	config.MemberlistConfig.BindAddr = d.bindAddress
+	config.MemberlistConfig.AdvertiseAddr = d.advertiseAddress
 
 	d.eventCh = make(chan serf.Event, 4)
 	config.EventCh = d.eventCh


### PR DESCRIPTION
**\- What I did**

This fix intends to address the issue raised in #22008 and #22087 where Docker's overlay networking can only bind to the IP specified in the option of `--cluster-advertise`. In certain situations, end user may want the overlay networking to bind to an internal IP while at the same time advertise a publicly accessible IP.

**\- How I did it**

This fix add an additional option of --cluster-listen to allow passing a differnt IP than --cluster-advertise.

**\- How to verify it**

Additional tests to cover the changes have been added.

In AWS,
1. Create an EC2 instances with IP of x.x.x.x
2. Assign an EIP y.y.y.y to the created instance.
3. Invoke docker daemon with
    `
    dockerd --debug --cluster-store=consul://<consul>:8500 --cluster-advertise=y.y.y.y:2376 --cluster-listen=0.0.0.0:2376
`
4. Run a docker daemon from another host and point the `--cluster-store` to the same key-value store.
5. Follow the same steps as specified in docs to create multi-host networking:
https://docs.docker.com/engine/userguide/networking/get-started-overlay/

**\- Description for the changelog**

Add the flag --cluster-listen for overlay network so that it will listen to a different IP than the advertised one (specified in --cluster-advertise).

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #22008. This fix fixes #22087.

**NOTE: Separate pull requests in libnetwork and engine-api:**
https://github.com/docker/libnetwork/pull/1175 
https://github.com/docker/engine-api/pull/365

Signed-off-by: Yong Tang yong.tang.github@outlook.com
