### PR TITLE
Fixes #23596-returns empty string for NetworkID

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -465,6 +465,7 @@ func (daemon *Daemon) transformContainer(container *container.Container, ctx *li
 			GlobalIPv6Address:   network.GlobalIPv6Address,
 			GlobalIPv6PrefixLen: network.GlobalIPv6PrefixLen,
 			MacAddress:          network.MacAddress,
+			NetworkID:           network.NetworkID,
 		}
 		if network.IPAMConfig != nil {
 			networks[name].IPAMConfig = &networktypes.EndpointIPAMConfig{


### PR DESCRIPTION
"closes #23596 "

Please provide the following information:
-->

**\- What I did**
Added missing NetworkID info to the daemon list code

**\- How I did it**

**\- How to verify it**
echo -e "GET /images/json HTTP/1.0\r\n" | socat unix-connect:/var/run/docker.sock STDIO
Check for NetworkID before and after the fix

**\- Description for the changelog**

<!--
transformContainer misses to populate NetworkID field before returning the info to the api request
-->

Signed-off-by: Sainath Grandhi sainath.grandhi@intel.com
