### PR TITLE
Need to create bind mount volume if it does not exist.

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/volume"
 	"github.com/docker/engine-api/types"
 	containertypes "github.com/docker/engine-api/types/container"
-	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 var (
@@ -148,11 +147,6 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}
 		}
 
-		if label.RelabelNeeded(bind.Mode) {
-			if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
-				return err
-			}
-		}
 		binds[bind.Destination] = true
 		mountPoints[bind.Destination] = bind
 	}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		if err := daemon.lazyInitializeVolume(c.ID, m); err != nil {
 			return nil, err
 		}
-		path, err := m.Setup()
+		path, err := m.Setup(c.MountLabel)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In order to be consistent on creation of volumes for bind mounts
we need to create the source directory if it does not exist and the
user specified he wants it relabeled.

Can not do this lower down the stack, since we are not passing in the
mode fields.

Fixes #17262

Signed-off-by: Dan Walsh dwalsh@redhat.com
