### PR TITLE
Double check 401 responses in case proxy intercepts authorization headers

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -328,6 +328,20 @@ func (r *Session) GetRemoteTag(registries []string, repositoryRef reference.Name
 			return "", err
 		}
 
+		if res.StatusCode == 401 && res.Header.Get("Set-Cookie") != "" {
+			// Some proxies expect browser-like behavior, with an Authorization
+			// header only sent in response to a server challenge. Try again,
+			// with cookies from the 401 response.
+			// See https://github.com/docker/docker/issues/22503
+			logrus.Debugf("Got status code %d from %s, retrying...", res.StatusCode, endpoint)
+			res.Body.Close()
+
+			res, err = r.client.Get(endpoint)
+			if err != nil {
+				return "", err
+			}
+		}
+
 		logrus.Debugf("Got status code %d from %s", res.StatusCode, endpoint)
 		defer res.Body.Close()
 
@@ -364,6 +378,20 @@ func (r *Session) GetRemoteTags(registries []string, repositoryRef reference.Nam
 		res, err := r.client.Get(endpoint)
 		if err != nil {
 			return nil, err
+		}
+
+		if res.StatusCode == 401 && res.Header.Get("Set-Cookie") != "" {
+			// Some proxies expect browser-like behavior, with an Authorization
+			// header only sent in response to a server challenge. Try again,
+			// with cookies from the 401 response.
+			// See https://github.com/docker/docker/issues/22503
+			logrus.Debugf("Got status code %d from %s, retrying...", res.StatusCode, endpoint)
+			res.Body.Close()
+
+			res, err = r.client.Get(endpoint)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		logrus.Debugf("Got status code %d from %s", res.StatusCode, endpoint)

--- a/registry/session.go
+++ b/registry/session.go
@@ -309,7 +309,7 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
 	return res.Body, nil
 }
 
-func (r *Session) get_response_body(endpoint string) (io.ReadCloser, error) {
+func (r *Session) getResponseBody(endpoint string) (io.ReadCloser, error) {
 	res, err := r.client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -357,7 +357,7 @@ func (r *Session) GetRemoteTag(registries []string, repositoryRef reference.Name
 	}
 	for _, host := range registries {
 		endpoint := fmt.Sprintf("%srepositories/%s/tags/%s", host, repository, askedTag)
-		body, err := r.get_response_body(endpoint)
+		body, err := r.getResponseBody(endpoint)
 		if err != nil {
 			return "", err
 		}
@@ -387,7 +387,7 @@ func (r *Session) GetRemoteTags(registries []string, repositoryRef reference.Nam
 	}
 	for _, host := range registries {
 		endpoint := fmt.Sprintf("%srepositories/%s/tags", host, repository)
-		body, err := r.get_response_body(endpoint)
+		body, err := r.getResponseBody(endpoint)
 		if err != nil {
 			return nil, err
 		}

--- a/registry/session.go
+++ b/registry/session.go
@@ -309,6 +309,40 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
 	return res.Body, nil
 }
 
+func (r *Session) get_response_body(endpoint string) (io.ReadCloser, error) {
+		res, err := r.client.Get(endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		if res.StatusCode == 401 && res.Header.Get("Set-Cookie") != "" {
+			// Some proxies expect browser-like behavior, with an Authorizaton
+			// header only sent in response to a server challenge. Try again
+			// with cookies from the 401 response.
+			// See https://github.com/docker/docker/issues/22503
+			logrus.Debugf("Got status code %d from %s, retrying...", res.StatusCode, endpoint)
+			res.Body.Close()
+
+			res, err = r.client.Get(endpoint)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		logrus.Debugf("Got status code %d from %s", res.StatusCode, endpoint)
+
+		if res.StatusCode == 404 {
+			res.Body.Close()
+			return nil, ErrRepoNotFound
+		}
+		if res.StatusCode != 200 {
+			res.Body.Close()
+			return nil, nil
+		}
+
+		return res.Body, nil
+}
+
 // GetRemoteTag retrieves the tag named in the askedTag argument from the given
 // repository. It queries each of the registries supplied in the registries
 // argument, and returns data from the first one that answers the query
@@ -323,40 +357,18 @@ func (r *Session) GetRemoteTag(registries []string, repositoryRef reference.Name
 	}
 	for _, host := range registries {
 		endpoint := fmt.Sprintf("%srepositories/%s/tags/%s", host, repository, askedTag)
-		res, err := r.client.Get(endpoint)
+		body, err := r.get_response_body(endpoint)
 		if err != nil {
 			return "", err
 		}
-
-		if res.StatusCode == 401 && res.Header.Get("Set-Cookie") != "" {
-			// Some proxies expect browser-like behavior, with an Authorization
-			// header only sent in response to a server challenge. Try again,
-			// with cookies from the 401 response.
-			// See https://github.com/docker/docker/issues/22503
-			logrus.Debugf("Got status code %d from %s, retrying...", res.StatusCode, endpoint)
-			res.Body.Close()
-
-			res, err = r.client.Get(endpoint)
-			if err != nil {
+		if body != nil {
+			defer body.Close()
+			var tagID string
+			if err := json.NewDecoder(body).Decode(&tagID); err != nil {
 				return "", err
 			}
+			return tagID, nil
 		}
-
-		logrus.Debugf("Got status code %d from %s", res.StatusCode, endpoint)
-		defer res.Body.Close()
-
-		if res.StatusCode == 404 {
-			return "", ErrRepoNotFound
-		}
-		if res.StatusCode != 200 {
-			continue
-		}
-
-		var tagID string
-		if err := json.NewDecoder(res.Body).Decode(&tagID); err != nil {
-			return "", err
-		}
-		return tagID, nil
 	}
 	return "", fmt.Errorf("Could not reach any registry endpoint")
 }
@@ -375,40 +387,18 @@ func (r *Session) GetRemoteTags(registries []string, repositoryRef reference.Nam
 	}
 	for _, host := range registries {
 		endpoint := fmt.Sprintf("%srepositories/%s/tags", host, repository)
-		res, err := r.client.Get(endpoint)
+		body, err := r.get_response_body(endpoint)
 		if err != nil {
 			return nil, err
 		}
-
-		if res.StatusCode == 401 && res.Header.Get("Set-Cookie") != "" {
-			// Some proxies expect browser-like behavior, with an Authorization
-			// header only sent in response to a server challenge. Try again,
-			// with cookies from the 401 response.
-			// See https://github.com/docker/docker/issues/22503
-			logrus.Debugf("Got status code %d from %s, retrying...", res.StatusCode, endpoint)
-			res.Body.Close()
-
-			res, err = r.client.Get(endpoint)
-			if err != nil {
+		if body != nil {
+			defer body.Close()
+			result := make(map[string]string)
+			if err := json.NewDecoder(body).Decode(&result); err != nil {
 				return nil, err
 			}
+			return result, nil
 		}
-
-		logrus.Debugf("Got status code %d from %s", res.StatusCode, endpoint)
-		defer res.Body.Close()
-
-		if res.StatusCode == 404 {
-			return nil, ErrRepoNotFound
-		}
-		if res.StatusCode != 200 {
-			continue
-		}
-
-		result := make(map[string]string)
-		if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
-			return nil, err
-		}
-		return result, nil
 	}
 	return nil, fmt.Errorf("Could not reach any registry endpoint")
 }


### PR DESCRIPTION
**\- What I did**

I modified the v1 pull code to retry if it receives a 401 Unauthorized error. This deals with proxies that expect authorization to follow the typical browser pattern of request with no Authorization header, response with 401, and subsequent request containing an Authorization header.  See https://github.com/docker/docker/issues/22503

**\- How I did it**

Initially, I modified the `GetRemoteTag` and `GetRemoteTags` functions to check if any 401 response includes a `Set-Cookie` header, and re-try in that case, to get past a proxy that intercepts Authorization headers unless a cookie is set.  The prescence of the cookie is how the proxy determines that the authorization request is a follow-up to a 401 error.

This added a lot more commonality to the `GetRemoteTag` and `GetRemoteTags` functions, so I then refactored the common code into a separate function.  This change highlighted that the functions were deferring closes inside a loop, which is not really a good idea. So, I also modified the code to close the body inside each iteration.

Things I didn't do:
- figure out how to make this work for v2 pull.
- emit a message advising the user that, for better performance, they might consider modifying their proxy rules.
- provide a test that mocks the described proxy pattern.

**\- How to verify it**

First, run a proxy that strips Authorization headers from requests, unless a cookie is set. The proxy sets a suitable cookie in any 401 responses.

In this case, `docker pull docker/whalesay` or `docker pull -a docker/whalesay` will fail with the message `Could not reach any registry endpoint`.

With this change, both commands will succeed, although warning that `this image was pulled from a legacy registry`.

Logs will show that requests were retried:

```
Jun 10 10:31:54 localhost docker: time="2016-06-10T10:31:54.032176288Z" level=de
bug msg="Got status code 401 from https://registry-1.docker.io/v1/repositories/d
ocker/whalesay/tags, retrying..."
Jun 10 10:31:54 localhost docker: time="2016-06-10T10:31:54.615268091Z" level=de
bug msg="Got status code 200 from https://registry-1.docker.io/v1/repositories/d
ocker/whalesay/tags"
```

**\- Description for the changelog**
Retry a request that returns 401, in case a proxy expects cookies with authorization requests

**\- A picture of a cute animal (not mandatory but encouraged)**

```
 ^..^
( oo )  )~
  ,,  ,,
```
