### PR TITLE
Fix a race in cmd/dockerd/hack.TestHeaderOverrideHack

### DIFF
--- a/cmd/dockerd/hack/malformed_host_override_test.go
+++ b/cmd/dockerd/hack/malformed_host_override_test.go
@@ -38,9 +38,9 @@ func TestHeaderOverrideHack(t *testing.T) {
 	read := make([]byte, 4096)
 
 	for _, pair := range tests {
-		go func() {
-			srv.Write(pair[0])
-		}()
+		go func(x []byte) {
+			srv.Write(x)
+		}(pair[0])
 		n, err := l.Read(read)
 		if err != nil && err != io.EOF {
 			t.Fatalf("read: %d - %d, err: %v\n%s", n, len(pair[0]), err, string(read[:n]))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixed a race found in #22940 

**\- How I did it**
Fixed a thing related to an iterator

**\- How to verify it**
`TESTDIRS=cmd/dockerd/hack BUILDFLAGS=-race make test-unit`

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
