### PR TITLE
Carry 23694: Default port for listen addr 

### DIFF
--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -35,7 +35,7 @@ func newInitCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
+	flags = cmd.Flags()
 	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address")
 	flags.Var(&opts.autoAccept, flagAutoAccept, "Auto acceptance policy (worker, manager, or none)")
 	flags.StringVar(&opts.secret, flagSecret, "", "Set secret value needed to accept nodes into cluster")

--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -22,7 +22,7 @@ type initOptions struct {
 func newInitCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var flags *pflag.FlagSet
 	opts := initOptions{
-		listenAddr: NewNodeAddrOption(),
+		listenAddr: NewListenAddrOption(),
 		autoAccept: NewAutoAcceptOption(),
 	}
 
@@ -35,10 +35,10 @@ func newInitCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 
-	flags = cmd.Flags()
-	flags.Var(&opts.listenAddr, "listen-addr", "Listen address")
-	flags.Var(&opts.autoAccept, "auto-accept", "Auto acceptance policy (worker, manager, or none)")
-	flags.StringVar(&opts.secret, "secret", "", "Set secret value needed to accept nodes into cluster")
+	flags := cmd.Flags()
+	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address")
+	flags.Var(&opts.autoAccept, flagAutoAccept, "Auto acceptance policy (worker, manager, or none)")
+	flags.StringVar(&opts.secret, flagSecret, "", "Set secret value needed to accept nodes into cluster")
 	flags.BoolVar(&opts.forceNewCluster, "force-new-cluster", false, "Force create a new cluster from current state.")
 	return cmd
 }

