### PR TITLE
Fix URLs for official Oracle installation guide.

### DIFF
--- a/docs/installation/linux/oracle.md
+++ b/docs/installation/linux/oracle.md
@@ -29,13 +29,8 @@ btrfs storage engine on both Oracle Linux 6 and 7.
 > follow the installation instructions provided in the
 > [Oracle Linux documentation](https://docs.oracle.com/en/operating-systems/?tab=2).
 >
-> The installation instructions for Oracle Linux 6 can be found in [Chapter 10 of
-> the Administrator&apos;s
-> Solutions Guide](https://docs.oracle.com/cd/E37670_01/E37355/html/ol_docker.html)
->
-> The installation instructions for Oracle Linux 7 can be found in [Chapter 29 of
-> the Administrator&apos;s
-> Guide](https://docs.oracle.com/cd/E52668_01/E54669/html/ol7-docker.html)
+> The installation instructions for Oracle Linux 6 and 7 can be found in [Chapter 2 of
+> the Docker User&apos;s Guide](https://docs.oracle.com/cd/E52668_01/E75728/html/docker_install_upgrade.html)
 
 
 1. Log into your machine as a user with `sudo` or `root` privileges.


### PR DESCRIPTION
**\- What I did**

Fix the URL to the official Oracle Linux Docker User's Guide now that it's been moved out into it's own documentation.

**\- How I did it**

Edited `oracle.md` in the `docs/installation/linux` directory

**\- How to verify it**

Generate the documentation and click the link inside the generated docs for the official Oracle installation guide.

**\- Description for the changelog**
Fix the URL to the official Oracle Linux Docker User's Guide

**\- A picture of a cute animal (not mandatory but encouraged)**

![melbourne-aquarium-penguins](https://cloud.githubusercontent.com/assets/103232/15557273/87f59cfc-2315-11e6-9ffc-2ef15497c15d.jpg)

Hello from the penguins at the Melbourne Aquarium. They approve this commit.

Signed-off-by: Avi Miller avi.miller@oracle.com
