### PR TITLE
Update Docker inspect command reference doc to match Docker 1.11

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -14,11 +14,10 @@ parent = "smn_cli"
 
     Return low-level information on a container or image
 
-      -f, --format=""         Format the output using the given go template
-      --help                  Print usage
-      --type=container|image  Return JSON for specified type, permissible
-                              values are "image" or "container"
-      -s, --size              Display total file sizes if the type is container
+      -f, --format       Format the output using the given go template
+      --help             Print usage
+      -s, --size         Display total file sizes if the type is container
+      --type             Return JSON for specified type, (e.g image or container)
 
 By default, this will render all results in a JSON array. If the container and
 image have the same name, this will return container JSON for unspecified type.
@@ -36,7 +35,7 @@ straightforward manner.
 
     $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $INSTANCE_ID
 
-**Get an instance's MAC Address:**
+**Get an instance's MAC address:**
 
 For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
@@ -47,14 +46,14 @@ straightforward manner.
 
     $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID
 
-**List All Port Bindings:**
+**List all port bindings:**
 
 One can loop over arrays and maps in the results to produce simple text
 output:
 
     $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
 
-**Find a Specific Port Mapping:**
+**Find a specific port mapping:**
 
 The `.Field` syntax doesn't work when the field name begins with a
 number, but the template language's `index` function does. The


### PR DESCRIPTION
I notice the information is slightly outdated, so a quickly update.
- Also touch up capitalization in the headings.

Signed-off-by: Charles Chan charleswhchan@users.noreply.github.com
