### PR TITLE
Update mailmap and re-generate Authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -89,6 +89,7 @@ Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 Sven Dowideit <SvenDowideit@home.org.au>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@fosiki.com>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@docker.com>
+Sven Dowideit <SvenDowideit@home.org.au> <¨SvenDowideit@home.org.au¨>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@home.org.au>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@users.noreply.github.com>
 Sven Dowideit <SvenDowideit@home.org.au> <sven@t440s.home.gateway>
@@ -159,6 +160,7 @@ Deshi Xiao <dxiao@redhat.com> <xiaods@gmail.com>
 Doug Davis <dug@us.ibm.com> <duglin@users.noreply.github.com>
 Jacob Atzen <jacob@jacobatzen.dk> <jatzen@gmail.com>
 Jeff Nickoloff <jeff.nickoloff@gmail.com> <jeff@allingeek.com>
+John Howard (VM) <John.Howard@microsoft.com> <jhowardmsft@users.noreply.github.com>
 John Howard (VM) <John.Howard@microsoft.com>
 John Howard (VM) <John.Howard@microsoft.com> <john.howard@microsoft.com>
 John Howard (VM) <John.Howard@microsoft.com> <jhoward@microsoft.com>
@@ -234,4 +236,19 @@ Vishnu Kannan <vishnuk@google.com>
 xlgao-zju <xlgao@zju.edu.cn> xlgao <xlgao@zju.edu.cn>
 yuchangchun <yuchangchun1@huawei.com> y00277921 <yuchangchun1@huawei.com> 
 <zij@case.edu> <zjaffee@us.ibm.com>
+<anujbahuguna.dev@gmail.com> <abahuguna@fiberlink.com>
+<eungjun.yi@navercorp.com> <semtlenori@gmail.com>
+<haosw@cn.ibm.com> <haoshuwei1989@163.com>
+Hao Shu Wei <haosw@cn.ibm.com>
+<matt.bentley@docker.com> <mbentley@mbentley.net>
+<MihaiBorob@gmail.com> <MihaiBorobocea@gmail.com>
+<redmond.martin@gmail.com> <xgithub@redmond5.com>
+<redmond.martin@gmail.com> <martin@tinychat.com>
+<srbrahma@us.ibm.com> <sbrahma@us.ibm.com>
+<suda.akihiro@lab.ntt.co.jp> <suda.kyoto@gmail.com>
+<thomas@gazagnaire.org> <thomas@gazagnaire.com>
+<thomassong@tencent.com> <mymneo@163.com>
+Shengbo Song <thomassong@tencent.com>
+<sylvain@ascribe.io> <sylvain.bellemare@ezeep.com>
+Sylvain Bellemare <sylvain@ascribe.io>
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ ajneu <ajneu@users.noreply.github.com>
 Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
 Al Tobey <al@ooyala.com>
 alambike <alambike@gmail.com>
+Alan Scherger <flyinprogrammer@gmail.com>
 Alan Thompson <cloojure@gmail.com>
 Albert Callarisa <shark234@gmail.com>
 Albert Zhang <zhgwenming@gmail.com>
@@ -41,6 +42,7 @@ Alessandro Boch <aboch@docker.com>
 Alessio Biancalana <dottorblaster@gmail.com>
 Alex Chan <alex@alexwlchan.net>
 Alex Crawford <alex.crawford@coreos.com>
+Alex Ellis <alexellis2@gmail.com>
 Alex Gaynor <alex.gaynor@gmail.com>
 Alex Samorukov <samm@os2.kiev.ua>
 Alex Warhawk <ax.warhawk@gmail.com>
@@ -56,6 +58,7 @@ Alexey Guskov <lexag@mail.ru>
 Alexey Kotlyarov <alexey@infoxchange.net.au>
 Alexey Shamrin <shamrin@gmail.com>
 Alexis THOMAS <fr.alexisthomas@gmail.com>
+Ali Dehghani <ali.dehghani.g@gmail.com>
 Allen Madsen <blatyo@gmail.com>
 Allen Sun <allen.sun@daocloud.io>
 almoehi <almoehi@users.noreply.github.com>
@@ -158,6 +161,7 @@ bobby abbott <ttobbaybbob@gmail.com>
 boucher <rboucher@gmail.com>
 Bouke Haarsma <bouke@webatoom.nl>
 Boyd Hemphill <boyd@feedmagnet.com>
