### PR TITLE
ioutils: fix race in access closeErr in bytespipe

### DIFF
--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -133,8 +133,9 @@ func (bp *BytesPipe) Read(p []byte) (n int, err error) {
 		}
 		bp.wait.Wait()
 		if bp.bufLen == 0 && bp.closeErr != nil {
+			err := bp.closeErr
 			bp.mu.Unlock()
-			return 0, bp.closeErr
+			return 0, err
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixed race condition in access to closeErr field
**\- How I did it**
Copied error before mutex Unlock
**\- How to verify it**
Build docker with -race and run foreground container and then terminate it.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](https://scontent-sjc2-1.cdninstagram.com/t51.2885-15/e35/13391073_186030225126877_933188692_n.jpg)
