### PR TITLE
Invert CgroupDevicesEnabled condition

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -550,8 +550,8 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 
 	sysInfo := sysinfo.New(false)
 	// Check if Devices cgroup is mounted, it is hard requirement for container security,
-	// on Linux/FreeBSD.
-	if runtime.GOOS != "windows" && runtime.GOOS != "solaris" && !sysInfo.CgroupDevicesEnabled {
+	// on Linux.
+	if runtime.GOOS == "linux" && !sysInfo.CgroupDevicesEnabled {
 		return nil, fmt.Errorf("Devices cgroup isn't mounted")
 	}
 


### PR DESCRIPTION
As a follow-up to #22091 and to follow @justincormack comment https://github.com/docker/docker/pull/22091#discussion-diff-64142769 🐼 :

> It seems better to test where it's required than listing everywhere it is not required.

/cc @thaJeztah @runcom @LK4D4 @amitkris

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
