### PR TITLE
add trace in docker engine's pprof to show execution trace in binary form

### DIFF
--- a/api/server/profiler.go
+++ b/api/server/profiler.go
@@ -18,6 +18,7 @@ func profilerSetup(mainRouter *mux.Router) {
 	r.HandleFunc("/pprof/cmdline", pprof.Cmdline)
 	r.HandleFunc("/pprof/profile", pprof.Profile)
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
+	r.HandleFunc("/pprof/trace", pprof.Trace)
 	r.HandleFunc("/pprof/block", pprof.Handler("block").ServeHTTP)
 	r.HandleFunc("/pprof/heap", pprof.Handler("heap").ServeHTTP)
 	r.HandleFunc("/pprof/goroutine", pprof.Handler("goroutine").ServeHTTP)


### PR DESCRIPTION
add trace in docker engine's pprof to show execution trace in binary form
