### PR TITLE
Fix incorrect usage of logrus when formatting string is present

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -362,7 +362,7 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 	}
 	if resources.CPUPercent > 0 {
 		warnings = append(warnings, "%s does not support CPU percent. Percent discarded.", runtime.GOOS)
-		logrus.Warn("%s does not support CPU percent. Percent discarded.", runtime.GOOS)
+		logrus.Warnf("%s does not support CPU percent. Percent discarded.", runtime.GOOS)
 		resources.CPUPercent = 0
 	}
 

--- a/integration-cli/events_utils.go
+++ b/integration-cli/events_utils.go
@@ -89,7 +89,7 @@ func (e *eventObserver) Match(match eventMatcher, process eventMatchProcessor) {
 		err = io.EOF
 	}
 
-	logrus.Debug("EventObserver scanner loop finished: %v", err)
+	logrus.Debugf("EventObserver scanner loop finished: %v", err)
 	e.disconnectionError = err
 }
 


### PR DESCRIPTION
This fix tries to fix logrus formatting by adding `f` to the end of `logrus.[Error|Warn|Debug|Fatal|Panic|Info](` when formatting string is present.

In the above case, the function `logrus.[Error|Warn|Debug|Fatal|Panic|Info]f(` should be used.

This fix is related to #23459, and is a follow up of #23461.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
