### PR TITLE
Windows: Fix RO test cases

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -239,7 +239,9 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 	c.Assert(m.Driver, checker.Equals, "")
 	c.Assert(m.Source, checker.Equals, prefix+slash+"data")
 	c.Assert(m.Destination, checker.Equals, prefix+slash+"data")
-	c.Assert(m.Mode, checker.Equals, "ro"+modifier)
+	if daemonPlatform != "windows" { // Windows does not set mode
+		c.Assert(m.Mode, checker.Equals, "ro"+modifier)
+	}
 	c.Assert(m.RW, checker.Equals, false)
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes two test cases which include read-only volumes on latest versions (post TP5) of Windows. They are both test errors. In TestInspectBindMountPoint, it wasn't taking account of the fact that Windows doesn't set mode (meaningless on Windows), and in TestVolumesFromGetsProperMode that the directory is pre-created. 

Verified here locally on latest Windows build (CI won't test this).
