### PR TITLE
fix RPM spec for man8

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -166,7 +166,7 @@ install -p -m 644 man/man1/*.1 $RPM_BUILD_ROOT/%{_mandir}/man1
 install -d %{buildroot}%{_mandir}/man5
 install -p -m 644 man/man5/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
 install -d %{buildroot}%{_mandir}/man8
-install -p -m 644 man/man5/*.8 $RPM_BUILD_ROOT/%{_mandir}/man8
+install -p -m 644 man/man8/*.8 $RPM_BUILD_ROOT/%{_mandir}/man8
 
 # add vimfiles
 install -d $RPM_BUILD_ROOT/usr/share/vim/vimfiles/doc


### PR DESCRIPTION
installation for man-8 was added in 1514b499f04e317d6bc81bb2d46a6623db422763 (pull-request https://github.com/docker/docker/pull/23236) but had a typo in a path, causing generation of the RPM's to fail.

This fixes the path
