### PR TITLE
Split the Seccomp tests into two

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1032,12 +1032,12 @@ func (s *DockerSuite) TestRunSeccompAllowSetrlimit(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunSeccompDefaultProfile(c *check.C) {
+func (s *DockerSuite) TestRunSeccompDefaultProfileAcct(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled, NotUserNamespace)
 
 	var group sync.WaitGroup
-	group.Add(11)
-	errChan := make(chan error, 11)
+	group.Add(5)
+	errChan := make(chan error, 5)
 	go func() {
 		out, _, err := dockerCmdWithError("run", "syscall-test", "acct-test")
 		if err == nil || !strings.Contains(out, "Operation not permitted") {
@@ -1077,6 +1077,21 @@ func (s *DockerSuite) TestRunSeccompDefaultProfile(c *check.C) {
 		}
 		group.Done()
 	}()
+
+	group.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		c.Assert(err, checker.IsNil)
+	}
+}
+
+func (s *DockerSuite) TestRunSeccompDefaultProfileNS(c *check.C) {
+	testRequires(c, SameHostDaemon, seccompEnabled, NotUserNamespace)
+
+	var group sync.WaitGroup
+	group.Add(6)
+	errChan := make(chan error, 6)
 
 	go func() {
 		out, _, err := dockerCmdWithError("run", "syscall-test", "ns-test", "echo", "hello0")


### PR DESCRIPTION
The Seccomp tests ran 11 tests in parallel and this appears to be
hitting some sort of bug on CI. Splitting into two tests means that
I can no longer repeoduce the failure on the slow laptop where I could
reproduce the failures before.

Obviously this does not fix the underlying issue, which I will
continue to investigate, but not having the tests failing a lot
before the freeze for 1.12 would be rather helpful.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![fox](https://cloud.githubusercontent.com/assets/482364/15622800/932296f4-2421-11e6-98ac-456d31d45e3f.jpeg)
