### PR TITLE
Update Golang requirements in PACKAGERS.md

### DIFF
--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -44,8 +44,7 @@ need to package Docker your way, without denaturing it in the process.
 To build Docker, you will need the following:
 
 * A recent version of Git and Mercurial
-* Go version 1.4 or later (Go version 1.5 or later required for hardware signing
-  support in Docker Content Trust)
+* Go version 1.6 or later
 * A clean checkout of the source added to a valid [Go
   workspace](https://golang.org/doc/code.html#Workspaces) under the path
   *src/github.com/docker/docker* (unless you plan to use `AUTO_GOPATH`,


### PR DESCRIPTION
Docker 1.12 now requires Go 1.6, so update the packagers.md accordingly

ping @tianon - I think this document needs more updates, but just fixing one thing I was aware of :D
