### PR TITLE
Fix wrong map usage

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -732,10 +732,10 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 		logrus.Errorf("Error deleting sandbox id %s for container %s: %v", sid, container.ID, err)
 	}
 
-	attributes := map[string]string{
-		"container": container.ID,
-	}
 	for _, nw := range networks {
+		attributes := map[string]string{
+			"container": container.ID,
+		}
 		daemon.LogNetworkEventWithAttributes(nw, "disconnect", attributes)
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

As map reference, if all networks use same, it could cause strange
results.
Closes: #23304
Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
