### PR TITLE
Windows: Remove windowsdiff graph driver

### DIFF
--- a/daemon/graphdriver/driver_windows.go
+++ b/daemon/graphdriver/driver_windows.go
@@ -4,8 +4,6 @@ var (
 	// Slice of drivers that should be used in order
 	priority = []string{
 		"windowsfilter",
-		"windowsdiff",
-		"vfs",
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Removes support for the windowsdiff graph driver. Platform support hasn't been inbox for many months now. 

@swernli 
