### PR TITLE
Set PRIORITY=6 in journald logging for container's stdout and stderr output

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -84,9 +84,6 @@ func validateLogOpt(cfg map[string]string) error {
 }
 
 func (s *journald) Log(msg *logger.Message) error {
-	if msg.Source == "stderr" {
-		return journal.Send(string(msg.Line), journal.PriErr, s.vars)
-	}
 	return journal.Send(string(msg.Line), journal.PriInfo, s.vars)
 }
 


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #23645 where journald logging driver records all stderr output with PRIORITY=3 (`journal.PriErr`).

Normally, application processes in containers write logs to stderr and not stdout, even though these are not errors. It would make sense to expect all messages in container applications written to stderr to have priority 6 (`journal.PriInfo`).

**\- How I did it**

This fix sets the PRIORITY=6 for both stdout and stderr outputs.

**\- How to verify it**

The test is done manually. With the following command

```
sudo docker run --log-driver journald ubuntu /bin/bash -c 'echo "ok" >&2'
```

, checking the priority would yield:

```
$ journalctl MESSAGE=ok -o json-pretty -r | grep PRIORITY
    "PRIORITY" : "6",
```

(Before the fix will have `"PRIORITY" : "3",`)

**\- Description for the changelog**

Set PRIORITY=6 in journald logging for container's stdout and stderr output

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #23645.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
