### PR TITLE
Deprecated the old 3-args form of `docker import`

### DIFF
--- a/api/client/import.go
+++ b/api/client/import.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -31,18 +30,11 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	var (
 		in      io.Reader
-		tag     string
 		src     = cmd.Arg(0)
 		srcName = src
 		ref     = cmd.Arg(1)
 		changes = flChanges.GetAll()
 	)
-
-	if cmd.NArg() == 3 {
-		// FIXME(vdemeester) Which version has this been deprecated ? should we remove it ?
-		fmt.Fprintf(cli.err, "[DEPRECATED] The format 'file|URL|- [REPOSITORY [TAG]]' has been deprecated. Please use file|URL|- [REPOSITORY[:TAG]]\n")
-		tag = cmd.Arg(2)
-	}
 
 	if src == "-" {
 		in = cli.in
@@ -63,7 +55,6 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	options := types.ImageImportOptions{
 		Message: *message,
-		Tag:     tag,
 		Changes: changes,
 	}
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -14,6 +14,13 @@ weight=80
 
 The following list of features are deprecated in Engine.
 
+### Three argument form in `docker import`
+**Deprecated In Release: [v0.6.7](https://github.com/docker/docker/releases/tag/v0.6.7)**
+
+**Removed In Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
+
+The `docker import` command format 'file|URL|- [REPOSITORY [TAG]]' is deprecated since November 2013. It's no more supported.
+
 ### `-e` and `--email` flags on `docker login`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 


### PR DESCRIPTION
It's been deprecated since November 2013 and v0.6.7 (see https://github.com/docker/docker/commit/ef57752bce5c333d0e2b8352a84d071f21cce132). Removing the cli side of it 🐮

`docker import myimage.tgz myimage mytag` is no more :angel:.

/cc @thaJeztah @icecrime @stevvooe 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
