### PR TITLE
Update vendored hcsshim to v0.3.4

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -43,7 +43,7 @@ esac
 
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
-clone git github.com/Microsoft/hcsshim v0.3.2
+clone git github.com/Microsoft/hcsshim v0.3.4
 clone git github.com/Microsoft/go-winio v0.3.4
 clone git github.com/Sirupsen/logrus v0.10.0 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/vendor/src/github.com/Microsoft/hcsshim/interface.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/interface.go
@@ -1,8 +1,31 @@
 package hcsshim
 
 import (
+	"errors"
 	"io"
 	"time"
+)
+
+var (
+	// ErrInvalidNotificationType is an error encountered when an invalid notification type is used
+	ErrInvalidNotificationType = errors.New("hcsshim: invalid notification type")
+
+	// ErrTimeout is an error encountered when waiting on a notification times out
+	ErrTimeout = errors.New("hcsshim: timeout waiting for notification")
+
+	// ErrHandleClose is an error returned when the handle generating the notification being waited on has been closed
+	ErrHandleClose = errors.New("hcsshim: the handle generating this notification has been closed")
+
+	// ErrInvalidProcessState is an error encountered when the process is not in a valid state for the requested operation
+	ErrInvalidProcessState = errors.New("the process is in an invalid state for the attempted operation")
+
+	// ErrUnexpectedContainerExit is the error returned when a container exits while waiting for
+	// a different expected notification
+	ErrUnexpectedContainerExit = errors.New("unexpected container exit")
+
+	// ErrUnexpectedProcessAbort is the error returned when communication with the compute service
+	// is lost while waiting for a notification
+	ErrUnexpectedProcessAbort = errors.New("lost communication with compute service")
 )
 
 // ProcessConfig is used as both the input of Container.CreateProcess


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Update vendored hcsshim to v0.3.4

This fixes a deadlock when a notification is received from HCS while unregistering for future notifications.

It also fixes a Windows container servicing bug, in which an incorrect query was being used.

**\- How to verify it**
The deadlock was encountered in internal stress tests. It no longer occurs with this version of hcsshim.

Servicing is also currently verified internally.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**\- A picture of a cute animal (not mandatory but encouraged)**
![Pig!](http://science-all.com/images/wallpapers/cute-animals-pictures/cute-animals-pictures-16.jpg)

@jhowardmsft PTAL

Signed-off-by: Darren Stahl darst@microsoft.com
