### PR TITLE
Fix create command flags

### DIFF
--- a/api/client/container/create.go
+++ b/api/client/container/create.go
@@ -46,6 +46,8 @@ func NewCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
+	flags.SetInterspersed(false)
+
 	flags.StringVar(&opts.name, "name", "", "Assign a name to the container")
 
 	// Add an explicit help that doesn't have a `-h` to prevent the conflict

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -25,7 +25,7 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 	if daemonPlatform == "windows" {
 		c.Skip("Fails on Windows CI")
 	}
-	out, _ := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space")
+	out, _ := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space", "-c", "flags")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 	c.Assert(string(cont.Path), checker.Equals, "command", check.Commentf("Unexpected container path. Expected command, received: %s", cont.Path))
 
 	b := false
-	expected := []string{"arg1", "arg2", "arg with space"}
+	expected := []string{"arg1", "arg2", "arg with space", "-c", "flags"}
 	for i, arg := range expected {
 		if arg != cont.Args[i] {
 			b = true


### PR DESCRIPTION
> Any command that expects extra flags after positional args needs to set `flags.SetInterspersed(false)`.

Fix #23329 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
