### PR TITLE
fix bash completion for dockerd invoked with path

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2319,7 +2319,7 @@ _docker() {
 	done
 
 	local binary="${words[0]}"
-	if [[ $binary == dockerd ]] ; then
+	if [[ $binary == ?(*/)dockerd ]] ; then
 		# for the dockerd binary, we reuse completion of `docker daemon`.
 		# dockerd does not have subcommands and global options.
 		command=daemon


### PR DESCRIPTION
This fixes a problem in bash completion for `dockerd`:
Without this fix, completion would not work properly if `dockerd` was invoked with absolute or relative paths, e.g. `bundles/latest/binary-daemon/dockerd`.
