### PR TITLE
DockerExternalVolumeSuite: add daemon to test

### DIFF
--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -472,8 +472,12 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverWithDaemonRestart(c 
 // Ensures that the daemon handles when the plugin responds to a `Get` request with a null volume and a null error.
 // Prior the daemon would panic in this scenario.
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGetEmptyResponse(c *check.C) {
-	dockerCmd(c, "volume", "create", "-d", "test-external-volume-driver", "--name", "abc2", "--opt", "ninja=1")
-	out, _, err := dockerCmdWithError("volume", "inspect", "abc2")
+	c.Assert(s.d.Start(), checker.IsNil)
+
+	out, err := s.d.Cmd("volume", "create", "-d", "test-external-volume-driver", "--name", "abc2", "--opt", "ninja=1")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	out, err = s.d.Cmd("volume", "inspect", "abc2")
 	c.Assert(err, checker.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "No such volume")
 }


### PR DESCRIPTION
Part of #23998. Adds a daemon to this test, so that the
volume that's created is added to this test daemon's vol store
instead of the main test daemons.

This doesn't solve the issue, as there isn't currently a way to remove a nil volume,
but does make sure no other tests are affected by it, increasing the integration
cli tests runtime by ~12 minutes.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
