### PR TITLE
Validate filter values before calling registry.

### DIFF
--- a/daemon/search.go
+++ b/daemon/search.go
@@ -32,11 +32,6 @@ func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs s
 		return nil, err
 	}
 
-	unfilteredResult, err := daemon.RegistryService.Search(ctx, term, authConfig, dockerversion.DockerUserAgent(ctx), headers)
-	if err != nil {
-		return nil, err
-	}
-
 	var isAutomated, isOfficial bool
 	var hasStarFilter = 0
 	if searchFilters.Include("is-automated") {
@@ -64,6 +59,11 @@ func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs s
 				hasStarFilter = iHasStar
 			}
 		}
+	}
+
+	unfilteredResult, err := daemon.RegistryService.Search(ctx, term, authConfig, dockerversion.DockerUserAgent(ctx), headers)
+	if err != nil {
+		return nil, err
 	}
 
 	filteredResults := []registrytypes.SearchResult{}


### PR DESCRIPTION
This moves the call to the registry/hub for `search` command after the validation of the filters 🐯.

This way, if the filters aren't valid, we don't call search anymore :angel: 

Closes #23016.

/cc @runcom @thaJeztah @coolljt0725 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
