### PR TITLE
Decouple the api/server/router packages from the daemon/cluster and libnetwork

### DIFF
--- a/api/server/backend/backend.go
+++ b/api/server/backend/backend.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/daemon/cluster"
+)
+
+// Backend is a facade for daemon.Daemon and cluster.Cluster.
+type Backend struct {
+	*daemon.Daemon
+	clusterProvider *cluster.Cluster
+}
+
+// New creates a new Backend instance.
+func New(d *daemon.Daemon, c *cluster.Cluster) *Backend {
+	return &Backend{
+		Daemon:          d,
+		clusterProvider: c,
+	}
+}

--- a/api/server/backend/network.go
+++ b/api/server/backend/network.go
@@ -1,0 +1,224 @@
+package backend
+
+import (
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/network"
+	"github.com/docker/libnetwork"
+)
+
+// GetNetworks returns a list of all networks.
+func (b *Backend) GetNetworks() ([]types.NetworkResource, error) {
+	list := []types.NetworkResource{}
+
+	if b.clusterProvider != nil {
+		if nr, err := b.clusterProvider.GetNetworks(); err == nil {
+			for _, nw := range nr {
+				list = append(list, nw)
+			}
+		}
+	}
+
+	// Combine the network list returned by Docker daemon if it is not already
+	// returned by the cluster manager
+SKIP:
+	for _, nw := range b.Daemon.GetNetworks() {
+		for _, nl := range list {
+			if nl.ID == nw.ID() {
+				continue SKIP
+			}
+		}
+		list = append(list, *b.buildNetworkResource(nw))
+	}
+
+	return list, nil
+}
+
+// FindNetwork function finds a network for a given string that can represent a network name or id.
+func (b *Backend) FindNetwork(idName string) (*types.NetworkResource, error) {
+	var err error
+	if nw, err := b.Daemon.FindNetwork(idName); err == nil {
+		return b.buildNetworkResource(nw), nil
+	}
+	if nr, err := b.clusterProvider.GetNetwork(idName); err == nil {
+		return &nr, nil
+	}
+	return nil, err
+}
+
+// CreateNetwork creates a network with the given name, driver and other optional parameters.
+func (b *Backend) CreateNetwork(create types.NetworkCreateRequest) (*types.NetworkCreateResponse, error) {
+	nw, err := b.Daemon.CreateNetwork(create)
+	if err == nil {
+		return nw, nil
+	}
+
+	// Ignore errors of type libnetwork.ManagerRedirectError
+	if _, ok := err.(libnetwork.ManagerRedirectError); !ok {
+		return nil, err
+	}
+
+	id, err := b.clusterProvider.CreateNetwork(create)
+	if err == nil {
+		return &types.NetworkCreateResponse{ID: id}, nil
+	}
+
+	return nil, err
+}
+
+// ConnectContainerToNetwork connects the given container to the
+// given network. If either cannot be found, an err is returned.
+// If the network cannot be set up, an err is returned.
+func (b *Backend) ConnectContainerToNetwork(containerID string, networkID string, endpointConfig *network.EndpointSettings) error {
+	nw, err := b.Daemon.FindNetwork(networkID)
+	if err != nil {
+		return err
+	}
+	return b.Daemon.ConnectContainerToNetwork(containerID, nw.Name(), endpointConfig)
+}
+
+// DisconnectContainerFromNetwork disconnects the given container from
+// the given network. If either cannot be found, an err is returned.
+func (b *Backend) DisconnectContainerFromNetwork(containerID string, networkID string, force bool) error {
+	nw, err := b.Daemon.FindNetwork(networkID)
+	if err != nil {
+		return err
+	}
+	return b.Daemon.DisconnectContainerFromNetwork(containerID, nw, force)
+}
+
+// DeleteNetwork destroys a network unless it's one of docker's predefined networks.
+func (b *Backend) DeleteNetwork(networkID string) error {
+	if _, err := b.clusterProvider.GetNetwork(networkID); err == nil {
+		return b.clusterProvider.RemoveNetwork(networkID)
+	}
+	if err := b.Daemon.DeleteNetwork(networkID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *Backend) buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {
+	r := &types.NetworkResource{}
+	if nw == nil {
+		return r
+	}
+
+	info := nw.Info()
+	r.Name = nw.Name()
+	r.ID = nw.ID()
+	r.Scope = info.Scope()
+	if b.clusterProvider.IsManager() {
+		if _, err := b.clusterProvider.GetNetwork(nw.Name()); err == nil {
+			r.Scope = "swarm"
+		}
+	} else if info.Dynamic() {
+		r.Scope = "swarm"
+	}
+	r.Driver = nw.Type()
+	r.EnableIPv6 = info.IPv6Enabled()
+	r.Internal = info.Internal()
+	r.Options = info.DriverOptions()
+	r.Containers = make(map[string]types.EndpointResource)
+	buildIpamResources(r, info)
+	r.Internal = info.Internal()
+	r.Labels = info.Labels()
+
+	epl := nw.Endpoints()
+	for _, e := range epl {
+		ei := e.Info()
+		if ei == nil {
+			continue
+		}
+		sb := ei.Sandbox()
+		key := "ep-" + e.ID()
+		if sb != nil {
+			key = sb.ContainerID()
+		}
+
+		r.Containers[key] = buildEndpointResource(e)
+	}
+	return r
+}
+
+func buildIpamResources(r *types.NetworkResource, nwInfo libnetwork.NetworkInfo) {
+	id, opts, ipv4conf, ipv6conf := nwInfo.IpamConfig()
+
+	ipv4Info, ipv6Info := nwInfo.IpamInfo()
+
+	r.IPAM.Driver = id
+
+	r.IPAM.Options = opts
+
+	r.IPAM.Config = []network.IPAMConfig{}
+	for _, ip4 := range ipv4conf {
+		if ip4.PreferredPool == "" {
+			continue
+		}
+		iData := network.IPAMConfig{}
+		iData.Subnet = ip4.PreferredPool
+		iData.IPRange = ip4.SubPool
+		iData.Gateway = ip4.Gateway
+		iData.AuxAddress = ip4.AuxAddresses
+		r.IPAM.Config = append(r.IPAM.Config, iData)
+	}
+
+	if len(r.IPAM.Config) == 0 {
+		for _, ip4Info := range ipv4Info {
+			iData := network.IPAMConfig{}
+			iData.Subnet = ip4Info.IPAMData.Pool.String()
+			iData.Gateway = ip4Info.IPAMData.Gateway.String()
+			r.IPAM.Config = append(r.IPAM.Config, iData)
+		}
+	}
+
+	hasIpv6Conf := false
+	for _, ip6 := range ipv6conf {
+		if ip6.PreferredPool == "" {
+			continue
+		}
+		hasIpv6Conf = true
+		iData := network.IPAMConfig{}
+		iData.Subnet = ip6.PreferredPool
+		iData.IPRange = ip6.SubPool
+		iData.Gateway = ip6.Gateway
+		iData.AuxAddress = ip6.AuxAddresses
+		r.IPAM.Config = append(r.IPAM.Config, iData)
+	}
+
+	if !hasIpv6Conf {
+		for _, ip6Info := range ipv6Info {
+			iData := network.IPAMConfig{}
+			iData.Subnet = ip6Info.IPAMData.Pool.String()
+			iData.Gateway = ip6Info.IPAMData.Gateway.String()
+			r.IPAM.Config = append(r.IPAM.Config, iData)
+		}
+	}
+}
+
+func buildEndpointResource(e libnetwork.Endpoint) types.EndpointResource {
+	er := types.EndpointResource{}
+	if e == nil {
+		return er
+	}
+
+	er.EndpointID = e.ID()
+	er.Name = e.Name()
+	ei := e.Info()
+	if ei == nil {
+		return er
+	}
+
+	if iface := ei.Iface(); iface != nil {
+		if mac := iface.MacAddress(); mac != nil {
+			er.MacAddress = mac.String()
+		}
+		if ip := iface.Address(); ip != nil && len(ip.IP) > 0 {
+			er.IPv4Address = ip.String()
+		}
+
+		if ipv6 := iface.AddressIPv6(); ipv6 != nil && len(ipv6.IP) > 0 {
+			er.IPv6Address = ipv6.String()
+		}
+	}
+	return er
+}

--- a/api/server/backend/system.go
+++ b/api/server/backend/system.go
@@ -1,0 +1,16 @@
+package backend
+
+import "github.com/docker/engine-api/types"
+
+// SystemInfo returns information about the host server the daemon
+// is running on, as well as the current cluster state.
+func (b *Backend) SystemInfo() (*types.Info, error) {
+	info, err := b.Daemon.SystemInfo()
+	if err != nil {
+		return nil, err
+	}
+	if b.clusterProvider != nil {
+		info.Swarm = b.clusterProvider.Info()
+	}
+	return info, nil
+}

--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -3,18 +3,15 @@ package network
 import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/network"
-	"github.com/docker/libnetwork"
 )
 
 // Backend is all the methods that need to be implemented
 // to provide network specific functionality.
 type Backend interface {
-	FindNetwork(idName string) (libnetwork.Network, error)
-	GetNetworkByName(idName string) (libnetwork.Network, error)
-	GetNetworksByID(partialID string) []libnetwork.Network
-	GetNetworks() []libnetwork.Network
+	FindNetwork(idName string) (*types.NetworkResource, error)
+	GetNetworks() ([]types.NetworkResource, error)
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
-	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
-	DisconnectContainerFromNetwork(containerName string, network libnetwork.Network, force bool) error
+	ConnectContainerToNetwork(containerID, networkID string, endpointConfig *network.EndpointSettings) error
+	DisconnectContainerFromNetwork(containerID string, networkID string, force bool) error
 	DeleteNetwork(name string) error
 }

