### PR TITLE
Dont leak DOCKER_INCREMENTAL_BINARY flag into go test.

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -9,6 +9,16 @@ set -e
 #
 bundle_test_unit() {
 	TESTFLAGS+=" -test.timeout=${TIMEOUT}"
+	INCBUILD="-i"
+	count=0
+	for flag in "${BUILDFLAGS[@]}"; do
+		if [ "${flag}" == ${INCBUILD} ]; then
+			unset BUILDFLAGS[${count}]
+			break
+		fi
+		count=$[ ${count} + 1 ]
+	done
+
 	date
 	if [ -z "$TESTDIRS" ]; then
 		TEST_PATH=./...


### PR DESCRIPTION
Setting DOCKER_INCREMENTAL_BINARY breaks "make test-unit". This is because the flags were passed through to go test, which does not recognize it. This commit removes the flag for test-unit.

Verified by running unit tests with and without incremental builds.

Signed-off-by: Anusha Ragunathan anusha@docker.com
