### PR TITLE
Docker reference error CMD with ENV variables

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -606,7 +606,7 @@ instruction as well.
 > This means that normal shell processing does not happen. For example,
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
-> a shell directly, for example: `CMD [ "sh", "-c", "echo", "$HOME" ]`.
+> a shell directly, for example: `CMD [ "sh", "-c", "echo $HOME" ]`.
 
 When used in the shell or exec formats, the `CMD` instruction sets the command
 to be executed when running the image.
@@ -1074,7 +1074,7 @@ sys	0m 0.03s
 > This means that normal shell processing does not happen. For example,
 > `ENTRYPOINT [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
-> a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo", "$HOME" ]`.
+> a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo $HOME" ]`.
 > Variables that are defined in the `Dockerfile`using `ENV`, will be substituted by
 > the `Dockerfile` parser.
 


### PR DESCRIPTION
The reason why the issue occurs is because sh parses the first argument after -c as the whole script to execute.
Everything after isn't executed as one might expect.

When working on the 'fix' I found out the same fix is also done in commit 2af7c5cfe24b4c8e931f751979b5e69e20ba77e2, except only for one occurrence.
