### PR TITLE
Remove DOCKER_HTTP_HOST_COMPAT env var

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -114,14 +114,12 @@ func notifyShutdown(err error) {
 }
 
 func wrapListeners(proto string, ls []net.Listener) []net.Listener {
-	if os.Getenv("DOCKER_HTTP_HOST_COMPAT") != "" {
-		switch proto {
-		case "unix":
-			ls[0] = &hack.MalformedHostHeaderOverride{ls[0]}
-		case "fd":
-			for i := range ls {
-				ls[i] = &hack.MalformedHostHeaderOverride{ls[i]}
-			}
+	switch proto {
+	case "unix":
+		ls[0] = &hack.MalformedHostHeaderOverride{ls[0]}
+	case "fd":
+		for i := range ls {
+			ls[i] = &hack.MalformedHostHeaderOverride{ls[i]}
 		}
 	}
 	return ls

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -849,20 +849,6 @@ set like this:
     export DOCKER_TMPDIR=/mnt/disk2/tmp
     /usr/local/bin/dockerd -D -g /var/lib/docker -H unix:// > /var/lib/docker-machine/docker.log 2>&1
 
-Docker clients <= 1.9.2 used an invalid Host header when making request to the
-daemon. Docker 1.12 is built using golang 1.6 which is now checking the validity
-of the Host header and as such clients <= 1.9.2 can't talk anymore to the daemon.
-Docker supports overcoming this issue via a Docker daemon
-environment variable. In case you are seeing this error when contacting the
-daemon:
-
-    Error response from daemon: 400 Bad Request: malformed Host header
-
-The `DOCKER_HTTP_HOST_COMPAT` can be set like this:
-
-    DOCKER_HTTP_HOST_COMPAT=1 /usr/local/bin/dockerd ...
-
-
 ## Default cgroup parent
 
 The `--cgroup-parent` option allows you to set the default cgroup parent


### PR DESCRIPTION
The whole go 1.6 breaking clients issue is a bit near and dear to my heart.  I've been playing whack-a-mole over the past month or so dealing with distros breaking old clients.  I'm glad to see the hack got merged, but disabling it by default really doesn't help.

First, before if you built docker wrong it would not work with old clients.  Now by default docker doesn't work with old clients unless you know the magic env var.  This is a terrible user experience but the key thing is that docker is by default incompatible with old clients.

Second, for those crying "technical debt! technical debt!"  Introducing a env var is far worse debt because this is a public interface.  Distros will have to set this env var.  I know Ubuntu already backported the hack, and other distros are doing the same.  So supporting old clients is important enough to them so they will set the env var.  This is the type of thing 5 years later when you don't need the env var anymore it will still be in scripts and documentation because nobody really knows what it does and is afraid to remove it.

Third, one code path is better than two.  If there is ever a bug caused by the hack it is not an obvious thing to consider if this env var is set or not.  This is just yet another variable to consider, another thing to ask a user if X is set or not, etc.

Finally, once 1.12 ships my whack-a-mole will change from "don't compile with 1.6" to "set DOCKER_HTTP_HOST_COMPAT=1."  This does not make me happy.

I really think the key point is that we are consciously choosing the purity of our code over user experience.  And that is bad.
