### PR TITLE
Removing some url links that can be resolved using src markdown links

### DIFF
--- a/docs/admin/formatting.md
+++ b/docs/admin/formatting.md
@@ -15,13 +15,13 @@ Docker uses [Go templates](https://golang.org/pkg/text/template/) to allow users
 of certain commands and log drivers. Each command a driver provides a detailed
 list of elements they support in their templates:
 
-- [Docker Images formatting](https://docs.docker.com/engine/reference/commandline/images/#formatting)
-- [Docker Inspect formatting](https://docs.docker.com/engine/reference/commandline/inspect/#examples)
-- [Docker Log Tag formatting](https://docs.docker.com/engine/admin/logging/log_tags/)
-- [Docker Network Inspect formatting](https://docs.docker.com/engine/reference/commandline/network_inspect/)
-- [Docker PS formatting](https://docs.docker.com/engine/reference/commandline/ps/#formatting)
-- [Docker Volume Inspect formatting](https://docs.docker.com/engine/reference/commandline/volume_inspect/)
-- [Docker Version formatting](https://docs.docker.com/engine/reference/commandline/version/#examples)
+- [Docker Images formatting](../reference/commandline/images.md#formatting)
+- [Docker Inspect formatting](../reference/commandline/inspect.md#examples)
+- [Docker Log Tag formatting](logging/log_tags.md)
+- [Docker Network Inspect formatting](../reference/commandline/network_inspect.md)
+- [Docker PS formatting](../reference/commandline/ps.md#formatting)
+- [Docker Volume Inspect formatting](../reference/commandline/volume_inspect.md)
+- [Docker Version formatting](../reference/commandline/version.md#examples)
 
 ## Template functions
 

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -51,7 +51,7 @@ respectively.
 
 ## Default user authorization mechanism
 
-If TLS is enabled in the [Docker daemon](https://docs.docker.com/engine/security/https/), the default user authorization flow extracts the user details from the certificate subject name.
+If TLS is enabled in the [Docker daemon](../security/https.md), the default user authorization flow extracts the user details from the certificate subject name.
 That is, the `User` field is set to the client certificate subject common name, and the `AuthenticationMethod` field is set to `TLS`.
 
 ## Basic architecture

--- a/docs/userguide/intro.md
+++ b/docs/userguide/intro.md
@@ -74,7 +74,7 @@ Docker Hub is the central hub for Docker. It hosts public Docker images
 and provides services to help you build and manage your Docker
 environment. To learn more:
 
-Go to [Using Docker Hub](https://docs.docker.com/docker-hub).
+Go to [Using Docker Hub](https://docs.docker.com/docker-hub/).
 
 ### Docker Machine
 
@@ -108,7 +108,7 @@ Go to [Docker Swarm user guide](https://docs.docker.com/swarm/).
 * [Docker Hub](https://hub.docker.com)
 * [Docker blog](https://blog.docker.com/)
 * [Docker documentation](https://docs.docker.com/)
-* [Docker Getting Started Guide](https://docs.docker.com/mac/started/)
+* [Docker Getting Started Guide](../getstarted/index.md)
 * [Docker code on GitHub](https://github.com/docker/docker)
 * [Docker mailing
   list](https://groups.google.com/forum/#!forum/docker-user)


### PR DESCRIPTION
one link (mac/starting/) was moved, and the others are working links that should really be source.md links to enable more detailed validation.
