### PR TITLE
uppercase output in node inspect to keep consistency

### DIFF
--- a/api/client/node/inspect.go
+++ b/api/client/node/inspect.go
@@ -96,7 +96,7 @@ func printNode(out io.Writer, node swarm.Node) {
 	if node.ManagerStatus != nil {
 		fmt.Fprintln(out, "Manager Status:")
 		fmt.Fprintf(out, " Address:\t\t%s\n", node.ManagerStatus.Addr)
-		fmt.Fprintf(out, " Raft status:\t\t%s\n", client.PrettyPrint(node.ManagerStatus.Reachability))
+		fmt.Fprintf(out, " Raft Status:\t\t%s\n", client.PrettyPrint(node.ManagerStatus.Reachability))
 		leader := "No"
 		if node.ManagerStatus.Leader {
 			leader = "Yes"

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -103,7 +103,7 @@ Example output:
      Availability:          Active
     Manager Status:
      Address:               172.17.0.2:2377
-     Raft status:           Reachable
+     Raft Status:           Reachable
      Leader:                Yes
     Platform:
      Operating System:      linux


### PR DESCRIPTION
uppercase output in node inspect to keep consistency

Signed-off-by: allencloud allen.sun@daocloud.io
