### PR TITLE
Vendor engine-api to allow docker daemon reload event

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -24,7 +24,7 @@ clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 1fb8f09960cc32b9648495a422c960fb2a4f8a09
+clone git github.com/docker/engine-api e374c4fb5b121a8fd4295ec5eb91a8068c6304f4
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -166,7 +166,7 @@ func TestPidModeTest(t *testing.T) {
 func TestRestartPolicy(t *testing.T) {
 	restartPolicies := map[container.RestartPolicy][]bool{
 		// none, always, failure
-		container.RestartPolicy{}:                {false, false, false},
+		container.RestartPolicy{}:                {true, false, false},
 		container.RestartPolicy{"something", 0}:  {false, false, false},
 		container.RestartPolicy{"no", 0}:         {true, false, false},
 		container.RestartPolicy{"always", 0}:     {false, true, false},

--- a/vendor/src/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_build.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"golang.org/x/net/context"
 
@@ -117,19 +116,4 @@ func getDockerOS(serverHeader string) string {
 		osType = matches[1]
 	}
 	return osType
-}
-
-// convertKVStringsToMap converts ["key=value"] to {"key":"value"}
-func convertKVStringsToMap(values []string) map[string]string {
-	result := make(map[string]string, len(values))
-	for _, value := range values {
-		kv := strings.SplitN(value, "=", 2)
-		if len(kv) == 1 {
-			result[kv[0]] = ""
-		} else {
-			result[kv[0]] = kv[1]
-		}
-	}
-
-	return result
 }

--- a/vendor/src/github.com/docker/engine-api/client/image_pull.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_pull.go
@@ -32,7 +32,7 @@ func (cli *Client) ImagePull(ctx context.Context, ref string, options types.Imag
 	}
 
 	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/vendor/src/github.com/docker/engine-api/client/image_push.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_push.go
@@ -35,7 +35,7 @@ func (cli *Client) ImagePush(ctx context.Context, ref string, options types.Imag
 	query.Set("tag", tag)
 
 	resp, err := cli.tryImagePush(ctx, distributionRef.Name(), query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/vendor/src/github.com/docker/engine-api/client/image_search.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_search.go
@@ -27,7 +27,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	}
 
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return results, privilegeErr

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -195,7 +195,7 @@ type RestartPolicy struct {
 // IsNone indicates whether the container has the "no" restart policy.
 // This means the container will not automatically restart when exiting.
 func (rp *RestartPolicy) IsNone() bool {
-	return rp.Name == "no"
+	return rp.Name == "no" || rp.Name == ""
 }
 
 // IsAlways indicates whether the container has the "always" restart policy.

--- a/vendor/src/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/src/github.com/docker/engine-api/types/events/events.go
@@ -9,6 +9,8 @@ const (
 	VolumeEventType = "volume"
 	// NetworkEventType is the event type that networks generate
 	NetworkEventType = "network"
+	// DaemonEventType is the event type that daemon generate
+	DaemonEventType = "daemon"
 )
 
 // Actor describes something that generates events,


### PR DESCRIPTION
This fix updated the vendored engine-api to version `e374c4fb5b121a8fd4295ec5eb91a8068c6304f4`, which defines a new event type of `DaemonEventType`. The purpose is to allow emitting `daemon reload` event as is raised in #22463 and #22590.

This fix is related to #22463 and #22590.

**NOTE:** In addition to update vendor/engine-api, this pull request also adds an additional commit to fix the failed test `TestRestartPolicy` due to the engine-api update.

After vendor/engine-api has been updated, the following unit test fails:

```
--- FAIL: TestRestartPolicy (0.00s)
       hostconfig_test.go:177: RestartPolicy.IsNone for { 0} should have been false but was true
```

See: https://jenkins.dockerproject.org/job/Docker-PRs/27408/console

The reason for the above failed unit test is that the pull request:

docker/engine-api#200

changed the behavior of the restart policy and makes `restartpolicy.IsNone` return true if restart policy name is `""`. As a result, the above mentioned unit test fails.

This second commit fixes the inconsistency of the unit test so that `TestRestartPolicy` could pass again.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
