### PR TITLE
Builder integration tests for Dockerfile outside context as a unit test

### DIFF
--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -53,3 +53,50 @@ func TestEmptyDockerfile(t *testing.T) {
 		t.Fatalf("Wrong error message. Should be \"%s\". Got \"%s\"", "The Dockerfile (Dockerfile) cannot be empty", err.Error())
 	}
 }
+
+func TestDockerfileOutsideTheBuildContext(t *testing.T) {
+	contextDir, cleanup := createTestTempDir(t, "", "builder-dockerfile-test")
+	defer cleanup()
+
+	tarStream, err := archive.Tar(contextDir, archive.Uncompressed)
+
+	if err != nil {
+		t.Fatalf("Error when creating tar stream: %s", err)
+	}
+
+	defer func() {
+		if err = tarStream.Close(); err != nil {
+			t.Fatalf("Error when closing tar stream: %s", err)
+		}
+	}()
+
+	context, err := builder.MakeTarSumContext(tarStream)
+
+	if err != nil {
+		t.Fatalf("Error when creating tar context: %s", err)
+	}
+
+	defer func() {
+		if err = context.Close(); err != nil {
+			t.Fatalf("Error when closing tar context: %s", err)
+		}
+	}()
+
+	options := &types.ImageBuildOptions{
+		Dockerfile: "../../Dockerfile",
+	}
+
+	b := &Builder{options: options, context: context}
+
+	err = b.readDockerfile()
+
+	if err == nil {
+		t.Fatalf("No error when executing test for Dockerfile outside the build context")
+	}
+
+	expectedError := "Forbidden path outside the build context"
+
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Fatalf("Wrong error message. Should be \"%s\". Got \"%s\"", expectedError, err.Error())
+	}
+}

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -11,39 +11,6 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestBuildApiDockerfilePath(c *check.C) {
-	// Test to make sure we stop people from trying to leave the
-	// build context when specifying the path to the dockerfile
-	buffer := new(bytes.Buffer)
-	tw := tar.NewWriter(buffer)
-	defer tw.Close()
-
-	dockerfile := []byte("FROM busybox")
-	err := tw.WriteHeader(&tar.Header{
-		Name: "Dockerfile",
-		Size: int64(len(dockerfile)),
-	})
-	//failed to write tar file header
-	c.Assert(err, checker.IsNil)
-
-	_, err = tw.Write(dockerfile)
-	// failed to write tar file content
-	c.Assert(err, checker.IsNil)
-
-	// failed to close tar archive
-	c.Assert(tw.Close(), checker.IsNil)
-
-	res, body, err := sockRequestRaw("POST", "/build?dockerfile=../Dockerfile", buffer, "application/x-tar")
-	c.Assert(err, checker.IsNil)
-	c.Assert(res.StatusCode, checker.Equals, http.StatusInternalServerError)
-
-	out, err := readBody(body)
-	c.Assert(err, checker.IsNil)
-
-	// Didn't complain about leaving build context
-	c.Assert(string(out), checker.Contains, "Forbidden path outside the build context")
-}
-
 func (s *DockerSuite) TestBuildApiDockerFileRemote(c *check.C) {
 	testRequires(c, NotUserNamespace)
 	testRequires(c, DaemonIsLinux)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2988,32 +2988,6 @@ func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestBuildForbiddenContextPath(c *check.C) {
-	name := "testbuildforbidpath"
-	ctx, err := fakeContext(`FROM `+minimalBaseImage()+`
-        ADD ../../ test/
-        `,
-		map[string]string{
-			"test.txt":  "test1",
-			"other.txt": "other",
-		})
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer ctx.Close()
-
-	expected := "Forbidden path outside the build context: ../../ "
-
-	if daemonPlatform == "windows" {
-		expected = "Forbidden path outside the build context: ..\\..\\ "
-	}
-
-	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
-		c.Fatalf("Wrong error: (should contain \"%s\") got:\n%v", expected, err)
-	}
-
-}
-
 func (s *DockerSuite) TestBuildAddFileNotFound(c *check.C) {
 	name := "testbuildaddnotfound"
 	expected := "foo: no such file or directory"


### PR DESCRIPTION
Reimplementing 2 integration tests for Dockerfile outside the context as a unit test.

Part of resolving #20784

Signed-off-by: Tomasz Kopczynski tomek@kopczynski.net.pl
