### PR TITLE
remove unused defaultExitOnUnhealthy constant

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -32,9 +32,6 @@ const (
 	// for the container to be considered unhealthy.
 	defaultProbeRetries = 3
 
-	// Shut down a container if it becomes Unhealthy.
-	defaultExitOnUnhealthy = true
-
 	// Maximum number of entries to record
 	maxLogEntries = 5
 )


### PR DESCRIPTION
the '--exit-on-unhealty' option was removed,
but we forgot to remove this constant.

(see the discussion on https://github.com/docker/docker/pull/22719)
