### PR TITLE
Correct docs for a docker container's clean-up.

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -834,7 +834,7 @@ does some more work:
 
 # USE the trap if you need to also do manual cleanup after the service is stopped,
 #     or need to start multiple services in the one container
-trap "echo TRAPed signal" HUP INT QUIT KILL TERM
+trap "echo TRAPed signal" HUP INT QUIT TERM
 
 # start service in background here
 /usr/sbin/apachectl start


### PR DESCRIPTION
The 'Unix Signals' (https://en.wikipedia.org/wiki/Unix_signal#Handling_signals) wiki explains that:
wiki explains that: 'There are two signals which cannot be intercepted and handled: SIGKILL and SIGSTOP.'

Signed-off-by: kevinmeredith kevin.m.meredith@gmail.com
