### PR TITLE
use reexec to get the current process's binary

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -16,6 +15,7 @@ import (
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/volume"
@@ -669,14 +669,14 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 
 	for _, ns := range s.Linux.Namespaces {
 		if ns.Type == "network" && ns.Path == "" && !c.Config.NetworkDisabled {
-			target, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(os.Getpid()), "exe"))
+			target, err := os.Readlink(reexec.Self())
 			if err != nil {
 				return nil, err
 			}
 
 			s.Hooks = specs.Hooks{
 				Prestart: []specs.Hook{{
-					Path: target, // FIXME: cross-platform
+					Path: target,
 					Args: []string{"libnetwork-setkey", c.ID, daemon.netController.ID()},
 				}},
 			}


### PR DESCRIPTION
Cross-platform support of getting the current process's binary
Signed-off-by: mYmNeo thomassong@tencent.com
