### PR TITLE
Remove blank line on daemon output when there are no containers to load

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -117,11 +117,13 @@ func (daemon *Daemon) restore() error {
 		return err
 	}
 
+	containerCount := 0
 	for _, v := range dir {
 		id := v.Name()
 		container, err := daemon.load(id)
 		if !debug && logrus.GetLevel() == logrus.InfoLevel {
 			fmt.Print(".")
+			containerCount++
 		}
 		if err != nil {
 			logrus.Errorf("Failed to load container %v: %v", id, err)
@@ -306,7 +308,7 @@ func (daemon *Daemon) restore() error {
 	group.Wait()
 
 	if !debug {
-		if logrus.GetLevel() == logrus.InfoLevel {
+		if logrus.GetLevel() == logrus.InfoLevel && containerCount > 0 {
 			fmt.Println()
 		}
 		logrus.Info("Loading containers: done.")


### PR DESCRIPTION
Its a minor thing but the daemon's output looks like this when there are
no containers to load:

```
INFO[0001] Loading containers: start.

INFO[0001] Loading containers: done.
```

That blank line (or more correctly, the \n) is unnecessary when
there are no containers to load since there is no `.` printed
