### PR TITLE
Healthcheck: set default retries to 3

### DIFF
--- a/builder/dockerfile/parser/testfiles/health/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/health/Dockerfile
@@ -2,7 +2,7 @@ FROM debian
 ADD check.sh main.sh /app/
 CMD /app/main.sh
 HEALTHCHECK
-HEALTHCHECK --interval=5s --timeout=3s --retries=1 \
+HEALTHCHECK --interval=5s --timeout=3s --retries=3 \
   CMD /app/check.sh --quiet
 HEALTHCHECK CMD
 HEALTHCHECK   CMD   a b

--- a/builder/dockerfile/parser/testfiles/health/result
+++ b/builder/dockerfile/parser/testfiles/health/result
@@ -2,7 +2,7 @@
 (add "check.sh" "main.sh" "/app/")
 (cmd "/app/main.sh")
 (healthcheck)
-(healthcheck ["--interval=5s" "--timeout=3s" "--retries=1"] "CMD" "/app/check.sh --quiet")
+(healthcheck ["--interval=5s" "--timeout=3s" "--retries=3"] "CMD" "/app/check.sh --quiet")
 (healthcheck "CMD")
 (healthcheck "CMD" "a b")
 (healthcheck ["--timeout=3s"] "CMD" "foo")

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -28,6 +28,10 @@ const (
 	// than this, the check is considered to have failed.
 	defaultProbeTimeout = 30 * time.Second
 
+	// Default number of consecutive failures of the health check
+	// for the container to be considered unhealthy.
+	defaultProbeRetries = 3
+
 	// Shut down a container if it becomes Unhealthy.
 	defaultExitOnUnhealthy = true
 
@@ -111,7 +115,7 @@ func handleProbeResult(d *Daemon, c *container.Container, result *types.Healthch
 
 	retries := c.Config.Healthcheck.Retries
 	if retries <= 0 {
-		retries = 1 // Default if unset or set to an invalid value
+		retries = defaultProbeRetries
 	}
 
 	h := c.State.Health

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1491,7 +1491,7 @@ The options that can appear before `CMD` are:
 
 * `--interval=DURATION` (default: `30s`)
 * `--timeout=DURATION` (default: `30s`)
-* `--retries=N` (default: `1`)
+* `--retries=N` (default: `3`)
 
 The health check will first run **interval** seconds after the container is
 started, and then again **interval** seconds after each previous check completes.


### PR DESCRIPTION
As suggested by @dongluochen in https://github.com/docker/docker/pull/22719#discussion_r65629322

I wasn't sure if the intent was to update the _test_ Dockerfile, or the _default_ so I changed both. Even if we decide to not change the default, I think having a `defaultProbeRetries` constant would be good to have.

Also ping @crosbymichael @talex5 
