### PR TITLE
Fixing exit code return on error case in Windows.

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -175,6 +175,10 @@ func (ctr *container) waitProcessExitCode(process *process) int {
 		if herr, ok := err.(*hcsshim.ProcessError); ok && herr.Err != syscall.ERROR_BROKEN_PIPE {
 			logrus.Warnf("Unable to get exit code from container %s", ctr.containerID)
 		}
+		// Since we got an error retrieving the exit code, make sure that the code we return
+		// doesn't incorrectly indicate success.
+		exitCode = -1
+
 		// Fall through here, do not return. This ensures we attempt to continue the
 		// shutdown in HCS and tell the docker engine that the process/container
 		// has exited to avoid a container being dropped on the floor.


### PR DESCRIPTION
Right now, if we hit an error retrieving the exit code in HCS process.ExitCode, we return that 0 and that error.  Golang convention says that if an error is returned the other values should not be used, but the caller of ExitCode in libcontainerd has to fall through if an error is received.  Rather than return a success exit code in that failure case, we should return -1 to indicate a generic failure.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
