### PR TITLE
TestPsGroupPortRange: allocate less ports

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -501,7 +501,7 @@ func (s *DockerSuite) TestPsLinkedWithNoTrunc(c *check.C) {
 func (s *DockerSuite) TestPsGroupPortRange(c *check.C) {
 	// Problematic on Windows as it doesn't support port ranges as of Jan 2016
 	testRequires(c, DaemonIsLinux)
-	portRange := "3800-3900"
+	portRange := "3850-3900"
 	dockerCmd(c, "run", "-d", "--name", "porttest", "-p", portRange+":"+portRange, "busybox", "top")
 
 	out, _ := dockerCmd(c, "ps")


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/22722

This should not change the tests behavior though I've opened https://github.com/docker/docker/issues/22787.

ping @aboch @mavenugo 

Signed-off-by: Antonio Murdaca runcom@redhat.com
