### PR TITLE
Change insane to infallible

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -43,7 +43,7 @@ var (
 		"high",
 		"hopeful",
 		"hungry",
-		"insane",
+		"infallible",
 		"jolly",
 		"jovial",
 		"kickass",


### PR DESCRIPTION
I got what I felt was an unfortunately insensitive combination of insane + person so it just seemed better to not have that adjective.
