### PR TITLE
Remove unused mounted function in overlay

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -374,10 +374,6 @@ func (d *Driver) Get(id string, mountLabel string) (s string, err error) {
 	return mergedDir, nil
 }
 
-func (d *Driver) mounted(dir string) (bool, error) {
-	return graphdriver.Mounted(graphdriver.FsMagicOverlay, dir)
-}
-
 // Put unmounts the mount path created for the give id.
 func (d *Driver) Put(id string) error {
 	mountpoint := path.Join(d.dir(id), "merged")


### PR DESCRIPTION
The mount check is now done by the `fsChecker`. This function is no longer needed and shouldn't be called.

ping @crosbymichael @tonistiigi 
