### PR TITLE
graphtest: fix cleanup logic

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1088,7 +1088,7 @@ func (devices *DeviceSet) setupVerifyBaseImageUUIDFS(baseInfo *devInfo) error {
 	}
 
 	if err := devices.verifyBaseDeviceUUIDFS(baseInfo); err != nil {
-		return fmt.Errorf("devmapper: Base Device UUID and Filesystem verification failed.%v", err)
+		return fmt.Errorf("devmapper: Base Device UUID and Filesystem verification failed: %v", err)
 	}
 
 	return nil

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -181,6 +181,12 @@ func DriverTestCreateEmpty(t *testing.T, drivername string) {
 		t.Fatal(err)
 	}
 
+	defer func() {
+		if err := driver.Remove("empty"); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	if !driver.Exists("empty") {
 		t.Fatal("Newly created image doesn't exist")
 	}
@@ -203,11 +209,6 @@ func DriverTestCreateEmpty(t *testing.T, drivername string) {
 	}
 
 	driver.Put("empty")
-
-	if err := driver.Remove("empty"); err != nil {
-		t.Fatal(err)
-	}
-
 }
 
 func createBase(t *testing.T, driver graphdriver.Driver, name string) {
@@ -260,7 +261,6 @@ func verifyBase(t *testing.T, driver graphdriver.Driver, name string) {
 	if len(fis) != 2 {
 		t.Fatal("Unexpected files in base image")
 	}
-
 }
 
 // DriverTestCreateBase create a base driver and verify.
@@ -269,11 +269,12 @@ func DriverTestCreateBase(t *testing.T, drivername string) {
 	defer PutDriver(t)
 
 	createBase(t, driver, "Base")
+	defer func() {
+		if err := driver.Remove("Base"); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	verifyBase(t, driver, "Base")
-
-	if err := driver.Remove("Base"); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // DriverTestCreateSnap Create a driver and snap and verify.
@@ -283,17 +284,20 @@ func DriverTestCreateSnap(t *testing.T, drivername string) {
 
 	createBase(t, driver, "Base")
 
+	defer func() {
+		if err := driver.Remove("Base"); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	if err := driver.Create("Snap", "Base", "", nil); err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if err := driver.Remove("Snap"); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	verifyBase(t, driver, "Snap")
-
-	if err := driver.Remove("Snap"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := driver.Remove("Base"); err != nil {
-		t.Fatal(err)
-	}
 }


### PR DESCRIPTION
device Base should not exists on failure:

```
--- FAIL: TestDevmapperCreateBase (0.06s)
    graphtest_unix.go:122: stat
/tmp/docker-graphtest-079240530/devicemapper/mnt/Base/rootfs/a subdir:
no such file or directory
--- FAIL: TestDevmapperCreateSnap (0.00s)
    graphtest_unix.go:219: devmapper: device Base already
exists.
```

it should be:

```
--- FAIL: TestDevmapperCreateBase (0.25s)
    graphtest_unix.go:122: stat
/tmp/docker-graphtest-828994195/devicemapper/mnt/Base/rootfs/a subdir:
no such file or directory
--- FAIL: TestDevmapperCreateSnap (0.13s)
    graphtest_unix.go:122: stat
/tmp/docker-graphtest-828994195/devicemapper/mnt/Snap/rootfs/a subdir:
no such file or directory
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
