### PR TITLE
Use "runc" as alias for the default runtime

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/pkg/discovery"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/registry"
-	"github.com/docker/engine-api/types"
 	"github.com/imdario/mergo"
 )
 
@@ -27,6 +26,9 @@ const (
 	// maximum number of uploads that
 	// may take place at a time for each push.
 	defaultMaxConcurrentUploads = 5
+	// stockRuntimeName is the reserved name/alias used to represent the
+	// OCI runtime being shipped with the docker daemon package.
+	stockRuntimeName = "runc"
 )
 
 const (
@@ -426,12 +428,12 @@ func ValidateConfiguration(config *Config) error {
 
 	// validate that "default" runtime is not reset
 	if runtimes := config.GetAllRuntimes(); len(runtimes) > 0 {
-		if _, ok := runtimes[types.DefaultRuntimeName]; ok {
-			return fmt.Errorf("runtime name '%s' is reserved", types.DefaultRuntimeName)
+		if _, ok := runtimes[stockRuntimeName]; ok {
+			return fmt.Errorf("runtime name '%s' is reserved", stockRuntimeName)
 		}
 	}
 
-	if defaultRuntime := config.GetDefaultRuntimeName(); defaultRuntime != "" && defaultRuntime != types.DefaultRuntimeName {
+	if defaultRuntime := config.GetDefaultRuntimeName(); defaultRuntime != "" && defaultRuntime != stockRuntimeName {
 		runtimes := config.GetAllRuntimes()
 		if _, ok := runtimes[defaultRuntime]; !ok {
 			return fmt.Errorf("specified default runtime '%s' does not exist", defaultRuntime)

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -88,8 +88,8 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.StringVar(&config.ContainerdAddr, []string{"-containerd"}, "", usageFn("Path to containerd socket"))
 	cmd.BoolVar(&config.LiveRestore, []string{"-live-restore"}, false, usageFn("Enable live restore of docker when containers are still running"))
 	config.Runtimes = make(map[string]types.Runtime)
-	cmd.Var(runconfigopts.NewNamedRuntimeOpt("runtimes", &config.Runtimes), []string{"-add-runtime"}, usageFn("Register an additional OCI compatible runtime"))
-	cmd.StringVar(&config.DefaultRuntime, []string{"-default-runtime"}, types.DefaultRuntimeName, usageFn("Default OCI runtime to be used"))
+	cmd.Var(runconfigopts.NewNamedRuntimeOpt("runtimes", &config.Runtimes, stockRuntimeName), []string{"-add-runtime"}, usageFn("Register an additional OCI compatible runtime"))
+	cmd.StringVar(&config.DefaultRuntime, []string{"-default-runtime"}, stockRuntimeName, usageFn("Default OCI runtime to be used"))
 
 	config.attachExperimentalFlags(cmd, usageFn)
 }

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -50,7 +50,7 @@ func (config *Config) GetRuntime(name string) *types.Runtime {
 
 // GetDefaultRuntimeName returns the current default runtime
 func (config *Config) GetDefaultRuntimeName() string {
-	return types.DefaultRuntimeName
+	return stockRuntimeName
 }
 
 // GetAllRuntimes returns a copy of the runtimes map

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -532,7 +532,7 @@ func (daemon *Daemon) platformReload(config *Config, attributes *map[string]stri
 	if config.IsValueSet("runtimes") {
 		daemon.configStore.Runtimes = config.Runtimes
 		// Always set the default one
-		daemon.configStore.Runtimes[types.DefaultRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+		daemon.configStore.Runtimes[stockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
 	}
 
 	if config.DefaultRuntime != "" {
@@ -574,12 +574,12 @@ func verifyDaemonSettings(config *Config) error {
 	}
 
 	if config.DefaultRuntime == "" {
-		config.DefaultRuntime = types.DefaultRuntimeName
+		config.DefaultRuntime = stockRuntimeName
 	}
 	if config.Runtimes == nil {
 		config.Runtimes = make(map[string]types.Runtime)
 	}
-	config.Runtimes[types.DefaultRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+	config.Runtimes[stockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
 
 	return nil
 }

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2409,7 +2409,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Run with default runtime explicitly
-	out, err = s.d.Cmd("run", "--rm", "--runtime=default", "busybox", "ls")
+	out, err = s.d.Cmd("run", "--rm", "--runtime=runc", "busybox", "ls")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Run with oci (same path as default) but keep it around
@@ -2434,7 +2434,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 	<-time.After(1 * time.Second)
 
 	// Run with default runtime
-	out, err = s.d.Cmd("run", "--rm", "--runtime=default", "busybox", "ls")
+	out, err = s.d.Cmd("run", "--rm", "--runtime=runc", "busybox", "ls")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Run with "oci"
@@ -2451,8 +2451,8 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 	config = `
 {
     "runtimes": {
-        "default": {
-            "path": "docker-runc"
+        "runc": {
+            "path": "my-runc"
         }
     }
 }
@@ -2463,7 +2463,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 	<-time.After(1 * time.Second)
 
 	content, _ := ioutil.ReadFile(s.d.logFile.Name())
-	c.Assert(string(content), checker.Contains, `file configuration validation failed (runtime name 'default' is reserved)`)
+	c.Assert(string(content), checker.Contains, `file configuration validation failed (runtime name 'runc' is reserved)`)
 
 	// Check that we can select a default runtime
 	config = `
@@ -2492,7 +2492,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *check.C) {
 	c.Assert(out, checker.Contains, "/usr/local/bin/vm-manager: no such file or directory")
 
 	// Run with default runtime explicitly
-	out, err = s.d.Cmd("run", "--rm", "--runtime=default", "busybox", "ls")
+	out, err = s.d.Cmd("run", "--rm", "--runtime=runc", "busybox", "ls")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 }
 
@@ -2505,7 +2505,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Run with default runtime explicitly
-	out, err = s.d.Cmd("run", "--rm", "--runtime=default", "busybox", "ls")
+	out, err = s.d.Cmd("run", "--rm", "--runtime=runc", "busybox", "ls")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Run with oci (same path as default) but keep it around
@@ -2523,7 +2523,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Run with default runtime
-	out, err = s.d.Cmd("run", "--rm", "--runtime=default", "busybox", "ls")
+	out, err = s.d.Cmd("run", "--rm", "--runtime=runc", "busybox", "ls")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	// Run with "oci"
@@ -2538,11 +2538,11 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
 
 	// Check that we can't override the default runtime
 	s.d.Stop()
-	err = s.d.Start("--add-runtime", "default=docker-runc")
+	err = s.d.Start("--add-runtime", "runc=my-runc")
 	c.Assert(err, check.NotNil)
 
 	content, _ := ioutil.ReadFile(s.d.logFile.Name())
-	c.Assert(string(content), checker.Contains, `runtime name 'default' is reserved`)
+	c.Assert(string(content), checker.Contains, `runtime name 'runc' is reserved`)
 
 	// Check that we can select a default runtime
 	s.d.Stop()
@@ -2554,6 +2554,6 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromCommandLine(c *check.C) {
 	c.Assert(out, checker.Contains, "/usr/local/bin/vm-manager: no such file or directory")
 
 	// Run with default runtime explicitly
-	out, err = s.d.Cmd("run", "--rm", "--runtime=default", "busybox", "ls")
+	out, err = s.d.Cmd("run", "--rm", "--runtime=runc", "busybox", "ls")
 	c.Assert(err, check.IsNil, check.Commentf(out))
 }

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -437,7 +437,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=default, labels=[\"bar=foo\"], max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=default:{docker-runc []})", daemonID, daemonName))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, labels=[\"bar=foo\"], max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=runc:{docker-runc []})", daemonID, daemonName))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -36,7 +36,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 	}
 
 	if DaemonIsLinux.Condition() {
-		stringsToCheck = append(stringsToCheck, "Runtimes:", "Default Runtime: default")
+		stringsToCheck = append(stringsToCheck, "Runtimes:", "Default Runtime: runc")
 	}
 
 	if utils.ExperimentalBuild() {

--- a/runconfig/opts/runtime.go
+++ b/runconfig/opts/runtime.go
@@ -9,16 +9,17 @@ import (
 
 // RuntimeOpt defines a map of Runtimes
 type RuntimeOpt struct {
-	name   string
-	values *map[string]types.Runtime
+	name             string
+	stockRuntimeName string
+	values           *map[string]types.Runtime
 }
 
 // NewNamedRuntimeOpt creates a new RuntimeOpt
-func NewNamedRuntimeOpt(name string, ref *map[string]types.Runtime) *RuntimeOpt {
+func NewNamedRuntimeOpt(name string, ref *map[string]types.Runtime, stockRuntime string) *RuntimeOpt {
 	if ref == nil {
 		ref = &map[string]types.Runtime{}
 	}
-	return &RuntimeOpt{name: name, values: ref}
+	return &RuntimeOpt{name: name, values: ref, stockRuntimeName: stockRuntime}
 }
 
 // Name returns the name of the NamedListOpts in the configuration.
@@ -40,8 +41,8 @@ func (o *RuntimeOpt) Set(val string) error {
 	}
 
 	parts[0] = strings.ToLower(parts[0])
-	if parts[0] == types.DefaultRuntimeName {
-		return fmt.Errorf("runtime name 'default' is reserved")
+	if parts[0] == o.stockRuntimeName {
+		return fmt.Errorf("runtime name '%s' is reserved", o.stockRuntimeName)
 	}
 
 	if _, ok := (*o.values)[parts[0]]; ok {


### PR DESCRIPTION
This also moves the variable holding the default runtime name from the
engine-api repository into docker repository

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

Closes #23699 
![](http://media.urbantabloid.com/wp-content/uploads/2014/11/Red-Pandow.jpg)

**Note**: I'll make a PR into engine-api to remove `types.DefaultRuntimeName` once this is merged.