+boynux <boynux@gmail.com>
 Bradley Cicenas <bradley.cicenas@gmail.com>
 Bradley Wright <brad@intranation.com>
 Brandon Liu <bdon@bdon.org>
@@ -165,6 +169,7 @@ Brandon Philips <brandon@ifup.org>
 Brandon Rhodes <brandon@rhodesmill.org>
 Brendan Dixon <brendand@microsoft.com>
 Brent Salisbury <brent.salisbury@docker.com>
+Brett Higgins <brhiggins@arbor.net>
 Brett Kochendorfer <brett.kochendorfer@gmail.com>
 Brian (bex) Exelbierd <bexelbie@redhat.com>
 Brian Bland <brian.bland@docker.com>
@@ -176,6 +181,7 @@ Brian McCallister <brianm@skife.org>
 Brian Olsen <brian@maven-group.org>
 Brian Shumate <brian@couchbase.com>
 Brian Torres-Gil <brian@dralth.com>
+Brian Trump <btrump@yelp.com>
 Brice Jaglin <bjaglin@teads.tv>
 Briehan Lombaard <briehan.lombaard@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
@@ -208,6 +214,7 @@ Chance Zibolski <chance.zibolski@gmail.com>
 Chander G <chandergovind@gmail.com>
 Charles Chan <charleswhchan@users.noreply.github.com>
 Charles Hooper <charles.hooper@dotcloud.com>
+Charles Law <claw@conduce.com>
 Charles Lindsay <chaz@chazomatic.us>
 Charles Merriam <charles.merriam@gmail.com>
 Charles Sarrazin <charles@sarraz.in>
@@ -237,6 +244,7 @@ Chris Weyl <cweyl@alumni.drew.edu>
 chrismckinnel <chris.mckinnel@tangentlabs.co.uk>
 Christian Berendt <berendt@b1-systems.de>
 Christian Böhme <developement@boehme3d.de>
+Christian Persson <saser@live.se>
 Christian Rotzoll <ch.rotzoll@gmail.com>
 Christian Simon <simon@swine.de>
 Christian Stefanescu <st.chris@gmail.com>
@@ -269,6 +277,7 @@ Daan van Berkel <daan.v.berkel.1980@gmail.com>
 Daehyeok Mun <daehyeok@gmail.com>
 Dafydd Crosby <dtcrsby@gmail.com>
 dalanlan <dalanlan925@gmail.com>
+Damien Nadé <github@livna.org>
 Damien Nozay <damien.nozay@gmail.com>
 Damjan Georgievski <gdamjan@gmail.com>
 Dan Anolik <dan@anolik.net>
@@ -306,6 +315,7 @@ Darren Shepherd <darren.s.shepherd@gmail.com>
 Darren Stahl <darst@microsoft.com>
 Dave Barboza <dbarboza@datto.com>
 Dave Henderson <Dave.Henderson@ca.ibm.com>
+Dave MacDonald <mindlapse@gmail.com>
 Dave Tucker <dt@docker.com>
 David Anderson <dave@natulte.net>
 David Calavera <david.calavera@gmail.com>
@@ -330,6 +340,7 @@ Davide Ceretti <davide.ceretti@hogarthww.com>
 Dawn Chen <dawnchen@google.com>
 dcylabs <dcylabs@gmail.com>
 decadent <decadent@users.noreply.github.com>
+deed02392 <georgehafiz@gmail.com>
 Deng Guangxing <dengguangxing@huawei.com>
 Deni Bertovic <deni@kset.org>
 Denis Gladkikh <denis@gladkikh.email>
@@ -347,11 +358,13 @@ Dharmit Shah <shahdharmit@gmail.com>
 Dieter Reuter <dieter.reuter@me.com>
 Dima Stopel <dima@twistlock.com>
 Dimitri John Ledkov <dimitri.j.ledkov@intel.com>
+Dimitry Andric <d.andric@activevideo.com>
 Dinesh Subhraveti <dineshs@altiscale.com>
 Diogo Monica <diogo@docker.com>
 DiuDiugirl <sophia.wang@pku.edu.cn>
 Djibril Koné <kone.djibril@gmail.com>
 dkumor <daniel@dkumor.com>
+Dmitri Logvinenko <dmitri.logvinenko@gmail.com>
 Dmitry Demeshchuk <demeshchuk@gmail.com>
 Dmitry Gusev <dmitry.gusev@gmail.com>
 Dmitry V. Krivenok <krivenok.dmitry@gmail.com>