--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -1,22 +1,17 @@
 package network
 
-import (
-	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/daemon/cluster"
-)
+import "github.com/docker/docker/api/server/router"
 
 // networkRouter is a router to talk with the network controller
 type networkRouter struct {
-	backend         Backend
-	clusterProvider *cluster.Cluster
-	routes          []router.Route
+	backend Backend
+	routes  []router.Route
 }
 
 // NewRouter initializes a new network router
-func NewRouter(b Backend, c *cluster.Cluster) router.Router {
+func NewRouter(b Backend) router.Router {
 	r := &networkRouter{
-		backend:         b,
-		clusterProvider: c,
+		backend: b,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -9,8 +9,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
-	"github.com/docker/engine-api/types/network"
-	"github.com/docker/libnetwork"
 )
 
 func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -24,24 +22,9 @@ func (n *networkRouter) getNetworksList(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
-	list := []types.NetworkResource{}
-
-	if nr, err := n.clusterProvider.GetNetworks(); err == nil {
-		for _, nw := range nr {
-			list = append(list, nw)
-		}
-	}
-
-	// Combine the network list returned by Docker daemon if it is not already
-	// returned by the cluster manager
-SKIP:
-	for _, nw := range n.backend.GetNetworks() {
-		for _, nl := range list {
-			if nl.ID == nw.ID() {
-				continue SKIP
-			}
-		}
-		list = append(list, *n.buildNetworkResource(nw))
+	list, err := n.backend.GetNetworks()
+	if err != nil {
+		return err
 	}
 
 	list, err = filterNetworks(list, netFilters)
@@ -55,42 +38,22 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-
-	nw, err := n.backend.FindNetwork(vars["id"])
+	nr, err := n.backend.FindNetwork(vars["id"])
 	if err != nil {
-		if nr, err := n.clusterProvider.GetNetwork(vars["id"]); err == nil {
-			return httputils.WriteJSON(w, http.StatusOK, nr)
-		}
 		return err
 	}
-	return httputils.WriteJSON(w, http.StatusOK, n.buildNetworkResource(nw))
+	return httputils.WriteJSON(w, http.StatusOK, nr)
 }
 
 func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var create types.NetworkCreateRequest
-
-	if err := httputils.ParseForm(r); err != nil {
-		return err
-	}
-
-	if err := httputils.CheckForJSON(r); err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&create); err != nil {
+	if err := decodeJSONRequest(r, &create); err != nil {
 		return err
 	}
 
 	nw, err := n.backend.CreateNetwork(create)
 	if err != nil {
-		if _, ok := err.(libnetwork.ManagerRedirectError); !ok {
-			return err
-		}
-		id, err := n.clusterProvider.CreateNetwork(create)
-		if err != nil {
-			return err
-		}
-		nw = &types.NetworkCreateResponse{ID: id}
+		return err
 	}
 
 	return httputils.WriteJSON(w, http.StatusCreated, nw)
@@ -98,54 +61,23 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 
 func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var connect types.NetworkConnect
-	if err := httputils.ParseForm(r); err != nil {
+	if err := decodeJSONRequest(r, &connect); err != nil {
 		return err
 	}
-
-	if err := httputils.CheckForJSON(r); err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&connect); err != nil {
-		return err
-	}
-
-	nw, err := n.backend.FindNetwork(vars["id"])
-	if err != nil {
-		return err
-	}
-
-	return n.backend.ConnectContainerToNetwork(connect.Container, nw.Name(), connect.EndpointConfig)
+	return n.backend.ConnectContainerToNetwork(connect.Container, vars["id"], connect.EndpointConfig)
 }
 
 func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var disconnect types.NetworkDisconnect
-	if err := httputils.ParseForm(r); err != nil {
+	if err := decodeJSONRequest(r, &disconnect); err != nil {
 		return err
 	}
-
-	if err := httputils.CheckForJSON(r); err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&disconnect); err != nil {
-		return err
-	}
-
-	nw, err := n.backend.FindNetwork(vars["id"])
-	if err != nil {
-		return err
-	}
-
-	return n.backend.DisconnectContainerFromNetwork(disconnect.Container, nw, disconnect.Force)
+	return n.backend.DisconnectContainerFromNetwork(disconnect.Container, vars["id"], disconnect.Force)
 }
 
 func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
-	}
-	if _, err := n.clusterProvider.GetNetwork(vars["id"]); err == nil {
-		return n.clusterProvider.RemoveNetwork(vars["id"])
 	}
 	if err := n.backend.DeleteNetwork(vars["id"]); err != nil {
 		return err
@@ -154,128 +86,15 @@ func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter
 	return nil
 }
 
