### PR TITLE
Typo fix wiildcard -> wildcard

### DIFF
--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -69,13 +69,13 @@ func initDispatchTestCases() []dispatchTestCase {
 			files:         map[string]string{"file1.txt": "test1", "file2.txt": "test2"},
 		},
 		{
-			name:          "Wiildcard ADD multiple files to file",
+			name:          "Wildcard ADD multiple files to file",
 			dockerfile:    "ADD file*.txt test",
 			expectedError: "When using ADD with more than one source file, the destination must be a directory and end with a /",
 			files:         map[string]string{"file1.txt": "test1", "file2.txt": "test2"},
 		},
 		{
-			name:          "Wiildcard JSON ADD multiple files to file",
+			name:          "Wildcard JSON ADD multiple files to file",
 			dockerfile:    `ADD ["file*.txt", "test"]`,
 			expectedError: "When using ADD with more than one source file, the destination must be a directory and end with a /",
 			files:         map[string]string{"file1.txt": "test1", "file2.txt": "test2"},


### PR DESCRIPTION
First commit, please be understanding. The PR was raised after being encouraged to do so by @thaJeztah 

**\- What I did**

Fixed a typo in PR20784

https://github.com/docker/docker/commit/cf2611f3239d18919e437e82554cec178028612e#commitcomment-17572123

**\- How I did it**

Cloned Docker, built, ran unit + int tests, fixed typo and ran unit tests again.

**\- How to verify it**

Tests still passing.

**\- Description for the changelog**

Fixes typo in unit test to improve readability.

**\- A picture of a cute animal (not mandatory but encouraged)**

![Doge](https://cdn.meme.am/instances/500x/45752017.jpg)

Signed-off-by: Alex Ellis alexellis2@gmail.com