@@ -396,6 +409,7 @@ Eric Rafaloff <erafaloff@gmail.com>
 Eric Rosenberg <ehaydenr@users.noreply.github.com>
 Eric Sage <eric.david.sage@gmail.com>
 Eric Windisch <eric@windisch.us>
+Eric Yang <windfarer@gmail.com>
 Eric-Olivier Lamey <eo@lamey.me>
 Erik Bray <erik.m.bray@gmail.com>
 Erik Dubbelboer <erik@dubbelboer.com>
@@ -423,6 +437,7 @@ Fabiano Rosas <farosas@br.ibm.com>
 Fabio Falci <fabiofalci@gmail.com>
 Fabio Rehm <fgrehm@gmail.com>
 Fabrizio Regini <freegenie@gmail.com>
+Fabrizio Soppelsa <fsoppelsa@mirantis.com>
 Faiz Khan <faizkhan00@gmail.com>
 falmp <chico.lopes@gmail.com>
 Fangyuan Gao <21551127@zju.edu.cn>
@@ -441,6 +456,7 @@ Filipe Oliveira <contato@fmoliveira.com.br>
 fl0yd <fl0yd@me.com>
 Flavio Castelli <fcastelli@suse.com>
 FLGMwt <ryan.stelly@live.com>
+Florian <FWirtz@users.noreply.github.com>
 Florian Klein <florian.klein@free.fr>
 Florian Maier <marsmensch@users.noreply.github.com>
 Florian Weingarten <flo@hackvalue.de>
@@ -457,6 +473,7 @@ Frederick F. Kautz IV <fkautz@redhat.com>
 Frederik Loeffert <frederik@zitrusmedia.de>
 Frederik Nordahl Jul Sabroe <frederikns@gmail.com>
 Freek Kalter <freek@kalteronline.org>
+fy2462 <fy2462@gmail.com>
 Félix Baylac-Jacqué <baylac.felix@gmail.com>
 Félix Cantournet <felix.cantournet@cloudwatt.com>
 Gabe Rosenhouse <gabe@missionst.com>
@@ -506,6 +523,7 @@ gwx296173 <gaojing3@huawei.com>
 Günter Zöchbauer <guenter@gzoechbauer.com>
 Hans Kristian Flaatten <hans@starefossen.com>
 Hans Rødtang <hansrodtang@gmail.com>
+Hao Shu Wei <haosw@cn.ibm.com>
 Hao Zhang <21521210@zju.edu.cn>
 Harald Albers <github@albersweb.de>
 Harley Laue <losinggeneration@gmail.com>
@@ -530,6 +548,7 @@ huqun <huqun@zju.edu.cn>
 Huu Nguyen <huu@prismskylabs.com>
 hyeongkyu.lee <hyeongkyu.lee@navercorp.com>
 hyp3rdino <markus.kortlang@lhsystems.com>
+Hyzhou <1187766782@qq.com>
 Ian Babrou <ibobrik@gmail.com>
 Ian Bishop <ianbishop@pace7.com>
 Ian Bull <irbull@gmail.com>
@@ -552,6 +571,7 @@ Isabel Jimenez <contact.isabeljimenez@gmail.com>
 Isao Jonas <isao.jonas@gmail.com>
 Ivan Babrou <ibobrik@gmail.com>
 Ivan Fraixedes <ifcdev@gmail.com>
+Ivan Grcic <igrcic@gmail.com>
 J Bruni <joaohbruni@yahoo.com.br>
 J. Nunn <jbnunn@gmail.com>
 Jack Danger Canty <jackdanger@squareup.com>
@@ -582,6 +602,7 @@ Jan-Jaap Driessen <janjaapdriessen@gmail.com>
 Jana Radhakrishnan <mrjana@docker.com>
 Januar Wayong <januar@gmail.com>
 Jared Biel <jared.biel@bolderthinking.com>
+Jared Hocutt <jaredh@netapp.com>
 Jaroslaw Zabiello <hipertracker@gmail.com>
 jaseg <jaseg@jaseg.net>
 Jasmine Hegman <jasmine@jhegman.com>
@@ -697,6 +718,7 @@ Julien Bisconti <veggiemonk@users.noreply.github.com>
 Julien Bordellier <julienbordellier@gmail.com>
 Julien Dubois <julien.dubois@gmail.com>
 Julien Pervillé <julien.perville@perfect-memory.com>
