### PR TITLE
Vendor engine-api to 5d8739372315f8147ceb7bcc53576893ff96ffc6

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api fa04f66c7871183dd53a5ec666479f49b452743d
+clone git github.com/docker/engine-api 5d8739372315f8147ceb7bcc53576893ff96ffc6
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/types/container/config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/config.go
@@ -1,9 +1,10 @@
 package container
 
 import (
+	"time"
+
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/docker/go-connections/nat"
-	"time"
 )
 
 // HealthConfig holds configuration settings for the HEALTHCHECK feature.
@@ -56,4 +57,6 @@ type Config struct {
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
 	StopSignal      string                `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                  `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           strslice.StrSlice     `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }


### PR DESCRIPTION
This fix tries to update engine-api to 5d8739372315f8147ceb7bcc53576893ff96ffc6

This fix brings engine-api up to date, which includes changes from:
https://github.com/docker/engine-api/pull/256
https://github.com/docker/engine-api/pull/254

This fix is directly related to
#22566 Add config parameter to change per-container stop timeout during daemon shutdown

This fix is indirectly related to 
#22489 Builder shell configuration

Signed-off-by: Yong Tang yong.tang.github@outlook.com
