### PR TITLE
Remove MountPoint.Named and replace it with IsNamed()

### DIFF
--- a/daemon/mounts.go
+++ b/daemon/mounts.go
@@ -27,7 +27,7 @@ func (daemon *Daemon) removeMountPoints(container *container.Container, rm bool)
 		if rm {
 			// Do not remove named mountpoints
 			// these are mountpoints specified like `docker run -v <name>:/foo`
-			if m.Named {
+			if m.IsNamed() {
 				continue
 			}
 			err := daemon.volumes.Remove(m.Volume)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -94,7 +94,6 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 				Driver:      m.Driver,
 				Destination: m.Destination,
 				Propagation: m.Propagation,
-				Named:       m.Named,
 			}
 
 			if len(cp.Source) == 0 {
@@ -121,7 +120,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			return fmt.Errorf("Duplicate mount point '%s'", bind.Destination)
 		}
 
-		if len(bind.Name) > 0 {
+		if bind.IsNamed() {
 			// create the volume
 			v, err := daemon.volumes.CreateWithRef(bind.Name, bind.Driver, container.ID, nil, nil)
 			if err != nil {
@@ -131,7 +130,6 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			bind.Source = v.Path()
 			// bind.Name is an already existing volume, we need to use that here
 			bind.Driver = v.DriverName()
-			bind.Named = true
 			if bind.Driver == "local" {
 				bind = setBindModeIfNull(bind)
 			}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -60,7 +60,6 @@ type MountPoint struct {
 
 	// Note Propagation is not used on Windows
 	Propagation string // Mount propagation string
-	Named       bool   // specifies if the mountpoint was specified by name
 
 	// Specifies if data should be copied from the container before the first mount
 	// Use a pointer here so we can tell if the user set this value explicitly
@@ -102,6 +101,11 @@ func (m *MountPoint) Path() string {
 		return m.Volume.Path()
 	}
 	return m.Source
+}
+
+// IsNamed returns true if the MountPoint is a named volume
+func (m *MountPoint) IsNamed() bool {
+	return m.Name != ""
 }
 
 // ParseVolumesFrom ensures that the supplied volumes-from is valid.


### PR DESCRIPTION
**What I did**

I noticed that `Named` is not set by any of the Parse functions, so it's possible that the value is incorrect if it gets accessed before something sets it. I removed `Named` and replaced it with `IsNamed()` which checks for a name.
