### PR TITLE
deb: skip hidden files when generating indexes

### DIFF
--- a/hack/make/generate-index-listing
+++ b/hack/make/generate-index-listing
@@ -40,8 +40,8 @@ create_index() {
 	# change IFS locally within subshell so the for loop saves line correctly to L var
 	IFS=$'\n';
 
-	# pretty sweet, will mimick the normal apache output
-	for L in $(find -L . -mount -depth -maxdepth 1 -type f ! -name 'index' -printf "<a href=\"%f\">%f|@_@%Td-%Tb-%TY %Tk:%TM  @%f@\n"|sort|column -t -s '|' | sed 's,\([\ ]\+\)@_@,</a>\1,g');
+	# pretty sweet, will mimick the normal apache output. skipping "index" and hidden files
+	for L in $(find -L . -mount -depth -maxdepth 1 -type f ! -name 'index' ! -name '.*' -prune -printf "<a href=\"%f\">%f|@_@%Td-%Tb-%TY %Tk:%TM  @%f@\n"|sort|column -t -s '|' | sed 's,\([\ ]\+\)@_@,</a>\1,g');
 	do
 		# file
 		F=$(sed -e 's,^.*@\([^@]\+\)@.*$,\1,g'<<<"$L");


### PR DESCRIPTION
We don't need hidden files to be listed in the indexes, so skip them if hidden files exist.

(noticed some `.DS_Store` files appearing in the indexes while testing)
