### PR TITLE
Added keyserver-options http-proxy to apt-key command in the install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -109,7 +109,7 @@ rpm_import_repository_key() {
 	local tmpdir=$(mktemp -d)
 	chmod 600 "$tmpdir"
 	for key_server in $key_servers ; do
-		gpg --homedir "$tmpdir" --keyserver "$key_server" --recv-keys "$key" && break
+		gpg --homedir "$tmpdir" --keyserver-options http-proxy=$http_proxy --keyserver "$key_server" --recv-keys "$key" && break
 	done
 	gpg --homedir "$tmpdir" -k "$key" >/dev/null
 	gpg --homedir "$tmpdir" --export --armor "$key" > "$tmpdir"/repo.key

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -109,7 +109,7 @@ rpm_import_repository_key() {
 	local tmpdir=$(mktemp -d)
 	chmod 600 "$tmpdir"
 	for key_server in $key_servers ; do
-		gpg --homedir "$tmpdir" --keyserver-options http-proxy=$http_proxy --keyserver "$key_server" --recv-keys "$key" && break
+		gpg --homedir "$tmpdir" --keyserver "$key_server" --recv-keys "$key" && break
 	done
 	gpg --homedir "$tmpdir" -k "$key" >/dev/null
 	gpg --homedir "$tmpdir" --export --armor "$key" > "$tmpdir"/repo.key
@@ -425,7 +425,7 @@ do_install() {
 			(
 			set -x
 			for key_server in $key_servers ; do
-				$sh_c "apt-key adv --keyserver hkp://${key_server}:80 --recv-keys ${gpg_fingerprint}" && break
+				$sh_c "apt-key adv --keyserver hkp://${key_server}:80 --keyserver-options http-proxy=$http_proxy --recv-keys ${gpg_fingerprint}" && break
 			done
 			$sh_c "apt-key adv -k ${gpg_fingerprint} >/dev/null"
 			$sh_c "mkdir -p /etc/apt/sources.list.d"


### PR DESCRIPTION
**\- What I did, how I did it & description for the changelog**
I added the usage of `$http_proxy` to the install script as mentioned in #20022.

**-How to verify it**
Occasionally seems to be an issue for some users that want to install Docker with the install script behind a proxy. Tested it on Ubuntu 14.04.4 with and without `$http_proxy` set, and seems to work fine for me so far. Good thing is that if the proxy is not set, apt-key just ignores the option. This means that no manual check in the script is required.

Signed-off-by: Helge Bruegner helge@bruegner.de
