### PR TITLE
Allow user defined dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell d
 
 # get OS/Arch of docker engine
 DOCKER_OSARCH := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKER_ENGINE_OSARCH:-$$DOCKER_CLIENT_OSARCH}')
-DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKERFILE}')
+DOCKERFILE := $(if $(DOCKERFILE),$(DOCKERFILE),$(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKERFILE}'))
 
 # env vars passed through directly to Docker's build scripts
 # to allow things like `make KEEPBUNDLE=1 binary` easily


### PR DESCRIPTION
If I compiled docker before, I want to use the built image directly in case that some library becomes unavailable in the future.

```
$ echo "FROM docker-dev:open-1.11.2
COPY . /go/src/github.com/docker/docker" > Dockerfile.mine
$ DOCKERFILE="Dockerfile.mine" BIND_DIR=. make binary
```

Signed-off-by: Chun Chen ramichen@tencent.com
