### PR TITLE
Escape brackets in hack/install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -429,7 +429,7 @@ do_install() {
 			done
 			$sh_c "apt-key adv -k ${gpg_fingerprint} >/dev/null"
 			$sh_c "mkdir -p /etc/apt/sources.list.d"
-			$sh_c "echo deb [arch=$(dpkg --print-architecture)] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
+			$sh_c "echo deb \[arch=$(dpkg --print-architecture)\] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'
 			)
 			echo_docker_as_nonroot


### PR DESCRIPTION
Fixes #23260

**\- What I did**
I fixed the issue of `hack/install.sh` (the script served from https://get.docker.com/) that caused a malformed line to be inserted to `/etc/apt/sources.list.d/docker.list` for debian/ubuntu based distros, when a file named `a`, `r`, `c` or `h` exists in the current working directory.

**\- How I did it**
By escaping the brackets in the line causing the issue.

**\- How to verify it**
Use a debian/based distro, touch a file named `a`, try to run the installation script. It should fail on master and succeed on this branch.
