### PR TITLE
daemon: Rename copy to copyFunc

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -126,7 +126,7 @@ func (daemon *Daemon) AttachStreams(id string, iop libcontainerd.IOPipe) error {
 		}
 	}
 
-	copy := func(w io.Writer, r io.Reader) {
+	copyFunc := func(w io.Writer, r io.Reader) {
 		s.Add(1)
 		go func() {
 			if _, err := io.Copy(w, r); err != nil {
@@ -137,10 +137,10 @@ func (daemon *Daemon) AttachStreams(id string, iop libcontainerd.IOPipe) error {
 	}
 
 	if iop.Stdout != nil {
-		copy(s.Stdout(), iop.Stdout)
+		copyFunc(s.Stdout(), iop.Stdout)
 	}
 	if iop.Stderr != nil {
-		copy(s.Stderr(), iop.Stderr)
+		copyFunc(s.Stderr(), iop.Stderr)
 	}
 
 	return nil


### PR DESCRIPTION
I think "copy" is misleading for humans because Go has its own builtin "copy" function

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
