### PR TITLE
Do not allow service mode change

### DIFF
--- a/api/client/service/create.go
+++ b/api/client/service/create.go
@@ -24,6 +24,8 @@ func newCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runCreate(dockerCli, opts)
 		},
 	}
+	flags := cmd.Flags()
+	flags.StringVar(&opts.mode, flagMode, "replicated", "Service mode (replicated or global)")
 	addServiceFlags(cmd, opts)
 	cmd.Flags().SetInterspersed(false)
 	return cmd

--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -447,7 +447,6 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.resources.resMemBytes, flagReserveMemory, "Reserve Memory")
 	flags.Var(&opts.stopGrace, "stop-grace-period", "Time to wait before force killing a container")
 
-	flags.StringVar(&opts.mode, flagMode, "replicated", "Service mode (replicated or global)")
 	flags.Var(&opts.replicas, flagReplicas, "Number of tasks")
 
 	flags.StringVar(&opts.restartPolicy.condition, flagRestartCondition, "", "Restart when condition is met (none, on_failure, or any)")

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -161,7 +161,7 @@ func updateService(spec *swarm.ServiceSpec, flags *pflag.FlagSet) error {
 		updateSlice(flagConstraint, &task.Placement.Constraints)
 	}
 
-	if err := updateMode(flags, &spec.Mode); err != nil {
+	if err := updateReplicas(flags, &spec.Mode); err != nil {
 		return err
 	}
 
@@ -240,40 +240,14 @@ func updateNetworks(flags *pflag.FlagSet, attachments *[]swarm.NetworkAttachment
 	*attachments = localAttachments
 }
 
-func updateMode(flags *pflag.FlagSet, serviceMode *swarm.ServiceMode) error {
-	if !flags.Changed(flagMode) && !flags.Changed(flagReplicas) {
+func updateReplicas(flags *pflag.FlagSet, serviceMode *swarm.ServiceMode) error {
+	if !flags.Changed(flagReplicas) {
 		return nil
 	}
 
-	var mode string
-	if flags.Changed(flagMode) {
-		mode, _ = flags.GetString(flagMode)
-	}
-
-	if !(mode == "replicated" || serviceMode.Replicated != nil) && flags.Changed(flagReplicas) {
+	if serviceMode.Replicated == nil {
 		return fmt.Errorf("replicas can only be used with replicated mode")
 	}
-
-	if mode == "global" {
-		serviceMode.Replicated = nil
-		serviceMode.Global = &swarm.GlobalService{}
-		return nil
-	}
-
-	if flags.Changed(flagReplicas) {
-		replicas := flags.Lookup(flagReplicas).Value.(*Uint64Opt).Value()
-		serviceMode.Replicated = &swarm.ReplicatedService{Replicas: replicas}
-		serviceMode.Global = nil
-		return nil
-	}
-
-	if mode == "replicated" {
-		if serviceMode.Replicated != nil {
-			return nil
-		}
-		serviceMode.Replicated = &swarm.ReplicatedService{Replicas: &DefaultReplicas}
-		serviceMode.Global = nil
-	}
-
+	serviceMode.Replicated.Replicas = flags.Lookup(flagReplicas).Value.(*Uint64Opt).Value()
 	return nil
 }


### PR DESCRIPTION
Current `docker service update` command allows `--mode` update. After some discussions in https://github.com/docker/swarmkit/issues/771 and https://github.com/docker/swarmkit/pull/995, it looks better not to support this update option. User can remove the existing service, and add a different one with the correct `mode`. 

Signed-off-by: Dong Chen dongluo.chen@docker.com
