### PR TITLE
Fixed spelling error in builder/dockerfile/parser/parser.go

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -91,7 +91,7 @@ func init() {
 // ParseLine parse a line and return the remainder.
 func ParseLine(line string) (string, *Node, error) {
 
-	// Handle the parser directive '# escape=<char>. Parser directives must preceed
+	// Handle the parser directive '# escape=<char>. Parser directives must precede
 	// any builder instruction or other comments, and cannot be repeated.
 	if lookingForDirectives {
 		tecMatch := tokenEscapeCommand.FindStringSubmatch(strings.ToLower(line))


### PR DESCRIPTION
Super minor edit...

![bunny](https://s-media-cache-ak0.pinimg.com/736x/99/29/72/992972d7b8918707a98ad60fe2622d1d.jpg)
