### PR TITLE
Do not restrict chown via seccomp, just let capabilities control access

### DIFF
--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -57,6 +57,16 @@
 			"args": []
 		},
 		{
+			"name": "chown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "chown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
 			"name": "clock_getres",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -208,6 +218,21 @@
 		},
 		{
 			"name": "fchmodat",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "fchown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "fchown32",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "fchownat",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
@@ -553,6 +578,16 @@
 		},
 		{
 			"name": "kill",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "lchown",
+			"action": "SCMP_ACT_ALLOW",
+			"args": []
+		},
+		{
+			"name": "lchown32",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
 		},
@@ -1523,41 +1558,6 @@
 			"args": []
 		},
 		{
-			"name": "chown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchownat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lchown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
 			"name": "chroot",
 			"action": "SCMP_ACT_ALLOW",
 			"args": []
@@ -1573,11 +1573,6 @@
 					"op": "SCMP_CMP_MASKED_EQ"
 				}
 			]
-		},
-		{
-			"name": "fchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
 		}
 	]
 }

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -89,6 +89,17 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 			Args:   []*types.Arg{},
 		},
 		{
+			Name:   "chown",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "chown32",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+
+		{
 			Name:   "clock_getres",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
@@ -240,6 +251,21 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 		},
 		{
 			Name:   "fchmodat",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "fchown",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "fchown32",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "fchownat",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 		},
@@ -585,6 +611,16 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 		},
 		{
 			Name:   "kill",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "lchown",
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Name:   "lchown32",
 			Action: types.ActAllow,
 			Args:   []*types.Arg{},
 		},
@@ -1591,44 +1627,6 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 	var cap string
 	for _, cap = range rs.Process.Capabilities {
 		switch cap {
-		case "CAP_CHOWN":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "chown",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "chown32",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "fchown",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "fchown32",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "fchownat",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "lchown",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "lchown32",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
 		case "CAP_DAC_READ_SEARCH":
 			syscalls = append(syscalls, []*types.Syscall{
 				{
@@ -1849,17 +1847,6 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 						Op:       types.OpMaskedEqual,
 					},
 				},
-			},
-		}...)
-	}
-
-	// We need some additional syscalls in this case see #22252
-	if !rs.Process.NoNewPrivileges {
-		syscalls = append(syscalls, []*types.Syscall{
-			{
-				Name:   "fchown",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
 			},
 		}...)
 	}


### PR DESCRIPTION
In #22554 I aligned seccomp and capabilities, however the case of
the chown calls and CAP_CHOWN was less clearcut, as these are
simple calls that the capabilities will block if they are not
allowed. They are needed when no new privileges is not set in
order to allow docker to call chown before the container is
started, so there was a workaround but this did not include
all the chown syscalls, and Arm was failing on some seccomp
tests because it was using a different syscall from just the
fchown that was allowed in this case. It is simpler to just
allow all the chown calls in the default seccomp profile and
let the capabilities subsystem block them.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![lemur](https://cloud.githubusercontent.com/assets/482364/15554312/697e7b60-2278-11e6-9a31-59d30741fc0b.jpg)

Should fix the remaining Arm CI issue on seccomp tests

cc @jfrazelle 
