### PR TITLE
Dockerfile.s390x: Move to gcc 6.1 (go 1.6.1)

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -15,7 +15,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM s390x/gcc:5.3
+FROM s390x/gcc:6.1
 
 # Packaged dependencies
 RUN apt-get update && apt-get install -y \
@@ -130,9 +130,12 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install notary and notary-server
+#
+# Note: We have to explicitly set GO15VENDOREXPERIMENT=0 because gccgo does not
+# support vendoring: https://github.com/golang/go/issues/15628
 ENV NOTARY_VERSION v0.3.0
 RUN set -x \
-	&& export GO15VENDOREXPERIMENT=1 \
+	&& export GO15VENDOREXPERIMENT=0 \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/notary.git "$GOPATH/src/github.com/docker/notary" \
 	&& (cd "$GOPATH/src/github.com/docker/notary" && git checkout -q "$NOTARY_VERSION" && ln -s . vendor/src) \


### PR DESCRIPTION
Pull request #22840 and commit 40b21745cc ("Upgrade to golang 1.6.2")
introduces gcc 6.1 for Dockerfile.gccgo and Dockerfile.ppc64le.
So do this also for s390x and use "s390x/gcc:6.1" as base image.

In addition to this use "GO15VENDOREXPERIMENT=0" for notary build
as a workaround for golang/go#15814

Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
