### PR TITLE
Add run network

### DIFF
--- a/docs/examples/apt-cacher-ng.md
+++ b/docs/examples/apt-cacher-ng.md
@@ -93,8 +93,8 @@ too.
 **Option 5** creates a custom network of APT proxy server and Debian-based containers:
 
     $ docker network create mynetwork
-    $ docker run -d -p 3142:3142 --net=mynetwork --name test_apt_cacher_ng eg_apt_cacher_ng
-    $ docker run --rm -it --net=mynetwork -e http_proxy=http://test_apt_cacher_ng:3142/ debian bash
+    $ docker run -d -p 3142:3142 --network=mynetwork --name test_apt_cacher_ng eg_apt_cacher_ng
+    $ docker run --rm -it --network=mynetwork -e http_proxy=http://test_apt_cacher_ng:3142/ debian bash
 
 Apt-cacher-ng has some tools that allow you to manage the repository,
 and they can be used by leveraging the `VOLUME`

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -35,7 +35,7 @@ Some network driver plugins are listed in [plugins](plugins.md)
 The `mynet` network is now owned by `weave`, so subsequent commands
 referring to that network will be sent to the plugin,
 
-    $ docker run --net=mynet busybox top
+    $ docker run --network=mynet busybox top
 
 
 ## Write a network plugin

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -72,13 +72,13 @@ Options:
       --memory-swap string          Swap limit equal to memory plus swap: '-1' to enable unlimited swap
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1)
       --name string                 Assign a name to the container
-      --net string                  Connect a container to a network (default "default")
+      --network-alias value         Add network-scoped alias for the container (default [])
+      --network string              Connect a container to a network (default "default")
                                     'bridge': create a network stack on the default Docker bridge
                                     'none': no networking
                                     'container:<name|id>': reuse another container's network stack
                                     'host': use the Docker host network stack
                                     '<network-name>|<network-id>': connect to a user-defined network
-      --net-alias value             Add network-scoped alias for the container (default [])
       --no-healthcheck              Disable any container-specified HEALTHCHECK
       --oom-kill-disable            Disable OOM Killer
       --oom-score-adj int           Tune host's OOM preferences (-1000 to 1000)

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -921,7 +921,7 @@ This option will completely disable user namespace mapping for the container's u
 The following standard Docker features are currently incompatible when
 running a Docker daemon with user namespaces enabled:
 
- - sharing PID or NET namespaces with the host (`--pid=host` or `--net=host`)
+ - sharing PID or NET namespaces with the host (`--pid=host` or `--network=host`)
  - A `--read-only` container filesystem (this is a Linux kernel restriction against remounting with modified flags of a currently mounted filesystem when inside a user namespace)
  - external (volume or graph) drivers which are unaware/incapable of using daemon user mappings
  - Using `--privileged` mode flag on `docker run` (unless also specifying `--userns=host`)

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -32,10 +32,10 @@ the same network.
 $ docker network connect multi-host-network container1
 ```
 
-You can also use the `docker run --net=<network-name>` option to start a container and immediately connect it to a network.
+You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
 
 ```bash
-$ docker run -itd --net=multi-host-network busybox
+$ docker run -itd --network=multi-host-network busybox
 ```
 
 You can specify the IP address you want to be assigned to the container's interface.

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -82,11 +82,11 @@ name conflicts.
 
 ## Connect containers
 
-When you start a container, use the `--net` flag to connect it to a network.
+When you start a container, use the `--network` flag to connect it to a network.
 This example adds the `busybox` container to the `mynet` network:
 
 ```bash
-$ docker run -itd --net=mynet busybox
+$ docker run -itd --network=mynet busybox
 ```
 
 If you want to add a container to a network after the container is already

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -78,13 +78,13 @@ Options:
       --memory-swap string          Swap limit equal to memory plus swap: '-1' to enable unlimited swap
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1).
       --name string                 Assign a name to the container
-      --net string                  Connect a container to a network (default "default")
+      --network-alias value         Add network-scoped alias for the container (default [])
+      --network string              Connect a container to a network
                                     'bridge': create a network stack on the default Docker bridge
                                     'none': no networking
                                     'container:<name|id>': reuse another container's network stack
                                     'host': use the Docker host network stack
                                     '<network-name>|<network-id>': connect to a user-defined network
-      --net-alias value             Add network-scoped alias for the container (default [])
       --no-healthcheck              Disable any container-specified HEALTHCHECK
       --oom-kill-disable            Disable OOM Killer
       --oom-score-adj int           Tune host's OOM preferences (-1000 to 1000)
@@ -360,20 +360,20 @@ For additional information on working with labels, see [*Labels - custom
 metadata in Docker*](../../userguide/labels-custom-metadata.md) in the Docker User
 Guide.
 
-### Connect a container to a network (--net)
+### Connect a container to a network (--network)
 
-When you start a container use the `--net` flag to connect it to a network.
+When you start a container use the `--network` flag to connect it to a network.
 This adds the `busybox` container to the `my-net` network.
 
 ```bash
-$ docker run -itd --net=my-net busybox
+$ docker run -itd --network=my-net busybox
 ```
 
 You can also choose the IP addresses for the container with `--ip` and `--ip6`
 flags when you start the container on a user-defined network.
 
 ```bash
-$ docker run -itd --net=my-net --ip=10.10.9.75 busybox
+$ docker run -itd --network=my-net --ip=10.10.9.75 busybox
 ```
 
 If you want to add a running container to a network use the `docker network connect` subcommand.
@@ -673,4 +673,4 @@ network namespace, run this command:
   `Network Namespace`:
       Sysctls beginning with net.*
 
-  If you use the `--net=host` option using these sysctls will not be allowed.
+  If you use the `--network=host` option using these sysctls will not be allowed.

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -259,7 +259,7 @@ $ strace -p 1
 
 The UTS namespace is for setting the hostname and the domain that is visible
 to running processes in that namespace.  By default, all containers, including
-those with `--net=host`, have their own UTS namespace.  The `host` setting will
+those with `--network=host`, have their own UTS namespace.  The `host` setting will
 result in the container using the same UTS namespace as the host.  Note that
 `--hostname` is invalid in `host` UTS mode.
 
@@ -289,13 +289,13 @@ of the containers.
 ## Network settings
 
     --dns=[]           : Set custom dns servers for the container
-    --net="bridge"     : Connect a container to a network
+    --network="bridge" : Connect a container to a network
                           'bridge': create a network stack on the default Docker bridge
                           'none': no networking
                           'container:<name|id>': reuse another container's network stack
                           'host': use the Docker host network stack
                           '<network-name>|<network-id>': connect to a user-defined network
-    --net-alias=[]     : Add network-scoped alias for the container
+    --network-alias=[] : Add network-scoped alias for the container
     --add-host=""      : Add a line to /etc/hosts (host:IP)
     --mac-address=""   : Sets the container's Ethernet device's MAC address
     --ip=""            : Sets the container's Ethernet device's IPv4 address
@@ -304,7 +304,7 @@ of the containers.
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking
-with `docker run --net none` which disables all incoming and outgoing
+with `docker run --network none` which disables all incoming and outgoing
 networking. In cases like this, you would perform I/O through files or
 `STDIN` and `STDOUT` only.
 
@@ -404,14 +404,14 @@ docker daemon. It is recommended to run containers in this mode when their
 networking performance is critical, for example, a production Load Balancer
 or a High Performance Web Server.
 
-> **Note**: `--net="host"` gives the container full access to local system
+> **Note**: `--network="host"` gives the container full access to local system
 > services such as D-bus and is therefore considered insecure.
 
 #### Network: container
 
 With the network set to `container` a container will share the
 network stack of another container.  The other container's name must be
-provided in the format of `--net container:<name|id>`. Note that `--add-host`
+provided in the format of `--network container:<name|id>`. Note that `--add-host`
 `--hostname` `--dns` `--dns-search` `--dns-opt` and `--mac-address` are
 invalid in `container` netmode, and `--publish` `--publish-all` `--expose` are
 also invalid in `container` netmode.
@@ -422,7 +422,7 @@ running the `redis-cli` command and connecting to the Redis server over the
 
     $ docker run -d --name redis example/redis --bind 127.0.0.1
     $ # use the redis container's network stack to access localhost
-    $ docker run --rm -it --net container:redis example/redis-cli -h 127.0.0.1
+    $ docker run --rm -it --network container:redis example/redis-cli -h 127.0.0.1
 
 #### User-defined network
 
@@ -440,7 +440,7 @@ driver and running a container in the created network
 
 ```
 $ docker network create -d bridge my-net
