### PR TITLE
docs: installation: SUSE: fix custom options section

### DIFF
--- a/docs/installation/linux/SUSE.md
+++ b/docs/installation/linux/SUSE.md
@@ -91,8 +91,9 @@ flag is set to `yes` like so:
 ## Custom daemon options
 
 If you need to add an HTTP Proxy, set a different directory or partition for the
-Docker runtime files, or make other customizations, read the systemd article to
-learn how to [customize your systemd Docker daemon options](../../admin/systemd.md).
+Docker runtime files, or make other customizations, you can add the relevant
+flags to the `DOCKER_OPTS` variable defined in `/etc/sysconfig/docker`. These
+are appended to the Docker daemon command line invocation.
 
 ## Uninstallation
 


### PR DESCRIPTION
On SUSE-based distributions, we use the /etc/sysconfig/docker file for
all user configuration of service files. This is done to ensure that
users' changes don't get clobbered by package updates, and that their
configuration is kept separate in a standard place (so our tools know
where to look).

Signed-off-by: Aleksa Sarai asarai@suse.de

[![cute](http://cdn.attackofthecute.com/October-18-2011-02-36-11-c25129.jpeg)](http://attackofthecute.com/on/?i=2509)

/cc @flavio 
