### PR TITLE
Windows: Default isolation and workdir

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -207,13 +207,13 @@ func (container *Container) SetupWorkingDirectory(rootUID, rootGID int) error {
 		return nil
 	}
 
+	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
+
 	// If can't mount container FS at this point (eg Hyper-V Containers on
 	// Windows) bail out now with no action.
 	if !container.canMountFS() {
 		return nil
 	}
-
-	container.Config.WorkingDir = filepath.Clean(container.Config.WorkingDir)
 
 	pth, err := container.GetResourcePath(container.Config.WorkingDir)
 	if err != nil {

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -11,6 +11,11 @@ import (
 
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
 func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+	// Make sure the host config has the default daemon isolation if not specified by caller.
+	if containertypes.Isolation.IsDefault(containertypes.Isolation(hostConfig.Isolation)) {
+		hostConfig.Isolation = daemon.defaultIsolation
+	}
+
 	for spec := range config.Volumes {
 
 		mp, err := volume.ParseMountSpec(spec, hostConfig.VolumeDriver)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes #23006. Missed a piece whereby the daemon wasn't setting the hostconfigs isolation to the daemon default if the user didn't specify it in docker run. Also noticed that we didn't clean the workdir (which was the last example in the linked issue) on a Hyper-V container. Moved the line before the check.
