### PR TITLE
remove --name flag from volume create

### DIFF
--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -11,7 +11,7 @@ parent = "smn_cli"
 # volume create
 
 ```markdown
-Usage:  docker volume create [OPTIONS]
+Usage:  docker volume create [OPTIONS] [VOLUME]
 
 Create a volume
 
@@ -19,14 +19,13 @@ Options:
   -d, --driver string   Specify volume driver name (default "local")
       --help            Print usage
       --label value     Set metadata for a volume (default [])
-      --name string     Specify volume name
   -o, --opt value       Set driver specific options (default map[])
 ```
 
 Creates a new volume that containers can consume and store data in. If a name is not specified, Docker generates a random name. You create a volume and then configure the container to use it, for example:
 
 ```bash
-$ docker volume create --name hello
+$ docker volume create hello
 hello
 
 $ docker run -d -v hello:/world busybox ls /world
@@ -62,19 +61,19 @@ The built-in `local` driver on Linux accepts options similar to the linux `mount
 For example, the following creates a `tmpfs` volume called `foo` with a size of 100 megabyte and `uid` of 1000.
 
 ```bash
-$ docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=size=100m,uid=1000 --name foo
+$ docker volume create --driver local --opt type=tmpfs --opt device=tmpfs --opt o=size=100m,uid=1000 foo
 ```
 
 Another example that uses `btrfs`:
 
 ```bash
-$ docker volume create --driver local --opt type=btrfs --opt device=/dev/sda2 --name foo
+$ docker volume create --driver local --opt type=btrfs --opt device=/dev/sda2 foo
 ```
 
 Another example that uses `nfs` to mount the `/path/to/dir` in `rw` mode from `192.168.1.1`:
 
 ```bash
-$ docker volume create --driver local --opt type=nfs --opt o=addr=192.168.1.1,rw --opt device=:/path/to/dir --name foo
+$ docker volume create --driver local --opt type=nfs --opt o=addr=192.168.1.1,rw --opt device=:/path/to/dir foo
 ```
 
 

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -34,9 +34,9 @@ Lists all the volumes Docker knows about. You can filter using the `-f` or `--fi
 Example output:
 
 ```bash
-$ docker volume create --name rosemary
+$ docker volume create rosemary
 rosemary
-$docker volume create --name tyler
+$docker volume create tyler
 tyler
 $ docker volume ls
 DRIVER              VOLUME NAME
@@ -91,9 +91,9 @@ a `label` and a value.
 First, let's create some volumes to illustrate this;
 
 ```bash
-$ docker volume create --name the-doctor --label is-timelord=yes
+$ docker volume create the-doctor --label is-timelord=yes
 the-doctor
-$ docker volume create --name daleks --label is-timelord=no
+$ docker volume create daleks --label is-timelord=no
 daleks
 ```
 

