### PR TITLE
v1.12.0: fixed date in CHANGELOG to be in YYYY-MM-DD form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
 
-## 1.12.0 (07-14-2016)
+## 1.12.0 (2016-07-14)
 
 ### Builder
 


### PR DESCRIPTION
Apparently rpm builds use this... from the changelog :S
