### PR TITLE
Now that the Docker4 links are online, we can use them

### DIFF
--- a/docs/getstarted/last_page.md
+++ b/docs/getstarted/last_page.md
@@ -30,11 +30,11 @@ Depending on your interest, the Docker documentation contains a wealth of inform
   </tr>
   <tr>
     <td class="tg-031e">More about Docker for Mac, features, examples, FAQs, relationship to Docker Machine and Docker Toolbox, and how this fits in the Docker ecosystem</td>
-    <td class="tg-031e">[Getting Started with Docker for Mac](/docker-for-mac/index.md)</td>
+    <td class="tg-031e">[Getting Started with Docker for Mac](https://docs.docker.com/docker-for-mac/)</td>
   </tr>
   <tr>
     <td class="tg-031e">More about Docker for Windows, features, examples, FAQs, relationship to Docker Machine and Docker Toolbox, and how this fits in the Docker ecosystem</td>
-    <td class="tg-031e">[Getting Started with Docker for Windows](/docker-for-windows/index.md)</td>
+    <td class="tg-031e">[Getting Started with Docker for Windows](https://docs.docker.com/docker-for-windows/)</td>
   </tr>
   <tr>
     <td class="tg-031e">More about Docker Toolbox</td>

--- a/docs/getstarted/step_one.md
+++ b/docs/getstarted/step_one.md
@@ -70,9 +70,9 @@ For full instructions on getting Docker for various Linux distributions, see [In
 
 ## Step 2: Install Docker
 
-- **Docker for Mac** - Install instructions are at [Getting Started with Docker for Mac](/docker-for-mac/index.md).
+- **Docker for Mac** - Install instructions are at [Getting Started with Docker for Mac](https://docs.docker.com/docker-for-mac/).
 
-- **Docker for Windows** - Install instructions are at [Getting Started with Docker for Windows](/docker-for-windows/index.md).
+- **Docker for Windows** - Install instructions are at [Getting Started with Docker for Windows](https://docs.docker.com/docker-for-windows/).
 
 - **Docker Toolbox** - Install instructions are at [Docker Toolbox Overview](/toolbox/overview.md).
 

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -20,7 +20,7 @@ You have two options for installing Docker on Mac:
 
 Docker for Mac is our newest offering for the Mac. It runs as a native Mac application and uses <a href="https://github.com/mist64/xhyve/" target="_blank">xhyve</a> to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-Go to [Getting Started with Docker for Mac](/docker-for-mac/index.md) for download and install instructions, and to learn all about Docker for Mac.
+Go to [Getting Started with Docker for Mac](https://docs.docker.com/docker-for-mac/) for download and install instructions, and to learn all about Docker for Mac.
 
 **Requirements**
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -20,7 +20,7 @@ You have two options for installing Docker on Windows:
 
 Docker for Windows is our newest offering for PCs. It runs as a native Windows application and uses Hyper-V to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-Go to [Getting Started with Docker for Windows](/docker-for-windows/index.md) for download and install instructions, and to learn all about Docker for Windows.
+Go to [Getting Started with Docker for Windows](https://docs.docker.com/docker-for-windows/) for download and install instructions, and to learn all about Docker for Windows.
 
 **Requirements**
 


### PR DESCRIPTION
Docs checker can now resolve the docker for \* links on docs.docker.com - and thus should pass.
