### PR TITLE
Improve `docker service inspect --pretty`

### DIFF
--- a/api/client/service/inspect.go
+++ b/api/client/service/inspect.go
@@ -94,11 +94,11 @@ func printService(out io.Writer, service swarm.Service) {
 	}
 
 	if service.Spec.Mode.Global != nil {
-		fmt.Fprintln(out, "Mode:\t\tGLOBAL")
+		fmt.Fprintln(out, "Mode:\t\tGlobal")
 	} else {
-		fmt.Fprintln(out, "Mode:\t\tREPLICATED")
+		fmt.Fprintln(out, "Mode:\t\tReplicated")
 		if service.Spec.Mode.Replicated.Replicas != nil {
-			fmt.Fprintf(out, " Replicas:\t\t%d\n", *service.Spec.Mode.Replicated.Replicas)
+			fmt.Fprintf(out, " Replicas:\t%d\n", *service.Spec.Mode.Replicated.Replicas)
 		}
 	}
 	fmt.Fprintln(out, "Placement:")
@@ -157,7 +157,7 @@ func printContainerSpec(out io.Writer, containerSpec swarm.ContainerSpec) {
 		fmt.Fprintf(out, " Command:\t%s\n", strings.Join(containerSpec.Command, " "))
 	}
 	if len(containerSpec.Args) > 0 {
-		fmt.Fprintf(out, " Args:\t%s\n", strings.Join(containerSpec.Args, " "))
+		fmt.Fprintf(out, " Args:\t\t%s\n", strings.Join(containerSpec.Args, " "))
 	}
 	if len(containerSpec.Env) > 0 {
 		fmt.Fprintf(out, " Env:\t\t%s\n", strings.Join(containerSpec.Env, " "))


### PR DESCRIPTION
Remove capitalization in placement, and remove spurious `\t`.

Example output:

```
# docker service inspect --pretty test
ID:             0td68v3z8hho8n4wjlnq8bgit
Name:           test
Mode:           Replicated
 Replicas:      5
Placement:
 Strategy:      Spread
UpdateConfig:
 Parallelism:   0
ContainerSpec:
 Image:         busybox
 Args:          top
Resources:
Reservations:
Limits:
```

Closes #23691.

Cc @tiborvass @vieux.
