### PR TITLE
remove "RC" warning from Markdown files

### DIFF
--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # node inspect
 
     Usage: docker node inspect [OPTIONS] self|NODE [NODE...]

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # node ls
 
     Usage:  docker node ls [OPTIONS]

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # node rm
 
 	Usage:	docker node rm NODE [NODE...]

--- a/docs/reference/commandline/node_tasks.md
+++ b/docs/reference/commandline/node_tasks.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # node tasks
 
     Usage:  docker node tasks [OPTIONS] NODE

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 ## update
 
     Usage: docker node update [OPTIONS] Node

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -9,8 +9,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service create
 
 ```Markdown

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service inspect
 
 ```Markdown

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service ls
 
 ```Markdown

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service rm
 
 ```Markdown

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service scale
 
     Usage:	docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]

--- a/docs/reference/commandline/service_tasks.md
+++ b/docs/reference/commandline/service_tasks.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service tasks
 
 ```Markdown

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # service update
 
 ```Markdown

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # swarm init
 
 	Usage:	docker swarm init [OPTIONS]

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # swarm join
 
 	Usage:	docker swarm join [OPTIONS] HOST:PORT

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # swarm leave
 
 	Usage:	docker swarm leave

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -8,8 +8,6 @@ parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-**Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
-
 # swarm update
 
     Usage:  docker swarm update [OPTIONS]


### PR DESCRIPTION
A site-wide banner is going to be used, so we don't need this warning
