### PR TITLE
update go-md2man to v1.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone --depth 1 -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone --depth 1 -b v1.0.5 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone --depth 1 -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -164,7 +164,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone --depth 1 -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone --depth 1 -b v1.0.5 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone --depth 1 -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -173,7 +173,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone --depth 1 -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone --depth 1 -b v1.0.5 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone --depth 1 -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -188,7 +188,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone --depth 1 -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone --depth 1 -b v1.0.5 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone --depth 1 -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -181,7 +181,7 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone --depth 1 -b v1.0.4 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone --depth 1 -b v1.0.5 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone --depth 1 -b v1.4 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \

--- a/man/Dockerfile
+++ b/man/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.4
+FROM golang:1.6.2
 RUN mkdir -p /go/src/github.com/cpuguy83
 RUN mkdir -p /go/src/github.com/cpuguy83 \
-    && git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
+    && git clone -b v1.0.5 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
     && cd /go/src/github.com/cpuguy83/go-md2man \
     && go get -v ./...
 CMD ["/go/bin/go-md2man", "--help"]


### PR DESCRIPTION
**\- What I did**
Fix the rendering for `man docker login`.

before:

```
       docker login requires user to use sudo or be root, except when:

       ·

         item connecting to  a remote daemon, such as a docker-machine provisioned docker engine.  item user is added to the docker group.  This will impact the security
         of your system; the docker group is root equivalent.  See ⟨https://docs.docker.com/articles/security/#docker-daemon-attack-surface⟩ for details.
```

after:

```
       docker login requires user to use sudo or be root, except when:

         1. connecting to  a remote daemon, such as a docker-machine provisioned docker engine.

         2. user is added to the docker group.  This will impact the security of your system; the docker group is root equivalent.  See
            ⟨https://docs.docker.com/articles/security/#docker-daemon-attack-surface⟩ for details.
```

**\- How I did it**
There was an issue in go-md2man and it was fixed in v1.0.5.
So I updated go-md2man to v1.0.5.
https://github.com/cpuguy83/go-md2man/commit/a8f937e11314ca0b085aa7a7a5526695e3ca5b49

**\- How to verify it**
`man docker login`

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
