### PR TITLE
Fix failing test of `docker rename`

### DIFF
--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -75,11 +75,11 @@ func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
 
 	out, _, err = dockerCmdWithError("rename", "myname", "")
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container to invalid name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "\"docker rename\" requires exactly 2 argument(s).", check.Commentf("%v", err))
+	c.Assert(out, checker.Contains, "may be empty", check.Commentf("%v", err))
 
 	out, _, err = dockerCmdWithError("rename", "", "newname")
 	c.Assert(err, checker.NotNil, check.Commentf("Renaming container with empty name should have failed: %s", out))
-	c.Assert(out, checker.Contains, "\"docker rename\" requires exactly 2 argument(s).", check.Commentf("%v", err))
+	c.Assert(out, checker.Contains, "may be empty", check.Commentf("%v", err))
 
 	out, _ = dockerCmd(c, "ps", "-a")
 	c.Assert(out, checker.Contains, "myname", check.Commentf("Output of docker ps should have included 'myname': %s", out))


### PR DESCRIPTION
At the time the pull request:

Use spf13/cobra for docker rename #23290

was created, there was an issue in cobra so the test `DockerSuite.TestRenameInvalidName` was updated.

Now the issue in cobra has been fixed in:
Use spf13/cobra for docker import #23269

so the test related to  `docker rename`
(`DockerSuite.TestRenameInvalidName`) needs to be reverted back.

This fix is related to spf13/cobra #23211.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
