### PR TITLE
Prevent CI from getting stuck if shims are left alive

### DIFF
--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -15,4 +15,17 @@ bundle_test_integration_cli() {
 	bundle_test_integration_cli
 
 	bundle .integration-daemon-stop
+
+	if [ "$(go env GOOS)" != 'windows' ]
+	then
+		leftovers=$(ps -ax -o pid,cmd | awk '$2 == "docker-containerd-shim" && $4 ~ /.*\/bundles\/.*\/test-integration-cli/ { print $1 }')
+		if [ -n "$leftovers" ]
+		then
+			ps aux
+			kill -9 $leftovers 2> /dev/null
+			echo "!!!! WARNING you have left over shim(s), Cleanup your test !!!!"
+			exit 1
+		fi
+	fi
+
 ) 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
Prevent CI from getting stuck if shims are left alive

This will kill any left over `containerd-shims` to avoid the integration
script to stay stuck while it waits on them.

It will then causes CI to fail (even if all the tests succeeded).

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
