### PR TITLE
Fix shutdown daemon during daemon staring casue crash

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -127,11 +127,6 @@ func (cli *DaemonCli) start() (err error) {
 	stopc := make(chan bool)
 	defer close(stopc)
 
-	signal.Trap(func() {
-		cli.stop()
-		<-stopc // wait for daemonCli.start() to return
-	})
-
 	// warn from uuid package when running the daemon
 	uuid.Loggerf = logrus.Warnf
 
@@ -258,6 +253,11 @@ func (cli *DaemonCli) start() (err error) {
 	if err != nil {
 		return err
 	}
+	cli.api = api
+	signal.Trap(func() {
+		cli.stop()
+		<-stopc // wait for daemonCli.start() to return
+	})
 
 	d, err := daemon.NewDaemon(cli.Config, registryService, containerdRemote)
 	if err != nil {
@@ -276,7 +276,6 @@ func (cli *DaemonCli) start() (err error) {
 	initRouter(api, d)
 
 	cli.d = d
-	cli.api = api
 	cli.setupConfigReloadTrap()
 
 	// The serve API routine never exits unless an error occurs


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

if we shutdown the daemon during daemon staring, it will cause daemon crash

```
time="2016-06-12T07:52:20.811531816-04:00" level=info msg="Graph migration to content-addressability took 0.00 seconds"
time="2016-06-12T07:52:20.846414608-04:00" level=info msg="Firewalld running: true"
time="2016-06-12T07:52:21.385224866-04:00" level=info msg="Default bridge (docker0) is assigned with an IP address 172.17.0.0/16. Daemon option --bip can be used to set a preferred IP address"
time="2016-06-12T07:52:22.293188607-04:00" level=info msg="Processing signal 'interrupt'"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x4f65ca]

goroutine 53 [running]:
github.com/docker/docker/api/server.(*Server).Close(0x0)
        /go/src/github.com/docker/docker/api/server/server.go:71 +0x17a
main.(*DaemonCli).stop(0xc82038d5f0)
        /go/src/github.com/docker/docker/cmd/dockerd/daemon.go:329 +0x25
main.(*DaemonCli).start.func1()
        /go/src/github.com/docker/docker/cmd/dockerd/daemon.go:131 +0x29
github.com/docker/docker/pkg/signal.Trap.func1.1(0xc8202b3a90, 0xc8203d0ce0, 0x7fd59c473190, 0xc820902020)
        /go/src/github.com/docker/docker/pkg/signal/trap.go:45 +0x1bc
created by github.com/docker/docker/pkg/signal.Trap.func1
        /go/src/github.com/docker/docker/pkg/signal/trap.go:60 +0x112

```

**\- What I did**
Fix shutdown daemon during daemon staring casue crash
**\- How I did it**
If the `cli.api` is nil, then just close the `stopc`
**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

regression from https://github.com/docker/docker/pull/22460
Signed-off-by: Lei Jitang leijitang@huawei.com
