### PR TITLE
multi-arch: fix runtime daemon tests

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2402,7 +2402,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 }
 `
 	ioutil.WriteFile(configName, []byte(config), 0644)
-	err = s.d.Start("--config-file", configName)
+	err = s.d.StartWithBusybox("--config-file", configName)
 	c.Assert(err, check.IsNil)
 
 	// Run with default runtime
@@ -2498,7 +2498,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
-	err := s.d.Start("--add-runtime", "oci=docker-runc", "--add-runtime", "vm=/usr/local/bin/vm-manager")
+	err := s.d.StartWithBusybox("--add-runtime", "oci=docker-runc", "--add-runtime", "vm=/usr/local/bin/vm-manager")
 	c.Assert(err, check.IsNil)
 
 	// Run with default runtime


### PR DESCRIPTION
Replaces two instances of daemon Start with StartWithBusybox. If the test
uses busybox, this has to be done once to cache the arch specific busybox
image.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
