### PR TITLE
Removed QoS validation on Windows

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -405,8 +405,8 @@ Json Parameters:
     -   **CpuQuota** - Microseconds of CPU time that the container can get in a CPU period.
     -   **CpusetCpus** - String value containing the `cgroups CpusetCpus` to use.
     -   **CpusetMems** - Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
-    -   **MaximumIOps** - Maximum IO absolute rate in terms of IOps. MaximumIOps and MaximumIOBps are mutually exclusive settings.
-    -   **MaximumIOBps** - Maximum IO absolute rate in terms of bytes per second. MaximumIOps and MaximumIOBps are mutually exclusive settings.
+    -   **MaximumIOps** - Maximum IO absolute rate in terms of IOps.
+    -   **MaximumIOBps** - Maximum IO absolute rate in terms of bytes per second.
     -   **BlkioWeight** - Block IO weight (relative weight) accepts a weight value between 10 and 1000.
     -   **BlkioWeightDevice** - Block IO weight (relative device weight) in the form of:        `"BlkioWeightDevice": [{"Path": "device_path", "Weight": weight}]`
     -   **BlkioDeviceReadBps** - Limit read rate (bytes per second) from a device in the form of:	`"BlkioDeviceReadBps": [{"Path": "device_path", "Rate": rate}]`, for example:

--- a/runconfig/hostconfig_solaris.go
+++ b/runconfig/hostconfig_solaris.go
@@ -42,7 +42,6 @@ func ValidateIsolation(hc *container.HostConfig) error {
 }
 
 // ValidateQoS performs platform specific validation of the QoS settings
-// a disk can be limited by either Bps or IOps, but not both.
 func ValidateQoS(hc *container.HostConfig) error {
 	return nil
 }

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -89,7 +89,6 @@ func ValidateIsolation(hc *container.HostConfig) error {
 }
 
 // ValidateQoS performs platform specific validation of the QoS settings
-// a disk can be limited by either Bps or IOps, but not both.
 func ValidateQoS(hc *container.HostConfig) error {
 	// We may not be passed a host config, such as in the case of docker commit
 	if hc == nil {
@@ -97,11 +96,11 @@ func ValidateQoS(hc *container.HostConfig) error {
 	}
 
 	if hc.IOMaximumBandwidth != 0 {
-		return fmt.Errorf("invalid QoS settings: %s does not support --maximum-bandwidth", runtime.GOOS)
+		return fmt.Errorf("invalid QoS settings: %s does not support --io-maxbandwidth", runtime.GOOS)
 	}
 
 	if hc.IOMaximumIOps != 0 {
-		return fmt.Errorf("invalid QoS settings: %s does not support --maximum-iops", runtime.GOOS)
+		return fmt.Errorf("invalid QoS settings: %s does not support --io-maxiops", runtime.GOOS)
 	}
 	return nil
 }

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -46,15 +46,6 @@ func ValidateIsolation(hc *container.HostConfig) error {
 }
 
 // ValidateQoS performs platform specific validation of the Qos settings
-// a disk can be limited by either Bps or IOps, but not both.
 func ValidateQoS(hc *container.HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
-
-	if hc.IOMaximumIOps != 0 && hc.IOMaximumBandwidth != 0 {
-		return fmt.Errorf("invalid QoS settings: maximum bandwidth and maximum iops cannot both be set")
-	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Removed the mutually exclusive check for maximum IOPS and maximum bandwidth on Windows containers. The settings were not intended to be mutually exclusive.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Disk IOPs and bandwidth QoS are no longer mutually exclusive on Windows

**\- A picture of a cute animal (not mandatory but encouraged)**
![Monkey!](https://i.ytimg.com/vi/iL1Dbfz7Mok/maxresdefault.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
