### PR TITLE
using os.PathListSeparator as separator between

### DIFF
--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -49,7 +49,9 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 			"\nUse '-' as the source to read a tar archive from stdin\n",
 			"and extract it to a directory destination in a container.\n",
 			"Use '-' as the destination to stream a tar archive of a\n",
-			"container source to stdout.",
+			"container source to stdout.\n",
+			"Separator between CONTAINER and PATH varies in different OS,\n",
+			"in Windows uses ';' as separator, uses ':' in Unix",
 		}, ""),
 		true,
 	)
@@ -117,7 +119,9 @@ func splitCpArg(arg string) (container, path string) {
 		return "", arg
 	}
 
-	parts := strings.SplitN(arg, ":", 2)
+	// OS allows separator used in filename, like file:name.dat in Unix,
+	// file;name.dat in Windows
+	parts := strings.SplitN(arg, string(os.PathListSeparator), 2)
 
 	if len(parts) == 1 || strings.HasPrefix(parts[0], ".") {
 		// Either there's no `:` in the arg

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -22,6 +22,7 @@ const (
 
 	cpContainerContents = "holla, i am the container"
 	cpHostContents      = "hello, i am the host"
+	cpSeparator         = string(os.PathListSeparator)
 )
 
 // Ensure that an all-local path case returns an error.
@@ -61,7 +62,7 @@ func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
 
 	path := path.Join("../../../../../../../../../../../../", cpFullPath)
 
-	dockerCmd(c, "cp", containerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", containerID+cpSeparator+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -110,7 +111,7 @@ func (s *DockerSuite) TestCpRelativePath(c *check.C) {
 	}
 	c.Assert(path.IsAbs(cpFullPath), checker.True, check.Commentf("path %s was assumed to be an absolute path", cpFullPath))
 
-	dockerCmd(c, "cp", containerID+":"+relPath, tmpdir)
+	dockerCmd(c, "cp", containerID+cpSeparator+relPath, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -153,7 +154,7 @@ func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
 
 	path := cpFullPath
 
-	dockerCmd(c, "cp", containerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", containerID+cpSeparator+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -197,7 +198,7 @@ func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
 
 	path := path.Join("/", "container_path")
 
-	dockerCmd(c, "cp", containerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", containerID+cpSeparator+path, tmpdir)
 
 	// We should have copied a symlink *NOT* the file itself!
 	linkTarget, err := os.Readlink(tmpname)
@@ -224,7 +225,7 @@ func (s *DockerSuite) TestCpFromSymlinkToDirectory(c *check.C) {
 
 	// This copy command should copy the symlink, not the target, into the
 	// temporary directory.
-	dockerCmd(c, "cp", containerID+":"+"/dir_link", testDir)
+	dockerCmd(c, "cp", containerID+cpSeparator+"/dir_link", testDir)
 
 	expectedPath := filepath.Join(testDir, "dir_link")
 	linkTarget, err := os.Readlink(expectedPath)
@@ -236,7 +237,7 @@ func (s *DockerSuite) TestCpFromSymlinkToDirectory(c *check.C) {
 
 	// This copy command should resolve the symlink (note the trailing
 	// separator), copying the target into the temporary directory.
-	dockerCmd(c, "cp", containerID+":"+"/dir_link/", testDir)
+	dockerCmd(c, "cp", containerID+cpSeparator+"/dir_link/", testDir)
 
 	// It *should not* have copied the directory using the target's name, but
 	// used the given name instead.
@@ -364,7 +365,7 @@ func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
 
 	path := path.Join("/", "container_path", cpTestName)
 
-	dockerCmd(c, "cp", containerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", containerID+cpSeparator+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -401,7 +402,7 @@ func (s *DockerSuite) TestCpUnprivilegedUser(c *check.C) {
 
 	path := cpTestName
 
-	_, _, err = runCommandWithOutput(exec.Command("su", "unprivilegeduser", "-c", dockerBinary+" cp "+containerID+":"+path+" "+tmpdir))
+	_, _, err = runCommandWithOutput(exec.Command("su", "unprivilegeduser", "-c", dockerBinary+" cp "+containerID+cpSeparator+path+" "+tmpdir))
 	c.Assert(err, checker.IsNil, check.Commentf("couldn't copy with unprivileged user: %s:%s", containerID, path))
 }
 
@@ -635,7 +636,7 @@ func (s *DockerSuite) TestCpSymlinkFromConToHostFollowSymlink(c *check.C) {
 
 	// This copy command should copy the symlink, not the target, into the
 	// temporary directory.
-	dockerCmd(c, "cp", "-L", cleanedContainerID+":"+"/dir_link", testDir)
+	dockerCmd(c, "cp", "-L", cleanedContainerID+cpSeparator+"/dir_link", testDir)
 
 	expectedPath := filepath.Join(testDir, "dir_link")
 
@@ -654,7 +655,7 @@ func (s *DockerSuite) TestCpSymlinkFromConToHostFollowSymlink(c *check.C) {
 		os.Remove(expectedPath)
 	}
 
-	dockerCmd(c, "cp", "-L", cleanedContainerID+":"+"/dir_link", expectedPath)
+	dockerCmd(c, "cp", "-L", cleanedContainerID+cpSeparator+"/dir_link", expectedPath)
 
 	actual, err = ioutil.ReadFile(expectedPath)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Replace separator ':' in cli cp with os.PathListPeparator. in api/client/cp.go.
Change separator ':' for os.PathListSeparator in integration-cli/docker_cli_cp_test.go.
**\- How I did it**

**\- How to verify it**
testcase in docker_cli_cp_test.go modified accordly for testing
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

containerID and path location in cp command
for enhancement #9932
Signed-off-by: Lin Lu doraalin@163.com

modify separator char in cli cp testcase

Signed-off-by: Lin Lu doraalin@163.com
