### PR TITLE
layer: remove tmp dir in fs metadata store

### DIFF
--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -33,6 +33,7 @@ type fileMetadataStore struct {
 type fileMetadataTransaction struct {
 	store *fileMetadataStore
 	root  string
+	tmp   string
 }
 
 // NewFSMetadataStore returns an instance of a metadata store
@@ -78,6 +79,7 @@ func (fms *fileMetadataStore) StartTransaction() (MetadataTransaction, error) {
 	return &fileMetadataTransaction{
 		store: fms,
 		root:  td,
+		tmp:   tmpDir,
 	}, nil
 }
 
@@ -125,7 +127,7 @@ func (fm *fileMetadataTransaction) Commit(layer ChainID) error {
 }
 
 func (fm *fileMetadataTransaction) Cancel() error {
-	return os.RemoveAll(fm.root)
+	return os.RemoveAll(fm.tmp)
 }
 
 func (fm *fileMetadataTransaction) String() string {

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -273,13 +273,13 @@ func (ls *layerStore) Register(ts io.Reader, parent ChainID) (Layer, error) {
 	}
 
 	defer func() {
+		if err := tx.Cancel(); err != nil {
+			logrus.Errorf("Error canceling metadata transaction %q: %s", tx.String(), err)
+		}
 		if err != nil {
 			logrus.Debugf("Cleaning up layer %s: %v", layer.cacheID, err)
 			if err := ls.driver.Remove(layer.cacheID); err != nil {
 				logrus.Errorf("Error cleaning up cache layer %s: %v", layer.cacheID, err)
-			}
-			if err := tx.Cancel(); err != nil {
-				logrus.Errorf("Error canceling metadata transaction %q: %s", tx.String(), err)
 			}
 		}
 	}()


### PR DESCRIPTION
remove the containing tmp dir when transaction finishes

```
[root@localhost layerdb]# ll
total 8
drwxr-xr-x. 6 root root 4096 May 26 17:02 sha256
drwxr-xr-x. 3 root root 4096 May 26 17:02 tmp
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
