### PR TITLE
awslogs: Fix a race in mockcwlogsclient

### DIFF
--- a/daemon/logger/awslogs/cwlogsiface_mock_test.go
+++ b/daemon/logger/awslogs/cwlogsiface_mock_test.go
@@ -44,7 +44,14 @@ func (m *mockcwlogsclient) CreateLogStream(input *cloudwatchlogs.CreateLogStream
 }
 
 func (m *mockcwlogsclient) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
-	m.putLogEventsArgument <- input
+	events := make([]*cloudwatchlogs.InputLogEvent, len(input.LogEvents))
+	copy(events, input.LogEvents)
+	m.putLogEventsArgument <- &cloudwatchlogs.PutLogEventsInput{
+		LogEvents:     events,
+		SequenceToken: input.SequenceToken,
+		LogGroupName:  input.LogGroupName,
+		LogStreamName: input.LogStreamName,
+	}
 	output := <-m.putLogEventsResult
 	return output.successResult, output.errorResult
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixed a race found in #22963 differently than #22971

**\- How I did it**
Copy the `LogEvents` slice in `mockcwlogsclient.PutLogEvents` since the tests may read through the slice asynchronously

**\- How to verify it**
`TESTDIRS=daemon/logger/awslogs BUILDFLAGS=-race TESTFLAGS="-test.count 100" make test-unit`

Closes #22971 
