### PR TITLE
[carry 23352] update peaceful zen

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -54,6 +54,7 @@ var (
 		"naughty",
 		"nauseous",
 		"nostalgic",
+		"peaceful",
 		"pedantic",
 		"pensive",
 		"prickly",
@@ -73,6 +74,7 @@ var (
 		"thirsty",
 		"tiny",
 		"trusting",
+		"zen",
 	}
 
 	// Docker, starting from 0.7.x, generates names from notable scientists and hackers.


### PR DESCRIPTION
This carries https://github.com/docker/docker/pull/23352, which was now signed-off, but needed a rebase and squash

closes https://github.com/docker/docker/pull/23352
