### PR TITLE
Enable to dynamically reload authorization plugins via daemon.config

### DIFF
--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -104,6 +104,8 @@ support the Docker client interactions detailed in this section.
 Enable the authorization plugin with a dedicated command line flag in the
 `--authorization-plugin=PLUGIN_ID` format. The flag supplies a `PLUGIN_ID`
 value. This value can be the plugin’s socket or a path to a specification file.
+Authorization plugins can be loaded without restarting the daemon. Refer
+to the [`dockerd` documentation](../reference/commandline/dockerd.md#configuration-reloading) for more information.
 
 ```bash
 $ docker daemon --authorization-plugin=plugin1 --authorization-plugin=plugin2,...

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1152,6 +1152,7 @@ The list of currently supported options that can be reconfigured is this:
   the runtime shipped with the official docker packages.
 - `runtimes`: it updates the list of available OCI runtimes that can
   be used to run containers
+- `authorization-plugin`: specifies the authorization plugins to use.
 
 Updating and reloading the cluster configurations such as `--cluster-store`,
 `--cluster-advertise` and `--cluster-store-opts` will take effect only if

--- a/pkg/authorization/middleware.go
+++ b/pkg/authorization/middleware.go
@@ -14,16 +14,25 @@ type Middleware struct {
 }
 
 // NewMiddleware creates a new Middleware
-// with a slice of plugins.
-func NewMiddleware(p []Plugin) Middleware {
-	return Middleware{
-		plugins: p,
+// with a slice of plugins names.
+func NewMiddleware(names []string) *Middleware {
+	return &Middleware{
+		plugins: newPlugins(names),
 	}
 }
 
+// SetPlugins sets the plugin used for authorization
+func (m *Middleware) SetPlugins(names []string) {
+	m.plugins = newPlugins(names)
+}
+
 // WrapHandler returns a new handler function wrapping the previous one in the request chain.
-func (m Middleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+
+		if len(m.plugins) == 0 {
+			return handler(ctx, w, r, vars)
+		}
 
 		user := ""
 		userAuthNMethod := ""

--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -19,8 +19,8 @@ type Plugin interface {
 	AuthZResponse(*Request) (*Response, error)
 }
 
-// NewPlugins constructs and initializes the authorization plugins based on plugin names
-func NewPlugins(names []string) []Plugin {
+// newPlugins constructs and initializes the authorization plugins based on plugin names
+func newPlugins(names []string) []Plugin {
 	plugins := []Plugin{}
 	pluginsMap := make(map[string]struct{})
 	for _, name := range names {


### PR DESCRIPTION
**\- What I did**
Enable to dynamically change the `authz` plugin configuration (using daemon.config mechanism)
**\- How I did it**
Store a ref to the authz middleware, and replace plugin content as required
**\- How to verify it**
Added new plugins and removed them.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Following #22729, enable to dynamically reload/remove the daemon
authorization plugins (via standard reloading mechanism).
https://docs.docker.com/engine/reference/commandline/daemon/#daemon-
configuration-file

Daemon must store a reference to the authorization middleware to refresh
the plugin on configuration changes.

Signed-off-by: Liron Levin liron@twistlock.com
