### PR TITLE
Fix the value of the Components value in apt {In,}Release files

### DIFF
--- a/hack/make/release-deb
+++ b/hack/make/release-deb
@@ -92,7 +92,7 @@ done >> "$APTDIR/conf/apt-ftparchive.conf"
 
 cat <<-EOF > "$APTDIR/conf/docker-engine-release.conf"
 APT::FTPArchive::Release::Origin "Docker";
-APT::FTPArchive::Release::Components "${component}";
+APT::FTPArchive::Release::Components "${components[*]}";
 APT::FTPArchive::Release::Label "Docker APT Repository";
 APT::FTPArchive::Release::Architectures "${arches[*]}";
 EOF
@@ -144,19 +144,19 @@ for dir in contrib/builder/deb/${PACKAGE_ARCH}/*/; do
 	codename="${version//debootstrap-}"
 
 	apt-ftparchive \
+		-c "$APTDIR/conf/docker-engine-release.conf" \
 		-o "APT::FTPArchive::Release::Codename=$codename" \
 		-o "APT::FTPArchive::Release::Suite=$codename" \
-		-c "$APTDIR/conf/docker-engine-release.conf" \
 		release \
 		"$APTDIR/dists/$codename" > "$APTDIR/dists/$codename/Release"
 
 	for arch in "${arches[@]}"; do
 		apt-ftparchive \
+			-c "$APTDIR/conf/docker-engine-release.conf" \
 			-o "APT::FTPArchive::Release::Codename=$codename" \
 			-o "APT::FTPArchive::Release::Suite=$codename" \
-			-o "APT::FTPArchive::Release::Component=$component" \
+			-o "APT::FTPArchive::Release::Components=$component" \
 			-o "APT::FTPArchive::Release::Architecture=$arch" \
-			-c "$APTDIR/conf/docker-engine-release.conf" \
 			release \
 			"$APTDIR/dists/$codename/$component/binary-$arch" > "$APTDIR/dists/$codename/$component/binary-$arch/Release"
 	done


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

**What this does**:
- revert the `Components` field of `docker-engine-release.conf` to contains all the available components (e.g. `main experimental testing`) as it is used verbatim for the top `{In,}Release` files.
- fix a typo when generating the per component `{In,}Release` file (a `s` was missing)
- move the configuration file to be the first argument to `apt-ftparchive` when generating the per component `{In,}Release` file in order to allow further `-o` options to override what's provided in the general configuration.

Fixes #23823

ping @tiborvass @tianon 

![](http://api.ning.com/files/DtcI2O2Ry7C49JrCkf-vcHATDxh3h1JcFkrbeU2GAnBtGD993qNuKf2UeRlWqewq8kRL01TXnKTnmYSXnRoj8OD4bulc-sTW/1082134072.jpeg)