-$ docker run --net=my-net -itd --name=container3 busybox
+$ docker run --network=my-net -itd --name=container3 busybox
 ```
 
 ### Managing /etc/hosts

--- a/docs/tutorials/networkingcontainers.md
+++ b/docs/tutorials/networkingcontainers.md
@@ -198,9 +198,9 @@ To build web applications that act in concert but do so securely, create a
 network. Networks, by definition, provide complete isolation for containers. You
 can add containers to a network when you first run a container.
 
-Launch a container running a PostgreSQL database and pass it the `--net=my-bridge-network` flag to connect it to your new network:
+Launch a container running a PostgreSQL database and pass it the `--network=my-bridge-network` flag to connect it to your new network:
 
-    $ docker run -d --net=my-bridge-network --name db training/postgres
+    $ docker run -d --network=my-bridge-network --name db training/postgres
 
 If you inspect your `my-bridge-network` you'll see it has a container attached.
 You can also inspect your container to see where it is connected:

--- a/docs/userguide/networking/configure-dns.md
+++ b/docs/userguide/networking/configure-dns.md
@@ -48,13 +48,13 @@ Various container options that affect container domain name services.
   <tr>
     <td>
     <p>
-    <code>--net-alias=ALIAS</code>
+    <code>--network-alias=ALIAS</code>
     </p>
     </td>
     <td>
     <p>
      In addition to <code>--name</code> as described above, a container is discovered by one or more 
-     of its configured <code>--net-alias</code> (or <code>--alias</code> in <code>docker network connect</code> command)
+     of its configured <code>--network-alias</code> (or <code>--alias</code> in <code>docker network connect</code> command)
      within the user-defined network. The embedded DNS server maintains the mapping between
      all of the container aliases and its IP address on a specific user-defined network.
      A container can have different aliases in different networks by using the <code>--alias</code>

--- a/docs/userguide/networking/default_network/container-communication.md
+++ b/docs/userguide/networking/default_network/container-communication.md
@@ -42,7 +42,7 @@ or to turn it on manually:
 ```
 
 > **Note**: this setting does not affect containers that use the host
-> network stack (`--net=host`).
+> network stack (`--network=host`).
 
 Many using Docker will want `ip_forward` to be on, to at least make
 communication _possible_ between containers and the wider world. May also be

--- a/docs/userguide/networking/dockernetworks.md
+++ b/docs/userguide/networking/dockernetworks.md
@@ -37,12 +37,12 @@ cf03ee007fb4        host                host
 ```
 
 Historically, these three networks are part of Docker's implementation. When
-you run a container you can use the `--net` flag to specify which network you
+you run a container you can use the `--network` flag to specify which network you
 want to run a container on. These three networks are still available to you.
 
 The `bridge` network represents the `docker0` network present in all Docker
 installations. Unless you specify otherwise with the `docker run
---net=<NETWORK>` option, the Docker daemon connects containers to this network
+--network=<NETWORK>` option, the Docker daemon connects containers to this network
 by default. You can see this bridge as part of a host's network stack by using
 the `ifconfig` command on the host.
 
@@ -352,10 +352,10 @@ c5ee82f76de3        isolated_nw         bridge
 
 ```
 
-After you create the network, you can launch containers on it using  the `docker run --net=<NETWORK>` option.
+After you create the network, you can launch containers on it using  the `docker run --network=<NETWORK>` option.
 
 ```
-$ docker run --net=isolated_nw -itd --name=container3 busybox
+$ docker run --network=isolated_nw -itd --name=container3 busybox
 
 8c1a0a5be480921d669a073393ade66a3fc49933f08bcc5515b37b8144f6d47c
 
@@ -473,7 +473,7 @@ provides complete isolation for the containers.
 
 Then, on each host, launch containers making sure to specify the network name.
 
-    $ docker run -itd --net=my-multi-host-network busybox
+    $ docker run -itd --network=my-multi-host-network busybox
 
 Once connected, each container has access to all the containers in the network
 regardless of which Docker host the container was launched on.

--- a/docs/userguide/networking/get-started-overlay.md
+++ b/docs/userguide/networking/get-started-overlay.md
@@ -223,11 +223,11 @@ Once your network is created, you can start a container on any of the hosts and 
 
 2. Start an Nginx web server on the `mhs-demo0` instance.
 
-		$ docker run -itd --name=web --net=my-net --env="constraint:node==mhs-demo0" nginx
+		$ docker run -itd --name=web --network=my-net --env="constraint:node==mhs-demo0" nginx
 
 4. Run a BusyBox instance on the `mhs-demo1` instance and get the contents of the Nginx server's home page.
 
-		$ docker run -it --rm --net=my-net --env="constraint:node==mhs-demo1" busybox wget -O- http://web
+		$ docker run -it --rm --network=my-net --env="constraint:node==mhs-demo1" busybox wget -O- http://web
 
 		Unable to find image 'busybox:latest' locally
 		latest: Pulling from library/busybox

--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -164,7 +164,7 @@ $ docker network inspect my-network
     }
 ]
 
-$ docker run -d -P --name redis --net my-network redis
+$ docker run -d -P --name redis --network my-network redis
 
 bafb0c808c53104b2c90346f284bda33a69beadcab4fc83ab8f2c5a4410cd129
 
@@ -244,10 +244,10 @@ $ docker network inspect isolated_nw
 You can see that the Engine automatically assigns an IP address to `container2`.
 Given we specified a `--subnet` when creating the network, Engine picked
 an address from that same subnet. Now, start a third container and connect it to
-the network on launch using the `docker run` command's `--net` option:
+the network on launch using the `docker run` command's `--network` option:
 
 ```bash
-$ docker run --net=isolated_nw --ip=172.25.3.3 -itd --name=container3 busybox
+$ docker run --network=isolated_nw --ip=172.25.3.3 -itd --name=container3 busybox
 
 467a7863c3f0277ef8e661b38427737f28099b61fa55622d6c30fb288d88c551
 ```
