### PR TITLE
Fix a race in pkg/integration.TestChannelBufferTimeout

### DIFF
--- a/pkg/integration/utils_test.go
+++ b/pkg/integration/utils_test.go
@@ -510,9 +510,11 @@ func TestChannelBufferTimeout(t *testing.T) {
 	buf := &ChannelBuffer{make(chan []byte, 1)}
 	defer buf.Close()
 
+	done := make(chan struct{}, 1)
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		io.Copy(buf, strings.NewReader(expected))
+		done <- struct{}{}
 	}()
 
 	// Wait long enough
@@ -521,9 +523,7 @@ func TestChannelBufferTimeout(t *testing.T) {
 	if err == nil && err.Error() != "timeout reading from channel" {
 		t.Fatalf("Expected an error, got %s", err)
 	}
-
-	// Wait for the end :)
-	time.Sleep(150 * time.Millisecond)
+	<-done
 }
 
 func TestChannelBuffer(t *testing.T) {


### PR DESCRIPTION
**\- What I did**
Fixed a race found in #22965

**\- How I did it**
Introduced a channel for waiting a goroutine completion

**\- How to verify it**
`TESTDIRS=pkg/integration BUILDFLAGS=-race TESTFLAGS="-test.run TestChannelBufferTimeout -test.count 100" make test-unit`

Update #22965 (not closable yet, due to other races related to `os/exec`)
Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
