### PR TITLE
Windows: Adding missing cleanup call when container start fails

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -153,7 +153,7 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 	}
 
 	// Call start, and if it fails, delete the container from our
-	// internal structure, and also keep HCS in sync by deleting the
+	// internal structure, start will keep HCS in sync by deleting the
 	// container there.
 	logrus.Debugf("Create() id=%s, Calling start()", containerID)
 	if err := container.start(); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Add cleanup code to terminate a container that fails to start.

![Fox!](https://s-media-cache-ak0.pinimg.com/736x/a3/4d/f0/a34df01e12faf137aa4aa1dac0b94c63.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
