### PR TITLE
fix TestEventsContainerWithMultiNetwork

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -244,12 +244,14 @@ func (s *DockerSuite) TestEventsContainerWithMultiNetwork(c *check.C) {
 	out, _ := dockerCmd(c, "events", "--since", since, "--until", until, "-f", "type=network")
 	netEvents := strings.Split(strings.TrimSpace(out), "\n")
 
+	// NOTE: order in which disconnect takes place is undetermined,
+	// so don't check for the *full* name
 	c.Assert(len(netEvents), checker.Equals, 2)
 	c.Assert(netEvents[0], checker.Contains, "disconnect")
-	c.Assert(netEvents[0], checker.Contains, "test-event-network-local-1")
+	c.Assert(netEvents[0], checker.Contains, "test-event-network-local-")
 
 	c.Assert(netEvents[1], checker.Contains, "disconnect")
-	c.Assert(netEvents[1], checker.Contains, "test-event-network-local-2")
+	c.Assert(netEvents[1], checker.Contains, "test-event-network-local-")
 }
 
 func (s *DockerSuite) TestEventsStreaming(c *check.C) {


### PR DESCRIPTION
the order in which disconnect takes place is undetermined,
so don't check for the full name

this test was passing due to a previous bug, that
always returned the same network-name.

this bug was recently fixed in 148bcda3292563df8e433a3d7987810cd5702dec
(pull request 23375), exposing this test to be
flaky.

fixes https://github.com/docker/docker/issues/23386
