### PR TITLE
bash completion for `-c` alias to `--cpu-shares`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -693,7 +693,7 @@ _docker_build() {
 		--cgroup-parent
 		--cpuset-cpus
 		--cpuset-mems
-		--cpu-shares
+		--cpu-shares -c
 		--cpu-period
 		--cpu-quota
 		--file -f
@@ -2134,7 +2134,7 @@ _docker_run() {
 		--cpu-quota
 		--cpuset-cpus
 		--cpuset-mems
-		--cpu-shares
+		--cpu-shares -c
 		--device
 		--device-read-bps
 		--device-read-iops
@@ -2529,7 +2529,7 @@ _docker_update() {
 		--cpu-quota
 		--cpuset-cpus
 		--cpuset-mems
-		--cpu-shares
+		--cpu-shares -c
 		--kernel-memory
 		--memory -m
 		--memory-reservation


### PR DESCRIPTION
This brings back the previously deprecated `-c` option because it was undeprecated.
Ref #22621
Please include in 1.12.0 as the feature is present there
ping @sdurrheimer for zsh completion
