### PR TITLE
Fix a leaked process handle of the first container to start on Windows

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -167,6 +167,10 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 		// has exited to avoid a container being dropped on the floor.
 	}
 
+	if err := process.hcsProcess.Close(); err != nil {
+		logrus.Error(err)
+	}
+
 	// Assume the container has exited
 	si := StateInfo{
 		CommonStateInfo: CommonStateInfo{
@@ -180,9 +184,6 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 
 	// But it could have been an exec'd process which exited
 	if !isFirstProcessToStart {
-		if err := process.hcsProcess.Close(); err != nil {
-			logrus.Error(err)
-		}
 		si.State = StateExitProcess
 	} else {
 		updatePending, err := ctr.hcsContainer.HasPendingUpdates()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

This fixes a leaked handle to the init process of Windows containers introduced in https://github.com/docker/docker/pull/22958

**\- How I did it**

Close the process handle for all exiting processes.

**\- How to verify it**

See below screenshot using the Handles utility after a simple `docker run --rm windowsservercore cmd`. Top cmd shows leaked handles, bottom shows that the leak is fixed. I am currently running CI locally to verify that all leaks are cleaned up, but I think this should get them all.

Edit: Local CI passed with no leaked handles.

![leak](https://cloud.githubusercontent.com/assets/14114019/15563845/669efb2e-22c1-11e6-8410-2fc0006dc275.png)

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

Signed-off-by: Darren Stahl darst@microsoft.com
