### PR TITLE
Replace occurrences of U+2018 and U+2019 with U+0027 in manpages

### DIFF
--- a/man/docker-events.1.md
+++ b/man/docker-events.1.md
@@ -47,7 +47,7 @@ Docker networks report the following events:
 
 The `--since` and `--until` parameters can be Unix timestamps, date formatted
 timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
-relative to the client machine’s time. If you do not provide the `--since` option,
+relative to the client machine's time. If you do not provide the `--since` option,
 the command returns only new and/or live events.  Supported formats for date
 formatted time stamps include RFC3339Nano, RFC3339, `2006-01-02T15:04:05`,
 `2006-01-02T15:04:05.999999999`, `2006-01-02Z07:00`, and `2006-01-02`. The local

--- a/man/docker-logs.1.md
+++ b/man/docker-logs.1.md
@@ -21,7 +21,7 @@ any logs at the time you execute docker logs).
 
 The **docker logs --follow** command combines commands **docker logs** and
 **docker attach**. It will first return all logs from the beginning and
-then continue streaming new output from the container’s stdout and stderr.
+then continue streaming new output from the container's stdout and stderr.
 
 **Warning**: This command works only for the **json-file** or **journald**
 logging drivers.
@@ -46,7 +46,7 @@ logging drivers.
    Output the specified number of lines at the end of logs (defaults to all logs)
 
 The `--since` option can be Unix timestamps, date formatted timestamps, or Go
-duration strings (e.g. `10m`, `1h30m`) computed relative to the client machine’s
+duration strings (e.g. `10m`, `1h30m`) computed relative to the client machine's
 time. Supported formats for date formatted time stamps include RFC3339Nano,
 RFC3339, `2006-01-02T15:04:05`, `2006-01-02T15:04:05.999999999`,
 `2006-01-02Z07:00`, and `2006-01-02`. The local timezone on the client will be

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -103,7 +103,7 @@ pull** IMAGE, before it starts the container from that image.
 
    In foreground mode (the default when **-d**
 is not specified), **docker run** can start the process in the container
-and attach the console to the process’s standard input, output, and standard
+and attach the console to the process's standard input, output, and standard
 error. It can even pretend to be a TTY (this is what most commandline
 executables expect) and pass along signals. The **-a** option can be set for
 each of stdin, stdout, and stderr.
@@ -735,7 +735,7 @@ This should list the message sent to logger.
 
 If you do not specify -a then Docker will attach everything (stdin,stdout,stderr)
 . You can specify to which of the three standard streams (stdin, stdout, stderr)
-you’d like to connect instead, as in:
+you'd like to connect instead, as in:
 
     # docker run -a stdin -a stdout -i -t fedora /bin/bash
 
@@ -849,7 +849,7 @@ If a container is connected to the default bridge network and `linked`
 with other containers, then the container's `/etc/hosts` file is updated
 with the linked container's name.
 
-> **Note** Since Docker may live update the container’s `/etc/hosts` file, there
+> **Note** Since Docker may live update the container's `/etc/hosts` file, there
 may be situations when processes inside the container can end up reading an
 empty or incomplete `/etc/hosts` file. In most cases, retrying the read again
 should fix the problem.


### PR DESCRIPTION
**\- What I did**
I replaced all occurrences of the character `U+2018 LEFT SINGLE QUOTATION MARK` and `U+2019 RIGHT SINGLE QUOTATION MARK` with `U+0027 APOSTROPHE` in the `man` folder.
**\- How I did it**
I used the tool [ag](https://github.com/ggreer/the_silver_searcher) to search for occurrences of `U+2018` and `U+2019` in git-tracked files, then used `xargs` to run a substitute command with `sed`. Below is the exact command I ran.

``` sh
ag --nocolor -l $(printf '[\u2018\u2019]') man | xargs -I {} sed -i "" -e "s/$(printf '[\u2018\u2019]')/\\'/g" {}
```

**\- How to verify it**
I noticed the problem when browsing through the manpages and found the character `a` where I expected the character `'`. See below for screenshots from `man docker-run`. These should display as normal `'` characters after this patch.
<img width="850" alt="screen shot 2016-05-20 at 20 02 53" src="https://cloud.githubusercontent.com/assets/582273/15437183/f2c26668-1ec5-11e6-9f6a-9940bf238a5b.png">
<img width="850" alt="screen shot 2016-05-20 at 20 03 06" src="https://cloud.githubusercontent.com/assets/582273/15437184/f2c2a8da-1ec5-11e6-8cbc-bcbe87225068.png">

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Replace special single quote characters with basic apostrophes in manpages.

**\- A picture of a cute animal (not mandatory but encouraged)**
<img src="http://i.imgur.com/E8iuInW.jpg">
Taken from [this /r/cats post](https://www.reddit.com/r/cats/comments/4k575q/i_made_a_replica_of_the_cardboard_cafe_from_neko/) by Reddit user [/u/umenohana](https://www.reddit.com/user/umenohana).
