### PR TITLE
Allow dynamic update of logging options via API

### DIFF
--- a/api/client/update.go
+++ b/api/client/update.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 
 	Cli "github.com/docker/docker/cli"
+	DOpts "github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/runconfig/opts"
 	"github.com/docker/engine-api/types/container"
@@ -29,6 +30,9 @@ func (cli *DockerCli) CmdUpdate(args ...string) error {
 	flMemorySwap := cmd.String([]string{"-memory-swap"}, "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
 	flKernelMemory := cmd.String([]string{"-kernel-memory"}, "", "Kernel memory limit")
 	flRestartPolicy := cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits")
+
+	logOpts := make(map[string]string)
+	cmd.Var(DOpts.NewNamedMapOpts("log-opts", logOpts, nil), []string{"-log-opt"}, "Set log driver options")
 
 	cmd.Require(flag.Min, 1)
 	cmd.ParseFlags(args, true)
@@ -94,9 +98,14 @@ func (cli *DockerCli) CmdUpdate(args ...string) error {
 		CPUQuota:          *flCPUQuota,
 	}
 
+	logConfig := container.LogConfig{
+		Config: logOpts,
+	}
+
 	updateConfig := container.UpdateConfig{
 		Resources:     resources,
 		RestartPolicy: restartPolicy,
+		LogConfig:     logConfig,
 	}
 
 	ctx := context.Background()

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -321,6 +321,7 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 	hostConfig := &container.HostConfig{
 		Resources:     updateConfig.Resources,
 		RestartPolicy: updateConfig.RestartPolicy,
+		LogConfig:     updateConfig.LogConfig,
 	}
 
 	name := vars["name"]

--- a/container/container.go
+++ b/container/container.go
@@ -895,6 +895,11 @@ func (container *Container) UpdateMonitor(restartPolicy containertypes.RestartPo
 	}
 }
 
+// UpdateLogConfig updates logging options for running container
+func (container *Container) UpdateLogConfig(logConfig containertypes.LogConfig) error {
+	return container.LogDriver.UpdateConfig(logConfig.Config)
+}
+
 // FullHostname returns hostname and optional domain appended to it.
 func (container *Container) FullHostname() string {
 	fullHostname := container.Config.Hostname

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -300,6 +300,11 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		container.HostConfig.RestartPolicy = hostConfig.RestartPolicy
 	}
 
+	// update LogConfig of container
+	if len(hostConfig.LogConfig.Config) != 0 {
+		container.HostConfig.LogConfig.Config = hostConfig.LogConfig.Config
+	}
+
 	if err := container.ToDisk(); err != nil {
 		logrus.Errorf("Error saving updated container: %v", err)
 		return err

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -182,6 +182,10 @@ func (l *logStream) Close() error {
 	return nil
 }
 
+func (l *logStream) UpdateConfig(cfg map[string]string) error {
+	return nil
+}
+
 // create creates a log stream for the instance of the awslogs logging driver
 func (l *logStream) create() error {
 	input := &cloudwatchlogs.CreateLogStreamInput{

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -28,6 +28,8 @@ func (l *TestLoggerJSON) Close() error { return nil }
 
 func (l *TestLoggerJSON) Name() string { return "json" }
 
+func (l *TestLoggerJSON) UpdateConfig(map[string]string) error { return nil }
+
 func TestCopier(t *testing.T) {
 	stdoutLine := "Line that thinks that it is log line from docker stdout"
 	stderrLine := "Line that thinks that it is log line from docker stderr"

--- a/daemon/logger/etwlogs/etwlogs_windows.go
+++ b/daemon/logger/etwlogs/etwlogs_windows.go
@@ -83,6 +83,10 @@ func (etwLogger *etwLogs) Name() string {
 	return name
 }
 
+func (etwLogger *etwLogs) UpdateConfig(cfg map[string]string) error {
+	return nil
+}
+
 func createLogMessage(etwLogger *etwLogs, msg *logger.Message) string {
 	return fmt.Sprintf("container_name: %s, image_name: %s, container_id: %s, image_id: %s, source: %s, log: %s",
 		etwLogger.containerName,

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -154,6 +154,10 @@ func (f *fluentd) Name() string {
 	return name
 }
 
+func (f *fluentd) UpdateConfig(cfg map[string]string) error {
+	return nil
+}
+
 // ValidateLogOpt looks for fluentd specific log option fluentd-address.
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -189,3 +189,7 @@ func (l *gcplogs) Close() error {
 func (l *gcplogs) Name() string {
 	return name
 }
+
+func (l *gcplogs) UpdateConfig(cfg map[string]string) error {
+	return nil
+}

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -152,6 +152,10 @@ func (s *gelfLogger) Name() string {
 	return name
 }
 
+func (s *gelfLogger) UpdateConfig(cfg map[string]string) error {
+	return nil
+}
+
 // ValidateLogOpt looks for gelf specific log option gelf-address.
 func ValidateLogOpt(cfg map[string]string) error {
 	for key, val := range cfg {

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -93,3 +93,7 @@ func (s *journald) Log(msg *logger.Message) error {
 func (s *journald) Name() string {
 	return name
 }
+
+func (s *journald) UpdateConfig(cfg map[string]string) error {
+	return nil
+}

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -145,3 +145,31 @@ func (l *JSONFileLogger) Close() error {
 func (l *JSONFileLogger) Name() string {
 	return Name
 }
+
+// Update logging configuration
+func (l *JSONFileLogger) UpdateConfig(cfg map[string]string) error {
+	defer l.mu.Unlock()
+	l.mu.Lock()
+	for key, val := range cfg {
+		switch key {
+		case "max-file":
+			maxFiles, err := strconv.Atoi(val)
+			if err != nil {
+				return err
+			}
+			if maxFiles < 1 {
+				return fmt.Errorf("max-file cannot be less than 1")
+			}
+			l.writer.SetMaxFiles(maxFiles)
+		case "max-size":
+			capval, err := units.FromHumanSize(val)
+			if err != nil {
+				return err
+			}
+			l.writer.SetCapacity(capval)
+		default:
+			return fmt.Errorf("unknown log opt '%s' for json-file log driver", key)
+		}
+	}
+	return nil
+}

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -146,7 +146,7 @@ func (l *JSONFileLogger) Name() string {
 	return Name
 }
 
-// Update logging configuration
+// UpdateConfig updates logging configuration
 func (l *JSONFileLogger) UpdateConfig(cfg map[string]string) error {
 	defer l.mu.Unlock()
 	l.mu.Lock()

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -62,6 +62,7 @@ type Logger interface {
 	Log(*Message) error
 	Name() string
 	Close() error
+	UpdateConfig(map[string]string) error
 }
 
 // ReadConfig is the configuration passed into ReadLogs.

--- a/daemon/logger/loggerutils/rotatefilewriter.go
+++ b/daemon/logger/loggerutils/rotatefilewriter.go
@@ -108,6 +108,20 @@ func (w *RotateFileWriter) MaxFiles() int {
 	return w.maxFiles
 }
 
+// SetMaxFiles set maximum number of files
+func (w *RotateFileWriter) SetMaxFiles(maxFiles int) {
+	w.mu.Lock()
+	w.maxFiles = maxFiles
+	w.mu.Unlock()
+}
+
+// SetCapacity set max file size
+func (w *RotateFileWriter) SetCapacity(capacity int64) {
+	w.mu.Lock()
+	w.capacity = capacity
+	w.mu.Unlock()
+}
+
 //NotifyRotate returns the new subscriber
 func (w *RotateFileWriter) NotifyRotate() chan interface{} {
 	return w.notifyRotate.Subscribe()

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -196,6 +196,10 @@ func (l *splunkLogger) Name() string {
 	return driverName
 }
 
+func (l *splunkLogger) UpdateConfig(cfg map[string]string) error {
+	return nil
+}
+
 // ValidateLogOpt looks for all supported by splunk driver options
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -148,6 +148,10 @@ func (s *syslogger) Name() string {
 	return name
 }
 
+func (s *syslogger) UpdateConfig(cfg map[string]string) error {
+	return nil
+}
+
 func parseAddress(address string) (string, string, error) {
 	if address == "" {
 		return "", "", nil

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -82,6 +82,11 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 			restoreConfig = true
 			return errCannotUpdate(container.ID, err)
 		}
+
+		if err := container.UpdateLogConfig(hostConfig.LogConfig); err != nil {
+			restoreConfig = true
+			return errCannotUpdate(container.ID, err)
+		}
 	}
 
 	daemon.LogContainerEvent(container, "update")

--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -29,3 +29,42 @@ func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 	maximumRetryCount := inspectField(c, id, "HostConfig.RestartPolicy.MaximumRetryCount")
 	c.Assert(maximumRetryCount, checker.Equals, "5")
 }
+
+func (s *DockerSuite) TestUpdateLogOptRunningContainer(c *check.C) {
+	name := "test-update-container"
+	dockerCmd(c, "run", "-d", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "top")
+	dockerCmd(c, "update", "--log-opt", "max-file=2", "--log-opt", "max-size=2m", name)
+
+	out, _ := dockerCmd(c, "inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", name)
+	c.Assert(out, checker.Contains, "max-size:2m")
+	c.Assert(out, checker.Contains, "max-file:2")
+}
+
+func (s *DockerSuite) TestUpdateLogOptStoppedContainer(c *check.C) {
+	name := "test-update-container"
+
+	dockerCmd(c, "run", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "ls")
+	dockerCmd(c, "update", "--log-opt", "max-file=2", "--log-opt", "max-size=2m", name)
+
+	out, _ := dockerCmd(c, "inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", name)
+	c.Assert(out, checker.Contains, "max-size:2m")
+	c.Assert(out, checker.Contains, "max-file:2")
+}
+
+func (s *DockerSuite) TestUpdateLogOptPausedContainer(c *check.C) {
+	name := "test-update-container"
+
+	dockerCmd(c, "run", "-d", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "top")
+	dockerCmd(c, "pause", name)
+	dockerCmd(c, "update", "--log-opt", "max-file=2", "--log-opt", "max-size=2m", name)
+
+	out, _ := dockerCmd(c, "inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", name)
+	c.Assert(out, checker.Contains, "max-size:2m")
+	c.Assert(out, checker.Contains, "max-file:2")
+
+	dockerCmd(c, "unpause", name)
+
+	out, _ = dockerCmd(c, "inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", name)
+	c.Assert(out, checker.Contains, "max-size:2m")
+	c.Assert(out, checker.Contains, "max-file:2")
+}

--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -32,7 +32,7 @@ func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 
 func (s *DockerSuite) TestUpdateLogOptRunningContainer(c *check.C) {
 	name := "test-update-container"
-	dockerCmd(c, "run", "-d", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "top")
+	dockerCmd(c, "run", "-d", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "sleep", "300")
 	dockerCmd(c, "update", "--log-opt", "max-file=2", "--log-opt", "max-size=2m", name)
 
 	out, _ := dockerCmd(c, "inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", name)
@@ -54,7 +54,7 @@ func (s *DockerSuite) TestUpdateLogOptStoppedContainer(c *check.C) {
 func (s *DockerSuite) TestUpdateLogOptPausedContainer(c *check.C) {
 	name := "test-update-container"
 
-	dockerCmd(c, "run", "-d", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "top")
+	dockerCmd(c, "run", "-d", "--name", name, "--log-driver=json-file", "--log-opt", "max-file=1", "--log-opt", "max-size=1m", "busybox", "sleep", "300")
 	dockerCmd(c, "pause", name)
 	dockerCmd(c, "update", "--log-opt", "max-file=2", "--log-opt", "max-size=2m", name)
 

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -269,6 +269,7 @@ type UpdateConfig struct {
 	// Contains container's resources (cgroups, ulimits)
 	Resources
 	RestartPolicy RestartPolicy
+	LogConfig     LogConfig
 }
 
 // HostConfig the non-portable Config structure of a container.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
- Setup provision for dynamically updating logging options, for re-configuring the logging
  driver
- Implement the same for `json-file` logger, for `max-size` and `max-file` setting. 

**\- How I did it**
- Add `UpdateConfig` method to `logger` interface.
- Add provision to update config via the API route.

**\- How to verify it**
- Start a container with `--log-driver json-file --log-opt max-size=1m --log-opt --max-file=2`
- Make a update API call to docker daemon with the following payload

``` json
{
    "LogConfig": {
      "Config": {
          "max-size": "2m",
          "max-file": "3"
      }
    }
}
```
- Do docker inspect on the container to verify the `LogConfig` settings have been updated and
  check the size and count of container logs `/var/lib/docker/containers/CONTAINER_ID/CONTAINER_ID-json.log.*`

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Allow dynamic update of logging options via API

Should the vendor change (separate commit here) to engine-api be requested at https://github.com/docker/engine-api ?
