### PR TITLE
Enable seccomp on ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -168,7 +168,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -1293,6 +1293,11 @@
 			"args": []
 		},
 		{
+			"name": "socketcall",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
 			"name": "socketpair",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -1322,6 +1322,11 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 			Args:   []*types.Arg{},
 		},
 		{
+			Name:   "socketcall",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
 			Name:   "socketpair",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},


### PR DESCRIPTION
In order to do this, allow the socketcall syscall in the default
seccomp profile. This is a multiplexing syscall for the socket
operations, which is becoming obsolete gradually, but it is used
in some architectures. libseccomp has special handling for it for
x86 where it is common, so we did not need it in the profile,
but does not have any handling for ppc64le. It turns out that the
Debian images we use for tests do use the socketcall, while the
newer images such as Ubuntu 16.04 do not. Enabling this does no
harm as we allow all the socket operations anyway, and we allow
the similar ipc call for similar reasons already.

Signed-off-by: Justin Cormack justin.cormack@docker.com

See #22537 #22565 for the previous enable, disable of this feature due to the tests failing.

cc @tophj-ibm

![goatinacoat](https://cloud.githubusercontent.com/assets/482364/15486455/d2aaeb34-20fa-11e6-85ec-225ed67a7dfc.jpg)