-func (n *networkRouter) buildNetworkResource(nw libnetwork.Network) *types.NetworkResource {
-	r := &types.NetworkResource{}
-	if nw == nil {
-		return r
+func decodeJSONRequest(r *http.Request, v interface{}) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
 	}
-
-	info := nw.Info()
-	r.Name = nw.Name()
-	r.ID = nw.ID()
-	r.Scope = info.Scope()
-	if n.clusterProvider.IsManager() {
-		if _, err := n.clusterProvider.GetNetwork(nw.Name()); err == nil {
-			r.Scope = "swarm"
-		}
-	} else if info.Dynamic() {
-		r.Scope = "swarm"
+	if err := httputils.CheckForJSON(r); err != nil {
+		return err
 	}
-	r.Driver = nw.Type()
-	r.EnableIPv6 = info.IPv6Enabled()
-	r.Internal = info.Internal()
-	r.Options = info.DriverOptions()
-	r.Containers = make(map[string]types.EndpointResource)
-	buildIpamResources(r, info)
-	r.Internal = info.Internal()
-	r.Labels = info.Labels()
-
-	epl := nw.Endpoints()
-	for _, e := range epl {
-		ei := e.Info()
-		if ei == nil {
-			continue
-		}
-		sb := ei.Sandbox()
-		key := "ep-" + e.ID()
-		if sb != nil {
-			key = sb.ContainerID()
-		}
-
-		r.Containers[key] = buildEndpointResource(e)
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		return err
 	}
-	return r
-}
-
-func buildIpamResources(r *types.NetworkResource, nwInfo libnetwork.NetworkInfo) {
-	id, opts, ipv4conf, ipv6conf := nwInfo.IpamConfig()
-
-	ipv4Info, ipv6Info := nwInfo.IpamInfo()
-
-	r.IPAM.Driver = id
-
-	r.IPAM.Options = opts
-
-	r.IPAM.Config = []network.IPAMConfig{}
-	for _, ip4 := range ipv4conf {
-		if ip4.PreferredPool == "" {
-			continue
-		}
-		iData := network.IPAMConfig{}
-		iData.Subnet = ip4.PreferredPool
-		iData.IPRange = ip4.SubPool
-		iData.Gateway = ip4.Gateway
-		iData.AuxAddress = ip4.AuxAddresses
-		r.IPAM.Config = append(r.IPAM.Config, iData)
-	}
-
-	if len(r.IPAM.Config) == 0 {
-		for _, ip4Info := range ipv4Info {
-			iData := network.IPAMConfig{}
-			iData.Subnet = ip4Info.IPAMData.Pool.String()
-			iData.Gateway = ip4Info.IPAMData.Gateway.String()
-			r.IPAM.Config = append(r.IPAM.Config, iData)
-		}
-	}
-
-	hasIpv6Conf := false
-	for _, ip6 := range ipv6conf {
-		if ip6.PreferredPool == "" {
-			continue
-		}
-		hasIpv6Conf = true
-		iData := network.IPAMConfig{}
-		iData.Subnet = ip6.PreferredPool
-		iData.IPRange = ip6.SubPool
-		iData.Gateway = ip6.Gateway
-		iData.AuxAddress = ip6.AuxAddresses
-		r.IPAM.Config = append(r.IPAM.Config, iData)
-	}
-
-	if !hasIpv6Conf {
-		for _, ip6Info := range ipv6Info {
-			iData := network.IPAMConfig{}
-			iData.Subnet = ip6Info.IPAMData.Pool.String()
-			iData.Gateway = ip6Info.IPAMData.Gateway.String()
-			r.IPAM.Config = append(r.IPAM.Config, iData)
-		}
-	}
-}
-
-func buildEndpointResource(e libnetwork.Endpoint) types.EndpointResource {
-	er := types.EndpointResource{}
-	if e == nil {
-		return er
-	}
-
-	er.EndpointID = e.ID()
-	er.Name = e.Name()
-	ei := e.Info()
-	if ei == nil {
-		return er
-	}
-
-	if iface := ei.Iface(); iface != nil {
-		if mac := iface.MacAddress(); mac != nil {
-			er.MacAddress = mac.String()
-		}
-		if ip := iface.Address(); ip != nil && len(ip.IP) > 0 {
-			er.IPv4Address = ip.String()
-		}
-
-		if ipv6 := iface.AddressIPv6(); ipv6 != nil && len(ipv6.IP) > 0 {
-			er.IPv6Address = ipv6.String()
-		}
-	}
-	return er
+	return nil
 }

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -2,22 +2,19 @@ package system
 
 import (
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/daemon/cluster"
 )
 
 // systemRouter provides information about the Docker system overall.
 // It gathers information about host, daemon and container events.
 type systemRouter struct {
-	backend         Backend
-	clusterProvider *cluster.Cluster
-	routes          []router.Route
+	backend Backend
+	routes  []router.Route
 }
 
 // NewRouter initializes a new system router
-func NewRouter(b Backend, c *cluster.Cluster) router.Router {
+func NewRouter(b Backend) router.Router {
 	r := &systemRouter{
-		backend:         b,
-		clusterProvider: c,
+		backend: b,
 	}
 
 	r.routes = []router.Route{

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -33,10 +33,6 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 	if err != nil {
 		return err
 	}
-	if s.clusterProvider != nil {
-		info.Swarm = s.clusterProvider.Info()
-	}
-
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }
 


### PR DESCRIPTION
**\- What I did**
- Refactor the `github.com/docker/docker/api/server/router/system` and `github.com/docker/docker/api/server/router/network` packages to remove the dependency on ``github.com/docker/docker/daemon/cluster` and `github.com/docker/libnetwork`.

**\- Why I did this**
- To work towards the extraction of `github.com/docker/docker/api/server` into the `github.com/docker/engine-api` repository.
  Note: In thise case, `github.com/docker/docker/api/server/backend` would stay in the `docker/docker` repository,
  while `github.com/docker/docker/api/server` and the other subpackages would be moved to `engine-api`.

**\- How I did it**
- The new package `github.com/docker/docker/api/server/backend` serves as a facade for `daemon.Daemon` and `cluster.Cluster`.
- This has the additional advantage of decoupling the API Server layer from the interaction between `daemon.Daemon` and `cluster.Cluster` (e.g. where to look first when looking for a specific network).

**\- How to verify it**

**\- Description for the changelog**
Decoupled `api/server/router/system` and `api/server/router/network` from the daemon & cluster implementation.
