### PR TITLE
Fix error for env variables example in docker reference

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -361,7 +361,7 @@ RUN /bin/bash -c 'source $HOME/.bashrc ; echo $HOME'
 > This means that normal shell processing does not happen. For example,
 > `RUN [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
-> a shell directly, for example: `RUN [ "sh", "-c", "echo", "$HOME" ]`.
+> a shell directly, for example: `RUN [ "sh", "-c", "echo $HOME" ]`.
 
 The cache for `RUN` instructions isn't invalidated automatically during
 the next build. The cache for an instruction like


### PR DESCRIPTION
**\- What I did**

Fix a typo in a small example using env variables in a command

**\- How I did it**

See previous

**\- How to verify it**

I created & ran a dockerfile that used a RUN command that passed an env variable as an arg.  (Also the correct syntax is used ~10 lines up)

**\- Description for the changelog**
Fix docker reference error for env variables example

**\- A picture of a cute animal (not mandatory but encouraged)**

![sugar glider](http://justsomething.co/wp-content/uploads/2013/11/cutest-baby-animals-4.jpg)
