### PR TITLE
Remove the logger.Message ContainerID field

### DIFF
--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -14,8 +14,6 @@ import (
 // ContainerID and Timestamp.
 // Writes are concurrent, so you need implement some sync in your logger
 type Copier struct {
-	// cid is the container id for which we are copying logs
-	cid string
 	// srcs is map of name -> reader pairs, for example "stdout", "stderr"
 	srcs     map[string]io.Reader
 	dst      Logger
@@ -24,9 +22,8 @@ type Copier struct {
 }
 
 // NewCopier creates a new Copier
-func NewCopier(cid string, srcs map[string]io.Reader, dst Logger) *Copier {
+func NewCopier(srcs map[string]io.Reader, dst Logger) *Copier {
 	return &Copier{
-		cid:    cid,
 		srcs:   srcs,
 		dst:    dst,
 		closed: make(chan struct{}),
@@ -56,7 +53,7 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 			// ReadBytes can return full or partial output even when it failed.
 			// e.g. it can return a full entry and EOF.
 			if err == nil || len(line) > 0 {
-				if logErr := c.dst.Log(&Message{ContainerID: c.cid, Line: line, Source: name, Timestamp: time.Now().UTC()}); logErr != nil {
+				if logErr := c.dst.Log(&Message{Line: line, Source: name, Timestamp: time.Now().UTC()}); logErr != nil {
 					logrus.Errorf("Failed to log msg %q for logger %s: %s", line, c.dst.Name(), logErr)
 				}
 			}

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -157,8 +157,7 @@ drain:
 				source = "stdout"
 			}
 			// Send the log message.
-			cid := s.vars["CONTAINER_ID_FULL"]
-			logWatcher.Msg <- &logger.Message{ContainerID: cid, Line: line, Source: source, Timestamp: timestamp}
+			logWatcher.Msg <- &logger.Message{Line: line, Source: source, Timestamp: timestamp}
 		}
 		// If we're at the end of the journal, we're done (for now).
 		if C.sd_journal_next(j) <= 0 {

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -31,13 +31,13 @@ func TestJSONFileLogger(t *testing.T) {
 	}
 	defer l.Close()
 
-	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line1"), Source: "src1"}); err != nil {
+	if err := l.Log(&logger.Message{Line: []byte("line1"), Source: "src1"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line2"), Source: "src2"}); err != nil {
+	if err := l.Log(&logger.Message{Line: []byte("line2"), Source: "src2"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line3"), Source: "src3"}); err != nil {
+	if err := l.Log(&logger.Message{Line: []byte("line3"), Source: "src3"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := ioutil.ReadFile(filename)
@@ -72,7 +72,7 @@ func BenchmarkJSONFileLogger(b *testing.B) {
 	defer l.Close()
 
 	testLine := "Line that thinks that it is log line from docker\n"
-	msg := &logger.Message{ContainerID: cid, Line: []byte(testLine), Source: "stderr", Timestamp: time.Now().UTC()}
+	msg := &logger.Message{Line: []byte(testLine), Source: "stderr", Timestamp: time.Now().UTC()}
 	jsonlog, err := (&jsonlog.JSONLog{Log: string(msg.Line) + "\n", Stream: msg.Source, Created: msg.Timestamp}).MarshalJSON()
 	if err != nil {
 		b.Fatal(err)
@@ -107,7 +107,7 @@ func TestJSONFileLoggerWithOpts(t *testing.T) {
 	}
 	defer l.Close()
 	for i := 0; i < 20; i++ {
-		if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line" + strconv.Itoa(i)), Source: "src1"}); err != nil {
+		if err := l.Log(&logger.Message{Line: []byte("line" + strconv.Itoa(i)), Source: "src1"}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -172,7 +172,7 @@ func TestJSONFileLoggerWithLabelsEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer l.Close()
-	if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line"), Source: "src1"}); err != nil {
+	if err := l.Log(&logger.Message{Line: []byte("line"), Source: "src1"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := ioutil.ReadFile(filename)
@@ -218,7 +218,7 @@ func BenchmarkJSONFileLoggerWithReader(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer l.Close()
-	msg := &logger.Message{ContainerID: cid, Line: []byte("line"), Source: "src1"}
+	msg := &logger.Message{Line: []byte("line"), Source: "src1"}
 	jsonlog, err := (&jsonlog.JSONLog{Log: string(msg.Line) + "\n", Stream: msg.Source, Created: msg.Timestamp}).MarshalJSON()
 	if err != nil {
 		b.Fatal(err)

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -27,11 +27,10 @@ const (
 
 // Message is datastructure that represents record from some container.
 type Message struct {
-	ContainerID string
-	Line        []byte
-	Source      string
-	Timestamp   time.Time
-	Attrs       LogAttributes
+	Line      []byte
+	Source    string
+	Timestamp time.Time
+	Attrs     LogAttributes
 }
 
 // LogAttributes is used to hold the extra attributes available in the log message

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -124,7 +124,7 @@ func (daemon *Daemon) StartLogging(container *container.Container) error {
 		return fmt.Errorf("Failed to initialize logging driver: %v", err)
 	}
 
-	copier := logger.NewCopier(container.ID, map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
+	copier := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
 	container.LogCopier = copier
 	copier.Run()
 	container.LogDriver = l


### PR DESCRIPTION
**\- What I did**
Based on conversations in https://github.com/docker/docker/issues/20726, I was looking at teaching the json-logs log reader logic to populate the `ContainerID` field in `Message`s that it was sending back to the `LogWatcher`, and noticed that the only code that ever read the field was test code.  Based on that, I'm proposing removing the field.

**\- How I did it**
Delete, delete, delete.

**\- How to verify it**
Confirm that logic that writes to logs in the log drivers is unaffected because it doesn't read the container ID from Message structures, and that the `logs` handler doesn't read them, either.

**\- Description for the changelog**
(none)
