### PR TITLE
Make --help information consistent

### DIFF
--- a/api/client/image/build.go
+++ b/api/client/image/build.go
@@ -67,7 +67,7 @@ func NewBuildCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "build PATH | URL | -",
+		Use:   "build [OPTIONS] PATH | URL | -",
 		Short: "Build an image from a Dockerfile",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/client/image/push.go
+++ b/api/client/image/push.go
@@ -14,7 +14,7 @@ import (
 // NewPushCommand creates a new `docker push` command
 func NewPushCommand(dockerCli *client.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "push NAME[:TAG]",
+		Use:   "push [OPTIONS] NAME[:TAG]",
 		Short: "Push an image or a repository to a registry",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Other docker command always print "[OPTIONS]" right after `docker
COMMAND`, but `build` and `push` has inconsistent help message.

This commit will fix help information format.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
