### PR TITLE
Windows: Re-enabled support for memory limit

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -176,8 +176,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 			Shares:  &cpuShares,
 		},
 		Memory: &windowsoci.Memory{
-		//TODO Limit: ...,
-		//TODO Reservation: ...,
+			Limit: &c.HostConfig.Memory,
+			//TODO Reservation: ...,
 		},
 		Network: &windowsoci.Network{
 		//TODO Bandwidth: ...,


### PR DESCRIPTION
Re-enabled memory limits on Windows. Limits were being set at the container config, but not being sent to CreateContainer.

Signed-off-by: Darren Stahl darst@microsoft.com
