### PR TITLE
integration-cli: Change "Dns" to "DNS".

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2343,7 +2343,7 @@ func (s *DockerDaemonSuite) TestBuildOnDisabledBridgeNetworkDaemon(c *check.C) {
 }
 
 // Test case for #21976
-func (s *DockerDaemonSuite) TestDaemonDnsInHostMode(c *check.C) {
+func (s *DockerDaemonSuite) TestDaemonDNSInHostMode(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	err := s.d.StartWithBusybox("--dns", "1.2.3.4")
@@ -2355,7 +2355,7 @@ func (s *DockerDaemonSuite) TestDaemonDnsInHostMode(c *check.C) {
 }
 
 // Test case for #21976
-func (s *DockerDaemonSuite) TestDaemonDnsSearchInHostMode(c *check.C) {
+func (s *DockerDaemonSuite) TestDaemonDNSSearchInHostMode(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	err := s.d.StartWithBusybox("--dns-search", "example.com")
@@ -2367,7 +2367,7 @@ func (s *DockerDaemonSuite) TestDaemonDnsSearchInHostMode(c *check.C) {
 }
 
 // Test case for #21976
-func (s *DockerDaemonSuite) TestDaemonDnsOptionsInHostMode(c *check.C) {
+func (s *DockerDaemonSuite) TestDaemonDNSOptionsInHostMode(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	err := s.d.StartWithBusybox("--dns-opt", "timeout:3")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -61,7 +61,7 @@ func (s *DockerSuite) TestRunLeakyFileDescriptors(c *check.C) {
 
 // it should be possible to lookup Google DNS
 // this will fail when Internet access is unavailable
-func (s *DockerSuite) TestRunLookupGoogleDns(c *check.C) {
+func (s *DockerSuite) TestRunLookupGoogleDNS(c *check.C) {
 	testRequires(c, Network, NotArm)
 	image := DefaultImage
 	if daemonPlatform == "windows" {
@@ -1255,7 +1255,7 @@ func (s *DockerSuite) TestRunDisallowBindMountingRootToRoot(c *check.C) {
 }
 
 // Verify that a container gets default DNS when only localhost resolvers exist
-func (s *DockerSuite) TestRunDnsDefaultOptions(c *check.C) {
+func (s *DockerSuite) TestRunDNSDefaultOptions(c *check.C) {
 	// Not applicable on Windows as this is testing Unix specific functionality
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
@@ -1289,7 +1289,7 @@ func (s *DockerSuite) TestRunDnsDefaultOptions(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunDnsOptions(c *check.C) {
+func (s *DockerSuite) TestRunDNSOptions(c *check.C) {
 	// Not applicable on Windows as Windows does not support --dns*, or
 	// the Unix-specific functionality of resolv.conf.
 	testRequires(c, DaemonIsLinux)
@@ -1313,7 +1313,7 @@ func (s *DockerSuite) TestRunDnsOptions(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunDnsRepeatOptions(c *check.C) {
+func (s *DockerSuite) TestRunDNSRepeatOptions(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _, _ := dockerCmdWithStdoutStderr(c, "run", "--dns=1.1.1.1", "--dns=2.2.2.2", "--dns-search=mydomain", "--dns-search=mydomain2", "--dns-opt=ndots:9", "--dns-opt=timeout:3", "busybox", "cat", "/etc/resolv.conf")
 
@@ -1323,7 +1323,7 @@ func (s *DockerSuite) TestRunDnsRepeatOptions(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
+func (s *DockerSuite) TestRunDNSOptionsBasedOnHostResolvConf(c *check.C) {
 	// Not applicable on Windows as testing Unix specific functionality
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
@@ -2907,7 +2907,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyEtcHostsAndLinkedContainer(c *
 	}
 }
 
-func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithDnsFlag(c *check.C) {
+func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithDNSFlag(c *check.C) {
 	// Not applicable on Windows which does not support either --read-only or --dns.
 	// --read-only + userns has remount issues
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
@@ -3719,7 +3719,7 @@ func (s *DockerSuite) TestRunContainerNetworkModeToSelf(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunContainerNetModeWithDnsMacHosts(c *check.C) {
+func (s *DockerSuite) TestRunContainerNetModeWithDNSMacHosts(c *check.C) {
 	// Not applicable on Windows which does not support --net=container
 	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "--name", "parent", "busybox", "top")
@@ -4433,7 +4433,7 @@ func (s *DockerSuite) TestRunTooLongHostname(c *check.C) {
 }
 
 // Test case for #21976
-func (s *DockerSuite) TestRunDnsInHostMode(c *check.C) {
+func (s *DockerSuite) TestRunDNSInHostMode(c *check.C) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	expectedOutput := "nameserver 127.0.0.1"


### PR DESCRIPTION
**\- What I did**

This PR fixes a really really minor style/lint issue, which makes this Go project slightly more idiomatic and hopefully slightly better.

According to Go style, which this project follows, acronyms should have a consistent case. Source: https://github.com/golang/go/wiki/CodeReviewComments#initialisms

See https://github.com/docker/docker/pull/11310#discussion_r67394302.

**\- How I did it**

Cloned the repo, edited it with an editor, made a commit and created a PR.

**\- How to verify it**

CI should pass. Look over the change visually, it simply renames a few test methods.

**\- Description for the changelog**

_Fix a minor lint/style issue in integration-cli package, change "Dns" to "DNS"._

**\- A picture of a cute animal (not mandatory but encouraged)**

Here's a gopher on a surfboard.

![surfing-js](https://cloud.githubusercontent.com/assets/1924134/16174363/37dc6dd4-3573-11e6-914e-4e2ce1c7b843.png)
