### PR TITLE
Add `install` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ docs: ## build the docs
 gccgo: build-gccgo ## build the gcc-go linux binaries
 	$(DOCKER_FLAGS) "$(DOCKER_IMAGE)-gccgo" hack/make.sh gccgo
 
+install: ## install the linux binaries
+	KEEPBUNDLE=1 hack/make.sh install-binary
+
 rpm: build ## build the rpm packages
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary build-rpm
 

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -333,6 +333,19 @@ copy_containerd() {
 	fi
 }
 
+install_binary() {
+	file="$1"
+	target="${DOCKER_MAKE_INSTALL_PREFIX:=/usr/local}/bin/"
+	if [ "$(go env GOOS)" == "linux" ]; then
+		echo "Installing $(basename $file) to ${target}"
+		cp $file $target
+	else
+		echo "Install is only supported on linux"
+		return 1
+	fi
+}
+
+
 main() {
 	# We want this to fail if the bundles already exist and cannot be removed.
 	# This is to avoid mixing bundles from different versions of the code.

--- a/hack/make/.binary-setup
+++ b/hack/make/.binary-setup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DOCKER_CLIENT_BINARY_NAME='docker'
+DOCKER_DAEMON_BINARY_NAME='dockerd'

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+rm -rf "$DEST"
 
 # This script exists as backwards compatibility for CI
 (

--- a/hack/make/binary-client
+++ b/hack/make/binary-client
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
+[ -z "$KEEPDEST" ] && \
+	rm -rf "$DEST"
+
 (
-	export BINARY_SHORT_NAME='docker'
+	source "${MAKEDIR}/.binary-setup"
+	export BINARY_SHORT_NAME="$DOCKER_CLIENT_BINARY_NAME"
 	export SOURCE_PATH='./cmd/docker'
 	source "${MAKEDIR}/.binary"
 )

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -e
 
+[ -z "$KEEPDEST" ] && \
+	rm -rf "$DEST"
+
 (
-	export BINARY_SHORT_NAME='dockerd'
+	source "${MAKEDIR}/.binary-setup"
+	export BINARY_SHORT_NAME="$DOCKER_DAEMON_BINARY_NAME"
 	export SOURCE_PATH='./cmd/dockerd'
 	source "${MAKEDIR}/.binary"
 	copy_containerd "$DEST" 'hash'

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -21,6 +21,7 @@ fi
 
 for platform in $DOCKER_CROSSPLATFORMS; do
 	(
+		export KEEPDEST=1
 		export DEST="$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
 		mkdir -p "$DEST"
 		ABS_DEST="$(cd "$DEST" && pwd -P)"
@@ -28,14 +29,14 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 		export GOARCH=${platform##*/}
 
 		if [ -z "${daemonSupporting[$platform]}" ]; then
-            # we just need a simple client for these platforms
+			# we just need a simple client for these platforms
 			export LDFLAGS_STATIC_DOCKER=""
-            # remove the "daemon" build tag from platforms that aren't supported
-            export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" )
-		    source "${MAKEDIR}/binary-client"
-        else
-		    source "${MAKEDIR}/binary-client"
-		    source "${MAKEDIR}/binary-daemon"
+			# remove the "daemon" build tag from platforms that aren't supported
+			export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" )
+			source "${MAKEDIR}/binary-client"
+		else
+			source "${MAKEDIR}/binary-client"
+			source "${MAKEDIR}/binary-daemon"
 		fi
 	)
 done

--- a/hack/make/install-binary
+++ b/hack/make/install-binary
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+rm -rf "$DEST"
+
+(
+	source "${MAKEDIR}/install-binary-client"
+)
+
+(
+	source "${MAKEDIR}/install-binary-daemon"
+)

--- a/hack/make/install-binary-client
+++ b/hack/make/install-binary-client
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+rm -rf "$DEST"
+
+(
+	DEST="$(dirname $DEST)/binary-client"
+	source "${MAKEDIR}/.binary-setup"
+	install_binary "${DEST}/${DOCKER_CLIENT_BINARY_NAME}"
+)

--- a/hack/make/install-binary-daemon
+++ b/hack/make/install-binary-daemon
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+rm -rf "$DEST"
+
+(
+	DEST="$(dirname $DEST)/binary-daemon"
+	source "${MAKEDIR}/.binary-setup"
+	install_binary "${DEST}/${DOCKER_DAEMON_BINARY_NAME}"
+)

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -13,8 +13,11 @@ fi
 for d in "$CROSS/"*/*; do
 	export GOARCH="$(basename "$d")"
 	export GOOS="$(basename "$(dirname "$d")")"
-	BINARY_NAME="docker-$VERSION"
-	DAEMON_BINARY_NAME="dockerd-$VERSION"
+
+	source "${MAKEDIR}/.binary-setup"
+
+	BINARY_NAME="${DOCKER_CLIENT_BINARY_NAME}-$VERSION"
+	DAEMON_BINARY_NAME="${DOCKER_DAEMON_BINARY_NAME}-$VERSION"
 	BINARY_EXTENSION="$(export GOOS && binary_extension)"
 	if [ "$GOOS" = 'windows' ]; then
 		# if windows use a zip, not tgz
@@ -40,9 +43,9 @@ for d in "$CROSS/"*/*; do
 
 	# Copy the correct docker binary
 	mkdir -p $TAR_PATH
-	cp -L "$d/$BINARY_FULLNAME" "$TAR_PATH/docker$BINARY_EXTENSION"
+	cp -L "$d/$BINARY_FULLNAME" "$TAR_PATH/${DOCKER_CLIENT_BINARY_NAME}${BINARY_EXTENSION}"
 	if [ -f "$d/$DAEMON_BINARY_FULLNAME" ]; then
-		cp -L "$d/$DAEMON_BINARY_FULLNAME" "$TAR_PATH/dockerd$BINARY_EXTENSION"
+		cp -L "$d/$DAEMON_BINARY_FULLNAME" "$TAR_PATH/${DOCKER_DAEMON_BINARY_NAME}${BINARY_EXTENSION}"
 	fi
 
 	# copy over all the containerd binaries


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Allow `make.sh binary` to install binaries

**\- How I did it**
`hack/make.sh binary-daemon` and `hack/make.sh binary-client` will now call `install_binary` which checks if `DOCKER_MAKE_INSTALL` is set, if so it copies the binaries to `/usr/local/bin`

**\- How to verify it**

```
$ make shell
$ hack/make.sh binary
...
$ ls /usr/local/bin/docker
ls: cannot access /usr/local/bin/docker: No such file or directory
$ export DOCKER_MAKE_INSTALL=1
$ hack/make.sh binary
....
$ ls /usr/local/bin/docker
/usr/local/bin/docker
$ 
```

Signed-off-by: Brian Goff cpuguy83@gmail.com
