### PR TITLE
Kill containers after restart tests

### DIFF
--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -101,49 +101,6 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *check.C) {
 	c.Assert(strings.Contains(string(mountOut), id), check.Equals, false, comment)
 }
 
-// TestDaemonRestartWithPausedRunningContainer requires live restore of running containers
-func (s *DockerDaemonSuite) TestDaemonRestartWithPausedRunningContainer(t *check.C) {
-	if err := s.d.StartWithBusybox("--live-restore"); err != nil {
-		t.Fatal(err)
-	}
-
-	cid, err := s.d.Cmd("run", "-d", "--name", "test", "busybox", "top")
-	defer s.d.Stop()
-	if err != nil {
-		t.Fatal(cid, err)
-	}
-	cid = strings.TrimSpace(cid)
-
-	// Kill the daemon
-	if err := s.d.Kill(); err != nil {
-		t.Fatal(err)
-	}
-
-	// kill the container
-	runCmd := exec.Command(ctrBinary, "--address", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "containers", "pause", cid)
-	if out, ec, err := runCommandWithOutput(runCmd); err != nil {
-		t.Fatalf("Failed to run ctr, ExitCode: %d, err: '%v' output: '%s' cid: '%s'\n", ec, err, out, cid)
-	}
-
-	// Give time to containerd to process the command if we don't
-	// the pause event might be received after we do the inspect
-	time.Sleep(3 * time.Second)
-
-	// restart the daemon
-	if err := s.d.Start("--live-restore"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check that we've got the correct status
-	out, err := s.d.Cmd("inspect", "-f", "{{.State.Status}}", cid)
-	t.Assert(err, check.IsNil)
-
-	out = strings.TrimSpace(out)
-	if out != "paused" {
-		t.Fatalf("Expected exit code '%s' got '%s' for container '%s'\n", "paused", out, cid)
-	}
-}
-
 // TestDaemonRestartWithUnpausedRunningContainer requires live restore of running containers.
 func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *check.C) {
 	// TODO(mlaventure): Not sure what would the exit code be on windows
@@ -191,5 +148,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *che
 	out = strings.TrimSpace(out)
 	if out != "running" {
 		t.Fatalf("Expected exit code '%s' got '%s' for container '%s'\n", "running", out, cid)
+	}
+	if _, err := s.d.Cmd("kill", cid); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This fixes the experimental tests from hanging because they are written poorly.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
