### PR TITLE
Remove deprecated -f flag on docker tag

### DIFF
--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -5,7 +5,6 @@ import (
 
 	Cli "github.com/docker/docker/cli"
 	flag "github.com/docker/docker/pkg/mflag"
-	"github.com/docker/engine-api/types"
 )
 
 // CmdTag tags an image into a repository.
@@ -13,14 +12,9 @@ import (
 // Usage: docker tag [OPTIONS] IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]
 func (cli *DockerCli) CmdTag(args ...string) error {
 	cmd := Cli.Subcmd("tag", []string{"IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]"}, Cli.DockerCommands["tag"].Description, true)
-	force := cmd.Bool([]string{"#f", "#-force"}, false, "Force the tagging even if there's a conflict")
 	cmd.Require(flag.Exact, 2)
 
 	cmd.ParseFlags(args, true)
 
-	options := types.ImageTagOptions{
-		Force: *force,
-	}
-
-	return cli.client.ImageTag(context.Background(), cmd.Arg(0), cmd.Arg(1), options)
+	return cli.client.ImageTag(context.Background(), cmd.Arg(0), cmd.Arg(1))
 }

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -265,11 +265,7 @@ func (cli *DockerCli) trustedReference(ctx context.Context, ref reference.NamedT
 func (cli *DockerCli) tagTrusted(ctx context.Context, trustedRef reference.Canonical, ref reference.NamedTagged) error {
 	fmt.Fprintf(cli.out, "Tagging %s as %s\n", trustedRef.String(), ref.String())
 
-	options := types.ImageTagOptions{
-		Force: true,
-	}
-
-	return cli.client.ImageTag(ctx, trustedRef.String(), ref.String(), options)
+	return cli.client.ImageTag(ctx, trustedRef.String(), ref.String())
 }
 
 func notaryError(repoName string, err error) error {

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -35,9 +35,9 @@ The fields `ID`, `Status` and `From` in the events API have been deprecated in f
 See the events API documentation for the new format.
 
 ### `-f` flag on `docker tag`
-**Deprecated In Release: v1.10**
+**Deprecated In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
-**Target For Removal In Release: v1.12**
+**Removed In Release: v1.12.0**
 
 To make tagging consistent across the various `docker` commands, the `-f` flag on the `docker tag` command is deprecated. It is not longer necessary to specify `-f` to move a tag from one image to another. Nor will `docker` generate an error if the `-f` flag is missing and the specified tag is already in use.
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -123,6 +123,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /events` now supports filtering by daemon name or ID.
 * `GET /images/json` now supports filters `since` and `before`.
 * `POST /containers/(id or name)/start` no longer accepts a `HostConfig`.
+* `POST /images/(name)/tag` no longer has a `force` query parameter.
 
 ### v1.23 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2031,7 +2031,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2040,7 +2040,6 @@ Tag the image `name` into a repository
 Query Parameters:
 
 -   **repo** – The repository to tag in
--   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
 Status Codes:

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 12fbeb3ac3ca5dc5d0f01d6bac9bda518d46d983
+clone git github.com/docker/engine-api 6facb3f3c38717b8f618dcedc4c8ce20d1bfc61e
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -240,7 +240,7 @@ func (s *DockerSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *check.C) {
 	imageID := stringid.TruncateID(strings.TrimSpace(out))
 
 	// overwrite the tag, making the previous image dangling
-	dockerCmd(c, "tag", "-f", "busybox", "foobox")
+	dockerCmd(c, "tag", "busybox", "foobox")
 
 	out, _ = dockerCmd(c, "images", "-q", "-f", "dangling=true")
 	// Expect one dangling image

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -658,7 +658,7 @@ func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
 	out, _, err = runCommandWithOutput(runCmd)
 	c.Assert(err, checker.IsNil)
 
-	runCmd = exec.Command(dockerBinary, "tag", "-f", updatedImageName, originalImageName)
+	runCmd = exec.Command(dockerBinary, "tag", updatedImageName, originalImageName)
 	out, _, err = runCommandWithOutput(runCmd)
 	c.Assert(err, checker.IsNil)
 

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -86,19 +86,6 @@ func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 	dockerCmd(c, "tag", "busybox:latest", "busybox:test")
 }
 
-// tag an image with an existed tag name with -f option should work
-func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
-	// Don't attempt to pull on Windows as not in hub. It's installed
-	// as an image through .ensure-frozen-images-windows
-	if daemonPlatform != "windows" {
-		if err := pullImageIfNotExist("busybox:latest"); err != nil {
-			c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
-		}
-	}
-	dockerCmd(c, "tag", "busybox:latest", "busybox:test")
-	dockerCmd(c, "tag", "-f", "busybox:latest", "busybox:test")
-}
-
 func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 	// Don't attempt to pull on Windows as not in hub. It's installed
 	// as an image through .ensure-frozen-images-windows

--- a/vendor/src/github.com/docker/engine-api/client/image_tag.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_tag.go
@@ -8,12 +8,11 @@ import (
 	"golang.org/x/net/context"
 
 	distreference "github.com/docker/distribution/reference"
-	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/reference"
 )
 
 // ImageTag tags an image in the docker host
-func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options types.ImageTagOptions) error {
+func (cli *Client) ImageTag(ctx context.Context, imageID, ref string) error {
 	distributionRef, err := distreference.ParseNamed(ref)
 	if err != nil {
 		return fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", ref)
@@ -28,9 +27,6 @@ func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options ty
 	query := url.Values{}
 	query.Set("repo", distributionRef.Name())
 	query.Set("tag", tag)
-	if options.Force {
-		query.Set("force", "1")
-	}
 
 	resp, err := cli.post(ctx, "/images/"+imageID+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -61,12 +61,13 @@ type APIClient interface {
 	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDelete, error)
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
-	ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error
+	ImageTag(ctx context.Context, image, ref string) error
 	Info(ctx context.Context) (types.Info, error)
 	NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
 	NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error
 	NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error)
+	NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, networkID string) error
 	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
@@ -74,6 +75,7 @@ type APIClient interface {
 	UpdateClientVersion(v string)
 	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
+	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string) error
 }

--- a/vendor/src/github.com/docker/engine-api/client/network_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/network_inspect.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/docker/engine-api/types"
@@ -10,15 +12,27 @@ import (
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
 func (cli *Client) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
+	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID)
+	return networkResource, err
+}
+
+// NetworkInspectWithRaw returns the information for a specific network configured in the docker host and it's raw representation.
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error) {
 	var networkResource types.NetworkResource
 	resp, err := cli.get(ctx, "/networks/"+networkID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
-			return networkResource, networkNotFoundError{networkID}
+			return networkResource, nil, networkNotFoundError{networkID}
 		}
-		return networkResource, err
+		return networkResource, nil, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&networkResource)
-	ensureReaderClosed(resp)
-	return networkResource, err
+	defer ensureReaderClosed(resp)
+
+	body, err := ioutil.ReadAll(resp.body)
+	if err != nil {
+		return networkResource, nil, err
+	}
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&networkResource)
+	return networkResource, body, err
 }

--- a/vendor/src/github.com/docker/engine-api/client/volume_inspect.go
+++ b/vendor/src/github.com/docker/engine-api/client/volume_inspect.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/docker/engine-api/types"
@@ -10,15 +12,27 @@ import (
 
 // VolumeInspect returns the information about a specific volume in the docker host.
 func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error) {
+	volume, _, err := cli.VolumeInspectWithRaw(ctx, volumeID)
+	return volume, err
+}
+
+// VolumeInspectWithRaw returns the information about a specific volume in the docker host and it's raw representation
+func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error) {
 	var volume types.Volume
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
-			return volume, volumeNotFoundError{volumeID}
+			return volume, nil, volumeNotFoundError{volumeID}
 		}
-		return volume, err
+		return volume, nil, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&volume)
-	ensureReaderClosed(resp)
-	return volume, err
+	defer ensureReaderClosed(resp)
+
+	body, err := ioutil.ReadAll(resp.body)
+	if err != nil {
+		return volume, nil, err
+	}
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&volume)
+	return volume, body, err
 }

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -215,11 +215,6 @@ type ImageSearchOptions struct {
 	Filters       filters.Args
 }
 
-// ImageTagOptions holds parameters to tag an image
-type ImageTagOptions struct {
-	Force bool
-}
-
 // ResizeOptions holds parameters to resize a tty.
 // It can be used to resize container ttys and
 // exec process ttys too.

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -28,7 +28,7 @@ type ContainerExecCreateResponse struct {
 }
 
 // ContainerUpdateResponse contains response of Remote API:
-// POST /containers/{name:.*}/update
+// POST "/containers/{name:.*}/update"
 type ContainerUpdateResponse struct {
 	// Warnings are any warnings encountered during the updating of the container.
 	Warnings []string `json:"Warnings"`
@@ -142,7 +142,7 @@ type Port struct {
 }
 
 // Container contains response of Remote API:
-// GET  "/containers/json"
+// GET "/containers/json"
 type Container struct {
 	ID         string `json:"Id"`
 	Names      []string
@@ -352,13 +352,13 @@ type SummaryNetworkSettings struct {
 
 // NetworkSettingsBase holds basic information about networks
 type NetworkSettingsBase struct {
-	Bridge                 string
-	SandboxID              string
-	HairpinMode            bool
-	LinkLocalIPv6Address   string
-	LinkLocalIPv6PrefixLen int
-	Ports                  nat.PortMap
-	SandboxKey             string
+	Bridge                 string      // Bridge is the Bridge name the network uses(e.g. `docker0`)
+	SandboxID              string      // SandboxID uniquely represents a container's network stack
+	HairpinMode            bool        // HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
+	LinkLocalIPv6Address   string      // LinkLocalIPv6Address is an IPv6 unicast address using the link-local prefix
+	LinkLocalIPv6PrefixLen int         // LinkLocalIPv6PrefixLen is the prefix length of an IPv6 unicast address
+	Ports                  nat.PortMap // Ports is a collection of PortBinding indexed by Port
+	SandboxKey             string      // SandboxKey identifies the sandbox
 	SecondaryIPAddresses   []network.Address
 	SecondaryIPv6Addresses []network.Address
 }
@@ -367,14 +367,14 @@ type NetworkSettingsBase struct {
 // during the 2 release deprecation period.
 // It will be removed in Docker 1.11.
 type DefaultNetworkSettings struct {
-	EndpointID          string
-	Gateway             string
-	GlobalIPv6Address   string
-	GlobalIPv6PrefixLen int
-	IPAddress           string
-	IPPrefixLen         int
-	IPv6Gateway         string
-	MacAddress          string
+	EndpointID          string // EndpointID uniquely represents a service endpoint in a Sandbox
+	Gateway             string // Gateway holds the gateway address for the network
+	GlobalIPv6Address   string // GlobalIPv6Address holds network's global IPv6 address
+	GlobalIPv6PrefixLen int    // GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
+	IPAddress           string // IPAddress holds the IPv4 address for the network
+	IPPrefixLen         int    // IPPrefixLen represents mask length of network's IPv4 address
+	IPv6Gateway         string // IPv6Gateway holds gateway address specific for IPv6
+	MacAddress          string // MacAddress holds the MAC address for the network
 }
 
 // MountPoint represents a mount point configuration inside the container.
@@ -416,16 +416,16 @@ type VolumeCreateRequest struct {
 
 // NetworkResource is the body of the "get network" http response message
 type NetworkResource struct {
-	Name       string
-	ID         string `json:"Id"`
-	Scope      string
-	Driver     string
-	EnableIPv6 bool
-	IPAM       network.IPAM
-	Internal   bool
-	Containers map[string]EndpointResource
-	Options    map[string]string
-	Labels     map[string]string
+	Name       string                      // Name is the requested name of the network
+	ID         string                      `json:"Id"` // ID uniquely indentifies a network on a single machine
+	Scope      string                      // Scope describes the level at which the network exists (e.g. `global` for cluster-wide or `local` for machine level)
+	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
+	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
+	IPAM       network.IPAM                // IPAM is the network's IP Address Management
+	Internal   bool                        // Internal respresents if the network is used internal only
+	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
+	Options    map[string]string           // Options holds the network specific options to use for when creating the network
+	Labels     map[string]string           // Labels holds metadata specific to the network being created
 }
 
 // EndpointResource contains network resources allocated and used for a container in a network


### PR DESCRIPTION
The -f flag on docker tag has been deprecated in docker 1.10 and is expected to be removed in docker 1.12.
This fix removed the -f flag on docker tag and also updated deprecated.md.

**\- Description for the changelog**

The deprecated `-f` flag on `docker tag` has been removed.

NOTE: A separate pull request for engine-api has been opened to cover the related changes:
https://github.com/docker/engine-api/pull/239

Signed-off-by: Yong Tang yong.tang.github@outlook.com
