### PR TITLE
Update ubuntulinux.md

### DIFF
--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -62,7 +62,7 @@ packages from the new repository:
 
 4. Add the new `GPG` key.
 
-        $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+        $ sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 
 5. Open the `/etc/apt/sources.list.d/docker.list` file in your favorite editor.
 


### PR DESCRIPTION
hkp URL should use pool.sks-keyservers.net, not a specific server of the pool that might be down.
