### PR TITLE
Improve the TestEventsContainerWithMultiNetwork UT

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -244,14 +244,14 @@ func (s *DockerSuite) TestEventsContainerWithMultiNetwork(c *check.C) {
 	out, _ := dockerCmd(c, "events", "--since", since, "--until", until, "-f", "type=network")
 	netEvents := strings.Split(strings.TrimSpace(out), "\n")
 
-	// NOTE: order in which disconnect takes place is undetermined,
-	// so don't check for the *full* name
+	// received two network disconnect events
 	c.Assert(len(netEvents), checker.Equals, 2)
 	c.Assert(netEvents[0], checker.Contains, "disconnect")
-	c.Assert(netEvents[0], checker.Contains, "test-event-network-local-")
-
 	c.Assert(netEvents[1], checker.Contains, "disconnect")
-	c.Assert(netEvents[1], checker.Contains, "test-event-network-local-")
+
+	//both networks appeared in the network event output
+	c.Assert(out, checker.Contains, "test-event-network-local-1")
+	c.Assert(out, checker.Contains, "test-event-network-local-2")
 }
 
 func (s *DockerSuite) TestEventsStreaming(c *check.C) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

As the #23387 comment, the temp fix for UT need to be improved
to make it test the expected behavior. The expected behavior would
make sure related disconnect events for two networks are properly
emitted. So let's add it.

Signed-off-by: Kai Qiang Wu(Kennan) wkqwu@cn.ibm.com
