### PR TITLE
Update experimental/docker-stacks.md

### DIFF
--- a/experimental/docker-stacks.md
+++ b/experimental/docker-stacks.md
@@ -33,7 +33,8 @@ From `docker-compose`:
 
 ## Creating a stack from a bundle
 
-A stack is created using the `docker deploy` command:
+A stack is created using the `docker deploy` (an alias of `docker stack deploy`)
+command:
 
     ```bash
     # docker deploy --help


### PR DESCRIPTION
Clarified that `docker deploy` is identical to `docker stack deploy`

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
