### PR TITLE
Fixing Windows update logic.

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -54,10 +54,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 			"exitCode": strconv.Itoa(int(e.ExitCode)),
 		}
 		daemon.LogContainerEventWithAttributes(c, "die", attributes)
-		if err := c.ToDisk(); err != nil {
-			return err
-		}
-		return daemon.postRunProcessing(c, e)
+		return c.ToDisk()
 	case libcontainerd.StateExitProcess:
 		c.Lock()
 		defer c.Unlock()


### PR DESCRIPTION
Removing the call to Shutdown from within Signal in order to rely on waitExit handling the exit of the process.

This replaces old PR https://github.com/docker/docker/pull/22645

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
