### PR TITLE
Fix TestRenameInvalidName

### DIFF
--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -73,13 +73,17 @@ func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
 	c.Assert(out, checker.Contains, "Invalid container name", check.Commentf("%v", err))
 
+	out, _, err = dockerCmdWithError("rename", "myname")
+	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
+	c.Assert(out, checker.Contains, "requires exactly 2 argument(s).", check.Commentf("%v", err))
+
 	out, _, err = dockerCmdWithError("rename", "myname", "")
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "\"docker rename\" requires exactly 2 argument(s).", check.Commentf("%v", err))
+	c.Assert(out, checker.Contains, "may be empty", check.Commentf("%v", err))
 
 	out, _, err = dockerCmdWithError("rename", "", "newname")
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container with empty name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "\"docker rename\" requires exactly 2 argument(s).", check.Commentf("%v", err))
+	c.Assert(out, checker.Contains, "may be empty", check.Commentf("%v", err))
 
 	out, _ = dockerCmd(c, "ps", "-a")
 	c.Assert(out, checker.Contains, "myname", check.Commentf("Output of docker ps should have included 'myname': %s", out))


### PR DESCRIPTION
Change the test back to what it was before e83dad090a1e890ac870808d776fa584276bf7ab (https://github.com/docker/docker/pull/23290),
and added an extra test-case to check the output if an incorrect number of arguments is passed.

For some reason, this test passed on https://github.com/docker/docker/pull/23290, but is now failing. It looks like the command executed is `docker rename "" newname`, including the quotes, which gives a different error than `docker rename myname`
