### PR TITLE
config: harmonize `ip-mask` -> `ip-masq`

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -41,7 +41,7 @@ type bridgeConfig struct {
 	EnableIPv6                  bool   `json:"ipv6,omitempty"`
 	EnableIPTables              bool   `json:"iptables,omitempty"`
 	EnableIPForward             bool   `json:"ip-forward,omitempty"`
-	EnableIPMasq                bool   `json:"ip-mask,omitempty"`
+	EnableIPMasq                bool   `json:"ip-masq,omitempty"`
 	EnableUserlandProxy         bool   `json:"userland-proxy,omitempty"`
 	DefaultIP                   net.IP `json:"ip,omitempty"`
 	IP                          string `json:"bip,omitempty"`

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -934,7 +934,7 @@ This is a full example of the allowed configuration options in the file:
 	"ipv6": false,
 	"iptables": false,
 	"ip-forward": false,
-	"ip-mask": false,
+	"ip-masq": false,
 	"userland-proxy": false,
 	"ip": "0.0.0.0",
 	"bridge": "",


### PR DESCRIPTION
**\- Description for the changelog**
Harmonize Docker Engine daemon parameter `--ip-masq`, replacing `--ip-mask` in `daemon.json`.

Closes #22807.
