### PR TITLE
Cobra - display "See 'docker cmd --help'." in error cases

### DIFF
--- a/cli/required.go
+++ b/cli/required.go
@@ -18,7 +18,8 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	return fmt.Errorf(
-		"\"%s\" accepts no argument(s).\n\nUsage:  %s\n\n%s",
+		"\"%s\" accepts no argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+		cmd.CommandPath(),
 		cmd.CommandPath(),
 		cmd.UseLine(),
 		cmd.Short,
@@ -32,9 +33,10 @@ func RequiresMinArgs(min int) cobra.PositionalArgs {
 			return nil
 		}
 		return fmt.Errorf(
-			"\"%s\" requires at least %d argument(s).\n\nUsage:  %s\n\n%s",
+			"\"%s\" requires at least %d argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
 			min,
+			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
 		)
@@ -48,9 +50,10 @@ func ExactArgs(number int) cobra.PositionalArgs {
 			return nil
 		}
 		return fmt.Errorf(
-			"\"%s\" requires exactly %d argument(s).\n\nUsage:  %s\n\n%s",
+			"\"%s\" requires exactly %d argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
 			number,
+			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
 		)


### PR DESCRIPTION
This follows-up https://github.com/docker/docker/pull/23253#issuecomment-223753455 and brings back "See 'docker %cmd% --help'." message in case missing arguments 🐼.

old:

```
docker: "run" requires a minimum of 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run a command in a new container
```

new

```
"docker run" requires at least 1 argument(s).
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run a command in a new container
```

/cc @thaJeztah @dnephin @cpuguy83 @LK4D4 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
