### PR TITLE
Fixes #22514 - Added example for using image digest in the docker run command

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -190,6 +190,11 @@ Images using the v2 or later image format have a content-addressable identifier
 called a digest. As long as the input used to generate the image is unchanged,
 the digest value is predictable and referenceable.
 
+The following example runs a container from the `alpine` image with the 
+`sha256:9cacb71397b640eca97488cf08582ae4e4068513101088e9f96c9814bfda95e0` digest:
+
+    $ docker run alpine@sha256:9cacb71397b640eca97488cf08582ae4e4068513101088e9f96c9814bfda95e0 date
+
 ## PID settings (--pid)
 
     --pid=""  : Set the PID (Process) Namespace mode for the container,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Added a sample `docker run` command which uses the image digest

**\- How I did it**
updated `docs/reference/run.md` with the relevant markup

**\- How to verify it**
Run a `make docs` and navigate to `http://<hostname-of-dev->:8000/engine/reference/run/`
and verify the "Image[@digest]" section

**\- Description for the changelog**
Fixes #22514 - Added a sample `docker run` command which uses the image digest
