### PR TITLE
plugins_volume.md: Add info about "Mountpoint"

### DIFF
--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -158,7 +158,7 @@ Docker needs reminding of the path to the volume on the host.
 ```
 
 Respond with the path on the host filesystem where the volume has been made
-available, and/or a string error if an error occurred.
+available, and/or a string error if an error occurred. If the volume is currently not mounted, but was created by your driver, return an empty string as `Mountpoint`.
 
 ### /VolumeDriver.Unmount
 
@@ -210,7 +210,7 @@ Get the volume info.
 }
 ```
 
-Respond with a string error if an error occurred.
+Respond with a string error if an error occurred. If the volume is currently not mounted, but was created by your driver, return an empty string as `Mountpoint`.
 
 
 ### /VolumeDriver.List
@@ -235,4 +235,4 @@ Get the list of volumes registered with the plugin.
 }
 ```
 
-Respond with a string error if an error occurred.
+Respond with a string error if an error occurred. If the volume is currently not mounted, but was created by your driver, return an empty string as `Mountpoint`.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Currently it was not clear how volume drivers should react if a volume
is created but currently not mounted. This clarifies the situation for
VolumeDriver.Path, VolumeDriver.Get, and VolumeDriver.List.

This fixes #22708

Signed-off-by: Roland Kammerer dev.rck@gmail.com
