### PR TITLE
Move GetExitCode to package container and unexport it

### DIFF
--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -118,7 +118,7 @@ func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 		return errAttach
 	}
 
-	_, status, err := dockerCli.GetExitCode(ctx, opts.container)
+	_, status, err := getExitCode(dockerCli, ctx, opts.container)
 	if err != nil {
 		return err
 	}

--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -283,7 +283,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		if status, err = client.ContainerWait(ctx, createResponse.ID); err != nil {
 			return runStartContainerErr(err)
 		}
-		if _, status, err = dockerCli.GetExitCode(ctx, createResponse.ID); err != nil {
+		if _, status, err = getExitCode(dockerCli, ctx, createResponse.ID); err != nil {
 			return err
 		}
 	} else {
@@ -296,7 +296,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		} else {
 			// In TTY mode, there is a race: if the process dies too slowly, the state could
 			// be updated after the getExitCode call and result in the wrong exit code being reported
-			if _, status, err = dockerCli.GetExitCode(ctx, createResponse.ID); err != nil {
+			if _, status, err = getExitCode(dockerCli, ctx, createResponse.ID); err != nil {
 				return err
 			}
 		}

--- a/api/client/container/start.go
+++ b/api/client/container/start.go
@@ -118,7 +118,7 @@ func runStart(dockerCli *client.DockerCli, opts *startOptions) error {
 		if attchErr := <-cErr; attchErr != nil {
 			return attchErr
 		}
-		_, status, err := dockerCli.GetExitCode(ctx, container)
+		_, status, err := getExitCode(dockerCli, ctx, container)
 		if err != nil {
 			return err
 		}

--- a/api/client/container/utils.go
+++ b/api/client/container/utils.go
@@ -1,0 +1,22 @@
+package container
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/api/client"
+	clientapi "github.com/docker/engine-api/client"
+)
+
+// getExitCode perform an inspect on the container. It returns
+// the running state and the exit code.
+func getExitCode(dockerCli *client.DockerCli, ctx context.Context, containerID string) (bool, int, error) {
+	c, err := dockerCli.Client().ContainerInspect(ctx, containerID)
+	if err != nil {
+		// If we can't connect, then the daemon probably died.
+		if err != clientapi.ErrConnectionFailed {
+			return false, -1, err
+		}
+		return false, -1, nil
+	}
+	return c.State.Running, c.State.ExitCode, nil
+}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -89,21 +89,6 @@ func (cli *DockerCli) ResizeTtyTo(ctx context.Context, id string, height, width 
 	}
 }
 
-// GetExitCode perform an inspect on the container. It returns
-// the running state and the exit code.
-func (cli *DockerCli) GetExitCode(ctx context.Context, containerID string) (bool, int, error) {
-	c, err := cli.client.ContainerInspect(ctx, containerID)
-	if err != nil {
-		// If we can't connect, then the daemon probably died.
-		if err != client.ErrConnectionFailed {
-			return false, -1, err
-		}
-		return false, -1, nil
-	}
-
-	return c.State.Running, c.State.ExitCode, nil
-}
-
 // getExecExitCode perform an inspect on the exec command. It returns
 // the running state and the exit code.
 func (cli *DockerCli) getExecExitCode(ctx context.Context, execID string) (bool, int, error) {


### PR DESCRIPTION
GetExitCode is used only by container package, so move it to package
container and unexport it

Signed-off-by: Zhang Wei zhangwei555@huawei.com

Other functions can be handled separately while doing migration to cobra,  `run`, `attach` and `start` is already done the migration, so it's ready to move this function into container package and unexport it again.

ping @vdemeester 
