### PR TITLE
image: Report load progress on compressed layer size

### DIFF
--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -170,27 +170,24 @@ func (l *tarexporter) loadLayer(filename string, rootFS image.RootFS, id string,
 	}
 	defer rawTar.Close()
 
-	inflatedLayerData, err := archive.DecompressStream(rawTar)
-	if err != nil {
-		return nil, err
-	}
-	defer inflatedLayerData.Close()
-
+	var r io.Reader
 	if progressOutput != nil {
-		fileInfo, err := os.Stat(filename)
+		fileInfo, err := rawTar.Stat()
 		if err != nil {
 			logrus.Debugf("Error statting file: %v", err)
 			return nil, err
 		}
 
-		progressReader := progress.NewProgressReader(inflatedLayerData, progressOutput, fileInfo.Size(), stringid.TruncateID(id), "Loading layer")
-
-		if ds, ok := l.ls.(layer.DescribableStore); ok {
-			return ds.RegisterWithDescriptor(progressReader, rootFS.ChainID(), foreignSrc)
-		}
-		return l.ls.Register(progressReader, rootFS.ChainID())
-
+		r = progress.NewProgressReader(rawTar, progressOutput, fileInfo.Size(), stringid.TruncateID(id), "Loading layer")
+	} else {
+		r = rawTar
 	}
+
+	inflatedLayerData, err := archive.DecompressStream(r)
+	if err != nil {
+		return nil, err
+	}
+	defer inflatedLayerData.Close()
 
 	if ds, ok := l.ls.(layer.DescribableStore); ok {
 		return ds.RegisterWithDescriptor(inflatedLayerData, rootFS.ChainID(), foreignSrc)


### PR DESCRIPTION
When calling `docker load` on an image tar containing a compressed layer, apply NewProgressReader to the compressed layer (whose size is known), not the uncompressed stream. This fixes progress reporting to the client in this case.

Note that this does not happen for images produced with `docker save`, since the contained layer tars are AFAIK never compressed.
