### PR TITLE
Expand instructions on using systemd to manage containers

### DIFF
--- a/docs/admin/host_integration.md
+++ b/docs/admin/host_integration.md
@@ -76,6 +76,10 @@ a new service that will be started after the docker daemon service has started.
     [Install]
     WantedBy=local.target
 
+If you intend to use this as a system service, put the above contents in a file
+in the `/etc/systemd/system` directory, e.g.
+`/etc/systemd/system/docker-redis_server.service`.
+
 If you need to pass options to the redis container (such as `--env`),
 then you'll need to use `docker run` rather than `docker start`. This will
 create a new container every time the service is started, which will be stopped
@@ -86,3 +90,12 @@ and removed when the service is stopped.
     ExecStart=/usr/bin/docker run --env foo=bar --name redis_server redis
     ExecStop=/usr/bin/docker stop -t 2 redis_server ; /usr/bin/docker rm -f redis_server
     ...
+
+To start using the service, reload systemd and start the service:
+
+    systemctl daemon-reload
+    systemctl start docker-redis_server.service
+
+To enable the service at system startup, execute:
+
+    systemctl enable docker-redis_server.service


### PR DESCRIPTION
**\- What I did**
I expanded [instructions on using systemd to manage containers](https://docs.docker.com/engine/admin/host_integration/#systemd).

**\- Why I did it**
The expanded instructions will help administrators less familiar with systemd to set it up with Docker more easily. Since systemd has become a default choice for almost all major Linux distributions, the expanded instructions will help a broad audience.

**\- Description for the changelog**
Probably none.
