### PR TITLE
Use IPVS for nating instead of iptables

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1636,9 +1636,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartRestoreBridgeNetwork(t *check.C) {
 
 	// start a new container, trying to publish port 80:80 should fail
 	out, err := s.d.Cmd("run", "-p", "80:80", "-d", "busybox", "top")
-	if err == nil || !strings.Contains(out, "Bind for 0.0.0.0:80 failed: port is already allocated") {
-		t.Fatalf("80 port is allocated to old running container, it should failed on allocating to new container")
-	}
+	t.Assert(err, checker.NotNil, check.Commentf(out))
+	t.Assert(out, checker.Contains, "port is already mapped to ip")
 
 	// kill old running container and try to allocate again
 	_, err = s.d.Cmd("kill", oldCon)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2137,27 +2137,6 @@ func (s *DockerSuite) TestRunWithInvalidMacAddress(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunDeallocatePortOnMissingIptablesRule(c *check.C) {
-	// TODO Windows. Network settings are not propagated back to inspect.
-	testRequires(c, SameHostDaemon, DaemonIsLinux)
-
-	out, _ := dockerCmd(c, "run", "-d", "-p", "23:23", "busybox", "top")
-
-	id := strings.TrimSpace(out)
-	ip := inspectField(c, id, "NetworkSettings.Networks.bridge.IPAddress")
-	iptCmd := exec.Command("iptables", "-D", "DOCKER", "-d", fmt.Sprintf("%s/32", ip),
-		"!", "-i", "docker0", "-o", "docker0", "-p", "tcp", "-m", "tcp", "--dport", "23", "-j", "ACCEPT")
-	out, _, err := runCommandWithOutput(iptCmd)
-	if err != nil {
-		c.Fatal(err, out)
-	}
-	if err := deleteContainer(id); err != nil {
-		c.Fatal(err)
-	}
-
-	dockerCmd(c, "run", "-d", "-p", "23:23", "busybox", "top")
-}
-
 func (s *DockerSuite) TestRunPortInUse(c *check.C) {
 	// TODO Windows. The duplicate NAT message returned by Windows will be
 	// changing as is currently completely undecipherable. Does need modifying

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -121,6 +121,7 @@ type driver struct {
 	natChain       *iptables.ChainInfo
 	filterChain    *iptables.ChainInfo
 	isolationChain *iptables.ChainInfo
+	mangleChain    *iptables.ChainInfo
 	networks       map[string]*bridgeNetwork
 	store          datastore.DataStore
 	nlh            *netlink.Handle
@@ -241,15 +242,15 @@ func (n *bridgeNetwork) registerIptCleanFunc(clean iptableCleanFunc) {
 	n.iptCleanFuncs = append(n.iptCleanFuncs, clean)
 }
 
-func (n *bridgeNetwork) getDriverChains() (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
+func (n *bridgeNetwork) getDriverChains() (*iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, *iptables.ChainInfo, error) {
 	n.Lock()
 	defer n.Unlock()
 
 	if n.driver == nil {
-		return nil, nil, nil, types.BadRequestErrorf("no driver found")
+		return nil, nil, nil, nil, types.BadRequestErrorf("no driver found")
 	}
 
-	return n.driver.natChain, n.driver.filterChain, n.driver.isolationChain, nil
+	return n.driver.natChain, n.driver.filterChain, n.driver.isolationChain, n.driver.mangleChain, nil
 }
 
 func (n *bridgeNetwork) getNetworkBridgeName() string {
@@ -348,6 +349,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 		natChain       *iptables.ChainInfo
 		filterChain    *iptables.ChainInfo
 		isolationChain *iptables.ChainInfo
+		mangleChain    *iptables.ChainInfo
 	)
 
 	genericData, ok := option[netlabel.GenericData]
@@ -382,7 +384,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 			}
 		}
 		removeIPChains()
-		natChain, filterChain, isolationChain, err = setupIPChains(config)
+		natChain, filterChain, isolationChain, mangleChain, err = setupIPChains(config)
 		if err != nil {
 			return err
 		}
@@ -394,6 +396,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 	d.natChain = natChain
 	d.filterChain = filterChain
 	d.isolationChain = isolationChain
+	d.mangleChain = mangleChain
 	d.config = config
 	d.Unlock()
 
@@ -618,6 +621,10 @@ func (d *driver) createNetwork(config *networkConfiguration) error {
 		config:     config,
 		portMapper: portmapper.New(),
 		driver:     d,
+	}
+
+	if err := network.portMapper.SetupIPVS(); err != nil {
+		return err
 	}
 
 	d.Lock()

--- a/vendor/src/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/src/github.com/docker/libnetwork/iptables/iptables.go
@@ -133,12 +133,12 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 			"--dst-type", "LOCAL",
 			"-j", c.Name}
 		if !Exists(Nat, "PREROUTING", preroute...) && enable {
-			if err := c.Prerouting(Append, preroute...); err != nil {
-				return fmt.Errorf("Failed to inject docker in PREROUTING chain: %s", err)
+			if err := c.Prerouting(Nat, Append, preroute...); err != nil {
+				return fmt.Errorf("Failed to inject docker in PREROUTING nat chain: %s", err)
 			}
 		} else if Exists(Nat, "PREROUTING", preroute...) && !enable {
-			if err := c.Prerouting(Delete, preroute...); err != nil {
-				return fmt.Errorf("Failed to remove docker in PREROUTING chain: %s", err)
+			if err := c.Prerouting(Nat, Delete, preroute...); err != nil {
+				return fmt.Errorf("Failed to remove docker in PREROUTING nat chain: %s", err)
 			}
 		}
 		output := []string{
@@ -155,6 +155,21 @@ func ProgramChain(c *ChainInfo, bridgeName string, hairpinMode, enable bool) err
 		} else if Exists(Nat, "OUTPUT", output...) && !enable {
 			if err := c.Output(Delete, output...); err != nil {
 				return fmt.Errorf("Failed to inject docker in OUTPUT chain: %s", err)
+			}
+		}
+	case Mangle:
+		preroute := []string{
+			"-m", "addrtype", "--dst-type", "LOCAL",
+			"-j", c.Name,
+			"!", "-d", "127.0.0.0/8",
+		}
+		if !Exists(Mangle, "PREROUTING", preroute...) && enable {
+			if err := c.Prerouting(Mangle, Append, preroute...); err != nil {
+				return fmt.Errorf("Failed to inject docker in PREROUTING mangle chain: %s", err)
+			}
+		} else if Exists(Mangle, "PREROUTING", preroute...) && !enable {
+			if err := c.Prerouting(Mangle, Delete, preroute...); err != nil {
+				return fmt.Errorf("Failed to remove docker in PREROUTING nat chain: %s", err)
 			}
 		}
 	case Filter:
@@ -197,8 +212,7 @@ func RemoveExistingChain(name string, table Table) error {
 	return c.Remove()
 }
 
-// Forward adds forwarding rule to 'filter' table and corresponding nat rule to 'nat' table.
-func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr string, destPort int, bridgeName string) error {
+func (c *ChainInfo) Mark(action Action, proto string, ip net.IP, port, mark int) error {
 	daddr := ip.String()
 	if ip.IsUnspecified() {
 		// iptables interprets "0.0.0.0" as "0.0.0.0/32", whereas we
@@ -206,44 +220,97 @@ func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto, destAddr 
 		// value" by both iptables and ip6tables.
 		daddr = "0/0"
 	}
-	args := []string{"-t", string(Nat), string(action), c.Name,
+	args := []string{"-t", string(Mangle), string(action), c.Name,
 		"-p", proto,
 		"-d", daddr,
 		"--dport", strconv.Itoa(port),
+		"-j", "MARK",
+		"--set-mark", strconv.Itoa(mark),
+	}
+
+	output, err := Raw(args...)
+	if err != nil {
+		return err
+	}
+	if len(output) != 0 {
+		return ChainError{Chain: "PREROUTING", Output: output}
+	}
+	return nil
+}
+
+// Forward adds forwarding rule to 'filter' table and corresponding nat rule to 'nat' table.
+func (c *ChainInfo) Forward(action Action, ip net.IP, port int, proto string, newIP net.IP, newPort int, bridgeName string) error {
+	args := []string{"-t", string(Nat), string(action), c.Name,
+		"-p", proto,
+		"-d", ip.String(),
+		"--dport", strconv.Itoa(port),
 		"-j", "DNAT",
-		"--to-destination", net.JoinHostPort(destAddr, strconv.Itoa(destPort))}
+		"--to-destination", net.JoinHostPort(newIP.String(), strconv.Itoa(newPort))}
 	if !c.HairpinMode {
 		args = append(args, "!", "-i", bridgeName)
 	}
-	if output, err := Raw(args...); err != nil {
+	output, err := Raw(args...)
+	if err != nil {
 		return err
-	} else if len(output) != 0 {
+	}
+	if len(output) != 0 {
 		return ChainError{Chain: "FORWARD", Output: output}
 	}
 
-	if output, err := Raw("-t", string(Filter), string(action), c.Name,
+	output, err = Raw("-t", string(Filter), string(action), c.Name,
 		"!", "-i", bridgeName,
 		"-o", bridgeName,
 		"-p", proto,
-		"-d", destAddr,
-		"--dport", strconv.Itoa(destPort),
-		"-j", "ACCEPT"); err != nil {
+		"-d", newIP.String(),
+		"--dport", strconv.Itoa(newPort),
+		"-j", "ACCEPT")
+	if err != nil {
 		return err
-	} else if len(output) != 0 {
+	}
+	if len(output) != 0 {
 		return ChainError{Chain: "FORWARD", Output: output}
 	}
+	return nil
+}
 
-	if output, err := Raw("-t", string(Nat), string(action), "POSTROUTING",
+func (c *ChainInfo) Masq(action Action, proto string, ip net.IP, port int) error {
+	output, err := Raw("-t", string(Nat), string(action), "POSTROUTING",
 		"-p", proto,
-		"-s", destAddr,
-		"-d", destAddr,
-		"--dport", strconv.Itoa(destPort),
-		"-j", "MASQUERADE"); err != nil {
+		"-s", ip.String(),
+		"-d", ip.String(),
+		"--dport", strconv.Itoa(port),
+		"-j", "MASQUERADE")
+	if err != nil {
 		return err
-	} else if len(output) != 0 {
+	}
+	if len(output) != 0 {
 		return ChainError{Chain: "FORWARD", Output: output}
 	}
+	return nil
+}
 
+func (c *ChainInfo) Hairpin(action Action, proto string, destIP net.IP, destPort int, sourceIP net.IP, newPort int) error {
+	destAddr := destIP.String()
+	if destIP.IsUnspecified() {
+		// iptables interprets "0.0.0.0" as "0.0.0.0/32", whereas we
+		// want "0.0.0.0/0". "0/0" is correctly interpreted as "any
+		// value" by both iptables and ip6tables.
+		destAddr = "0/0"
+	}
+	output, err := Raw("-t", string(Nat), string(action), c.Name,
+		"-p", proto,
+		"-s", sourceIP.String(),
+		"-d", destAddr,
+		"--dport", strconv.Itoa(destPort),
+		"-j", "DNAT",
+		"--to-destination", net.JoinHostPort(sourceIP.String(), strconv.Itoa(newPort)),
+	)
+	if err != nil {
+		return err
+	}
+	if len(output) > 0 {
+		return ChainError{Chain: "PREROUTING", Output: output}
+	}
 	return nil
 }
 
@@ -276,8 +343,8 @@ func (c *ChainInfo) Link(action Action, ip1, ip2 net.IP, port int, proto string,
 }
 
 // Prerouting adds linking rule to nat/PREROUTING chain.
-func (c *ChainInfo) Prerouting(action Action, args ...string) error {
-	a := []string{"-t", string(Nat), string(action), "PREROUTING"}
+func (c *ChainInfo) Prerouting(table Table, action Action, args ...string) error {
+	a := []string{"-t", string(table), string(action), "PREROUTING"}
 	if len(args) > 0 {
 		a = append(a, args...)
 	}
@@ -306,13 +373,17 @@ func (c *ChainInfo) Output(action Action, args ...string) error {
 // Remove removes the chain.
 func (c *ChainInfo) Remove() error {
 	// Ignore errors - This could mean the chains were never set up
-	if c.Table == Nat {
-		c.Prerouting(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name)
+	switch c.Table {
+	case Nat:
+		c.Prerouting(c.Table, Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name)
 		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "!", "--dst", "127.0.0.0/8", "-j", c.Name)
 		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name) // Created in versions <= 0.1.6
 
-		c.Prerouting(Delete)
+		c.Prerouting(c.Table, Delete)
 		c.Output(Delete)
+	case Mangle:
+		c.Prerouting(Mangle, Delete, "-m", "addrtype", "--dst-type", "LOCAL", "-j", c.Name)
+		c.Prerouting(Mangle, Delete)
 	}
 	Raw("-t", string(c.Table), "-F", c.Name)
 	Raw("-t", string(c.Table), "-X", c.Name)


### PR DESCRIPTION
This is a POC using IPVS to setup port forwards (nat) rather than using
iptables.
Using iptables for setting up nat rules has a nasty tendancy to conflict
with user-defined firewall rules, and tend to be invisible to tools like
UFW.
Meanwhile using ipvs for nat is fairly natural and does not require
mucking around in iptables rules.

The one thing we do need to continue using iptables for here is nating
against localhost, however this shouldn't intefere with user-defined
rules unless they are denying localhost (not likely)... and still much
better than having public interfaces here.

Fixes #4737
Fixes #22054
Fixes #14435

Signed-off-by: Brian Goff cpuguy83@gmail.com
