### PR TITLE
Add newlines to CLI output for swarm join and leave

### DIFF
--- a/api/client/swarm/join.go
+++ b/api/client/swarm/join.go
@@ -57,9 +57,9 @@ func runJoin(dockerCli *client.DockerCli, opts joinOptions) error {
 		return err
 	}
 	if opts.manager {
-		fmt.Fprintln(dockerCli.Out(), "This node joined a Swarm as a manager.")
+		fmt.Fprintln(dockerCli.Out(), "This node joined a Swarm as a manager.\n")
 	} else {
-		fmt.Fprintln(dockerCli.Out(), "This node joined a Swarm as a worker.")
+		fmt.Fprintln(dockerCli.Out(), "This node joined a Swarm as a worker.\n")
 	}
 	return nil
 }

--- a/api/client/swarm/leave.go
+++ b/api/client/swarm/leave.go
@@ -39,6 +39,6 @@ func runLeave(dockerCli *client.DockerCli, opts leaveOptions) error {
 		return err
 	}
 
-	fmt.Fprintln(dockerCli.Out(), "Node left the default swarm.")
+	fmt.Fprintln(dockerCli.Out(), "Node left the default swarm.\n")
 	return nil
 }


### PR DESCRIPTION
Some `docker swarm join` and `docker swarm leave` CLI outputs were missing newlines at the end of the output.

Signed-off-by: Anil Madhavapeddy anil@docker.com
