### PR TITLE
Error out if user tries to specify a custom seccomp profile on system that does not support it

### DIFF
--- a/daemon/seccomp_disabled.go
+++ b/daemon/seccomp_disabled.go
@@ -3,10 +3,15 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/container"
 	"github.com/opencontainers/specs/specs-go"
 )
 
 func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
+	if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {
+		return fmt.Errorf("seccomp profiles are not supported on this daemon, you cannot specify a custom seccomp profile")
+	}
 	return nil
 }


### PR DESCRIPTION
Fixes #23031

If a profile is explicitly passed but the system is not built with seccomp support,
error out rather than just running without a profile at all as we would previously.
Behaviour is unchanged if no profile is specified or unconfined is specified.

Signed-off-by: Justin Cormack justin.cormack@docker.com
