### PR TITLE
integration-cli: use distribution/reference.DigestRegexp

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
@@ -215,7 +215,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *check.C) {
 	// ensure that none of the layers were mounted from another repository during push
 	c.Assert(strings.Contains(out1, "Mounted from"), check.Equals, false)
 
-	digest1 := digest.DigestRegexp.FindString(out1)
+	digest1 := reference.DigestRegexp.FindString(out1)
 	c.Assert(len(digest1), checker.GreaterThan, 0, check.Commentf("no digest found for pushed manifest"))
 
 	destRepoName := fmt.Sprintf("%v/dockercli/crossrepopush", privateRegistryURL)
@@ -227,7 +227,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *check.C) {
 	// ensure that layers were mounted from the first repo during push
 	c.Assert(strings.Contains(out2, "Mounted from dockercli/busybox"), check.Equals, true)
 
-	digest2 := digest.DigestRegexp.FindString(out2)
+	digest2 := reference.DigestRegexp.FindString(out2)
 	c.Assert(len(digest2), checker.GreaterThan, 0, check.Commentf("no digest found for pushed manifest"))
 	c.Assert(digest1, check.Equals, digest2)
 
@@ -248,7 +248,7 @@ func (s *DockerSchema1RegistrySuite) TestCrossRepositoryLayerPushNotSupported(c 
 	// ensure that none of the layers were mounted from another repository during push
 	c.Assert(strings.Contains(out1, "Mounted from"), check.Equals, false)
 
-	digest1 := digest.DigestRegexp.FindString(out1)
+	digest1 := reference.DigestRegexp.FindString(out1)
 	c.Assert(len(digest1), checker.GreaterThan, 0, check.Commentf("no digest found for pushed manifest"))
 
 	destRepoName := fmt.Sprintf("%v/dockercli/crossrepopush", privateRegistryURL)
@@ -260,9 +260,9 @@ func (s *DockerSchema1RegistrySuite) TestCrossRepositoryLayerPushNotSupported(c 
 	// schema1 registry should not support cross-repo layer mounts, so ensure that this does not happen
 	c.Assert(strings.Contains(out2, "Mounted from"), check.Equals, false)
 
-	digest2 := digest.DigestRegexp.FindString(out2)
+	digest2 := reference.DigestRegexp.FindString(out2)
 	c.Assert(len(digest2), checker.GreaterThan, 0, check.Commentf("no digest found for pushed manifest"))
-	c.Assert(digest1, check.Equals, digest2)
+	c.Assert(digest1, check.Not(check.Equals), digest2)
 
 	// ensure that we can pull and run the second pushed repository
 	dockerCmd(c, "rmi", destRepoName)


### PR DESCRIPTION
from a docker push output `digest.DigestRegexp.FindString(output)` does
not retrive the `sha256:` prefixed digest but just a string - in many
cases it's the registry host. The checks in the code are completely
wrong then. Fix this by using the `DigestRegexp` from the
`distribution/reference` package which correctly retrieves the digest
from the output.

You can check this by printing the digests and fail the test:            

```
224     // FAIL: docker_cli_push_test.go:208: DockerRegistrySuite.TestCrossRepositoryLayerPush
225                                                                                 
226     //127.0.0.1:5000                                                            
227     //PASS: docker_cli_push_test.go:244: DockerSchema1RegistrySuite.TestCrossRepositoryLayerPushNotSupported    0    .758s
228     //OOPS: 1 passed, 1 FAILED                                               
```

You can see `127.0.0.1:5000` which is clearly not a digest. By using `distribution/reference` the above will print the correct digest.

Signed-off-by: Antonio Murdaca runcom@redhat.com
