### PR TITLE
Fixing file handle leak for "docker logs"

### DIFF
--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -77,6 +77,9 @@ func (l *JSONFileLogger) readLogs(logWatcher *logger.LogWatcher, config logger.R
 	}
 
 	if !config.Follow {
+		if err := latestFile.Close(); err != nil {
+			logrus.Errorf("Error closing file: %v", err)
+		}
 		return
 	}
 

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -87,6 +87,13 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 			if !ok {
 				logrus.Debug("logs: end stream")
 				logs.Close()
+				if cLog != container.LogDriver {
+					// Since the logger isn't cached in the container, which occurs if it is running, it
+					// must get explicitly closed here to avoid leaking it and any file handles it has.
+					if err := cLog.Close(); err != nil {
+						logrus.Errorf("Error closing logger: %v", err)
+					}
+				}
 				return nil
 			}
 			logLine := msg.Line


### PR DESCRIPTION
@jhowardmsft @jstarks @darrenstahlmsft 
If "docker logs" was used on an offline container, the logger is leaked, leaving it up to the finalizer to close the file handle, which could block removal of the container.  Further, the json file logger could leak an open handle if the logs are read without follow due to an early return without a close.  This change addresses both cases.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
