### PR TITLE
Fix a Jenkins build error for doc reference link

### DIFF
--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -357,9 +357,7 @@ $ journalctl -fu dm-event.service
 If you run into repeated problems with thin pool, you can use the
 `dm.min_free_space` option to tune the Engine behavior. This value ensures that
 operations fail with a warning when the free space is at or near the minimum.
-For information, see <a
-href="../../../reference/commandline/dockerd/#storage-driver-options"
-target="_blank">the storage driver options in the Engine daemon reference</a>.
+For information, see [the storage driver options in the Engine daemon reference](../../reference/commandline/dockerd/#storage-driver-options)
 
 
 ### Examine devicemapper structures on the host


### PR DESCRIPTION
This is an attempt to addresses a Jenkins build error for doc reference link

There are 7 errors:
https://jenkins.dockerproject.org/job/docs-docker-pr/9754/

This fix addresses one of them:
`* link error: (in page engine/userguide/storagedriver/device-mapper-driver.md) ../../reference/commandline/dockerd/#storage-driver-options`

NOTE: Not sure about the other 6 errors. Might be outside of the docker docs.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