@@ -450,7 +450,7 @@ Continuing with the above example, create another container `container4` in
 for other containers in the same network.
 
 ```bash
-$ docker run --net=isolated_nw -itd --name=container4 --link container5:c5 busybox
+$ docker run --network=isolated_nw -itd --name=container4 --link container5:c5 busybox
 
 01b5df970834b77a9eadbaff39051f237957bd35c4c56f11193e0594cfd5117c
 ```
@@ -471,7 +471,7 @@ Now let us launch another container named `container5` linking `container4` to
 c4.
 
 ```bash
-$ docker run --net=isolated_nw -itd --name=container5 --link container4:c4 busybox
+$ docker run --network=isolated_nw -itd --name=container5 --link container4:c4 busybox
 
 72eccf2208336f31e9e33ba327734125af00d1e1d2657878e2ee8154fbb23c7a
 ```
@@ -629,7 +629,7 @@ Continuing with the above example, create another container in `isolated_nw`
 with a network alias.
 
 ```bash
-$ docker run --net=isolated_nw -itd --name=container6 --net-alias app busybox
+$ docker run --network=isolated_nw -itd --name=container6 --network-alias app busybox
 
 8ebe6767c1e0361f27433090060b33200aac054a68476c3be87ef4005eb1df17
 ```
@@ -702,7 +702,7 @@ network-scoped alias within the same network. For example, let's launch
 `container7` in `isolated_nw` with the same alias as `container6`
 
 ```bash
-$ docker run --net=isolated_nw -itd --name=container7 --net-alias app busybox
+$ docker run --network=isolated_nw -itd --name=container7 --network-alias app busybox
 
 3138c678c123b8799f4c7cc6a0cecc595acbdfa8bf81f621834103cd4f504554
 ```
@@ -859,7 +859,7 @@ endpoint from the network. Once the endpoint is cleaned up, the container can
 be connected to the network.
 
 ```bash
-$ docker run -d --name redis_db --net multihost redis
+$ docker run -d --name redis_db --network multihost redis
 
 ERROR: Cannot start container bc0b19c089978f7845633027aa3435624ca3d12dd4f4f764b61eac4c0610f32e: container already connected to network multihost
 
@@ -867,7 +867,7 @@ $ docker rm -f redis_db
 
 $ docker network disconnect -f multihost redis_db
 
-$ docker run -d --name redis_db --net multihost redis
+$ docker run -d --name redis_db --network multihost redis
 
 7d986da974aeea5e9f7aca7e510bdb216d58682faa83a9040c2f2adc0544795a
 ```

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1660,3 +1660,15 @@ func (s *DockerDaemonSuite) TestDaemonRestartRestoreBridgeNetwork(t *check.C) {
 		t.Fatal(err)
 	}
 }
