### PR TITLE
Add some events to swarm/node/services

### DIFF
--- a/daemon/cluster/events.go
+++ b/daemon/cluster/events.go
@@ -1,0 +1,11 @@
+package cluster
+
+import (
+	"github.com/docker/engine-api/types/events"
+	swarmagent "github.com/docker/swarmkit/agent"
+)
+
+// LogSwarmEvent generates an event related to the Swarm.
+func (c *Cluster) LogSwarmEvent(node *swarmagent.Node, action string, attributes map[string]string) {
+	c.config.Backend.LogEventWithAttributes(events.SwarmEventType, node.NodeID(), action, attributes)
+}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -33,4 +33,5 @@ type Backend interface {
 	SetNetworkBootstrapKeys([]*networktypes.EncryptionKey) error
 	SetClusterProvider(provider cluster.Provider)
 	IsSwarmCompatible() error
+	LogEventWithAttributes(eventtype, id string, action string, attributes map[string]string)
 }

--- a/daemon/events.go
+++ b/daemon/events.go
@@ -94,6 +94,17 @@ func (daemon *Daemon) LogDaemonEventWithAttributes(action string, attributes map
 	}
 }
 
+// LogEventWithAttributes generates an generic event with specific given attributes
+func (daemon *Daemon) LogEventWithAttributes(eventtype, id string, action string, attributes map[string]string) {
+	if daemon.EventsService != nil {
+		actor := events.Actor{
+			ID:         id,
+			Attributes: attributes,
+		}
+		daemon.EventsService.Log(action, eventtype, actor)
+	}
+}
+
 // SubscribeToEvents returns the currently record of events, a channel to stream new events from, and a function to cancel the stream of events.
 func (daemon *Daemon) SubscribeToEvents(since, until time.Time, filter filters.Args) ([]events.Message, chan interface{}) {
 	ef := daemonevents.NewFilter(filter)

--- a/vendor/src/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/src/github.com/docker/engine-api/types/events/events.go
@@ -9,8 +9,14 @@ const (
 	VolumeEventType = "volume"
 	// NetworkEventType is the event type that networks generate
 	NetworkEventType = "network"
-	// DaemonEventType is the event type that daemon generate
+	// DaemonEventType is the event type that daemon generates
 	DaemonEventType = "daemon"
+	// SwarmEventType is the event type that swarm generates
+	SwarmEventType = "swarm"
+	// NodeEventType is the event type that nodes generate
+	NodeEventType = "node"
+	// ServiceEventType is the event type that services generate
+	ServiceEventType = "service"
 )
 
 // Actor describes something that generates events,


### PR DESCRIPTION
Update cluster package (swarm mode), to generate some events 🐳. This is related to #23827. `vendor` is expected to build – will do an `engine-api` PR once in code-review :wink: .
- [ ] Possibily add more events ? more fields more some of those events ?
- [ ] Add integration tests
- [ ] Add documentation tests

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
