### PR TITLE
docs: update menu order in security section

### DIFF
--- a/docs/security/non-events.md
+++ b/docs/security/non-events.md
@@ -5,7 +5,6 @@ description = "Review of security vulnerabilities Docker mitigated"
 keywords = ["Docker, Docker documentation,  security, security non-events"]
 [menu.main]
 parent = "smn_secure_docker"
-weight =-99
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
oops, missed this in https://github.com/docker/docker/pull/22579; this page shouldn't be the first item in the menu :-)
