### PR TITLE
Add security info to `docker info`

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -94,6 +94,10 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "Default Runtime: %s\n", info.DefaultRuntime)
 	}
 
+	fmt.Fprintf(cli.out, "Security Options:")
+	ioutils.FprintfIfNotEmpty(cli.out, " %s", strings.Join(info.SecurityOptions, " "))
+	fmt.Fprintf(cli.out, "\n")
+
 	ioutils.FprintfIfNotEmpty(cli.out, "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
 	ioutils.FprintfIfNotEmpty(cli.out, "OSType: %s\n", info.OSType)

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -32,6 +32,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Storage Driver:",
 		"Volume:",
 		"Network:",
+		"Security Options:",
 	}
 
 	if DaemonIsLinux.Condition() {

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package main
+
+import (
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestInfoSecurityOptions(c *check.C) {
+	testRequires(c, SameHostDaemon, seccompEnabled, Apparmor, DaemonIsLinux)
+
+	out, _ := dockerCmd(c, "info")
+	c.Assert(out, checker.Contains, "Security Options: apparmor seccomp")
+}


### PR DESCRIPTION
**\- What I did**

The security infomation has already been added to `GET /info` in #21172. However, it is not part of the output of `docker info` yet.

This fix adds the security information to `docker info`.

**\- How I did it**

**\- How to verify it**

Additional tests has been added to cover changes.

**\- Description for the changelog**

Adds security information `apparmor`, `seccomp`, `selinux` to the output of `docker info`.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #23500. This fix is related to #20909, #21172.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
