### PR TITLE
Fix a race in daemon/logger/awslogs

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -271,10 +271,12 @@ func (l *logStream) collectBatch() {
 // publishBatch calls PutLogEvents for a given set of InputLogEvents,
 // accounting for sequencing requirements (each request must reference the
 // sequence token returned by the previous request).
-func (l *logStream) publishBatch(events []*cloudwatchlogs.InputLogEvent) {
-	if len(events) == 0 {
+func (l *logStream) publishBatch(origEvents []*cloudwatchlogs.InputLogEvent) {
+	if len(origEvents) == 0 {
 		return
 	}
+	events := make([]*cloudwatchlogs.InputLogEvent, len(origEvents))
+	copy(events, origEvents)
 
 	sort.Sort(byTimestamp(events))
 


### PR DESCRIPTION
**\- What I did**
Fixed a race found in #22963

**\- How I did it**
Copied a slice to avoid the race

**\- How to verify it**
`TESTDIRS=daemon/logger/awslogs BUILDFLAGS=-race TESTFLAGS="-test.count 100" make test-unit`

Fix #22963 (with #22969)
Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp

---

PTAL @samuelkarp
