### PR TITLE
docs: move "advisory" to  general metadata

### DIFF
--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -3,9 +3,9 @@
 title = "plugin disable"
 description = "the plugin disable command description and usage"
 keywords = ["plugin, disable"]
+advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
-advisory = "experimental"
 +++
 <![end-metadata]-->
 

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -3,9 +3,9 @@
 title = "plugin enable"
 description = "the plugin enable command description and usage"
 keywords = ["plugin, enable"]
+advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
-advisory = "experimental"
 +++
 <![end-metadata]-->
 

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -3,9 +3,9 @@
 title = "plugin inspect"
 description = "The plugin inspect command description and usage"
 keywords = ["plugin, inspect"]
+advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
-advisory = "experimental"
 +++
 <![end-metadata]-->
 

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -3,9 +3,9 @@
 title = "plugin install"
 description = "the plugin install command description and usage"
 keywords = ["plugin, install"]
+advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
-advisory = "experimental"
 +++
 <![end-metadata]-->
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -3,9 +3,9 @@
 title = "plugin ls"
 description = "The plugin ls command description and usage"
 keywords = ["plugin, list"]
+advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
-advisory = "experimental"
 +++
 <![end-metadata]-->
 

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -3,9 +3,9 @@
 title = "plugin rm"
 description = "the plugin rm command description and usage"
 keywords = ["plugin, rm"]
+advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
-advisory = "experimental"
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
the advisory option should not be below "menu"

for reference, see https://github.com/docker/docker/pull/23623
