### PR TITLE
Windows: Remove a double free on hcs container handle

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -230,9 +230,6 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 		// Remove process from list if we have exited
 		// We need to do so here in case the Message Handler decides to restart it.
 		if si.State == StateExit {
-			if err := ctr.hcsContainer.Close(); err != nil {
-				logrus.Error(err)
-			}
 			ctr.client.deleteContainer(ctr.friendlyName)
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Removed a double free on an exiting container

**\- How to verify it**

No longer double free errors in logs.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

Signed-off-by: Darren Stahl darst@microsoft.com
