### PR TITLE
Multiple fixes for SELinux labels.

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -118,7 +118,9 @@ func (container *Container) NetworkMounts() []Mount {
 		if _, err := os.Stat(container.ResolvConfPath); err != nil {
 			logrus.Warnf("ResolvConfPath set to %q, but can't stat this filename (err = %v); skipping", container.ResolvConfPath, err)
 		} else {
-			label.Relabel(container.ResolvConfPath, container.MountLabel, shared)
+			if !container.HasMountFor("/etc/resolv.conf") {
+				label.Relabel(container.ResolvConfPath, container.MountLabel, shared)
+			}
 			writable := !container.HostConfig.ReadonlyRootfs
 			if m, exists := container.MountPoints["/etc/resolv.conf"]; exists {
 				writable = m.RW
@@ -135,7 +137,9 @@ func (container *Container) NetworkMounts() []Mount {
 		if _, err := os.Stat(container.HostnamePath); err != nil {
 			logrus.Warnf("HostnamePath set to %q, but can't stat this filename (err = %v); skipping", container.HostnamePath, err)
 		} else {
-			label.Relabel(container.HostnamePath, container.MountLabel, shared)
+			if !container.HasMountFor("/etc/hostname") {
+				label.Relabel(container.HostnamePath, container.MountLabel, shared)
+			}
 			writable := !container.HostConfig.ReadonlyRootfs
 			if m, exists := container.MountPoints["/etc/hostname"]; exists {
 				writable = m.RW
@@ -152,7 +156,9 @@ func (container *Container) NetworkMounts() []Mount {
 		if _, err := os.Stat(container.HostsPath); err != nil {
 			logrus.Warnf("HostsPath set to %q, but can't stat this filename (err = %v); skipping", container.HostsPath, err)
 		} else {
-			label.Relabel(container.HostsPath, container.MountLabel, shared)
+			if !container.HasMountFor("/etc/hosts") {
+				label.Relabel(container.HostsPath, container.MountLabel, shared)
+			}
 			writable := !container.HostConfig.ReadonlyRootfs
 			if m, exists := container.MountPoints["/etc/hosts"]; exists {
 				writable = m.RW

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -142,8 +142,8 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 	return container, nil
 }
 
-func (daemon *Daemon) generateSecurityOpt(ipcMode containertypes.IpcMode, pidMode containertypes.PidMode) ([]string, error) {
-	if ipcMode.IsHost() || pidMode.IsHost() {
+func (daemon *Daemon) generateSecurityOpt(ipcMode containertypes.IpcMode, pidMode containertypes.PidMode, privileged bool) ([]string, error) {
+	if ipcMode.IsHost() || pidMode.IsHost() || privileged {
 		return label.DisableSecOpt(), nil
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -247,7 +247,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 	}
 	var err error
 	if hostConfig.SecurityOpt == nil {
-		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
+		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode, hostConfig.Privileged)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
SELinux labeling should be disabled when using --privileged mode

/etc/hosts, /etc/resolv.conf, /etc/hostname should not be relabeled if they
are volume mounted into the container.

Signed-off-by: Dan Walsh dwalsh@redhat.com