+Julio Montes <imc.coder@gmail.com>
 Jun-Ru Chang <jrjang@gmail.com>
 Jussi Nummelin <jussi.nummelin@gmail.com>
 Justas Brazauskas <brazauskasjustas@gmail.com>
@@ -704,12 +726,14 @@ Justin Cormack <justin.cormack@docker.com>
 Justin Force <justin.force@gmail.com>
 Justin Plock <jplock@users.noreply.github.com>
 Justin Simonelis <justin.p.simonelis@gmail.com>
+Justin Terry <juterry@microsoft.com>
 Jyrki Puttonen <jyrkiput@gmail.com>
 Jérôme Petazzoni <jerome.petazzoni@dotcloud.com>
 Jörg Thalheim <joerg@higgsboson.tk>
 Kai Blin <kai@samba.org>
 Kai Qiang Wu(Kennan) <wkqwu@cn.ibm.com>
 Kamil Domański <kamil@domanski.co>
+kamjar gerami <kami.gerami@gmail.com>
 Kanstantsin Shautsou <kanstantsin.sha@gmail.com>
 Karan Lyons <karan@karanlyons.com>
 Kareem Khazem <karkhaz@karkhaz.com>
@@ -721,6 +745,7 @@ Kato Kazuyoshi <kato.kazuyoshi@gmail.com>
 Katrina Owen <katrina.owen@gmail.com>
 Kawsar Saiyeed <kawsar.saiyeed@projiris.com>
 kayrus <kay.diam@gmail.com>
+Ke Xu <leonhartx.k@gmail.com>
 Keli Hu <dev@keli.hu>
 Ken Cochrane <kencochrane@gmail.com>
 Ken ICHIKAWA <ichikawa.ken@jp.fujitsu.com>
@@ -735,6 +760,7 @@ Kevin P. Kucharczyk <kevinkucharczyk@gmail.com>
 Kevin Shi <kshi@andrew.cmu.edu>
 Kevin Wallace <kevin@pentabarf.net>
 Kevin Yap <me@kevinyap.ca>
+kevinmeredith <kevin.m.meredith@gmail.com>
 Keyvan Fatehi <keyvanfatehi@gmail.com>
 kies <lleelm@gmail.com>
 Kim BKC Carlbacker <kim.carlbacker@gmail.com>
@@ -764,6 +790,7 @@ Lalatendu Mohanty <lmohanty@redhat.com>
 lalyos <lalyos@yahoo.com>
 Lance Chen <cyen0312@gmail.com>
 Lance Kinley <lkinley@loyaltymethods.com>
+Lars Butler <Lars.Butler@gmail.com>
 Lars Kellogg-Stedman <lars@redhat.com>
 Lars R. Damerow <lars@pixar.com>
 Laszlo Meszaros <lacienator@gmail.com>
@@ -785,6 +812,8 @@ Liang Mingqiang <mqliang.zju@gmail.com>
 Liang-Chi Hsieh <viirya@gmail.com>
 liaoqingwei <liaoqingwei@huawei.com>
 limsy <seongyeol37@gmail.com>
+Lin Lu <doraalin@163.com>
+LingFaKe <lingfake@huawei.com>
 Linus Heckemann <lheckemann@twig-world.com>
 Liran Tal <liran.tal@gmail.com>
 Liron Levin <liron@twistlock.com>
@@ -818,6 +847,7 @@ Malte Janduda <mail@janduda.net>
 manchoz <giampaolo@trampolineup.com>
 Manfred Touron <m@42.am>
 Manfred Zabarauskas <manfredas@zabarauskas.com>
+mansinahar <mansinahar@users.noreply.github.com>
 Manuel Meurer <manuel@krautcomputing.com>
 Manuel Woelker <github@manuel.woelker.org>
 mapk0y <mapk0y@gmail.com>
@@ -848,7 +878,7 @@ Martijn van Oosterhout <kleptog@svana.org>
 Martin Honermeyer <maze@strahlungsfrei.de>
 Martin Kelly <martin@surround.io>
 Martin Mosegaard Amdisen <martin.amdisen@praqma.com>
-Martin Redmond <martin@tinychat.com>
+Martin Redmond <redmond.martin@gmail.com>
 Mary Anthony <mary.anthony@docker.com>
 Masahito Zembutsu <zembutsu@users.noreply.github.com>
 Mason Malone <mason.malone@gmail.com>
