### PR TITLE
User network does not work with IPv6

### DIFF
--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -228,7 +228,8 @@ $ docker run --net=isolated_nw --ip=172.25.3.3 -itd --name=container3 busybox
 As you can see you were able to specify the ip address for your container.
 As long as the network to which the container is connecting was created with
 a user specified subnet, you will be able to select the IPv4 and/or IPv6 address(es)
-for your container when executing `docker run` and `docker network connect` commands.
+for your container when executing `docker run` and `docker network connect` commands
+by respectively passing the `--ip` and `--ip6` flags for IPv4 and IPv6.
 The selected IP address is part of the container networking configuration and will be
 preserved across container reload. The feature is only available on user defined networks,
 because they guarantee their subnets configuration does not change across daemon reload.


### PR DESCRIPTION
<!--
If you are reporting a new issue, make sure that we do not have any duplicates
already open. You can ensure this by searching the issue list for this
repository. If there is a duplicate, please close your issue and add a comment
to the existing issue instead.

If you suspect your issue is a bug, please edit your issue description to
include the BUG REPORT INFORMATION shown below. If you fail to provide this
information within 7 days, we cannot debug your issue and will close it. We
will, however, reopen it if you later provide the information.

For more information about reporting issues, see
https://github.com/docker/docker/blob/master/CONTRIBUTING.md#reporting-other-issues

---------------------------------------------------
BUG REPORT INFORMATION
---------------------------------------------------
Use the commands below to provide key information from your environment:
You do NOT have to include this information if this is a FEATURE REQUEST
-->

**Output of `docker version`:**

```
Client:
 Version:      1.11.1
 API version:  1.23
 Go version:   go1.5.4
 Git commit:   5604cbe
 Built:        Tue Apr 26 23:11:07 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.11.1
 API version:  1.23
 Go version:   go1.5.4
 Git commit:   5604cbe
 Built:        Tue Apr 26 23:11:07 2016
 OS/Arch:      linux/amd64
```

**Output of `docker info`:**

```
Containers: 12
 Running: 6
 Paused: 0
 Stopped: 6
Images: 110
Server Version: 1.11.1
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: extfs
 Dirs: 290
 Dirperm1 Supported: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins: 
 Volume: local
 Network: bridge null host
Kernel Version: 3.16.0-4-amd64
Operating System: Debian GNU/Linux 8 (jessie)
OSType: linux
Architecture: x86_64
CPUs: 2
Total Memory: 3.84 GiB
Name: *snip*
ID: *snip*
Docker Root Dir: /var/lib/docker
Debug mode (client): false
Debug mode (server): false
Registry: https://index.docker.io/v1/
WARNING: No memory limit support
WARNING: No swap limit support
WARNING: No kernel memory limit support
WARNING: No oom kill disable support
WARNING: No cpu cfs quota support
WARNING: No cpu cfs period support
```

**Additional environment details (AWS, VirtualBox, physical, etc.):**

Bare Metal Debian Jessie

**Steps to reproduce the issue:**

```
[root@~]docker network create -d bridge --ipv6 --subnet=2001:db8:1234:5678:1338::/80 test
366dbbe31c3847f14d9d662c484371cdb9e72bd722c191e04872e9b83aecf9bc
[root@~]docker run -it --rm --net=test --ip=2001:db8:1234:5678:1338::dead --ip=2001:db8:1234:5678:1338::beef debian
docker: Error response from daemon: User specified IP address is supported only when connecting to networks with user configured subnets.
[root@~ [125]]docker network rm test
[root@~]docker network create -d bridge --ipv6 --subnet=2001:db8:1234:5678:1338::/80 --subnet=172.25.0.0/16 test
8e5ef9b578199d965ab78701f1dc1a2feff7840dcacc349a6c960a0a7722999f
[root@~]docker run -it --rm --net=test --ip=2001:db8:1234:5678:1338::dead --ip=2001:db8:1234:5678:1338::beef debian
docker: Error response from daemon: Invalid address 2001:db8:1234:5678:1338::beef: It does not belong to any of this network's subnets.
[root@~ [125]]docker run -it --rm --net=test --ip=172.25.16.16 debian
*runs fine and even has IPv6 connectivity on a random IPv address*
```

**Describe the results you received:**

Using a custom docker bridge network does not properly detect IPv6 subnets.

**Describe the results you expected:**

Using a custom docker bridge network does properly detect IPv6 subnets.

**Additional information you deem important (e.g. issue happens only occasionally):**
