### PR TITLE
Passing registry auth token for service create, update

### DIFF
--- a/api/client/registry.go
+++ b/api/client/registry.go
@@ -149,8 +149,8 @@ func (cli *DockerCli) ConfigureAuth(flUser, flPassword, serverAddress string, is
 	return authconfig, nil
 }
 
-// ResolveAuthConfigFromImage retrieves that AuthConfig using the image string
-func (cli *DockerCli) ResolveAuthConfigFromImage(ctx context.Context, image string) (types.AuthConfig, error) {
+// resolveAuthConfigFromImage retrieves that AuthConfig using the image string
+func (cli *DockerCli) resolveAuthConfigFromImage(ctx context.Context, image string) (types.AuthConfig, error) {
 	registryRef, err := reference.ParseNamed(image)
 	if err != nil {
 		return types.AuthConfig{}, err
@@ -166,7 +166,7 @@ func (cli *DockerCli) ResolveAuthConfigFromImage(ctx context.Context, image stri
 // RetrieveAuthTokenFromImage retrieves an encoded auth token given a complete image
 func (cli *DockerCli) RetrieveAuthTokenFromImage(ctx context.Context, image string) (string, error) {
 	// Retrieve encoded auth token from the image reference
-	authConfig, err := cli.ResolveAuthConfigFromImage(ctx, image)
+	authConfig, err := cli.resolveAuthConfigFromImage(ctx, image)
 	if err != nil {
 		return "", err
 	}

--- a/api/client/registry.go
+++ b/api/client/registry.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/pkg/term"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/engine-api/types"
 	registrytypes "github.com/docker/engine-api/types/registry"
@@ -146,6 +147,34 @@ func (cli *DockerCli) ConfigureAuth(flUser, flPassword, serverAddress string, is
 	authconfig.IdentityToken = ""
 
 	return authconfig, nil
+}
+
+// ResolveAuthConfigFromImage retrieves that AuthConfig using the image string
+func (cli *DockerCli) ResolveAuthConfigFromImage(ctx context.Context, image string) (types.AuthConfig, error) {
+	registryRef, err := reference.ParseNamed(image)
+	if err != nil {
+		return types.AuthConfig{}, err
+	}
+	repoInfo, err := registry.ParseRepositoryInfo(registryRef)
+	if err != nil {
+		return types.AuthConfig{}, err
+	}
+	authConfig := cli.ResolveAuthConfig(ctx, repoInfo.Index)
+	return authConfig, nil
+}
+
+// RetrieveAuthTokenFromImage retrieves an encoded auth token given a complete image
+func (cli *DockerCli) RetrieveAuthTokenFromImage(ctx context.Context, image string) (string, error) {
+	// Retrieve encoded auth token from the image reference
+	authConfig, err := cli.ResolveAuthConfigFromImage(ctx, image)
+	if err != nil {
+		return "", err
+	}
+	encodedAuth, err := EncodeAuthToBase64(authConfig)
+	if err != nil {
+		return "", err
+	}
+	return encodedAuth, nil
 }
 
 func readInput(in io.Reader, out io.Writer) string {

--- a/api/client/service/create.go
+++ b/api/client/service/create.go
@@ -47,7 +47,7 @@ func runCreate(dockerCli *client.DockerCli, opts *serviceOptions) error {
 	}
 
 	headers := map[string][]string{
-		"x-registry-auth": {encodedAuth},
+		"X-Registry-Auth": {encodedAuth},
 	}
 
 	response, err := apiClient.ServiceCreate(ctx, service, headers)

--- a/api/client/service/create.go
+++ b/api/client/service/create.go
@@ -33,6 +33,7 @@ func newCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 func runCreate(dockerCli *client.DockerCli, opts *serviceOptions) error {
 	apiClient := dockerCli.Client()
+	headers := map[string][]string{}
 
 	service, err := opts.ToService()
 	if err != nil {
@@ -40,14 +41,15 @@ func runCreate(dockerCli *client.DockerCli, opts *serviceOptions) error {
 	}
 
 	ctx := context.Background()
-	// Retrieve encoded auth token from the image reference
-	encodedAuth, err := dockerCli.RetrieveAuthTokenFromImage(ctx, opts.image)
-	if err != nil {
-		return err
-	}
 
-	headers := map[string][]string{
-		"X-Registry-Auth": {encodedAuth},
+	// only send auth if flag was set
+	if opts.registryAuth {
+		// Retrieve encoded auth token from the image reference
+		encodedAuth, err := dockerCli.RetrieveAuthTokenFromImage(ctx, opts.image)
+		if err != nil {
+			return err
+		}
+		headers["X-Registry-Auth"] = []string{encodedAuth}
 	}
 
 	response, err := apiClient.ServiceCreate(ctx, service, headers)

--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -373,6 +373,8 @@ type serviceOptions struct {
 	update        updateOptions
 	networks      []string
 	endpoint      endpointOptions
+
+	registryAuth bool
 }
 
 func newServiceOptions() *serviceOptions {
@@ -436,7 +438,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 	return service, nil
 }
 
-// addServiceFlags adds all flags that are common to both `create` and `update.
+// addServiceFlags adds all flags that are common to both `create` and `update`.
 // Any flags that are not common are added separately in the individual command
 func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags := cmd.Flags()
@@ -469,6 +471,8 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")
 	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "", "Endpoint mode(Valid values: vip, dnsrr)")
 	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
+
+	flags.BoolVar(&opts.registryAuth, flagRegistryAuth, false, "Send registry authentication details to Swarm agents")
 }
 
 const (
@@ -493,4 +497,5 @@ const (
 	flagUpdateDelay        = "update-delay"
 	flagUpdateParallelism  = "update-parallelism"
 	flagUser               = "user"
+	flagRegistryAuth       = "registry-auth"
 )

--- a/api/client/service/scale.go
+++ b/api/client/service/scale.go
@@ -76,9 +76,7 @@ func runServiceScale(dockerCli *client.DockerCli, serviceID string, scale string
 		if err != nil {
 			return err
 		}
-		headers = map[string][]string{
-			"x-registry-auth": {encodedAuth},
-		}
+		headers["X-Registry-Auth"] = []string{encodedAuth}
 	}
 
 	serviceMode := &service.Spec.Mode

--- a/api/client/service/scale.go
+++ b/api/client/service/scale.go
@@ -60,23 +60,11 @@ func runScale(dockerCli *client.DockerCli, args []string) error {
 func runServiceScale(dockerCli *client.DockerCli, serviceID string, scale string) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
-	headers := map[string][]string{}
 
 	service, _, err := client.ServiceInspectWithRaw(ctx, serviceID)
 
 	if err != nil {
 		return err
-	}
-
-	// TODO(nishanttotla): Is this the best way to get the image?
-	image := service.Spec.TaskTemplate.ContainerSpec.Image
-	if image != "" {
-		// Retrieve encoded auth token from the image reference
-		encodedAuth, err := dockerCli.RetrieveAuthTokenFromImage(ctx, image)
-		if err != nil {
-			return err
-		}
-		headers["X-Registry-Auth"] = []string{encodedAuth}
 	}
 
 	serviceMode := &service.Spec.Mode
@@ -89,7 +77,7 @@ func runServiceScale(dockerCli *client.DockerCli, serviceID string, scale string
 	}
 	serviceMode.Replicated.Replicas = &uintScale
 
-	err = client.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, headers)
+	err = client.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -53,9 +53,7 @@ func runUpdate(dockerCli *client.DockerCli, flags *pflag.FlagSet, serviceID stri
 		if err != nil {
 			return err
 		}
-		headers = map[string][]string{
-			"x-registry-auth": {encodedAuth},
-		}
+		headers["X-Registry-Auth"] = []string{encodedAuth}
 	}
 
 	service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID)

--- a/api/client/stack/deploy.go
+++ b/api/client/stack/deploy.go
@@ -184,18 +184,21 @@ func deployServices(
 		if service, exists := existingServiceMap[name]; exists {
 			fmt.Fprintf(out, "Updating service %s (id: %s)\n", name, service.ID)
 
+			// TODO(nishanttotla): Pass headers with X-Registry-Auth
 			if err := apiClient.ServiceUpdate(
 				ctx,
 				service.ID,
 				service.Version,
 				serviceSpec,
+				nil,
 			); err != nil {
 				return err
 			}
 		} else {
 			fmt.Fprintf(out, "Creating service %s\n", name)
 
-			if _, err := apiClient.ServiceCreate(ctx, serviceSpec); err != nil {
+			// TODO(nishanttotla): Pass headers with X-Registry-Auth
+			if _, err := apiClient.ServiceCreate(ctx, serviceSpec, nil); err != nil {
 				return err
 			}
 		}

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -14,8 +14,8 @@ type Backend interface {
 	Update(uint64, types.Spec) error
 	GetServices(basictypes.ServiceListOptions) ([]types.Service, error)
 	GetService(string) (types.Service, error)
-	CreateService(types.ServiceSpec) (string, error)
-	UpdateService(string, uint64, types.ServiceSpec) error
+	CreateService(types.ServiceSpec, string) (string, error)
+	UpdateService(string, uint64, types.ServiceSpec, string) error
 	RemoveService(string) error
 	GetNodes(basictypes.NodeListOptions) ([]types.Node, error)
 	GetNode(string) (types.Node, error)

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -107,10 +107,7 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	encodedAuth := ""
-	if auth, ok := r.Header["x-registry-auth"]; ok {
-		encodedAuth = auth[0]
-	}
+	encodedAuth := r.Header.Get("X-Registry-Auth")
 
 	id, err := sr.backend.CreateService(service, encodedAuth)
 	if err != nil {
@@ -135,10 +132,7 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 		return fmt.Errorf("Invalid service version '%s': %s", rawVersion, err.Error())
 	}
 
-	encodedAuth := ""
-	if auth, ok := r.Header["x-registry-auth"]; ok {
-		encodedAuth = auth[0]
-	}
+	encodedAuth := r.Header.Get("X-Registry-Auth")
 
 	if err := sr.backend.UpdateService(vars["id"], version, service, encodedAuth); err != nil {
 		logrus.Errorf("Error updating service %s: %v", vars["id"], err)

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -107,6 +107,7 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
+	// Get returns "" if the header does not exist
 	encodedAuth := r.Header.Get("X-Registry-Auth")
 
 	id, err := sr.backend.CreateService(service, encodedAuth)
@@ -132,6 +133,7 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 		return fmt.Errorf("Invalid service version '%s': %s", rawVersion, err.Error())
 	}
 
+	// Get returns "" if the header does not exist
 	encodedAuth := r.Header.Get("X-Registry-Auth")
 
 	if err := sr.backend.UpdateService(vars["id"], version, service, encodedAuth); err != nil {

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -107,7 +107,12 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	id, err := sr.backend.CreateService(service)
+	encodedAuth := ""
+	if auth, ok := r.Header["x-registry-auth"]; ok {
+		encodedAuth = auth[0]
+	}
+
+	id, err := sr.backend.CreateService(service, encodedAuth)
 	if err != nil {
 		logrus.Errorf("Error creating service %s: %v", id, err)
 		return err
@@ -130,7 +135,12 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 		return fmt.Errorf("Invalid service version '%s': %s", rawVersion, err.Error())
 	}
 
-	if err := sr.backend.UpdateService(vars["id"], version, service); err != nil {
+	encodedAuth := ""
+	if auth, ok := r.Header["x-registry-auth"]; ok {
+		encodedAuth = auth[0]
+	}
+
+	if err := sr.backend.UpdateService(vars["id"], version, service, encodedAuth); err != nil {
 		logrus.Errorf("Error updating service %s: %v", vars["id"], err)
 		return err
 	}

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -44,7 +44,6 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 	var encodedAuthConfig string
 	if spec.PullOptions != nil {
 		encodedAuthConfig = spec.PullOptions.RegistryAuth
-
 	}
 
 	authConfig := &types.AuthConfig{}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
-clone git github.com/docker/engine-api c57d0447ea1ae71f6dad83c8d8a1215a89869a0c
+clone git github.com/docker/engine-api 19b4fb48a86c3318e610e156ec06b684f79ac31d
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/client/interface.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface.go
@@ -100,11 +100,11 @@ type NodeAPIClient interface {
 
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
-	ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error)
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, headers map[string][]string) (types.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
-	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, headers map[string][]string) error
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 }

--- a/vendor/src/github.com/docker/engine-api/client/service_create.go
+++ b/vendor/src/github.com/docker/engine-api/client/service_create.go
@@ -9,9 +9,9 @@ import (
 )
 
 // ServiceCreate creates a new Service.
-func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error) {
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, headers map[string][]string) (types.ServiceCreateResponse, error) {
 	var response types.ServiceCreateResponse
-	resp, err := cli.post(ctx, "/services/create", nil, service, nil)
+	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
 	if err != nil {
 		return response, err
 	}

--- a/vendor/src/github.com/docker/engine-api/client/service_update.go
+++ b/vendor/src/github.com/docker/engine-api/client/service_update.go
@@ -9,10 +9,10 @@ import (
 )
 
 // ServiceUpdate updates a Service.
-func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error {
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, headers map[string][]string) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, nil)
+	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	ensureReaderClosed(resp)
 	return err
 }


### PR DESCRIPTION
Currently, it is not possible to create or update services that require pulling of private images. This is a temporary fix to pass an auth token to SwarmKit. The token is retrieved at the client, and passed through as an `X-Registry-Auth` header which is then retrieved and added to `ContainerSpec` just before making a call to SwarmKit.

Also relevant: https://github.com/docker/swarmkit/pull/965 and https://github.com/docker/swarmkit/pull/1000

Fix #23642
Fix #24019
