### PR TITLE
Add rinse32 script

### DIFF
--- a/contrib/mkimage/rinse32
+++ b/contrib/mkimage/rinse32
@@ -8,7 +8,7 @@ shift
 
 (
 	set -x
-	linux32 rinse --directory "$rootfsDir" --arch amd64 "$@"
+	linux32 rinse --directory "$rootfsDir" --arch i386 "$@"
 )
 
 "$(dirname "$BASH_SOURCE")/.febootstrap-minimize" "$rootfsDir"

--- a/contrib/mkimage/rinse32
+++ b/contrib/mkimage/rinse32
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+rootfsDir="$1"
+shift
+
+# specifying --arch below is safe because "$@" can override it and the "latest" one wins :)
+
+(
+	set -x
+	linux32 rinse --directory "$rootfsDir" --arch amd64 "$@"
+)
+
+"$(dirname "$BASH_SOURCE")/.febootstrap-minimize" "$rootfsDir"
+
+if [ -d "$rootfsDir/etc/sysconfig" ]; then
+	# allow networking init scripts inside the container to work without extra steps
+	echo 'NETWORKING=yes' > "$rootfsDir/etc/sysconfig/network"
+fi
+
+# make sure we're fully up-to-date, too
+(
+	set -x
+	linux32 chroot "$rootfsDir" yum update -y
+)


### PR DESCRIPTION
To build 32-bits docker images using rinse a few small modifications need to be made to the rinse script. This pull adds a rinse32 script which includes these changes, allowing for easy building of 32-bit centos and other rpm based linux distro docker images.
