### PR TITLE
Windows: Added stateinfo to WaitExit info to aid debugging daemon hangs

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -263,12 +263,12 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 	}
 
 	// Call into the backend to notify it of the state change.
-	logrus.Debugf("waitExit() calling backend.StateChanged %v", si)
+	logrus.Debugf("waitExit() calling backend.StateChanged %+v", si)
 	if err := ctr.client.backend.StateChanged(ctr.containerID, si); err != nil {
 		logrus.Error(err)
 	}
 
-	logrus.Debugln("waitExit() completed OK")
+	logrus.Debugf("waitExit() completed OK, %+v", si)
 	return nil
 }
 


### PR DESCRIPTION
When debugging daemon hangs due to a container lock being held, correlating the WaitExit StateChanged log line to the Completed OK line would help immensely. This prints the stateinfo (new state, pid, exitcode, and process ID) when WaitExit completes. 
