### PR TITLE
test trusted push: use a nonexistant hostname

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -321,7 +321,8 @@ func (s *DockerTrustSuite) TestTrustedPushWithFailingServer(c *check.C) {
 	dockerCmd(c, "tag", "busybox", repoName)
 
 	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	s.trustedCmdWithServer(pushCmd, "https://example.com:81/")
+	// Using a name that doesn't resolve to an address makes this test faster
+	s.trustedCmdWithServer(pushCmd, "https://server.invalid:81/")
 	out, _, err := runCommandWithOutput(pushCmd)
 	c.Assert(err, check.NotNil, check.Commentf("Missing error while running trusted push w/ no server"))
 	c.Assert(out, checker.Contains, "error contacting notary server", check.Commentf("Missing expected output on trusted push"))
@@ -333,7 +334,8 @@ func (s *DockerTrustSuite) TestTrustedPushWithoutServerAndUntrusted(c *check.C) 
 	dockerCmd(c, "tag", "busybox", repoName)
 
 	pushCmd := exec.Command(dockerBinary, "push", "--disable-content-trust", repoName)
-	s.trustedCmdWithServer(pushCmd, "https://example.com/")
+	// Using a name that doesn't resolve to an address makes this test faster
+	s.trustedCmdWithServer(pushCmd, "https://server.invalid")
 	out, _, err := runCommandWithOutput(pushCmd)
 	c.Assert(err, check.IsNil, check.Commentf("trusted push with no server and --disable-content-trust failed: %s\n%s", err, out))
 	c.Assert(out, check.Not(checker.Contains), "Error establishing connection to notary repository", check.Commentf("Missing expected output on trusted push with --disable-content-trust:"))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Sped up two tests from 30s to <1s
**\- How I did it**
Changed the hostname in the tests
**\- How to verify it**
Run the tests, and they fail more quickly.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Use a nonexistant hostname for the "failing server" instead of one that does resolve (e.g. example.com) which I'm assuming was just a coincidence. 

**\- A picture of a cute animal (not mandatory but encouraged)**

![owlett](http://hdwallpaperia.com/wp-content/uploads/2014/12/cute-little-owl-wallpaper-yvt.jpg)

Before, the TCP handshake had to time out (approx 30s) before
this test completed. If you use a hostname that doesn't resolve,
then it fails faster.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
