### PR TITLE
Fix directory walker error checking

### DIFF
--- a/builder/context.go
+++ b/builder/context.go
@@ -29,6 +29,16 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 		return err
 	}
 	return filepath.Walk(contextRoot, func(filePath string, f os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsPermission(err) {
+				return fmt.Errorf("can't stat '%s'", filePath)
+			}
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
 		// skip this directory/file if it's not in the path, it won't get added to the context
 		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
 			return err
@@ -39,16 +49,6 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 				return filepath.SkipDir
 			}
 			return nil
-		}
-
-		if err != nil {
-			if os.IsPermission(err) {
-				return fmt.Errorf("can't stat '%s'", filePath)
-			}
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
 		}
 
 		// skip checking if symlinks point to non-existing files, such symlinks can be useful


### PR DESCRIPTION
Move context walker error checking so that it returns before possible access of the fileinfo in `f.IsDir()`.

This happens when a directory inside the context is deleted(or receives another error) while the context is being scanned.

Fixes #23004

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
