### PR TITLE
Skip always pulling images on integration tests

### DIFF
--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -172,7 +172,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 
 	args = append(args, providedArgs...)
 	d.cmd = exec.Command(dockerdBinary, args...)
-
+	d.cmd.Env = append(os.Environ(), "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE=1")
 	d.cmd.Stdout = out
 	d.cmd.Stderr = out
 	d.logFile = out


### PR DESCRIPTION
Allow tests to skip latest-image check and use the image already in node as first option. The added environment variable should not be considered a supported configuration option.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
