### PR TITLE
fixes #23097 zsh completion on `docker rm -f`

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1138,7 +1138,16 @@ __docker_subcommand() {
                 "($help -f --force)"{-f,--force}"[Force removal]" \
                 "($help -l --link)"{-l,--link}"[Remove the specified link and not the underlying container]" \
                 "($help -v --volumes)"{-v,--volumes}"[Remove the volumes associated to the container]" \
-                "($help -)*:containers:__docker_stoppedcontainers" && ret=0
+                "($help -)*:containers:->values" && ret=0
+            case $state in
+                (values)
+                    if [[ ${words[(r)-f]} == -f || ${words[(r)--force]} == --force ]]; then
+                        __docker_containers && ret=0
+                    else
+                        __docker_stoppedcontainers && ret=0
+                    fi
+                    ;;
+            esac
             ;;
         (rmi)
             _arguments $(__docker_arguments) \


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/23097

**\- What I did**
List all containers on `docker rm -f`

**\- How I did it**
Simply list all containers when `docker rm` followed by `-f` or `--force`.

**\- How to verify it**
`$docker run -d --name test nginx`
`$docker rm <TAB>` container `test` will not appear.
`$docker rm -f <TAB>` container `test` appears.

**\- Description for the changelog**
List all containers on `docker rm -f`

**\- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](http://www.cutestpaw.com/wp-content/uploads/2011/12/Teenie-Meerkats.jpg)

Signed-off-by: Tianyi Wang capkurmagati@gmail.com
