### PR TITLE
Add detail error logs when 'Unknown Device' error happens if devicema…

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -901,10 +901,12 @@ func (devices *DeviceSet) loadMetadata(hash string) *devInfo {
 
 	jsonData, err := ioutil.ReadFile(devices.metadataFile(info))
 	if err != nil {
+		logrus.Debugf("devmapper: Failed to read %s with err: %v", devices.metadataFile(info), err)
 		return nil
 	}
 
 	if err := json.Unmarshal(jsonData, &info); err != nil {
+		logrus.Debugf("devmapper: Failed to unmarshal devInfo from %s with err: %v", devices.metadataFile(info), err)
 		return nil
 	}
 


### PR DESCRIPTION
Dear maintainers,
This PR is to add the detail error logs for device mapper storage when the error "unknown device' happens as below when tries to restart a container:
"Handler for GET /containers/d355ff91fe74b635b8ed325b880c5e1654e5e57b9b23e6455c3e8fb2b30a1f4f/json returned error: Unknown device d355ff91fe74b635b8ed325b880c5e1654e5e57b9b23e6455c3e8fb2b30a1f4f"
In order to find the reason why read the data failed from devicemapped device, these error logs are added. 
Please review it, thanks a lot.
