### PR TITLE
correct output description - only one task is running on manager

### DIFF
--- a/docs/swarm/swarm-tutorial/scale-service.md
+++ b/docs/swarm/swarm-tutorial/scale-service.md
@@ -51,7 +51,7 @@ service running in the swarm:
 
     You can see that swarm has created 4 new tasks to scale to a total of 5
     running instances of Alpine Linux. The tasks are distributed between the
-    three nodes of the swarm. Two are running on `manager1`.
+    three nodes of the swarm. One is running on `manager1`.
 
 4. Run `docker ps` to see the containers running on the node where you're
 connected. The following example shows the tasks running on `manager1`:


### PR DESCRIPTION
Change description of output to clarify that there's only one task on manager node.

Signed-off-by: Charles Smith charles.smith@docker.com
