### PR TITLE
profiles: apparmor: restrict access to private files by default.

### DIFF
--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -43,11 +43,16 @@ func (p *profileData) generateDefault(out io.Writer) error {
 		p.Imports = append(p.Imports, "#include <tunables/global>")
 	} else {
 		p.Imports = append(p.Imports, "@{PROC}=/proc/")
+		p.Imports = append(p.Imports, "@{HOME}=/home/*/ /root/")
 	}
 
 	if macroExists("abstractions/base") {
 		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
 	}
+	if macroExists("abstractions/private-files-strict") {
+		p.InnerImports = append(p.InnerImports, "#include <abstractions/private-files-strict>")
+	}
+
 
 	ver, err := aaparser.GetVersion()
 	if err != nil {


### PR DESCRIPTION
**\- What I did**

Included `abstractions/private-files-strict` profile to the default apparmor profile when it is available.

**\- How I did it**
Updated profiles/apparmor/apparmor.go.

**\- How to verify it**
Run a docker container and test if it is permitted to access a file that should be denied by `abstractions/private-files-strict`, for example `~/.gnupg/anything`

**\- Description for the changelog**
When the abstract private-files-strict profile is defined include it in the default apparmor profile.

Signed-off-by: David Black dblack@atlassian.com