+
+func (s *DockerNetworkSuite) TestDockerNetworkFlagAlias(c *check.C) {
+	dockerCmd(c, "network", "create", "user")
+	output, status := dockerCmd(c, "run", "--rm", "--network=user", "--network-alias=foo", "busybox", "true")
+	c.Assert(status, checker.Equals, 0, check.Commentf("unexpected status code %d (%s)", status, output))
+
+	output, status, _ = dockerCmdWithError("run", "--rm", "--net=user", "--network=user", "busybox", "true")
+	c.Assert(status, checker.Equals, 0, check.Commentf("unexpected status code %d (%s)", status, output))
+
+	output, status, _ = dockerCmdWithError("run", "--rm", "--network=user", "--net-alias=foo", "--network-alias=bar", "busybox", "true")
+	c.Assert(status, checker.Equals, 0, check.Commentf("unexpected status code %d (%s)", status, output))
+}

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -52,8 +52,8 @@ docker-create - Create a new container
 [**--memory-swap**[=*LIMIT*]]
 [**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
 [**--name**[=*NAME*]]
-[**--net**[=*"bridge"*]]
-[**--net-alias**[=*[]*]]
+[**--network-alias**[=*[]*]]
+[**--network**[=*"bridge"*]]
 [**--oom-kill-disable**]
 [**--oom-score-adj**[=*0*]]
 [**-P**|**--publish-all**]
@@ -276,7 +276,7 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
                                'host': use the Docker host network stack.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
                                '<network-name>|<network-id>': connect to a user-defined network
 
-**--net-alias**=[]
+**--network-alias**=[]
    Add network-scoped alias for the container
 
 **--oom-kill-disable**=*true*|*false*

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -54,8 +54,8 @@ docker-run - Run a command in a new container
 [**--memory-swap**[=*LIMIT*]]
 [**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
 [**--name**[=*NAME*]]
-[**--net**[=*"bridge"*]]
-[**--net-alias**[=*[]*]]
+[**--network-alias**[=*[]*]]
+[**--network**[=*"bridge"*]]
 [**--oom-kill-disable**]
 [**--oom-score-adj**[=*0*]]
 [**-P**|**--publish-all**]
@@ -395,7 +395,7 @@ and foreground Docker containers.
                                'host': use the Docker host network stack. Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
                                '<network-name>|<network-id>': connect to a user-defined network
 
-**--net-alias**=[]
+**--network-alias**=[]
    Add network-scoped alias for the container
 
 **--oom-kill-disable**=*true*|*false*

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -182,10 +182,16 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.Var(&copts.flLinks, "link", "Add link to another container")
 	flags.Var(&copts.flLinkLocalIPs, "link-local-ip", "Container IPv4/IPv6 link-local addresses")
 	flags.StringVar(&copts.flMacAddress, "mac-address", "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
-	flags.StringVar(&copts.flNetMode, "net", "default", "Connect a container to a network")
-	flags.Var(&copts.flAliases, "net-alias", "Add network-scoped alias for the container")
 	flags.VarP(&copts.flPublish, "publish", "p", "Publish a container's port(s) to the host")
 	flags.BoolVarP(&copts.flPublishAll, "publish-all", "P", false, "Publish all exposed ports to random ports")
+	// We allow for both "--net" and "--network", although the latter is the recommended way.
+	flags.StringVar(&copts.flNetMode, "net", "default", "Connect a container to a network")
+	flags.StringVar(&copts.flNetMode, "network", "default", "Connect a container to a network")
+	flags.MarkHidden("net")
+	// We allow for both "--net-alias" and "--network-alias", although the latter is the recommended way.
+	flags.Var(&copts.flAliases, "net-alias", "Add network-scoped alias for the container")
+	flags.Var(&copts.flAliases, "network-alias", "Add network-scoped alias for the container")
+	flags.MarkHidden("net-alias")
 
 	// Logging and storage
 	flags.StringVar(&copts.flLoggingDriver, "log-driver", "", "Logging driver for container")

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -55,54 +55,54 @@ type ContainerOptions struct {
 	flStorageOpt        opts.ListOpts
 	flLabelsFile        opts.ListOpts
 	flLoggingOpts       opts.ListOpts
-	flPrivileged        *bool
-	flPidMode           *string
-	flUTSMode           *string
-	flUsernsMode        *string
-	flPublishAll        *bool
-	flStdin             *bool
-	flTty               *bool
-	flOomKillDisable    *bool
-	flOomScoreAdj       *int
-	flContainerIDFile   *string
-	flEntrypoint        *string
-	flHostname          *string
-	flMemoryString      *string
-	flMemoryReservation *string
-	flMemorySwap        *string
-	flKernelMemory      *string
-	flUser              *string
-	flWorkingDir        *string
-	flCPUShares         *int64
-	flCPUPercent        *int64
-	flCPUPeriod         *int64
-	flCPUQuota          *int64
-	flCpusetCpus        *string
-	flCpusetMems        *string
-	flBlkioWeight       *uint16
-	flIOMaxBandwidth    *string
-	flIOMaxIOps         *uint64
-	flSwappiness        *int64
-	flNetMode           *string
-	flMacAddress        *string
-	flIPv4Address       *string
-	flIPv6Address       *string
-	flIpcMode           *string
-	flPidsLimit         *int64
-	flRestartPolicy     *string
-	flReadonlyRootfs    *bool
-	flLoggingDriver     *string
-	flCgroupParent      *string
-	flVolumeDriver      *string
-	flStopSignal        *string
-	flIsolation         *string
-	flShmSize           *string
-	flNoHealthcheck     *bool
-	flHealthCmd         *string
-	flHealthInterval    *time.Duration
-	flHealthTimeout     *time.Duration
-	flHealthRetries     *int
-	flRuntime           *string
+	flPrivileged        bool
+	flPidMode           string
+	flUTSMode           string
+	flUsernsMode        string
+	flPublishAll        bool
+	flStdin             bool
+	flTty               bool
+	flOomKillDisable    bool
+	flOomScoreAdj       int
+	flContainerIDFile   string
+	flEntrypoint        string
+	flHostname          string
+	flMemoryString      string
+	flMemoryReservation string
+	flMemorySwap        string
+	flKernelMemory      string
+	flUser              string
+	flWorkingDir        string
+	flCPUShares         int64
+	flCPUPercent        int64
+	flCPUPeriod         int64
+	flCPUQuota          int64
+	flCpusetCpus        string
+	flCpusetMems        string
+	flBlkioWeight       uint16
+	flIOMaxBandwidth    string
+	flIOMaxIOps         uint64
+	flSwappiness        int64
+	flNetMode           string
+	flMacAddress        string
+	flIPv4Address       string
+	flIPv6Address       string
+	flIpcMode           string
+	flPidsLimit         int64
+	flRestartPolicy     string
+	flReadonlyRootfs    bool
+	flLoggingDriver     string
+	flCgroupParent      string
+	flVolumeDriver      string
+	flStopSignal        string
+	flIsolation         string
+	flShmSize           string
+	flNoHealthcheck     bool
+	flHealthCmd         string
+	flHealthInterval    time.Duration
+	flHealthTimeout     time.Duration
+	flHealthRetries     int
+	flRuntime           string
 
 	Image string
 	Args  []string
@@ -111,122 +111,131 @@ type ContainerOptions struct {
 // AddFlags adds all command line flags that will be used by Parse to the FlagSet
 func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	copts := &ContainerOptions{
-		flAttach:            opts.NewListOpts(ValidateAttach),
-		flVolumes:           opts.NewListOpts(nil),
-		flTmpfs:             opts.NewListOpts(nil),
-		flBlkioWeightDevice: NewWeightdeviceOpt(ValidateWeightDevice),
-		flDeviceReadBps:     NewThrottledeviceOpt(ValidateThrottleBpsDevice),
-		flDeviceWriteBps:    NewThrottledeviceOpt(ValidateThrottleBpsDevice),
-		flLinks:             opts.NewListOpts(ValidateLink),
 		flAliases:           opts.NewListOpts(nil),
-		flLinkLocalIPs:      opts.NewListOpts(nil),
+		flAttach:            opts.NewListOpts(ValidateAttach),
+		flBlkioWeightDevice: NewWeightdeviceOpt(ValidateWeightDevice),
+		flCapAdd:            opts.NewListOpts(nil),
+		flCapDrop:           opts.NewListOpts(nil),
+		flDNS:               opts.NewListOpts(opts.ValidateIPAddress),
+		flDNSOptions:        opts.NewListOpts(nil),
+		flDNSSearch:         opts.NewListOpts(opts.ValidateDNSSearch),
+		flDeviceReadBps:     NewThrottledeviceOpt(ValidateThrottleBpsDevice),
 		flDeviceReadIOps:    NewThrottledeviceOpt(ValidateThrottleIOpsDevice),
+		flDeviceWriteBps:    NewThrottledeviceOpt(ValidateThrottleBpsDevice),
 		flDeviceWriteIOps:   NewThrottledeviceOpt(ValidateThrottleIOpsDevice),
-		flEnv:               opts.NewListOpts(ValidateEnv),
-		flLabels:            opts.NewListOpts(ValidateEnv),
 		flDevices:           opts.NewListOpts(ValidateDevice),
-
-		flUlimits: NewUlimitOpt(nil),
-		flSysctls: opts.NewMapOpts(nil, opts.ValidateSysctl),
-
-		flPublish:     opts.NewListOpts(nil),
-		flExpose:      opts.NewListOpts(nil),
-		flDNS:         opts.NewListOpts(opts.ValidateIPAddress),
-		flDNSSearch:   opts.NewListOpts(opts.ValidateDNSSearch),
-		flDNSOptions:  opts.NewListOpts(nil),
-		flExtraHosts:  opts.NewListOpts(ValidateExtraHost),
-		flVolumesFrom: opts.NewListOpts(nil),
-		flEnvFile:     opts.NewListOpts(nil),
-		flCapAdd:      opts.NewListOpts(nil),
-		flCapDrop:     opts.NewListOpts(nil),
-		flGroupAdd:    opts.NewListOpts(nil),
-		flSecurityOpt: opts.NewListOpts(nil),
-		flStorageOpt:  opts.NewListOpts(nil),
-		flLabelsFile:  opts.NewListOpts(nil),
-		flLoggingOpts: opts.NewListOpts(nil),
-
-		flPrivileged:        flags.Bool("privileged", false, "Give extended privileges to this container"),
-		flPidMode:           flags.String("pid", "", "PID namespace to use"),
-		flUTSMode:           flags.String("uts", "", "UTS namespace to use"),
-		flUsernsMode:        flags.String("userns", "", "User namespace to use"),
-		flPublishAll:        flags.BoolP("publish-all", "P", false, "Publish all exposed ports to random ports"),
-		flStdin:             flags.BoolP("interactive", "i", false, "Keep STDIN open even if not attached"),
-		flTty:               flags.BoolP("tty", "t", false, "Allocate a pseudo-TTY"),
-		flOomKillDisable:    flags.Bool("oom-kill-disable", false, "Disable OOM Killer"),
-		flOomScoreAdj:       flags.Int("oom-score-adj", 0, "Tune host's OOM preferences (-1000 to 1000)"),
-		flContainerIDFile:   flags.String("cidfile", "", "Write the container ID to the file"),
-		flEntrypoint:        flags.String("entrypoint", "", "Overwrite the default ENTRYPOINT of the image"),
-		flHostname:          flags.StringP("hostname", "h", "", "Container host name"),
-		flMemoryString:      flags.StringP("memory", "m", "", "Memory limit"),
-		flMemoryReservation: flags.String("memory-reservation", "", "Memory soft limit"),
-		flMemorySwap:        flags.String("memory-swap", "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap"),
-		flKernelMemory:      flags.String("kernel-memory", "", "Kernel memory limit"),
-		flUser:              flags.StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])"),
-		flWorkingDir:        flags.StringP("workdir", "w", "", "Working directory inside the container"),
-		flCPUShares:         flags.Int64P("cpu-shares", "c", 0, "CPU shares (relative weight)"),
-		flCPUPercent:        flags.Int64("cpu-percent", 0, "CPU percent (Windows only)"),
-		flCPUPeriod:         flags.Int64("cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period"),
-		flCPUQuota:          flags.Int64("cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota"),
-		flCpusetCpus:        flags.String("cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)"),
-		flCpusetMems:        flags.String("cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)"),
-		flBlkioWeight:       flags.Uint16("blkio-weight", 0, "Block IO (relative weight), between 10 and 1000"),
-		flIOMaxBandwidth:    flags.String("io-maxbandwidth", "", "Maximum IO bandwidth limit for the system drive (Windows only)"),
-		flIOMaxIOps:         flags.Uint64("io-maxiops", 0, "Maximum IOps limit for the system drive (Windows only)"),
-		flSwappiness:        flags.Int64("memory-swappiness", -1, "Tune container memory swappiness (0 to 100)"),
-		flNetMode:           flags.String("net", "default", "Connect a container to a network"),
-		flMacAddress:        flags.String("mac-address", "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)"),
-		flIPv4Address:       flags.String("ip", "", "Container IPv4 address (e.g. 172.30.100.104)"),
-		flIPv6Address:       flags.String("ip6", "", "Container IPv6 address (e.g. 2001:db8::33)"),
-		flIpcMode:           flags.String("ipc", "", "IPC namespace to use"),
-		flPidsLimit:         flags.Int64("pids-limit", 0, "Tune container pids limit (set -1 for unlimited)"),
-		flRestartPolicy:     flags.String("restart", "no", "Restart policy to apply when a container exits"),
-		flReadonlyRootfs:    flags.Bool("read-only", false, "Mount the container's root filesystem as read only"),
-		flLoggingDriver:     flags.String("log-driver", "", "Logging driver for container"),
-		flCgroupParent:      flags.String("cgroup-parent", "", "Optional parent cgroup for the container"),
-		flVolumeDriver:      flags.String("volume-driver", "", "Optional volume driver for the container"),
-		flStopSignal:        flags.String("stop-signal", signal.DefaultStopSignal, fmt.Sprintf("Signal to stop a container, %v by default", signal.DefaultStopSignal)),
-		flIsolation:         flags.String("isolation", "", "Container isolation technology"),
-		flShmSize:           flags.String("shm-size", "", "Size of /dev/shm, default value is 64MB"),
-		flNoHealthcheck:     flags.Bool("no-healthcheck", false, "Disable any container-specified HEALTHCHECK"),
-		flHealthCmd:         flags.String("health-cmd", "", "Command to run to check health"),
-		flHealthInterval:    flags.Duration("health-interval", 0, "Time between running the check"),
-		flHealthTimeout:     flags.Duration("health-timeout", 0, "Maximum time to allow one check to run"),
-		flHealthRetries:     flags.Int("health-retries", 0, "Consecutive failures needed to report unhealthy"),
-		flRuntime:           flags.String("runtime", "", "Runtime to use for this container"),
+		flEnv:               opts.NewListOpts(ValidateEnv),
+		flEnvFile:           opts.NewListOpts(nil),
+		flExpose:            opts.NewListOpts(nil),
+		flExtraHosts:        opts.NewListOpts(ValidateExtraHost),
+		flGroupAdd:          opts.NewListOpts(nil),
+		flLabels:            opts.NewListOpts(ValidateEnv),
+		flLabelsFile:        opts.NewListOpts(nil),
+		flLinkLocalIPs:      opts.NewListOpts(nil),
+		flLinks:             opts.NewListOpts(ValidateLink),
+		flLoggingOpts:       opts.NewListOpts(nil),
+		flPublish:           opts.NewListOpts(nil),
+		flSecurityOpt:       opts.NewListOpts(nil),
+		flStorageOpt:        opts.NewListOpts(nil),
+		flSysctls:           opts.NewMapOpts(nil, opts.ValidateSysctl),
+		flTmpfs:             opts.NewListOpts(nil),
+		flUlimits:           NewUlimitOpt(nil),
+		flVolumes:           opts.NewListOpts(nil),
+		flVolumesFrom:       opts.NewListOpts(nil),
 	}
 
+	// General purpose flags
 	flags.VarP(&copts.flAttach, "attach", "a", "Attach to STDIN, STDOUT or STDERR")
-	flags.Var(&copts.flBlkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
-	flags.Var(&copts.flDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
-	flags.Var(&copts.flDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) to a device")
-	flags.Var(&copts.flDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
-	flags.Var(&copts.flDeviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) to a device")
-	flags.VarP(&copts.flVolumes, "volume", "v", "Bind mount a volume")
-	flags.Var(&copts.flTmpfs, "tmpfs", "Mount a tmpfs directory")
-	flags.Var(&copts.flLinks, "link", "Add link to another container")
-	flags.Var(&copts.flAliases, "net-alias", "Add network-scoped alias for the container")
-	flags.Var(&copts.flLinkLocalIPs, "link-local-ip", "Container IPv4/IPv6 link-local addresses")
 	flags.Var(&copts.flDevices, "device", "Add a host device to the container")
-	flags.VarP(&copts.flLabels, "label", "l", "Set meta data on a container")
-	flags.Var(&copts.flLabelsFile, "label-file", "Read in a line delimited file of labels")
 	flags.VarP(&copts.flEnv, "env", "e", "Set environment variables")
 	flags.Var(&copts.flEnvFile, "env-file", "Read in a file of environment variables")
-	flags.VarP(&copts.flPublish, "publish", "p", "Publish a container's port(s) to the host")
-	flags.Var(&copts.flExpose, "expose", "Expose a port or a range of ports")
-	flags.Var(&copts.flDNS, "dns", "Set custom DNS servers")
-	flags.Var(&copts.flDNSSearch, "dns-search", "Set custom DNS search domains")
-	flags.Var(&copts.flDNSOptions, "dns-opt", "Set DNS options")
-	flags.Var(&copts.flExtraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")
-	flags.Var(&copts.flVolumesFrom, "volumes-from", "Mount volumes from the specified container(s)")
+	flags.StringVar(&copts.flEntrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
+	flags.Var(&copts.flGroupAdd, "group-add", "Add additional groups to join")
+	flags.StringVarP(&copts.flHostname, "hostname", "h", "", "Container host name")
+	flags.BoolVarP(&copts.flStdin, "interactive", "i", false, "Keep STDIN open even if not attached")
+	flags.VarP(&copts.flLabels, "label", "l", "Set meta data on a container")
+	flags.Var(&copts.flLabelsFile, "label-file", "Read in a line delimited file of labels")
+	flags.BoolVar(&copts.flReadonlyRootfs, "read-only", false, "Mount the container's root filesystem as read only")
+	flags.StringVar(&copts.flRestartPolicy, "restart", "no", "Restart policy to apply when a container exits")
+	flags.StringVar(&copts.flStopSignal, "stop-signal", signal.DefaultStopSignal, fmt.Sprintf("Signal to stop a container, %v by default", signal.DefaultStopSignal))
+	flags.Var(copts.flSysctls, "sysctl", "Sysctl options")
+	flags.BoolVarP(&copts.flTty, "tty", "t", false, "Allocate a pseudo-TTY")
+	flags.Var(copts.flUlimits, "ulimit", "Ulimit options")
+	flags.StringVarP(&copts.flUser, "user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	flags.StringVarP(&copts.flWorkingDir, "workdir", "w", "", "Working directory inside the container")
+
+	// Security
 	flags.Var(&copts.flCapAdd, "cap-add", "Add Linux capabilities")
 	flags.Var(&copts.flCapDrop, "cap-drop", "Drop Linux capabilities")
-	flags.Var(&copts.flGroupAdd, "group-add", "Add additional groups to join")
+	flags.BoolVar(&copts.flPrivileged, "privileged", false, "Give extended privileges to this container")
 	flags.Var(&copts.flSecurityOpt, "security-opt", "Security Options")
-	flags.Var(&copts.flStorageOpt, "storage-opt", "Set storage driver options per container")
-	flags.Var(copts.flUlimits, "ulimit", "Ulimit options")
-	flags.Var(copts.flSysctls, "sysctl", "Sysctl options")
-	flags.Var(&copts.flLoggingOpts, "log-opt", "Log driver options")
+	flags.StringVar(&copts.flUsernsMode, "userns", "", "User namespace to use")
 
+	// Network and port publishing flag
+	flags.Var(&copts.flExtraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")
+	flags.Var(&copts.flDNS, "dns", "Set custom DNS servers")
+	flags.Var(&copts.flDNSOptions, "dns-opt", "Set DNS options")
+	flags.Var(&copts.flDNSSearch, "dns-search", "Set custom DNS search domains")
+	flags.Var(&copts.flExpose, "expose", "Expose a port or a range of ports")
+	flags.StringVar(&copts.flIPv4Address, "ip", "", "Container IPv4 address (e.g. 172.30.100.104)")
+	flags.StringVar(&copts.flIPv6Address, "ip6", "", "Container IPv6 address (e.g. 2001:db8::33)")
+	flags.Var(&copts.flLinks, "link", "Add link to another container")
+	flags.Var(&copts.flLinkLocalIPs, "link-local-ip", "Container IPv4/IPv6 link-local addresses")
+	flags.StringVar(&copts.flMacAddress, "mac-address", "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
+	flags.StringVar(&copts.flNetMode, "net", "default", "Connect a container to a network")
+	flags.Var(&copts.flAliases, "net-alias", "Add network-scoped alias for the container")
+	flags.VarP(&copts.flPublish, "publish", "p", "Publish a container's port(s) to the host")
+	flags.BoolVarP(&copts.flPublishAll, "publish-all", "P", false, "Publish all exposed ports to random ports")
+
+	// Logging and storage
+	flags.StringVar(&copts.flLoggingDriver, "log-driver", "", "Logging driver for container")
+	flags.StringVar(&copts.flVolumeDriver, "volume-driver", "", "Optional volume driver for the container")
+	flags.Var(&copts.flLoggingOpts, "log-opt", "Log driver options")
+	flags.Var(&copts.flStorageOpt, "storage-opt", "Set storage driver options per container")
+	flags.Var(&copts.flTmpfs, "tmpfs", "Mount a tmpfs directory")
+	flags.Var(&copts.flVolumesFrom, "volumes-from", "Mount volumes from the specified container(s)")
+	flags.VarP(&copts.flVolumes, "volume", "v", "Bind mount a volume")
+
+	// Health-checking
+	flags.StringVar(&copts.flHealthCmd, "health-cmd", "", "Command to run to check health")
+	flags.DurationVar(&copts.flHealthInterval, "health-interval", 0, "Time between running the check")
+	flags.IntVar(&copts.flHealthRetries, "health-retries", 0, "Consecutive failures needed to report unhealthy")
+	flags.DurationVar(&copts.flHealthTimeout, "health-timeout", 0, "Maximum time to allow one check to run")
+	flags.BoolVar(&copts.flNoHealthcheck, "no-healthcheck", false, "Disable any container-specified HEALTHCHECK")
+
+	// Resource management
+	flags.Uint16Var(&copts.flBlkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000")
+	flags.Var(&copts.flBlkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
+	flags.StringVar(&copts.flContainerIDFile, "cidfile", "", "Write the container ID to the file")
+	flags.StringVar(&copts.flCpusetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
+	flags.StringVar(&copts.flCpusetMems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
+	flags.Int64Var(&copts.flCPUPercent, "cpu-percent", 0, "CPU percent (Windows only)")
+	flags.Int64Var(&copts.flCPUPeriod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period")
+	flags.Int64Var(&copts.flCPUQuota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
+	flags.Int64VarP(&copts.flCPUShares, "cpu-shares", "c", 0, "CPU shares (relative weight)")
+	flags.Var(&copts.flDeviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
+	flags.Var(&copts.flDeviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
+	flags.Var(&copts.flDeviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) to a device")
+	flags.Var(&copts.flDeviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) to a device")
+	flags.StringVar(&copts.flIOMaxBandwidth, "io-maxbandwidth", "", "Maximum IO bandwidth limit for the system drive (Windows only)")
+	flags.Uint64Var(&copts.flIOMaxIOps, "io-maxiops", 0, "Maximum IOps limit for the system drive (Windows only)")
+	flags.StringVar(&copts.flKernelMemory, "kernel-memory", "", "Kernel memory limit")
+	flags.StringVarP(&copts.flMemoryString, "memory", "m", "", "Memory limit")
+	flags.StringVar(&copts.flMemoryReservation, "memory-reservation", "", "Memory soft limit")
+	flags.StringVar(&copts.flMemorySwap, "memory-swap", "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
+	flags.Int64Var(&copts.flSwappiness, "memory-swappiness", -1, "Tune container memory swappiness (0 to 100)")
+	flags.BoolVar(&copts.flOomKillDisable, "oom-kill-disable", false, "Disable OOM Killer")
+	flags.IntVar(&copts.flOomScoreAdj, "oom-score-adj", 0, "Tune host's OOM preferences (-1000 to 1000)")
+	flags.Int64Var(&copts.flPidsLimit, "pids-limit", 0, "Tune container pids limit (set -1 for unlimited)")
+
+	// Low-level execution (cgroups, namespaces, ...)
+	flags.StringVar(&copts.flCgroupParent, "cgroup-parent", "", "Optional parent cgroup for the container")
+	flags.StringVar(&copts.flIpcMode, "ipc", "", "IPC namespace to use")
+	flags.StringVar(&copts.flIsolation, "isolation", "", "Container isolation technology")
+	flags.StringVar(&copts.flPidMode, "pid", "", "PID namespace to use")
+	flags.StringVar(&copts.flShmSize, "shm-size", "", "Size of /dev/shm, default value is 64MB")
+	flags.StringVar(&copts.flUTSMode, "uts", "", "UTS namespace to use")
+	flags.StringVar(&copts.flRuntime, "runtime", "", "Runtime to use for this container")
 	return copts
 }
 
@@ -241,12 +250,12 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	)
 
 	// Validate the input mac address
-	if *copts.flMacAddress != "" {
-		if _, err := ValidateMACAddress(*copts.flMacAddress); err != nil {
-			return nil, nil, nil, fmt.Errorf("%s is not a valid mac address", *copts.flMacAddress)
+	if copts.flMacAddress != "" {
+		if _, err := ValidateMACAddress(copts.flMacAddress); err != nil {
+			return nil, nil, nil, fmt.Errorf("%s is not a valid mac address", copts.flMacAddress)
 		}
 	}
-	if *copts.flStdin {
+	if copts.flStdin {
 		attachStdin = true
 	}
 	// If -a is not set, attach to stdout and stderr
@@ -258,27 +267,27 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	var err error
 
 	var flMemory int64
-	if *copts.flMemoryString != "" {
-		flMemory, err = units.RAMInBytes(*copts.flMemoryString)
+	if copts.flMemoryString != "" {
+		flMemory, err = units.RAMInBytes(copts.flMemoryString)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
 	var MemoryReservation int64
-	if *copts.flMemoryReservation != "" {
-		MemoryReservation, err = units.RAMInBytes(*copts.flMemoryReservation)
+	if copts.flMemoryReservation != "" {
+		MemoryReservation, err = units.RAMInBytes(copts.flMemoryReservation)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
 	var memorySwap int64
-	if *copts.flMemorySwap != "" {
-		if *copts.flMemorySwap == "-1" {
+	if copts.flMemorySwap != "" {
+		if copts.flMemorySwap == "-1" {
 			memorySwap = -1
 		} else {
-			memorySwap, err = units.RAMInBytes(*copts.flMemorySwap)
+			memorySwap, err = units.RAMInBytes(copts.flMemorySwap)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -286,21 +295,21 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	}
 
 	var KernelMemory int64
-	if *copts.flKernelMemory != "" {
-		KernelMemory, err = units.RAMInBytes(*copts.flKernelMemory)
+	if copts.flKernelMemory != "" {
+		KernelMemory, err = units.RAMInBytes(copts.flKernelMemory)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
-	swappiness := *copts.flSwappiness
+	swappiness := copts.flSwappiness
 	if swappiness != -1 && (swappiness < 0 || swappiness > 100) {
 		return nil, nil, nil, fmt.Errorf("invalid value: %d. Valid memory swappiness range is 0-100", swappiness)
 	}
 
 	var shmSize int64
-	if *copts.flShmSize != "" {
-		shmSize, err = units.RAMInBytes(*copts.flShmSize)
+	if copts.flShmSize != "" {
+		shmSize, err = units.RAMInBytes(copts.flShmSize)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -308,13 +317,13 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 
 	// TODO FIXME units.RAMInBytes should have a uint64 version
 	var maxIOBandwidth int64
-	if *copts.flIOMaxBandwidth != "" {
-		maxIOBandwidth, err = units.RAMInBytes(*copts.flIOMaxBandwidth)
+	if copts.flIOMaxBandwidth != "" {
+		maxIOBandwidth, err = units.RAMInBytes(copts.flIOMaxBandwidth)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		if maxIOBandwidth < 0 {
-			return nil, nil, nil, fmt.Errorf("invalid value: %s. Maximum IO Bandwidth must be positive", *copts.flIOMaxBandwidth)
+			return nil, nil, nil, fmt.Errorf("invalid value: %s. Maximum IO Bandwidth must be positive", copts.flIOMaxBandwidth)
 		}
 	}
 
@@ -349,8 +358,8 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	if len(copts.Args) > 0 {
 		runCmd = strslice.StrSlice(copts.Args)
 	}
-	if *copts.flEntrypoint != "" {
-		entrypoint = strslice.StrSlice{*copts.flEntrypoint}
+	if copts.flEntrypoint != "" {
+		entrypoint = strslice.StrSlice{copts.flEntrypoint}
 	}
 
 	ports, portBindings, err := nat.ParsePortSpecs(copts.flPublish.GetAll())
@@ -404,32 +413,32 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		return nil, nil, nil, err
 	}
 
-	ipcMode := container.IpcMode(*copts.flIpcMode)
+	ipcMode := container.IpcMode(copts.flIpcMode)
 	if !ipcMode.Valid() {
 		return nil, nil, nil, fmt.Errorf("--ipc: invalid IPC mode")
 	}
 
-	pidMode := container.PidMode(*copts.flPidMode)
+	pidMode := container.PidMode(copts.flPidMode)
 	if !pidMode.Valid() {
 		return nil, nil, nil, fmt.Errorf("--pid: invalid PID mode")
 	}
 
-	utsMode := container.UTSMode(*copts.flUTSMode)
+	utsMode := container.UTSMode(copts.flUTSMode)
 	if !utsMode.Valid() {
 		return nil, nil, nil, fmt.Errorf("--uts: invalid UTS mode")
 	}
 
-	usernsMode := container.UsernsMode(*copts.flUsernsMode)
+	usernsMode := container.UsernsMode(copts.flUsernsMode)
 	if !usernsMode.Valid() {
 		return nil, nil, nil, fmt.Errorf("--userns: invalid USER mode")
 	}
 
-	restartPolicy, err := ParseRestartPolicy(*copts.flRestartPolicy)
+	restartPolicy, err := ParseRestartPolicy(copts.flRestartPolicy)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	loggingOpts, err := parseLoggingOpts(*copts.flLoggingDriver, copts.flLoggingOpts.GetAll())
+	loggingOpts, err := parseLoggingOpts(copts.flLoggingDriver, copts.flLoggingOpts.GetAll())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -446,11 +455,11 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 
 	// Healthcheck
 	var healthConfig *container.HealthConfig
-	haveHealthSettings := *copts.flHealthCmd != "" ||
-		*copts.flHealthInterval != 0 ||
-		*copts.flHealthTimeout != 0 ||
-		*copts.flHealthRetries != 0
-	if *copts.flNoHealthcheck {
+	haveHealthSettings := copts.flHealthCmd != "" ||
+		copts.flHealthInterval != 0 ||
+		copts.flHealthTimeout != 0 ||
+		copts.flHealthRetries != 0
+	if copts.flNoHealthcheck {
 		if haveHealthSettings {
 			return nil, nil, nil, fmt.Errorf("--no-healthcheck conflicts with --health-* options")
 		}
@@ -458,62 +467,62 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		healthConfig = &container.HealthConfig{Test: test}
 	} else if haveHealthSettings {
 		var probe strslice.StrSlice
-		if *copts.flHealthCmd != "" {
-			args := []string{"CMD-SHELL", *copts.flHealthCmd}
+		if copts.flHealthCmd != "" {
+			args := []string{"CMD-SHELL", copts.flHealthCmd}
 			probe = strslice.StrSlice(args)
 		}
-		if *copts.flHealthInterval < 0 {
+		if copts.flHealthInterval < 0 {
 			return nil, nil, nil, fmt.Errorf("--health-interval cannot be negative")
 		}
-		if *copts.flHealthTimeout < 0 {
+		if copts.flHealthTimeout < 0 {
 			return nil, nil, nil, fmt.Errorf("--health-timeout cannot be negative")
 		}
 
 		healthConfig = &container.HealthConfig{
 			Test:     probe,
-			Interval: *copts.flHealthInterval,
-			Timeout:  *copts.flHealthTimeout,
-			Retries:  *copts.flHealthRetries,
+			Interval: copts.flHealthInterval,
+			Timeout:  copts.flHealthTimeout,
+			Retries:  copts.flHealthRetries,
 		}
 	}
 
 	resources := container.Resources{
-		CgroupParent:         *copts.flCgroupParent,
+		CgroupParent:         copts.flCgroupParent,
 		Memory:               flMemory,
 		MemoryReservation:    MemoryReservation,
 		MemorySwap:           memorySwap,
-		MemorySwappiness:     copts.flSwappiness,
+		MemorySwappiness:     &copts.flSwappiness,
 		KernelMemory:         KernelMemory,
-		OomKillDisable:       copts.flOomKillDisable,
-		CPUPercent:           *copts.flCPUPercent,
-		CPUShares:            *copts.flCPUShares,
-		CPUPeriod:            *copts.flCPUPeriod,
-		CpusetCpus:           *copts.flCpusetCpus,
-		CpusetMems:           *copts.flCpusetMems,
-		CPUQuota:             *copts.flCPUQuota,
-		PidsLimit:            *copts.flPidsLimit,
-		BlkioWeight:          *copts.flBlkioWeight,
+		OomKillDisable:       &copts.flOomKillDisable,
+		CPUPercent:           copts.flCPUPercent,
+		CPUShares:            copts.flCPUShares,
+		CPUPeriod:            copts.flCPUPeriod,
+		CpusetCpus:           copts.flCpusetCpus,
+		CpusetMems:           copts.flCpusetMems,
+		CPUQuota:             copts.flCPUQuota,
+		PidsLimit:            copts.flPidsLimit,
+		BlkioWeight:          copts.flBlkioWeight,
 		BlkioWeightDevice:    copts.flBlkioWeightDevice.GetList(),
 		BlkioDeviceReadBps:   copts.flDeviceReadBps.GetList(),
 		BlkioDeviceWriteBps:  copts.flDeviceWriteBps.GetList(),
 		BlkioDeviceReadIOps:  copts.flDeviceReadIOps.GetList(),
 		BlkioDeviceWriteIOps: copts.flDeviceWriteIOps.GetList(),
-		IOMaximumIOps:        *copts.flIOMaxIOps,
+		IOMaximumIOps:        copts.flIOMaxIOps,
 		IOMaximumBandwidth:   uint64(maxIOBandwidth),
 		Ulimits:              copts.flUlimits.GetList(),
 		Devices:              deviceMappings,
 	}
 
 	config := &container.Config{
-		Hostname:     *copts.flHostname,
+		Hostname:     copts.flHostname,
 		ExposedPorts: ports,
-		User:         *copts.flUser,
-		Tty:          *copts.flTty,
+		User:         copts.flUser,
+		Tty:          copts.flTty,
 		// TODO: deprecated, it comes from -n, --networking
 		// it's still needed internally to set the network to disabled
 		// if e.g. bridge is none in daemon opts, and in inspect
 		NetworkDisabled: false,
-		OpenStdin:       *copts.flStdin,
+		OpenStdin:       copts.flStdin,
 		AttachStdin:     attachStdin,
 		AttachStdout:    attachStdout,
 		AttachStderr:    attachStderr,
@@ -521,24 +530,24 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		Cmd:             runCmd,
 		Image:           copts.Image,
 		Volumes:         copts.flVolumes.GetMap(),
-		MacAddress:      *copts.flMacAddress,
+		MacAddress:      copts.flMacAddress,
 		Entrypoint:      entrypoint,
-		WorkingDir:      *copts.flWorkingDir,
+		WorkingDir:      copts.flWorkingDir,
 		Labels:          ConvertKVStringsToMap(labels),
 		Healthcheck:     healthConfig,
 	}
 	if flags.Changed("stop-signal") {
-		config.StopSignal = *copts.flStopSignal
+		config.StopSignal = copts.flStopSignal
 	}
 
 	hostConfig := &container.HostConfig{
 		Binds:           binds,
-		ContainerIDFile: *copts.flContainerIDFile,
-		OomScoreAdj:     *copts.flOomScoreAdj,
-		Privileged:      *copts.flPrivileged,
+		ContainerIDFile: copts.flContainerIDFile,
+		OomScoreAdj:     copts.flOomScoreAdj,
+		Privileged:      copts.flPrivileged,
 		PortBindings:    portBindings,
 		Links:           copts.flLinks.GetAll(),
-		PublishAllPorts: *copts.flPublishAll,
+		PublishAllPorts: copts.flPublishAll,
 		// Make sure the dns fields are never nil.
 		// New containers don't ever have those fields nil,
 		// but pre created containers can still have those nil values.
@@ -549,7 +558,7 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		DNSOptions:     copts.flDNSOptions.GetAllOrEmpty(),
 		ExtraHosts:     copts.flExtraHosts.GetAll(),
 		VolumesFrom:    copts.flVolumesFrom.GetAll(),
-		NetworkMode:    container.NetworkMode(*copts.flNetMode),
+		NetworkMode:    container.NetworkMode(copts.flNetMode),
 		IpcMode:        ipcMode,
 		PidMode:        pidMode,
 		UTSMode:        utsMode,
@@ -560,15 +569,15 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		RestartPolicy:  restartPolicy,
 		SecurityOpt:    securityOpts,
 		StorageOpt:     storageOpts,
-		ReadonlyRootfs: *copts.flReadonlyRootfs,
-		LogConfig:      container.LogConfig{Type: *copts.flLoggingDriver, Config: loggingOpts},
-		VolumeDriver:   *copts.flVolumeDriver,
-		Isolation:      container.Isolation(*copts.flIsolation),
+		ReadonlyRootfs: copts.flReadonlyRootfs,
+		LogConfig:      container.LogConfig{Type: copts.flLoggingDriver, Config: loggingOpts},
+		VolumeDriver:   copts.flVolumeDriver,
+		Isolation:      container.Isolation(copts.flIsolation),
 		ShmSize:        shmSize,
 		Resources:      resources,
 		Tmpfs:          tmpfs,
 		Sysctls:        copts.flSysctls.GetAll(),
-		Runtime:        *copts.flRuntime,
+		Runtime:        copts.flRuntime,
 	}
 
 	// When allocating stdin in attached mode, close stdin at client disconnect
@@ -580,13 +589,13 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		EndpointsConfig: make(map[string]*networktypes.EndpointSettings),
 	}
 
-	if *copts.flIPv4Address != "" || *copts.flIPv6Address != "" || copts.flLinkLocalIPs.Len() > 0 {
+	if copts.flIPv4Address != "" || copts.flIPv6Address != "" || copts.flLinkLocalIPs.Len() > 0 {
 		epConfig := &networktypes.EndpointSettings{}
 		networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)] = epConfig
 
 		epConfig.IPAMConfig = &networktypes.EndpointIPAMConfig{
-			IPv4Address: *copts.flIPv4Address,
-			IPv6Address: *copts.flIPv6Address,
+			IPv4Address: copts.flIPv4Address,
+			IPv6Address: copts.flIPv6Address,
 		}
 
 		if copts.flLinkLocalIPs.Len() > 0 {


### PR DESCRIPTION
Since we added support for top-level networks, it feels like `--network` would be a better name for the corresponding `docker run` flag.

This PR adds the `--network` flag and hides the `--net` one, without removing it.

Cc @dnephin @mavenugo.
