### PR TITLE
Windows: Disable VM cloning for TP5 image

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -43,7 +43,7 @@ esac
 
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
-clone git github.com/Microsoft/hcsshim v0.3.5
+clone git github.com/Microsoft/hcsshim v0.3.6
 clone git github.com/Microsoft/go-winio v0.3.4
 clone git github.com/Sirupsen/logrus v0.10.0 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -85,6 +85,13 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 		configuration.HvRuntime = &hcsshim.HvRuntime{
 			ImagePath: spec.Windows.HvRuntime.ImagePath,
 		}
+
+		// Images with build verison < 14350 don't support running with clone, but
+		// Windows cannot automatically detect this. Explicitly block cloning in this
+		// case.
+		if build := buildFromVersion(spec.Platform.OSVersion); build > 0 && build < 14350 {
+			configuration.HvRuntime.SkipTemplate = true
+		}
 	}
 
 	if configuration.HvPartition {

--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -2,8 +2,6 @@ package libcontainerd
 
 import (
 	"io"
-	"strconv"
-	"strings"
 
 	"github.com/Microsoft/hcsshim"
 )
@@ -38,12 +36,7 @@ func fixStdinBackspaceBehavior(w io.WriteCloser, osversion string, tty bool) io.
 	if !tty {
 		return w
 	}
-	v := strings.Split(osversion, ".")
-	if len(v) < 3 {
-		return w
-	}
-
-	if build, err := strconv.Atoi(v[2]); err != nil || build >= 14350 {
+	if build := buildFromVersion(osversion); build == 0 || build >= 14350 {
 		return w
 	}
 

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -1,6 +1,9 @@
 package libcontainerd
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // setupEnvironmentVariables convert a string array of environment variables
 // into a map as required by the HCS. Source array is in format [v1=k1] [v2=k2] etc.
@@ -18,4 +21,17 @@ func setupEnvironmentVariables(a []string) map[string]string {
 // Apply for a servicing option is a no-op.
 func (s *ServicingOption) Apply(interface{}) error {
 	return nil
+}
+
+// buildFromVersion takes an image version string and returns the Windows build
+// number. It returns 0 if the build number is not present.
+func buildFromVersion(osver string) int {
+	v := strings.Split(osver, ".")
+	if len(v) < 3 {
+		return 0
+	}
+	if build, err := strconv.Atoi(v[2]); err == nil {
+		return build
+	}
+	return 0
 }

--- a/vendor/src/github.com/Microsoft/hcsshim/README.md
+++ b/vendor/src/github.com/Microsoft/hcsshim/README.md
@@ -1,0 +1,12 @@
+# hcsshim
+
+This package supports launching Windows Server containers from Go. It is
+primarily used in the [Docker Engine](https://github.com/docker/docker) project,
+but it can be freely used by other projects as well.
+
+This project has adopted the [Microsoft Open Source Code of
+Conduct](https://opensource.microsoft.com/codeofconduct/). For more information
+see the [Code of Conduct
+FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
+questions or comments.

--- a/vendor/src/github.com/Microsoft/hcsshim/interface.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/interface.go
@@ -31,12 +31,12 @@ type MappedDir struct {
 }
 
 type HvRuntime struct {
-	ImagePath string `json:",omitempty"`
+	ImagePath    string `json:",omitempty"`
+	SkipTemplate bool   `json:",omitempty"`
 }
 
 // ContainerConfig is used as both the input of CreateContainer
 // and to convert the parameters to JSON for passing onto the HCS
-// TODO Windows: @darrenstahlmsft Add ProcessorCount
 type ContainerConfig struct {
 	SystemType              string      // HCS requires this to be hard-coded to "Container"
 	Name                    string      // Name of the container. We use the docker ID.
@@ -47,6 +47,7 @@ type ContainerConfig struct {
 	LayerFolderPath         string      // Where the layer folders are located
 	Layers                  []Layer     // List of storage layers
 	Credentials             string      `json:",omitempty"` // Credentials information
+	ProcessorCount          uint32      `json:",omitempty"` // Number of processors to assign to the container.
 	ProcessorWeight         uint64      `json:",omitempty"` // CPU Shares 0..10000 on Windows; where 0 will be omitted and HCS will default.
 	ProcessorMaximum        int64       `json:",omitempty"` // CPU maximum usage percent 1..100
 	StorageIOPSMaximum      uint64      `json:",omitempty"` // Maximum Storage IOPS
@@ -61,18 +62,6 @@ type ContainerConfig struct {
 	HvRuntime               *HvRuntime  // Hyper-V container settings
 	Servicing               bool        // True if this container is for servicing
 }
-
-const (
-	notificationTypeNone           string = "None"
-	notificationTypeGracefulExit   string = "GracefulExit"
-	notificationTypeForcedExit     string = "ForcedExit"
-	notificationTypeUnexpectedExit string = "UnexpectedExit"
-	notificationTypeReboot         string = "Reboot"
-	notificationTypeConstructed    string = "Constructed"
-	notificationTypeStarted        string = "Started"
-	notificationTypePaused         string = "Paused"
-	notificationTypeUnknown        string = "Unknown"
-)
 
 // Container represents a created (but not necessarily running) container.
 type Container interface {


### PR DESCRIPTION
The Windows TP5 image is not compatible with the Hyper-V isolated
container clone feature. Detect old images and pass a flag specifying that
clone should not be enabled.

cc @jhowardmsft @darrenstahlmsft
