### PR TITLE
Fixes#23189 docker restart get stuck when do it several times at the

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -135,6 +135,25 @@ func (s *State) WaitStop(timeout time.Duration) (int, error) {
 	return s.getExitCode(), nil
 }
 
+//GetWaitChan return waitChan
+func (s *State) GetWaitChan() <-chan struct{} {
+	return s.waitChan
+}
+
+//WaitOnChan wait on given waitChan until it's timeout
+func (s *State) WaitOnChan(waitChan <-chan struct{}, timeout time.Duration) error {
+	if timeout < 0 {
+		<-waitChan
+		return nil
+	}
+	select {
+	case <-time.After(timeout):
+		return fmt.Errorf("Timed out: %v", timeout)
+	case <-waitChan:
+		return nil
+	}
+}
+
 // IsRunning returns whether the running flag is set. Used by Container to check whether a container is running.
 func (s *State) IsRunning() bool {
 	s.Lock()

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -130,14 +130,13 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 	}
 
 	// 2. Wait for the process to die, in last resort, try to kill the process directly
+	wc := container.GetWaitChan()
 	if err := killProcessDirectly(container); err != nil {
 		if isErrNoSuchProcess(err) {
 			return nil
 		}
-		return err
 	}
-
-	container.WaitStop(-1 * time.Second)
+	container.WaitOnChan(wc, -1*time.Second)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixes#23189 docker restart get stuck when do it several times at the same time
**\- How I did it**
Add two functions ,container.GetWaitChan() get the old container's waitChan.
WaitOnChan wait on channel get by GetWaitChan.
**\- How to verify it**
 do docker restart contianerid & several times.
 all docker restart will exit in the end.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

…same time

Signed-off-by: liucw2012 liucw2012@gmail.com
