### PR TITLE
Fix concurrent map access in bytespipe

### DIFF
--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -20,7 +20,8 @@ var (
 	// ErrClosed is returned when Write is called on a closed BytesPipe.
 	ErrClosed = errors.New("write to closed BytesPipe")
 
-	bufPools = make(map[int]*sync.Pool)
+	bufPools     = make(map[int]*sync.Pool)
+	bufPoolsLock sync.Mutex
 )
 
 // BytesPipe is io.ReadWriteCloser which works similarly to pipe(queue).
@@ -164,17 +165,21 @@ func (bp *BytesPipe) Read(p []byte) (n int, err error) {
 
 func returnBuffer(b *fixedBuffer) {
 	b.Reset()
+	bufPoolsLock.Lock()
 	pool := bufPools[b.Cap()]
+	bufPoolsLock.Unlock()
 	if pool != nil {
 		pool.Put(b)
 	}
 }
 
 func getBuffer(size int) *fixedBuffer {
+	bufPoolsLock.Lock()
 	pool, ok := bufPools[size]
 	if !ok {
 		pool = &sync.Pool{New: func() interface{} { return &fixedBuffer{buf: make([]byte, 0, size)} }}
 		bufPools[size] = pool
 	}
+	bufPoolsLock.Unlock()
 	return pool.Get().(*fixedBuffer)
 }


### PR DESCRIPTION
When getting and returning a buffer, need to make sure to synchronize
access to the pools map.

Fixes #22612
