### PR TITLE
Bug fix: `docker run -i --restart always` hangs

### DIFF
--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -287,7 +287,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		}
 	} else {
 		// No Autoremove: Simply retrieve the exit code
-		if !config.Tty {
+		if !config.Tty && hostConfig.RestartPolicy.IsNone() {
 			// In non-TTY mode, we can't detach, so we must wait for container exit
 			if status, err = client.ContainerWait(ctx, createResponse.ID); err != nil {
 				return err


### PR DESCRIPTION
Bug fix: docker run -i --restart always hangs on exit.

e.g.

```
$ docker run -i --restart always busybox sh
pwd
/
exit 11

<...hang...>
```

This is because Attach(daemon side) and Run(client side) both hangs on
`WaitStop`, if container is restarted too quickly, wait won't have chance
to get stop signal.

Besides that, restarting state should be considered stopped while
calling Wait, `docker wait` a restarting container should return
immediately too.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
