### PR TITLE
Carry #23007 :  Say something useful during docker load

### DIFF
--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -12,11 +12,12 @@ parent = "smn_cli"
 
     Usage: docker load [OPTIONS]
 
-    Load an image from a tar archive or STDIN
+    Load an image from a tar archive or STDIN and shows image names or
+    IDs imported.
 
       --help             Print usage
       -i, --input=""     Read from a tar archive file, instead of STDIN. The tarball may be compressed with gzip, bzip, or xz
-      -q, --quiet        Suppress the load output. Without this option, a progress bar is displayed.
+      -q, --quiet        Suppress the load progress bar but still outputs the imported images
 
 Loads a tarred repository from a file or the standard input stream.
 Restores both images and tags.
@@ -24,10 +25,17 @@ Restores both images and tags.
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     $ docker load < busybox.tar.gz
+    # […]
+    Loaded image: busybox:latest
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
     $ docker load --input fedora.tar
+    # […]
+    Loaded image: fedora:rawhide
+    # […]
+    Loaded image: fedora:20
+    # […]
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -350,3 +350,33 @@ func (s *DockerSuite) TestSaveLoadParents(c *check.C) {
 	inspectOut = inspectField(c, idFoo, "Parent")
 	c.Assert(inspectOut, checker.Equals, "")
 }
+
+func (s *DockerSuite) TestSaveLoadNoTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	name := "saveloadnotag"
+
+	_, err := buildImage(name, "FROM busybox\nENV foo=bar", true)
+	c.Assert(err, checker.IsNil, check.Commentf("%v", err))
+
+	id := inspectField(c, name, "Id")
+
+	// Test to make sure that save w/o name just shows imageID during load
+	out, _, err := runCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", id),
+		exec.Command(dockerBinary, "load"))
+	c.Assert(err, checker.IsNil, check.Commentf("failed to save and load repo: %s, %v", out, err))
+
+	// Should not show 'name' but should show the image ID during the load
+	c.Assert(out, checker.Not(checker.Contains), "Loaded image: ")
+	c.Assert(out, checker.Contains, "Loaded image ID:")
+	c.Assert(out, checker.Contains, id)
+
+	// Test to make sure that save by name shows that name during load
+	out, _, err = runCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", name),
+		exec.Command(dockerBinary, "load"))
+	c.Assert(err, checker.IsNil, check.Commentf("failed to save and load repo: %s, %v", out, err))
+	c.Assert(out, checker.Contains, "Loaded image: "+name+":latest")
+	c.Assert(out, checker.Not(checker.Contains), "Loaded image ID:")
+}

--- a/man/docker-load.1.md
+++ b/man/docker-load.1.md
@@ -13,7 +13,8 @@ docker-load - Load an image from a tar archive or STDIN
 # DESCRIPTION
 
 Loads a tarred repository from a file or the standard input stream.
-Restores both images and tags.
+Restores both images and tags. Write image names or IDs imported it
+standard output stream.
 
 # OPTIONS
 **--help**
@@ -23,7 +24,7 @@ Restores both images and tags.
    Read from a tar archive file, instead of STDIN. The tarball may be compressed with gzip, bzip, or xz.
 
 **-q**, **--quiet**
-   Suppress the load output. Without this option, a progress bar is displayed.
+   Suppress the load progress bar but still outputs the imported images.
 
 # EXAMPLES
 
@@ -31,6 +32,11 @@ Restores both images and tags.
     REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
     $ docker load --input fedora.tar
+    # […]
+    Loaded image: fedora:rawhide
+    # […]
+    Loaded image: fedora:20
+    # […]
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB
@@ -47,3 +53,4 @@ April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 July 2015 update by Mary Anthony <mary@docker.com>
+June 2016 update by Vincent Demeester <vincent@sbr.pm>


### PR DESCRIPTION
Carry #23007 with documentation updates.

Closes #23007 
Closes #21660

/cc @thaJeztah

---

During a `docker load` there are times when nothing is printed
to the screen, leaving the user with no idea whether something happened.
When something _is_ printed, often its just something like:

```
1834950e52ce: Loading layer 1.311 MB/1.311 MB
5f70bf18a086: Loading layer 1.024 kB/1.024 kB
```

which isn't necessarily the same as the image IDs.

This PR will either show:
- all of the tags for the image, or
- all of the image IDs if there are no tags

Sample output:

```
$ docker load -i busybox.tar
Loaded image: busybox:latest

$ docker load -i a.tar
Loaded image ID: sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb
```

IOW, show the human-friendly stuff first and then only if there are no tags
default back to the image IDs, so they have something to work with.

For me this this is needed because I have lots of images and after a
recent `docker load` I had no idea what image I just imported and had a
hard time figuring it out.  This should fix that by telling the user
which images they just imported.

I'll add tests once there's agreement that we want this change.

Signed-off-by: Doug Davis dug@us.ibm.com
