### PR TITLE
builder: fixed workdir comment

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -266,7 +266,7 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 		return err
 	}
 
-	return b.commit("", b.runConfig.Cmd, fmt.Sprintf("WORKDIR %v", workdir))
+	return b.commit("", b.runConfig.Cmd, fmt.Sprintf("WORKDIR %v", b.runConfig.WorkingDir))
 }
 
 // RUN some command yo


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
I fixed workdir to replace a function pointer with the correct value.

**\- How I did it**
Replaced workdir with b.runConfig.WorkingDir.

**\- How to verify it**
Inspect intermediate container from the build.  Before it had function pointer as working directory.  After, it had the value.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed workdir comment.

**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](http://i.dailymail.co.uk/i/pix/2014/12/23/243CD9EC00000578-0-image-a-85_1419346133384.jpg)

Signed-off-by: Wendel Fleming wfleming@usc.edu
