### PR TITLE
Fixing man page link in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -284,5 +284,5 @@ aws cloudfront  create-invalidation --profile docs.docker.com --distribution-id 
 ### Generate the man pages
 
 For information on generating man pages (short for manual page), see the README.md
-document in [the man page directory](https://github.com/docker/docker/tree/master/docker)
+document in [the man page directory](https://github.com/docker/docker/tree/master/man)
 in this project.


### PR DESCRIPTION
There was a broken link to the man page directory.
I've replaced it, hope with the right one.

Signed-off-by: Andrew Pogrebnoy absourd.noise@gmail.com
