### PR TITLE
add `--format` flag to `docker info`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1290,9 +1290,15 @@ _docker_import() {
 }
 
 _docker_info() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+    
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -200,6 +200,8 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from import' -l help -d 'Pri
 
 # info
 complete -c docker -f -n '__fish_docker_no_subcommand' -a info -d 'Display system-wide information'
+complete -c docker -A -f -n '__fish_seen_subcommand_from info' -s f -l format  -d 'Format the output using the given go template'
+complete -c docker -A -f -n '__fish_seen_subcommand_from info' -l help -d 'Print usage'
 
 # inspect
 complete -c docker -f -n '__fish_docker_no_subcommand' -a inspect -d 'Return low-level information on a container or image'
@@ -393,6 +395,8 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from unpause' -a '(__fish_pr
 
 # version
 complete -c docker -f -n '__fish_docker_no_subcommand' -a version -d 'Show the Docker version information'
+complete -c docker -A -f -n '__fish_seen_subcommand_from version' -s f -l format  -d 'Format the output using the given go template'
+complete -c docker -A -f -n '__fish_seen_subcommand_from version' -l help -d 'Print usage'
 
 # wait
 complete -c docker -f -n '__fish_docker_no_subcommand' -a wait -d 'Block until a container stops, then print its exit code'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1709,7 +1709,8 @@ __docker_subcommand() {
             ;;
         (info|version)
             _arguments $(__docker_arguments) \
-                $opts_help && ret=0
+                $opts_help \
+		"($help -f --format)"{-f=,--format=}"[Format the output using the given go template]:template: " && ret=0
             ;;
         (inspect)
             local state

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -16,13 +16,18 @@ Usage:  docker info
 Display system-wide information
 
 Options:
-      --help   Print usage
+  -f, --format string   Format the output using the given go template
+      --help            Print usage
 ```
 
 This command displays system wide information regarding the Docker installation.
 Information displayed includes the kernel version, number of containers and images.
 The number of images shown is the number of unique images. The same image tagged
 under different names is counted only once.
+
+If a format is specified, the given template will be executed instead of the
+default format. Go's [text/template](http://golang.org/pkg/text/template/) package
+describes all the details of the format.
 
 Depending on the storage driver in use, additional information can be shown, such
 as pool name, data file, metadata file, data space used, total data space, metadata
@@ -144,3 +149,8 @@ information about the devicemapper storage driver is shown:
     Insecure registries:
      myinsecurehost:5000
      127.0.0.0/8
+
+You can also specify the output format:
+
+    $ docker info --format '{{json .}}'
+	{"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -47,6 +48,17 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 	for _, linePrefix := range stringsToCheck {
 		c.Assert(out, checker.Contains, linePrefix, check.Commentf("couldn't find string %v in output", linePrefix))
 	}
+}
+
+// TestInfoFormat tests `docker info --format`
+func (s *DockerSuite) TestInfoFormat(c *check.C) {
+	out, status := dockerCmd(c, "info", "--format", "{{json .}}")
+	c.Assert(status, checker.Equals, 0)
+	var m map[string]interface{}
+	err := json.Unmarshal([]byte(out), &m)
+	c.Assert(err, checker.IsNil)
+	_, _, err = dockerCmdWithError("info", "--format", "{{.badString}}")
+	c.Assert(err, checker.NotNil)
 }
 
 // TestInfoDiscoveryBackend verifies that a daemon run with `--cluster-advertise` and

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -7,13 +7,17 @@ docker-info - Display system-wide information
 # SYNOPSIS
 **docker info**
 [**--help**]
-
+[**-f**|**--format**[=*FORMAT*]]
 
 # DESCRIPTION
 This command displays system wide information regarding the Docker installation.
 Information displayed includes the kernel version, number of containers and images.
 The number of images shown is the number of unique images. The same image tagged
 under different names is counted only once.
+
+If a format is specified, the given template will be executed instead of the
+default format. Go's **text/template** package
+describes all the details of the format.
 
 Depending on the storage driver in use, additional information can be shown, such
 as pool name, data file, metadata file, data space used, total data space, metadata
@@ -27,6 +31,9 @@ available on the volume where `/var/lib/docker` is mounted.
 # OPTIONS
 **--help**
   Print usage statement
+
+**-f**, **--format**=""
+  Format the output using the given go template
 
 # EXAMPLES
 
@@ -139,6 +146,11 @@ information about the devicemapper storage driver is shown:
     Insecure registries:
      myinsecurehost:5000
      127.0.0.0/8
+
+You can also specify the output format:
+
+    $ docker info --format '{{json .}}'
+	{"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)


### PR DESCRIPTION
**\- What I did**
add `--format` flag to `docker info`

**\- How to verify it**
`docker info --format {{json .}}`

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
