### PR TITLE
Fix postRunProcessing behavior during docker build

### DIFF
--- a/daemon/monitor_windows.go
+++ b/daemon/monitor_windows.go
@@ -16,7 +16,7 @@ func platformConstructExitStatus(e libcontainerd.StateInfo) *container.ExitStatu
 
 // postRunProcessing perfoms any processing needed on the container after it has stopped.
 func (daemon *Daemon) postRunProcessing(container *container.Container, e libcontainerd.StateInfo) error {
-	if e.UpdatePending {
+	if e.ExitCode == 0 && e.UpdatePending {
 		spec, err := daemon.createSpec(container)
 		if err != nil {
 			return err
@@ -29,6 +29,7 @@ func (daemon *Daemon) postRunProcessing(container *container.Container, e libcon
 		// Create a new servicing container, which will start, complete the update, and merge back the
 		// results if it succeeded, all as part of the below function call.
 		if err := daemon.containerd.Create((container.ID + "_servicing"), *spec, servicingOption); err != nil {
+			container.ExitCode = -1
 			return fmt.Errorf("Post-run update servicing failed: %s", err)
 		}
 	}


### PR DESCRIPTION
@jhowardmsft 
If Windows updates are being applied via a RUN command in a docker build, the build will not stop if there was a failure in postRunProcessing.  To enable this behavior, we explicitly set the exit code of the container to a failure if postRunProcessing fails during servicing container step.  For completeness, also avoid running servicing operation if the original exit code of the container is non-zero so that original failure exit code does not get overwritten.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
