### PR TITLE
add option to specify runtime

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -71,6 +71,9 @@ func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 		args := []string{"--systemd-cgroup=true"}
 		opts = append(opts, libcontainerd.WithRuntimeArgs(args))
 	}
+	if cli.Config.Runtime != "" {
+		opts = append(opts, libcontainerd.WithRuntime(cli.Config.Runtime))
+	}
 	return opts
 }
 

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -118,6 +118,7 @@ type CommonConfig struct {
 	LogLevel  string   `json:"log-level,omitempty"`
 	TLS       bool     `json:"tls,omitempty"`
 	TLSVerify bool     `json:"tlsverify,omitempty"`
+	Runtime   string   `json:"runtime,omitempty"`
 
 	// Embedded structs that allow config
 	// deserialization without the full struct.

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -82,6 +82,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))
 	cmd.StringVar(&config.RemappedRoot, []string{"-userns-remap"}, "", usageFn("User/Group setting for user namespaces"))
 	cmd.StringVar(&config.ContainerdAddr, []string{"-containerd"}, "", usageFn("Path to containerd socket"))
+	cmd.StringVar(&config.Runtime, []string{"-runtime"}, "", usageFn("Name or path of runtime"))
 
 	config.attachExperimentalFlags(cmd, usageFn)
 }


### PR DESCRIPTION
Add a option to specify which runtime user wants to use, it makes testing docker daemon with new runtime more convenient.
