### PR TITLE
No need for container.Lock if rename same name

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -33,12 +33,12 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	oldName = container.Name
 	oldIsAnonymousEndpoint := container.NetworkSettings.IsAnonymousEndpoint
 
-	container.Lock()
-	defer container.Unlock()
-
 	if oldName == newName {
 		return fmt.Errorf("Renaming a container with the same name as its current name")
 	}
+
+	container.Lock()
+	defer container.Unlock()
 
 	if newName, err = daemon.reserveName(container.ID, newName); err != nil {
 		return fmt.Errorf("Error when allocating new name: %v", err)


### PR DESCRIPTION
During the renaming of a container, no need to call `container.Lock()` if `oldName == newName` 🐍.

This is a follow-up from #23360 (commit 88d1ee6c112d980a63c625389524047fea32e6d9). As commented https://github.com/docker/docker/pull/23360#discussion_r68436103, I'm still looking for other small improvement :wink:

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
