### PR TITLE
Enable seccomp for s390x and ppc: s390x part

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -161,7 +161,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor selinux seccomp
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1184,7 +1184,7 @@ func (s *DockerSuite) TestRunApparmorProcDirectory(c *check.C) {
 // make sure the default profile can be successfully parsed (using unshare as it is
 // something which we know is blocked in the default profile)
 func (s *DockerSuite) TestRunSeccompWithDefaultProfile(c *check.C) {
-	testRequires(c, SameHostDaemon, seccompEnabled, NotArm, NotPpc64le)
+	testRequires(c, SameHostDaemon, seccompEnabled, NotArm, NotPpc64le, NotS390X)
 
 	out, _, err := dockerCmdWithError("run", "--security-opt", "seccomp=../profiles/seccomp/default.json", "debian:jessie", "unshare", "--map-root-user", "--user", "sh", "-c", "whoami")
 	c.Assert(err, checker.NotNil, check.Commentf(out))

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -42,6 +42,10 @@ var (
 		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "ppc64le" },
 		"Test requires a daemon not running on ppc64le",
 	}
+	NotS390X = testRequirement{
+		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "s390x" },
+		"Test requires a daemon not running on s390x",
+	}
 	SameHostDaemon = testRequirement{
 		func() bool { return isLocalDaemon },
 		"Test requires docker daemon to run on the same machine as CLI",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -29,6 +29,8 @@ func arches() []types.Arch {
 		return []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64, types.ArchMIPSEL64N32}
 	case "mipsel64n32":
 		return []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64, types.ArchMIPSEL64N32}
+	case "s390x":
+		return []types.Arch{types.ArchS390, types.ArchS390X}
 	default:
 		return []types.Arch{}
 	}
@@ -1579,6 +1581,7 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 		},
 	}
 
+	var sysCloneFlagsIndex uint
 	var arch string
 	var native, err = libseccomp.GetNativeArch()
 	if err == nil {
@@ -1620,6 +1623,26 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 				Args:   []*types.Arg{},
 			},
 		}...)
+	case "s390", "s390x":
+		syscalls = append(syscalls, []*types.Syscall{
+			{
+				Name:   "s390_pci_mmio_read",
+				Action: types.ActAllow,
+				Args:   []*types.Arg{},
+			},
+			{
+				Name:   "s390_pci_mmio_write",
+				Action: types.ActAllow,
+				Args:   []*types.Arg{},
+			},
+			{
+				Name:   "s390_runtime_instr",
+				Action: types.ActAllow,
+				Args:   []*types.Arg{},
+			},
+		}...)
+		/* Flags parameter of the clone syscall is the 2nd on s390 */
+		sysCloneFlagsIndex = 1
 	}
 
 	capSysAdmin := false
@@ -1841,7 +1864,7 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 				Action: types.ActAllow,
 				Args: []*types.Arg{
 					{
-						Index:    0,
+						Index:    sysCloneFlagsIndex,
 						Value:    syscall.CLONE_NEWNS | syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWUSER | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
 						ValueTwo: 0,
 						Op:       types.OpMaskedEqual,


### PR DESCRIPTION
Patches required to enable seccomp support for s390x:
- seccomp_default: Add s390 compat mode
- seccomp_default: Use correct flags parameter for sys_clone on s390x
- seccomp_default: Add s390 specific syscalls
- test_integration: Do not run seccomp default profile test on s390x
- Dockerfile.s390x: Enable seccomp for s390x

Please do not merge until all prerequisites of issue #23171 are fulfilled.
