### PR TITLE
Say something useful during docker load

### DIFF
--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -61,6 +61,8 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 	}
 
 	var parentLinks []parentLink
+	var imageIDsStr string
+	var imageRefCount int
 
 	for _, m := range manifest {
 		configPath, err := safePath(tmpDir, m.Config)
@@ -108,7 +110,9 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		if err != nil {
 			return err
 		}
+		imageIDsStr += fmt.Sprintf("Loaded image ID: %s\n", imgID)
 
+		imageRefCount = 0
 		for _, repoTag := range m.RepoTags {
 			named, err := reference.ParseNamed(repoTag)
 			if err != nil {
@@ -119,6 +123,8 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 				return fmt.Errorf("invalid tag %q", repoTag)
 			}
 			l.setLoadedTag(ref, imgID, outStream)
+			outStream.Write([]byte(fmt.Sprintf("Loaded image: %s\n", ref)))
+			imageRefCount++
 		}
 
 		parentLinks = append(parentLinks, parentLink{imgID, m.Parent})
@@ -131,6 +137,10 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 				return err
 			}
 		}
+	}
+
+	if imageRefCount == 0 {
+		outStream.Write([]byte(imageIDsStr))
 	}
 
 	return nil

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -350,3 +350,33 @@ func (s *DockerSuite) TestSaveLoadParents(c *check.C) {
 	inspectOut = inspectField(c, idFoo, "Parent")
 	c.Assert(inspectOut, checker.Equals, "")
 }
+
+func (s *DockerSuite) TestSaveLoadNoTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	name := "saveloadnotag"
+
+	_, err := buildImage(name, "FROM busybox\nENV foo=bar", true)
+	c.Assert(err, checker.IsNil, check.Commentf("%v", err))
+
+	id := inspectField(c, name, "Id")
+
+	// Test to make sure that save w/o name just shows imageID during load
+	out, _, err := runCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", id),
+		exec.Command(dockerBinary, "load"))
+	c.Assert(err, checker.IsNil, check.Commentf("failed to save and load repo: %s, %v", out, err))
+
+	// Should not show 'name' but should show the image ID during the load
+	c.Assert(out, checker.Not(checker.Contains), "Loaded image: ")
+	c.Assert(out, checker.Contains, "Loaded image ID:")
+	c.Assert(out, checker.Contains, id)
+
+	// Test to make sure that save by name shows that name during load
+	out, _, err = runCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", name),
+		exec.Command(dockerBinary, "load"))
+	c.Assert(err, checker.IsNil, check.Commentf("failed to save and load repo: %s, %v", out, err))
+	c.Assert(out, checker.Contains, "Loaded image: "+name+":latest")
+	c.Assert(out, checker.Not(checker.Contains), "Loaded image ID:")
+}


### PR DESCRIPTION
During a `docker load` there are times when nothing is printed
to the screen, leaving the user with no idea whether something happened.
When something _is_ printed, often its just something like:

```
1834950e52ce: Loading layer 1.311 MB/1.311 MB
5f70bf18a086: Loading layer 1.024 kB/1.024 kB
```

which isn't necessarily the same as the image IDs.

This PR will either show:
- all of the tags for the image, or
- all of the image IDs if there are no tags

Sample output:

```
$ docker load -i busybox.tar
Loaded image: busybox:latest

$ docker load -i a.tar
Loaded image ID: sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb
```

IOW, show the human-friendly stuff first and then only if there are no tags
default back to the image IDs, so they have something to work with.

For me this this is needed because I have lots of images and after a
recent `docker load` I had no idea what image I just imported and had a
hard time figuring it out.  This should fix that by telling the user
which images they just imported.

I'll add tests once there's agreement that we want this change.

Signed-off-by: Doug Davis dug@us.ibm.com
