### PR TITLE
make.sh: use PKG_CONFIG environment variable if it exists

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -26,6 +26,7 @@ set -o pipefail
 export DOCKER_PKG='github.com/docker/docker'
 export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export MAKEDIR="$SCRIPTDIR/make"
+export PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 
 : ${TEST_REPEAT:=0}
 
@@ -134,9 +135,9 @@ if [ "$DOCKER_EXPERIMENTAL" ]; then
 fi
 
 DOCKER_BUILDTAGS+=" daemon"
-if pkg-config 'libsystemd >= 209' 2> /dev/null ; then
+if ${PKG_CONFIG} 'libsystemd >= 209' 2> /dev/null ; then
 	DOCKER_BUILDTAGS+=" journald"
-elif pkg-config 'libsystemd-journal' 2> /dev/null ; then
+elif ${PKG_CONFIG} 'libsystemd-journal' 2> /dev/null ; then
 	DOCKER_BUILDTAGS+=" journald journald_compat"
 fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Change the script that builds docker

**\- How to verify it**
I rebuilt docker from source outside of a container using `make.sh dynbinary`

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Use PKG_CONFIG environment variable instead of hardcoded path

pkg-config is not always available in the path, this lets people choose its location.
I'm not quite sure if I implemented that well, so let me know if there is anything I can improve here.

Signed-off-by: Arnaud Lefebvre a.lefebvre@outlook.fr
