### PR TITLE
Add make target for OS X cross binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ cross: build ## cross build the binaries for darwin, freebsd and\nwindows
 win: build ## cross build the binary for windows
 	$(DOCKER_RUN_DOCKER) hack/make.sh win
 
+darwin: build ## cross build the binary for OS X
+	$(DOCKER_RUN_DOCKER) hack/make.sh darwin
+
 tgz: build ## build the archives (.zip on windows and .tgz\notherwise) containing the binaries
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz
 

--- a/hack/make/darwin
+++ b/hack/make/darwin
@@ -1,23 +1,12 @@
 #!/bin/bash
 set -e
 
-# explicit list of os/arch combos that support being a daemon
-declare -A daemonSupporting
-daemonSupporting=(
-	[linux/amd64]=1
-	[windows/amd64]=1
-)
 platform="darwin/amd64"
-export DEST="$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
+export DEST="$DEST/$platform" # bundles/VERSION/darwin/darwin/amd64/docker-VERSION
 mkdir -p "$DEST"
 ABS_DEST="$(cd "$DEST" && pwd -P)"
 export GOOS=${platform%/*}
 export GOARCH=${platform##*/}
-if [ -z "${daemonSupporting[$platform]}" ]; then
-	export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
-	export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
-	source "${MAKEDIR}/binary-client"
-else
-	source "${MAKEDIR}/binary-client"
-	source "${MAKEDIR}/binary-daemon"
-fi
+export LDFLAGS_STATIC_DOCKER="" # we just need a simple client
+export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag
+source "${MAKEDIR}/binary-client"

--- a/hack/make/darwin
+++ b/hack/make/darwin
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# explicit list of os/arch combos that support being a daemon
+declare -A daemonSupporting
+daemonSupporting=(
+	[linux/amd64]=1
+	[windows/amd64]=1
+)
+platform="darwin/amd64"
+export DEST="$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
+mkdir -p "$DEST"
+ABS_DEST="$(cd "$DEST" && pwd -P)"
+export GOOS=${platform%/*}
+export GOARCH=${platform##*/}
+if [ -z "${daemonSupporting[$platform]}" ]; then
+	export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
+	export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
+	source "${MAKEDIR}/binary-client"
+else
+	source "${MAKEDIR}/binary-client"
+	source "${MAKEDIR}/binary-daemon"
+fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Add make target for building OS X cross binary

**\- How I did it**
Copy the file in hack/make for building the Windows cross binary, update it to call `binary-client` and `binary-daemon` as appropriate, and add a target to `Makefile`.

**\- How to verify it**
Run `make darwin` on an OS X machine and run the resulting binary.

**\- Description for the changelog**
Add make target for building OSX binary.

**\- A picture of a cute animal (not mandatory but encouraged)**
![Capybara](http://media.mnn.com/assets/images/2015/04/big-capybara.jpg.653x0_q80_crop-smart.jpg)

Signed-off-by: Kara Alexandra kalexandra@us.ibm.com
