### PR TITLE
Multi-arch: fix TestBuildOnDisabledBridgeNetworkDaemon

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2322,7 +2322,7 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *chec
 }
 
 func (s *DockerDaemonSuite) TestBuildOnDisabledBridgeNetworkDaemon(c *check.C) {
-	err := s.d.Start("-b=none", "--iptables=false")
+	err := s.d.StartWithBusybox("-b=none", "--iptables=false")
 	c.Assert(err, check.IsNil)
 	s.d.c.Logf("dockerBinary %s", dockerBinary)
 	out, code, err := s.d.buildImageWithOut("busyboxs",


### PR DESCRIPTION
Fixes the test by loading in the architecture specific busybox
image when the test daemon starts.

![bestdog](https://cloud.githubusercontent.com/assets/15270681/15519422/07e6712a-21c7-11e6-8e82-ec67be863ea5.png)

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
