### PR TITLE
output some details when stack name does not exist

### DIFF
--- a/api/client/node/cmd.go
+++ b/api/client/node/cmd.go
@@ -35,7 +35,7 @@ func NewNodeCommand(dockerCli *client.DockerCli) *cobra.Command {
 	return cmd
 }
 
-// Reference return the reference of a node. The special value "self" for a node
+// Reference returns the reference of a node. The special value "self" for a node
 // reference is mapped to the current node, hence the node ID is retrieved using
 // the `/info` endpoint.
 func Reference(client apiclient.APIClient, ctx context.Context, ref string) (string, error) {

--- a/api/client/stack/cmd.go
+++ b/api/client/stack/cmd.go
@@ -29,7 +29,7 @@ func NewStackCommand(dockerCli *client.DockerCli) *cobra.Command {
 	return cmd
 }
 
-// NewTopLevelDeployCommand return a command for `docker deploy`
+// NewTopLevelDeployCommand returns a command for `docker deploy`
 func NewTopLevelDeployCommand(dockerCli *client.DockerCli) *cobra.Command {
 	cmd := newDeployCommand(dockerCli)
 	// Remove the aliases at the top level

--- a/api/client/stack/remove.go
+++ b/api/client/stack/remove.go
@@ -63,6 +63,11 @@ func runRemove(dockerCli *client.DockerCli, opts removeOptions) error {
 		}
 	}
 
+	if len(services) == 0 && len(networks) == 0 {
+		fmt.Fprintf(dockerCli.Out(), "Nothing found in stack: %s\n", namespace)
+		return nil
+	}
+
 	if hasError {
 		return fmt.Errorf("Failed to remove some resources")
 	}

--- a/api/client/stack/tasks.go
+++ b/api/client/stack/tasks.go
@@ -3,6 +3,8 @@
 package stack
 
 import (
+	"fmt"
+
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/client"
@@ -43,6 +45,7 @@ func newTasksCommand(dockerCli *client.DockerCli) *cobra.Command {
 }
 
 func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
+	namespace := opts.namespace
 	client := dockerCli.Client()
 	ctx := context.Background()
 
@@ -56,6 +59,11 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})
 	if err != nil {
 		return err
+	}
+
+	if len(tasks) == 0 {
+		fmt.Fprintf(dockerCli.Out(), "Nothing found in stack: %s\n", namespace)
+		return nil
 	}
 
 	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve))

--- a/integration-cli/docker_cli_stack_test.go
+++ b/integration-cli/docker_cli_stack_test.go
@@ -1,0 +1,28 @@
+// +build experimental
+
+package main
+
+import (
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSwarmSuite) TestStackRemove(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	stackArgs := append([]string{"remove", "UNKNOWN_STACK"})
+
+	out, err := d.Cmd("stack", stackArgs...)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, check.Equals, "Nothing found in stack: UNKNOWN_STACK\n")
+}
+
+func (s *DockerSwarmSuite) TestStackTasks(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	stackArgs := append([]string{"tasks", "UNKNOWN_STACK"})
+
+	out, err := d.Cmd("stack", stackArgs...)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, check.Equals, "Nothing found in stack: UNKNOWN_STACK\n")
+}

--- a/pkg/integration/checker/checker.go
+++ b/pkg/integration/checker/checker.go
@@ -1,4 +1,4 @@
-// Package checker provide Docker specific implementations of the go-check.Checker interface.
+// Package checker provides Docker specific implementations of the go-check.Checker interface.
 package checker
 
 import (


### PR DESCRIPTION
fix #23727 

return err when stack name does not exist

Since there is no stack concept in the docker engine side, so check this in the client side.

As a result, output shows like this:

```
root@10-11-17-53:~/docker/bundles/1.12.0-dev/binary-client# ./docker stack tasks asasas
Nothing found in stack: asasas
root@10-11-17-53:~/docker/bundles/1.12.0-dev/binary-client# ./docker stack rm dsadasdsa
Nothing found in stack: dsadasdsa
```

This PR did:
1. add hint with nothing found in stack in command `docker stack service xxx` and `docker stack remove xxx`
2. add test for stack
3. fix some typos

Signed-off-by: allencloud allen.sun@daocloud.io
