### PR TITLE
Change log.printf service creation msg to debug

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -3,10 +3,11 @@ package container
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/Sirupsen/logrus"
 
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/docker/reference"
@@ -345,7 +346,7 @@ func (c *containerConfig) serviceConfig() *clustertypes.ServiceConfig {
 		return nil
 	}
 
-	log.Printf("Creating service config in agent for t = %+v", c.task)
+	logrus.Debugf("Creating service config in agent for t = %+v", c.task)
 	svcCfg := &clustertypes.ServiceConfig{
 		Name:             c.task.ServiceAnnotations.Name,
 		Aliases:          make(map[string][]string),


### PR DESCRIPTION
This reduces the log level for the 'service creation' log message.

Currently, each time a service configuration is created, the logs display the following message:

```
2016-06-17 11:28:38.538697 I | Creating service config in agent for t = &Task{ID:0iukgr1bnjtm5mtg2vdvxq8jq,Meta:Meta{Version:Version{Index:26,},CreatedAt:&docker_swarmkit_v1.Timestamp{Seconds:1466162914,Nanos:482457418,},UpdatedAt:&docker_swarmkit_v1.Timestamp{Seconds:1466162914,Nanos:484410647,},},Spec:TaskSpec{Runtime:&TaskSpec_Container{Container:&ContainerSpec{Image:ehazlett/docker-demo,Labels:map[string]string{},Command:[],Args:[/bin/docker-demo -listen=:8080 -close-conn],Env:[],Dir:,User:,Mounts:[],StopGracePeriod:nil,RegistryAuth:,},},Resources:&ResourceRequirements{Limits:&Resources{NanoCPUs:0,MemoryBytes:0,},Reservations:&Resources{NanoCPUs:0,MemoryBytes:0,},},Restart:&RestartPolicy{Condition:ANY,Delay:nil,MaxAttempts:0,Window:nil,},Placement:&Placement{Constraints:[],},},ServiceID:bca7koq2tr1c68fhiuxydlbbv,Slot:2,NodeID:bzh87tey1uzbzb3yn8t3c329v,Annotations:Annotations{Name:,Labels:map[string]string{},},ServiceAnnotations:Annotations{Name:web,Labels:map[string]string{},},Status:TaskStatus{Timestamp:&docker_swarmkit_v1.Timestamp{Seconds:1466162914,Nanos:484347844,},State:ASSIGNED,Message:scheduler assigned task to node,Err:,RuntimeStatus:<nil>,},DesiredState:RUNNING,Networks:[&NetworkAttachment{Network:&Network{ID:4p7kzrly2hwx6g762ik8of7mb,Meta:Meta{Version:Version{Index:7,},CreatedAt:&docker_swarmkit_v1.Timestamp{Seconds:1466162911,Nanos:506739541,},UpdatedAt:&docker_swarmkit_v1.Timestamp{Seconds:1466162911,Nanos:582508528,},},Spec:NetworkSpec{Annotations:Annotations{Name:ingress,Labels:map[string]string{com.docker.swarm.internal: true,},},DriverConfig:&Driver{Name:,Options:map[string]string{},},Ipv6Enabled:false,Internal:false,IPAM:&IPAMOptions{Driver:&Driver{Name:,Options:map[string]string{},},Configs:[&IPAMConfig{Family:UNKNOWN,Subnet:10.255.0.0/16,Range:,Gateway:10.255.0.1,Reserved:map[string]string{},}],},},DriverState:&Driver{Name:overlay,Options:map[string]string{com.docker.network.driver.overlay.vxlanid_list: 256,},},IPAM:&IPAMOptions{Driver:&Driver{Name:default,Options:map[string]string{},},Configs:[&IPAMConfig{Family:UNKNOWN,Subnet:10.255.0.0/16,Range:,Gateway:10.255.0.1,Reserved:map[string]string{},}],},},Addresses:[10.255.0.8/16],}],Endpoint:&Endpoint{Spec:nil,Ports:[&PortConfig{Name:,Protocol:TCP,TargetPort:8080,PublishedPort:30000,}],VirtualIPs:[&Endpoint_VirtualIP{NetworkID:4p7kzrly2hwx6g762ik8of7mb,Addr:10.255.0.6/16,}],},}
```

I'm not sure how important this message is, but this reduces the log level to `DEBUG` and uses `logrus` instead of `log`.

I'm a bit confused as to the recommended approach for logging, as I've seen that other packages use the `github.com/docker/swarmkit/log` package too, but that appears to require a `swarmkit` context in scope.
