### PR TITLE
Fixes for `service update` of Args

### DIFF
--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -45,7 +45,7 @@ func runUpdate(dockerCli *client.DockerCli, flags *pflag.FlagSet, serviceID stri
 		return err
 	}
 
-	err = updateService(&service.Spec, flags)
+	err = updateService(flags, &service.Spec)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func runUpdate(dockerCli *client.DockerCli, flags *pflag.FlagSet, serviceID stri
 	return nil
 }
 
-func updateService(spec *swarm.ServiceSpec, flags *pflag.FlagSet) error {
+func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 
 	updateString := func(flag string, field *string) {
 		if flags.Changed(flag) {
@@ -123,7 +123,7 @@ func updateService(spec *swarm.ServiceSpec, flags *pflag.FlagSet) error {
 	updateLabels(flags, &spec.Labels)
 	updateString("image", &cspec.Image)
 	updateSlice("command", &cspec.Command)
-	updateSlice("arg", &cspec.Command)
+	updateSlice("arg", &cspec.Args)
 	updateListOpts("env", &cspec.Env)
 	updateString("workdir", &cspec.Dir)
 	updateString(flagUser, &cspec.User)

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/docker/engine-api/types/swarm"
+)
+
+func TestUpdateServiceCommandAndArgs(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("command", "the")
+	flags.Set("command", "new")
+	flags.Set("command", "command")
+	flags.Set("arg", "the")
+	flags.Set("arg", "new args")
+
+	spec := &swarm.ServiceSpec{}
+	cspec := &spec.TaskTemplate.ContainerSpec
+	cspec.Command = []string{"old", "command"}
+	cspec.Args = []string{"old", "args"}
+
+	updateService(flags, spec)
+	assert.EqualStringSlice(t, cspec.Command, []string{"the", "new", "command"})
+	assert.EqualStringSlice(t, cspec.Args, []string{"the", "new args"})
+}

--- a/pkg/testutil/assert/assert.go
+++ b/pkg/testutil/assert/assert.go
@@ -19,6 +19,21 @@ func Equal(t TestingT, actual, expected interface{}) {
 	}
 }
 
+//EqualStringSlice compares two slices and fails the test if they do not contain
+// the same items.
+func EqualStringSlice(t TestingT, actual, expected []string) {
+	if len(actual) != len(expected) {
+		t.Fatalf("Expected (length %d): %q\nActual (length %d): %q",
+			len(expected), expected, len(actual), actual)
+	}
+	for i, item := range actual {
+		if item != expected[i] {
+			t.Fatalf("Slices differ at element %d, expected %q got %q",
+				i, expected[i], item)
+		}
+	}
+}
+
 // NilError asserts that the error is nil, otherwise it fails the test.
 func NilError(t TestingT, err error) {
 	if err != nil {


### PR DESCRIPTION
Fixes #23924 by setting `Args` properly instead of setting `Command`

Removed from this PR: ~~Fixes #23923 - `args` (previously `arg`) and `comand` now accept a single string instead of a slice. So `--args "echo 100"` works instead of `--arg echo --arg 100`~~
