### PR TITLE
Fix link doesn't work sometimes when container start with multiple networks

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -397,7 +397,21 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) error {
 		updateSettings = true
 	}
 
+	// always connect default network first since only default
+	// network mode support link and we need do some setting
+	// on sanbox initialize for link, but the sandbox only be initialized
+	// on first network connecting.
+	defaultNetName := runconfig.DefaultDaemonNetworkMode().NetworkName()
+	if nConf, ok := container.NetworkSettings.Networks[defaultNetName]; ok {
+		if err := daemon.connectToNetwork(container, defaultNetName, nConf, updateSettings); err != nil {
+			return err
+		}
+
+	}
 	for n, nConf := range container.NetworkSettings.Networks {
+		if n == defaultNetName {
+			continue
+		}
 		if err := daemon.connectToNetwork(container, n, nConf, updateSettings); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

If there is multiple networks to connect to on container starting,
the order of these networks is random because we "range a map". But
the defautl network "bridge" should be connected first since only
"bridge" support link and we should have do some settings on sandbox
creation(https://github.com/docker/docker/blob/master/daemon/container_operations.go#L178), and only the first connect will setting the sandbox（https://github.com/docker/docker/blob/master/daemon/container_operations.go#L564）.
Signed-off-by: Lei Jitang leijitang@huawei.com
**\- What I did**

Fix link doesn't work sometimes when container start with multiple networks
**\- How I did it**
always connect default network first if there is default network `bridge`
**\- How to verify it**
create a container which link to another container,
and then connect to multiple networks with `docker network connect`,
the link should always work.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

ping @mavenugo 
