### PR TITLE
Fix bad error doing docker login in from non TTY

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -41,7 +41,6 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	}
 
 	ctx := context.Background()
-
 	var serverAddress string
 	var isDefaultRegistry bool
 	if len(cmd.Args()) > 0 {
@@ -50,17 +49,14 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		serverAddress = cli.electAuthServer(ctx)
 		isDefaultRegistry = true
 	}
-
 	authConfig, err := cli.configureAuth(*flUser, *flPassword, serverAddress, isDefaultRegistry)
 	if err != nil {
 		return err
 	}
-
 	response, err := cli.client.RegistryLogin(ctx, authConfig)
 	if err != nil {
 		return err
 	}
-
 	if response.IdentityToken != "" {
 		authConfig.Password = ""
 		authConfig.IdentityToken = response.IdentityToken
@@ -89,6 +85,17 @@ func (cli *DockerCli) configureAuth(flUser, flPassword, serverAddress string, is
 		return authconfig, err
 	}
 
+	// Some links documenting this:
+	// - https://code.google.com/archive/p/mintty/issues/56
+	// - https://github.com/docker/docker/issues/15272
+	// - https://mintty.github.io/ (compatibility)
+	// Linux will hit this if you attempt `cat | docker login`, and Windows
+	// will hit this if you attempt docker login from mintty where stdin
+	// is a pipe, not a character based console.
+	if flPassword == "" && !cli.isTerminalIn {
+		return authconfig, fmt.Errorf("Error: Cannot perform an interactive logon from a non TTY device")
+	}
+
 	authconfig.Username = strings.TrimSpace(authconfig.Username)
 
 	if flUser = strings.TrimSpace(flUser); flUser == "" {
@@ -103,11 +110,9 @@ func (cli *DockerCli) configureAuth(flUser, flPassword, serverAddress string, is
 			flUser = authconfig.Username
 		}
 	}
-
 	if flUser == "" {
 		return authconfig, fmt.Errorf("Error: Non-null Username Required")
 	}
-
 	if flPassword == "" {
 		oldState, err := term.SaveState(cli.inFd)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

"Fixes" (well not really, as it's by design) https://github.com/docker/docker/issues/15272. 

mintty does not present a terminal on stdin which can be used by console apps on Windows, hence will bomb out "The handle is invalid" when a Win32 console API is attempted to turn off echo on the console (actually a step early when it's trying to save the current state of the console, and performs a console API call on something which isn't a console). You see exactly the same type of error in Linux if you try something silly like `cat | docker login`. 

This unifies things to give a clearer error message on both Windows and Linux by looking to determine if the stdin is a terminal in the docker login. 

The solution to `mintty not working for docker login` is to not use it. The not being a terminal and incompatibility is well documented, and I added a bunch of links in the code for future reference.

The right solution is to use a shell which does provide a terminal such as cmd, powershell, lxss, git-for-windows bash (msys2 I believe). Just not mintty.

Screenshot below shows mintty above with new error message, and the experience under a few shells.

1 - `mintty` (fails)
2 - git for Windows 2.8 bash (works)
3 - PowerShell
4 - cmd

![tty](https://cloud.githubusercontent.com/assets/10522484/15523408/08d142f6-21cf-11e6-990f-c1e7dbd11e4c.JPG)

And for completeness, here's what you would see (without this fix) on Linux doing that `cat | docker login` example. With this PR, you'll get the same new error on Linux and Windows.

![image](https://cloud.githubusercontent.com/assets/10522484/15523438/2c8d216a-21cf-11e6-95b3-6da4485e7c19.png)
