### PR TITLE
Suppress "IPv4 forwarding" warning for --net=none

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -489,8 +489,8 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		return warnings, fmt.Errorf("Invalid value %d, range for oom score adj is [-1000, 1000]", hostConfig.OomScoreAdj)
 	}
 
-	// ip-forwarding does not affect container with '--net=host'
-	if sysInfo.IPv4ForwardingDisabled && !hostConfig.NetworkMode.IsHost() {
+	// ip-forwarding does not affect container with '--net=host' (or '--net=none')
+	if sysInfo.IPv4ForwardingDisabled && !(hostConfig.NetworkMode.IsHost() || hostConfig.NetworkMode.IsNone()) {
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
 		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
 	}


### PR DESCRIPTION
There's no need to warn that "ip-forwarding" is disabled if a container doesn't use networking.
see https://github.com/docker/docker/issues/22805#issuecomment-220636773 for reference

To test;

```
echo 0 > /proc/sys/net/ipv4/ip_forward
dockerd -D --ip-forward=false &
```

should give no warning:

```
docker run -dit --net=host alpine sh
docker run -dit --net=none alpine sh
```

should give a warning:

```
docker run -dit alpine sh
WARNING: IPv4 forwarding is disabled. Networking will not work.
```
