### PR TITLE
`docker swarm`: more consistent CLI help

### DIFF
--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -28,7 +28,7 @@ func newInitCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Initialize a Swarm.",
+		Short: "Initialize a Swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInit(dockerCli, flags, opts)

--- a/api/client/swarm/join.go
+++ b/api/client/swarm/join.go
@@ -25,7 +25,7 @@ func newJoinCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "join [OPTIONS] HOST:PORT",
-		Short: "Join a Swarm as a node and/or manager.",
+		Short: "Join a Swarm as a node and/or manager",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]

--- a/api/client/swarm/leave.go
+++ b/api/client/swarm/leave.go
@@ -19,7 +19,7 @@ func newLeaveCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "leave",
-		Short: "Leave a Swarm.",
+		Short: "Leave a Swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLeave(dockerCli, opts)

--- a/api/client/swarm/update.go
+++ b/api/client/swarm/update.go
@@ -27,7 +27,7 @@ func newUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "update the Swarm.",
+		Short: "Update the Swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(dockerCli, flags, opts)


### PR DESCRIPTION
This changes `docker swarm help` to be consistent with capitals and full stops.

Before:

```
Commands:
  init        Initialize a Swarm.
  join        Join a Swarm as a node and/or manager.
  update      update the Swarm.
  leave       Leave a Swarm.
  inspect     Inspect the Swarm
```

After:

```
Commands:
  init        Initialize a Swarm
  join        Join a Swarm as a node and/or manager
  update      Update the Swarm
  leave       Leave a Swarm
  inspect     Inspect the Swarm
```
