### PR TITLE
Allow unset `--entrypoint` in `docker run` or `docker create`

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -240,6 +240,10 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *containertypes.Config, img *i
 			return err
 		}
 	}
+	// Reset the Entrypoint if it is [""]
+	if len(config.Entrypoint) == 1 && config.Entrypoint[0] == "" {
+		config.Entrypoint = nil
+	}
 	if len(config.Entrypoint) == 0 && len(config.Cmd) == 0 {
 		return fmt.Errorf("No command specified")
 	}

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -377,7 +377,9 @@ Create a container
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entry point for the container as a string or an array
-      of strings.
+      of strings. If the array consists of exactly one empty string (`[""]`) then the entry point
+      is reset to system default (i.e., the entry point used by docker when there is no `ENTRYPOINT`
+      instruction in the Dockerfile).
 -   **Image** - A string specifying the image name to use for the container.
 -   **Volumes** - An object mapping mount point paths (strings) inside the
       container to empty objects.

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1305,6 +1305,10 @@ or two examples of how to pass more parameters to that ENTRYPOINT:
     $ docker run -it --entrypoint /bin/bash example/redis -c ls -l
     $ docker run -it --entrypoint /usr/bin/redis-cli example/redis --help
 
+You can reset a containers entrypoint by passing an empty string, for example:
+
+    $ docker run -it --entrypoint="" mysql bash
+
 > **Note**: Passing `--entrypoint` will clear out any default command set on the
 > image (i.e. any `CMD` instruction in the Dockerfile used to build it).
 

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -366,6 +366,9 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	}
 	if copts.flEntrypoint != "" {
 		entrypoint = strslice.StrSlice{copts.flEntrypoint}
+	} else if flags.Changed("entrypoint") {
+		// if `--entrypoint=` is parsed then Entrypoint is reset
+		entrypoint = []string{""}
 	}
 
 	ports, portBindings, err := nat.ParsePortSpecs(copts.flPublish.GetAll())


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #23498 to allow unset `--entrypoint` in `docker run` or `docker create`.

**\- How I did it**

This fix checks the flag `--entrypoint` and, in case `--entrypoint=` (`""`) is passed, unset the Entrypoint during the container run.

**\- How to verify it**

Additional integration tests have been created to cover changes in this fix.

**\- Description for the changelog**

Allow unset `--entrypoint` in `docker run` or `docker create` by passing `--entrypoint=`.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #23498.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
