### PR TITLE
bash completion for `docker swarm update --cert-expiry`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1639,9 +1639,15 @@ _docker_swarm_join() {
 }
 
 _docker_swarm_update() {
+	case "$prev" in
+		--auto-accept|--cert-expiry|--dispatcher-heartbeat|--secret|--task-history-limit)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--auto-accept --dispatcher-heartbeat --help --secret --task-history-limit" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--auto-accept --cert-expiry --dispatcher-heartbeat --help --secret --task-history-limit" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
ref: #23651
also features a fix for the other non-boolean options
