### PR TITLE
Fixes issues with stuck state locks blocking API

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -260,6 +260,8 @@ func (container *Container) IpcMounts() []Mount {
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	// update resources of container
 	resources := hostConfig.Resources

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -61,6 +61,8 @@ func (container *Container) TmpfsMounts() []Mount {
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 	resources := hostConfig.Resources
 	if resources.BlkioWeight != 0 || resources.CPUShares != 0 ||
 		resources.CPUPeriod != 0 || resources.CPUQuota != 0 ||

--- a/container/monitor.go
+++ b/container/monitor.go
@@ -15,6 +15,8 @@ func (container *Container) Reset(lock bool) {
 	if lock {
 		container.Lock()
 		defer container.Unlock()
+		container.DataLock.Lock()
+		defer container.DataLock.Unlock()
 	}
 
 	if err := container.CloseStreams(); err != nil {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -172,6 +172,8 @@ func (daemon *Daemon) generateHostname(id string, config *containertypes.Config)
 func (daemon *Daemon) setSecurityOptions(container *container.Container, hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 	return parseSecurityOpt(container, hostConfig)
 }
 
@@ -182,8 +184,8 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 		return err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	// Register any links from the host config before starting the container
 	if err := daemon.registerLinks(container, hostConfig); err != nil {

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -32,8 +32,8 @@ func (daemon *Daemon) containerInspectCurrent(name string, size bool) (*types.Co
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	base, err := daemon.getInspectData(container, size)
 	if err != nil {
@@ -72,8 +72,8 @@ func (daemon *Daemon) containerInspect120(name string) (*v1p20.ContainerJSON, er
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	base, err := daemon.getInspectData(container, false)
 	if err != nil {

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -27,8 +27,8 @@ func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON,
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	base, err := daemon.getInspectData(container, false)
 	if err != nil {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -172,8 +172,8 @@ func (daemon *Daemon) reduceContainers(config *types.ContainerListOptions, reduc
 
 // reducePsContainer is the basic representation for a container as expected by the ps command.
 func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *listContext, reducer containerReducer) (*types.Container, error) {
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	// filter containers to return
 	action := includeContainerInList(container, ctx)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -157,7 +157,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 		mountPoints[bind.Destination] = bind
 	}
 
-	container.Lock()
+	container.DataLock.Lock()
 
 	// 4. Cleanup old volumes that are about to be reassigned.
 	for _, m := range mountPoints {
@@ -169,7 +169,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 	}
 	container.MountPoints = mountPoints
 
-	container.Unlock()
+	container.DataLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fix issues with the API becoming unavailable due to stuck container state locks.
Fixes #17443

**\- How I did it**
This introduces a new lock specifically for reading/writing to the
container struct. 

This allows things like the API to continue to be
operable even if there is a problem with the main container lock (for
example, a stuck netlink call).

**\- How to verify it**
Make container hang (for example reproduce kernel bug in #17443), and call `docker ps`, `docker inspect`, etc.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Separates container state synchronization with container field access

Signed-off-by: Brian Goff cpuguy83@gmail.com
