### PR TITLE
Release memoryStore locks before filter/apply

### DIFF
--- a/container/history.go
+++ b/container/history.go
@@ -24,11 +24,6 @@ func (history *History) Swap(i, j int) {
 	containers[i], containers[j] = containers[j], containers[i]
 }
 
-// Add the given container to history.
-func (history *History) Add(container *Container) {
-	*history = append(*history, container)
-}
-
 // sort orders the history by creation date in descendant order.
 func (history *History) sort() {
 	sort.Sort(history)


### PR DESCRIPTION
Rework `memoryStore` so that filters and apply run
on a cloned list of containers after the lock has
been released. This avoids possible deadlocks when
these filter/apply callbacks take locks for a
container.

Fixes #22732

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
