### PR TITLE
Add remove flags for service update

### DIFF
--- a/api/client/service/create.go
+++ b/api/client/service/create.go
@@ -28,7 +28,15 @@ func newCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&opts.mode, flagMode, "replicated", "Service mode (replicated or global)")
 	addServiceFlags(cmd, opts)
-	cmd.Flags().SetInterspersed(false)
+
+	flags.VarP(&opts.labels, flagLabel, "l", "Service labels")
+	flags.VarP(&opts.env, flagEnv, "e", "Set environment variables")
+	flags.Var(&opts.mounts, flagMount, "Attach a mount to the service")
+	flags.StringSliceVar(&opts.constraints, flagConstraint, []string{}, "Placement constraints")
+	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")
+	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
+
+	flags.SetInterspersed(false)
 	return cmd
 }
 

--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -493,6 +493,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 const (
 	flagConstraint         = "constraint"
+	flagConstraintRemove   = "remove-constraint"
 	flagEndpointMode       = "endpoint-mode"
 	flagEnv                = "env"
 	flagEnvRemove          = "remove-env"

--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -459,12 +459,9 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags := cmd.Flags()
 	flags.StringVar(&opts.name, flagName, "", "Service name")
-	flags.VarP(&opts.labels, flagLabel, "l", "Service labels")
 
-	flags.VarP(&opts.env, flagEnv, "e", "Set environment variables")
 	flags.StringVarP(&opts.workdir, "workdir", "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID")
-	flags.Var(&opts.mounts, flagMount, "Attach a mount to the service")
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")
@@ -479,36 +476,38 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.restartPolicy.maxAttempts, flagRestartMaxAttempts, "Maximum number of restarts before giving up")
 	flags.Var(&opts.restartPolicy.window, flagRestartWindow, "Window used to evaluate the restart policy")
 
-	flags.StringSliceVar(&opts.constraints, flagConstraint, []string{}, "Placement constraints")
-
 	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 0, "Maximum number of tasks updated simultaneously")
 	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates")
 
-	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")
 	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "", "Endpoint mode (vip or dnsrr)")
