### PR TITLE
Fix filepath.Walk misusage in pkg/directory

### DIFF
--- a/pkg/directory/directory_test.go
+++ b/pkg/directory/directory_test.go
@@ -183,3 +183,10 @@ func TestMoveToSubdir(t *testing.T) {
 		t.Fatalf("Results after migration do not equal list of files: expected: %v, got: %v", filesList, results)
 	}
 }
+
+// Test a non-existing directory
+func TestSizeNonExistingDirectory(t *testing.T) {
+	if _, err := Size("/thisdirectoryshouldnotexist/TestSizeNonExistingDirectory"); err == nil {
+		t.Fatalf("error is expected")
+	}
+}

--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -11,7 +11,16 @@ import (
 // Size walks a directory tree and returns its total size in bytes.
 func Size(dir string) (size int64, err error) {
 	data := make(map[uint64]struct{})
-	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, e error) error {
+	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			// if dir does not exist, Size() returns the error.
+			// if dir/x disappeared while walking, Size() ignores dir/x.
+			if os.IsNotExist(err) && d != dir {
+				return nil
+			}
+			return err
+		}
+
 		// Ignore directory sizes
 		if fileInfo == nil {
 			return nil

--- a/pkg/directory/directory_windows.go
+++ b/pkg/directory/directory_windows.go
@@ -9,7 +9,16 @@ import (
 
 // Size walks a directory tree and returns its total size in bytes.
 func Size(dir string) (size int64, err error) {
-	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, e error) error {
+	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			// if dir does not exist, Size() returns the error.
+			// if dir/x disappeared while walking, Size() ignores dir/x.
+			if os.IsNotExist(err) && d != dir {
+				return nil
+			}
+			return err
+		}
+
 		// Ignore directory sizes
 		if fileInfo == nil {
 			return nil


### PR DESCRIPTION
**\- What I did**
Fix filepath.Walk misusage in pkg/directory

**\- How I did it**
Check error in filepath.Walk

**\- How to verify it**
`go test -v ./pkg/directory`

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp

---

Related: https://github.com/docker/docker/pull/23037
