### PR TITLE
fix docs not building if branch-name contains slashes

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -23,9 +23,8 @@ HUGO_BASE_URL=$(shell test -z "$(DOCKER_IP)" && echo localhost || echo "$(DOCKER
 HUGO_BIND_IP=0.0.0.0
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
-DOCKER_DOCS_IMAGE := docs-base$(if $(GIT_BRANCH),:$(GIT_BRANCH))
-
+GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
+DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 
 DOCKER_RUN_DOCS := docker run --rm -it $(DOCS_MOUNT) -e AWS_S3_BUCKET -e NOCACHE
 


### PR DESCRIPTION
**\- What I did**

updated the docs/Makefile to allow branches with characters that are
invalid as a "tag". Also see https://github.com/docker/docker/pull/22400, which did the same for the main Makefile

**\- How to verify it**

check out this branch, and run `make docs`

**\- Description for the changelog**

similar to the changes made in a4192471cd6d6012a66c19a635a11c7f6139d683,
clean the branch-name before using it as a tag-name
for the image that's built.

this also changes the "image name" for docs images
being built from "docs-base" to "docker-docs", to
be in line with the main Makefile

before this change:

```
  /usr/bin/make -C docs docs
  docker build -t "docs-base:docs/slashes" .
  invalid value "docs-base:docs/slashes" for flag -t: Error parsing reference: "docs-base:docs/slashes" is not a valid repository/tag
  See 'docker build --help'.
  make[1]: *** [docs-build] Error 125
  make: *** [docs] Error 2
```

after this change:

```
  /usr/bin/make -C docs docs
  docker build -t "docker-docs:docs-slashes" .
  Sending build context to Docker daemon 9.165 MB
  ...
```

**\- A picture of a cute animal (not mandatory but encouraged)**

![balloon-fish](https://cloud.githubusercontent.com/assets/1804568/15454852/02a79452-2044-11e6-952f-fa775584fd49.jpg)
