### PR TITLE
Remove MountFlags in systemd unit to allow shared mount propagation

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,7 +11,6 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
-MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LimitCORE=infinity


### PR DESCRIPTION
ref https://github.com/docker/docker/issues/19625#issuecomment-219967798
