### PR TITLE
Dockerfile.s390x: Remove 'seccomp' again from DOCKER_BUILDTAGS

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -161,7 +161,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
 
 VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
-ENV DOCKER_BUILDTAGS apparmor selinux seccomp
+ENV DOCKER_BUILDTAGS apparmor selinux
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc


### PR DESCRIPTION
We have to wait until runc version (RUNC_COMMIT) is bumped.
Otherwise we get the following error:

 oci runtime error: string SCMP_ARCH_S390 is not a valid
 arch for seccomp

See also #23171 

Fixes: bf2a577c131d899 ("Enable seccomp for s390x")
Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
