### PR TITLE
Remove the node leader column, show leader as status.

### DIFF
--- a/api/client/node/list.go
+++ b/api/client/node/list.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	listItemFmt = "%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+	listItemFmt = "%s\t%s\t%s\t%s\t%s\t%s\n"
 )
 
 type listOptions struct {
@@ -74,7 +74,7 @@ func printTable(out io.Writer, nodes []swarm.Node, info types.Info) {
 	// Ignore flushing errors
 	defer writer.Flush()
 
-	fmt.Fprintf(writer, listItemFmt, "ID", "NAME", "MEMBERSHIP", "STATUS", "AVAILABILITY", "MANAGER STATUS", "LEADER")
+	fmt.Fprintf(writer, listItemFmt, "ID", "NAME", "MEMBERSHIP", "STATUS", "AVAILABILITY", "MANAGER STATUS")
 	for _, node := range nodes {
 		name := node.Spec.Name
 		availability := string(node.Spec.Availability)
@@ -84,14 +84,13 @@ func printTable(out io.Writer, nodes []swarm.Node, info types.Info) {
 			name = node.Description.Hostname
 		}
 
-		leader := ""
-		if node.ManagerStatus != nil && node.ManagerStatus.Leader {
-			leader = "Yes"
-		}
-
 		reachability := ""
 		if node.ManagerStatus != nil {
-			reachability = string(node.ManagerStatus.Reachability)
+			if node.ManagerStatus.Leader {
+				reachability = "Leader"
+			} else {
+				reachability = string(node.ManagerStatus.Reachability)
+			}
 		}
 
 		ID := node.ID
@@ -107,8 +106,7 @@ func printTable(out io.Writer, nodes []swarm.Node, info types.Info) {
 			client.PrettyPrint(membership),
 			client.PrettyPrint(string(node.Status.State)),
 			client.PrettyPrint(availability),
-			client.PrettyPrint(reachability),
-			leader)
+			client.PrettyPrint(reachability))
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Removed the `Leader` column from `docker node ls`. Display `Leader` in the `MANAGER STATUS` column instead as the status of the leader node. 

**\- How I did it**
Changed the string formatting code in the `api/client/node/list.go`. Did not alter the underlying data structure, just the porcelain.

**\- How to verify it**
`docker node ls`, note the lack of leader column. 

![manager status](https://cloud.githubusercontent.com/assets/2367858/16064842/9b359418-3259-11e6-8056-0eb32f0972bc.png)

Signed-off-by: Drew Erny drew.erny@docker.com
