### PR TITLE
Add accept-permissions flag for install.

### DIFF
--- a/api/client/plugin/install.go
+++ b/api/client/plugin/install.go
@@ -13,21 +13,31 @@ import (
 	"golang.org/x/net/context"
 )
 
+type pluginOptions struct {
+	name       string
+	grantPerms bool
+}
+
 func newInstallCommand(dockerCli *client.DockerCli) *cobra.Command {
+	var options pluginOptions
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install a plugin",
 		Args:  cli.RequiresMinArgs(1), // TODO: allow for set args
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInstall(dockerCli, args[0], args[1:])
+			options.name = args[0]
+			return runInstall(dockerCli, options)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&options.grantPerms, "grant-permissions", true, "grant all permissions necessary to run the plugin")
 
 	return cmd
 }
 
-func runInstall(dockerCli *client.DockerCli, name string, args []string) error {
-	named, err := reference.ParseNamed(name) // FIXME: validate
+func runInstall(dockerCli *client.DockerCli, options pluginOptions) error {
+	named, err := reference.ParseNamed(options.name) // FIXME: validate
 	if err != nil {
 		return err
 	}
@@ -46,6 +56,6 @@ func runInstall(dockerCli *client.DockerCli, name string, args []string) error {
 	if err != nil {
 		return err
 	}
-	// TODO: pass acceptAllPermissions and noEnable flag
-	return dockerCli.Client().PluginInstall(ctx, ref.String(), encodedAuth, false, false, dockerCli.In(), dockerCli.Out())
+	// TODO: pass noEnable flag
+	return dockerCli.Client().PluginInstall(ctx, ref.String(), encodedAuth, options.grantPerms, false, dockerCli.In(), dockerCli.Out())
 }

--- a/api/client/plugin/install.go
+++ b/api/client/plugin/install.go
@@ -31,7 +31,7 @@ func newInstallCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVar(&options.grantPerms, "grant-permissions", true, "grant all permissions necessary to run the plugin")
+	flags.BoolVar(&options.grantPerms, "grant-all-permissions", true, "grant all permissions necessary to run the plugin")
 
 	return cmd
 }

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestPluginBasicOps(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
+	name := "tiborvass/no-remove"
+	tag := "latest"
+	nameWithTag := name + ":" + tag
+
+	_, _, err := dockerCmdWithError("plugin", "install", name)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err := dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, name)
+	c.Assert(out, checker.Contains, tag)
+	c.Assert(out, checker.Contains, "true")
+
+	out, _, err = dockerCmdWithError("plugin", "inspect", nameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "A test plugin for Docker")
+
+	out, _, err = dockerCmdWithError("plugin", "remove", nameWithTag)
+	c.Assert(out, checker.Contains, "is active")
+
+	_, _, err = dockerCmdWithError("plugin", "disable", nameWithTag)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err = dockerCmdWithError("plugin", "remove", nameWithTag)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, nameWithTag)
+}

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -30,6 +30,10 @@ var (
 		func() bool { return daemonPlatform == "linux" },
 		"Test requires a Linux daemon",
 	}
+	ExperimentalDaemon = testRequirement{
+		func() bool { return utils.ExperimentalBuild() },
+		"Test requires an experimental daemon",
+	}
 	NotExperimentalDaemon = testRequirement{
 		func() bool { return !utils.ExperimentalBuild() },
 		"Test requires a non experimental daemon",


### PR DESCRIPTION
Add flag for "plugin install" to grant all permissions required for the plugin. This is necessary for unattended installs. Also add basic cli integration tests.
