### PR TITLE
[WIP, RFC] new logger: rawfifo (infra for plugin)

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -77,8 +77,8 @@ type CommonContainer struct {
 	HostConfig             *containertypes.HostConfig `json:"-"` // do not serialize the host config in the json, otherwise we'll make the container unportable
 	ExecCommands           *exec.Store                `json:"-"`
 	// logDriver for closing
-	LogDriver      logger.Logger  `json:"-"`
-	LogCopier      *logger.Copier `json:"-"`
+	LogDriver      logger.Logger `json:"-"`
+	LogCopier      logger.Copier `json:"-"`
 	restartManager restartmanager.RestartManager
 	attachContext  *attachContext
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -402,6 +402,7 @@ __docker_complete_log_drivers() {
 		journald
 		json-file
 		none
+		rawfifo
 		splunk
 		syslog
 	" -- "$cur" ) )

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -739,7 +739,7 @@ __docker_subcommand() {
         "($help)--ipc=[IPC namespace to use]:IPC namespace: "
         "($help)*--link=[Add link to another container]:link:->link"
         "($help)*"{-l=,--label=}"[Container metadata]:label: "
-        "($help)--log-driver=[Default driver for container logs]:Logging driver:(awslogs etwlogs fluentd gcplogs gelf journald json-file none splunk syslog)"
+        "($help)--log-driver=[Default driver for container logs]:Logging driver:(awslogs etwlogs fluentd gcplogs gelf journald json-file none rawfifo splunk syslog)"
         "($help)*--log-opt=[Log driver specific options]:log driver options:__docker_log_options"
         "($help)--mac-address=[Container MAC address]:MAC address: "
         "($help)--name=[Container name]:name: "
@@ -882,7 +882,7 @@ __docker_subcommand() {
                 "($help)--ipv6[Enable IPv6 networking]" \
                 "($help -l --log-level)"{-l=,--log-level=}"[Logging level]:level:(debug info warn error fatal)" \
                 "($help)*--label=[Key=value labels]:label: " \
-                "($help)--log-driver=[Default driver for container logs]:Logging driver:(awslogs etwlogs fluentd gcplogs gelf journald json-file none splunk syslog)" \
+                "($help)--log-driver=[Default driver for container logs]:Logging driver:(awslogs etwlogs fluentd gcplogs gelf journald json-file none rawfifo splunk syslog)" \
                 "($help)*--log-opt=[Log driver specific options]:log driver options:__docker_log_options" \
                 "($help)--max-concurrent-downloads[Set the max concurrent downloads for each pull]" \
                 "($help)--max-concurrent-uploads[Set the max concurrent uploads for each push]" \

--- a/daemon/logdrivers_linux.go
+++ b/daemon/logdrivers_linux.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/docker/docker/daemon/logger/gelf"
 	_ "github.com/docker/docker/daemon/logger/journald"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
+	_ "github.com/docker/docker/daemon/logger/rawfifo"
 	_ "github.com/docker/docker/daemon/logger/splunk"
 	_ "github.com/docker/docker/daemon/logger/syslog"
 )

--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -1,83 +1,23 @@
 package logger
 
 import (
-	"bufio"
-	"bytes"
+	"fmt"
 	"io"
-	"sync"
-	"time"
-
-	"github.com/Sirupsen/logrus"
 )
 
-// Copier can copy logs from specified sources to Logger and attach
-// ContainerID and Timestamp.
-// Writes are concurrent, so you need implement some sync in your logger
-type Copier struct {
-	// srcs is map of name -> reader pairs, for example "stdout", "stderr"
-	srcs     map[string]io.Reader
-	dst      Logger
-	copyJobs sync.WaitGroup
-	closed   chan struct{}
+// Copier can copy logs from specified sources to Logger
+type Copier interface {
+	Run()
+	Wait()
+	Close()
 }
 
 // NewCopier creates a new Copier
-func NewCopier(srcs map[string]io.Reader, dst Logger) *Copier {
-	return &Copier{
-		srcs:   srcs,
-		dst:    dst,
-		closed: make(chan struct{}),
+func NewCopier(srcs map[string]io.Reader, dst Logger) (Copier, error) {
+	if ml, ok := dst.(MessageLogger); ok {
+		return NewMessageCopier(srcs, ml), nil
+	} else if rl, ok := dst.(RawLogger); ok {
+		return NewRawCopier(srcs, rl), nil
 	}
-}
-
-// Run starts logs copying
-func (c *Copier) Run() {
-	for src, w := range c.srcs {
-		c.copyJobs.Add(1)
-		go c.copySrc(src, w)
-	}
-}
-
-func (c *Copier) copySrc(name string, src io.Reader) {
-	defer c.copyJobs.Done()
-	reader := bufio.NewReader(src)
-
-	for {
-		select {
-		case <-c.closed:
-			return
-		default:
-			line, err := reader.ReadBytes('\n')
-			line = bytes.TrimSuffix(line, []byte{'\n'})
-
-			// ReadBytes can return full or partial output even when it failed.
-			// e.g. it can return a full entry and EOF.
-			if err == nil || len(line) > 0 {
-				if logErr := c.dst.Log(&Message{Line: line, Source: name, Timestamp: time.Now().UTC()}); logErr != nil {
-					logrus.Errorf("Failed to log msg %q for logger %s: %s", line, c.dst.Name(), logErr)
-				}
-			}
-
-			if err != nil {
-				if err != io.EOF {
-					logrus.Errorf("Error scanning log stream: %s", err)
-				}
-				return
-			}
-		}
-	}
-}
-
-// Wait waits until all copying is done
-func (c *Copier) Wait() {
-	c.copyJobs.Wait()
-}
-
-// Close closes the copier
-func (c *Copier) Close() {
-	select {
-	case <-c.closed:
-	default:
-		close(c.closed)
-	}
+	return nil, fmt.Errorf("strange logger %s", dst.Name())
 }

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -46,12 +46,15 @@ func TestCopier(t *testing.T) {
 
 	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf)}
 
-	c := NewCopier(
+	c, err := NewCopier(
 		map[string]io.Reader{
 			"stdout": &stdout,
 			"stderr": &stderr,
 		},
 		jsonLog)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c.Run()
 	wait := make(chan struct{})
 	go func() {
@@ -101,7 +104,10 @@ func TestCopierSlow(t *testing.T) {
 	//encoder := &encodeCloser{Encoder: json.NewEncoder(&jsonBuf)}
 	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf), delay: 100 * time.Millisecond}
 
-	c := NewCopier(map[string]io.Reader{"stdout": &stdout}, jsonLog)
+	c, err := NewCopier(map[string]io.Reader{"stdout": &stdout}, jsonLog)
+	if err != nil {
+		t.Fatal(err)
+	}
 	c.Run()
 	wait := make(chan struct{})
 	go func() {

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -31,13 +31,13 @@ func TestJSONFileLogger(t *testing.T) {
 	}
 	defer l.Close()
 
-	if err := l.Log(&logger.Message{Line: []byte("line1"), Source: "src1"}); err != nil {
+	if err := l.(logger.MessageLogger).Log(&logger.Message{Line: []byte("line1"), Source: "src1"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := l.Log(&logger.Message{Line: []byte("line2"), Source: "src2"}); err != nil {
+	if err := l.(logger.MessageLogger).Log(&logger.Message{Line: []byte("line2"), Source: "src2"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := l.Log(&logger.Message{Line: []byte("line3"), Source: "src3"}); err != nil {
+	if err := l.(logger.MessageLogger).Log(&logger.Message{Line: []byte("line3"), Source: "src3"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := ioutil.ReadFile(filename)
@@ -81,7 +81,7 @@ func BenchmarkJSONFileLogger(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 30; j++ {
-			if err := l.Log(msg); err != nil {
+			if err := l.(logger.MessageLogger).Log(msg); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -107,7 +107,7 @@ func TestJSONFileLoggerWithOpts(t *testing.T) {
 	}
 	defer l.Close()
 	for i := 0; i < 20; i++ {
-		if err := l.Log(&logger.Message{Line: []byte("line" + strconv.Itoa(i)), Source: "src1"}); err != nil {
+		if err := l.(logger.MessageLogger).Log(&logger.Message{Line: []byte("line" + strconv.Itoa(i)), Source: "src1"}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -172,7 +172,7 @@ func TestJSONFileLoggerWithLabelsEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer l.Close()
-	if err := l.Log(&logger.Message{Line: []byte("line"), Source: "src1"}); err != nil {
+	if err := l.(logger.MessageLogger).Log(&logger.Message{Line: []byte("line"), Source: "src1"}); err != nil {
 		t.Fatal(err)
 	}
 	res, err := ioutil.ReadFile(filename)
@@ -230,7 +230,7 @@ func BenchmarkJSONFileLoggerWithReader(b *testing.B) {
 	go func() {
 		for i := 0; i < b.N; i++ {
 			for j := 0; j < 30; j++ {
-				l.Log(msg)
+				l.(logger.MessageLogger).Log(msg)
 			}
 		}
 		l.Close()

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -9,6 +9,7 @@ package logger
 
 import (
 	"errors"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -59,9 +60,20 @@ func (a LogAttributes) String() string {
 
 // Logger is the interface for docker logging drivers.
 type Logger interface {
-	Log(*Message) error
 	Name() string
 	Close() error
+}
+
+// MessageLogger is the interface for standard logging drivers.
+type MessageLogger interface {
+	Logger
+	Log(*Message) error
+}
+
+// RawLogger is the interface for raw logging drivers.
+type RawLogger interface {
+	Logger
+	RawWriter(string) (io.WriteCloser, error)
 }
 
 // ReadConfig is the configuration passed into ReadLogs.

--- a/daemon/logger/messagecopier.go
+++ b/daemon/logger/messagecopier.go
@@ -1,0 +1,82 @@
+package logger
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// MessageCopier can copy log messagess from specified sources to Logger and attach Timestamp.
+// Writes are concurrent, so you need implement some sync in your logger
+type MessageCopier struct {
+	// srcs is map of name -> reader pairs, for example "stdout", "stderr"
+	srcs     map[string]io.Reader
+	dst      MessageLogger
+	copyJobs sync.WaitGroup
+	closed   chan struct{}
+}
+
+// NewMessageCopier creates a new MessageCopier
+func NewMessageCopier(srcs map[string]io.Reader, dst MessageLogger) *MessageCopier {
+	return &MessageCopier{
+		srcs:   srcs,
+		dst:    dst,
+		closed: make(chan struct{}),
+	}
+}
+
+// Run starts logs copying
+func (c *MessageCopier) Run() {
+	for src, w := range c.srcs {
+		c.copyJobs.Add(1)
+		go c.copySrc(src, w)
+	}
+}
+
+func (c *MessageCopier) copySrc(name string, src io.Reader) {
+	defer c.copyJobs.Done()
+	reader := bufio.NewReader(src)
+
+	for {
+		select {
+		case <-c.closed:
+			return
+		default:
+			line, err := reader.ReadBytes('\n')
+			line = bytes.TrimSuffix(line, []byte{'\n'})
+
+			// ReadBytes can return full or partial output even when it failed.
+			// e.g. it can return a full entry and EOF.
+			if err == nil || len(line) > 0 {
+				if logErr := c.dst.Log(&Message{Line: line, Source: name, Timestamp: time.Now().UTC()}); logErr != nil {
+					logrus.Errorf("Failed to log msg %q for logger %s: %s", line, c.dst.Name(), logErr)
+				}
+			}
+
+			if err != nil {
+				if err != io.EOF {
+					logrus.Errorf("Error scanning log stream: %s", err)
+				}
+				return
+			}
+		}
+	}
+}
+
+// Wait waits until all copying is done
+func (c *MessageCopier) Wait() {
+	c.copyJobs.Wait()
+}
+
+// Close closes the copier
+func (c *MessageCopier) Close() {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+}

--- a/daemon/logger/rawcopier.go
+++ b/daemon/logger/rawcopier.go
@@ -1,0 +1,73 @@
+package logger
+
+import (
+	"io"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// RawCopier can copy logs from specified sources
+type RawCopier struct {
+	// srcs is map of name -> reader pairs, for example "stdout", "stderr"
+	srcs     map[string]io.Reader
+	dst      RawLogger
+	copyJobs sync.WaitGroup
+	closed   chan struct{}
+}
+
+// NewRawCopier creates a new RawCopier
+func NewRawCopier(srcs map[string]io.Reader, dst RawLogger) *RawCopier {
+	return &RawCopier{
+		srcs:   srcs,
+		dst:    dst,
+		closed: make(chan struct{}),
+	}
+}
+
+// Run starts logs copying
+func (c *RawCopier) Run() {
+	for src, w := range c.srcs {
+		c.copyJobs.Add(1)
+		go c.copySrc(src, w)
+	}
+}
+
+func (c *RawCopier) copySrc(name string, src io.Reader) {
+	defer c.copyJobs.Done()
+	w, err := c.dst.RawWriter(name)
+	if err != nil {
+		logrus.Errorf("error while opening RawWriter for %s: %v", name, err)
+		return
+	}
+	for {
+		select {
+		case <-c.closed:
+			if err = w.Close(); err != nil {
+				logrus.Errorf("error while closing RawWriter for %s: %v", name, err)
+			}
+			return
+		default:
+			// use io.CopyN rather than io.Copy, so that we can catch <-c.closed
+			bufsz := int64(64 * 1024)
+			if _, err := io.CopyN(w, src, bufsz); err != nil {
+				logrus.Errorf("stream copy error: %s: %v", name, err)
+				return
+			}
+		}
+	}
+}
+
+// Wait waits until all copying is done
+func (c *RawCopier) Wait() {
+	c.copyJobs.Wait()
+}
+
+// Close closes the copier
+func (c *RawCopier) Close() {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+}

--- a/daemon/logger/rawfifo/rawfifo.go
+++ b/daemon/logger/rawfifo/rawfifo.go
@@ -1,0 +1,119 @@
+// +build !windows
+
+// Package rawfifo provides the logdriver for forwarding logs to named pipes.
+package rawfifo
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/daemon/logger"
+)
+
+const (
+	name          = "rawfifo"
+	keyRawfifoDir = "rawfifo-dir"
+)
+
+type rawfifoLogger struct {
+	dir     string
+	mu      sync.Mutex
+	writers map[string]io.WriteCloser
+}
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// New creates new rawfifoLogger.
+func New(ctx logger.Context) (logger.Logger, error) {
+	dir, ok := ctx.Config[keyRawfifoDir]
+	if !ok {
+		return nil, fmt.Errorf("logger option %s is not set", keyRawfifoDir)
+	}
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		logrus.Debugf("Creating %s", dir)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, err
+		}
+	} else {
+		logrus.Debugf("Reusing %s", dir)
+	}
+	return &rawfifoLogger{
+		dir:     dir,
+		writers: make(map[string]io.WriteCloser, 0),
+	}, nil
+}
+
+func (l *rawfifoLogger) RawWriter(name string) (io.WriteCloser, error) {
+	// if an user specify --log-opt="rawfifo-dir=/tmp/foo",
+	// fname becomes /tmp/t1/{stdout, stderr}.
+	// how to determine fname is not fixed yet. we need to discuss it.
+
+	fname := filepath.Join(l.dir, name)
+	var w io.WriteCloser
+	l.mu.Lock()
+	w, ok := l.writers[fname]
+	defer l.mu.Unlock()
+	if ok {
+		logrus.Debugf("Returning existing Writer for %s", fname)
+		return w, nil
+	}
+
+	logrus.Debugf("Creating fifo %s", fname)
+	if err := syscall.Mkfifo(fname, 0700); err != nil {
+		return nil, fmt.Errorf("mkfifo: %s %v", fname, err)
+	}
+	w, err := os.OpenFile(fname, syscall.O_WRONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	l.writers[fname] = w
+	logrus.Debugf("Returning Writer for %s", fname)
+	return w, nil
+}
+
+func (l *rawfifoLogger) Close() error {
+	var errors []error
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for fname, w := range l.writers {
+		logrus.Debugf("Closing Writer for %s", fname)
+		err := w.Close()
+		logrus.Debugf("Closed Writer for %s(err=%v)", fname, err)
+		if err != nil {
+			errors = append(errors, err)
+		}
+		delete(l.writers, fname)
+	}
+
+	return fmt.Errorf("error while closing %s: %v", l.Name(), errors)
+}
+
+func (l *rawfifoLogger) Name() string {
+	return name
+}
+
+// ValidateLogOpt looks for rawfifo specific log options,
+// rawfifo-dir
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case keyRawfifoDir:
+		default:
+			return fmt.Errorf("unknown log opt '%s' for rawfifo log driver", key)
+		}
+	}
+	return nil
+}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -124,7 +124,10 @@ func (daemon *Daemon) StartLogging(container *container.Container) error {
 		return fmt.Errorf("Failed to initialize logging driver: %v", err)
 	}
 
-	copier := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
+	copier, err := logger.NewCopier(map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
+	if err != nil {
+		return nil
+	}
 	container.LogCopier = copier
 	copier.Run()
 	container.LogDriver = l

--- a/docs/admin/logging/index.md
+++ b/docs/admin/logging/index.md
@@ -21,3 +21,4 @@ weight=8
 * [Amazon CloudWatch Logs logging driver](awslogs.md)
 * [Splunk logging driver](splunk.md)
 * [ETW logging driver](etwlogs.md)
+* [Raw FIFO logging driver](rawfifo.md)

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -31,6 +31,7 @@ supported:
 | `splunk`    | Splunk logging driver for Docker. Writes log messages to `splunk` using HTTP Event Collector.                                 |
 | `etwlogs`   | ETW logging driver for Docker on Windows. Writes log messages as ETW events.                                                  |
 | `gcplogs`   | Google Cloud Logging driver for Docker. Writes log messages to Google Cloud Logging.                                          |
+| `rawfifo`    | Raw FIFO logging driver for Docker. Writes raw log streams to UNIX named pipes.                                              |
 
 The `docker logs`command is available only for the `json-file` and `journald`
 logging drivers.

--- a/docs/admin/logging/rawfifo.md
+++ b/docs/admin/logging/rawfifo.md
@@ -1,0 +1,50 @@
+<!--[metadata]>
++++
+aliases = ["/engine/reference/logging/rawfifo/"]
+title = "Raw FIFO logging driver"
+description = "Describes how to use the Raw FIFO logging driver."
+keywords = ["logging, driver"]
+[menu.main]
+parent = "smn_logging"
++++
+<![end-metadata]-->
+
+# Raw FIFO logging driver
+
+The `rawfifo` logging driver sends raw container logs to UNIX named pipes.
+
+Users can implement their own logging driver plugin by reading from the pipes.
+The output from the container can be buffered up to the number of bytes allowed
+by the system. (see also `fcntl(2)` and `proc(5)`).
+The output is blocked if the buffer is full.
+
+The driver does not support [tags](log_tags.md).
+
+## Usage
+
+You can set the logging driver for a specific container by using the
+`--log-driver` option to `docker run`:
+
+    docker run --log-driver=rawfifo ...
+
+## Raw FIFO options
+
+You can use the `--log-opt NAME=VALUE` flag to specify Raw FIFO logging driver
+options.
+
+### rawfifo-dir
+
+The `rawfifo` logging driver sends your Docker logs to FIFOs named `stdout` and 
+`stderr` under a specific directory. Use the `rawfifo-dir` log option to set the
+directory.
+Currently, the driver has no default value for `rawfifo-dir` and specifying the 
+option is mandatory.
+
+    docker run --log-driver=rawfifo --log-opt rawfifo-dir=/tmp/log1 ...
+
+Since the driver does not support [tags](log_tags.md), it is recommended to
+specify the directory which path contains the container name and other
+information instead.
+
+    docker run --log-driver=rawfifo --log-opt rawfifo-dir=/tmp/alpine/c1 --name c1 alpine
+

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -220,7 +220,7 @@ millions of trillions.
    Add link to another container in the form of <name or id>:alias or just
    <name or id> in which case the alias will match the name.
 
-**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*none*"
+**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*rawfifo*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: the `docker logs` command works only for the `json-file` and
   `journald` logging drivers.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -326,7 +326,7 @@ container can access the exposed port via a private networking interface. Docker
 will set some environment variables in the client container to help indicate
 which interface and port to use.
 
-**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*none*"
+**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*rawfifo*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: the `docker logs` command works only for the `json-file` and
   `journald` logging drivers.

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -195,7 +195,7 @@ is `hyperv`. Linux only supports `default`.
 **--label**="[]"
   Set key=value labels to the daemon (displayed in `docker info`)
 
-**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*none*"
+**--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*rawfifo*|*none*"
   Default driver for container logs. Default is `json-file`.
   **Warning**: `docker logs` command works only for `json-file` logging driver.
 


### PR DESCRIPTION
## What I did

Added a new logger called `rawfifo`.

This can be used for implementing logging plugins _outside_ the daemon process.

Related: https://github.com/docker/docker/issues/18604
Related: https://github.com/docker/docker/pull/18001#issuecomment-191956626,
## How I did it
- Introduced a new interface: `RawLogger`. `RawLogger` embeds `Logger`.
- Converted `Copier` from a structure into an interface.
- Introduced two implementations for `Copier`: `MessageCopier` and `RawCopier`.
  `MessageCopier` is identical to the former `Copier`.
  `RawCopier` is different from `MessageCopier` in that it does not try to detect '\n' and just copies raw log streams to an `io.Writer`, which is returned from `RawLogger.RawWriter()`.
- Introduced a `rawfifo` logging driver which implements `RawLogger` (and `Logger` as well).
## How to verify it
### Scenario 1: standard workload

Execute:

```
host$ docker run -it --log-driver rawfifo --log-opt="rawfifo-dir=/tmp/t1" alpine sh
```

Make sure you can execute a command in the container interactively.

```
container$ echo hello
```

Make sure the output is copied to the log:

```
host$ cat /tmp/t1/stdout
```

You may have an issue when you try to stop the container.
This issue will be fixed after discussing the core design.
### Scenario 2: make sure infinite output does not lead to OOM

Execute:

```
host$ docker run -itd --log-driver rawfifo --log-opt="rawfifo-dir=/tmp/t2" alpine sh -c "while :; do date; done"
```

Wait for 5 or more minutes.
Make sure there is no significant impact in CPU and RAM usage.

```
host$ for f in $(seq 1 $((5 * 60)));do uptime; free -mt; sleep 1; done
```

Make sure the output is copied to the log.
Note that some output were blocked during we were waiting for several minutes.

```
host$ cat -n /tmp/t2/stdout | less
1: Thu Jun  2 07:00:00 UTC 2016
2: Thu Jun  2 07:00:00 UTC 2016
3: Thu Jun  2 07:00:00 UTC 2016
...
...
XXX0: Thu Jun  2 07:00:00 UTC 2016  <<- the pipe buffer was full at that time
XXX1: Thu Jun  2 07:05:00 UTC 2016
XXX2: Thu Jun  2 07:05:00 UTC 2016
```
### Scenario 3: make sure infinite output without \n does not lead to OOM (see also #20600, #18057)

Execute:

```
host$ docker run -itd --log-driver rawfifo --log-opt="rawfifo-dir=/tmp/t3" alpine sh -c cat /dev/zero
```

Wait for 5 or more minutes.
Make sure there is no significant impact in CPU and RAM usage.

```
host$ for f in $(seq 1 $((5 * 60)));do uptime; free -mt; sleep 1; done
```

Open the log, and Make sure there is still no significant impact in CPU and RAM usage.

```
host$ cat /tmp/t3/stdout
host$ for f in $(seq 1 $((5 * 60)));do uptime; free -mt; sleep 1; done
```
## Description for the changelog

new logger: rawfifo
## A picture of a cute animal (not mandatory but encouraged)

https://upload.wikimedia.org/wikipedia/commons/4/40/Adelie_Penguins_on_iceberg.jpg

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp

---
## Motivation: split the logging routine from the daemon process

I know this PR is controversial and GELF _is_ the standard way for connecting the Docker daemon to other logging software.
https://github.com/docker/docker/pull/18001#issuecomment-191956626

But having complicated logging routines (including GELF) in the daemon itself can lead to some issues related to performance and stability. 
- OOM: https://github.com/docker/docker/issues/18057#issuecomment-158539705
- CPU 100% + OOM: https://github.com/docker/docker/issues/21181#issuecomment-196331268

So I suggest making in-daemon routines as small as possible with this `rawfifo` driver, and do substantial work _outside_ the daemon process (a.k.a plugin).

As we can limit resource usage for external logging processes via cgroup, we can prevent them from crasing the daemon.

If the external logging process does not read from the fifo, write to stdout is blocked, and the daemon does not need to be busy for buffering the write and waiting for '\n'.

Even if I cannot get positive comments for my implementation, I would like to hear comments about how we can split loggers from the damon in aspect of performance and stability :smile:
## Tags

`RawLogger` does not support tags because it just copies the raw log stream from a container to a named pipe without appending meta data.

So it is recommended to specify the `rawfifo-dir` which path contains the container name and other information instead.

```
docker run --log-driver=rawfifo --log-opt rawfifo-dir=/tmp/alpine/c1 --name c1 alpine
```
## Timestamps

`RawLogger` does not support timestamps.
It is up to the external logging process to read logs as fast as possible and determine arbitrary timestamps.
## TODO
- tests (especially, close())
- better way for specifying log option `rawfifo-dir`
- integrate to common plugin infrastructure https://github.com/docker/docker/issues/20363
