### PR TITLE
Change root_maxkeys

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -387,6 +387,11 @@ func (daemon *Daemon) IsSwarmCompatible() error {
 func NewDaemon(config *Config, registryService registry.Service, containerdRemote libcontainerd.Remote) (daemon *Daemon, err error) {
 	setDefaultMtu(config)
 
+	// Ensure that we have a correct root key limit for launching containers.
+	if err := ModifyRootKeyLimit(); err != nil {
+		logrus.Warnf("unable to modify root key limit, number of containers could be limitied by this quota: %v", err)
+	}
+
 	// Ensure we have compatible and valid configuration options
 	if err := verifyDaemonSettings(config); err != nil {
 		return nil, err

--- a/daemon/keys.go
+++ b/daemon/keys.go
@@ -1,0 +1,59 @@
+// +build linux
+
+package daemon
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	rootKeyFile   = "/proc/sys/kernel/keys/root_maxkeys"
+	rootBytesFile = "/proc/sys/kernel/keys/root_maxbytes"
+	rootKeyLimit  = 1000000
+	// it is standard configuration to allocate 25 bytes per key
+	rootKeyByteMultiplier = 25
+)
+
+// ModifyRootKeyLimit checks to see if the root key limit is set to
+// at least 1000000 and changes it to that limit along with the maxbytes
+// allocated to the keys at a 25 to 1 multiplier.
+func ModifyRootKeyLimit() error {
+	value, err := readRootKeyLimit(rootKeyFile)
+	if err != nil {
+		return err
+	}
+	if value < rootKeyLimit {
+		return setRootKeyLimit(rootKeyLimit)
+	}
+	return nil
+}
+
+func setRootKeyLimit(limit int) error {
+	keys, err := os.OpenFile(rootKeyFile, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer keys.Close()
+	if _, err := fmt.Fprintf(keys, "%d", limit); err != nil {
+		return err
+	}
+	bytes, err := os.OpenFile(rootBytesFile, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer bytes.Close()
+	_, err = fmt.Fprintf(bytes, "%d", limit*rootKeyByteMultiplier)
+	return err
+}
+
+func readRootKeyLimit(path string) (int, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return -1, err
+	}
+	return strconv.Atoi(strings.Trim(string(data), "\n"))
+}

--- a/daemon/keys_unsupported.go
+++ b/daemon/keys_unsupported.go
@@ -1,0 +1,8 @@
+// +build !linux
+
+package daemon
+
+// ModifyRootKeyLimit is an noop on unsupported platforms.
+func ModifyRootKeyLimit() error {
+	return nil
+}


### PR DESCRIPTION
Fixes #22865 

Most modern distros have the limit for the maximum root keys at 1000000
but some do not.  Because we are creating a new key for each container
we need to bump this up as the older distros are having this limit at
200.

Using 1000000 as the limit because that is that most distros are setting
this to now.  If someone has this value configured over that we do not
change it.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
