### PR TITLE
Added the functionality to create an image for Docker, without having…

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -16,6 +16,8 @@ OPTIONS:
                    The default is "Core".
   -y <yumconf>     The path to the yum config to install packages from. The
                    default is /etc/yum.conf for Centos/RHEL and /etc/dnf/dnf.conf for Fedora
+  -f <filename>    The filename of the output tarfile
+  -c               If specified, the tarfile will be bzip2 compressed
 EOOPTS
     exit 1
 }
@@ -27,12 +29,15 @@ if [ -f /etc/dnf/dnf.conf ] && command -v dnf &> /dev/null; then
 	alias yum=dnf
 fi
 install_groups="Core"
-while getopts ":y:p:g:h" opt; do
+filename=''
+compress='N'
+while getopts ":f:y:p:g:hc" opt; do
     case $opt in
         y)
             yum_config=$OPTARG
             ;;
         h)
+	    echo 'in h'
             usage
             ;;
         p)
@@ -40,6 +45,12 @@ while getopts ":y:p:g:h" opt; do
             ;;
         g)
             install_groups="$OPTARG"
+            ;;
+        f)
+            filename="$OPTARG"
+            ;;
+        c)
+            compress='Y'
             ;;
         \?)
             echo "Invalid option: -$OPTARG"
@@ -127,8 +138,19 @@ if [ -z "$version" ]; then
     version=$name
 fi
 
-tar --numeric-owner -c -C "$target" . | docker import - $name:$version
+if [ -n "${filename}" ] ; then
+    if [ "${compress}" = 'Y' ] ; then
+        taropts="-j"
+        filename="${filename}.tar.bz2"
+    else
+        filename="${filename}.tar"
+        taropts=''
+    fi
+    tar --numeric-owner -c -C "$target" ${taropts} -f "${filename}" .
+else
+    tar --numeric-owner -c -C "$target" . | docker import - $name:$version
 
-docker run -i -t --rm $name:$version /bin/bash -c 'echo success'
+    docker run -i -t --rm $name:$version /bin/bash -c 'echo success'
+fi
 
 rm -rf "$target"


### PR DESCRIPTION
**\- What I did**
Added the functionality to the mkimage-yum.sh script to create an image of an CentOS or other RHEL based system without having docker installed on that system. You can then simply copy the resulting .tar or .tar.bz2 file to a machine that has docker on it and just run an docker import directly on the .tar file.

**\- How I did it**
Added 2 options to the shell script and processed the options in the script later on. I added the options in such a way that if you don't specify them, the original behavior is kept. Thus having Docker installed is a must then.

**\- How to verify it**
Create an .tar of .tar.bz2 file on a RHEL-based machine, without having Docker installed on it, copy the resulting .tar or .tar.bz2 to a machine with docker on it and run an docker import on the .tar file.

**\- Description for the changelog**
Made it possible to create an RHEL-based image on a RHEL-based system without having Docker installed.

v1.11.2 Docker installed
