### PR TITLE
hack/make/test-unit: support coverprofile

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -223,6 +223,11 @@ if \
 	HAVE_GO_TEST_COVER=1
 fi
 
+GCCGOFLAGS=
+if [[ "$(go version)" == *"gccgo"* ]]; then
+	GCCGOFLAGS+=-gccgoflags="-lpthread"
+fi
+
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
 # You can use this to select certain tests to run, eg.
 #
@@ -233,34 +238,38 @@ fi
 #
 #     TESTFLAGS='-check.f DockerSuite.TestBuild*' ./hack/make.sh binary test-integration-cli
 #
-go_test_dir() {
-	dir=$1
-	coverpkg=$2
+go_test_pkgs() {
+	pkgs=$@
 	testcover=()
-	testcoverprofile=()
-	testbinary="$DEST/test.main"
+	testcoverargs=()
 	if [ "$HAVE_GO_TEST_COVER" ]; then
 		# if our current go install has -cover, we want to use it :)
-		mkdir -p "$DEST/coverprofiles"
-		coverprofile="docker${dir#.}"
-		coverprofile="$ABS_DEST/coverprofiles/${coverprofile//\//-}"
-		testcover=( -test.cover )
-		testcoverprofile=( -test.coverprofile "$coverprofile" $coverpkg )
+		#
+		# coverprofile is temporarily put into $pkg/cover.out.
+		# then it is moved to $DEST/coverprofiles/docker-$pkg.
+		#
+		# `go run -test.coverprofile` is not allowed for multiple packages. so we use `-args`
+		testcover=( -cover )
+		testcoverargs=( -args -test.coverprofile "cover.out" )
+		mkdir -p $ABS_DEST/coverprofiles
 	fi
-	(
-		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
-		cd "$dir"
-		export DEST="$ABS_DEST" # we're in a subshell, so this is safe -- our integration-cli tests need DEST, and "cd" screws it up
-		go test -c -o "$testbinary" ${testcover[@]} -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}"
-		i=0
-		while ((++i)); do
-			test_env "$testbinary" ${testcoverprofile[@]} $TESTFLAGS
-			if [ $i -gt "$TEST_REPEAT" ]; then
-				break
-			fi
-			echo "Repeating test ($i)"
+	i=0
+	while ((++i)); do
+		test_env go test ${testcover[@]} $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkgs ${testcoverargs[@]}
+		if [ $i -gt "$TEST_REPEAT" ]; then
+			break
+		fi
+		echo "Repeating test ($i)"
+	done
+	if [ "$HAVE_GO_TEST_COVER" ]; then
+		for from in $( find . -name cover.out ); do
+			# e.g. from=./api/client/cover.out, to=$ABS_DEST/coverprofiles/docker-api-client
+			dirname=$(dirname $from)
+			pkgname=docker${dirname#.}
+			to=$ABS_DEST/coverprofiles/${pkgname//\//-}
+			mv $from $to
 		done
-	)
+	fi
 }
 test_env() {
 	# use "env -i" to tightly control the environment variables that bleed into the tests
@@ -279,6 +288,8 @@ test_env() {
 		HOME="$ABS_DEST/fake-HOME" \
 		PATH="$PATH" \
 		TEMP="$TEMP" \
+		USERPROFILE="$ABS_DEST/fake-USERPROFILE" \
+		ProgramData="$ABS_DEST/fake-ProgramData" \
 		"$@"
 }
 

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -3,7 +3,11 @@ set -e
 
 bundle_test_integration_cli() {
 	TESTFLAGS="$TESTFLAGS -check.v -check.timeout=${TIMEOUT} -test.timeout=360m"
-	go_test_dir ./integration-cli
+	(
+		cd integration-cli
+		export DEST="$ABS_DEST" # we're in a subshell, so this is safe -- our integration-cli tests need DEST, and "cd" screws it up
+		go_test_pkgs .
+	)
 }
 
 # subshell so that we can export PATH without breaking other things

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -15,21 +15,13 @@ bundle_test_unit() {
 	else
 		TEST_PATH=./${TESTDIRS}
 	fi
-	pkg_list=$(go list -e \
-		-f '{{if ne .Name "github.com/docker/docker"}}
-			{{.ImportPath}}
-		    {{end}}' \
-		"${BUILDFLAGS[@]}" $TEST_PATH \
+	pkg_list=$(go list -e "${BUILDFLAGS[@]}" $TEST_PATH \
 		| grep github.com/docker/docker \
 		| grep -v github.com/docker/docker/vendor \
 		| grep -v github.com/docker/docker/integration-cli)
-	go test $COVER $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list
+
+	go_test_pkgs $pkg_list
 }
 
 
-if [[ "$(go version)" == *"gccgo"* ]]; then
-	GCCGOFLAGS=-gccgoflags="-lpthread"
-else
-	COVER=-cover
-fi
 bundle_test_unit 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Support coverprofiles for `hack/make/test-unit`.

**\- How I did it**
`test-integration-cli` uses `go_test_dir` for fetching the coverprofile.
Now test-unit utilizes `go_test_dir` as well.

**\- How to verify it**

```
$ make test-unit
$ ls bundles/latest/test-unit/coverprofiles/
docker-api
docker-api-client
...
```

**\- Description for the changelog**

Update #22899

TODOs suggested in #22899 (should be done in separate PRs after merging this PR)
- Update https://github.com/docker/opensource/blob/master/docs/project/test-and-docs.md
- Integrate  https://codecov.io
- Having Jenkins output the code coverage to its workspace

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
