### PR TITLE
Adding network filter to docker ps command

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -33,6 +33,7 @@ var acceptedPsFilterTags = map[string]bool{
 	"status":    true,
 	"since":     true,
 	"volume":    true,
+	"network":   true,
 }
 
 // iterationAction represents possible outcomes happening during the container iteration.
@@ -315,6 +316,19 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 			return excludeContainer
 		}
 		if !ctx.images[container.ImageID] {
+			return excludeContainer
+		}
+	}
+
+	networkExist := fmt.Errorf("container part of network")
+	if ctx.filters.Include("network") {
+		err := ctx.filters.WalkValues("network", func(value string) error {
+			if network := container.NetworkSettings.Networks[value]; network != nil {
+				return networkExist
+			}
+			return nil
+		})
+		if err != networkExist {
 			return excludeContainer
 		}
 	}

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -122,6 +122,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /events` now supports a `reload` event that is emitted when the daemon configuration is reloaded.
 * `GET /events` now supports filtering by daemon name or ID.
 * `GET /images/json` now supports filters `since` and `before`.
+* `GET /containers/json` now takes network name/s as one of the filters. Contianers connected to the provided network/s will be listed
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -223,6 +223,7 @@ Query Parameters:
   -   `before`=(`<container id>` or `<container name>`)
   -   `since`=(`<container id>` or `<container name>`)
   -   `volume`=(`<volume name>` or `<mount point destination>`)
+  -   `network`=(`<network name>`)
 
 Status Codes:
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -62,7 +62,7 @@ The currently supported filters are:
 * since (container's id or name) - filters containers created since given id or name
 * isolation (default|process|hyperv)   (Windows daemon only)
 * volume (volume name or mount point) - filters containers that mount volumes.
-
+* network (network name) - filters containers connected to the provided network name
 
 #### Label
 
@@ -206,6 +206,17 @@ The `volume` filter shows only containers that mount a specific volume or have a
     $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
     CONTAINER ID        MOUNTS
     9c3527ed70ce        remote-volume
+
+#### Network
+
+The `network` filter shows only containers that has endpoints on the provided network name.
+
+    $docker run -d --net=net1 --name=test1 ubuntu top
+    $docker run -d --net=net2 --name=test2 ubuntu top
+
+    $docker ps --filter network=net1
+    CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+    9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
 
 
 ## Formatting

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -36,6 +36,7 @@ the running containers.
    - since=(<container-name>|<container-id>)
    - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
    - volume=(<volume-name>|<mount-point-destination>)
+   - network=(<network-name>) - containers connected to the provided network name
 
 **--format**="*TEMPLATE*"
    Pretty-print containers using a Go template.


### PR DESCRIPTION
Added network to the docker ps filter. This would help filter the containers from docker ps based on the network name passed to the filter switch. 

docker run -d --net=bridge --name=onbridgenetwork busybox top
docker run -d --net=none --name=onnonenetwork busybox top

docker ps --filter network=bridge 
Output should show only the container with name "onbridgenetwork"

docker ps --filter network=bridge --filter network=none
Output should show both the containers "onbrigenetwork" and "onnonenetwork"

Signed-off-by: Sainath Grandhi sainath.grandhi@intel.com
