### PR TITLE
Fix parallel push of the same image to different registries

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -137,6 +137,7 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, ima
 	descriptorTemplate := v2PushDescriptor{
 		v2MetadataService: p.v2MetadataService,
 		repoInfo:          p.repoInfo,
+		ref:               p.ref,
 		repo:              p.repo,
 		pushState:         &p.pushState,
 	}
@@ -222,13 +223,14 @@ type v2PushDescriptor struct {
 	layer             layer.Layer
 	v2MetadataService *metadata.V2MetadataService
 	repoInfo          reference.Named
+	ref               reference.Named
 	repo              distribution.Repository
 	pushState         *pushState
 	remoteDescriptor  distribution.Descriptor
 }
 
 func (pd *v2PushDescriptor) Key() string {
-	return "v2push:" + pd.repo.Named().Name() + " " + pd.layer.DiffID().String()
+	return "v2push:" + pd.ref.FullName() + " " + pd.layer.DiffID().String()
 }
 
 func (pd *v2PushDescriptor) ID() string {


### PR DESCRIPTION
Layer uploads are deduplicated by a "key" made up of the layer DiffID
and the repository name. The repository name being used to form this key
was a remote version of the name that didn't include the name of the
registry. Consequently, pushes of the same layer in a repository with
the same remote name to different registries would wrongly be
deduplicated.

Correct the key by using the full name of the repository, which includes
the registry hostname as well as the image's name.

**\- How to verify it**

Follow the excellent repro instructions in #22854. I have verified that this PR fixes the problem, as well as verifying that parallel pushes **to the same registry** are still deduplicated when the layers and image name are the same.

**\- Description for the changelog**

Fixed a bug that could cause image pushes to fail when one of the same layers in an image with the same name was being pushed to a different repository at the same time.

Fixes #22854
