### PR TITLE
Make use of header constants also in ps raw format

### DIFF
--- a/api/client/formatter/formatter.go
+++ b/api/client/formatter/formatter.go
@@ -124,11 +124,29 @@ func (ctx ContainerContext) Write() {
 		}
 	case rawFormatKey:
 		if ctx.Quiet {
-			ctx.Format = `container_id: {{.ID}}`
+			ctx.Format = fmt.Sprintf(`%s: {{.ID}}`, containerIDHeader)
 		} else {
-			ctx.Format = `container_id: {{.ID}}\nimage: {{.Image}}\ncommand: {{.Command}}\ncreated_at: {{.CreatedAt}}\nstatus: {{.Status}}\nnames: {{.Names}}\nlabels: {{.Labels}}\nports: {{.Ports}}\n`
+			ctx.Format = fmt.Sprintf(`%s: {{.ID}}
+%s: {{.Image}}
+%s: {{.Command}}
+%s: {{.CreatedAt}}
+%s: {{.Status}}
+%s: {{.Names}}
+%s: {{.Labels}}
+%s: {{.Ports}}
+`,
+				containerIDHeader,
+				imageHeader,
+				commandHeader,
+				createdAtHeader,
+				statusHeader,
+				namesHeader,
+				labelsHeader,
+				portsHeader,
+			)
+
 			if ctx.Size {
-				ctx.Format += `size: {{.Size}}\n`
+				ctx.Format += fmt.Sprintf("%s: {{.Size}}\n", sizeHeader)
 			}
 		}
 	}

--- a/api/client/formatter/formatter_test.go
+++ b/api/client/formatter/formatter_test.go
@@ -90,23 +90,23 @@ containerID2        ubuntu              ""                  24 hours ago        
 					Format: "raw",
 				},
 			},
-			fmt.Sprintf(`container_id: containerID1
-image: ubuntu
-command: ""
-created_at: %s
-status: 
-names: foobar_baz
-labels: 
-ports: 
+			fmt.Sprintf(`CONTAINER ID: containerID1
+IMAGE: ubuntu
+COMMAND: ""
+CREATED AT: %s
+STATUS: 
+NAMES: foobar_baz
+LABELS: 
+PORTS: 
 
-container_id: containerID2
-image: ubuntu
-command: ""
-created_at: %s
-status: 
-names: foobar_bar
-labels: 
-ports: 
+CONTAINER ID: containerID2
+IMAGE: ubuntu
+COMMAND: ""
+CREATED AT: %s
+STATUS: 
+NAMES: foobar_bar
+LABELS: 
+PORTS: 
 
 `, expectedTime, expectedTime),
 		},
@@ -117,25 +117,25 @@ ports:
 				},
 				Size: true,
 			},
-			fmt.Sprintf(`container_id: containerID1
-image: ubuntu
-command: ""
-created_at: %s
-status: 
-names: foobar_baz
-labels: 
-ports: 
-size: 0 B
+			fmt.Sprintf(`CONTAINER ID: containerID1
+IMAGE: ubuntu
+COMMAND: ""
+CREATED AT: %s
+STATUS: 
+NAMES: foobar_baz
+LABELS: 
+PORTS: 
+SIZE: 0 B
 
-container_id: containerID2
-image: ubuntu
-command: ""
-created_at: %s
-status: 
-names: foobar_bar
-labels: 
-ports: 
-size: 0 B
+CONTAINER ID: containerID2
+IMAGE: ubuntu
+COMMAND: ""
+CREATED AT: %s
+STATUS: 
+NAMES: foobar_bar
+LABELS: 
+PORTS: 
+SIZE: 0 B
 
 `, expectedTime, expectedTime),
 		},
@@ -146,7 +146,7 @@ size: 0 B
 					Quiet:  true,
 				},
 			},
-			"container_id: containerID1\ncontainer_id: containerID2\n",
+			"CONTAINER ID: containerID1\nCONTAINER ID: containerID2\n",
 		},
 		// Custom Format
 		{

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -802,7 +802,7 @@ func (s *DockerSuite) TestPsFormatSize(c *check.C) {
 
 	out, _ = dockerCmd(c, "ps", "--size", "--format", "raw")
 	lines = strings.Split(out, "\n")
-	c.Assert(lines[8], checker.HasPrefix, "size:", check.Commentf("Size should be appended on a newline"))
+	c.Assert(lines[8], checker.HasPrefix, "SIZE:", check.Commentf("Size should be appended on a newline"))
 }
 
 func (s *DockerSuite) TestPsListContainersFilterNetwork(c *check.C) {


### PR DESCRIPTION
It closes https://github.com/docker/docker/issues/23952

**\- What I did**
Make use of classical header constants also in ps raw format

**\- How I did it**
The diff should be easy to be understood

**\- How to verify it**
`$ docker ps --format=raw`

**\- A picture of a cute animal (not mandatory but encouraged)**
These are my nice two cats!
![My nice cats](https://scontent-frt3-1.cdninstagram.com/t51.2885-15/e35/13277584_565734386947342_399823809_n.jpg?ig_cache_key=MTI2NTQwMTI4ODY1MzYxMzE2Ng%3D%3D.2)

Signed-off-by: Daniele Megna megna.dany@gmail.com
