### PR TITLE
removed unused const in config.go

### DIFF
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -16,11 +16,6 @@ const (
 	ConfigFileName = "config.json"
 	configFileDir  = ".docker"
 	oldConfigfile  = ".dockercfg"
-
-	// This constant is only used for really old config files when the
-	// URL wasn't saved as part of the config file and it was just
-	// assumed to be this value.
-	defaultIndexserver = "https://index.docker.io/v1/"
 )
 
 var (


### PR DESCRIPTION
**\- What I did**
Removed unused const in cliconfig/config.go 

**\- How I did it**
Removed the lines of code that specified unused constant

**\- How to verify it**
Ran local test to verify it doesn't effect docker cliconfig

**\- Description for the changelog**
removed unused const in cliconfig/config.go

Signed-off-by: Nirmal Mehta nirmalkmehta@gmail.com
