### PR TITLE
Missing line feed after accepting node

### DIFF
--- a/api/client/node/accept.go
+++ b/api/client/node/accept.go
@@ -33,7 +33,7 @@ func runAccept(dockerCli *client.DockerCli, flags *pflag.FlagSet, args []string)
 		}); err != nil {
 			return err
 		}
-		fmt.Fprintf(dockerCli.Out(), "Node %s accepted in the swarm.", id)
+		fmt.Fprintf(dockerCli.Out(), "Node %s accepted in the swarm.\n", id)
 	}
 
 	return nil


### PR DESCRIPTION
Avoids

```
root@swarmatorium:~# docker node accept 3dnh6k13o44np9fwl83e7gh80
Node 3dnh6k13o44np9fwl83e7gh80 accepted in the swarm.root@swarmatorium:~#
```

Signed-off-by: Justin Cormack justin.cormack@docker.com
