### PR TITLE
Windows CI: Fail if busybox image fails to build

### DIFF
--- a/hack/make/.ensure-frozen-images-windows
+++ b/hack/make/.ensure-frozen-images-windows
@@ -1,10 +1,9 @@
 #!/bin/bash
-set -e
+set +e
 
 # This scripts sets up the required images for Windows to Windows CI
 
 # Tag (microsoft/)windowsservercore as latest
-set +e
 ! BUILD=$(docker images | grep windowsservercore | grep -v latest | awk '{print $2}')
 if [ -z $BUILD ]; then
 	echo "ERROR: Could not find windowsservercore images"
@@ -18,9 +17,9 @@ if [ -z $IMAGENAME ]; then
 	exit 1
 fi
 
+set -e
 ! LATESTCOUNT=$(docker images | grep windowsservercore | grep -v $BUILD | wc -l)
 if [ $LATESTCOUNT -ne 1 ]; then
-	set -e
 	docker tag $IMAGENAME:$BUILD windowsservercore:latest
 	echo "INFO: Tagged $IMAGENAME:$BUILD as windowsservercore:latest"
 fi


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Couple of tweaks:

On an internal run where a server was unavailable, the busybox image failed to build, but the scripts continued regardless to attempt to run the CLI suite (which obviously failed). This is because the `set -e` was in the LATESTCOUNT if statement so a docker build failure didn't error out. Moved it outside the `if` block.

Also noticed that the file had a redundant `set -e` at the start as it was immediately followed by a `set +e`.

@tianon 
