### PR TITLE
Support external url layers in other os also

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/distribution"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/container"
@@ -171,7 +172,8 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 		osFeatures = img.OSFeatures
 	}
 
-	l, err := daemon.layerStore.Register(rwTar, rootFS.ChainID())
+	// TODO(runcom): generate descriptor
+	l, err := daemon.layerStore.Register(rwTar, rootFS.ChainID(), distribution.Descriptor{})
 	if err != nil {
 		return "", err
 	}

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/docker/distribution"
 	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
@@ -88,7 +89,8 @@ func (daemon *Daemon) ImportImage(src string, repository, tag string, msg string
 		return err
 	}
 	// TODO: support windows baselayer?
-	l, err := daemon.layerStore.Register(inflatedLayerData, "")
+	// TODO(runcom): generate descriptor
+	l, err := daemon.layerStore.Register(inflatedLayerData, "", distribution.Descriptor{})
 	if err != nil {
 		return err
 	}

--- a/distribution/pull_v2_unix.go
+++ b/distribution/pull_v2_unix.go
@@ -3,17 +3,10 @@
 package distribution
 
 import (
-	"github.com/docker/distribution"
-	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/docker/image"
 )
 
 func detectBaseLayer(is image.Store, m *schema1.Manifest, rootFS *image.RootFS) error {
 	return nil
-}
-
-func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
-	blobs := ld.repo.Blobs(ctx)
-	return blobs.Open(ctx, ld.digest)
 }

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -5,14 +5,8 @@ package distribution
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"os"
 
-	"github.com/docker/distribution"
-	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/manifest/schema2"
-	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/image"
 )
 
@@ -33,37 +27,4 @@ func detectBaseLayer(is image.Store, m *schema1.Manifest, rootFS *image.RootFS) 
 		}
 	}
 	return fmt.Errorf("Invalid base layer %q", v1img.Parent)
