### PR TITLE
Allow granular vendoring

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -1,9 +1,45 @@
 #!/usr/bin/env bash
 set -e
 
+# this script is used to update vendored dependencies
+#
+# Usage:
+# vendor.sh revendor all dependencies
+# vendor.sh github.com/docker/engine-api revendor only the engine-api dependency.
+# vendor.sh github.com/docker/engine-api v0.3.3 vendor only engine-api at the specified tag/commit.
+# vendor.sh git github.com/docker/engine-api v0.3.3 is the same but specifies the VCS for cases where the VCS is something else than git
+# vendor.sh git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git vendor only golang.org/x/sys downloading from the specified URL
+
 cd "$(dirname "$BASH_SOURCE")/.."
-rm -rf vendor/
 source 'hack/.vendor-helpers.sh'
+
+case $# in
+0)
+	rm -rf vendor/
+	;;
+# If user passed arguments to the script
+1)
+	eval "$(grep -E "^clone [^ ]+ $1" "$0")"
+	clean
+	exit 0
+	;;
+2)
+	rm -rf "vendor/src/$1"
+	clone git "$1" "$2"
+	clean
+	exit 0
+	;;
+[34])
+	rm -rf "vendor/src/$2"
+	clone "$@"
+	clean
+	exit 0
+	;;
+*)
+	>&2 echo "error: unexpected parameters"
+	exit 1
+	;;
+esac
 
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62


### PR DESCRIPTION
Carry of https://github.com/docker/docker/pull/22151 - moves the USAGE description from `hack/.vendor-helpers.sh` to `hack/vendor.sh`

closes https://github.com/docker/docker/pull/22151

**\- What I did**

Allow vendoring only one dependency.

**\- How I did it**

Passing command line parameters to hack/vendor.sh

**\- How to verify it**

Run examples below

**\- A picture of a cute animal (not mandatory but encouraged)**

![cute insect](http://petslady.com/files/images/Incredible-Eye-Macros-caterpillar1-490x367.img_assist_custom.jpg)

hack/vendor.sh can now accept command line arguments

`./hack/vendor.sh github.com/docker/engine-api` will revendor only the
engine-api dependency.

`./hack/vendor.sh github.com/docker/engine-api v0.3.3` will vendor only
engine-api at the specified tag/commit.

`./hack/vendor.sh git github.com/docker/engine-api v0.3.3` is the same
but specifies the VCS for cases where the VCS is something else than git

`./hack/vendor.sh git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git` will vendor only golang.org/x/sys
downloading from the specified URL
