### PR TITLE
[carry 22894] Adding network filter to docker ps command

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -33,6 +33,7 @@ var acceptedPsFilterTags = map[string]bool{
 	"status":    true,
 	"since":     true,
 	"volume":    true,
+	"network":   true,
 }
 
 // iterationAction represents possible outcomes happening during the container iteration.
@@ -370,6 +371,19 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 			return excludeContainer
 		}
 		if !ctx.images[container.ImageID] {
+			return excludeContainer
+		}
+	}
+
+	networkExist := fmt.Errorf("container part of network")
+	if ctx.filters.Include("network") {
+		err := ctx.filters.WalkValues("network", func(value string) error {
+			if network := container.NetworkSettings.Networks[value]; network != nil {
+				return networkExist
+			}
+			return nil
+		})
+		if err != networkExist {
 			return excludeContainer
 		}
 	}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -378,8 +378,13 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 	networkExist := fmt.Errorf("container part of network")
 	if ctx.filters.Include("network") {
 		err := ctx.filters.WalkValues("network", func(value string) error {
-			if network := container.NetworkSettings.Networks[value]; network != nil {
+			if _, ok := container.NetworkSettings.Networks[value]; ok {
 				return networkExist
+			}
+			for _, nw := range container.NetworkSettings.Networks {
+				if nw.NetworkID == value {
+					return networkExist
+				}
 			}
 			return nil
 		})

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -117,7 +117,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now takes `StorageOpt` field.
 * `GET /info` now returns `SecurityOptions` field, showing if `apparmor`, `seccomp`, or `selinux` is supported.
 * `GET /networks` now supports filtering by `label` and `driver`.
-* `GET /containers/json` now supports filtering containers by `network` name.
+* `GET /containers/json` now supports filtering containers by `network` name or id.
 * `POST /containers/create` now takes `MaximumIOps` and `MaximumIOBps` fields. Windows daemon only.
 * `POST /containers/create` now returns an HTTP 400 "bad parameter" message
   if no command is specified (instead of an HTTP 500 "server error")

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -117,6 +117,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now takes `StorageOpt` field.
 * `GET /info` now returns `SecurityOptions` field, showing if `apparmor`, `seccomp`, or `selinux` is supported.
 * `GET /networks` now supports filtering by `label` and `driver`.
+* `GET /containers/json` now supports filtering containers by `network` name.
 * `POST /containers/create` now takes `MaximumIOps` and `MaximumIOBps` fields. Windows daemon only.
 * `POST /containers/create` now returns an HTTP 400 "bad parameter" message
   if no command is specified (instead of an HTTP 500 "server error")

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -223,6 +223,7 @@ Query Parameters:
   -   `before`=(`<container id>` or `<container name>`)
   -   `since`=(`<container id>` or `<container name>`)
   -   `volume`=(`<volume name>` or `<mount point destination>`)
+  -   `network`=(`<network name>`)
 
 Status Codes:
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -223,7 +223,7 @@ Query Parameters:
   -   `before`=(`<container id>` or `<container name>`)
   -   `since`=(`<container id>` or `<container name>`)
   -   `volume`=(`<volume name>` or `<mount point destination>`)
-  -   `network`=(`<network name>`)
+  -   `network`=(`<network id>` or `<network name>`)
 
 Status Codes:
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -62,7 +62,7 @@ The currently supported filters are:
 * since (container's id or name) - filters containers created since given id or name
 * isolation (default|process|hyperv)   (Windows daemon only)
 * volume (volume name or mount point) - filters containers that mount volumes.
-* network (network name) - filters containers connected to the provided network name
+* network (network id or name) - filters containers connected to the provided network
 
 #### Label
 
@@ -209,15 +209,33 @@ The `volume` filter shows only containers that mount a specific volume or have a
 
 #### Network
 
-The `network` filter shows only containers that has endpoints on the provided network name.
+The `network` filter shows only containers that are connected to a network with
+a given name or id.
 
-    $docker run -d --net=net1 --name=test1 ubuntu top
-    $docker run -d --net=net2 --name=test2 ubuntu top
+The following filter matches all containers that are connected to a network
+with a name containing `net1`.
 
-    $docker ps --filter network=net1
-    CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
-    9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+```bash
+$ docker run -d --net=net1 --name=test1 ubuntu top
+$ docker run -d --net=net2 --name=test2 ubuntu top
 
+$ docker ps --filter network=net1
+CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+```
+
+The network filter matches on both the network's name and id. The following
+example shows all containers that are attached to the `net1` network, using
+the network id as a filter;
+
+```bash
+$ docker network inspect --format "{{.ID}}" net1
+8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
+
+$ docker ps --filter network=8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
+CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+```
 
 ## Formatting
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -62,7 +62,7 @@ The currently supported filters are:
 * since (container's id or name) - filters containers created since given id or name
 * isolation (default|process|hyperv)   (Windows daemon only)
 * volume (volume name or mount point) - filters containers that mount volumes.
-
+* network (network name) - filters containers connected to the provided network name
 
 #### Label
 
@@ -206,6 +206,17 @@ The `volume` filter shows only containers that mount a specific volume or have a
     $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
     CONTAINER ID        MOUNTS
     9c3527ed70ce        remote-volume
+
+#### Network
+
+The `network` filter shows only containers that has endpoints on the provided network name.
+
+    $docker run -d --net=net1 --name=test1 ubuntu top
+    $docker run -d --net=net2 --name=test2 ubuntu top
+
+    $docker ps --filter network=net1
+    CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
+    9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
 
 
 ## Formatting

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -806,15 +806,30 @@ func (s *DockerSuite) TestPsFormatSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterNetwork(c *check.C) {
-	// create a container
-	out, _ := runSleepingContainer(c, "--net=bridge", "--name=onbridgenetwork")
-	out, _ = runSleepingContainer(c, "--net=none", "--name=onnonenetwork")
+	// TODO default network on Windows is not called "bridge", and creating a
+	// custom network fails on Windows fails with "Error response from daemon: plugin not found")
+	testRequires(c, DaemonIsLinux)
+
+	// create some containers
+	runSleepingContainer(c, "--net=bridge", "--name=onbridgenetwork")
+	runSleepingContainer(c, "--net=none", "--name=onnonenetwork")
+
+	// Filter docker ps on non existing network
+	out, _ := dockerCmd(c, "ps", "--filter", "network=doesnotexist")
+	containerOut := strings.TrimSpace(string(out))
+	lines := strings.Split(containerOut, "\n")
+
+	// skip header
+	lines = lines[1:]
+
+	// ps output should have no containers
+	c.Assert(lines, checker.HasLen, 0)
 
 	// Filter docker ps on network bridge
 	out, _ = dockerCmd(c, "ps", "--filter", "network=bridge")
-	containerOut := strings.TrimSpace(string(out))
+	containerOut = strings.TrimSpace(string(out))
 
-	lines := strings.Split(containerOut, "\n")
+	lines = strings.Split(containerOut, "\n")
 
 	// skip header
 	lines = lines[1:]
@@ -823,7 +838,7 @@ func (s *DockerSuite) TestPsListContainersFilterNetwork(c *check.C) {
 	c.Assert(lines, checker.HasLen, 1)
 
 	// Making sure onbridgenetwork is on the output
-	c.Assert(lines[0], checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on network\n"))
+	c.Assert(containerOut, checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on network\n"))
 
 	// Filter docker ps on networks bridge and none
 	out, _ = dockerCmd(c, "ps", "--filter", "network=bridge", "--filter", "network=none")
@@ -838,6 +853,14 @@ func (s *DockerSuite) TestPsListContainersFilterNetwork(c *check.C) {
 	c.Assert(lines, checker.HasLen, 2)
 
 	// Making sure onbridgenetwork and onnonenetwork is on the output
-	c.Assert(lines[0], checker.Contains, "onnonenetwork", check.Commentf("Missing the container on none network\n"))
-	c.Assert(lines[1], checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on bridge network\n"))
+	c.Assert(containerOut, checker.Contains, "onnonenetwork", check.Commentf("Missing the container on none network\n"))
+	c.Assert(containerOut, checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on bridge network\n"))
+
+	nwID, _ := dockerCmd(c, "network", "inspect", "--format", "{{.ID}}", "bridge")
+
+	// Filter by network ID
+	out, _ = dockerCmd(c, "ps", "--filter", "network="+nwID)
+	containerOut = strings.TrimSpace(string(out))
+
+	c.Assert(containerOut, checker.Contains, "onbridgenetwork")
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -804,3 +804,40 @@ func (s *DockerSuite) TestPsFormatSize(c *check.C) {
 	lines = strings.Split(out, "\n")
 	c.Assert(lines[8], checker.HasPrefix, "size:", check.Commentf("Size should be appended on a newline"))
 }
+
+func (s *DockerSuite) TestPsListContainersFilterNetwork(c *check.C) {
+	// create a container
+	out, _ := runSleepingContainer(c, "--net=bridge", "--name=onbridgenetwork")
+	out, _ = runSleepingContainer(c, "--net=none", "--name=onnonenetwork")
+
+	// Filter docker ps on network bridge
+	out, _ = dockerCmd(c, "ps", "--filter", "network=bridge")
+	containerOut := strings.TrimSpace(string(out))
+
+	lines := strings.Split(containerOut, "\n")
+
+	// skip header
+	lines = lines[1:]
+
+	// ps output should have only one container
+	c.Assert(lines, checker.HasLen, 1)
+
+	// Making sure onbridgenetwork is on the output
+	c.Assert(lines[0], checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on network\n"))
+
+	// Filter docker ps on networks bridge and none
+	out, _ = dockerCmd(c, "ps", "--filter", "network=bridge", "--filter", "network=none")
+	containerOut = strings.TrimSpace(string(out))
+
+	lines = strings.Split(containerOut, "\n")
+
+	// skip header
+	lines = lines[1:]
+
+	//ps output should have both the containers
+	c.Assert(lines, checker.HasLen, 2)
+
+	// Making sure onbridgenetwork and onnonenetwork is on the output
+	c.Assert(lines[0], checker.Contains, "onnonenetwork", check.Commentf("Missing the container on none network\n"))
+	c.Assert(lines[1], checker.Contains, "onbridgenetwork", check.Commentf("Missing the container on bridge network\n"))
+}

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -36,7 +36,7 @@ the running containers.
    - since=(<container-name>|<container-id>)
    - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
    - volume=(<volume-name>|<mount-point-destination>)
-   - network=(<network-name>) - containers connected to the provided network name
+   - network=(<network-name>|<network-id>) - containers connected to the provided network
 
 **--format**="*TEMPLATE*"
    Pretty-print containers using a Go template.

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -36,6 +36,7 @@ the running containers.
    - since=(<container-name>|<container-id>)
    - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
    - volume=(<volume-name>|<mount-point-destination>)
+   - network=(<network-name>) - containers connected to the provided network name
 
 **--format**="*TEMPLATE*"
    Pretty-print containers using a Go template.


### PR DESCRIPTION
closes https://github.com/docker/docker/pull/22894

**\- What I did**

Carry of https://github.com/docker/docker/pull/22894, rebased, and adding filter by network _id_.

**\- How to verify it**

```
docker run -d --net=bridge --name=onbridgenetwork busybox top
docker run -d --net=none --name=onnonenetwork busybox top

docker ps --filter network=bridge 
```

Output should show only the container with name "onbridgenetwork"

```
docker ps --filter network=bridge --filter network=none
```

Output should show both the containers "onbrigenetwork" and "onnonenetwork"

``` bash
$ docker network inspect --format "{{.ID}}" net1
8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5

$ docker ps --filter network=8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
```

Output should only show the `onbridgenetwork` container

**\- Description for the changelog**

Add support for `docker ps --filter network=<network-id | network-name>` to filter containers by the network(s) they're connected to.
