### PR TITLE
Better error on attach no tty

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -67,7 +67,11 @@ func (cli *DockerCli) CheckTtyInput(attachStdin, ttyMode bool) error {
 	// be a tty itself: redirecting or piping the client standard input is
 	// incompatible with `docker run -t`, `docker exec -t` or `docker attach`.
 	if ttyMode && attachStdin && !cli.isTerminalIn {
-		return errors.New("cannot enable tty mode on non tty input")
+		eText := "the input device is not a TTY"
+		if runtime.GOOS == "windows" {
+			return errors.New(eText + ".  If you are using mintty, try prefixing the command with 'winpty'")
+		}
+		return errors.New(eText)
 	}
 	return nil
 }

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -103,7 +104,10 @@ func (s *DockerSuite) TestAttachTTYWithoutStdin(c *check.C) {
 			return
 		}
 
-		expected := "cannot enable tty mode"
+		expected := "the input device is not a TTY"
+		if runtime.GOOS == "windows" {
+			expected += ".  If you are using mintty, try prefixing the command with 'winpty'"
+		}
 		if out, _, err := runCommandWithOutput(cmd); err == nil {
 			done <- fmt.Errorf("attach should have failed")
 			return

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -182,7 +183,10 @@ func (s *DockerSuite) TestExecTTYWithoutStdin(c *check.C) {
 			return
 		}
 
-		expected := "cannot enable tty mode"
+		expected := "the input device is not a TTY"
+		if runtime.GOOS == "windows" {
+			expected += ".  If you are using mintty, try prefixing the command with 'winpty'"
+		}
 		if out, _, err := runCommandWithOutput(cmd); err == nil {
 			errChan <- fmt.Errorf("exec should have failed")
 			return

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -2642,7 +2643,10 @@ func (s *DockerSuite) TestRunTTYWithPipe(c *check.C) {
 			return
 		}
 
-		expected := "cannot enable tty mode"
+		expected := "the input device is not a TTY"
+		if runtime.GOOS == "windows" {
+			expected += ".  If you are using mintty, try prefixing the command with 'winpty'"
+		}
 		if out, _, err := runCommandWithOutput(cmd); err == nil {
 			errChan <- fmt.Errorf("run should have failed")
 			return
@@ -2655,7 +2659,7 @@ func (s *DockerSuite) TestRunTTYWithPipe(c *check.C) {
 	select {
 	case err := <-errChan:
 		c.Assert(err, check.IsNil)
-	case <-time.After(6 * time.Second):
+	case <-time.After(30 * time.Second):
 		c.Fatal("container is running but should have failed")
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This gives a better error attempting to docker attach or docker run -it from a non tty stdin. Further, on Windows, it gives a hint to users potentially using mintty (not sure why so many - see https://github.com/docker/docker/issues/12469) on Windows to try using winpty. On Linux, just gives the improved (IMO, but @thaJeztah will no doubt have an opinion :innocent:) message. Relates to https://github.com/docker/docker/pull/22956

Before:

![worse error](https://cloud.githubusercontent.com/assets/10522484/15549645/67f9375a-2262-11e6-8d4e-3fd2be29265a.JPG)

After:

![better errror](https://cloud.githubusercontent.com/assets/10522484/15549649/6d82cd30-2262-11e6-9451-6901b5711927.JPG)
