### PR TITLE
Suppress "IPv4 forwarding" warning for --net=host

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -488,7 +488,9 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	if hostConfig.OomScoreAdj < -1000 || hostConfig.OomScoreAdj > 1000 {
 		return warnings, fmt.Errorf("Invalid value %d, range for oom score adj is [-1000, 1000]", hostConfig.OomScoreAdj)
 	}
-	if sysInfo.IPv4ForwardingDisabled {
+
+	// ip-forwarding does not affect container with '--net=host'
+	if sysInfo.IPv4ForwardingDisabled && !hostConfig.NetworkMode.IsHost() {
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
 		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
 	}

--- a/docs/userguide/networking/default_network/container-communication.md
+++ b/docs/userguide/networking/default_network/container-communication.md
@@ -37,6 +37,9 @@ or to turn it on manually:
   net.ipv4.conf.all.forwarding = 1
 ```
 
+> **Note**: this setting does not affect containers that use the host
+> network stack (`--net=host`).
+
 Many using Docker will want `ip_forward` to be on, to at least make
 communication _possible_ between containers and the wider world. May also be
 needed for inter-container communication if you are in a multiple bridge setup.


### PR DESCRIPTION
Containers using the host network stack (--net=host) are not affected by "ip-forwarding" being disabled, so there's not need to show a warning.

fixes https://github.com/docker/docker/issues/22805
