### PR TITLE
Windows: fix Windows graph driver name

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -80,9 +80,10 @@ func InitFilter(home string, options []string, uidMaps, gidMaps []idtools.IDMap)
 	return d, nil
 }
 
-// String returns the string representation of a driver.
+// String returns the string representation of a driver. This should match
+// the name the graph driver has been registered with.
 func (d *Driver) String() string {
-	return "Windows filter storage driver"
+	return "windowsfilter"
 }
 
 // Status returns the status of the driver.


### PR DESCRIPTION
@jhowardmsft, #22775 changed the name of the Windows graph driver from `windowsfilter` to `Windows filter storage driver`, not realizing that this string was used as a component in a file path. This caused all my images to disappear, and now I have this silly directory `c:\programdata\docker\image\Windows filter storage driver` on my machine.

Reverting the name change.
