### PR TITLE
Standardize default logging tag value

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -65,7 +65,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, err
 	}
 
-	tag, err := loggerutils.ParseLogTag(ctx, "{{.DaemonName}}.{{.ID}}")
+	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -58,7 +58,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	containerName := bytes.TrimLeft([]byte(ctx.ContainerName), "/")
 
 	// parse log tag
-	tag, err := loggerutils.ParseLogTag(ctx, "")
+	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -50,7 +50,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	}
 
 	// parse log tag
-	tag, err := loggerutils.ParseLogTag(ctx, "")
+	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/logger/loggerutils/log_tag.go
+++ b/daemon/logger/loggerutils/log_tag.go
@@ -7,6 +7,9 @@ import (
 	"github.com/docker/docker/utils/templates"
 )
 
+// DefaultTemplate defines the defaults template logger should use.
+const DefaultTemplate = "{{.ID}}"
+
 // ParseLogTag generates a context aware tag for consistency across different
 // log drivers based on the context of the running container.
 func ParseLogTag(ctx logger.Context, defaultTemplate string) (string, error) {

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -131,7 +131,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	nullMessage.SourceType = ctx.Config[splunkSourceTypeKey]
 	nullMessage.Index = ctx.Config[splunkIndexKey]
 
-	tag, err := loggerutils.ParseLogTag(ctx, "{{.ID}}")
+	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -90,7 +90,7 @@ func rfc5424microformatterWithAppNameAsTag(p syslog.Priority, hostname, tag, con
 // the context. Supported context configuration variables are
 // syslog-address, syslog-facility, syslog-format.
 func New(ctx logger.Context) (logger.Logger, error) {
-	tag, err := loggerutils.ParseLogTag(ctx, "{{.DaemonName}}/{{.ID}}")
+	tag, err := loggerutils.ParseLogTag(ctx, loggerutils.DefaultTemplate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is an attempt to fix #20033, by using the same default tag value for all loggers that support tags 🐙.

It felt so silly to let the issue open for a small change like that. **But** it might break or at least change current setup using these loggers (the one that do not used `{{.ID}}` as default tag) so I'm not sure either :sweat:.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
