### PR TITLE
Add missing links in deprecated.md

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -15,21 +15,21 @@ weight=80
 The following list of features are deprecated in Engine.
 
 ### `-e` and `--email` flags on `docker login`
-**Deprecated In Release: v1.11**
+**Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
 **Target For Removal In Release: v1.13**
 
 The docker login command is removing the ability to automatically register for an account with the target registry if the given username doesn't exist. Due to this change, the email flag is no longer required, and will be deprecated.
 
 ### Separator (`:`) of `--security-opt` flag on `docker run`
-**Deprecated In Release: v1.11**
+**Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
 **Target For Removal In Release: v1.13**
 
 The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consinstency with other similar flags, like `--storage-opt`.
 
 ### Ambiguous event fields in API
-**Deprecated In Release: v1.10**
+**Deprecated In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
 The fields `ID`, `Status` and `From` in the events API have been deprecated in favor of a more rich structure.
 See the events API documentation for the new format.
@@ -37,14 +37,14 @@ See the events API documentation for the new format.
 ### `-f` flag on `docker tag`
 **Deprecated In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
-**Removed In Release: v1.12.0**
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
 To make tagging consistent across the various `docker` commands, the `-f` flag on the `docker tag` command is deprecated. It is not longer necessary to specify `-f` to move a tag from one image to another. Nor will `docker` generate an error if the `-f` flag is missing and the specified tag is already in use.
 
 ### HostConfig at API container start
-**Deprecated In Release: v1.10**
+**Deprecated In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
-**Target For Removal In Release: v1.12**
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
 Passing an `HostConfig` to `POST /containers/{name}/start` is deprecated in favor of
 defining it at container creation (`POST /containers/create`).
@@ -53,7 +53,7 @@ defining it at container creation (`POST /containers/create`).
 
 **Deprecated In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
-**Removed In Release: v1.12**
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
 The `docker ps --before` and `docker ps --since` options are deprecated.
 Use `docker ps --filter=before=...` and `docker ps --filter=since=...` instead.
@@ -62,15 +62,15 @@ Use `docker ps --filter=before=...` and `docker ps --filter=since=...` instead.
 
 **Deprecated in Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
-**Removed In Release: v1.14**
+**Target For Removal In Release: v1.14**
 
 The `docker search --automated` and `docker search --stars` options are deprecated.
 Use `docker search --filter=is-automated=...` and `docker search --filter=stars=...` instead.
 
 ### Driver Specific Log Tags
-**Deprecated In Release: v1.9**
+**Deprecated In Release: [v1.9.0](https://github.com/docker/docker/releases/tag/v1.9.0)**
 
-**Removed In Release: v1.12**
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
 Log tags are now generated in a standard way across different logging drivers.
 Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` and
@@ -79,9 +79,9 @@ Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` a
     docker --log-driver=syslog --log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}"
 
 ### LXC built-in exec driver
-**Deprecated In Release: v1.8**
+**Deprecated In Release: [v1.8.0](https://github.com/docker/docker/releases/tag/v1.8.0)**
 
-**Removed In Release: v1.10**
+**Removed In Release: [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0)**
 
 The built-in LXC execution driver, the lxc-conf flag, and API fields have been removed.
 
@@ -139,9 +139,9 @@ The following double-dash options are deprecated and have no replacement:
 Version 1.9 adds a flag (`--disable-legacy-registry=false`) which prevents the docker daemon from `pull`, `push`, and `login` operations against v1 registries.  Though disabled by default, this signals the intent to deprecate the v1 protocol.
 
 ### Docker Content Trust ENV passphrase variables name change
-**Deprecated In Release: v1.9**
+**Deprecated In Release: [v1.9.0](https://github.com/docker/docker/releases/tag/v1.9.0)**
 
-**Removed In Release: v1.12**
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
 Since 1.9, Docker Content Trust Offline key has been renamed to Root key and the Tagging key has been renamed to Repository key. Due to this renaming, we're also changing the corresponding environment variables
 


### PR DESCRIPTION
This fix tries to address several issues in deprecated.md:
1. For `deprecated` and `removal` versions, some include link reference to the release tag but some does not point to the release tag. This fix adds the missing links as long as the version is <= 1.12.
2. Technically, 1.12 is not released yet so the link to 1.12 does not exist yet. However, at the time 1.12 is released this deprecated.md doc should have been part of the release as well. Therefore there is a circular dependency. This fix adds 1.12 for now.
3. `HostConfig at API container start` has already been removed by #22570 so this fix changes `Target For Removal In Release: v1.12` to `Removed In Release: v1.12`.
4. `Docker search 'automated' and 'stars' options` has not been removed yet so this fix changes `Removed In Release: v1.14` to `Target For Removal In Release: v1.14`

Signed-off-by: Yong Tang yong.tang.github@outlook.com
