### PR TITLE
Add link to notary environment vars from docker trust automation section

### DIFF
--- a/docs/security/trust/trust_automation.md
+++ b/docs/security/trust/trust_automation.md
@@ -41,6 +41,8 @@ latest: digest: sha256:d149ab53f871 size: 3355
 Signing and pushing trust metadata
 ```
 
+When working directly with the Notary client, it will use its [own set of environment variables](/notary/reference/client-config.md#environment-variables-optional).
+
 ## Building with content trust
 
 You can also build with content trust. Before running the `docker build` command, you should set the environment variable `DOCKER_CONTENT_TRUST` either manually or in a scripted fashion. Consider the simple Dockerfile below.


### PR DESCRIPTION
Adds a link to the notary environment variables in the DCT automation docs, since users may be using the notary CLI for some key and/or delegation management.

<img src="https://s-media-cache-ak0.pinimg.com/736x/c2/ec/3c/c2ec3ce2221495e33f7d3bc5c33e9225.jpg" width="250px" />

Signed-off-by: Riyaz Faizullabhoy riyaz.faizullabhoy@docker.com
