### PR TITLE
deprecate '-h' shorthand and remove '-help'

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -21,6 +21,17 @@ The following list of features are deprecated in Engine.
 
 The `docker import` command format 'file|URL|- [REPOSITORY [TAG]]' is deprecated since November 2013. It's no more supported.
 
+### `-h` shorthand for `--help`
+
+**Deprecated In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
+
+**Target For Removal In Release: [v1.14.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
+
+The shorthand (`-h`) is less common than `--help` on Linux and cannot be used
+on all subcommands (due to it conflicting with, e.g. `-h` / `--hostname` on
+`docker create`). For this reason, the `-h` shorthand was not printed in the
+"usage" output of subcommands, nor docummented, and is now marked "deprecated".
+
 ### `-e` and `--email` flags on `docker login`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
@@ -148,6 +159,16 @@ The following double-dash options are deprecated and have no replacement:
     docker ps --since-id
     docker ps --before-id
     docker search --trusted
+
+**Deprecated In Release: [v1.5.0](https://github.com/docker/docker/releases/tag/v1.5.0)**
+
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
+
+The single-dash (`-help`) was removed, in favor of the double-dash `--help`
+
+    docker -help
+    docker [COMMAND] -help
+
 
 ### Interacting with V1 registries
 


### PR DESCRIPTION
closes https://github.com/docker/docker/issues/22972

This deprecates the shorthand `-h`, because we don`t mention it as an option,
and it conflicts with the`docker create -h/--hostname` option, so cannot be
used for all commands consistently.

This also removes the (single-dash) `-help` option. The single-dash variant was
marked "deprecated" in version 1.5.0 (basically, since it was added in
a2b529ead21e6ab9eafcb1b1d2437c725c43a06a), but still kept around to
prevent `-help` being treated as `-h -e -l -p`, causing confusing
warnings.

Before this change:

```
$ docker images -h
(no warning)

$docker images -help
Warning: '-help' is deprecated, it will be replaced by '--help' soon. See usage.

$ docker create -help
Warning: '-help' is deprecated, it will be replaced by '--help' soon. See usage.
```

After this change:

```
$ docker -help
flag provided but not defined: -help
See 'docker --help'.

$ docker -h
Warning: '-h' is deprecated, it will be replaced by '--help' soon. See usage.
Usage: docker [OPTIONS] COMMAND [arg...]
...


$ docker images -h
Warning: '-h' is deprecated, it will be replaced by '--help' soon. See usage.
Usage:  docker images [OPTIONS] [REPOSITORY[:TAG]]
...

$ docker images -help
flag provided but not defined: -help
See 'docker images --help'.

$ docker create -help
flag provided but not defined: -help
See 'docker create --help'.
```
