### PR TITLE
Rework usage of context.Context in api/client

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -19,7 +19,7 @@ import (
 	networktypes "github.com/docker/engine-api/types/network"
 )
 
-func (cli *DockerCli) pullImage(image string, out io.Writer) error {
+func (cli *DockerCli) pullImage(ctx context.Context, image string, out io.Writer) error {
 	ref, err := reference.ParseNamed(image)
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func (cli *DockerCli) pullImage(image string, out io.Writer) error {
 		return err
 	}
 
-	authConfig := cli.resolveAuthConfig(repoInfo.Index)
+	authConfig := cli.resolveAuthConfig(ctx, repoInfo.Index)
 	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (cli *DockerCli) pullImage(image string, out io.Writer) error {
 		RegistryAuth: encodedAuth,
 	}
 
-	responseBody, err := cli.client.ImageCreate(context.Background(), image, options)
+	responseBody, err := cli.client.ImageCreate(ctx, image, options)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func newCIDFile(path string) (*cidFile, error) {
 	return &cidFile{path: path, file: f}, nil
 }
 
-func (cli *DockerCli) createContainer(config *container.Config, hostConfig *container.HostConfig, networkingConfig *networktypes.NetworkingConfig, cidfile, name string) (*types.ContainerCreateResponse, error) {
+func (cli *DockerCli) createContainer(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *networktypes.NetworkingConfig, cidfile, name string) (*types.ContainerCreateResponse, error) {
 	var containerIDFile *cidFile
 	if cidfile != "" {
 		var err error
@@ -89,7 +89,7 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 
 		if ref, ok := ref.(reference.NamedTagged); ok && isTrusted() {
 			var err error
-			trustedRef, err = cli.trustedReference(ref)
+			trustedRef, err = cli.trustedReference(ctx, ref)
 			if err != nil {
 				return nil, err
 			}
@@ -98,7 +98,7 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 	}
 
 	//create the container
-	response, err := cli.client.ContainerCreate(context.Background(), config, hostConfig, networkingConfig, name)
+	response, err := cli.client.ContainerCreate(ctx, config, hostConfig, networkingConfig, name)
 
 	//if image not found try to pull it
 	if err != nil {
@@ -106,17 +106,17 @@ func (cli *DockerCli) createContainer(config *container.Config, hostConfig *cont
 			fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", ref.String())
 
 			// we don't want to write to stdout anything apart from container.ID
-			if err = cli.pullImage(config.Image, cli.err); err != nil {
+			if err = cli.pullImage(ctx, config.Image, cli.err); err != nil {
 				return nil, err
 			}
 			if ref, ok := ref.(reference.NamedTagged); ok && trustedRef != nil {
-				if err := cli.tagTrusted(trustedRef, ref); err != nil {
+				if err := cli.tagTrusted(ctx, trustedRef, ref); err != nil {
 					return nil, err
 				}
 			}
 			// Retry
 			var retryErr error
-			response, retryErr = cli.client.ContainerCreate(context.Background(), config, hostConfig, networkingConfig, name)
+			response, retryErr = cli.client.ContainerCreate(ctx, config, hostConfig, networkingConfig, name)
 			if retryErr != nil {
 				return nil, retryErr
 			}
@@ -158,7 +158,7 @@ func (cli *DockerCli) CmdCreate(args ...string) error {
 		cmd.Usage()
 		return nil
 	}
-	response, err := cli.createContainer(config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, *flName)
+	response, err := cli.createContainer(context.Background(), config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, *flName)
 	if err != nil {
 		return err
 	}

--- a/api/client/export.go
+++ b/api/client/export.go
@@ -38,5 +38,4 @@ func (cli *DockerCli) CmdExport(args ...string) error {
 	}
 
 	return copyToFile(*outfile, responseBody)
-
 }

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -40,12 +40,14 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		cli.in = os.Stdin
 	}
 
+	ctx := context.Background()
+
 	var serverAddress string
 	var isDefaultRegistry bool
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	} else {
-		serverAddress = cli.electAuthServer()
+		serverAddress = cli.electAuthServer(ctx)
 		isDefaultRegistry = true
 	}
 
@@ -54,7 +56,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		return err
 	}
 
-	response, err := cli.client.RegistryLogin(context.Background(), authConfig)
+	response, err := cli.client.RegistryLogin(ctx, authConfig)
 	if err != nil {
 		return err
 	}

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -3,6 +3,8 @@ package client
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -22,7 +24,7 @@ func (cli *DockerCli) CmdLogout(args ...string) error {
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	} else {
-		serverAddress = cli.electAuthServer()
+		serverAddress = cli.electAuthServer(context.Background())
 	}
 
 	// check if we're logged in based on the records in the config file

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -33,7 +33,9 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 
 	name := cmd.Arg(0)
 
-	c, err := cli.client.ContainerInspect(context.Background(), name)
+	ctx := context.Background()
+
+	c, err := cli.client.ContainerInspect(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -51,7 +53,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		Tail:       *tail,
 		Details:    *details,
 	}
-	responseBody, err := cli.client.ContainerLogs(context.Background(), name, options)
+	responseBody, err := cli.client.ContainerLogs(ctx, name, options)
 	if err != nil {
 		return err
 	}

--- a/api/client/network.go
+++ b/api/client/network.go
@@ -104,9 +104,11 @@ func (cli *DockerCli) CmdNetworkRm(args ...string) error {
 		return err
 	}
 
+	ctx := context.Background()
+
 	status := 0
 	for _, net := range cmd.Args() {
-		if err := cli.client.NetworkRemove(context.Background(), net); err != nil {
+		if err := cli.client.NetworkRemove(ctx, net); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			status = 1
 			continue
@@ -239,8 +241,10 @@ func (cli *DockerCli) CmdNetworkInspect(args ...string) error {
 		return err
 	}
 
+	ctx := context.Background()
+
 	inspectSearcher := func(name string) (interface{}, []byte, error) {
-		i, err := cli.client.NetworkInspect(context.Background(), name)
+		i, err := cli.client.NetworkInspect(ctx, name)
 		return i, nil, err
 	}
 

--- a/api/client/pause.go
+++ b/api/client/pause.go
@@ -19,9 +19,11 @@ func (cli *DockerCli) CmdPause(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
+	ctx := context.Background()
+
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerPause(context.Background(), name); err != nil {
+		if err := cli.client.ContainerPause(ctx, name); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -55,18 +55,20 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 		return err
 	}
 
-	authConfig := cli.resolveAuthConfig(repoInfo.Index)
+	ctx := context.Background()
+
+	authConfig := cli.resolveAuthConfig(ctx, repoInfo.Index)
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(repoInfo.Index, "pull")
 
 	if isTrusted() && !registryRef.HasDigest() {
 		// Check if tag is digest
-		return cli.trustedPull(repoInfo, registryRef, authConfig, requestPrivilege)
+		return cli.trustedPull(ctx, repoInfo, registryRef, authConfig, requestPrivilege)
 	}
 
-	return cli.imagePullPrivileged(authConfig, distributionRef.String(), requestPrivilege, *allTags)
+	return cli.imagePullPrivileged(ctx, authConfig, distributionRef.String(), requestPrivilege, *allTags)
 }
 
-func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc, all bool) error {
+func (cli *DockerCli) imagePullPrivileged(ctx context.Context, authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc, all bool) error {
 
 	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {
@@ -78,7 +80,7 @@ func (cli *DockerCli) imagePullPrivileged(authConfig types.AuthConfig, ref strin
 		All:           all,
 	}
 
-	responseBody, err := cli.client.ImagePull(context.Background(), ref, options)
+	responseBody, err := cli.client.ImagePull(ctx, ref, options)
 	if err != nil {
 		return err
 	}

--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -23,6 +23,8 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
+	ctx := context.Background()
+
 	var errs []string
 	for _, name := range cmd.Args() {
 		if name == "" {
@@ -30,7 +32,7 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 		}
 		name = strings.Trim(name, "/")
 
-		if err := cli.removeContainer(name, *v, *link, *force); err != nil {
+		if err := cli.removeContainer(ctx, name, *v, *link, *force); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)
@@ -42,13 +44,13 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 	return nil
 }
 
-func (cli *DockerCli) removeContainer(container string, removeVolumes, removeLinks, force bool) error {
+func (cli *DockerCli) removeContainer(ctx context.Context, container string, removeVolumes, removeLinks, force bool) error {
 	options := types.ContainerRemoveOptions{
 		RemoveVolumes: removeVolumes,
 		RemoveLinks:   removeLinks,
 		Force:         force,
 	}
-	if err := cli.client.ContainerRemove(context.Background(), container, options); err != nil {
+	if err := cli.client.ContainerRemove(ctx, container, options); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/rmi.go
+++ b/api/client/rmi.go
@@ -31,6 +31,8 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 		v.Set("noprune", "1")
 	}
 
+	ctx := context.Background()
+
 	var errs []string
 	for _, image := range cmd.Args() {
 		options := types.ImageRemoveOptions{
@@ -38,7 +40,7 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 			PruneChildren: !*noprune,
 		}
 
-		dels, err := cli.client.ImageRemove(context.Background(), image, options)
+		dels, err := cli.client.ImageRemove(ctx, image, options)
 		if err != nil {
 			errs = append(errs, err.Error())
 		} else {

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -147,20 +147,20 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = cli.getTtySize()
 	}
 
-	createResponse, err := cli.createContainer(config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, *flName)
+	ctx, cancelFun := context.WithCancel(context.Background())
+
+	createResponse, err := cli.createContainer(ctx, config, hostConfig, networkingConfig, hostConfig.ContainerIDFile, *flName)
 	if err != nil {
 		cmd.ReportError(err.Error(), true)
 		return runStartContainerErr(err)
 	}
 	if sigProxy {
-		sigc := cli.forwardAllSignals(createResponse.ID)
+		sigc := cli.forwardAllSignals(ctx, createResponse.ID)
 		defer signal.StopCatch(sigc)
 	}
 	var (
 		waitDisplayID chan struct{}
 		errCh         chan error
-		cancelFun     context.CancelFunc
-		ctx           context.Context
 	)
 	if !config.AttachStdout && !config.AttachStderr {
 		// Make this asynchronous to allow the client to write to stdin before having to read the ID
@@ -205,7 +205,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			DetachKeys: cli.configFile.DetachKeys,
 		}
 
-		resp, errAttach := cli.client.ContainerAttach(context.Background(), createResponse.ID, options)
+		resp, errAttach := cli.client.ContainerAttach(ctx, createResponse.ID, options)
 		if errAttach != nil && errAttach != httputil.ErrPersistEOF {
 			// ContainerAttach returns an ErrPersistEOF (connection closed)
 			// means server met an error and put it in Hijacked connection
@@ -214,7 +214,6 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		}
 		defer resp.Close()
 
-		ctx, cancelFun = context.WithCancel(context.Background())
 		errCh = promise.Go(func() error {
 			errHijack := cli.holdHijackedConnection(ctx, config.Tty, in, out, stderr, resp)
 			if errHijack == nil {
@@ -226,14 +225,16 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 
 	if *flAutoRemove {
 		defer func() {
-			if err := cli.removeContainer(createResponse.ID, true, false, true); err != nil {
+			// Explicitly not sharing the context as it could be "Done" (by calling cancelFun)
+			// and thus the container would not be removed.
+			if err := cli.removeContainer(context.Background(), createResponse.ID, true, false, true); err != nil {
 				fmt.Fprintf(cli.err, "%v\n", err)
 			}
 		}()
 	}
 
 	//start the container
-	if err := cli.client.ContainerStart(context.Background(), createResponse.ID); err != nil {
+	if err := cli.client.ContainerStart(ctx, createResponse.ID); err != nil {
 		// If we have holdHijackedConnection, we should notify
 		// holdHijackedConnection we are going to exit and wait
 		// to avoid the terminal are not restored.
@@ -247,7 +248,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	}
 
 	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && cli.isTerminalOut {
-		if err := cli.monitorTtySize(createResponse.ID, false); err != nil {
+		if err := cli.monitorTtySize(ctx, createResponse.ID, false); err != nil {
 			fmt.Fprintf(cli.err, "Error monitoring TTY size: %s\n", err)
 		}
 	}
@@ -272,23 +273,23 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	if *flAutoRemove {
 		// Autoremove: wait for the container to finish, retrieve
 		// the exit code and remove the container
-		if status, err = cli.client.ContainerWait(context.Background(), createResponse.ID); err != nil {
+		if status, err = cli.client.ContainerWait(ctx, createResponse.ID); err != nil {
 			return runStartContainerErr(err)
 		}
-		if _, status, err = getExitCode(cli, createResponse.ID); err != nil {
+		if _, status, err = cli.getExitCode(ctx, createResponse.ID); err != nil {
 			return err
 		}
 	} else {
 		// No Autoremove: Simply retrieve the exit code
 		if !config.Tty {
 			// In non-TTY mode, we can't detach, so we must wait for container exit
-			if status, err = cli.client.ContainerWait(context.Background(), createResponse.ID); err != nil {
+			if status, err = cli.client.ContainerWait(ctx, createResponse.ID); err != nil {
 				return err
 			}
 		} else {
 			// In TTY mode, there is a race: if the process dies too slowly, the state could
 			// be updated after the getExitCode call and result in the wrong exit code being reported
-			if _, status, err = getExitCode(cli, createResponse.ID); err != nil {
+			if _, status, err = cli.getExitCode(ctx, createResponse.ID); err != nil {
 				return err
 			}
 		}

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -58,7 +58,9 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		return err
 	}
 
-	authConfig := cli.resolveAuthConfig(indexInfo)
+	ctx := context.Background()
+
+	authConfig := cli.resolveAuthConfig(ctx, indexInfo)
 	requestPrivilege := cli.registryAuthenticationPrivilegedFunc(indexInfo, "search")
 
 	encodedAuth, err := encodeAuthToBase64(authConfig)
@@ -72,7 +74,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		Filters:       filterArgs,
 	}
 
-	unorderedResults, err := cli.client.ImageSearch(context.Background(), name, options)
+	unorderedResults, err := cli.client.ImageSearch(ctx, name, options)
 	if err != nil {
 		return err
 	}

--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -33,6 +33,8 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 	showAll := len(names) == 0
 	closeChan := make(chan error)
 
+	ctx := context.Background()
+
 	// monitorContainerEvents watches for container creation and removal (only
 	// used when calling `docker stats` without arguments).
 	monitorContainerEvents := func(started chan<- struct{}, c chan events.Message) {
@@ -41,7 +43,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 		options := types.EventsOptions{
 			Filters: f,
 		}
-		resBody, err := cli.client.Events(context.Background(), options)
+		resBody, err := cli.client.Events(ctx, options)
 		// Whether we successfully subscribed to events or not, we can now
 		// unblock the main goroutine.
 		close(started)
@@ -71,7 +73,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 		options := types.ContainerListOptions{
 			All: *all,
 		}
-		cs, err := cli.client.ContainerList(context.Background(), options)
+		cs, err := cli.client.ContainerList(ctx, options)
 		if err != nil {
 			closeChan <- err
 		}
@@ -79,7 +81,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 			s := &containerStats{Name: container.ID[:12]}
 			if cStats.add(s) {
 				waitFirst.Add(1)
-				go s.Collect(cli.client, !*noStream, waitFirst)
+				go s.Collect(ctx, cli.client, !*noStream, waitFirst)
 			}
 		}
 	}
@@ -96,7 +98,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 				s := &containerStats{Name: e.ID[:12]}
 				if cStats.add(s) {
 					waitFirst.Add(1)
-					go s.Collect(cli.client, !*noStream, waitFirst)
+					go s.Collect(ctx, cli.client, !*noStream, waitFirst)
 				}
 			}
 		})
@@ -105,7 +107,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 			s := &containerStats{Name: e.ID[:12]}
 			if cStats.add(s) {
 				waitFirst.Add(1)
-				go s.Collect(cli.client, !*noStream, waitFirst)
+				go s.Collect(ctx, cli.client, !*noStream, waitFirst)
 			}
 		})
 
@@ -131,7 +133,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 			s := &containerStats{Name: name}
 			if cStats.add(s) {
 				waitFirst.Add(1)
-				go s.Collect(cli.client, !*noStream, waitFirst)
+				go s.Collect(ctx, cli.client, !*noStream, waitFirst)
 			}
 		}
 

--- a/api/client/stats_helpers.go
+++ b/api/client/stats_helpers.go
@@ -63,7 +63,7 @@ func (s *stats) isKnownContainer(cid string) (int, bool) {
 	return -1, false
 }
 
-func (s *containerStats) Collect(cli client.APIClient, streamStats bool, waitFirst *sync.WaitGroup) {
+func (s *containerStats) Collect(ctx context.Context, cli client.APIClient, streamStats bool, waitFirst *sync.WaitGroup) {
 	logrus.Debugf("collecting stats for %s", s.Name)
 	var (
 		getFirst       bool
@@ -80,7 +80,7 @@ func (s *containerStats) Collect(cli client.APIClient, streamStats bool, waitFir
 		}
 	}()
 
-	responseBody, err := cli.ContainerStats(context.Background(), s.Name, streamStats)
+	responseBody, err := cli.ContainerStats(ctx, s.Name, streamStats)
 	if err != nil {
 		s.mu.Lock()
 		s.err = err

--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -22,9 +22,11 @@ func (cli *DockerCli) CmdStop(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
+	ctx := context.Background()
+
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerStop(context.Background(), name, *nSeconds); err != nil {
+		if err := cli.client.ContainerStop(ctx, name, *nSeconds); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/unpause.go
+++ b/api/client/unpause.go
@@ -19,9 +19,11 @@ func (cli *DockerCli) CmdUnpause(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
+	ctx := context.Background()
+
 	var errs []string
 	for _, name := range cmd.Args() {
-		if err := cli.client.ContainerUnpause(context.Background(), name); err != nil {
+		if err := cli.client.ContainerUnpause(ctx, name); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/update.go
+++ b/api/client/update.go
@@ -99,10 +99,13 @@ func (cli *DockerCli) CmdUpdate(args ...string) error {
 		RestartPolicy: restartPolicy,
 	}
 
+	ctx := context.Background()
+
 	names := cmd.Args()
 	var errs []string
+
 	for _, name := range names {
-		if err := cli.client.ContainerUpdate(context.Background(), name, updateConfig); err != nil {
+		if err := cli.client.ContainerUpdate(ctx, name, updateConfig); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)

--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -110,8 +110,10 @@ func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
 		return nil
 	}
 
+	ctx := context.Background()
+
 	inspectSearcher := func(name string) (interface{}, []byte, error) {
-		i, err := cli.client.VolumeInspect(context.Background(), name)
+		i, err := cli.client.VolumeInspect(ctx, name)
 		return i, nil, err
 	}
 
@@ -161,8 +163,10 @@ func (cli *DockerCli) CmdVolumeRm(args ...string) error {
 
 	var status = 0
 
+	ctx := context.Background()
+
 	for _, name := range cmd.Args() {
-		if err := cli.client.VolumeRemove(context.Background(), name); err != nil {
+		if err := cli.client.VolumeRemove(ctx, name); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			status = 1
 			continue

--- a/api/client/wait.go
+++ b/api/client/wait.go
@@ -21,9 +21,11 @@ func (cli *DockerCli) CmdWait(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
+	ctx := context.Background()
+
 	var errs []string
 	for _, name := range cmd.Args() {
-		status, err := cli.client.ContainerWait(context.Background(), name)
+		status, err := cli.client.ContainerWait(ctx, name)
 		if err != nil {
 			errs = append(errs, err.Error())
 		} else {


### PR DESCRIPTION
Make better default usage on context.Context on the `api/client` package to share the context (it is useless if not shared, which was the case for a lot of commands) 🐮.

I did this pretty naively though and did not think of other possible non default (`context.Background()`) usage expected for the current one (currently `start`, `run`). But at least the changes for those would be easier then.

/cc @stevvooe @aaronlehmann @calavera @runcom @LK4D4 

🐸

_This follows quick discussion on https://github.com/docker/docker/pull/22861#discussion-diff-64094963_

Signed-off-by: Vincent Demeester vincent@sbr.pm
