### PR TITLE
daemon: allow tmpfs to trump over VOLUME(s)

### DIFF
--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -54,7 +54,8 @@ func (container *Container) UnmountVolumes(forceSyscall bool, volumeEventLog fun
 
 // TmpfsMounts returns the list of tmpfs mounts
 func (container *Container) TmpfsMounts() []Mount {
-	return nil
+	var mounts []Mount
+	return mounts
 }
 
 // UpdateContainer updates configuration of a container

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -480,9 +480,10 @@ func setMounts(daemon *Daemon, s *specs.Spec, c *container.Container, mounts []c
 		}
 
 		if m.Source == "tmpfs" {
+			data := c.HostConfig.Tmpfs[m.Destination]
 			options := []string{"noexec", "nosuid", "nodev", volume.DefaultPropagationMode}
-			if m.Data != "" {
-				options = append(options, strings.Split(m.Data, ",")...)
+			if data != "" {
+				options = append(options, strings.Split(data, ",")...)
 			}
 
 			merged, err := mount.MergeTmpfsOptions(options)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -129,7 +129,8 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			return err
 		}
 
-		if binds[bind.Destination] {
+		_, tmpfsExists := hostConfig.Tmpfs[bind.Destination]
+		if binds[bind.Destination] || tmpfsExists {
 			return fmt.Errorf("Duplicate mount point '%s'", bind.Destination)
 		}
 

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -16,7 +16,15 @@ import (
 // /etc/resolv.conf, and if it is not, appends it to the array of mounts.
 func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, error) {
 	var mounts []container.Mount
+	// TODO: tmpfs mounts should be part of Mountpoints
+	tmpfsMounts := make(map[string]bool)
+	for _, m := range c.TmpfsMounts() {
+		tmpfsMounts[m.Destination] = true
+	}
 	for _, m := range c.MountPoints {
+		if tmpfsMounts[m.Destination] {
+			continue
+		}
 		if err := daemon.lazyInitializeVolume(c.ID, m); err != nil {
 			return nil, err
 		}

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -829,6 +829,23 @@ func (s *DockerSuite) TestRunTmpfsMounts(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunTmpfsMountsOverrideImageVolumes(c *check.C) {
+	name := "img-with-volumes"
+	_, err := buildImage(
+		name,
+		`
+    FROM busybox
+    VOLUME /run
+    RUN touch /run/stuff
+    `,
+		true)
+	if err != nil {
+		c.Fatal(err)
+	}
+	out, _ := dockerCmd(c, "run", "--tmpfs", "/run", name, "ls", "/run")
+	c.Assert(out, checker.Not(checker.Contains), "stuff")
+}
+
 // Test case for #22420
 func (s *DockerSuite) TestRunTmpfsMountsWithOptions(c *check.C) {
 	testRequires(c, DaemonIsLinux)


### PR DESCRIPTION
Much like binds override image's defined VOLUME(s) - tmpfs should do the same:

```
docker run --rm -v /tmp:/run test true <--- this pass
docker run --rm --tmpfs /run test true <--- this should pass as well
```

Right now, the second case fails with "duplicate mounts"

ping @cpuguy83 

Signed-off-by: Antonio Murdaca runcom@redhat.com
