### PR TITLE
Fix too short time.Sleep() in pkg/discovery/kv/kv_test.go

### DIFF
--- a/pkg/discovery/kv/kv_test.go
+++ b/pkg/discovery/kv/kv_test.go
@@ -251,7 +251,7 @@ func (ds *DiscoverySuite) TestWatch(c *check.C) {
 
 	close(mockCh)
 	// Give it enough time to call WatchTree.
-	time.Sleep(3)
+	time.Sleep(3 * time.Second)
 
 	// Stop and make sure it closes all channels.
 	close(stopCh)


### PR DESCRIPTION
**\- What I did**
`time.Sleep(3)` --> `time.Sleep(3 * time.Second)`

**\- How I did it**
Found this short sleep using https://github.com/dominikh/go-staticcheck

**\- How to verify it**
Observe the CI result

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp

---

PTAL @icecrime 
Maybe `3 * time.Second` is too long
