### PR TITLE
Volume mounts need to use "Binds" API field

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -91,13 +91,12 @@ func (c *containerConfig) image() string {
 func (c *containerConfig) volumes() map[string]struct{} {
 	r := make(map[string]struct{})
 
-	for _, mount := range c.spec().Mounts {
+	for _, m := range c.spec().Mounts {
 		// pick off all the volume mounts.
-		if mount.Type != api.MountTypeVolume {
+		if m.Type != api.MountTypeVolume || m.Source != "" {
 			continue
 		}
-
-		r[fmt.Sprintf("%s:%s", mount.Target, getMountMask(&mount))] = struct{}{}
+		r[m.Target] = struct{}{}
 	}
 
 	return r
@@ -165,7 +164,7 @@ func (c *containerConfig) bindMounts() []string {
 
 	for _, val := range c.spec().Mounts {
 		mask := getMountMask(&val)
-		if val.Type == api.MountTypeBind {
+		if val.Type == api.MountTypeBind || (val.Type == api.MountTypeVolume && val.Source != "") {
 			r = append(r, fmt.Sprintf("%s:%s:%s", val.Source, val.Target, mask))
 		}
 	}


### PR DESCRIPTION
Swarm was putting volume type mounts into the container config's
"Volumes" field, but really these need to go into "Binds".
"Volumes" is only for normal "-v /foo" volumes, not named volumes or
anything else.

I was looking at adding an integration test for this, however it dawned on me I was testing implementation detail as there is not really an easy way to actually get at the underlying container object to have a look at it, or really any good way to dive into this service.
