### PR TITLE
advisory can't be in the [menu] section

### DIFF
--- a/docs/swarm/index.md
+++ b/docs/swarm/index.md
@@ -3,11 +3,11 @@
 title = "Swarm overview"
 description = "Docker Swarm overview"
 keywords = ["docker, container, cluster, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="swarm_overview"
 parent="engine_swarm"
 weight="1"
-advisory = "rc"
 +++
 <![end-metadata]-->
 # Docker Swarm overview

--- a/docs/swarm/key-concepts.md
+++ b/docs/swarm/key-concepts.md
@@ -3,11 +3,11 @@
 title = "Swarm key concepts"
 description = "Introducing key concepts for Docker Swarm"
 keywords = ["docker, container, cluster, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="swarm-concepts"
 parent="engine_swarm"
 weight="2"
-advisory = "rc"
 +++
 <![end-metadata]-->
 # Docker Swarm key concepts

--- a/docs/swarm/menu.md
+++ b/docs/swarm/menu.md
@@ -3,11 +3,11 @@
 title = "Manage a Swarm (1.12 RC)"
 description = "How to use Docker Swarm to create and manage Docker Engine clusters"
 keywords = [" docker, documentation, developer, "]
+advisory = "rc"
 [menu.main]
 identifier = "engine_swarm"
 parent = "engine_use"
 weight = 0
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/add-nodes.md
+++ b/docs/swarm/swarm-tutorial/add-nodes.md
@@ -3,11 +3,11 @@
 title = "Add nodes to the Swarm"
 description = "Add nodes to the Swarm"
 keywords = ["tutorial, cluster management, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="add-nodes"
 parent="swarm-tutorial"
 weight=13
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -3,11 +3,11 @@
 title = "Create a Swarm"
 description = "Initialize the Swarm"
 keywords = ["tutorial, cluster management, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="initialize-swarm"
 parent="swarm-tutorial"
 weight=12
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/delete-service.md
+++ b/docs/swarm/swarm-tutorial/delete-service.md
@@ -3,11 +3,11 @@
 title = "Delete the service"
 description = "Remove the service on the Swarm"
 keywords = ["tutorial, cluster management, swarm, service"]
+advisory = "rc"
 [menu.main]
 identifier="swarm-tutorial-delete-service"
 parent="swarm-tutorial"
 weight=19
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/deploy-service.md
+++ b/docs/swarm/swarm-tutorial/deploy-service.md
@@ -3,11 +3,11 @@
 title = "Deploy a service"
 description = "Deploy the application"
 keywords = ["tutorial, cluster management, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="deploy-application"
 parent="swarm-tutorial"
 weight=16
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -3,6 +3,7 @@
 title = "Drain a node"
 description = "Drain nodes on the Swarm"
 keywords = ["tutorial, cluster management, swarm, service, drain"]
+advisory = "rc"
 [menu.main]
 identifier="swarm-tutorial-drain-node"
 parent="swarm-tutorial"

--- a/docs/swarm/swarm-tutorial/index.md
+++ b/docs/swarm/swarm-tutorial/index.md
@@ -3,11 +3,11 @@
 title = "Set up for the tutorial"
 description = "Getting Started tutorial for Docker Swarm"
 keywords = ["tutorial, cluster management, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="tutorial-setup"
 parent="swarm-tutorial"
 weight=11
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/inspect-service.md
+++ b/docs/swarm/swarm-tutorial/inspect-service.md
@@ -3,11 +3,11 @@
 title = "Inspect the service"
 description = "Inspect the application"
 keywords = ["tutorial, cluster management, swarm"]
+advisory = "rc"
 [menu.main]
 identifier="inspect-application"
 parent="swarm-tutorial"
 weight=17
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/menu.md
+++ b/docs/swarm/swarm-tutorial/menu.md
@@ -3,11 +3,11 @@
 title = "Get started with Swarm"
 description = "Getting started tutorial for Docker Swarm"
 keywords = ["cluster, swarm, tutorial"]
+advisory = "rc"
 [menu.main]
 identifier="swarm-tutorial"
 parent="engine_swarm"
 weight=10
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/rolling-update.md
+++ b/docs/swarm/swarm-tutorial/rolling-update.md
@@ -3,11 +3,11 @@
 title = "Apply rolling updates"
 description = "Apply rolling updates to a service on the Swarm"
 keywords = ["tutorial, cluster management, swarm, service, rolling-update"]
+advisory = "rc"
 [menu.main]
 identifier="swarm-tutorial-rolling-update"
 parent="swarm-tutorial"
 weight=20
-advisory = "rc"
 +++
 <![end-metadata]-->
 

--- a/docs/swarm/swarm-tutorial/scale-service.md
+++ b/docs/swarm/swarm-tutorial/scale-service.md
@@ -3,11 +3,11 @@
 title = "Scale the service"
 description = "Scale the service running in the Swarm"
 keywords = ["tutorial, cluster management, swarm, scale"]
+advisory = "rc"
 [menu.main]
 identifier="swarm-tutorial-scale-service"
 parent="swarm-tutorial"
 weight=18
-advisory = "rc"
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
Move the advisory marker up into the general metadata so we can use it in the doc templates
