### PR TITLE
Fix error in dockerd.md for incorrect cluster-store-opts example.

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -913,7 +913,7 @@ This is a full example of the allowed configuration options in the file:
 	"pidfile": "",
 	"graph": "",
 	"cluster-store": "",
-	"cluster-store-opts": [],
+	"cluster-store-opts": {},
 	"cluster-advertise": "",
 	"max-concurrent-downloads": 3,
 	"max-concurrent-uploads": 5,


### PR DESCRIPTION
This fix fixes an error in documentation (dockerd.md). In the example given by dockerd.md, the option `cluster-store-opts` is assigned with an array but this option can only be assigned as a map.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
