### PR TITLE
Update deprecated docs for cli flags removal.

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -92,7 +92,7 @@ The lxc-conf flag and API fields will also be removed.
 ### Old Command Line Options
 **Deprecated In Release: [v1.8.0](https://github.com/docker/docker/releases/tag/v1.8.0)**
 
-**Target For Removal In Release: v1.10**
+**Removed In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
 The flags `-d` and `--daemon` are deprecated in favor of the `daemon` subcommand:
 


### PR DESCRIPTION
The old command line options have been deprecated in 1.8.0 and eventually removed in 1.10.0 through PR #17724, though the deprecated.md still shows `Target For Removal In Release`.

This fix updates the deprecated.md and changes `Target For Removal In Release` to `Removed In Release`.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
