### PR TITLE
Fix error channel size in seccomp test

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -949,7 +949,7 @@ func (s *DockerSuite) TestRunSeccompDefaultProfile(c *check.C) {
 
 	var group sync.WaitGroup
 	group.Add(11)
-	errChan := make(chan error, 4)
+	errChan := make(chan error, 11)
 	go func() {
 		out, _, err := dockerCmdWithError("run", "syscall-test", "acct-test")
 		if err == nil || !strings.Contains(out, "Operation not permitted") {


### PR DESCRIPTION
This was not changed when the additional tests were added.
It may be the reason for occasional test failures.

Signed-off-by: Justin Cormack justin.cormack@docker.com