@@ -857,7 +887,7 @@ Mathias Monnerville <mathias@monnerville.com>
 Mathieu Le Marec - Pasquet <kiorky@cryptelium.net>
 Matt Apperson <me@mattapperson.com>
 Matt Bachmann <bachmann.matt@gmail.com>
-Matt Bentley <mbentley@mbentley.net>
+Matt Bentley <matt.bentley@docker.com>
 Matt Haggard <haggardii@gmail.com>
 Matt McCormick <matt.mccormick@kitware.com>
 Matt Moore <mattmoor@google.com>
@@ -892,8 +922,10 @@ Michael Brown <michael@netdirect.ca>
 Michael Chiang <mchiang@docker.com>
 Michael Crosby <michael@docker.com>
 Michael Currie <mcurrie@bruceforceresearch.com>
+Michael Friis <friism@gmail.com>
 Michael Gorsuch <gorsuch@github.com>
 Michael Grauer <michael.grauer@kitware.com>
+Michael Holzheu <holzheu@linux.vnet.ibm.com>
 Michael Hudson-Doyle <michael.hudson@linaro.org>
 Michael Huettermann <michael@huettermann.net>
 Michael Käufl <docker@c.michael-kaeufl.de>
@@ -913,7 +945,7 @@ Michał Czeraszkiewicz <czerasz@gmail.com>
 Michiel@unhosted <michiel@unhosted.org>
 Miguel Angel Fernández <elmendalerenda@gmail.com>
 Miguel Morales <mimoralea@gmail.com>
-Mihai Borobocea <MihaiBorobocea@gmail.com>
+Mihai Borobocea <MihaiBorob@gmail.com>
 Mihuleacc Sergiu <mihuleac.sergiu@gmail.com>
 Mike Brown <brownwm@us.ibm.com>
 Mike Chelen <michael.chelen@gmail.com>
@@ -926,6 +958,7 @@ Mike Leone <mleone896@gmail.com>
 Mike MacCana <mike.maccana@gmail.com>
 Mike Naberezny <mike@naberezny.com>
 Mike Snitzer <snitzer@redhat.com>
+mikelinjie <294893458@qq.com>
 Mikhail Sobolev <mss@mawhrin.net>
 Miloslav Trmač <mitr@redhat.com>
 mingqing <limingqing@cyou-inc.com>
@@ -945,14 +978,19 @@ mqliang <mqliang.zju@gmail.com>
 Mrunal Patel <mrunalp@gmail.com>
 msabansal <sabansal@microsoft.com>
 mschurenko <matt.schurenko@gmail.com>
+muge <stevezhang2014@gmail.com>
 Mustafa Akın <mustafa91@gmail.com>
 Muthukumar R <muthur@gmail.com>
+mYmNeo <thomassong@tencent.com>
+Máximo Cuadros <mcuadros@gmail.com>
 Médi-Rémi Hashim <medimatrix@users.noreply.github.com>
+Nahum Shalman <nshalman@omniti.com>
 Nakul Pathak <nakulpathak3@hotmail.com>
 Nalin Dahyabhai <nalin@redhat.com>
 Nan Monnand Deng <monnand@gmail.com>
 Naoki Orii <norii@cs.cmu.edu>
 Natalie Parker <nparker@omnifone.com>
+Natanael Copa <natanael.copa@docker.com>
 Nate Brennand <nate.brennand@clever.com>
 Nate Eagleson <nate@nateeag.com>
 Nate Jones <nate@endot.org>
@@ -980,6 +1018,7 @@ Nicolás Hock Isaza <nhocki@gmail.com>
 Nigel Poulton <nigelpoulton@hotmail.com>
 NikolaMandic <mn080202@gmail.com>
 nikolas <nnyby@columbia.edu>
+Nirmal Mehta <nirmalkmehta@gmail.com>
 Nishant Totla <nishanttotla@gmail.com>
 NIWA Hideyuki <niwa.niwa@nifty.ne.jp>
 noducks <onemannoducks@gmail.com>
@@ -988,6 +1027,7 @@ nponeccop <andy.melnikov@gmail.com>
 Nuutti Kotivuori <naked@iki.fi>
 nzwsch <hi@nzwsch.com>
 O.S. Tezer <ostezer@gmail.com>
+objectified <objectified@gmail.com>
 OddBloke <daniel@daniel-watkins.co.uk>
 odk- <github@odkurzacz.org>
 Oguz Bilgic <fisyonet@gmail.com>
