### PR TITLE
Remove status column from client libraries page

### DIFF
--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -18,17 +18,15 @@ with the library maintainers.
 
 <table border="1" class="docutils">
   <colgroup>
-    <col width="24%">
-    <col width="17%">
+    <col width="29%">
+    <col width="23%">
     <col width="48%">
-    <col width="11%">
   </colgroup>
   <thead valign="bottom">
     <tr>
       <th class="head">Language/Framework</th>
       <th class="head">Name</th>
       <th class="head">Repository</th>
-      <th class="head">Status</th>
     </tr>
   </thead>
   <tbody valign = "top">
@@ -36,122 +34,101 @@ with the library maintainers.
       <td>C#</td>
       <td>Docker.DotNet</td>
       <td><a class="reference external" href="https://github.com/ahmetalpbalkan/Docker.DotNet">https://github.com/ahmetalpbalkan/Docker.DotNet</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>C++</td>
       <td>lasote/docker_client</td>
       <td><a class="reference external" href="https://github.com/lasote/docker_client">https://github.com/lasote/docker_client</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Erlang</td>
       <td>erldocker</td>
       <td><a class="reference external" href="https://github.com/proger/erldocker">https://github.com/proger/erldocker</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Dart</td>
       <td>bwu_docker</td>
       <td><a class="reference external" href="https://github.com/bwu-dart/bwu_docker">https://github.com/bwu-dart/bwu_docker</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Go</td>
       <td>engine-api</td>
       <td><a class="reference external" href="https://github.com/docker/engine-api">https://github.com/docker/engine-api</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Gradle</td>
       <td>gradle-docker-plugin</td>
       <td><a class="reference external" href="https://github.com/gesellix/gradle-docker-plugin">https://github.com/gesellix/gradle-docker-plugin</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Groovy</td>
       <td>docker-client</td>
       <td><a class="reference external" href="https://github.com/gesellix/docker-client">https://github.com/gesellix/docker-client</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Haskell</td>
       <td>docker-hs</td>
       <td><a class="reference external" href="https://github.com/denibertovic/docker-hs">https://github.com/denibertovic/docker-hs</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>HTML (Web Components)</td>
       <td>docker-elements</td>
       <td><a class="reference external" href="https://github.com/kapalhq/docker-elements">https://github.com/kapalhq/docker-elements</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Java</td>
       <td>docker-java</td>
       <td><a class="reference external" href="https://github.com/docker-java/docker-java">https://github.com/docker-java/docker-java</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Java</td>
       <td>docker-client</td>
       <td><a class="reference external" href="https://github.com/spotify/docker-client">https://github.com/spotify/docker-client</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>NodeJS</td>
       <td>dockerode</td>
-      <td><a class="reference external" href="https://github.com/apocas/dockerode">https://github.com/apocas/dockerode</a>
-  Install via NPM: <cite>npm install dockerode</cite></td>
-      <td>Active</td>
+      <td><a class="reference external" href="https://github.com/apocas/dockerode">https://github.com/apocas/dockerode</a></td>
     </tr>
     <tr>
       <td>Perl</td>
       <td>Eixo::Docker</td>
       <td><a class="reference external" href="https://github.com/alambike/eixo-docker">https://github.com/alambike/eixo-docker</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>PHP</td>
       <td>Docker-PHP</td>
       <td><a class="reference external" href="https://github.com/docker-php/docker-php">https://github.com/docker-php/docker-php</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Python</td>
       <td>docker-py</td>
       <td><a class="reference external" href="https://github.com/docker/docker-py">https://github.com/docker/docker-py</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Ruby</td>
       <td>docker-api</td>
       <td><a class="reference external" href="https://github.com/swipely/docker-api">https://github.com/swipely/docker-api</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Rust</td>
       <td>docker-rust</td>
       <td><a class="reference external" href="https://github.com/abh1nav/docker-rust">https://github.com/abh1nav/docker-rust</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Rust</td>
       <td>shiplift</td>
       <td><a class="reference external" href="https://github.com/softprops/shiplift">https://github.com/softprops/shiplift</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Scala</td>
       <td>tugboat</td>
       <td><a class="reference external" href="https://github.com/softprops/tugboat">https://github.com/softprops/tugboat</a></td>
-      <td>Active</td>
     </tr>
     <tr>
       <td>Scala</td>
       <td>reactive-docker</td>
       <td><a class="reference external" href="https://github.com/almoehi/reactive-docker">https://github.com/almoehi/reactive-docker</a></td>
-      <td>Active</td>
     </tr>
   </tbody>
 </table>

--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -11,10 +11,10 @@ weight = 90
 
 # Docker Remote API client libraries
 
-These libraries have not been tested by the Docker maintainers for
-compatibility. Please file issues with the library owners. If you find
-more library implementations, please list them in Docker doc bugs and we
-will add the libraries here.
+These libraries make it easier to build applications on top of the Docker
+Remote API with various programming languages. They have not been tested by the
+Docker maintainers for compatibility, so if you run into any issues, file them
+with the library maintainers.
 
 <table border="1" class="docutils">
   <colgroup>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Remove status column from client libraries page because they are all active. If they are not active, we should probably just remove them from the page.

Also updated the intro text to explain what the libraries are for.

**\- A picture of a cute animal (not mandatory but encouraged)**

![giphy-8](https://cloud.githubusercontent.com/assets/40906/15693573/18c90bac-278e-11e6-9ce4-0516ab711950.gif)