-	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
 
 	flags.BoolVar(&opts.registryAuth, flagRegistryAuth, false, "Send registry authentication details to Swarm agents")
 }
 
 const (
 	flagConstraint         = "constraint"
-	flagConstraintRemove   = "remove-constraint"
+	flagConstraintRemove   = "constraint-rm"
+	flagConstraintAdd      = "constraint-add"
 	flagEndpointMode       = "endpoint-mode"
 	flagEnv                = "env"
-	flagEnvRemove          = "remove-env"
+	flagEnvRemove          = "env-rm"
+	flagEnvAdd             = "env-add"
 	flagLabel              = "label"
-	flagLabelRemove        = "remove-label"
+	flagLabelRemove        = "label-rm"
+	flagLabelAdd           = "label-add"
 	flagLimitCPU           = "limit-cpu"
 	flagLimitMemory        = "limit-memory"
 	flagMode               = "mode"
 	flagMount              = "mount"
-	flagMountRemove        = "remove-mount"
+	flagMountRemove        = "mount-rm"
+	flagMountAdd           = "mount-add"
 	flagName               = "name"
 	flagNetwork            = "network"
-	flagNetworkRemove      = "remove-network"
+	flagNetworkRemove      = "network-rm"
+	flagNetworkAdd         = "network-add"
 	flagPublish            = "publish"
-	flagPublishRemove      = "remove-publish"
+	flagPublishRemove      = "publish-rm"
+	flagPublishAdd         = "publish-add"
 	flagReplicas           = "replicas"
 	flagReserveCPU         = "reserve-cpu"
 	flagReserveMemory      = "reserve-memory"

--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -461,7 +461,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.StringVar(&opts.name, flagName, "", "Service name")
 	flags.VarP(&opts.labels, flagLabel, "l", "Service labels")
 
-	flags.VarP(&opts.env, "env", "e", "Set environment variables")
+	flags.VarP(&opts.env, flagEnv, "e", "Set environment variables")
 	flags.StringVarP(&opts.workdir, "workdir", "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID")
 	flags.Var(&opts.mounts, flagMount, "Attach a mount to the service")
@@ -494,14 +494,20 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 const (
 	flagConstraint         = "constraint"
 	flagEndpointMode       = "endpoint-mode"
+	flagEnv                = "env"
+	flagEnvRemove          = "remove-env"
 	flagLabel              = "label"
+	flagLabelRemove        = "remove-label"
 	flagLimitCPU           = "limit-cpu"
 	flagLimitMemory        = "limit-memory"
 	flagMode               = "mode"
 	flagMount              = "mount"
+	flagMountRemove        = "remove-mount"
 	flagName               = "name"
 	flagNetwork            = "network"
+	flagNetworkRemove      = "remove-network"
 	flagPublish            = "publish"
+	flagPublishRemove      = "remove-publish"
 	flagReplicas           = "replicas"
 	flagReserveCPU         = "reserve-cpu"
 	flagReserveMemory      = "reserve-memory"

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -35,6 +35,15 @@ func TestUpdateLabels(t *testing.T) {
 	assert.Equal(t, labels["toadd"], "newlabel")
 }
 
+func TestUpdateLabelsRemoveALabelThatDoesNotExist(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("label-rm", "dne")
+
+	labels := map[string]string{"foo": "theoldlabel"}
+	updateLabels(flags, &labels)
+	assert.Equal(t, len(labels), 1)
+}
+
 func TestUpdatePlacement(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("constraint-add", "node=toadd")
@@ -61,6 +70,18 @@ func TestUpdateEnvironment(t *testing.T) {
 	assert.Equal(t, len(envs), 2)
 	assert.Equal(t, envs[0], "tokeep=value")
 	assert.Equal(t, envs[1], "toadd=newenv")
+}
+
+func TestUpdateEnvironmentWithDuplicateValues(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("env-add", "foo=newenv")
+	flags.Set("env-add", "foo=dupe")
+	flags.Set("env-rm", "foo")
+
+	envs := []string{"foo=value"}
+
+	updateEnvironment(flags, &envs)
+	assert.Equal(t, len(envs), 0)
 }
 
 func TestUpdateMounts(t *testing.T) {

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -35,15 +35,27 @@ func TestUpdateLabels(t *testing.T) {
 	assert.Equal(t, labels["toadd"], "newlabel")
 }
 
+func TestUpdatePlacement(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("constraint", "node=toadd")
+	flags.Set("remove-constraint", "node!=toremove")
+
+	placement := &swarm.Placement{
+		Constraints: []string{"node!=toremove", "container=tokeep"},
+	}
+
+	updatePlacement(flags, placement)
+	assert.Equal(t, len(placement.Constraints), 2)
+	assert.Equal(t, placement.Constraints[0], "container=tokeep")
+	assert.Equal(t, placement.Constraints[1], "node=toadd")
+}
+
 func TestUpdateEnvironment(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("env", "toadd=newenv")
 	flags.Set("remove-env", "toremove")
 
-	envs := []string{
-		"toremove=theenvtoremove",
-		"tokeep=value",
-	}
+	envs := []string{"toremove=theenvtoremove", "tokeep=value"}
 
 	updateEnvironment(flags, &envs)
 	assert.Equal(t, len(envs), 2)

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -21,8 +21,8 @@ func TestUpdateServiceArgs(t *testing.T) {
 
 func TestUpdateLabels(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("label", "toadd=newlabel")
-	flags.Set("remove-label", "toremove")
+	flags.Set("label-add", "toadd=newlabel")
+	flags.Set("label-rm", "toremove")
 
 	labels := map[string]string{
 		"toremove": "thelabeltoremove",
@@ -37,8 +37,8 @@ func TestUpdateLabels(t *testing.T) {
 
 func TestUpdatePlacement(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("constraint", "node=toadd")
-	flags.Set("remove-constraint", "node!=toremove")
+	flags.Set("constraint-add", "node=toadd")
+	flags.Set("constraint-rm", "node!=toremove")
 
 	placement := &swarm.Placement{
 		Constraints: []string{"node!=toremove", "container=tokeep"},
@@ -52,8 +52,8 @@ func TestUpdatePlacement(t *testing.T) {
 
 func TestUpdateEnvironment(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("env", "toadd=newenv")
-	flags.Set("remove-env", "toremove")
+	flags.Set("env-add", "toadd=newenv")
+	flags.Set("env-rm", "toremove")
 
 	envs := []string{"toremove=theenvtoremove", "tokeep=value"}
 
@@ -65,8 +65,8 @@ func TestUpdateEnvironment(t *testing.T) {
 
 func TestUpdateMounts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("mount", "type=volume,target=/toadd")
-	flags.Set("remove-mount", "/toremove")
+	flags.Set("mount-add", "type=volume,target=/toadd")
+	flags.Set("mount-rm", "/toremove")
 
 	mounts := []swarm.Mount{
 		{Target: "/toremove", Type: swarm.MountType("BIND")},
@@ -81,8 +81,8 @@ func TestUpdateMounts(t *testing.T) {
 
 func TestUpdateNetworks(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("network", "toadd")
-	flags.Set("remove-network", "toremove")
+	flags.Set("network-add", "toadd")
+	flags.Set("network-rm", "toremove")
 
 	attachments := []swarm.NetworkAttachmentConfig{
 		{Target: "toremove", Aliases: []string{"foo"}},
@@ -97,8 +97,8 @@ func TestUpdateNetworks(t *testing.T) {
 
 func TestUpdatePorts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("publish", "1000:1000")
-	flags.Set("remove-publish", "333/udp")
+	flags.Set("publish-add", "1000:1000")
+	flags.Set("publish-rm", "333/udp")
 
 	portConfigs := []swarm.PortConfig{
 		{TargetPort: 333, Protocol: swarm.PortConfigProtocol("udp")},

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -18,3 +18,83 @@ func TestUpdateServiceArgs(t *testing.T) {
 	updateService(flags, spec)
 	assert.EqualStringSlice(t, cspec.Args, []string{"the", "new args"})
 }
+
+func TestUpdateLabels(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("label", "toadd=newlabel")
+	flags.Set("remove-label", "toremove")
+
+	labels := map[string]string{
+		"toremove": "thelabeltoremove",
+		"tokeep":   "value",
+	}
+
+	updateLabels(flags, &labels)
+	assert.Equal(t, len(labels), 2)
+	assert.Equal(t, labels["tokeep"], "value")
+	assert.Equal(t, labels["toadd"], "newlabel")
+}
+
+func TestUpdateEnvironment(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("env", "toadd=newenv")
+	flags.Set("remove-env", "toremove")
+
+	envs := []string{
+		"toremove=theenvtoremove",
+		"tokeep=value",
+	}
+
+	updateEnvironment(flags, &envs)
+	assert.Equal(t, len(envs), 2)
+	assert.Equal(t, envs[0], "tokeep=value")
+	assert.Equal(t, envs[1], "toadd=newenv")
+}
+
+func TestUpdateMounts(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("mount", "type=volume,target=/toadd")
+	flags.Set("remove-mount", "/toremove")
+
+	mounts := []swarm.Mount{
+		{Target: "/toremove", Type: swarm.MountType("BIND")},
+		{Target: "/tokeep", Type: swarm.MountType("BIND")},
+	}
+
+	updateMounts(flags, &mounts)
+	assert.Equal(t, len(mounts), 2)
+	assert.Equal(t, mounts[0].Target, "/tokeep")
+	assert.Equal(t, mounts[1].Target, "/toadd")
+}
+
+func TestUpdateNetworks(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("network", "toadd")
+	flags.Set("remove-network", "toremove")
+
+	attachments := []swarm.NetworkAttachmentConfig{
+		{Target: "toremove", Aliases: []string{"foo"}},
+		{Target: "tokeep"},
+	}
+
+	updateNetworks(flags, &attachments)
+	assert.Equal(t, len(attachments), 2)
+	assert.Equal(t, attachments[0].Target, "tokeep")
+	assert.Equal(t, attachments[1].Target, "toadd")
+}
+
+func TestUpdatePorts(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("publish", "1000:1000")
+	flags.Set("remove-publish", "333/udp")
+
+	portConfigs := []swarm.PortConfig{
+		{TargetPort: 333, Protocol: swarm.PortConfigProtocol("udp")},
+		{TargetPort: 555},
+	}
+
+	updatePorts(flags, &portConfigs)
+	assert.Equal(t, len(portConfigs), 2)
+	assert.Equal(t, portConfigs[0].TargetPort, uint32(555))
+	assert.Equal(t, portConfigs[1].TargetPort, uint32(1000))
+}

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -22,7 +22,7 @@ func (s *DockerSwarmSuite) TestServiceUpdatePort(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
 
 	// Update the service: changed the port mapping from 8080:8081 to 8082:8083.
-	_, err = d.Cmd("service", "update", "-p", "8082:8083", "--remove-publish", "8081", serviceName)
+	_, err = d.Cmd("service", "update", "--publish-add", "8082:8083", "--publish-rm", "8081", serviceName)
 	c.Assert(err, checker.IsNil)
 
 	// Inspect the service and verify port mapping

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -22,7 +22,7 @@ func (s *DockerSwarmSuite) TestServiceUpdatePort(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
 
 	// Update the service: changed the port mapping from 8080:8081 to 8082:8083.
-	_, err = d.Cmd("service", "update", "-p", "8082:8083", serviceName)
+	_, err = d.Cmd("service", "update", "-p", "8082:8083", "--remove-publish", "8081", serviceName)
 	c.Assert(err, checker.IsNil)
 
 	// Inspect the service and verify port mapping


### PR DESCRIPTION
Following up on #23701

Updating array and mapping types by starting with an empty collection is fine when there are a small number of items, but it becomes a large burden for users if they have many ports, labels, or mounts, and would like to just add or remove a single one. The case of just adding or removing a single item should be a lot more common than removing everything.

This PR adds `--remove-x` flags and restores the old merge behaviour for these types.

Fixes #24064

cc @icecrime 
