### PR TITLE
Fixed install script that was not working for RHEL7 host

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -243,7 +243,8 @@ do_install() {
 		lsb_dist='centos'
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/redhat-release ]; then
-		lsb_dist='redhat'
+		# we use centos for both redhat and centos releases
+		lsb_dist='centos'
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/os-release ]; then
 		lsb_dist="$(. /etc/os-release && echo "$ID")"


### PR DESCRIPTION
Looks like a recent change to the install script in this PR: #23124 caused a regression that prevented docker from getting installed on RHEL7

This PR should fix this issue #23787

Signed-off-by: Ken Cochrane kencochrane@gmail.com

/cc @thaJeztah
