### PR TITLE
docs validation fixes

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -91,7 +91,7 @@ membership.
 If you need to access the Docker daemon remotely, you need to enable the `tcp`
 Socket. Beware that the default setup provides un-encrypted and
 un-authenticated direct access to the Docker daemon - and should be secured
-either using the [built in HTTPS encrypted socket](../../security/https/), or by
+either using the [built in HTTPS encrypted socket](../../security/https.md), or by
 putting a secure web proxy in front of it. You can listen on port `2375` on all
 network interfaces with `-H tcp://0.0.0.0:2375`, or on a particular network
 interface using its IP address: `-H tcp://192.168.59.103:2375`. It is

--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -358,7 +358,7 @@ If you run into repeated problems with thin pool, you can use the
 `dm.min_free_space` option to tune the Engine behavior. This value ensures that
 operations fail with a warning when the free space is at or near the minimum.
 For information, see <a
-href="../../../reference/commandline/dockerd/#storage-driver-options"
+href="../../../reference/commandline/dockerd.md#storage-driver-options"
 target="_blank">the storage driver options in the Engine daemon reference</a>.
 
 
@@ -658,4 +658,4 @@ data volumes.
 * [Select a storage driver](selectadriver.md)
 * [AUFS storage driver in practice](aufs-driver.md)
 * [Btrfs storage driver in practice](btrfs-driver.md)
-* [daemon reference](../../reference/commandline/dockerd#storage-driver-options)
+* [daemon reference](../../reference/commandline/dockerd.md#storage-driver-options)


### PR DESCRIPTION
and when this gets cherry-picked, we need to remmember to add an alias in the `daemon.md` file to create a `dockerd.md` redirect.

@thaJeztah 