@@ -1118,17 +1158,20 @@ Robin Naundorf <r.naundorf@fh-muenster.de>
 Robin Schneider <ypid@riseup.net>
 Robin Speekenbrink <robin@kingsquare.nl>
 robpc <rpcann@gmail.com>
+Rodolfo Carvalho <rhcarvalho@gmail.com>
 Rodrigo Vaz <rodrigo.vaz@gmail.com>
 Roel Van Nyen <roel.vannyen@gmail.com>
 Roger Peppe <rogpeppe@gmail.com>
 Rohit Jnagal <jnagal@google.com>
 Rohit Kadam <rohit.d.kadam@gmail.com>
 Roland Huß <roland@jolokia.org>
+Roland Kammerer <roland.kammerer@linbit.com>
 Roland Moriz <rmoriz@users.noreply.github.com>
 Roma Sokolov <sokolov.r.v@gmail.com>
 Roman Strashkin <roman.strashkin@gmail.com>
 Ron Smits <ron.smits@gmail.com>
 root <docker-dummy@example.com>
+root <root@localhost>
 root <root@ubuntu-14.04-amd64-vbox>
 root <root@webm215.cluster016.ha.ovh.net>
 Rory Hunter <roryhunter2@gmail.com>
@@ -1157,6 +1200,7 @@ s00318865 <sunyuan3@huawei.com>
 Sabin Basyal <sabin.basyal@gmail.com>
 Sachin Joshi <sachin_jayant_joshi@hotmail.com>
 Sagar Hani <sagarhani33@gmail.com>
+Sainath Grandhi <sainath.grandhi@intel.com>
 Sally O'Malley <somalley@redhat.com>
 Sam Abed <sam.abed@gmail.com>
 Sam Alba <sam.alba@gmail.com>
@@ -1185,6 +1229,7 @@ Scott Johnston <scott@docker.com>
 Scott Stamp <scottstamp851@gmail.com>
 Scott Walls <sawalls@umich.edu>
 sdreyesg <sdreyesg@gmail.com>
+Sean Christopherson <sean.j.christopherson@intel.com>
 Sean Cronin <seancron@gmail.com>
 Sean OMeara <sean@chef.io>
 Sean P. Kane <skane@newrelic.com>
@@ -1193,6 +1238,7 @@ Sebastiaan van Stijn <github@gone.nl>
 Senthil Kumar Selvaraj <senthil.thecoder@gmail.com>
 SeongJae Park <sj38.park@gmail.com>
 Seongyeol Lim <seongyeol37@gmail.com>
+Serge Hallyn <serge.hallyn@ubuntu.com>
 Sergey Alekseev <sergey.alekseev.minsk@gmail.com>
 Sergey Evstifeev <sergey.evstifeev@gmail.com>
 Sevki Hasirci <s@sevki.org>
@@ -1203,6 +1249,7 @@ Shawn Landden <shawn@churchofgit.com>
 Shawn Siefkas <shawn.siefkas@meredith.com>
 Shekhar Gulati <shekhargulati84@gmail.com>
 Sheng Yang <sheng@yasker.org>
+Shengbo Song <thomassong@tencent.com>
 Shih-Yuan Lee <fourdollars@gmail.com>
 Shijiang Wei <mountkin@gmail.com>
 Shishir Mahajan <shishir.mahajan@redhat.com>
@@ -1226,8 +1273,8 @@ Spencer Brown <spencer@spencerbrown.org>
 Spencer Smith <robertspencersmith@gmail.com>
 Sridatta Thatipamala <sthatipamala@gmail.com>
 Sridhar Ratnakumar <sridharr@activestate.com>
-Srini Brahmaroutu <sbrahma@us.ibm.com>
 Srini Brahmaroutu <srbrahma@us.ibm.com>
+srinsriv <srinsriv@users.noreply.github.com>
 Steeve Morin <steeve.morin@gmail.com>
 Stefan Berger <stefanb@linux.vnet.ibm.com>
 Stefan J. Wernli <swernli@microsoft.com>
@@ -1246,12 +1293,13 @@ Steven Iveson <sjiveson@outlook.com>
 Steven Merrill <steven.merrill@gmail.com>
 Steven Richards <steven@axiomzen.co>
 Steven Taylor <steven.taylor@me.com>
