### PR TITLE
Make `--dispatcher-heartbeat-period` a duration

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1641,7 +1641,7 @@ _docker_swarm_join() {
 _docker_swarm_update() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--auto-accept --dispatcher-heartbeat-period --help --secret --task-history-limit" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--auto-accept --dispatcher-heartbeat --help --secret --task-history-limit" -- "$cur" ) )
 			;;
 	esac
 }

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -12,15 +12,16 @@ parent = "smn_cli"
 
 # swarm update
 
-	Usage:    docker swarm update [OPTIONS]
-
-	update the Swarm.
-
-	Options:
-	      --auto-accept value   Acceptance policy (default [worker,manager])
-	      --help                Print usage
-	      --secret string       Set secret value needed to accept nodes into cluster
-
+    Usage:  docker swarm update [OPTIONS]
+    
+    update the Swarm.
+    
+    Options:
+          --auto-accept value               Auto acceptance policy (worker, manager or none)
+          --dispatcher-heartbeat duration   Dispatcher heartbeat period (default 5s)
+          --help                            Print usage
+          --secret string                   Set secret value needed to accept nodes into cluster
+          --task-history-limit int          Task history retention limit (default 10)
 
 Updates a Swarm cluster with new parameter values. This command must target a manager node.
 


### PR DESCRIPTION
Make `--dispatcher-heartbeat-period` a duration in `docker swarm
update`, allowing to express the value as "5s", "1h", etc.

Ping @stevvooe @dnephin.

Signed-off-by: Arnaud Porterie (icecrime) arnaud.porterie@docker.com
