### PR TITLE
Remove GO15VENDOREXPERIMENT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,6 @@ RUN set -x \
 # Install notary and notary-server
 ENV NOTARY_VERSION v0.3.0
 RUN set -x \
-	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -119,7 +119,6 @@ RUN set -x \
 # Install notary and notary-server
 ENV NOTARY_VERSION v0.3.0
 RUN set -x \
-	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -128,7 +128,6 @@ RUN set -x \
 # Install notary and notary-server
 ENV NOTARY_VERSION v0.3.0
 RUN set -x \
-	&& export GO15VENDOREXPERIMENT=1 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION") \


### PR DESCRIPTION
This environment variable is no longer
needed in Go 1.6 (as it's not the default).

Removed this environment variable from
all Dockerfiles except the Dockerfile.s390x,
which is still using gcc 5.3 (Go 1.5)

Relates to https://github.com/docker/docker/pull/22840#issuecomment-222152433
