### PR TITLE
Fixes #23376 Broken URL for Centos yum repo for docker fixed to harcoded version number.

### DIFF
--- a/docs/installation/linux/centos.md
+++ b/docs/installation/linux/centos.md
@@ -57,7 +57,7 @@ package manager.
         $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
         [dockerrepo]
         name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+        baseurl=https://yum.dockerproject.org/repo/main/centos/7/
         enabled=1
         gpgcheck=1
         gpgkey=https://yum.dockerproject.org/gpg


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
updated the $releasever yum variable with a hardcoded centos version of 7 . The updated URL is https://yum.dockerproject.org/repo/main/centos/7/

**\- How I did it**
Modified in the test editor

**\- How to verify it**
Run a make docs and navigate to http://<DEV-HOST>:8000/engine/installation/linux/centos/ and check "Install with yum" step 3

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Installation docs for Centos updated : The yum repo URL for docker on centos is now hardcoded to 7.