+Subhajit Ghosh <isubuz.g@gmail.com>
 Sujith Haridasan <sujith.h@gmail.com>
 Suryakumar Sudar <surya.trunks@gmail.com>
 Sven Dowideit <SvenDowideit@home.org.au>
 Swapnil Daingade <swapnil.daingade@gmail.com>
 Sylvain Baubeau <sbaubeau@redhat.com>
-Sylvain Bellemare <sylvain.bellemare@ezeep.com>
+Sylvain Bellemare <sylvain@ascribe.io>
 Sébastien <sebastien@yoozio.com>
 Sébastien Luttringer <seblu@seblu.net>
 Sébastien Stormacq <sebsto@users.noreply.github.com>
@@ -1275,18 +1323,23 @@ Thijs Terlouw <thijsterlouw@gmail.com>
 Thomas Bikeev <thomas.bikeev@mac.com>
 Thomas Frössman <thomasf@jossystem.se>
 Thomas Gazagnaire <thomas@gazagnaire.org>
+Thomas Grainger <tagrain@gmail.com>
 Thomas Hansen <thomas.hansen@gmail.com>
+Thomas Leonard <thomas.leonard@docker.com>
 Thomas LEVEIL <thomasleveil@gmail.com>
 Thomas Orozco <thomas@orozco.fr>
+Thomas Riccardi <riccardi@systran.fr>
 Thomas Schroeter <thomas@cliqz.com>
 Thomas Sjögren <konstruktoid@users.noreply.github.com>
 Thomas Swift <tgs242@gmail.com>
+Thomas Tanaka <thomas.tanaka@oracle.com>
 Thomas Texier <sharkone@en-mousse.org>
 Tianon Gravi <admwiggin@gmail.com>
 Tibor Vass <teabee89@gmail.com>
 Tiffany Low <tiffany@box.com>
 Tim Bosse <taim@bosboot.org>
 Tim Dettrick <t.dettrick@uq.edu.au>
+Tim Düsterhus <tim@bastelstu.be>
 Tim Hockin <thockin@google.com>
 Tim Ruffles <oi@truffles.me.uk>
 Tim Smith <timbot@google.com>
@@ -1381,6 +1434,7 @@ waitingkuo <waitingkuo0527@gmail.com>
 Walter Leibbrandt <github@wrl.co.za>
 Walter Stanish <walter@pratyeka.org>
 WANG Chao <wcwxyz@gmail.com>
+Wang Xing <hzwangxing@corp.netease.com>
 Ward Vandewege <ward@jhvc.com>
 WarheadsSE <max@warheads.net>
 Wayne Chang <wayne@neverfear.org>
@@ -1388,6 +1442,7 @@ Wei-Ting Kuo <waitingkuo0527@gmail.com>
 weiyan <weiyan3@huawei.com>
 Weiyang Zhu <cnresonant@gmail.com>
 Wen Cheng Ma <wenchma@cn.ibm.com>
+Wendel Fleming <wfleming@usc.edu>
 Wenxuan Zhao <viz@linux.com>
 Wenyu You <21551128@zju.edu.cn>
 Wes Morgan <cap10morgan@gmail.com>
@@ -1426,6 +1481,7 @@ Ying Li <cyli@twistedmatrix.com>
 Yohei Ueda <yohei@jp.ibm.com>
 Yong Tang <yong.tang.github@outlook.com>
 Yongzhi Pan <panyongzhi@gmail.com>
+yorkie <yorkiefixer@gmail.com>
 Youcef YEKHLEF <yyekhlef@gmail.com>
 Yuan Sun <sunyuan3@huawei.com>
 yuchangchun <yuchangchun1@huawei.com>
@@ -1454,7 +1510,9 @@ zmarouf <zeid.marouf@gmail.com>
 Zoltan Tombol <zoltan.tombol@gmail.com>
 zqh <zqhxuyuan@gmail.com>
 Zuhayr Elahi <elahi.zuhayr@gmail.com>
+Zunayed Ali <zunayed@gmail.com>
 Álex González <agonzalezro@gmail.com>
 Álvaro Lázaro <alvaro.lazaro.g@gmail.com>
 Átila Camurça Alves <camurca.home@gmail.com>
 尹吉峰 <jifeng.yin@gmail.com>
+搏通 <yufeng.pyf@alibaba-inc.com>


### PR DESCRIPTION
Update mailmap file and re-generate authors; includes changes from https://github.com/docker/docker/pull/23168

closes https://github.com/docker/docker/pull/23168
