### PR TITLE
docker rename fix to address the issue of renaming with the same name

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -21,6 +21,10 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 		return fmt.Errorf("Neither old nor new names may be empty")
 	}
 
+	if newName[0] != '/' {
+		newName = "/" + newName
+	}
+
 	container, err := daemon.GetContainer(oldName)
 	if err != nil {
 		return err
@@ -31,6 +35,11 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 
 	container.Lock()
 	defer container.Unlock()
+
+	if oldName == newName {
+		return fmt.Errorf("Renaming a container with the same name as its current name")
+	}
+
 	if newName, err = daemon.reserveName(container.ID, newName); err != nil {
 		return fmt.Errorf("Error when allocating new name: %v", err)
 	}

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -108,3 +108,16 @@ func (s *DockerSuite) TestRenameAnonymousContainer(c *check.C) {
 	_, _, err := dockerCmdWithError("run", "--net", "network1", "busybox", "ping", count, "1", "container1")
 	c.Assert(err, check.IsNil, check.Commentf("Embedded DNS lookup fails after renaming anonymous container: %v", err))
 }
+
+func (s *DockerSuite) TestRenameContainerWithSameName(c *check.C) {
+	out, _ := runSleepingContainer(c, "--name", "old")
+	ContainerID := strings.TrimSpace(out)
+
+	out, _, err := dockerCmdWithError("rename", "old", "old")
+	c.Assert(err, checker.NotNil, check.Commentf("Renaming a container with the same name should have failed"))
+	c.Assert(out, checker.Contains, "Renaming a container with the same name", check.Commentf("%v", err))
+
+	out, _, err = dockerCmdWithError("rename", ContainerID, "old")
+	c.Assert(err, checker.NotNil, check.Commentf("Renaming a container with the same name should have failed"))
+	c.Assert(out, checker.Contains, "Renaming a container with the same name", check.Commentf("%v", err))
+}


### PR DESCRIPTION
Fixes #23319 

**\- What I did**
docker rename cont_name cont_name , using same name to rename creates an inconsistent nameIndex for daemon. Added a check in daemon rename code to see if oldname is same as newname. If so return an error

**\- How to verify it**
Before the fix
docker run -itd --name=old busybox
docker rename old old - successful without any error
docker rename old old - should complain there is no container with name old

After the fix
docker run -itd --name=old busybox
docker rename old old - error "Renaming a container with the same name as its current name"
docker rename old old - error "Renaming a container with the same name as its current name"

**\- Description for the changelog**
A check in the docker daemon rename function to see if the current name of the container is same as the passed in new name. If the names match, daemon returns an error saying "names matched"

Signed-off-by: Sainath Grandhi sainath.grandhi@intel.com