-}
-
-var _ distribution.Describable = &v2LayerDescriptor{}
-
-func (ld *v2LayerDescriptor) Descriptor() distribution.Descriptor {
-	if ld.src.MediaType == schema2.MediaTypeForeignLayer && len(ld.src.URLs) > 0 {
-		return ld.src
-	}
-	return distribution.Descriptor{}
-}
-
-func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
-	if len(ld.src.URLs) == 0 {
-		blobs := ld.repo.Blobs(ctx)
-		return blobs.Open(ctx, ld.digest)
-	}
-
-	var (
-		err error
-		rsc distribution.ReadSeekCloser
-	)
-
-	// Find the first URL that results in a 200 result code.
-	for _, url := range ld.src.URLs {
-		rsc = transport.NewHTTPReadSeeker(http.DefaultClient, url, nil)
-		_, err = rsc.Seek(0, os.SEEK_SET)
-		if err == nil {
-			break
-		}
-		rsc.Close()
-		rsc = nil
-	}
-	return rsc, err
 }

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -241,7 +241,7 @@ func (pd *v2PushDescriptor) DiffID() layer.DiffID {
 
 func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.Output) (distribution.Descriptor, error) {
 	if fs, ok := pd.layer.(distribution.Describable); ok {
-		if d := fs.Descriptor(); len(d.URLs) > 0 {
+		if d := fs.Descriptor(); fs.Descriptor().MediaType == schema2.MediaTypeForeignLayer {
 			progress.Update(progressOutput, pd.ID(), "Skipped foreign layer")
 			return d, nil
 		}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -323,11 +323,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 			if fs, ok := descriptor.(distribution.Describable); ok {
 				src = fs.Descriptor()
 			}
-			if ds, ok := d.layerStore.(layer.DescribableStore); ok {
-				d.layer, err = ds.RegisterWithDescriptor(inflatedLayerData, parentLayer, src)
-			} else {
-				d.layer, err = d.layerStore.Register(inflatedLayerData, parentLayer)
-			}
+			d.layer, err = d.layerStore.Register(inflatedLayerData, parentLayer, src)
 			if err != nil {
 				select {
 				case <-d.Transfer.Context().Done():
@@ -422,11 +418,7 @@ func (ldm *LayerDownloadManager) makeDownloadFuncFromDownload(descriptor Downloa
 			if fs, ok := l.(distribution.Describable); ok {
 				src = fs.Descriptor()
 			}
-			if ds, ok := d.layerStore.(layer.DescribableStore); ok {
-				d.layer, err = ds.RegisterWithDescriptor(layerReader, parentLayer, src)
-			} else {
-				d.layer, err = d.layerStore.Register(layerReader, parentLayer)
-			}
+			d.layer, err = d.layerStore.Register(layerReader, parentLayer, src)
 			if err != nil {
 				d.err = fmt.Errorf("failed to register layer: %v", err)
 				return

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -71,11 +71,7 @@ func createChainIDFromParent(parent layer.ChainID, dgsts ...layer.DiffID) layer.
 	return createChainIDFromParent(layer.ChainID(dgst), dgsts[1:]...)
 }
 
-func (ls *mockLayerStore) Register(reader io.Reader, parentID layer.ChainID) (layer.Layer, error) {
-	return ls.RegisterWithDescriptor(reader, parentID, distribution.Descriptor{})
-}
-
-func (ls *mockLayerStore) RegisterWithDescriptor(reader io.Reader, parentID layer.ChainID, _ distribution.Descriptor) (layer.Layer, error) {
+func (ls *mockLayerStore) Register(reader io.Reader, parentID layer.ChainID, descriptor distribution.Descriptor) (layer.Layer, error) {
 	var (
 		parent layer.Layer
 		err    error
@@ -270,7 +266,7 @@ func TestSuccessfulDownload(t *testing.T) {
 	firstDescriptor := descriptors[0].(*mockDownloadDescriptor)
 
 	// Pre-register the first layer to simulate an already-existing layer
-	l, err := layerStore.Register(firstDescriptor.mockTarStream(), "")
+	l, err := layerStore.Register(firstDescriptor.mockTarStream(), "", distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -185,17 +185,10 @@ func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string,
 
 		progressReader := progress.NewProgressReader(inflatedLayerData, progressOutput, fileInfo.Size(), stringid.TruncateID(id), "Loading layer")
 
-		if ds, ok := l.ls.(layer.DescribableStore); ok {
-			return ds.RegisterWithDescriptor(progressReader, rootFS.ChainID(), foreignSrc)
-		}
-		return l.ls.Register(progressReader, rootFS.ChainID())
-
+		return l.ls.Register(progressReader, rootFS.ChainID(), foreignSrc)
 	}
 
-	if ds, ok := l.ls.(layer.DescribableStore); ok {
-		return ds.RegisterWithDescriptor(inflatedLayerData, rootFS.ChainID(), foreignSrc)
-	}
-	return l.ls.Register(inflatedLayerData, rootFS.ChainID())
+	return l.ls.Register(inflatedLayerData, rootFS.ChainID(), foreignSrc)
 }
 
 func (l *tarexporter) setLoadedTag(ref reference.NamedTagged, imgID image.ID, outStream io.Writer) error {

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -168,7 +168,7 @@ type MountInit func(root string) error
 // Store represents a backend for managing both
 // read-only and read-write layers.
 type Store interface {
-	Register(io.Reader, ChainID) (Layer, error)
+	Register(io.Reader, ChainID, distribution.Descriptor) (Layer, error)
 	Get(ChainID) (Layer, error)
 	Release(Layer) ([]Metadata, error)
 
@@ -180,12 +180,6 @@ type Store interface {
 	Cleanup() error
 	DriverStatus() [][2]string
 	DriverName() string
-}
-
-// DescribableStore represents a layer store capable of storing
-// descriptors for layers.
-type DescribableStore interface {
-	RegisterWithDescriptor(io.Reader, ChainID, distribution.Descriptor) (Layer, error)
 }
 
 // MetadataTransaction represents functions for setting layer metadata

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -234,11 +234,7 @@ func (ls *layerStore) applyTar(tx MetadataTransaction, ts io.Reader, parent stri
 	return nil
 }
 
-func (ls *layerStore) Register(ts io.Reader, parent ChainID) (Layer, error) {
-	return ls.registerWithDescriptor(ts, parent, distribution.Descriptor{})
-}
-
-func (ls *layerStore) registerWithDescriptor(ts io.Reader, parent ChainID, descriptor distribution.Descriptor) (Layer, error) {
+func (ls *layerStore) Register(ts io.Reader, parent ChainID, descriptor distribution.Descriptor) (Layer, error) {
 	// err is used to hold the error which will always trigger
 	// cleanup of creates sources but may not be an error returned
 	// to the caller (already exists).

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/vfs"
@@ -104,7 +105,7 @@ func createLayer(ls Store, parent ChainID, layerFunc layerInit) (Layer, error) {
 	}
 	defer ts.Close()
 
-	layer, err := ls.Register(ts, parent)
+	layer, err := ls.Register(ts, parent, distribution.Descriptor{})
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +498,7 @@ func TestTarStreamStability(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1, err := ls.Register(bytes.NewReader(tar1), "")
+	layer1, err := ls.Register(bytes.NewReader(tar1), "", distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +517,7 @@ func TestTarStreamStability(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer2, err := ls.Register(bytes.NewReader(tar2), layer1.ChainID())
+	layer2, err := ls.Register(bytes.NewReader(tar2), layer1.ChainID(), distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -684,12 +685,12 @@ func TestRegisterExistingLayer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer2a, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID())
+	layer2a, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID(), distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	layer2b, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID())
+	layer2b, err := ls.Register(bytes.NewReader(tar1), layer1.ChainID(), distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,12 +725,12 @@ func TestTarStreamVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1, err := ls.Register(bytes.NewReader(tar1), "")
+	layer1, err := ls.Register(bytes.NewReader(tar1), "", distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	layer2, err := ls.Register(bytes.NewReader(tar2), "")
+	layer2, err := ls.Register(bytes.NewReader(tar2), "", distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/docker/distribution"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/stringid"
@@ -110,14 +111,14 @@ func TestLayerMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1b, err := ls.Register(bytes.NewReader(tar1), "")
+	layer1b, err := ls.Register(bytes.NewReader(tar1), "", distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assertReferences(t, layer1a, layer1b)
 	// Attempt register, should be same
-	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID())
+	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID(), distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +239,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	layer1b, err := ls.Register(bytes.NewReader(tar1), "")
+	layer1b, err := ls.Register(bytes.NewReader(tar1), "", distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +247,7 @@ func TestLayerMigrationNoTarsplit(t *testing.T) {
 	assertReferences(t, layer1a, layer1b)
 
 	// Attempt register, should be same
-	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID())
+	layer2a, err := ls.Register(bytes.NewReader(tar2), layer1a.ChainID(), distribution.Descriptor{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -8,6 +8,12 @@ import (
 	"github.com/docker/distribution/digest"
 )
 
+var _ distribution.Describable = &roLayer{}
+
+func (rl *roLayer) Descriptor() distribution.Descriptor {
+	return rl.descriptor
+}
+
 type roLayer struct {
 	chainID    ChainID
 	diffID     DiffID

--- a/layer/ro_layer_windows.go
+++ b/layer/ro_layer_windows.go
@@ -1,9 +1,0 @@
-package layer
-
-import "github.com/docker/distribution"
-
-var _ distribution.Describable = &roLayer{}
-
-func (rl *roLayer) Descriptor() distribution.Descriptor {
-	return rl.descriptor
-}


### PR DESCRIPTION
This is based on https://github.com/docker/docker/pull/22866 (I'll drop @jstarks commits once merged)
I've been testing this and it works great on linux also. I still struggle to understand why we want to go windows only for this feature (sorry I haven't really understood).
The last patch just gets rid of the windows-only code and move it to the general pull_v2 file. The code seems to be working fine, I was able to use it with a registry from docker/distribution master code and I was successful in downloading a layer hosted on an external url.

Pushing is, however, pushing the layer..need to see what's happening
