### PR TITLE
err.Error() will calling self forever

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -43,7 +43,7 @@ func New(handlers ...Handler) *Cli {
 type initErr struct{ error }
 
 func (err initErr) Error() string {
-	return err.Error()
+	return err.error.Error()
 }
 
 func (cli *Cli) command(args ...string) (func(...string) error, error) {


### PR DESCRIPTION
``` go
type initErr struct{ error }

func (err initErr) Error() string {
    return err.Error()
}

func main() {
    var i initErr = initErr{errors.New("error....")}
    fmt.Println(i.Error())
}

>>> runtime: goroutine stack exceeds 250000000-byte limit
>>> fatal error: stack overflow
```
