### PR TITLE
Add pid_max check

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -289,4 +289,5 @@ check_limit_over()
 
 echo 'Limits:'
 check_limit_over /proc/sys/kernel/keys/root_maxkeys 10000
+check_limit_over /proc/sys/kernel/pid_max 327680
 echo


### PR DESCRIPTION
If pid_max is too small, system won't be able to start lots of
containers. Adding a check will give user some suggestions about how to
tune their system.

Related issues: #23332

Signed-off-by: Zhang Wei zhangwei555@huawei.com
