### PR TITLE
Windows: Ensure frozen cope with prefix

### DIFF
--- a/hack/make/.ensure-frozen-images-windows
+++ b/hack/make/.ensure-frozen-images-windows
@@ -3,7 +3,7 @@ set -e
 
 # This scripts sets up the required images for Windows to Windows CI
 
-# Tag windowsservercore as latest
+# Tag (microsoft/)windowsservercore as latest
 set +e
 ! BUILD=$(docker images | grep windowsservercore | grep -v latest | awk '{print $2}')
 if [ -z $BUILD ]; then
@@ -11,11 +11,18 @@ if [ -z $BUILD ]; then
 	exit 1
 fi
 
+# Get the name. Around 2016 6D TP5, these have the microsoft/ prefix, hence cater for both.
+! IMAGENAME=$(docker images | grep windowsservercore | grep -v latest | awk '{print $1}')
+if [ -z $IMAGENAME ]; then
+	echo "ERROR: Could not find windowsservercore image"
+	exit 1
+fi
+
 ! LATESTCOUNT=$(docker images | grep windowsservercore | grep -v $BUILD | wc -l)
 if [ $LATESTCOUNT -ne 1 ]; then
 	set -e
-	docker tag windowsservercore:$BUILD windowsservercore:latest
-	echo "INFO: Tagged windowsservercore:$BUILD with latest"
+	docker tag $IMAGENAME:$BUILD windowsservercore:latest
+	echo "INFO: Tagged $IMAGENAME:$BUILD as windowsservercore:latest"
 fi
 
 # Busybox (requires windowsservercore)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

_IMPORTANT_ TP5 CI will imminently break without this change - it's a "must have" for 1.12. 

The Windows image format work also has the side effect of prefixing the image names microsoft/. Hence, rather than just assume the prefix, in .ensure-frozen-images-windows, we extract it directly for use in tagging. This way it copes both before and after the changes.

(@tianon - although related to, this is orthogonal to our conversation yesterday) 
@icecrime @swernli @thaJeztah @tiborvass 
