### PR TITLE
Fixing typo on service log output.

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -109,7 +109,7 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 
 	id, err := sr.backend.CreateService(service)
 	if err != nil {
-		logrus.Errorf("Error reating service %s: %v", id, err)
+		logrus.Errorf("Error creating service %s: %v", id, err)
 		return err
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixed a typo.
**\- How I did it**
With my editor.
**\- How to verify it**
Run 1.12-rc2 in swarm mode, create two services with the same name while tailing the logs. Before patch will say "Error reating...", after will say "Error creating...".
**\- Description for the changelog**
Fixing typo on service log output.

**\- A picture of a cute animal (not mandatory but encouraged)**
![](https://media1.giphy.com/media/vHo2UnTHbRNT2/200_s.gif)
