### PR TITLE
Add rinse32 script

### DIFF
--- a/contrib/mkimage/rinse32
+++ b/contrib/mkimage/rinse32
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+rootfsDir="$1"
+shift
+
+# specifying --arch below is safe because "$@" can override it and the "latest" one wins :)
+
+(
+	set -x
+	linux32 rinse --directory "$rootfsDir" --arch i386 "$@"
+)
+
+"$(dirname "$BASH_SOURCE")/.febootstrap-minimize" "$rootfsDir"
+
+if [ -d "$rootfsDir/etc/sysconfig" ]; then
+	# allow networking init scripts inside the container to work without extra steps
+	echo 'NETWORKING=yes' > "$rootfsDir/etc/sysconfig/network"
+fi
+
+# make sure we're fully up-to-date, too
+(
+	set -x
+	linux32 chroot "$rootfsDir" yum update -y
+)


### PR DESCRIPTION
Add a rinse32 script which is capable of building 32-bits docker images for RPM based distro's

Signed-off-by: Robin Geuze robing@transip.nl
