### PR TITLE
Fix check code for --cluster-store and --cluster-advertise in config_…

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -123,7 +123,7 @@ func (config *Config) GetAllRuntimes() map[string]types.Runtime {
 }
 
 func (config *Config) isSwarmCompatible() error {
-	if config.IsValueSet("cluster-store") || config.IsValueSet("cluster-advertise") {
+	if config.ClusterStore != "" || config.ClusterAdvertise != "" {
 		return fmt.Errorf("--cluster-store and --cluster-advertise daemon configurations are incompatible with swarm mode")
 	}
 	if config.LiveRestore {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
I fixed the issue which was brought up from https://github.com/docker/docker/pull/23524#discussion_r68729838 .

**\- How I did it**
I just changed(in fact, 'restored') code to `config.ClusterStore != "" || config.ClusterAdvertise != ""`. 

**\- How to verify it**
On swarm mode, it should throw an error when restarting a docker daemon with added --cluster-store option and --cluster-advertise. I tested it and that worked.

```
FATA[0001] Error creating cluster component: --cluster-store and --cluster-advertise daemon configurations are incompatible with swarm mode
```

**\- Description for the changelog**
Fixed https://github.com/docker/docker/pull/23524#discussion_r68729838

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
![331757576t06140236068054](https://cloud.githubusercontent.com/assets/3197984/16426154/d3ef764e-3da2-11e6-9a4e-97dc3fe3763c.jpg)

Signed-off-by: Wonjun Kim wonjun.kim@navercorp.com
