### PR TITLE
Allow `docker inspect` on all types

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -11,15 +11,16 @@ parent = "smn_cli"
 # inspect
 
 ```markdown
-Usage:  docker inspect [OPTIONS] CONTAINER|IMAGE|TASK [CONTAINER|IMAGE|TASK...]
+Usage:  docker inspect [OPTIONS] NAME|ID [NAME|ID...]
 
-Return low-level information on a container, image or task
+Return low-level information on one or multiple containers, images, volumes,
+networks, nodes, services, or tasks identified by name or ID.
 
   -f, --format       Format the output using the given go template
   --help             Print usage
   -s, --size         Display total file sizes if the type is container
                      values are "image" or "container" or "task
-  --type             Return JSON for specified type, (e.g image, container or task)
+  --type             Return JSON for specified type
 ```
 
 By default, this will render all results in a JSON array. If the container and

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -176,7 +176,7 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
 	_, err = inspectFieldWithError(imageReference, "Id")
 	//unexpected nil err trying to inspect what should be a non-existent image
 	c.Assert(err, checker.NotNil)
-	c.Assert(err.Error(), checker.Contains, "No such container, image")
+	c.Assert(err.Error(), checker.Contains, "No such object")
 }
 
 func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -65,7 +65,7 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 	result := dockerCmdWithResult("inspect", "-f={{.Name}}", "first_name")
 	c.Assert(result, icmd.Matches, icmd.Expected{
 		ExitCode: 1,
-		Err:      "No such container, image or task: first_name",
+		Err:      "No such object: first_name",
 	})
 }
 

--- a/man/docker-inspect.1.md
+++ b/man/docker-inspect.1.md
@@ -2,23 +2,23 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-inspect - Return low-level information on a container or image
+docker-inspect - Return low-level information on docker objects
 
 # SYNOPSIS
 **docker inspect**
 [**--help**]
 [**-f**|**--format**[=*FORMAT*]]
 [**-s**|**--size**]
-[**--type**=*container*|*image*]
-CONTAINER|IMAGE [CONTAINER|IMAGE...]
+[**--type**=*container*|*image*|*network*|*node*|*service*|*task*|*volume*]
+NAME|ID [NAME|ID...]
 
 # DESCRIPTION
 
-This displays all the information available in Docker for a given
-container or image. By default, this will render all results in a JSON
-array. If the container and image have the same name, this will return
-container JSON for unspecified type. If a format is specified, the given
-template will be executed for each result.
+This displays all the information available in Docker for one or multiple given
+containers, images, volumes, networks, nodes, services, or tasks. By default,
+this will render all results in a JSON array. If the container and image have
+the same name, this will return container JSON for unspecified type. If a format
+is specified, the given template will be executed for each result.
 
 # OPTIONS
 **--help**
@@ -30,8 +30,9 @@ template will be executed for each result.
 **-s**, **--size**
     Display total file sizes if the type is container.
 
-**--type**="*container*|*image*"
-    Return JSON for specified type, permissible values are "image" or "container"
+**--type**=*container*|*image*|*network*|*node*|*service*|*task*|*volume*
+    Return JSON for specified type, permissible values are "image", "container",
+    "network", "node", "service", "task", and "volume".
 
 # EXAMPLES
 


### PR DESCRIPTION
Allow top-level `docker inspect` command to inspect any kind of resources. The rationale is that `inspect` already does images and containers for historical reasons, so it might as well support them all. More specialized inspects (e.g., `docker network inspect`) should exist to support type specific options.

Depends on docker/engine-api#283.
