### PR TITLE
Service `--update-parallelism` defauls to 0

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -456,7 +456,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 	flags.StringSliceVar(&opts.constraints, flagConstraint, []string{}, "Placement constraints")
 
-	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 1, "Maximum number of tasks updated simultaneously")
+	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 0, "Maximum number of tasks updated simultaneously")
 	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates")
 
 	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")


### PR DESCRIPTION
The `--update-parallelism` flaag should default to 0, which is
interpreted by the backend as unlimited. In other words, by default all
services should update simultaneously.

Cc @aluzzardi @dnephin @vieux.

Signed-off-by: Arnaud Porterie (icecrime) arnaud.porterie@docker.com
