### PR TITLE
added another alias for getting started stuff

### DIFF
--- a/docs/getstarted/index.md
+++ b/docs/getstarted/index.md
@@ -4,6 +4,7 @@ aliases = [
 "/mac/started/",
 "/windows/started/",
 "/linux/started/",
+"/getting-started/"
 ]
 title = "Get Started with Docker"
 description = "Getting started with Docker"


### PR DESCRIPTION
Added a redirect for `/getting-started/` here, which had mistakenly been in the Docker for Windows `index.md` and was wreaking havoc.
