### PR TITLE
fixing a link that showed up as build error in docker/pinata/docs PR#…

### DIFF
--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -357,9 +357,7 @@ $ journalctl -fu dm-event.service
 If you run into repeated problems with thin pool, you can use the
 `dm.min_free_space` option to tune the Engine behavior. This value ensures that
 operations fail with a warning when the free space is at or near the minimum.
-For information, see <a
-href="../../../reference/commandline/dockerd/#storage-driver-options"
-target="_blank">the storage driver options in the Engine daemon reference</a>.
+For information, see [the storage driver options in the Engine daemon reference](../../reference/commandline/dockerd.md#storage-driver-options).
 
 
 ### Examine devicemapper structures on the host


### PR DESCRIPTION
**\- What I did**

Fixed a link that is showing up as a docs build error in PR #4019  `docker/pinata/`

Signed-off-by: Victoria Bialas victoria.bialas@docker.com
