### PR TITLE
Remove unnecessary check for number of commands

### DIFF
--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -137,17 +137,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 				c.Fatal(err)
 			}
 		}
-
-		// Number of commands for standard release and experimental release
-		standard := 41
-		experimental := 1
-		expected := standard + experimental
-		if isLocalDaemon {
-			expected++ // for the daemon command
-		}
-		c.Assert(len(cmds), checker.LessOrEqualThan, expected, check.Commentf("Wrong # of cmds, it should be: %d\nThe list:\n%q", expected, cmds))
 	}
-
 }
 
 func (s *DockerSuite) TestHelpExitCodesHelpOutput(c *check.C) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Testing for the number of commands in `help` output doesn't seem to
contribute much to the quality of the project, and adds additional
burden for the developer to update.

Signed-off-by: Arnaud Porterie (icecrime) arnaud.porterie@docker.com
