### PR TITLE
pkg: proxy: fix TCPEchoServer.Close() in unit test

### DIFF
--- a/pkg/proxy/network_proxy_test.go
+++ b/pkg/proxy/network_proxy_test.go
@@ -65,7 +65,7 @@ func (server *TCPEchoServer) Run() {
 }
 
 func (server *TCPEchoServer) LocalAddr() net.Addr { return server.listener.Addr() }
-func (server *TCPEchoServer) Close()              { server.listener.Addr() }
+func (server *TCPEchoServer) Close()              { server.listener.Close() }
 
 func (server *UDPEchoServer) Run() {
 	go func() {


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca runcom@redhat.com
