### PR TITLE
Add support for comments in .dockerignore

### DIFF
--- a/builder/dockerignore/dockerignore.go
+++ b/builder/dockerignore/dockerignore.go
@@ -20,7 +20,12 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 	var excludes []string
 
 	for scanner.Scan() {
-		pattern := strings.TrimSpace(scanner.Text())
+		// Lines starting with # (comments) are ignored before processing
+		pattern := scanner.Text()
+		if strings.HasPrefix(pattern, "#") {
+			continue
+		}
+		pattern = strings.TrimSpace(pattern)
 		if pattern == "" {
 			continue
 		}

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -379,9 +379,13 @@ the working and the root directory.  For example, the patterns
 in the `foo` subdirectory of `PATH` or in the root of the git
 repository located at `URL`.  Neither excludes anything else.
 
+If a line in `.dockerignore` file starts with `#` in column 1, then this line is
+considered as a comment and is ignored before interpreted by the CLI.
+
 Here is an example `.dockerignore` file:
 
 ```
+# comment
     */temp*
     */*/temp*
     temp?
@@ -391,6 +395,7 @@ This file causes the following build behavior:
 
 | Rule           | Behavior                                                                                                                                                                     |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `# comment`    | Ignored.                 |
 | `*/temp*`      | Exclude files and directories whose names start with `temp` in any immediate subdirectory of the root.  For example, the plain file `/somedir/temporary.txt` is excluded, as is the directory `/somedir/temp`.                 |
 | `*/*/temp*`    | Exclude files and directories starting with `temp` from any subdirectory that is two levels below the root. For example, `/somedir/subdir/temporary.txt` is excluded. |
 | `temp?`        | Exclude files and directories in the root directory whose names are a one-character extension of `temp`.  For example, `/tempa` and `/tempb` are excluded.


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #20083 where comment is not supported in `.dockerignore`.

**\- How I did it**

This fix updated the processing of `.dockerignore` so that any lines starting with `#` are ignored, which is similiar to the behavior of `.gitignore`.

Related documentation has been updated.

**\- How to verify it**

Additional tests have been added to cover the changes.

**\- Description for the changelog**

Add support for comments (lines starting with `#`) in .dockerignore.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #20083.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
