### PR TITLE
Fix filepath.Walk misusage in builder/context.go

### DIFF
--- a/builder/context.go
+++ b/builder/context.go
@@ -29,6 +29,16 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 		return err
 	}
 	return filepath.Walk(contextRoot, func(filePath string, f os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsPermission(err) {
+				return fmt.Errorf("can't stat '%s'", filePath)
+			}
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
 		// skip this directory/file if it's not in the path, it won't get added to the context
 		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
 			return err
@@ -39,16 +49,6 @@ func ValidateContextDirectory(srcPath string, excludes []string) error {
 				return filepath.SkipDir
 			}
 			return nil
-		}
-
-		if err != nil {
-			if os.IsPermission(err) {
-				return fmt.Errorf("can't stat '%s'", filePath)
-			}
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
 		}
 
 		// skip checking if symlinks point to non-existing files, such symlinks can be useful


### PR DESCRIPTION
**\- What I did**

Fix panic issue #23004

**\- How I did it**
Check `error` in `filepath.Walk`

**\- How to verify it**
 fire off a lot of parallel builds (described in #23004)

**\- Description for the changelog**

Fix #23004

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp

---

There are other similar misusages of `filepath.Walk` in 29dbcbad878483d9239d6a432c85620aced895c4
-  builder/tarsum.go
- daemon/archive_unix.go
- daemon/container_operations_unix.go
- pkg/directory/directory_unix.go
- pkg/directory/directory_windows.go

I'll open separate PRs for other misusages rather than fix them at once in this PR, so that we can easily revert the change in case of regression
