### PR TITLE
Fix Malformed history layer - missing Sprintf

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -172,7 +172,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	}
 
 	cmd := b.runConfig.Cmd
-	b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), "#(nop) %s %s in %s ", cmdName, srcHash, dest))
+	b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s %s in %s ", cmdName, srcHash, dest)))
 	defer func(cmd strslice.StrSlice) { b.runConfig.Cmd = cmd }(cmd)
 
 	if hit, err := b.probeCache(); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Added a missing Sprintf statement

**\- How to verify it**
As the issue states, create a Dockerfile containing:

```
FROM debian:latest
ADD somefile somefile
CMD ["hostname"]
```

and `docker build` it --> before the fix the malformed history line will look like:
`"created_by": "/bin/sh -c #(nop) %s %s in %s  ADD file:21ba419c49a88ccaa420c52df237f9253b6a94058f770dfa4425cc9f6a49d58d somefile"
`

**\- Description for the changelog**
Fixes #24030 

**\- A picture of a cute animal (not mandatory but encouraged)**

![1](https://cloud.githubusercontent.com/assets/9161287/16408450/813f7380-3d21-11e6-82a5-5f1be616d41d.jpg)
