### PR TITLE
Use @cpuguy83's patch and add a global cleanup lock

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -260,6 +260,8 @@ func (container *Container) IpcMounts() []Mount {
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	// update resources of container
 	resources := hostConfig.Resources

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -61,6 +61,8 @@ func (container *Container) TmpfsMounts() []Mount {
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 	resources := hostConfig.Resources
 	if resources.BlkioWeight != 0 || resources.CPUShares != 0 ||
 		resources.CPUPeriod != 0 || resources.CPUQuota != 0 ||

--- a/container/monitor.go
+++ b/container/monitor.go
@@ -15,6 +15,8 @@ func (container *Container) Reset(lock bool) {
 	if lock {
 		container.Lock()
 		defer container.Unlock()
+		container.DataLock.Lock()
+		defer container.DataLock.Unlock()
 	}
 
 	if err := container.CloseStreams(); err != nil {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -172,6 +172,8 @@ func (daemon *Daemon) generateHostname(id string, config *containertypes.Config)
 func (daemon *Daemon) setSecurityOptions(container *container.Container, hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 	return parseSecurityOpt(container, hostConfig)
 }
 
@@ -182,8 +184,8 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 		return err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	// Register any links from the host config before starting the container
 	if err := daemon.registerLinks(container, hostConfig); err != nil {

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -32,8 +32,8 @@ func (daemon *Daemon) containerInspectCurrent(name string, size bool) (*types.Co
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	base, err := daemon.getInspectData(container, size)
 	if err != nil {
@@ -72,8 +72,8 @@ func (daemon *Daemon) containerInspect120(name string) (*v1p20.ContainerJSON, er
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	base, err := daemon.getInspectData(container, false)
 	if err != nil {

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -27,8 +27,8 @@ func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON,
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	base, err := daemon.getInspectData(container, false)
 	if err != nil {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -172,8 +172,8 @@ func (daemon *Daemon) reduceContainers(config *types.ContainerListOptions, reduc
 
 // reducePsContainer is the basic representation for a container as expected by the ps command.
 func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *listContext, reducer containerReducer) (*types.Container, error) {
-	container.Lock()
-	defer container.Unlock()
+	container.DataLock.Lock()
+	defer container.DataLock.Unlock()
 
 	// filter containers to return
 	action := includeContainerInList(container, ctx)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -151,7 +151,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 		mountPoints[bind.Destination] = bind
 	}
 
-	container.Lock()
+	container.DataLock.Lock()
 
 	// 4. Cleanup old volumes that are about to be reassigned.
 	for _, m := range mountPoints {
@@ -163,7 +163,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 	}
 	container.MountPoints = mountPoints
 
-	container.Unlock()
+	container.DataLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
I got stuck in #5618 and #17443 for a week without finding a good solution, except
for the great @cpuguy83 's PR #23178 that unlocked at least the readers (ps, inspect)
but could not avoid NMI watchdog soft lockups nor unregister_netdevice errors.

I found the issue #19758 and https://github.com/docker/docker/issues/19758#issuecomment-182305310
 gave me the idea: since it only occours for concurrent cleanups, why not
putting a Global Cleanup Lock in place? (I come from a Python background, does it show? 😄  )

It works well, I have used a modified version of the docker stress tool that you can find
at https://github.com/etamponi/docker-stress . I used this configuration:

```
docker-stress --containers 10000 --concurrent 200 --kill 3s busybox
```

with the `stress.json` file that I put in that repo. I tried several times, and no issues of
sort happened. Using the same command on v1.11.2, or v1.10 and any kernel from 3.16 to 4.5 causes
NMI watchdog lockups and/or unregister_netdevice errors.

Of course this is a POC patch that shows where the issue is. From here we can try to add finer
locks, only where they are needed (perhaps just around the `releaseNetwork` call). But until the
kernel data race is fixed I fear we cannot get anything less than a "global" lock somewhere.

Beautiful animal: an hummigbird :)

![screen shot 2016-06-03 at 17 20 08](https://cloud.githubusercontent.com/assets/578612/15783690/73713f7a-29af-11e6-9c8b-ff519b668c6a.png)

Signed-off-by: Emanuele Tamponi emanuele.tamponi@gmail.com
