### PR TITLE
Windows: Added support for storage-opt size

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -185,7 +185,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		Storage: &windowsoci.Storage{
 			Bps:  &c.HostConfig.IOMaximumBandwidth,
 			Iops: &c.HostConfig.IOMaximumIOps,
-			//TODO SandboxSize: ...,
 		},
 	}
 	return (*libcontainerd.Spec)(&s), nil

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -155,7 +155,7 @@ Set storage driver options per container.
 
 This (size) will allow to set the container rootfs size to 120G at creation time. 
 User cannot pass a size less than the Default BaseFS Size. This option is only 
-available for the `devicemapper`, `btrfs`, and `zfs` graph drivers.
+available for the `devicemapper`, `btrfs`, `windowsfilter`, and `zfs` graph drivers.
 
 ### Specify isolation technology for container (--isolation)
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -187,7 +187,7 @@ The `-w` lets the command being executed inside directory given, here
 
 This (size) will allow to set the container rootfs size to 120G at creation time. 
 User cannot pass a size less than the Default BaseFS Size. This option is only 
-available for the `devicemapper`, `btrfs`, and `zfs` graph drivers.
+available for the `devicemapper`, `btrfs`, `windowsfilter`, and `zfs` graph drivers.
 
 ### Mount tmpfs (--tmpfs)
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -74,9 +74,6 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 			if spec.Windows.Resources.Storage.Iops != nil {
 				configuration.StorageIOPSMaximum = *spec.Windows.Resources.Storage.Iops
 			}
-			if spec.Windows.Resources.Storage.SandboxSize != nil {
-				configuration.StorageSandboxSize = *spec.Windows.Resources.Storage.SandboxSize
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Added support for storage-opt size on Windows.

**\- How I did it**

Added ExpandSandboxSize api to hcsshim, and called it after creating a sandbox layer.

**\- How to verify it**

This does not work on TP5, but does work on internal builds. Manually tested currently, I will add a CI test gated on build number.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added support for storage-opt size on Windows daemons

**\- A picture of a cute animal (not mandatory but encouraged)**

![Hippo!](https://img.buzzfeed.com/buzzfeed-static/static/enhanced/webdr06/2013/5/6/12/enhanced-buzz-20493-1367856817-1.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
