### PR TITLE
fix #23017, add zsh completion for dockerd

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1,4 +1,4 @@
-#compdef docker
+#compdef docker dockerd
 #
 # zsh completion for docker (http://docker.com)
 #
@@ -1407,6 +1407,13 @@ _docker() {
             ;;
     esac
 
+    return ret
+}
+
+_dockerd() {
+    integer ret=1
+    words[1]='daemon'
+    __docker_subcommand && ret=0
     return ret
 }
 


### PR DESCRIPTION
Just call all `docker daemon` completion when the command is `dockerd`. 

Signed-off-by: Ke Xu leonhartx.k@gmail.com
