### PR TITLE
faster vendoring

### DIFF
--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -37,8 +37,7 @@ clone() {
 	echo -n 'clone, '
 	case "$vcs" in
 		git)
-			git clone --quiet --no-checkout "$url" "$target"
-			( cd "$target" && git checkout --quiet "$rev" && git reset --quiet --hard "$rev" )
+			git clone -o "$rev" --depth 1 --quiet "$url" "$target"
 			;;
 		hg)
 			hg clone --quiet --updaterev "$rev" "$url" "$target"


### PR DESCRIPTION
Right now the script clones the entire repo and then checkout the
branch.

This makes the script clones only the right revision, hopefully making
it a little faster (for big repos at least).
