### PR TITLE
Update experimental/README.md

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -49,9 +49,9 @@ refined or entirely removed.
 To download the latest experimental `docker` binary for Linux,
 use the following URLs:
 
-    https://experimental.docker.com/builds/Linux/i386/docker-latest
+    https://experimental.docker.com/builds/Linux/i386/docker-latest.tgz
 
-    https://experimental.docker.com/builds/Linux/x86_64/docker-latest
+    https://experimental.docker.com/builds/Linux/x86_64/docker-latest.tgz
 
 After downloading the appropriate binary, you can follow the instructions
 [here](https://docs.docker.com/installation/binaries/#get-the-docker-binary) to run the `docker` daemon.


### PR DESCRIPTION
- Now dockerd is split from docker
- dockerd needs PATH to be set for running containerd and runc

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
