### PR TITLE
Set systemd KillMode

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -20,6 +20,8 @@ LimitCORE=infinity
 TimeoutStartSec=0
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Change the kill mode to process so that systemd does not kill container
processes when the daemon is shutdown but only the docker daemon

Fixes #21933

Signed-off-by: Michael Crosby crosbymichael@gmail.com
