### PR TITLE
Bumping libnetwork to v0.7.2-rc1

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -30,7 +30,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.7.0-rc.7
+clone git github.com/docker/libnetwork v0.7.2-rc.1
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
+++ b/vendor/src/github.com/docker/libnetwork/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.2-rc.1 (2016-05-07)
+- Fixed a stale endpoint issue on overlay networks during ungraceful restart
+
 ## 0.7.0-rc.7 (2016-04-22)
 - Fixes https://github.com/docker/libnetwork/issues/1113
 - Fixes https://github.com/docker/libnetwork/issues/1069

--- a/vendor/src/github.com/docker/libnetwork/sandbox_store.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox_store.go
@@ -213,7 +213,7 @@ func (c *controller) sandboxCleanup() {
 			var ep *endpoint
 			if err != nil {
 				logrus.Errorf("getNetworkFromStore for nid %s failed while trying to build sandbox for cleanup: %v", eps.Nid, err)
-				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}}
+				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}, persist: true}
 				ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
 			} else {
 				ep, err = n.getEndpointFromStore(eps.Eid)


### PR DESCRIPTION
- Fixed a stale endpoint issue on overlay networks during ungraceful restart
