### PR TITLE
Windows: Skip TestBuildEmptyCmd on RS1

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4200,6 +4200,14 @@ func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
+	// Windows Server 2016 RS1 builds load the windowsservercore image from a tar rather than
+	// a .WIM file, and the tar layer has the default CMD set (same as the Linux ubuntu image),
+	// where-as the TP5 .WIM had a blank CMD. Hence this test is not applicable on RS1 or later
+	// builds
+	if daemonPlatform == "windows" && windowsDaemonKV >= 14375 {
+		c.Skip("Not applicable on Windows RS1 or later builds")
+	}
+
 	name := "testbuildemptycmd"
 	if _, err := buildImage(name, "FROM "+minimalBaseImage()+"\nMAINTAINER quux\n", true); err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@tiborvass This test is being disabled for newer versions of Windows as the new .tar layer for the Windows base images have the default cmd set in them (same as the Ubuntu image for example). This is one we should take for 1.12 as CI will fail start failing as soon as we move the CI servers forward (which is imminent). Note there's one other test failure on RS1 which I'm also investigating.
