### PR TITLE
Load environment files to systemd service and utilize DOCKER_OPTS for backward compatibility while upgrading docker on long lived systems

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -9,7 +9,9 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+EnvironmentFile=-/etc/default/docker
+EnvironmentFile=-/etc/sysconfig/docker
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS $other_args
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/contrib/init/sysvinit-debian/docker.default
+++ b/contrib/init/sysvinit-debian/docker.default
@@ -1,7 +1,10 @@
 # Docker Upstart and SysVinit configuration file
 
 #
-# THIS FILE DOES NOT APPLY TO SYSTEMD
+# THIS FILE SHOULDN'T BE USED ON SYSTEMD CONTROLLED OPERATING SYSTEMS
+#
+#   Systemd has become the default init system for multiple systems.
+#   For ex.: RHEL >= 7.x, Ubuntu >= 15.04, Debian >= 8
 #
 #   Please see the documentation for "systemd drop-ins":
 #   https://docs.docker.com/engine/articles/systemd/


### PR DESCRIPTION
**\- What I did**

I have added optional reading of Debian and RHEL system default configuration files. I did that to ensure backward compatibility while upgrading Docker/OSs.

**\- How I did it**

I have added `EnvironmentFile` for `/etc/default/docker` and `/etc/sysconfig/docker` files. I've also utilized `$DOCKER_OPTS` and `$other_args` variables in docker daemon command. In this way those opts will be read on systems that are long lived (especially production docker hosts).

**\- How to verify it**

The changes refer to configuration files, so I think only VM test can verify this.

**\- Description for the changelog**
- Load environment files to systemd service and utilize DOCKER_OPTS

**\- A picture of a cute animal (not mandatory but encouraged)**

![Cute whale](http://data.whicdn.com/images/112100631/large.jpg)

Signed-off-by: Suszyński Krzysztof krzysztof.suszynski@coi.gov.pl
