### PR TITLE
Refactor foreign sources to describable interfaces

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -133,7 +133,7 @@ type v2LayerDescriptor struct {
 	V2MetadataService *metadata.V2MetadataService
 	tmpFile           *os.File
 	verifier          digest.Verifier
-	foreignSrc        *distribution.Descriptor
+	src               distribution.Descriptor
 }
 
 func (ld *v2LayerDescriptor) Key() string {
@@ -511,14 +511,7 @@ func (p *v2Puller) pullSchema2(ctx context.Context, ref reference.Named, mfst *s
 			repo:              p.repo,
 			repoInfo:          p.repoInfo,
 			V2MetadataService: p.V2MetadataService,
-		}
-
-		if d.MediaType == schema2.MediaTypeForeignLayer && len(d.URLs) > 0 {
-			if !layer.ForeignSourceSupported() {
-				return "", "", errors.New("foreign layers are not supported on this OS")
-			}
-
-			layerDescriptor.foreignSrc = &d
+			src:               d,
 		}
 
 		descriptors = append(descriptors, layerDescriptor)

--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -11,9 +11,9 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/image"
-	"github.com/docker/docker/layer"
 )
 
 func detectBaseLayer(is image.Store, m *schema1.Manifest, rootFS *image.RootFS) error {
@@ -35,14 +35,17 @@ func detectBaseLayer(is image.Store, m *schema1.Manifest, rootFS *image.RootFS) 
 	return fmt.Errorf("Invalid base layer %q", v1img.Parent)
 }
 
-var _ layer.ForeignSourcer = &v2LayerDescriptor{}
+var _ distribution.Describable = &v2LayerDescriptor{}
 
