### PR TITLE
Use spf13/cobra for docker version

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -22,6 +22,5 @@ func (cli *DockerCli) Command(name string) func(...string) error {
 		"stats":   cli.CmdStats,
 		"tag":     cli.CmdTag,
 		"update":  cli.CmdUpdate,
-		"version": cli.CmdVersion,
 	}[name]
 }

--- a/cli/cobraadaptor/adaptor.go
+++ b/cli/cobraadaptor/adaptor.go
@@ -5,6 +5,7 @@ import (
 	"github.com/docker/docker/api/client/container"
 	"github.com/docker/docker/api/client/image"
 	"github.com/docker/docker/api/client/network"
+	"github.com/docker/docker/api/client/system"
 	"github.com/docker/docker/api/client/volume"
 	"github.com/docker/docker/cli"
 	cliflags "github.com/docker/docker/cli/flags"
@@ -55,6 +56,7 @@ func NewCobraAdaptor(clientFlags *cliflags.ClientFlags) CobraAdaptor {
 		image.NewSearchCommand(dockerCli),
 		image.NewImportCommand(dockerCli),
 		network.NewNetworkCommand(dockerCli),
+		system.NewVersionCommand(dockerCli),
 		volume.NewVolumeCommand(dockerCli),
 	)
 

--- a/cli/usage.go
+++ b/cli/usage.go
@@ -27,7 +27,6 @@ var DockerCommandUsage = []Command{
 	{"stats", "Display a live stream of container(s) resource usage statistics"},
 	{"tag", "Tag an image into a repository"},
 	{"update", "Update configuration of one or more containers"},
-	{"version", "Show the Docker version information"},
 }
 
 // DockerCommands stores all the docker command


### PR DESCRIPTION
This fix is part of the effort to convert commands to spf13/cobra #23211.

This fix coverted command `docker version` to use spf13/cobra

NOTE: Most of the commands like `run`, `images` etc. goes to packages of `container`, `image`, `network`, etc.

Didn't find a good place for `docker version` so just use the package `client` for now.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