--- a/api/client/swarm/join.go
+++ b/api/client/swarm/join.go
@@ -20,7 +20,7 @@ type joinOptions struct {
 
 func newJoinCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := joinOptions{
-		listenAddr: NodeAddrOption{addr: defaultListenAddr},
+		listenAddr: NewListenAddrOption(),
 	}
 
 	cmd := &cobra.Command{
@@ -34,7 +34,7 @@ func newJoinCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.Var(&opts.listenAddr, "listen-addr", "Listen address")
+	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address")
 	flags.BoolVar(&opts.manager, "manager", false, "Try joining as a manager.")
 	flags.StringVar(&opts.secret, "secret", "", "Secret for node acceptance")
 	flags.StringVar(&opts.CACertHash, "ca-hash", "", "Hash of the Root Certificate Authority certificate used for trusted join")

--- a/api/client/swarm/opts.go
+++ b/api/client/swarm/opts.go
@@ -95,10 +95,10 @@ type AutoAcceptOption struct {
 // String prints a string representation of this option
 func (o *AutoAcceptOption) String() string {
 	keys := []string{}
-	for key := range o.values {
-		keys = append(keys, key)
+	for key, value := range o.values {
+		keys = append(keys, fmt.Sprintf("%s=%v", strings.ToLower(key), value))
 	}
-	return strings.Join(keys, " ")
+	return strings.Join(keys, ", ")
 }
 
 // Set sets a new value on this option

--- a/api/client/swarm/opts_test.go
+++ b/api/client/swarm/opts_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/docker/engine-api/types/swarm"
 )
 
 func TestNodeAddrOptionSetHostAndPort(t *testing.T) {
@@ -32,4 +33,86 @@ func TestNodeAddrOptionSetPortOnly(t *testing.T) {
 func TestNodeAddrOptionSetInvalidFormat(t *testing.T) {
 	opt := NewListenAddrOption()
 	assert.Error(t, opt.Set("http://localhost:4545"), "Invalid url")
+}
+
+func TestAutoAcceptOptionSetWorker(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	assert.NilError(t, opt.Set("worker"))
+	assert.Equal(t, opt.values[WORKER], true)
+}
+
+func TestAutoAcceptOptionSetManager(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	assert.NilError(t, opt.Set("manager"))
+	assert.Equal(t, opt.values[MANAGER], true)
+}
+
+func TestAutoAcceptOptionSetInvalid(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	assert.Error(t, opt.Set("bogus"), "must be one of")
+}
+
+func TestAutoAcceptOptionSetNone(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	assert.NilError(t, opt.Set("none"))
+	assert.Equal(t, opt.values[MANAGER], false)
+	assert.Equal(t, opt.values[WORKER], false)
+}
+
+func TestAutoAcceptOptionSetConflict(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	assert.NilError(t, opt.Set("manager"))
+	assert.Error(t, opt.Set("none"), "value NONE is incompatible with MANAGER")
+
+	opt = NewAutoAcceptOption()
+	assert.NilError(t, opt.Set("none"))
+	assert.Error(t, opt.Set("worker"), "value NONE is incompatible with WORKER")
+}
+
+func TestAutoAcceptOptionPoliciesDefault(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	secret := "thesecret"
+
+	policies := opt.Policies(&secret)
+	assert.Equal(t, len(policies), 2)
+	assert.Equal(t, policies[0], swarm.Policy{
+		Role:       WORKER,
+		Autoaccept: true,
+		Secret:     &secret,
+	})
+	assert.Equal(t, policies[1], swarm.Policy{
+		Role:       MANAGER,
+		Autoaccept: false,
+		Secret:     &secret,
+	})
+}
+
+func TestAutoAcceptOptionPoliciesWithManager(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	secret := "thesecret"
+
+	assert.NilError(t, opt.Set("manager"))
+
+	policies := opt.Policies(&secret)
+	assert.Equal(t, len(policies), 2)
+	assert.Equal(t, policies[0], swarm.Policy{
+		Role:       WORKER,
+		Autoaccept: false,
+		Secret:     &secret,
+	})
+	assert.Equal(t, policies[1], swarm.Policy{
+		Role:       MANAGER,
+		Autoaccept: true,
+		Secret:     &secret,
+	})
+}
+
+func TestAutoAcceptOptionString(t *testing.T) {
+	opt := NewAutoAcceptOption()
+	assert.NilError(t, opt.Set("manager"))
+	assert.NilError(t, opt.Set("worker"))
+
+	repr := opt.String()
+	assert.Contains(t, repr, "worker=true")
+	assert.Contains(t, repr, "manager=true")
 }

--- a/api/client/swarm/opts_test.go
+++ b/api/client/swarm/opts_test.go
@@ -1,0 +1,35 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
+)
+
+func TestNodeAddrOptionSetHostAndPort(t *testing.T) {
+	opt := NewNodeAddrOption("old", 123)
+	addr := "newhost:5555"
+	assert.NilError(t, opt.Set(addr))
+	assert.Equal(t, opt.addr, "newhost")
+	assert.Equal(t, opt.port, uint16(5555))
+	assert.Equal(t, opt.Value(), addr)
+}
+
+func TestNodeAddrOptionSetHostOnly(t *testing.T) {
+	opt := NewListenAddrOption()
+	assert.NilError(t, opt.Set("newhost"))
+	assert.Equal(t, opt.addr, "newhost")
+	assert.Equal(t, opt.port, defaultListenPort)
+}
+
+func TestNodeAddrOptionSetPortOnly(t *testing.T) {
+	opt := NewListenAddrOption()
+	assert.NilError(t, opt.Set(":4545"))
+	assert.Equal(t, opt.addr, defaultListenAddr)
+	assert.Equal(t, opt.port, uint16(4545))
+}
+
+func TestNodeAddrOptionSetInvalidFormat(t *testing.T) {
+	opt := NewListenAddrOption()
+	assert.Error(t, opt.Set("http://localhost:4545"), "Invalid url")
+}


### PR DESCRIPTION
Closes #23694 
# 

Allow `--listen-addr a.x.y.z` to use a default port

Adds some unit tests for swarm options 
