### PR TITLE
Fix building image  error if bridge network is disabled

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/runconfig"
 	volumestore "github.com/docker/docker/volume/store"
 	"github.com/docker/engine-api/types"
 	containertypes "github.com/docker/engine-api/types/container"
@@ -122,6 +123,9 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 	if params.NetworkingConfig != nil {
 		endpointsConfigs = params.NetworkingConfig.EndpointsConfig
 	}
+	// Make sure NetworkMode has an acceptable value. We do this to ensure
+	// backwards API compatibility.
+	container.HostConfig = runconfig.SetDefaultNetModeIfBlank(container.HostConfig)
 
 	if err := daemon.updateContainerNetworkSettings(container, endpointsConfigs); err != nil {
 		return nil, err

--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -486,3 +486,8 @@ func (d *Daemon) findContainerIP(id string) string {
 	}
 	return strings.Trim(out, " \r\n'")
 }
+
+func (d *Daemon) buildImageWithOut(name, dockerfile string, useCache bool, buildFlags ...string) (string, int, error) {
+	buildCmd := buildImageCmdWithHost(name, dockerfile, d.sock(), useCache, buildFlags...)
+	return runCommandWithOutput(buildCmd)
+}

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2320,3 +2320,15 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *chec
 	c.Assert(string(content), checker.Contains, expectedMaxConcurrentUploads)
 	c.Assert(string(content), checker.Contains, expectedMaxConcurrentDownloads)
 }
+
+func (s *DockerDaemonSuite) TestBuildOnDisabledBridgeNetworkDaemon(c *check.C) {
+	err := s.d.Start("-b=none", "--iptables=false")
+	c.Assert(err, check.IsNil)
+	s.d.c.Logf("dockerBinary %s", dockerBinary)
+	out, code, err := s.d.buildImageWithOut("busyboxs",
+		`FROM busybox
+                RUN cat /etc/hosts`, false)
+	comment := check.Commentf("Failed to build image. output %s, exitCode %d, err %v", out, code, err)
+	c.Assert(err, check.IsNil, comment)
+	c.Assert(code, check.Equals, 0, comment)
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -930,7 +930,15 @@ func getContainerState(c *check.C, id string) (int, bool, error) {
 }
 
 func buildImageCmd(name, dockerfile string, useCache bool, buildFlags ...string) *exec.Cmd {
-	args := []string{"build", "-t", name}
+	return buildImageCmdWithHost(name, dockerfile, "", useCache, buildFlags...)
+}
+
+func buildImageCmdWithHost(name, dockerfile, host string, useCache bool, buildFlags ...string) *exec.Cmd {
+	args := []string{}
+	if host != "" {
+		args = append(args, "--host", host)
+	}
+	args = append(args, "build", "-t", name)
 	if !useCache {
 		args = append(args, "--no-cache")
 	}


### PR DESCRIPTION
On a fresh setup, start daemon with `-b=none`. Building a simple image using this instance errors out `invalid id:`.

```
root@docker-1:/home/vagrant# docker -v
Docker version 1.11.1, build 5604cbe
# make sure there is no prestored bridge network
root@docker-1:/home/vagrant# docker network ls
NETWORK ID          NAME                DRIVER
60d12a7f05f7        host                host                
30a1c4dd5a51        none                null  
root@docker-1:/home/vagrant# cat Dockerfile 
FROM ubuntu 
RUN cat /etc/hosts
root@docker-1:/home/vagrant# docker build -f Dockerfile -t test .
Sending build context to Docker daemon 343.7 MB
Step 1 : FROM ubuntu
 ---> 58fd0b7b3497
Step 2 : RUN cat /etc/hosts
invalid id:
```

relates to https://github.com/docker/docker/issues/22872

Signed-off-by: Chun Chen ramichen@tencent.com
