### PR TITLE
Remove out-of-date health test

### DIFF
--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -127,12 +127,10 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	c.Check(last.ExitCode, checker.Equals, 0)
 	c.Check(last.Output, checker.Equals, "OK\n")
 
-	// Fail the check, which should now make it exit
+	// Fail the check
 	dockerCmd(c, "exec", "fatal_healthcheck", "rm", "/status")
-	waitForStatus(c, "fatal_healthcheck", "running", "exited")
+	waitForHealthStatus(c, "fatal_healthcheck", "healthy", "unhealthy")
 
-	out, _ = dockerCmd(c, "inspect", "--format={{.State.Health.Status}}", "fatal_healthcheck")
-	c.Check(out, checker.Equals, "unhealthy\n")
 	failsStr, _ := dockerCmd(c, "inspect", "--format={{.State.Health.FailingStreak}}", "fatal_healthcheck")
 	fails, err := strconv.Atoi(strings.TrimSpace(failsStr))
 	c.Check(err, check.IsNil)


### PR DESCRIPTION
Issue #23519 says this check sometimes fails:

```
13:11:48    panic: DockerSuite.TestHealth test timed out after 1h30m0s
```

The test was waiting for the container to exit after failing its healthcheck. However, we no longer automatically terminate containers, so this part of the test isn't useful any longer. This PR removes it.

However, this doesn't expain why the test was timing out. The test container should have exited anyway after a couple of minutes.
