### PR TITLE
Fix issues with get.docker.com install script with redhat 

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -239,10 +239,11 @@ do_install() {
 	if [ -z "$lsb_dist" ] && [ -r /etc/oracle-release ]; then
 		lsb_dist='oracleserver'
 	fi
-	if [ -z "$lsb_dist" ]; then
-		if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ]; then
-			lsb_dist='centos'
-		fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/centos-release ]; then
+		lsb_dist='centos'
+	fi
+	if [ -z "$lsb_dist" ] && [ -r /etc/redhat-release ]; then
+		lsb_dist='redhat'
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/os-release ]; then
 		lsb_dist="$(. /etc/os-release && echo "$ID")"
@@ -279,8 +280,8 @@ do_install() {
 			dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//')"
 		;;
 
-		fedora|centos)
-			dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//')"
+		fedora|centos|redhat)
+			dist_version="$(rpm -q --whatprovides ${lsb_dist}-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//' | sort | tail -1)"
 		;;
 
 		*)
@@ -435,7 +436,7 @@ do_install() {
 			exit 0
 			;;
 
-		fedora|centos|oraclelinux)
+		fedora|centos|redhat|oraclelinux)
 			$sh_c "cat >/etc/yum.repos.d/docker-${repo}.repo" <<-EOF
 			[docker-${repo}-repo]
 			name=Docker ${repo} Repository


### PR DESCRIPTION
This PR fixes the issues described in #23101

First, on a CentOS6 or 7 system, both /etc/centos-release and /etc/redhat-release files are present, but the package redhat-release is NOT present, it's centos-release. Thus,
the command:

`# rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//`

will fail, generating an erroneous repo file in /etc/yum.repos.d/, then the installation cannot continue.

Also, on some RH6/7 where the base system is an upgrade from a previous version (say, a RHEL5 that has been upgraded to RHEL6 for instance), the following command will return several lines instead of the expected one:

```
# rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n" | sed 's/\/.*//' | sed 's/\..*//' | sed 's/Server*//
5
6
```

because:

```
# rpm -q --whatprovides redhat-release
redhat-release-5Server-5.3.0.3.x86_64
redhat-release-server-6Server-6.5.0.1.el6.x86_64
```

and the dist_version then the generated /etc/yum.repos.d/docker-main.repo
will be wrong.

This PR is the suggested fixes to the install script, that makes a distinction between redhat and centos systems and is enforced in detecting package version.

closes #23101
Signed-off-by: Ken Cochrane kencochrane@gmail.com
