### PR TITLE
seccomp: block IPT_SO_SET_REPLACE for setsockopt

### DIFF
--- a/contrib/syscall-test/Dockerfile
+++ b/contrib/syscall-test/Dockerfile
@@ -6,4 +6,5 @@ WORKDIR /usr/src/
 
 RUN gcc -g -Wall -static userns.c -o /usr/bin/userns-test \
 	&& gcc -g -Wall -static ns.c -o /usr/bin/ns-test \
-	&& gcc -g -Wall -static acct.c -o /usr/bin/acct-test
+	&& gcc -g -Wall -static acct.c -o /usr/bin/acct-test \
+	&& gcc -g -Wall -static setsockopt.c -o /usr/bin/setsockopt-test

--- a/contrib/syscall-test/setsockopt.c
+++ b/contrib/syscall-test/setsockopt.c
@@ -1,0 +1,126 @@
+/*
+ * THis is a slightly modified version of the code described in
+ * https://bugs.chromium.org/p/project-zero/issues/detail?id=758&redir=1
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sched.h>
+#include <linux/sched.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <unistd.h>
+#include <sys/ptrace.h>
+#include <netinet/in.h>
+#include <net/if.h>
+#include <linux/netfilter_ipv4/ip_tables.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+
+int netfilter_setsockopt(void *p)
+{
+	int sock;
+	int ret;
+	void *data;
+	size_t size;
+	struct ipt_replace *repl;
+	struct ipt_entry *entry;
+	struct xt_standard_target *target;
+	int x;
+
+	for (x = 0; x < 65536; x++) {
+
+		sock = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
+
+		if (sock == -1) {
+			perror("socket");
+			return -1;
+		}
+
+		size =
+		    sizeof(struct ipt_replace) + sizeof(struct ipt_entry) +
+		    sizeof(struct xt_standard_target) + 4;
+
+		data = malloc(size);
+
+		if (data == NULL) {
+			perror("malloc");
+			return -1;
+		}
+
+		memset(data, 0, size);
+
+		repl = (struct ipt_replace *)data;
+		entry = (struct ipt_entry *)(data + sizeof(struct ipt_replace));
+		target =
+		    (struct xt_standard_target *)(data +
+						  sizeof(struct ipt_replace) +
+						  sizeof(struct ipt_entry) + 4);
+
+		repl->num_counters = 0x1;
+		repl->size =
+		    sizeof(struct ipt_entry) +
+		    sizeof(struct xt_standard_target);
+		repl->valid_hooks = 0x1;
+		repl->num_entries = 0x1;
+
+		memset(&repl->underflow, 1, sizeof(repl->underflow));
+		repl->underflow[0] = 0;
+
+		entry->next_offset = x;
+		entry->target_offset = sizeof(struct ipt_entry) + 4;
+
+		target->verdict = -(NF_ACCEPT + 1);
+
+		ret =
+		    setsockopt(sock, SOL_IP, IPT_SO_SET_REPLACE, (void *)data,
+			       size);
+
+		close(sock);
+		free(data);
+
+		if (ret != -1) {
+			printf("repl %p (%lx) entry %p (%lx) target %p\n", repl,
+			       sizeof(struct ipt_replace), entry,
+			       sizeof(struct ipt_entry), target);
+
+			printf("done %d => %d\n", x, ret);
+		}
+	}
+
+	return ret;
+}
+
+int main(void)
+{
+	void *stack;
+	int ret;
+
+	ret = unshare(CLONE_NEWUSER);
+	if (ret == -1) {
+		fprintf(stderr, "unshare failed: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	stack = (void *)malloc(65536);
+	if (stack == NULL) {
+		fprintf(stderr, "malloc failed: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	pid_t pid =
+	    clone(netfilter_setsockopt, stack + 65536, CLONE_NEWNET, NULL);
+	if (pid < 0) {
+		fprintf(stderr, "clone failed: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+	// lets wait on our child process here before we, the parent, exits
+	if (waitpid(pid, NULL, 0) == -1) {
+		fprintf(stderr, "failed to wait pid %d\n", pid);
+		exit(EXIT_FAILURE);
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/docs/security/non-events.md
+++ b/docs/security/non-events.md
@@ -73,6 +73,14 @@ seccomp profile.
 A bug in eBPF -- the special in-kernel DSL used to express things like seccomp
 filters -- allowed arbitrary reads of kernel memory. The `bpf()` system call
 is blocked inside Docker containers using (ironically) seccomp.
+* [CVE-2016-3134](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3134),
+[4997](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4997),
+[4998](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4998):
+A bugs in setsockopt with `IPT_SO_SET_REPLACE`, `ARPT_SO_SET_REPLACE`,  and
+`ARPT_SO_SET_REPLACE` causing memory corruption / local privilege escalation.
+These arguments are blocked when passed to `setsockopt`. We do not allow the
+`compat_setsockopt()` syscall at all.
+
 
 Bugs *not* mitigated:
 

--- a/hack/make/.ensure-syscall-test
+++ b/hack/make/.ensure-syscall-test
@@ -9,6 +9,7 @@ if [ "$DOCKER_ENGINE_GOOS" = "linux" ]; then
 		gcc -g -Wall -static contrib/syscall-test/userns.c -o "${tmpdir}/userns-test"
 		gcc -g -Wall -static contrib/syscall-test/ns.c -o "${tmpdir}/ns-test"
 		gcc -g -Wall -static contrib/syscall-test/acct.c -o "${tmpdir}/acct-test"
+		gcc -g -Wall -static contrib/syscall-test/setsockopt.c -o "${tmpdir}/setsockopt-test"
 
 		dockerfile="${tmpdir}/Dockerfile"
 		cat <<-EOF > "$dockerfile"

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1064,6 +1064,20 @@ func (s *DockerSuite) TestRunSeccompAllowSetrlimit(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunSeccompDefaultProfileSetsockopt(c *check.C) {
+	testRequires(c, SameHostDaemon, seccompEnabled, NotUserNamespace)
+
+	out, _, err := dockerCmdWithError("run", "syscall-test", "setsockopt-test")
+	if err == nil || !strings.Contains(out, "Operation not permitted") {
+		c.Fatalf("expected Operation not permitted, got: %s", out)
+	}
+
+	out, _, err = dockerCmdWithError("run", "--cap-add", "ALL", "syscall-test", "setsockopt-test")
+	if err == nil {
+		c.Fatalf("expected Operation not permitted, got: %s", out)
+	}
+}
+
 func (s *DockerSuite) TestRunSeccompDefaultProfileAcct(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled, NotUserNamespace)
 

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -1265,7 +1265,20 @@
 		{
 			"name": "setsockopt",
 			"action": "SCMP_ACT_ALLOW",
-			"args": []
+			"args": [
+				{
+					"index": 1,
+					"value": 41,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				},
+				{
+					"index": 2,
+					"value": 96,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			]
 		},
 		{
 			"name": "set_thread_area",

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -1297,7 +1297,22 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 		{
 			Name:   "setsockopt",
 			Action: types.ActAllow,
-			Args:   []*types.Arg{},
+			Args: []*types.Arg{
+				{
+					// disallow IPT_SO_SET_REPLACE, ARPT_SO_SET_REPLACE when SOL_IP,
+					// and IP6T_SO_SET_REPLACE when SOL_IPV6
+					Index:    1,
+					Value:    0x0 | 0x29,
+					ValueTwo: 0,
+					Op:       types.OpMaskedEqual,
+				},
+				{
+					Index:    2,
+					Value:    0x40 | 0x60,
+					ValueTwo: 0,
+					Op:       types.OpMaskedEqual,
+				},
+			},
 		},
 		{
 			Name:   "set_thread_area",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Blocked `IPT_SO_SET_REPLACE` for `setsockopt`

**\- How I did it**

Added it to seccomp profile.

**\- How to verify it**

Added a test.

**\- Description for the changelog**

Made world better place

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Prevents https://bugs.chromium.org/p/project-zero/issues/detail?id=758&redir=1

Signed-off-by: Jess Frazelle jessfraz@google.com
