### PR TITLE
Windows: Use image version, not OS version for TTY fixup

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -34,6 +34,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		return nil, fmt.Errorf("Failed to graph.Get on ImageID %s - %s", c.ImageID, err)
 	}
 
+	s.Platform.OSVersion = img.OSVersion
+
 	// In base spec
 	s.Hostname = c.FullHostname()
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -222,7 +222,7 @@ func (clnt *client) AddProcess(containerID, processFriendlyName string, procToAd
 	iopipe.Stdin = createStdInCloser(stdin, newProcess)
 
 	// TEMP: Work around Windows BS/DEL behavior.
-	iopipe.Stdin = fixStdinBackspaceBehavior(iopipe.Stdin, procToAdd.Terminal)
+	iopipe.Stdin = fixStdinBackspaceBehavior(iopipe.Stdin, container.ociSpec.Platform.OSVersion, procToAdd.Terminal)
 
 	// Convert io.ReadClosers to io.Readers
 	if stdout != nil {

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -106,7 +106,7 @@ func (ctr *container) start() error {
 	iopipe.Stdin = createStdInCloser(stdin, hcsProcess)
 
 	// TEMP: Work around Windows BS/DEL behavior.
-	iopipe.Stdin = fixStdinBackspaceBehavior(iopipe.Stdin, ctr.ociSpec.Process.Terminal)
+	iopipe.Stdin = fixStdinBackspaceBehavior(iopipe.Stdin, ctr.ociSpec.Platform.OSVersion, ctr.ociSpec.Process.Terminal)
 
 	// Convert io.ReadClosers to io.Readers
 	if stdout != nil {

--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -2,9 +2,10 @@ package libcontainerd
 
 import (
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/docker/docker/pkg/system"
 )
 
 // process keeps the state for both main container process and exec process.
@@ -33,10 +34,19 @@ func openReaderFromPipe(p io.ReadCloser) io.Reader {
 // fixStdinBackspaceBehavior works around a bug in Windows before build 14350
 // where it interpreted DEL as VK_DELETE instead of as VK_BACK. This replaces
 // DEL with BS to work around this.
-func fixStdinBackspaceBehavior(w io.WriteCloser, tty bool) io.WriteCloser {
-	if !tty || system.GetOSVersion().Build >= 14350 {
+func fixStdinBackspaceBehavior(w io.WriteCloser, osversion string, tty bool) io.WriteCloser {
+	if !tty {
 		return w
 	}
+	v := strings.Split(osversion, ".")
+	if len(v) < 3 {
+		return w
+	}
+
+	if build, err := strconv.Atoi(v[2]); err != nil || build >= 14350 {
+		return w
+	}
+
 	return &delToBsWriter{w}
 }
 

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -86,6 +86,8 @@ type Platform struct {
 	OS string `json:"os"`
 	// Arch is the architecture
 	Arch string `json:"arch"`
+	// OSVersion is the version of the operating system.
+	OSVersion string `json:"os.version,omitempty"`
 }
 
 // Mount specifies a mount for a container.


### PR DESCRIPTION
A previous change added a TTY fixup for stdin on older Windows versions to
work around a Windows issue with backspace/delete behavior. This change
used the OS version to determine whether to activate the behavior.
However, the Windows bug is actually in the image, not the OS, so it
should have used the image's OS version.

This ensures that a Server TP5 container running on Windows 10 will have
reasonable console behavior.

cc @jhowardmsft 
