### PR TITLE
Do not run the seccomp tests that use default.json on non x86 architectures

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1076,7 +1076,7 @@ func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 // make sure the default profile can be successfully parsed (using unshare as it is
 // something which we know is blocked in the default profile)
 func (s *DockerSuite) TestRunSeccompWithDefaultProfile(c *check.C) {
-	testRequires(c, SameHostDaemon, seccompEnabled)
+	testRequires(c, SameHostDaemon, seccompEnabled, NotArm, NotPpc64le)
 
 	out, _, err := dockerCmdWithError("run", "--security-opt", "seccomp=../profiles/seccomp/default.json", "debian:jessie", "unshare", "--map-root-user", "--user", "sh", "-c", "whoami")
 	c.Assert(err, checker.NotNil, check.Commentf(out))


### PR DESCRIPTION
The generated profile that we check in is for amd64 and i386 architectures
and does not work correctly on arm as it is missing required syscalls,
and also specifies the architectures that are supported. It works on
ppc64le at the moment but better to skip the test as it is likely to
break in future.

Signed-off-by: Justin Cormack justin.cormack@docker.com

This fixes one of the current breakages in the arm CI, the other one is still broken.
