### PR TITLE
print network name when rm successfully

### DIFF
--- a/api/client/network.go
+++ b/api/client/network.go
@@ -113,6 +113,7 @@ func (cli *DockerCli) CmdNetworkRm(args ...string) error {
 			status = 1
 			continue
 		}
+		fmt.Fprintf(cli.out, "%s\n", net)
 	}
 	if status != 0 {
 		return Cli.StatusError{StatusCode: status}


### PR DESCRIPTION
Like `docker rm`, `docker volume rm`, when removing succefully, 
Docker CLI print the name.

So, this PR did:
1.print network name when rm successfully
