### PR TITLE
Fix a couple of typos in docker attach docs.

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -52,7 +52,7 @@ foreground over a slow client connection. Instead, users should use the
 ## Override the detach sequence
 
 If you want, you can configure an override the Docker key sequence for detach.
-This is is useful if the Docker default sequence conflicts with key squence you
+This is useful if the Docker default sequence conflicts with key sequence you
 use for other applications. There are two ways to defines a your own detach key
 sequence, as a per-container override or as a configuration property on  your
 entire configuration.

--- a/man/docker-attach.1.md
+++ b/man/docker-attach.1.md
@@ -44,7 +44,7 @@ attaching to a tty-enabled container (i.e.: launched with `-t`).
 # Override the detach sequence
 
 If you want, you can configure an override the Docker key sequence for detach.
-This is is useful if the Docker default sequence conflicts with key squence you
+This is useful if the Docker default sequence conflicts with key sequence you
 use for other applications. There are two ways to defines a your own detach key
 sequence, as a per-container override or as a configuration property on  your
 entire configuration.


### PR DESCRIPTION
This fix fixes a couple of typos in docker attach docs:

`docs/reference/commandline/attach.md`

`man/docker-attach.1.md`

Signed-off-by: Yong Tang yong.tang.github@outlook.com
