### PR TITLE
Use 'default.target' in systemd unit file example

### DIFF
--- a/docs/admin/host_integration.md
+++ b/docs/admin/host_integration.md
@@ -74,7 +74,7 @@ a new service that will be started after the docker daemon service has started.
     ExecStop=/usr/bin/docker stop -t 2 redis_server
 
     [Install]
-    WantedBy=local.target
+    WantedBy=default.target
 
 If you need to pass options to the redis container (such as `--env`),
 then you'll need to use `docker run` rather than `docker start`. This will


### PR DESCRIPTION
**\- What I did**
Changed systemd example in [_Automatically start containers_ part of the documentation](https://docs.docker.com/engine/admin/host_integration/) to use the `default.target` instead of `local.target`.

**\- Why I did it**
Previously, `local.target` was used which is not going to work out-of-the-box for lots of users (it hit me on a vanilla CentOS 7 machine).
The `default.target` is the [default unit systemd starts at bootup](https://www.freedesktop.org/software/systemd/man/systemd.special.html#Special%20System%20Units) and hence what most users would be expected to use.

**\- Description for the changelog**
Probably none.