-func (ld *v2LayerDescriptor) ForeignSource() *distribution.Descriptor {
-	return ld.foreignSrc
+func (ld *v2LayerDescriptor) Descriptor() distribution.Descriptor {
+	if ld.src.MediaType == schema2.MediaTypeForeignLayer && len(ld.src.URLs) > 0 {
+		return ld.src
+	}
+	return distribution.Descriptor{}
 }
 
 func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekCloser, error) {
-	if ld.foreignSrc == nil {
+	if len(ld.src.URLs) == 0 {
 		blobs := ld.repo.Blobs(ctx)
 		return blobs.Open(ctx, ld.digest)
 	}
@@ -53,7 +56,7 @@ func (ld *v2LayerDescriptor) open(ctx context.Context) (distribution.ReadSeekClo
 	)
 
 	// Find the first URL that results in a 200 result code.
-	for _, url := range ld.foreignSrc.URLs {
+	for _, url := range ld.src.URLs {
 		rsc = transport.NewHTTPReadSeeker(http.DefaultClient, url, nil)
 		_, err = rsc.Seek(0, os.SEEK_SET)
 		if err == nil {

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -240,10 +240,10 @@ func (pd *v2PushDescriptor) DiffID() layer.DiffID {
 }
 
 func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.Output) (distribution.Descriptor, error) {
-	if fs, ok := pd.layer.(layer.ForeignSourcer); ok {
-		if d := fs.ForeignSource(); d != nil {
+	if fs, ok := pd.layer.(distribution.Describable); ok {
+		if d := fs.Descriptor(); len(d.URLs) > 0 {
 			progress.Update(progressOutput, pd.ID(), "Skipped foreign layer")
-			return *d, nil
+			return d, nil
 		}
 	}
 

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -72,10 +72,10 @@ func createChainIDFromParent(parent layer.ChainID, dgsts ...layer.DiffID) layer.
 }
 
 func (ls *mockLayerStore) Register(reader io.Reader, parentID layer.ChainID) (layer.Layer, error) {
-	return ls.RegisterForeign(reader, parentID, nil)
+	return ls.RegisterWithDescriptor(reader, parentID, distribution.Descriptor{})
 }
 
-func (ls *mockLayerStore) RegisterForeign(reader io.Reader, parentID layer.ChainID, _ *distribution.Descriptor) (layer.Layer, error) {
+func (ls *mockLayerStore) RegisterWithDescriptor(reader io.Reader, parentID layer.ChainID, _ distribution.Descriptor) (layer.Layer, error) {
 	var (
 		parent layer.Layer
 		err    error

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -19,8 +19,8 @@ type manifestItem struct {
 	Config       string
 	RepoTags     []string
 	Layers       []string
-	Parent       image.ID                                  `json:",omitempty"`
-	LayerSources map[layer.DiffID]*distribution.Descriptor `json:",omitempty"`
+	Parent       image.ID                                 `json:",omitempty"`
+	LayerSources map[layer.DiffID]distribution.Descriptor `json:",omitempty"`
 }
 
 type tarexporter struct {

--- a/layer/filestore.go
+++ b/layer/filestore.go
@@ -26,9 +26,6 @@ var (
 		// digest.SHA384, // Currently not used
 		// digest.SHA512, // Currently not used
 	}
-
-	// ErrNoForeignSource is returned when no foreign source is set for a layer.
-	ErrNoForeignSource = errors.New("layer does not have a foreign source")
 )
 
 type fileMetadataStore struct {
@@ -103,7 +100,7 @@ func (fm *fileMetadataTransaction) SetCacheID(cacheID string) error {
 	return ioutil.WriteFile(filepath.Join(fm.root, "cache-id"), []byte(cacheID), 0644)
 }
 
-func (fm *fileMetadataTransaction) SetForeignSource(ref distribution.Descriptor) error {
+func (fm *fileMetadataTransaction) SetDescriptor(ref distribution.Descriptor) error {
 	jsonRef, err := json.Marshal(ref)
 	if err != nil {
 		return err
@@ -204,11 +201,12 @@ func (fms *fileMetadataStore) GetCacheID(layer ChainID) (string, error) {
 	return content, nil
 }
 
-func (fms *fileMetadataStore) GetForeignSource(layer ChainID) (distribution.Descriptor, error) {
+func (fms *fileMetadataStore) GetDescriptor(layer ChainID) (distribution.Descriptor, error) {
 	content, err := ioutil.ReadFile(fms.getLayerFilename(layer, "descriptor.json"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return distribution.Descriptor{}, ErrNoForeignSource
+			// only return empty descriptor to represent what is stored
+			return distribution.Descriptor{}, nil
 		}
 		return distribution.Descriptor{}, err
 	}

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -108,14 +108,6 @@ type Layer interface {
 	Metadata() (map[string]string, error)
 }
 
-// ForeignSourcer is an interface used to describe the source of layers
-// and objects representing layers, when the source is a foreign URL.
-type ForeignSourcer interface {
-	// ForeignSource returns the descriptor for this layer if it is
-	// a foreign layer, or nil for ordinary layers.
-	ForeignSource() *distribution.Descriptor
-}
-
 // RWLayer represents a layer which is
 // read and writable
 type RWLayer interface {
@@ -177,7 +169,6 @@ type MountInit func(root string) error
 // read-only and read-write layers.
 type Store interface {
 	Register(io.Reader, ChainID) (Layer, error)
-	RegisterForeign(io.Reader, ChainID, *distribution.Descriptor) (Layer, error)
 	Get(ChainID) (Layer, error)
 	Release(Layer) ([]Metadata, error)
 
@@ -191,6 +182,12 @@ type Store interface {
 	DriverName() string
 }
 
+// DescribableStore represents a layer store capable of storing
+// descriptors for layers.
+type DescribableStore interface {
+	RegisterWithDescriptor(io.Reader, ChainID, distribution.Descriptor) (Layer, error)
+}
+
 // MetadataTransaction represents functions for setting layer metadata
 // with a single transaction.
 type MetadataTransaction interface {
@@ -198,7 +195,7 @@ type MetadataTransaction interface {
 	SetParent(parent ChainID) error
 	SetDiffID(DiffID) error
 	SetCacheID(string) error
-	SetForeignSource(distribution.Descriptor) error
+	SetDescriptor(distribution.Descriptor) error
 	TarSplitWriter(compressInput bool) (io.WriteCloser, error)
 
 	Commit(ChainID) error
@@ -218,7 +215,7 @@ type MetadataStore interface {
 	GetParent(ChainID) (ChainID, error)
 	GetDiffID(ChainID) (DiffID, error)
 	GetCacheID(ChainID) (string, error)
-	GetForeignSource(ChainID) (distribution.Descriptor, error)
+	GetDescriptor(ChainID) (distribution.Descriptor, error)
 	TarSplitReader(ChainID) (io.ReadCloser, error)
 
 	SetMountID(string, string) error

--- a/layer/layer_store_windows.go
+++ b/layer/layer_store_windows.go
@@ -1,0 +1,11 @@
+package layer
+
+import (
+	"io"
+
+	"github.com/docker/distribution"
+)
+
+func (ls *layerStore) RegisterWithDescriptor(ts io.Reader, parent ChainID, descriptor distribution.Descriptor) (Layer, error) {
+	return ls.registerWithDescriptor(ts, parent, descriptor)
+}

--- a/layer/layer_unix.go
+++ b/layer/layer_unix.go
@@ -7,9 +7,3 @@ import "github.com/docker/docker/pkg/stringid"
 func (ls *layerStore) mountID(name string) string {
 	return stringid.GenerateRandomID()
 }
-
-// ForeignSourceSupported returns whether layers downloaded from foreign sources are
-// supported in this daemon.
-func ForeignSourceSupported() bool {
-	return false
-}

--- a/layer/layer_windows.go
+++ b/layer/layer_windows.go
@@ -96,9 +96,3 @@ func (ls *layerStore) mountID(name string) string {
 func (ls *layerStore) GraphDriver() graphdriver.Driver {
 	return ls.driver
 }
-
-// ForeignSourceSupported returns whether layers downloaded from foreign sources are
-// supported in this daemon.
-func ForeignSourceSupported() bool {
-	return true
-}

--- a/layer/ro_layer.go
+++ b/layer/ro_layer.go
@@ -15,7 +15,7 @@ type roLayer struct {
 	cacheID    string
 	size       int64
 	layerStore *layerStore
-	foreignSrc *distribution.Descriptor
+	descriptor distribution.Descriptor
 
 	referenceCount int
 	references     map[Layer]struct{}
@@ -120,13 +120,14 @@ func storeLayer(tx MetadataTransaction, layer *roLayer) error {
 	if err := tx.SetCacheID(layer.cacheID); err != nil {
 		return err
 	}
-	if layer.parent != nil {
-		if err := tx.SetParent(layer.parent.chainID); err != nil {
+	// Do not store empty descriptors
+	if layer.descriptor.Digest != "" {
+		if err := tx.SetDescriptor(layer.descriptor); err != nil {
 			return err
 		}
 	}
-	if layer.foreignSrc != nil {
-		if err := tx.SetForeignSource(*layer.foreignSrc); err != nil {
+	if layer.parent != nil {
+		if err := tx.SetParent(layer.parent.chainID); err != nil {
 			return err
 		}
 	}

--- a/layer/ro_layer_windows.go
+++ b/layer/ro_layer_windows.go
@@ -2,8 +2,8 @@ package layer
 
 import "github.com/docker/distribution"
 
-var _ ForeignSourcer = &roLayer{}
+var _ distribution.Describable = &roLayer{}
 
-func (rl *roLayer) ForeignSource() *distribution.Descriptor {
-	return rl.foreignSrc
+func (rl *roLayer) Descriptor() distribution.Descriptor {
+	return rl.descriptor
 }


### PR DESCRIPTION
This was a suggestion for #22866 and #23014. The use of the descriptor should be represented more generically in the interfaces rather than being tied to "foreign" sources. As part of this, the [distribution.Descriptor](https://godoc.org/github.com/docker/distribution#Descriptor) type and [distribution.Describable](https://godoc.org/github.com/docker/distribution#Describable) interface can be used to simply the code.

ping @stevvooe @aaronlehmann 
