### PR TITLE
Fix pkg/streamformatter.TestJSONFormatProgress

### DIFF
--- a/pkg/streamformatter/streamformatter_test.go
+++ b/pkg/streamformatter/streamformatter_test.go
@@ -94,8 +94,12 @@ func TestJSONFormatProgress(t *testing.T) {
 
 	// Compare the progress strings before the timeLeftBox
 	expectedProgress := "[=========================>                         ]     15 B/30 B"
-	if !strings.HasPrefix(msg.ProgressMessage, expectedProgress) {
-		t.Fatalf("ProgressMessage without the timeLeftBox must be %s, got: %s", expectedProgress, msg.ProgressMessage)
+	// if terminal column is <= 110, expectedProgressShort is expected.
+	expectedProgressShort := "    15 B/30 B"
+	if !(strings.HasPrefix(msg.ProgressMessage, expectedProgress) ||
+		strings.HasPrefix(msg.ProgressMessage, expectedProgressShort)) {
+		t.Fatalf("ProgressMessage without the timeLeftBox must be %s or %s, got: %s",
+			expectedProgress, expectedProgressShort, msg.ProgressMessage)
 	}
 
 	if !reflect.DeepEqual(msg.Progress, progress) {


### PR DESCRIPTION
This is an addendum to #23113.

**\- What I did**
Fix pkg/streamformatter.TestJSONFormatProgress, which was failing if the terminal column width is <= 110.

```
$ go test -c ./pkg/streamformatter && go test -v ./streamformatter.test
--- FAIL: TestJSONFormatProgress (0.00s)
        streamformatter_test.go:98: ProgressMessage without the timeLeftBox must be [=========================>                         ]     15 B/30 B, got:     15 B/30 B 406857h10m55s
FAIL
```

**\- How I did it**
Check the terminal window size

**\- How to verify it**
1. Set the terminal column (`$COLUMNS`) to <= 110 so as to confirm the issue is resolved

```
$ echo $COLUMNS
$ go test -c ./pkg/streamformatter && go test -v ./streamformatter.test
```
1. Set the terminal column (`$COLUMNS`) to > 110 so as to confirm there is no regression.

```
$ echo $COLUMNS
$ go test -v ./streamformatter.test
```
1. Run with nohup as well

```
$ nohup go test -v ./streamformatter.test && cat nohup.out
```

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
