### PR TITLE
aufs,overlay: disable on eCryptfs

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -93,7 +93,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	switch fsMagic {
-	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs:
+	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("AUFS is not supported over %s", backingFs)
 		return nil, graphdriver.ErrIncompatibleFS
 	}

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -16,6 +16,8 @@ const (
 	FsMagicBtrfs = FsMagic(0x9123683E)
 	// FsMagicCramfs filesystem id for Cramfs
 	FsMagicCramfs = FsMagic(0x28cd3d45)
+	// FsMagicEcryptfs filesystem id for eCryptfs
+	FsMagicEcryptfs = FsMagic(0xf15f)
 	// FsMagicExtfs filesystem id for Extfs
 	FsMagicExtfs = FsMagic(0x0000EF53)
 	// FsMagicF2fs filesystem id for F2fs

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -119,7 +119,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	switch fsMagic {
-	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicZfs:
+	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicZfs, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("'overlay' is not supported over %s", backingFs)
 		return nil, graphdriver.ErrIncompatibleFS
 	}

--- a/docs/userguide/storagedriver/selectadriver.md
+++ b/docs/userguide/storagedriver/selectadriver.md
@@ -71,14 +71,14 @@ For example, the `btrfs` storage driver on a Btrfs backing filesystem. The
 following table lists each storage driver and whether it must match the host's
 backing file system:
 
-|Storage driver |Commonly used on |Disabled on                   |
-|---------------|-----------------|------------------------------|
-|`overlay`      |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `zfs`|
-|`aufs`         |`ext4` `xfs`     |`btrfs` `aufs`                |
-|`btrfs`        |`btrfs` _only_   |   N/A                        |
-|`devicemapper` |`direct-lvm`     |   N/A                        |
-|`vfs`          |debugging only   |   N/A                        |
-|`zfs`          |`zfs` _only_     |   N/A                        |
+|Storage driver |Commonly used on |Disabled on                              |
+|---------------|-----------------|-----------------------------------------|
+|`overlay`      |`ext4` `xfs`     |`btrfs` `aufs` `overlay` `zfs` `eCryptfs`|
+|`aufs`         |`ext4` `xfs`     |`btrfs` `aufs` `eCryptfs`                |
+|`btrfs`        |`btrfs` _only_   |   N/A                                   |
+|`devicemapper` |`direct-lvm`     |   N/A                                   |
+|`vfs`          |debugging only   |   N/A                                   |
+|`zfs`          |`zfs` _only_     |   N/A                                   |
 
 
 > **Note**


### PR DESCRIPTION
**\- What I did**
I've changed the aufs and overlay driver code to disable it when using eCryptfs as a backing file system.

We know aufs and eCryptfs won't work. There's no point in having other people waste time investigating this known problem, opening issues and having to investigate every time.

Fixes #22577
Fixes #19336
Fixes #10380
Fixes #7554

**\- How I did it**
I've added a new FsMagic.

**\- How to verify it**
Set up eCryptfs and switch Docker to use a folder on eCryptfs.

**\- Description for the changelog**
aufs and overlay: disable on eCryptfs
