### PR TITLE
Update 'run' command doc for better readability.  Issue:#22721

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -246,12 +246,12 @@ system's interfaces.
 This sets simple (non-array) environmental variables in the container. For
 illustration all three
 flags are shown here. Where `-e`, `--env` take an environment variable and
-value, or if no `=` is provided, then that variable's current value is passed
-through (i.e. `$MYVAR1` from the host is set to `$MYVAR1` in the container).
-When no `=` is provided and that variable is not defined in the client's
-environment then that variable will be removed from the container's list of
-environment variables.
-All three flags, `-e`, `--env` and `--env-file` can be repeated.
+value, or if no `=` is provided, then that variable's current value, set via
+`export`, is passed through (i.e. `$MYVAR1` from the host is set to `$MYVAR1`
+in the container). When no `=` is provided and that variable is not defined
+in the client's environment then that variable will be removed from the
+container's list of environment variables. All three flags, `-e`, `--env` and
+`--env-file` can be repeated.
 
 Regardless of the order of these three flags, the `--env-file` are processed
 first, and then `-e`, `--env` flags. This way, the `-e` or `--env` will


### PR DESCRIPTION
closes #22721

**\- What I did**
Changed the documentation for 'run' cmd as recommended in #22721 i.e. in the [Set environment variables](https://github.com/docker/docker/blob/master/docs/reference/commandline/run.md#set-environment-variables--e---env---env-file) section, changed the following:

_From_: then that variable's current value is passed through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the container).

_To_: then that variable's current value, set via `export`, is passed through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the container).

**\- Description for the changelog**
'run' cmd doc updation for better readability
