### PR TITLE
#23837 Added long flag to docker ps for checking latest n containers

### DIFF
--- a/api/client/container/ps.go
+++ b/api/client/container/ps.go
@@ -55,7 +55,7 @@ func NewPsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	flags.BoolVarP(&opts.all, "all", "a", false, "Show all containers (default shows just running)")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Don't truncate output")
 	flags.BoolVarP(&opts.nLatest, "latest", "l", false, "Show the latest created container (includes all states)")
-	flags.IntVarP(&opts.last, "", "n", -1, "Show n last created containers (includes all states)")
+	flags.IntVarP(&opts.last, "last", "n", -1, "Show n last created containers (includes all states)")
 	flags.StringVarP(&opts.format, "format", "", "", "Pretty-print containers using a Go template")
 	flags.StringSliceVarP(&opts.filter, "filter", "f", []string{}, "Filter output based on conditions provided")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
--> 

**\- What I did**
Add a long flag to the existing short flag named **--latest-n** in _docker ps --help_ associated with listing latest n containers.
**\- How I did it**
updated api/client/container/ps.go

**\- How to verify it**
Run _docker -ps --help_ and verify the line containing _Show n last created containers (includes all states)_

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixes  #23837 : Added long flag for CLI help option for listing latest n containers.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Shoubhik Bose sbose78@gmail.com
