### PR TITLE
bash completion for `docker {run,create,network connect} --link-local…

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1355,6 +1355,7 @@ _docker_network_connect() {
 		--ip
 		--ip6
 		--link
+		--link-local-ip
 	"
 
 	local boolean_options="
@@ -2157,6 +2158,7 @@ _docker_run() {
 		--label-file
 		--label -l
 		--link
+		--link-local-ip
 		--log-driver
 		--log-opt
 		--mac-address


### PR DESCRIPTION
Ref: #23415
Please include in 1.12 as the feature is present there.
