### PR TITLE
Man page fix: Mention supported drivers for --storage-opt size option in docker create/run.

### DIFF
--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -340,7 +340,7 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
    $ docker create -it --storage-opt size=120G fedora /bin/bash
 
    This (size) will allow to set the container rootfs size to 120G at creation time. User cannot pass a size less than the Default BaseFS Size.
-   This option is only available for the `devicemapper`, `btrfs` and `zfs` graphrivers.
+   This option is only available for the `devicemapper`, `btrfs`, and `zfs` graph drivers.
   
 **--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -492,7 +492,7 @@ its root filesystem mounted as read only prohibiting any writes.
    $ docker run -it --storage-opt size=120G fedora /bin/bash
 
    This (size) will allow to set the container rootfs size to 120G at creation time. User cannot pass a size less than the Default BaseFS Size.
-   This option is only available for the `devicemapper`, `btrfs` and `zfs` graphrivers.
+   This option is only available for the `devicemapper`, `btrfs`, and `zfs` graph drivers.
 
 **--stop-signal**=*SIGTERM*
   Signal to stop a container. Default is SIGTERM.


### PR DESCRIPTION
Signed-off-by: Shishir Mahajan shishir.mahajan@redhat.com
