### PR TITLE
Allow user to specify container's link-local addresses

### DIFF
--- a/api/client/network/connect.go
+++ b/api/client/network/connect.go
@@ -12,12 +12,13 @@ import (
 )
 
 type connectOptions struct {
-	network     string
-	container   string
-	ipaddress   string
-	ipv6address string
-	links       opts.ListOpts
-	aliases     []string
+	network      string
+	container    string
+	ipaddress    string
+	ipv6address  string
+	links        opts.ListOpts
+	aliases      []string
+	linklocalips []string
 }
 
 func newConnectCommand(dockerCli *client.DockerCli) *cobra.Command {
@@ -41,6 +42,7 @@ func newConnectCommand(dockerCli *client.DockerCli) *cobra.Command {
 	flags.StringVar(&opts.ipv6address, "ip6", "", "IPv6 Address")
 	flags.Var(&opts.links, "link", "Add link to another container")
 	flags.StringSliceVar(&opts.aliases, "alias", []string{}, "Add network-scoped alias for the container")
+	flags.StringSliceVar(&opts.linklocalips, "link-local-ip", []string{}, "Add a link-local address for the container")
 
 	return cmd
 }
@@ -50,8 +52,9 @@ func runConnect(dockerCli *client.DockerCli, opts connectOptions) error {
 
 	epConfig := &network.EndpointSettings{
 		IPAMConfig: &network.EndpointIPAMConfig{
-			IPv4Address: opts.ipaddress,
-			IPv6Address: opts.ipv6address,
+			IPv4Address:  opts.ipaddress,
+			IPv6Address:  opts.ipv6address,
+			LinkLocalIPs: opts.linklocalips,
 		},
 		Links:   opts.links.GetAll(),
 		Aliases: opts.aliases,

--- a/container/container.go
+++ b/container/container.go
@@ -789,9 +789,15 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 
 	if epConfig != nil {
 		ipam := epConfig.IPAMConfig
-		if ipam != nil && (ipam.IPv4Address != "" || ipam.IPv6Address != "") {
+		if ipam != nil && (ipam.IPv4Address != "" || ipam.IPv6Address != "" || len(ipam.LinkLocalIPs) > 0) {
+			var ipList []net.IP
+			for _, ips := range ipam.LinkLocalIPs {
+				if ip := net.ParseIP(ips); ip != nil {
+					ipList = append(ipList, ip)
+				}
+			}
 			createOptions = append(createOptions,
-				libnetwork.CreateOptionIpam(net.ParseIP(ipam.IPv4Address), net.ParseIP(ipam.IPv6Address), nil, nil))
+				libnetwork.CreateOptionIpam(net.ParseIP(ipam.IPv4Address), net.ParseIP(ipam.IPv6Address), ipList, nil))
 		}
 
 		for _, alias := range epConfig.Aliases {

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -339,7 +339,8 @@ Create a container
               "isolated_nw" : {
                   "IPAMConfig": {
                       "IPv4Address":"172.20.30.33",
-                      "IPv6Address":"2001:db8:abcd::3033"
+                      "IPv6Address":"2001:db8:abcd::3033",
+                      "LinkLocalIPs:["169.254.34.68", "fe80::3468"]
                   },
                   "Links":["container_1", "container_2"],
                   "Aliases":["server_x", "server_y"]

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -54,6 +54,7 @@ Creates a new container.
       -l, --label=[]                Set metadata on the container (e.g., --label=com.example.key=value)
       --label-file=[]               Read in a line delimited file of labels
       --link=[]                     Add link to another container
+      --link-local-ip=[]            Container IPv4/IPv6 link-local addresses (e.g. 169.254.0.77, fe80::77)
       --log-driver=""               Logging driver for container
       --log-opt=[]                  Log driver specific options
       -m, --memory=""               Memory limit

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -19,6 +19,7 @@ parent = "smn_cli"
       --ip               IPv4 Address
       --ip6              IPv6 Address
       --link=[]          Add a link to another container
+      --link-local-ip=[] IPv4/IPv6 link-local addresses
 
 Connects a container to a network. You can connect a container by name
 or by ID. Once connected, the container can communicate with other containers in

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -55,6 +55,7 @@ parent = "smn_cli"
       -l, --label=[]                Set metadata on the container (e.g., --label=com.example.key=value)
       --label-file=[]               Read in a file of labels (EOL delimited)
       --link=[]                     Add link to another container
+      --link-local-ip=[]            Container IPv4/IPv6 link-local addresses (e.g. 169.254.0.77, fe80::77)
       --log-driver=""               Logging driver for container
       --log-opt=[]                  Log driver specific options
       -m, --memory=""               Memory limit

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -288,18 +288,19 @@ of the containers.
 
 ## Network settings
 
-    --dns=[]         : Set custom dns servers for the container
-    --net="bridge"   : Connect a container to a network
-                        'bridge': create a network stack on the default Docker bridge
-                        'none': no networking
-                        'container:<name|id>': reuse another container's network stack
-                        'host': use the Docker host network stack
-                        '<network-name>|<network-id>': connect to a user-defined network
-    --net-alias=[]   : Add network-scoped alias for the container
-    --add-host=""    : Add a line to /etc/hosts (host:IP)
-    --mac-address="" : Sets the container's Ethernet device's MAC address
-    --ip=""          : Sets the container's Ethernet device's IPv4 address
-    --ip6=""         : Sets the container's Ethernet device's IPv6 address
+    --dns=[]           : Set custom dns servers for the container
+    --net="bridge"     : Connect a container to a network
+                          'bridge': create a network stack on the default Docker bridge
+                          'none': no networking
+                          'container:<name|id>': reuse another container's network stack
+                          'host': use the Docker host network stack
+                          '<network-name>|<network-id>': connect to a user-defined network
+    --net-alias=[]     : Add network-scoped alias for the container
+    --add-host=""      : Add a line to /etc/hosts (host:IP)
+    --mac-address=""   : Sets the container's Ethernet device's MAC address
+    --ip=""            : Sets the container's Ethernet device's IPv4 address
+    --ip6=""           : Sets the container's Ethernet device's IPv6 address
+    --link-local-ip=[] : Sets one or more container's Ethernet device's link local IPv4/IPv6 addresses
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -43,6 +43,7 @@ docker-create - Create a new container
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
+[**--link-local-ip**[=*[]*]]
 [**--log-driver**[=*[]*]]
 [**--log-opt**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
@@ -219,6 +220,9 @@ millions of trillions.
 **--link**=[]
    Add link to another container in the form of <name or id>:alias or just
    <name or id> in which case the alias will match the name.
+
+**--link-local-ip**=[]
+   Add one or more link-local IPv4/IPv6 addresses to the container's interface
 
 **--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -45,6 +45,7 @@ docker-run - Run a command in a new container
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
+[**--link-local-ip**[=*[]*]]
 [**--log-driver**[=*[]*]]
 [**--log-opt**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
@@ -325,6 +326,9 @@ uses **--link** when starting the new client container, then the client
 container can access the exposed port via a private networking interface. Docker
 will set some environment variables in the client container to help indicate
 which interface and port to use.
+
+**--link-local-ip**=[]
+   Add one or more link-local IPv4/IPv6 addresses to the container's interface
 
 **--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.


### PR DESCRIPTION
Allows docker containers to fit in deployments which make use of link-local IPs to segregate and expose local host services.

Follows usage example:

```
~$ docker network create nw1
c5be8936aecc7b276f22a9f3f2f441ef1c33811417d56f044ce6ac2a7a0649dc
~$ docker network create nw2
d05ddc77d6132193988dc0f01beb5fb6dbe2e5119c8595ecce4dda4373fb2e9a
~$ 
~$ docker run -d --name c0 --link-local-ip 169.254.1.1 --net nw1 alpine top
23631c5fc3349176b2dd3edc92b5a442751406edc9cacc5f1ebaf5367da1955f
~$ docker network connect --link-local-ip 169.254.2.2 --link-local-ip fe80::169:254:2:2 nw2 c0
~$ 
~$ docker exec c0 ip addr show eth0 | grep 169
    inet 169.254.1.1/16 scope global eth0
~$ docker exec c0 ip addr show eth1 | grep 169
    inet 169.254.2.2/16 scope global eth1
    inet6 fe80::169:254:2:2/64 scope link 
~$ 
~$ docker stop c0 && docker start c0
c0
c0
~$ docker exec c0 ip addr show eth0 | grep 169
    inet 169.254.1.1/16 scope global eth0
~$ docker exec c0 ip addr show eth1 | grep 169
    inet 169.254.2.2/16 scope global eth1
    inet6 fe80::169:254:2:2/64 scope link 
~$ 
~$ docker run --link-local-ip 192.168.4.4 --net nw1 alpine ifconfig
docker: Error response from daemon: invalid link local IP address: 192.168.4.4.
```

Link-local IPs are special IPs which belong to a well known subnet and are purely managed by the operator, usually dependent on the architecture where they are deployed. Therefore they are not managed by docker (IPAM driver). Libnetwork will honor the request, only check they are effectively of link-local type, and program them on the container's interface.

~~Note: Won't build as it depends on https://github.com/docker/libnetwork/pull/1228 and https://github.com/docker/engine-api/pull/269. But want this PR open to start docker changes review process.~~

Signed-off-by: Alessandro Boch aboch@docker.com
