### PR TITLE
Timeout as time.duration

### DIFF
--- a/api/client/container/restart.go
+++ b/api/client/container/restart.go
@@ -3,6 +3,7 @@ package container
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -39,7 +40,7 @@ func NewRestartCommand(dockerCli *client.DockerCli) *cobra.Command {
 func runRestart(dockerCli *client.DockerCli, opts *restartOptions) error {
 	var errs []string
 	for _, name := range opts.containers {
-		if err := dockerCli.Client().ContainerRestart(context.Background(), name, opts.nSeconds); err != nil {
+		if err := dockerCli.Client().ContainerRestart(context.Background(), name, time.Duration(opts.nSeconds)*time.Second); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(dockerCli.Out(), "%s\n", name)

--- a/api/client/container/stop.go
+++ b/api/client/container/stop.go
@@ -3,6 +3,7 @@ package container
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -42,7 +43,7 @@ func runStop(dockerCli *client.DockerCli, opts *stopOptions) error {
 
 	var errs []string
 	for _, container := range opts.containers {
-		if err := dockerCli.Client().ContainerStop(ctx, container, opts.time); err != nil {
+		if err := dockerCli.Client().ContainerStop(ctx, container, time.Duration(opts.time)*time.Second); err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(dockerCli.Out(), "%s\n", container)

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 78cb2c067747f08b343f20614155233ab4ea2ad3 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 772250a752e34cacaeef7c92b8e0ddf43450b629
+clone git github.com/docker/engine-api 8c2141e14bb9e7540938d155976b3ef0661e4814
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/container_restart.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_restart.go
@@ -2,17 +2,18 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	query.Set("t", timetypes.DurationToSecondsString(timeout))
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/src/github.com/docker/engine-api/client/container_stop.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_stop.go
@@ -2,16 +2,17 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	query.Set("t", timetypes.DurationToSecondsString(timeout))
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/src/github.com/docker/engine-api/client/errors.go
+++ b/vendor/src/github.com/docker/engine-api/client/errors.go
@@ -8,26 +8,47 @@ import (
 // ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
+type notFound interface {
+	error
+	NotFound() bool // Is the error a NotFound error
+}
+
+// IsErrNotFound returns true if the error is caused with an
+// object (image, container, network, volume, …) is not found in the docker host.
+func IsErrNotFound(err error) bool {
+	te, ok := err.(notFound)
+	return ok && te.NotFound()
+}
+
 // imageNotFoundError implements an error returned when an image is not in the docker host.
 type imageNotFoundError struct {
 	imageID string
 }
 
+// NoFound indicates that this error type is of NotFound
+func (e imageNotFoundError) NotFound() bool {
+	return true
+}
+
 // Error returns a string representation of an imageNotFoundError
-func (i imageNotFoundError) Error() string {
-	return fmt.Sprintf("Error: No such image: %s", i.imageID)
+func (e imageNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such image: %s", e.imageID)
 }
 
 // IsErrImageNotFound returns true if the error is caused
 // when an image is not found in the docker host.
 func IsErrImageNotFound(err error) bool {
-	_, ok := err.(imageNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // containerNotFoundError implements an error returned when a container is not in the docker host.
 type containerNotFoundError struct {
 	containerID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e containerNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a containerNotFoundError
@@ -38,13 +59,17 @@ func (e containerNotFoundError) Error() string {
 // IsErrContainerNotFound returns true if the error is caused
 // when a container is not found in the docker host.
 func IsErrContainerNotFound(err error) bool {
-	_, ok := err.(containerNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // networkNotFoundError implements an error returned when a network is not in the docker host.
 type networkNotFoundError struct {
 	networkID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e networkNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -55,13 +80,17 @@ func (e networkNotFoundError) Error() string {
 // IsErrNetworkNotFound returns true if the error is caused
 // when a network is not found in the docker host.
 func IsErrNetworkNotFound(err error) bool {
-	_, ok := err.(networkNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // volumeNotFoundError implements an error returned when a volume is not in the docker host.
 type volumeNotFoundError struct {
 	volumeID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e volumeNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -72,8 +101,7 @@ func (e volumeNotFoundError) Error() string {
 // IsErrVolumeNotFound returns true if the error is caused
 // when a volume is not found in the docker host.
 func IsErrVolumeNotFound(err error) bool {
-	_, ok := err.(volumeNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // unauthorizedError represents an authorization error in a remote registry.

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"io"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -37,11 +38,11 @@ type APIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout int) error
+	ContainerRestart(ctx context.Context, container string, timeout time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
-	ContainerStop(ctx context.Context, container string, timeout int) error
+	ContainerStop(ctx context.Context, container string, timeout time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error

--- a/vendor/src/github.com/docker/engine-api/types/time/duration_convert.go
+++ b/vendor/src/github.com/docker/engine-api/types/time/duration_convert.go
@@ -1,0 +1,12 @@
+package time
+
+import (
+	"strconv"
+	"time"
+)
+
+// DurationToSecondsString converts the specified duration to the number
+// seconds it represents, formatted as a string.
+func DurationToSecondsString(duration time.Duration) string {
+	return strconv.FormatFloat(duration.Seconds(), 'f', 0, 64)
+}

--- a/vendor/src/github.com/docker/engine-api/types/versions/README.md
+++ b/vendor/src/github.com/docker/engine-api/types/versions/README.md
@@ -9,6 +9,6 @@ Consider moving a type here when you need to keep backwards compatibility in the
 The package name convention is to use `v` as a prefix for the version number and `p`(patch) as a separator. We use this nomenclature due to a few restrictions in the Go package name convention:
 
 1. We cannot use `.` because it's interpreted by the language, think of `v1.20.CallFunction`.
-2. We cannot use `_` because golint complains abount it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
+2. We cannot use `_` because golint complains about it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
 
 For instance, if you want to modify a type that was available in the version `1.21` of the API but it will have different fields in the version `1.22`, you want to create a new package under `api/types/versions/v1p21`.


### PR DESCRIPTION
This PR follows up docker/engine-api#235 and updates calls to the engine-api to used timeouts as `time.Duration` instead of `int`s.
The engine-api dependency has been updated accordingly (not including the latest changes which depends on #23219).

And a cute animal as a bonus :)
![image](https://cloud.githubusercontent.com/assets/1514127/15865296/7fa2ad78-2cda-11e6-84c8-029bfed805e1.png)
