### PR TITLE
Remove log warning on task update

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -60,7 +60,6 @@ func (r *controller) ContainerStatus(ctx context.Context) (*api.ContainerStatus,
 
 // Update tasks a recent task update and applies it to the container.
 func (r *controller) Update(ctx context.Context, t *api.Task) error {
-	log.G(ctx).Warnf("task updates not yet supported")
 	// TODO(stevvooe): While assignment of tasks is idempotent, we do allow
 	// updates of metadata, such as labelling, as well as any other properties
 	// that make sense.


### PR DESCRIPTION
This warning appears in the course of normal use of swarm mode. Since
it's meant more as an internal TODO than something which should be
exposed to a user, remove the log message.
