### PR TITLE
Set --state-dir on containerd

### DIFF
--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -33,6 +33,7 @@ const (
 	containerdBinary          = "docker-containerd"
 	containerdPidFilename     = "docker-containerd.pid"
 	containerdSockFilename    = "docker-containerd.sock"
+	containerdStateDir        = "containerd"
 	eventTimestampFilename    = "event.ts"
 )
 
@@ -354,6 +355,7 @@ func (r *remote) runContainerdDaemon() error {
 		"--shim", "docker-containerd-shim",
 		"--runtime", "docker-runc",
 		"--metrics-interval=0",
+		"--state-dir", filepath.Join(r.stateDir, containerdStateDir),
 	}
 	if r.debugLog {
 		args = append(args, "--debug")


### PR DESCRIPTION
I was trying to run an instance of the daemon with something like this:

```
dockerd \
    -g /tmp/dockerdev \
    --exec-root=/tmp/dockerdev \
   ...
```

and I got the following error

```
FATA[0000] open /run/containerd/events.log: permission denied
```

which was unexpected, because I was setting all the paths to `/tmp/dockerdev`.

**What I did**

Set the `containerd` `--start-dir` arg to the `stateDir` so that the `events.log` ends up in the path under the docker exec root. After I made this change I was able to run the second instance of the daemon.
