### PR TITLE
Daemon images search refactoring

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -234,7 +234,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	}
 
 	//start the container
-	if err := cli.client.ContainerStart(ctx, createResponse.ID); err != nil {
+	if err := cli.client.ContainerStart(ctx, createResponse.ID, ""); err != nil {
 		// If we have holdHijackedConnection, we should notify
 		// holdHijackedConnection we are going to exit and wait
 		// to avoid the terminal are not restored.

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -113,7 +113,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		})
 
 		// 3. Start the container.
-		if err := cli.client.ContainerStart(ctx, container); err != nil {
+		if err := cli.client.ContainerStart(ctx, container, ""); err != nil {
 			cancelFun()
 			<-cErr
 			return err
@@ -147,7 +147,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 func (cli *DockerCli) startContainersWithoutAttachments(ctx context.Context, containers []string) error {
 	var failedContainers []string
 	for _, container := range containers {
-		if err := cli.client.ContainerStart(ctx, container); err != nil {
+		if err := cli.client.ContainerStart(ctx, container, ""); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			failedContainers = append(failedContainers, container)
 		} else {

--- a/daemon/search.go
+++ b/daemon/search.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"fmt"
+	"strconv"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	registrytypes "github.com/docker/engine-api/types/registry"
+)
+
+var acceptedSearchFilterTags = map[string]bool{
+	"is-automated": true,
+	"is-official":  true,
+	"stars":        true,
+}
+
+// SearchRegistryForImages queries the registry for images matching
+// term. authConfig is used to login.
+func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs string, term string,
+	authConfig *types.AuthConfig,
+	headers map[string][]string) (*registrytypes.SearchResults, error) {
+
+	searchFilters, err := filters.FromParam(filtersArgs)
+	if err != nil {
+		return nil, err
+	}
+	if err := searchFilters.Validate(acceptedSearchFilterTags); err != nil {
+		return nil, err
+	}
+
+	unfilteredResult, err := daemon.RegistryService.Search(ctx, term, authConfig, dockerversion.DockerUserAgent(ctx), headers)
+	if err != nil {
+		return nil, err
+	}
+
+	var isAutomated, isOfficial bool
+	var hasStarFilter = 0
+	if searchFilters.Include("is-automated") {
+		if searchFilters.UniqueExactMatch("is-automated", "true") {
+			isAutomated = true
+		} else if !searchFilters.UniqueExactMatch("is-automated", "false") {
+			return nil, fmt.Errorf("Invalid filter 'is-automated=%s'", searchFilters.Get("is-automated"))
+		}
+	}
+	if searchFilters.Include("is-official") {
+		if searchFilters.UniqueExactMatch("is-official", "true") {
+			isOfficial = true
+		} else if !searchFilters.UniqueExactMatch("is-official", "false") {
+			return nil, fmt.Errorf("Invalid filter 'is-official=%s'", searchFilters.Get("is-official"))
+		}
+	}
+	if searchFilters.Include("stars") {
+		hasStars := searchFilters.Get("stars")
+		for _, hasStar := range hasStars {
+			iHasStar, err := strconv.Atoi(hasStar)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid filter 'stars=%s'", hasStar)
+			}
+			if iHasStar > hasStarFilter {
+				hasStarFilter = iHasStar
+			}
+		}
+	}
+
+	filteredResults := []registrytypes.SearchResult{}
+	for _, result := range unfilteredResult.Results {
+		if searchFilters.Include("is-automated") {
+			if isAutomated != result.IsAutomated {
+				continue
+			}
+		}
+		if searchFilters.Include("is-official") {
+			if isOfficial != result.IsOfficial {
+				continue
+			}
+		}
+		if searchFilters.Include("stars") {
+			if result.StarCount < hasStarFilter {
+				continue
+			}
+		}
+		filteredResults = append(filteredResults, result)
+	}
+
+	return &registrytypes.SearchResults{
+		Query:      unfilteredResult.Query,
+		NumResults: len(filteredResults),
+		Results:    filteredResults,
+	}, nil
+}

--- a/daemon/search_test.go
+++ b/daemon/search_test.go
@@ -1,0 +1,357 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/registry"
+	"github.com/docker/engine-api/types"
+	registrytypes "github.com/docker/engine-api/types/registry"
+)
+
+type FakeService struct {
+	registry.DefaultService
+
+	shouldReturnError bool
+
+	term    string
+	results []registrytypes.SearchResult
+}
+
+func (s *FakeService) Search(ctx context.Context, term string, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
+	if s.shouldReturnError {
+		return nil, fmt.Errorf("Search unknown error")
+	}
+	return &registrytypes.SearchResults{
+		Query:      s.term,
+		NumResults: len(s.results),
+		Results:    s.results,
+	}, nil
+}
+
+func TestSearchRegistryForImagesErrors(t *testing.T) {
+	errorCases := []struct {
+		filtersArgs       string
+		shouldReturnError bool
+		expectedError     string
+	}{
+		{
+			expectedError:     "Search unknown error",
+			shouldReturnError: true,
+		},
+		{
+			filtersArgs:   "invalid json",
+			expectedError: "invalid character 'i' looking for beginning of value",
+		},
+		{
+			filtersArgs:   `{"type":{"custom":true}}`,
+			expectedError: "Invalid filter 'type'",
+		},
+		{
+			filtersArgs:   `{"is-automated":{"invalid":true}}`,
+			expectedError: "Invalid filter 'is-automated=[invalid]'",
+		},
+		{
+			filtersArgs:   `{"is-automated":{"true":true,"false":true}}`,
+			expectedError: "Invalid filter 'is-automated",
+		},
+		{
+			filtersArgs:   `{"is-official":{"invalid":true}}`,
+			expectedError: "Invalid filter 'is-official=[invalid]'",
+		},
+		{
+			filtersArgs:   `{"is-official":{"true":true,"false":true}}`,
+			expectedError: "Invalid filter 'is-official",
+		},
+		{
+			filtersArgs:   `{"stars":{"invalid":true}}`,
+			expectedError: "Invalid filter 'stars=invalid'",
+		},
+		{
+			filtersArgs:   `{"stars":{"1":true,"invalid":true}}`,
+			expectedError: "Invalid filter 'stars=invalid'",
+		},
+	}
+	for index, e := range errorCases {
+		daemon := &Daemon{
+			RegistryService: &FakeService{
+				shouldReturnError: e.shouldReturnError,
+			},
+		}
+		_, err := daemon.SearchRegistryForImages(context.Background(), e.filtersArgs, "term", nil, map[string][]string{})
+		if err == nil {
+			t.Errorf("%d: expected an error, got nothing", index)
+		}
+		if !strings.Contains(err.Error(), e.expectedError) {
+			t.Errorf("%d: expected error to contain %s, got %s", index, e.expectedError, err.Error())
+		}
+	}
+}
+
+func TestSearchRegistryForImages(t *testing.T) {
+	term := "term"
+	successCases := []struct {
+		filtersArgs     string
+		registryResults []registrytypes.SearchResult
+		expectedResults []registrytypes.SearchResult
+	}{
+		{
+			filtersArgs:     "",
+			registryResults: []registrytypes.SearchResult{},
+			expectedResults: []registrytypes.SearchResult{},
+		},
+		{
+			filtersArgs: "",
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+				},
+			},
+		},
+		{
+			filtersArgs: `{"is-automated":{"true":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{},
+		},
+		{
+			filtersArgs: `{"is-automated":{"true":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsAutomated: true,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsAutomated: true,
+				},
+			},
+		},
+		{
+			filtersArgs: `{"is-automated":{"false":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsAutomated: true,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{},
+		},
+		{
+			filtersArgs: `{"is-automated":{"false":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsAutomated: false,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsAutomated: false,
+				},
+			},
+		},
+		{
+			filtersArgs: `{"is-official":{"true":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{},
+		},
+		{
+			filtersArgs: `{"is-official":{"true":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsOfficial:  true,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsOfficial:  true,
+				},
+			},
+		},
+		{
+			filtersArgs: `{"is-official":{"false":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsOfficial:  true,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{},
+		},
+		{
+			filtersArgs: `{"is-official":{"false":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsOfficial:  false,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					IsOfficial:  false,
+				},
+			},
+		},
+		{
+			filtersArgs: `{"stars":{"0":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					StarCount:   0,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					StarCount:   0,
+				},
+			},
+		},
+		{
+			filtersArgs: `{"stars":{"1":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name",
+					Description: "description",
+					StarCount:   0,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{},
+		},
+		{
+			filtersArgs: `{"stars":{"1":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name0",
+					Description: "description0",
+					StarCount:   0,
+				},
+				{
+					Name:        "name1",
+					Description: "description1",
+					StarCount:   1,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name1",
+					Description: "description1",
+					StarCount:   1,
+				},
+			},
+		},
+		{
+			filtersArgs: `{"stars":{"1":true}, "is-official":{"true":true}, "is-automated":{"true":true}}`,
+			registryResults: []registrytypes.SearchResult{
+				{
+					Name:        "name0",
+					Description: "description0",
+					StarCount:   0,
+					IsOfficial:  true,
+					IsAutomated: true,
+				},
+				{
+					Name:        "name1",
+					Description: "description1",
+					StarCount:   1,
+					IsOfficial:  false,
+					IsAutomated: true,
+				},
+				{
+					Name:        "name2",
+					Description: "description2",
+					StarCount:   1,
+					IsOfficial:  true,
+					IsAutomated: false,
+				},
+				{
+					Name:        "name3",
+					Description: "description3",
+					StarCount:   2,
+					IsOfficial:  true,
+					IsAutomated: true,
+				},
+			},
+			expectedResults: []registrytypes.SearchResult{
+				{
+					Name:        "name3",
+					Description: "description3",
+					StarCount:   2,
+					IsOfficial:  true,
+					IsAutomated: true,
+				},
+			},
+		},
+	}
+	for index, s := range successCases {
+		daemon := &Daemon{
+			RegistryService: &FakeService{
+				term:    term,
+				results: s.registryResults,
+			},
+		}
+		results, err := daemon.SearchRegistryForImages(context.Background(), s.filtersArgs, term, nil, map[string][]string{})
+		if err != nil {
+			t.Errorf("%d: %v", index, err)
+		}
+		if results.Query != term {
+			t.Errorf("%d: expected Query to be %s, got %s", index, term, results.Query)
+		}
+		if results.NumResults != len(s.expectedResults) {
+			t.Errorf("%d: expected NumResults to be %d, got %d", index, len(s.expectedResults), results.NumResults)
+		}
+		for _, result := range results.Results {
+			found := false
+			for _, expectedResult := range s.expectedResults {
+				if expectedResult.Name == result.Name &&
+					expectedResult.Description == result.Description &&
+					expectedResult.IsAutomated == result.IsAutomated &&
+					expectedResult.IsOfficial == result.IsOfficial &&
+					expectedResult.StarCount == result.StarCount {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%d: expected results %v, got %v", index, s.expectedResults, results.Results)
+			}
+		}
+	}
+}

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -27,7 +27,7 @@ type ImagePullConfig struct {
 	ProgressOutput progress.Output
 	// RegistryService is the registry service to use for TLS configuration
 	// and endpoint lookup.
-	RegistryService *registry.Service
+	RegistryService registry.Service
 	// ImageEventLogger notifies events for a given image
 	ImageEventLogger func(id, name, action string)
 	// MetadataStore is the storage backend for distribution-specific

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -31,7 +31,7 @@ type ImagePushConfig struct {
 	ProgressOutput progress.Output
 	// RegistryService is the registry service to use for TLS configuration
 	// and endpoint lookup.
-	RegistryService *registry.Service
+	RegistryService registry.Service
 	// ImageEventLogger notifies events for a given image
 	ImageEventLogger func(id, name, action string)
 	// MetadataStore is the storage backend for distribution-specific

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api e374c4fb5b121a8fd4295ec5eb91a8068c6304f4
+clone git github.com/docker/engine-api 12fbeb3ac3ca5dc5d0f01d6bac9bda518d46d983
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -661,7 +661,7 @@ func TestMirrorEndpointLookup(t *testing.T) {
 		}
 		return false
 	}
-	s := Service{config: makeServiceConfig([]string{"my.mirror"}, nil)}
+	s := DefaultService{config: makeServiceConfig([]string{"my.mirror"}, nil)}
 
 	imageName, err := reference.WithName(IndexName + "/test/image")
 	if err != nil {

--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *Service) lookupV1Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *DefaultService) lookupV1Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
 	if hostname == DefaultNamespace {

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
 	if hostname == DefaultNamespace || hostname == DefaultV1Registry.Host {

--- a/vendor/src/github.com/docker/engine-api/client/checkpoint_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/checkpoint_create.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// CheckpointCreate creates a checkpoint from the given container with the given name
+func (cli *Client) CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error {
+	resp, err := cli.post(ctx, "/containers/"+container+"/checkpoints", nil, options, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/src/github.com/docker/engine-api/client/checkpoint_delete.go
+++ b/vendor/src/github.com/docker/engine-api/client/checkpoint_delete.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// CheckpointDelete deletes the checkpoint with the given name from the given container
+func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, checkpointID string) error {
+	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+checkpointID, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/src/github.com/docker/engine-api/client/checkpoint_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/checkpoint_list.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// CheckpointList returns the volumes configured in the docker host.
+func (cli *Client) CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error) {
+	var checkpoints []types.Checkpoint
+
+	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", nil, nil)
+	if err != nil {
+		return checkpoints, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&checkpoints)
+	ensureReaderClosed(resp)
+	return checkpoints, err
+}

--- a/vendor/src/github.com/docker/engine-api/client/container_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_inspect.go
@@ -52,14 +52,3 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 	err = json.NewDecoder(rdr).Decode(&response)
 	return response, body, err
 }
-
-func (cli *Client) containerInspectWithResponse(ctx context.Context, containerID string, query url.Values) (types.ContainerJSON, *serverResponse, error) {
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
-	if err != nil {
-		return types.ContainerJSON{}, serverResp, err
-	}
-
-	var response types.ContainerJSON
-	err = json.NewDecoder(serverResp.body).Decode(&response)
-	return response, serverResp, err
-}

--- a/vendor/src/github.com/docker/engine-api/client/container_start.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_start.go
@@ -1,10 +1,17 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ContainerStart sends a request to the docker daemon to start a container.
-func (cli *Client) ContainerStart(ctx context.Context, containerID string) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", nil, nil, nil)
+func (cli *Client) ContainerStart(ctx context.Context, containerID string, checkpointID string) error {
+	query := url.Values{}
+	query.Set("checkpoint", checkpointID)
+
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/src/github.com/docker/engine-api/client/events.go
+++ b/vendor/src/github.com/docker/engine-api/client/events.go
@@ -33,7 +33,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (io.
 		query.Set("until", ts)
 	}
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/src/github.com/docker/engine-api/client/image_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_list.go
@@ -15,7 +15,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return images, err
 		}

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -15,6 +15,9 @@ import (
 // APIClient is an interface that clients that talk with a docker server must implement.
 type APIClient interface {
 	ClientVersion() string
+	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
+	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
+	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
@@ -37,7 +40,7 @@ type APIClient interface {
 	ContainerRestart(ctx context.Context, container string, timeout int) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
-	ContainerStart(ctx context.Context, container string) error
+	ContainerStart(ctx context.Context, container string, checkpointID string) error
 	ContainerStop(ctx context.Context, container string, timeout int) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error

--- a/vendor/src/github.com/docker/engine-api/client/network_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_list.go
@@ -13,7 +13,7 @@ import (
 func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/src/github.com/docker/engine-api/client/request.go
+++ b/vendor/src/github.com/docker/engine-api/client/request.go
@@ -172,6 +172,8 @@ func encodeData(data interface{}) (*bytes.Buffer, error) {
 
 func ensureReaderClosed(response *serverResponse) {
 	if response != nil && response.body != nil {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, response.body, 512)
 		response.body.Close()
 	}
 }

--- a/vendor/src/github.com/docker/engine-api/client/volume_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/volume_list.go
@@ -15,7 +15,7 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (types.V
 	query := url.Values{}
 
 	if filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
 		if err != nil {
 			return volumes, err
 		}

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -10,6 +10,12 @@ import (
 	"github.com/docker/go-units"
 )
 
+// CheckpointCreateOptions holds parameters to create a checkpoint from a container
+type CheckpointCreateOptions struct {
+	CheckpointID string
+	Exit         bool
+}
+
 // ContainerAttachOptions holds parameters to attach to a container.
 type ContainerAttachOptions struct {
 	Stream     bool

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -257,11 +257,10 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount                int64  `json:"CpuCount"`   // CPU count
-	CPUPercent              int64  `json:"CpuPercent"` // CPU percent
-	IOMaximumIOps           uint64 // Maximum IOps for the container system drive
-	IOMaximumBandwidth      uint64 // Maximum IO in bytes per second for the container system drive
-	NetworkMaximumBandwidth uint64 // Maximum bandwidth of the network endpoint in bytes per second
+	CPUCount           int64  `json:"CpuCount"`   // CPU count
+	CPUPercent         int64  `json:"CpuPercent"` // CPU percent
+	IOMaximumIOps      uint64 // Maximum IOps for the container system drive
+	IOMaximumBandwidth uint64 // Maximum IO in bytes per second for the container system drive
 }
 
 // UpdateConfig holds the mutable attributes of a Container.

--- a/vendor/src/github.com/docker/engine-api/types/filters/parse.go
+++ b/vendor/src/github.com/docker/engine-api/types/filters/parse.go
@@ -215,10 +215,22 @@ func (filters Args) ExactMatch(field, source string) bool {
 	}
 
 	// try to match full name value to avoid O(N) regular expression matching
-	if fieldValues[source] {
+	return fieldValues[source]
+}
+
+// UniqueExactMatch returns true if there is only one filter and the source matches exactly this one.
+func (filters Args) UniqueExactMatch(field, source string) bool {
+	fieldValues := filters.fields[field]
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
 		return true
 	}
-	return false
+	if len(filters.fields[field]) != 1 {
+		return false
+	}
+
+	// try to match full name value to avoid O(N) regular expression matching
+	return fieldValues[source]
 }
 
 // FuzzyMatch returns true if the source matches exactly one of the filters,

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -471,3 +471,8 @@ type NetworkDisconnect struct {
 	Container string
 	Force     bool
 }
+
+// Checkpoint represents the details of a checkpoint
+type Checkpoint struct {
+	Name string // Name is the name of the checkpoint
+}


### PR DESCRIPTION
Add Unit test to `daemon.SearchRegistryForImages`…
… and refactor a little bit some daemon on the way 🐙.
- Move `SearchRegistryForImages` to a new file (`daemon/search.go`) as `daemon.go` is getting pretty big.
- `registry.Service` is now an interface (allowing us to decouple it a little bit and thus unit test easily).
- Add some unit test for `SearchRegistryForImages`.
- Use `UniqueExactMatch` for search filters
- And use empty restore id for now in `client.ContainerStart`.

/cc @thaJeztah @runcom @calavera @stevvooe @aaronlehmann 
/cc @boucher @crosbymichael for checkpoint stuff.

🐸
