### PR TITLE
Fix a race in daemon/logger.TestCopier

### DIFF
--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"sync"
 	"testing"
 	"time"
 )
 
 type TestLoggerJSON struct {
 	*json.Encoder
+	mu    sync.Mutex
 	delay time.Duration
 }
 
@@ -17,6 +19,8 @@ func (l *TestLoggerJSON) Log(m *Message) error {
 	if l.delay > 0 {
 		time.Sleep(l.delay)
 	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	return l.Encode(m)
 }
 


### PR DESCRIPTION
**\- What I did**
Fixed a race found in #22963

**\- How I did it**
Introduced a mutex

**\- How to verify it**
`TESTDIRS=daemon/logger BUILDFLAGS=-race TESTFLAGS="-test.count 1000" make test-unit`

Update #22963 (not closable yet, due to another race in awslogs)
Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
