### PR TITLE
Begin a section in the check-config script to check limits

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -275,3 +275,16 @@ echo '- Storage Drivers:'
 } | sed 's/^/  /'
 echo
 
+check_limit_over()
+{
+	if [ $(cat "$1") -le "$2" ]; then
+		wrap_bad "- $1" "$(cat $1)"
+		wrap_color "    This should be set to at least $2, for example set: sysctl -w kernel/keys/root_maxkeys=1000000" bold black
+	else
+		wrap_good "- $1" "$(cat $1)"
+	fi
+}
+
+echo 'Limits:'
+check_limit_over /proc/sys/kernel/keys/root_maxkeys 10000
+echo


### PR DESCRIPTION
Initially this checks the kernel's maxkeys setting which is
low in some older distribution kernels, such that only 200 containers
can be created, reported in #22865.

Signed-off-by: Justin Cormack justin.cormack@docker.com

In future other limit checks can be added here.

![cute-alpaca-wallpaper-4](https://cloud.githubusercontent.com/assets/482364/15444412/325596ae-1ea5-11e6-8c0a-5b7b32a80367.jpg)
