### PR TITLE
pkg/integration: Port tests to Windows

### DIFF
--- a/pkg/integration/utils_test.go
+++ b/pkg/integration/utils_test.go
@@ -14,30 +14,32 @@ import (
 )
 
 func TestIsKilledFalseWithNonKilledProcess(t *testing.T) {
-	// TODO Windows: Port this test
-	if runtime.GOOS == "windows" {
-		t.Skip("Needs porting to Windows")
+	var lsCmd *exec.Cmd
+	if runtime.GOOS != "windows" {
+		lsCmd = exec.Command("ls")
+	} else {
+		lsCmd = exec.Command("cmd", "/c", "dir")
 	}
 
-	lsCmd := exec.Command("ls")
-	lsCmd.Start()
-	// Wait for it to finish
-	err := lsCmd.Wait()
+	err := lsCmd.Run()
 	if IsKilled(err) {
 		t.Fatalf("Expected the ls command to not be killed, was.")
 	}
 }
 
 func TestIsKilledTrueWithKilledProcess(t *testing.T) {
-	// TODO Windows: Using golang 1.5.3, this seems to hit
-	// a bug in go where Process.Kill() causes a panic.
-	// Needs further investigation @jhowardmsft
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
+	var longCmd *exec.Cmd
+	if runtime.GOOS != "windows" {
+		longCmd = exec.Command("top")
+	} else {
+		longCmd = exec.Command("powershell", "while ($true) { sleep 1 }")
 	}
-	longCmd := exec.Command("top")
+
 	// Start a command
-	longCmd.Start()
+	err := longCmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Capture the error when *dying*
 	done := make(chan error, 1)
 	go func() {
@@ -46,7 +48,7 @@ func TestIsKilledTrueWithKilledProcess(t *testing.T) {
 	// Then kill it
 	longCmd.Process.Kill()
 	// Get the error
-	err := <-done
+	err = <-done
 	if !IsKilled(err) {
 		t.Fatalf("Expected the command to be killed, was not.")
 	}


### PR DESCRIPTION
Just porting some simple unit tests to Windows. This came up as part of #22840.

cc @jhowardmsft 
