### PR TITLE
Fix bash completion for `docker {swarm,node}` subcommands

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1531,6 +1531,7 @@ _docker_service() {
 		inspect
 		ls list
 		rm remove
+		scale
 		tasks
 		update
 	"
@@ -1703,6 +1704,18 @@ _docker_service_ls() {
 	esac
 }
 
+_docker_service_scale() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $(compgen -S "=" -W "$(__docker_services $1)" -- "$cur") )
+			__docker_nospace
+			;;
+	esac
+}
+
 _docker_swarm() {
 	local subcommands="
 		init
@@ -1726,7 +1739,7 @@ _docker_swarm() {
 _docker_swarm_init() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --auto-accept --force-new-cluster --secret" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--auto-accept --force-new-cluster --help --secret" -- "$cur" ) )
 			;;
 	esac
 }
@@ -1805,7 +1818,7 @@ _docker_node_accept() {
 _docker_node_inspect() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --format --pretty" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format --help --pretty" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes
@@ -1815,7 +1828,7 @@ _docker_node_inspect() {
 _docker_node_ls() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --filter --quiet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter --help --quiet" -- "$cur" ) )
 			;;
 	esac
 }
@@ -1853,7 +1866,7 @@ _docker_node_rm() {
 _docker_node_tasks() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --no-resolve --filter --all" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all --filter --help --no-resolve" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes_plus_self
@@ -1863,7 +1876,7 @@ _docker_node_tasks() {
 _docker_node_update() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --availability --membership --role" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--availability --help --membership --role" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1591,6 +1591,82 @@ _docker_service_create() {
 	esac
 }
 
+_docker_service_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format -f --help --pretty -p" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_services
+	esac
+}
+
+_docker_service_list() {
+	_docker_service_ls
+}
+
+_docker_service_ls() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "-f --filter --help --quiet -q" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_service_remove() {
+	_docker_service_rm
+}
+
+_docker_service_rm() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_services
+	esac
+}
+
+_docker_service_scale() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $(compgen -S "=" -W "$(__docker_services $1)" -- "$cur") )
+			__docker_nospace
+			;;
+	esac
+}
+
+_docker_service_tasks() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve -n" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_services
+	esac
+}
+
 _docker_service_update() {
 	local options_with_args="
 		--arg
@@ -1640,89 +1716,13 @@ _docker_service_update() {
 	esac
 }
 
-_docker_service_inspect() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help --pretty -p" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_services
-	esac
-}
-
-_docker_service_tasks() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve -n" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_services
-	esac
-}
-
-_docker_service_remove() {
-	_docker_service_rm
-}
-
-_docker_service_rm() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_services
-	esac
-}
-
-_docker_service_list() {
-	_docker_service_ls
-}
-
-_docker_service_ls() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "-f --filter --help --quiet -q" -- "$cur" ) )
-			;;
-	esac
-}
-
-_docker_service_scale() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			COMPREPLY=( $(compgen -S "=" -W "$(__docker_services $1)" -- "$cur") )
-			__docker_nospace
-			;;
-	esac
-}
-
 _docker_swarm() {
 	local subcommands="
 		init
-		join
-		update
-		leave
 		inspect
+		join
+		leave
+		update
 	"
 	__docker_subcommands "$subcommands" && return
 
@@ -1744,10 +1744,26 @@ _docker_swarm_init() {
 	esac
 }
 
+_docker_swarm_inspect() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format --help" -- "$cur" ) )
+			;;
+	esac
+}
+
 _docker_swarm_join() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--ca-hash --help --listen-addr --manager --secret" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_swarm_leave() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--force --help" -- "$cur" ) )
 			;;
 	esac
 }
@@ -1762,22 +1778,6 @@ _docker_swarm_update() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--auto-accept --cert-expiry --dispatcher-heartbeat --help --secret --task-history-limit" -- "$cur" ) )
-			;;
-	esac
-}
-
-_docker_swarm_leave() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--force --help" -- "$cur" ) )
-			;;
-	esac
-}
-
-_docker_swarm_inspect() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--format --help" -- "$cur" ) )
 			;;
 	esac
 }
@@ -1815,6 +1815,16 @@ _docker_node_accept() {
 	esac
 }
 
+_docker_node_demote() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_manager_nodes
+	esac
+}
+
 _docker_node_inspect() {
 	case "$cur" in
 		-*)
@@ -1840,16 +1850,6 @@ _docker_node_promote() {
 			;;
 		*)
 			__docker_complete_worker_nodes
-	esac
-}
-
-_docker_node_demote() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_manager_nodes
 	esac
 }
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1737,22 +1737,40 @@ _docker_swarm() {
 }
 
 _docker_swarm_init() {
+	case "$prev" in
+		--auto-accept|--listen-addr|--secret)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--auto-accept --force-new-cluster --help --secret" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--auto-accept --force-new-cluster --help --listen-addr --secret" -- "$cur" ) )
 			;;
 	esac
 }
 
 _docker_swarm_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
 			;;
 	esac
 }
 
 _docker_swarm_join() {
+	case "$prev" in
+		--ca-hash|--listen-addr|--secret)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--ca-hash --help --listen-addr --manager --secret" -- "$cur" ) )
@@ -1787,9 +1805,9 @@ _docker_node() {
 		accept
 		demote
 		inspect
-		ls
+		ls list
 		promote
-		rm
+		rm remove
 		tasks
 		update
 	"
@@ -1826,19 +1844,35 @@ _docker_node_demote() {
 }
 
 _docker_node_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format --help --pretty" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format -f --help --pretty -p" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes
 	esac
 }
 
+_docker_node_list() {
+	_docker_node_ls
+}
+
 _docker_node_ls() {
+	case "$prev" in
+		--filter|-f)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter --help --quiet" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter -f --help --quiet -q" -- "$cur" ) )
 			;;
 	esac
 }
@@ -1853,6 +1887,10 @@ _docker_node_promote() {
 	esac
 }
 
+_docker_node_remove() {
+	_docker_node_rm
+}
+
 _docker_node_rm() {
 	case "$cur" in
 		-*)
@@ -1864,9 +1902,15 @@ _docker_node_rm() {
 }
 
 _docker_node_tasks() {
+	case "$prev" in
+		--filter|-f)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all --filter --help --no-resolve" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve -n" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes_plus_self
@@ -1874,6 +1918,12 @@ _docker_node_tasks() {
 }
 
 _docker_node_update() {
+	case "$prev" in
+		--availability|--membership|--role)
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--availability --help --membership --role" -- "$cur" ) )


### PR DESCRIPTION
Ref #23363, #23476
This continues my work from #23665 for the remaining completions introduced in #23476.
Also carries #23586 by @mgoelzer.

Like in #23665, I
- added a default no-op completion for non-boolean args (should be refined later)
- updated arguments
- added one-letter-args
- added command aliases for `rm` and `ls`
- corrected sort order

Please take a thorough look, I had to do this with an awful headache :unamused:
