### PR TITLE
check running again before restore active sandbox

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -179,7 +179,7 @@ func (daemon *Daemon) restore() error {
 					logrus.Errorf("Failed to restore with containerd: %q", err)
 					return
 				}
-				if !c.HostConfig.NetworkMode.IsContainer() {
+				if !c.HostConfig.NetworkMode.IsContainer() && c.IsRunning() {
 					options, err := daemon.buildSandboxOptions(c)
 					if err != nil {
 						logrus.Warnf("Failed build sandbox option to restore container %s: %v", c.ID, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

we store the active sandbox after daemon.containerd.Restore, but there
is a chance the `Restore` will set the container to exit see
(https://github.com/docker/docker/blob/master/libcontainerd/client_linux.go#L469).
so we should check if the container is really running before add it to
activesandbox.

Signed-off-by: Lei Jitang leijitang@huawei.com
