### PR TITLE
Update deprecated docs for LXC built-in exec driver

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -84,10 +84,9 @@ Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` a
 ### LXC built-in exec driver
 **Deprecated In Release: v1.8**
 
-**Target For Removal In Release: v1.10**
+**Removed In Release: v1.10**
 
-The built-in LXC execution driver is deprecated for an external implementation.
-The lxc-conf flag and API fields will also be removed.
+The built-in LXC execution driver, the lxc-conf flag, and API fields have been removed.
 
 ### Old Command Line Options
 **Deprecated In Release: [v1.8.0](https://github.com/docker/docker/releases/tag/v1.8.0)**


### PR DESCRIPTION
The LXC built-in exec driver has been deprecated in 1.8 and further removed in 1.10, yet in deprecated.md it still shows:

```
Target For Removal In Release: v1.10
```

This fix changes the above to `Removed In Release:`.

In addition, lxc-conf flag and API fields have already been removed in 1.10 as well so the related description has also been updated in this fix.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
