### PR TITLE
Fix high cpu usage caused by docker stats.

### DIFF
--- a/api/client/container/stats.go
+++ b/api/client/container/stats.go
@@ -192,13 +192,23 @@ func runStats(dockerCli *client.DockerCli, opts *statsOptions) error {
 
 	for range time.Tick(500 * time.Millisecond) {
 		printHeader()
+		toRemove := []string{}
 		cStats.mu.Lock()
 		for _, s := range cStats.cs {
 			if err := s.Display(w); err != nil && !opts.noStream {
 				logrus.Debugf("stats: got error for %s: %v", s.Name, err)
+				if err == io.EOF {
+					toRemove = append(toRemove, s.Name)
+				}
 			}
 		}
 		cStats.mu.Unlock()
+		for _, name := range toRemove {
+			cStats.remove(name)
+		}
+		if len(cStats.cs) == 0 && !showAll {
+			return nil
+		}
 		w.Flush()
 		if opts.noStream {
 			break

--- a/api/client/container/stats_helpers.go
+++ b/api/client/container/stats_helpers.go
@@ -97,6 +97,10 @@ func (s *containerStats) Collect(ctx context.Context, cli client.APIClient, stre
 			if err := dec.Decode(&v); err != nil {
 				dec = json.NewDecoder(io.MultiReader(dec.Buffered(), responseBody))
 				u <- err
+				if err == io.EOF {
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
 				continue
 			}
 


### PR DESCRIPTION
**\- How to reproduce the problem**

```
$ docker stats
# in a other terminal
$ docker run --rm alpine ping localhost
# kill it by ctrl-c
# CPU will go very high 
```

**\- What I did**
1. Close event stream when receives a `EOF` sent by server
2. Put the gorutine to sleep for 200 millisecond when the `err` is not `EOF` 
3. Terminate the command when no container is alive  

**\- How to verify it**

```
$ docker stats
# in a other terminal
$ docker run --rm alpine ping localhost
# kill it by ctrl-c
# everything is fine
```

Signed-off-by: Tianyi Wang capkurmagati@gmail.com

Fixes #24999
