### PR TITLE
Fix install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -92,7 +92,7 @@ check_forked() {
 				lsb_dist=debian
 				dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 				case "$dist_version" in
-					8|'Kali Linux 2')
+					8|'Kali Linux Rolling')
 						dist_version="jessie"
 					;;
 					7)
@@ -428,7 +428,7 @@ do_install() {
 			done
 			$sh_c "apt-key adv -k ${gpg_fingerprint} >/dev/null"
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
-			$sh_c "echo deb [arch=$(dpkg --print-architecture)] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
+			$sh_c "echo deb '[arch=$(dpkg --print-architecture)]' ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'
 			)
 			echo_docker_as_nonroot


### PR DESCRIPTION
**\- What I did**
I added support for kali linux rolling and fixed an issue with architecture being added incorrectly in docker.list
**\- How I did it**
I changed the install script
**\- How to verify it**
I used kali linux rolling and latest ubuntu desktop to verify it on.
**\- Description for the changelog**

Add support for Kali Linux Rolling.
Fix an issue where the architecture was incorrectly added in docker.list.

This updates the installation of Kali Linux to use its new rolling
release form. It also adds singlequotes to the "arch" part in
sources.list.d/docker.list so it produces [arch=amd64] and not
just the single letter d.

Signed-off-by: Paul Liljenberg liljenberg.paul@gmail.com
