### PR TITLE
Windows: run -it not crash in PowerShell ISE

### DIFF
--- a/pkg/term/windows/ansi_reader.go
+++ b/pkg/term/windows/ansi_reader.go
@@ -28,6 +28,7 @@ type ansiReader struct {
 }
 
 func newAnsiReader(nFile int) *ansiReader {
+	initLogger()
 	file, fd := winterm.GetStdFile(nFile)
 	return &ansiReader{
 		file:    file,

--- a/pkg/term/windows/ansi_writer.go
+++ b/pkg/term/windows/ansi_writer.go
@@ -3,15 +3,11 @@
 package windows
 
 import (
-	"io/ioutil"
 	"os"
 
 	ansiterm "github.com/Azure/go-ansiterm"
 	"github.com/Azure/go-ansiterm/winterm"
-	"github.com/Sirupsen/logrus"
 )
-
-var logger *logrus.Logger
 
 // ansiWriter wraps a standard output file (e.g., os.Stdout) providing ANSI sequence translation.
 type ansiWriter struct {
@@ -25,18 +21,7 @@ type ansiWriter struct {
 }
 
 func newAnsiWriter(nFile int) *ansiWriter {
-	logFile := ioutil.Discard
-
-	if isDebugEnv := os.Getenv(ansiterm.LogEnv); isDebugEnv == "1" {
-		logFile, _ = os.Create("ansiReaderWriter.log")
-	}
-
-	logger = &logrus.Logger{
-		Out:       logFile,
-		Formatter: new(logrus.TextFormatter),
-		Level:     logrus.DebugLevel,
-	}
-
+	initLogger()
 	file, fd := winterm.GetStdFile(nFile)
 	info, err := winterm.GetConsoleScreenBufferInfo(fd)
 	if err != nil {

--- a/pkg/term/windows/windows.go
+++ b/pkg/term/windows/windows.go
@@ -3,3 +3,31 @@
 // and return pseudo-streams that convert ANSI sequences to / from Windows Console API calls.
 
 package windows
+
+import (
+	"io/ioutil"
+	"os"
+	"sync"
+
+	ansiterm "github.com/Azure/go-ansiterm"
+	"github.com/Sirupsen/logrus"
+)
+
+var logger *logrus.Logger
+var initOnce sync.Once
+
+func initLogger() {
+	initOnce.Do(func() {
+		logFile := ioutil.Discard
+
+		if isDebugEnv := os.Getenv(ansiterm.LogEnv); isDebugEnv == "1" {
+			logFile, _ = os.Create("ansiReaderWriter.log")
+		}
+
+		logger = &logrus.Logger{
+			Out:       logFile,
+			Formatter: new(logrus.TextFormatter),
+			Level:     logrus.DebugLevel,
+		}
+	})
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes https://github.com/docker/docker/issues/22934 #21368 and at least one other similar issue which I can't locate (@thaJeztah - any chance your search skills can find it?)

Note that the ISE fakes the console to some extent, so things won't really work correctly with -it (including attach), and there's no easy fix which doesn't break other scenarios as they deliberately try and obfuscate the fact. However, this does stop the client crashing when using `-it` on `docker run`. The problem is we only set `logger` in the `newAnsiWriter`, but not in the `newAnsiReader` case. Made it common and shared across both reader and writer.

@jstarks. 
