### PR TITLE
Temporarily disable API v1.25 docs

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -35,15 +35,14 @@ If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the
 default.
 
-The current version of the API is v1.25 which means calling `/info` is the same
-as calling `/v1.25/info`. To call an older version of the API use
-`/v1.24/info`.
+The current version of the API is v1.24 which means calling `/info` is the same
+as calling `/v1.24/info`. To call an older version of the API use
+`/v1.23/info`.
 
 Use the table below to find the API version for a Docker version:
 
 Docker version  | API version                        | Changes
 ----------------|------------------------------------|------------------------------------------------------
-1.13.x          | [1.25](docker_remote_api_v1.25.md) | [API changes](docker_remote_api.md#v1-25-api-changes)
 1.12.x          | [1.24](docker_remote_api_v1.24.md) | [API changes](docker_remote_api.md#v1-24-api-changes)
 1.11.x          | [1.23](docker_remote_api_v1.23.md) | [API changes](docker_remote_api.md#v1-23-api-changes)
 1.10.x          | [1.22](docker_remote_api_v1.22.md) | [API changes](docker_remote_api.md#v1-22-api-changes)

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3,6 +3,7 @@
 title = "Remote API v1.25"
 description = "API Documentation for Docker"
 keywords = ["API, Docker, rcli, REST,  documentation"]
+draft = true
 [menu.main]
 parent="engine_remoteapi"
 weight=-6


### PR DESCRIPTION
The docs are currently published from "master" for the RC,
so hiding v1.25 API, which is for docker 1.13

ping @sanscontext @SvenDowideit @sfsmithcha let me know if we need to update this