--- a/docs/tutorials/dockervolumes.md
+++ b/docs/tutorials/dockervolumes.md
@@ -203,7 +203,7 @@ The following example also creates the `my-named-volume` volume, this time
 using the `docker volume create` command.
 
 ```bash
-$ docker volume create -d flocker --name my-named-volume -o size=20GB
+$ docker volume create -d flocker my-named-volume -o size=20GB
 
 $ docker run -d -P \
   -v my-named-volume:/opt/webapp \

--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -196,7 +196,7 @@ func (s *DockerDaemonSuite) TestVolumePlugin(c *check.C) {
 		}
 	}()
 
-	out, err = s.d.Cmd("volume", "create", "-d", pluginName, "--name", volName)
+	out, err = s.d.Cmd("volume", "create", "-d", pluginName, volName)
 	if err != nil {
 		c.Fatalf("Could not create volume: %v %s", err, out)
 	}

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1827,7 +1827,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartRmVolumeInUse(c *check.C) {
 func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *check.C) {
 	c.Assert(s.d.Start(), check.IsNil)
 
-	_, err := s.d.Cmd("volume", "create", "--name", "test")
+	_, err := s.d.Cmd("volume", "create", "test")
 	c.Assert(err, check.IsNil)
 	c.Assert(s.d.Restart(), check.IsNil)
 

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -178,7 +178,7 @@ func (s *DockerSuite) TestVolumeEvents(c *check.C) {
 	since := daemonUnixTime(c)
 
 	// Observe create/mount volume actions
-	dockerCmd(c, "volume", "create", "--name", "test-event-volume-local")
+	dockerCmd(c, "volume", "create", "test-event-volume-local")
 	dockerCmd(c, "run", "--name", "test-volume-container", "--volume", "test-event-volume-local:/foo", "-d", "busybox", "true")
 	waitRun("test-volume-container")
 
@@ -355,7 +355,7 @@ func (s *DockerSuite) TestEventsFilterVolumeAndNetworkType(c *check.C) {
 	since := daemonUnixTime(c)
 
 	dockerCmd(c, "network", "create", "test-event-network-type")
-	dockerCmd(c, "volume", "create", "--name", "test-event-volume-type")
+	dockerCmd(c, "volume", "create", "test-event-volume-type")
 
 	out, _ := dockerCmd(c, "events", "--filter", "type=volume", "--filter", "type=network", "--since", since, "--until", daemonUnixTime(c))
 	events := strings.Split(strings.TrimSpace(out), "\n")
@@ -373,7 +373,7 @@ func (s *DockerSuite) TestEventsFilterVolumeID(c *check.C) {
 
 	since := daemonUnixTime(c)
 
-	dockerCmd(c, "volume", "create", "--name", "test-event-volume-id")
+	dockerCmd(c, "volume", "create", "test-event-volume-id")
 	out, _ := dockerCmd(c, "events", "--filter", "volume=test-event-volume-id", "--since", since, "--until", daemonUnixTime(c))
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(events, checker.HasLen, 1)

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -409,7 +409,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverRetryNotImmediatelyE
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c *check.C) {
-	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "--name", "foo")
+	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "foo")
 	dockerCmd(c, "run", "-d", "--name", "testing", "-v", "foo:/bar", "busybox", "top")
 
 	var mounts []struct {
@@ -424,7 +424,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverList(c *check.C) {
-	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "--name", "abc3")
+	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "abc3")
 	out, _ := dockerCmd(c, "volume", "ls")
 	ls := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(ls), check.Equals, 2, check.Commentf("\n%s", out))
@@ -443,7 +443,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *check.C) {
 	c.Assert(s.ec.gets, check.Equals, 1)
 	c.Assert(out, checker.Contains, "No such volume")
 
-	dockerCmd(c, "volume", "create", "--name", "test", "-d", "test-external-volume-driver")
+	dockerCmd(c, "volume", "create", "test", "-d", "test-external-volume-driver")
 	out, _ = dockerCmd(c, "volume", "inspect", "test")
 
 	type vol struct {
@@ -458,7 +458,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *check.C) {
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c *check.C) {
-	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "--name", "abc1")
+	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "abc1")
 	err := s.d.Restart()
 	c.Assert(err, checker.IsNil)
 
@@ -474,7 +474,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGetEmptyResponse(c *check.C) {
 	c.Assert(s.d.Start(), checker.IsNil)
 
-	out, err := s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "--name", "abc2", "--opt", "ninja=1")
+	out, err := s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "abc2", "--opt", "ninja=1")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	out, err = s.d.Cmd("volume", "inspect", "abc2")
@@ -487,7 +487,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverPathCalls(c *check.C
 	c.Assert(s.d.Start(), checker.IsNil)
 	c.Assert(s.ec.paths, checker.Equals, 0)
 
-	out, err := s.d.Cmd("volume", "create", "--name=test", "--driver=test-external-volume-driver")
+	out, err := s.d.Cmd("volume", "create", "test", "--driver=test-external-volume-driver")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	c.Assert(s.ec.paths, checker.Equals, 1)
 
@@ -516,7 +516,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverCapabilities(c *chec
 	c.Assert(s.ec.caps, checker.Equals, 0)
 
 	for i := 0; i < 3; i++ {
-		out, err := s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "--name", fmt.Sprintf("test%d", i))
+		out, err := s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", fmt.Sprintf("test%d", i))
 		c.Assert(err, checker.IsNil, check.Commentf(out))
 		c.Assert(s.ec.caps, checker.Equals, 1)
 		out, err = s.d.Cmd("volume", "inspect", "--format={{.Scope}}", fmt.Sprintf("test%d", i))

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -282,11 +282,12 @@ func testCommand(cmd string, newEnvs []string, scanForHome bool, home string) er
 
 	// These commands will never print a short-usage so don't test
 	noShortUsage := map[string]string{
-		"images":  "",
-		"login":   "",
-		"logout":  "",
-		"network": "",
-		"stats":   "",
+		"images":        "",
+		"login":         "",
+		"logout":        "",
+		"network":       "",
+		"stats":         "",
+		"volume create": "",
 	}
 
 	if _, ok := noShortUsage[cmd]; !ok {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -704,7 +704,7 @@ func (s *DockerSuite) TestPsShowMounts(c *check.C) {
 
 	mp := prefix + slash + "test"
 
-	dockerCmd(c, "volume", "create", "--name", "ps-volume-test")
+	dockerCmd(c, "volume", "create", "ps-volume-test")
 	// volume mount containers
 	runSleepingContainer(c, "--name=volume-test-1", "--volume", "ps-volume-test:"+mp)
 	c.Assert(waitRun("volume-test-1"), checker.IsNil)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4307,7 +4307,7 @@ func (s *DockerSuite) TestRunNamedVolumeCopyImageData(c *check.C) {
 func (s *DockerSuite) TestRunNamedVolumeNotRemoved(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
-	dockerCmd(c, "volume", "create", "--name", "test")
+	dockerCmd(c, "volume", "create", "test")
 
 	dockerCmd(c, "run", "--rm", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
 	dockerCmd(c, "volume", "inspect", "test")
@@ -4324,7 +4324,7 @@ func (s *DockerSuite) TestRunNamedVolumeNotRemoved(c *check.C) {
 func (s *DockerSuite) TestRunNamedVolumesFromNotRemoved(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 
-	dockerCmd(c, "volume", "create", "--name", "test")
+	dockerCmd(c, "volume", "create", "test")
 	dockerCmd(c, "run", "--name=parent", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
 	dockerCmd(c, "run", "--name=child", "--volumes-from=parent", "busybox", "true")
 
@@ -4381,7 +4381,7 @@ func (s *DockerSuite) TestRunVolumeCopyFlag(c *check.C) {
 	)
 	c.Assert(err, checker.IsNil)
 
-	dockerCmd(c, "volume", "create", "--name=test")
+	dockerCmd(c, "volume", "create", "test")
 
 	// test with the nocopy flag
 	out, _, err := dockerCmdWithError("run", "-v", "test:/foo:nocopy", "volumecopy")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Make the `--name` flag for `docker volume create` optional (the name can be specified as an argument, or still using the `--name` flag).
Fixes #23345.

**\- How I did it**
Changed `api/client/volume/create.go`:
- changed args of create command to `cli.RequiresMaxArgs(1)` instead of `cli.NoArgs`
- added checking first argument to function in create command

Changed `integration-cli/docker_cli_help_test.go`
- added `create volume` to `noShortUsage` (currently the test expects the command to either fail with no args or with one arg, but this command should work with zero or one args, but fail with more--it seemed odd to add a check to try with two args if it succeeded with zero and one args, but I have no problem doing that if preferred)

Updated documentation where I could find it to use the argument method and remove references to the `--name` flag.

**\- How to verify it**
Create a volume with and without an argument; create a volume using the `--name` flag (kept for backwards compatibility) or using the name as an argument.

**\- Description for the changelog**
Allow specifying name as argument for docker create volume

**\- A picture of a cute animal (not mandatory but encouraged)**
![capybara](https://www.chessington.com/images/uploads/attractions/940/capybara.jpg)
