### PR TITLE
Windows: Daemon default to Hyper-V containers on client

### DIFF
--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -164,7 +164,8 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 
 | Value     | Description                                                                                                                                                   |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value.  |
+| `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value if the
+daemon is running on Windows server, or `hyperv` if running on Windows client.  |
 | `process` | Namespace isolation only.                                                                                                                                     |
 | `hyperv`   | Hyper-V hypervisor partition-based isolation.                                                                                                                  |
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -527,8 +527,9 @@ can specify default container isolation technology with this, for example:
 
     $ dockerd --exec-opt isolation=hyperv
 
-Will make `hyperv` the default isolation technology on Windows, without specifying
-isolation value on daemon start, Windows isolation technology will default to `process`.
+Will make `hyperv` the default isolation technology on Windows. If no isolation
+value is specified on daemon start, on Windows client, the default is
+`hyperv`, and on Windows server, the default is `process`. 
 
 ## Daemon DNS options
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -618,14 +618,16 @@ On Microsoft Windows, can take any of these values:
 | `process` | Namespace isolation only.                                                                                                                                     |
 | `hyperv`   | Hyper-V hypervisor partition-based isolation.                                                                                                                  |
 
-In practice, when running on Microsoft Windows without a `daemon` option set,  these two commands are equivalent:
-
+On Windows, the default isolation for client is `hyperv`, and for server is
+`process`. Therefore when running on Windows server without a `daemon` option 
+set, these two commands are equivalent:
 ```
 $ docker run -d --isolation default busybox top
 $ docker run -d --isolation process busybox top
 ```
 
-If you have set the `--exec-opt isolation=hyperv` option on the Docker `daemon`, any of these commands also result in `hyperv` isolation:
+If you have set the `--exec-opt isolation=hyperv` option on the Docker `daemon`, 
+if running on Windows server, any of these commands also result in `hyperv` isolation:
 
 ```
 $ docker run -d --isolation default busybox top

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -197,7 +197,9 @@ two memory nodes.
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 
 **--isolation**="*default*"
-   Isolation specifies the type of isolation technology used by containers. 
+   Isolation specifies the type of isolation technology used by containers. Note
+that the default on Windows server is `process`, and the default on Windows client
+is `hyperv`. Linux only supports `default`.
 
 **--kernel-memory**=""
    Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -297,7 +297,9 @@ redirection on the host system.
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 
 **--isolation**="*default*"
-   Isolation specifies the type of isolation technology used by containers.
+   Isolation specifies the type of isolation technology used by containers. Note
+that the default on Windows server is `process`, and the default on Windows client
+is `hyperv`. Linux only supports `default`.
 
 **-l**, **--label**=[]
    Set metadata on the container (e.g., --label com.example.key=value)

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -39,6 +39,7 @@ dockerd - Enable daemon mode
 [**--ip-masq**[=*true*]]
 [**--iptables**[=*true*]]
 [**--ipv6**]
+[**--isolation**[=*default*]]
 [**-l**|**--log-level**[=*info*]]
 [**--label**[=*[]*]]
 [**--log-driver**[=*json-file*]]
@@ -182,6 +183,11 @@ unix://[/path/to/socket] to use.
 
 **--ipv6**=*true*|*false*
   Enable IPv6 support. Default is false. Docker will create an IPv6-enabled bridge with address fe80::1 which will allow you to create IPv6-enabled containers. Use together with `--fixed-cidr-v6` to provide globally routable IPv6 addresses. IPv6 forwarding will be enabled if not used with `--ip-forward=false`. This may collide with your host's current IPv6 settings. For more information please consult the documentation about "Advanced Networking - IPv6".
+
+**--isolation**="*default*"
+   Isolation specifies the type of isolation technology used by containers. Note
+that the default on Windows server is `process`, and the default on Windows client
+is `hyperv`. Linux only supports `default`.
 
 **-l**, **--log-level**="*debug*|*info*|*warn*|*error*|*fatal*"
   Set the logging level. Default is `info`.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes https://github.com/Microsoft/Virtualization-Documentation/issues/200. On client SKUs, sets the default isolation to Hyper-V and errors out if set to process, as client does not support Windows server containers. No change to server SKUs.

@mebersol @taylorb-microsoft
