### PR TITLE
Fix a typo in work-with-networks.md

### DIFF
--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -289,7 +289,7 @@ examine its networking stack:
 $ docker attach container2
 ```
 
-If you look a the container's network stack you should see two Ethernet interfaces, one for the default bridge network and one for the `isolated_nw` network.
+If you look at the container's network stack you should see two Ethernet interfaces, one for the default bridge network and one for the `isolated_nw` network.
 
 ```bash
 / # ifconfig


### PR DESCRIPTION
This fix fixes a typo in the documentation of `work-with-networks.md`.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
