### PR TITLE
pkg: authorization: lock when lazy loading

### DIFF
--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -76,7 +76,6 @@ func (s *DockerAuthzSuite) TearDownTest(c *check.C) {
 func (s *DockerAuthzSuite) SetUpSuite(c *check.C) {
 	mux := http.NewServeMux()
 	s.server = httptest.NewServer(mux)
-	c.Assert(s.server, check.NotNil, check.Commentf("Failed to start an HTTP Server"))
 
 	mux.HandleFunc("/Plugin.Activate", func(w http.ResponseWriter, r *http.Request) {
 		b, err := json.Marshal(plugins.Manifest{Implements: []string{authorization.AuthZApiImplements}})

--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -130,7 +130,7 @@ func (c *Client) callWithRetry(serviceMethod string, data io.Reader, retry bool)
 				return nil, err
 			}
 			retries++
-			logrus.Warnf("Unable to connect to plugin: %s:%s, retrying in %v", req.URL.Host, req.URL.Path, timeOff)
+			logrus.Warnf("Unable to connect to plugin: %s%s: %v, retrying in %v", req.URL.Host, req.URL.Path, err, timeOff)
 			time.Sleep(timeOff)
 			continue
 		}


### PR DESCRIPTION
Found a data race in docker journal - fix this by locking at each request @justincormack @LK4D4 PTAL

```
7]: ==================
7]: WARNING: DATA RACE
7]: Write by goroutine 55:
7]: github.com/docker/docker/pkg/authorization.(*authorizationPlugin).initPlugin()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/plugin.go:77 +
7]: github.com/docker/docker/pkg/authorization.(*authorizationPlugin).AuthZRequest()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/plugin.go:47 +
7]: github.com/docker/docker/pkg/authorization.(*Ctx).AuthZRequest()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/authz.go:82 +0
7]: github.com/docker/docker/pkg/authorization.Middleware.WrapHandler.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/middleware.go:
7]: github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/middleware/debug.go:2
7]: github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:137 +0x177
7]: Write by goroutine 55:
7]: github.com/docker/docker/pkg/authorization.(*authorizationPlugin).initPlugin()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/plugin.go:77 +
7]: github.com/docker/docker/pkg/authorization.(*authorizationPlugin).AuthZRequest()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/plugin.go:47 +
7]: github.com/docker/docker/pkg/authorization.(*Ctx).AuthZRequest()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/authz.go:82 +0
7]: github.com/docker/docker/pkg/authorization.Middleware.WrapHandler.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/middleware.go:
7]: github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/middleware/debug.go:2
7]: github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:137 +0x177
7]: net/http.HandlerFunc.ServeHTTP()
7]: /usr/lib/golang/src/net/http/server.go:1422 +0x47
7]: github.com/gorilla/mux.(*Router).ServeHTTP()
7]: /home/amurdaca/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x37f
7]: github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/router_swapper.go:29 
7]: net/http.serverHandler.ServeHTTP()
7]: /usr/lib/golang/src/net/http/server.go:1862 +0x206
7]: net/http.(*conn).serve()
7]: /usr/lib/golang/src/net/http/server.go:1361 +0x117c
7]: 
7]: Previous read by goroutine 57:
7]: github.com/docker/docker/pkg/authorization.(*authorizationPlugin).initPlugin()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/plugin.go:75 +
7]: github.com/docker/docker/pkg/authorization.(*authorizationPlugin).AuthZRequest()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/plugin.go:47 +
7]: github.com/docker/docker/pkg/authorization.(*Ctx).AuthZRequest()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/authz.go:82 +0
7]: github.com/docker/docker/pkg/authorization.Middleware.WrapHandler.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/pkg/authorization/middleware.go:
7]: github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/middleware/debug.go:2
7]: github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:137 +0x177
7]: net/http.HandlerFunc.ServeHTTP()
7]: /usr/lib/golang/src/net/http/server.go:1422 +0x47
7]: github.com/gorilla/mux.(*Router).ServeHTTP()
7]: /home/amurdaca/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x37f
7]: github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/router_swapper.go:29 
7]: net/http.serverHandler.ServeHTTP()
7]: /usr/lib/golang/src/net/http/server.go:1862 +0x206
7]: net/http.(*conn).serve()
7]: /usr/lib/golang/src/net/http/server.go:1361 +0x117c
7]: 
7]: Goroutine 55 (running) created at:
7]: net/http.(*Server).Serve()
7]: /usr/lib/golang/src/net/http/server.go:1910 +0x464
7]: github.com/docker/docker/api/server.(*HTTPServer).Serve()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:112 +0x79
7]: github.com/docker/docker/api/server.(*Server).serveAPI.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:85 +0x17e
7]: 
7]: Goroutine 57 (running) created at:
7]: net/http.(*Server).Serve()
7]: /usr/lib/golang/src/net/http/server.go:1910 +0x464
7]: github.com/docker/docker/api/server.(*HTTPServer).Serve()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:112 +0x79
7]: github.com/docker/docker/api/server.(*Server).serveAPI.func1()
7]: /home/amurdaca/src/github.com/docker/docker/.gopath/src/github.com/docker/docker/api/server/server.go:85 +0x17e
7]: ==================
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
