### PR TITLE
Windows: CMD not honouring arg escaping

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -407,6 +407,8 @@ func cmd(b *Builder, args []string, attributes map[string]bool, original string)
 	}
 
 	b.runConfig.Cmd = strslice.StrSlice(cmdSlice)
+	// set config as already being escaped, this prevents double escaping on windows
+	b.runConfig.ArgsEscaped = true
 
 	if err := b.commit("", b.runConfig.Cmd, fmt.Sprintf("CMD %q", cmdSlice)); err != nil {
 		return err

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -74,6 +74,7 @@ func merge(userConf, imageConf *containertypes.Config) error {
 	if len(userConf.Entrypoint) == 0 {
 		if len(userConf.Cmd) == 0 {
 			userConf.Cmd = imageConf.Cmd
+			userConf.ArgsEscaped = imageConf.ArgsEscaped
 		}
 
 		if userConf.Entrypoint == nil {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6952,3 +6952,28 @@ func (s *DockerSuite) TestBuildShellWindowsPowershell(c *check.C) {
 		c.Fatalf("Line with 'John' not found in output %q", out)
 	}
 }
+
+// #22868. Make sure shell-form CMD is marked as escaped in the config of the image
+func (s *DockerSuite) TestBuildCmdShellArgsEscaped(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	name := "testbuildcmdshellescaped"
+
+	_, err := buildImage(name, `
+  FROM `+minimalBaseImage()+`
+  CMD "tasklist"
+  `, true)
+	if err != nil {
+		c.Fatal(err)
+	}
+	res := inspectFieldJSON(c, name, "Config.ArgsEscaped")
+	if res != "true" {
+		c.Fatalf("CMD did not update Config.ArgsEscaped on image: %v", res)
+	}
+	dockerCmd(c, "run", "--name", "inspectme", name)
+	dockerCmd(c, "wait", "inspectme")
+	res = inspectFieldJSON(c, name, "Config.Cmd")
+
+	if res != `["cmd","/S","/C","\"tasklist\""]` {
+		c.Fatalf("CMD was not escaped Config.Cmd: got %v", res)
+	}
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes https://github.com/Microsoft/Virtualization-Documentation/issues/266#issuecomment-220093401 when validated in conjunction with https://github.com/docker/docker/pull/22489.

@darrenstahlmsft There are two things here: This ensures that the builder also sets the argument escaping for CMD (Windows specific), the exact same way it does for RUN. The second is that when merging an image config with a user config, we were not honouring the fact that arguments had been escaped.
