### PR TITLE
Skip UTF-8 BOM bytes from Dockerfile and .dockerignore if exist

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"regexp"
@@ -152,8 +153,14 @@ func Parse(rwc io.Reader) (*Node, error) {
 	root.StartLine = -1
 	scanner := bufio.NewScanner(rwc)
 
+	utf8bom := []byte{0xEF, 0xBB, 0xBF}
 	for scanner.Scan() {
-		scannedLine := strings.TrimLeftFunc(scanner.Text(), unicode.IsSpace)
+		scannedBytes := scanner.Bytes()
+		// We trim UTF8 BOM
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		scannedLine := strings.TrimLeftFunc(string(scannedBytes), unicode.IsSpace)
 		currentLine++
 		line, child, err := ParseLine(scannedLine)
 		if err != nil {

--- a/builder/dockerignore/dockerignore.go
+++ b/builder/dockerignore/dockerignore.go
@@ -2,6 +2,7 @@ package dockerignore
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -18,10 +19,18 @@ func ReadAll(reader io.ReadCloser) ([]string, error) {
 	defer reader.Close()
 	scanner := bufio.NewScanner(reader)
 	var excludes []string
+	currentLine := 0
 
+	utf8bom := []byte{0xEF, 0xBB, 0xBF}
 	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		// We trim UTF8 BOM
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		pattern := string(scannedBytes)
+		currentLine++
 		// Lines starting with # (comments) are ignored before processing
-		pattern := scanner.Text()
 		if strings.HasPrefix(pattern, "#") {
 			continue
 		}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6805,3 +6805,27 @@ func (s *DockerSuite) TestBuildWithUTF8BOM(c *check.C) {
 	_, err = buildImageFromContext(name, ctx, true)
 	c.Assert(err, check.IsNil)
 }
+
+// Test case for UTF-8 BOM in .dockerignore, related to #23221
+func (s *DockerSuite) TestBuildWithUTF8BOMDockerignore(c *check.C) {
+	name := "test-with-utf8-bom-dockerignore"
+	dockerfile := `
+        FROM busybox
+		ADD . /tmp/
+		RUN ls -la /tmp
+		RUN sh -c "! ls /tmp/Dockerfile"
+		RUN ls /tmp/.dockerignore`
+	dockerignore := []byte("./Dockerfile\n")
+	bomDockerignore := append([]byte{0xEF, 0xBB, 0xBF}, dockerignore...)
+	ctx, err := fakeContext(dockerfile, map[string]string{
+		"Dockerfile": dockerfile,
+	})
+	c.Assert(err, check.IsNil)
+	defer ctx.Close()
+	err = ctx.addFile(".dockerignore", bomDockerignore)
+	c.Assert(err, check.IsNil)
+	_, err = buildImageFromContext(name, ctx, true)
+	if err != nil {
+		c.Fatal(err)
+	}
+}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6791,3 +6791,17 @@ foo2
 		c.Fatal(err)
 	}
 }
+
+// Test case for #23221
+func (s *DockerSuite) TestBuildWithUTF8BOM(c *check.C) {
+	name := "test-with-utf8-bom"
+	dockerfile := []byte(`FROM busybox`)
+	bomDockerfile := append([]byte{0xEF, 0xBB, 0xBF}, dockerfile...)
+	ctx, err := fakeContextFromNewTempDir()
+	c.Assert(err, check.IsNil)
+	defer ctx.Close()
+	err = ctx.addFile("Dockerfile", bomDockerfile)
+	c.Assert(err, check.IsNil)
+	_, err = buildImageFromContext(name, ctx, true)
+	c.Assert(err, check.IsNil)
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address issues in #23221 where Dockerfile or .dockerignore may consists of UTF-8 BOM. This likely happens when Notepad tries to save a file as UTF-8 in Windows.

**\- How I did it**

This fix skips the UTF-8 BOM bytes from the beginning of the Dockerfile or .dockerignore if exist.

**\- How to verify it**

Additional tests has been added to cover the changes in this fix.

**\- Description for the changelog**

Skip UTF-8 BOM bytes from the beginning of the Dockerfile or .dockerignore if exist.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #23221.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
