### PR TITLE
add menu.md, make index.md command line reference, update typos/minor…

### DIFF
--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -1,11 +1,11 @@
 <!-- [metadata]>
 +++
-title = "Command line reference"
+title = "Docker commands"
 description = "Docker's CLI command description and usage"
 keywords = ["Docker, Docker documentation, CLI,  command line"]
 [menu.main]
-identifier= "smn_cli"
-parent = "engine_ref"
+identifier= "smn_cli_guide"
+parent = "smn_cli"
 weight=-70
 +++
 <![end-metadata]-->
@@ -14,103 +14,129 @@ weight=-70
 
 # The Docker commands
 
-This section contains reference information on using Docker's command line client. Each command has a reference page along with samples. If you are unfamiliar with the command line, you should start by reading about how to [Use the Docker command line](cli.md).  
+This section contains reference information on using Docker's command line
+client. Each command has a reference page along with samples. If you are
+unfamiliar with the command line, you should start by reading about how to [Use
+the Docker command line](cli.md).
 
-You start the Docker daemon with the command line. How you start the daemon affects your Docker containers. For that reason you should also make sure to read the [`dockerd`](dockerd.md) reference page.
+You start the Docker daemon with the command line. How you start the daemon
+affects your Docker containers. For that reason you should also make sure to
+read the [`dockerd`](dockerd.md) reference page.
 
 ### Docker management commands
 
-* [dockerd](dockerd.md)
-* [info](info.md)
-* [inspect](inspect.md)
-* [version](version.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [dockerd](dockerd.md) | Launch the Docker daemon                             |
+| [info](info.md) | Display system-wide information                            |
+| [inspect](inspect.md)| Return low-level information on a container or image  |
+| [version](version.md) | Show the Docker version information                  |
+
 
 ### Image commands
 
-* [build](build.md)
-* [commit](commit.md)
-* [export](export.md)
-* [history](history.md)
-* [images](images.md)
-* [import](import.md)
-* [load](load.md)
-* [rmi](rmi.md)
-* [save](save.md)
-* [tag](tag.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [build](build.md) |  Build an image from a Dockerfile                        |
+| [commit](commit.md) | Create a new image from a container's changes          |
+| [export](export.md) | Export a container's filesystem as a tar archive       |
+| [history](history.md) | Show the history of an image                         |
+| [images](images.md) | List images                                            |
+| [import](import.md) | Import the contents from a tarball to create a filesystem image |
+| [load](load.md) | Load an image from a tar archive or STDIN                  |
+| [rmi](rmi.md) | Remove one or more images                                    |
+| [save](save.md) | Save images to a tar archive                               |
+| [tag](tag.md) | Tag an image into a repository                               |
 
 ### Container commands
 
-* [attach](attach.md)
-* [cp](cp.md)
-* [create](create.md)
-* [diff](diff.md)
-* [events](events.md)
-* [exec](exec.md)
-* [kill](kill.md)
-* [logs](logs.md)
-* [pause](pause.md)
-* [port](port.md)
-* [ps](ps.md)
-* [rename](rename.md)
-* [restart](restart.md)
-* [rm](rm.md)
-* [run](run.md)
-* [start](start.md)
-* [stats](stats.md)
-* [stop](stop.md)
-* [top](top.md)
-* [unpause](unpause.md)
-* [update](update.md)
-* [wait](wait.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [attach](attach.md) | Attach to a running container                          |
+| [cp](cp.md) | Copy files/folders from a container to a HOSTDIR or to STDOUT  |
+| [create](create.md) | Create a new container                                 |
+| [diff](diff.md) | Inspect changes on a container's filesystem                |
+| [events](events.md) | Get real time events from the server                   |
+| [exec](exec.md) | Run a command in a running container                       |
+| [kill](kill.md) | Kill a running container                                   |
+| [logs](logs.md) | Fetch the logs of a container                              |
+| [pause](pause.md) | Pause all processes within a container                   |
+| [port](port.md) | List port mappings or a specific mapping for the container |
+| [ps](ps.md) | List containers                                                |
+| [rename](rename.md) | Rename a container                                     |
+| [restart](restart.md) | Restart a running container                          |
+| [rm](rm.md) | Remove one or more containers                                  |
+| [run](run.md) | Run a command in a new container                             |
+| [start](start.md) | Start one or more stopped containers                     |
+| [stats](stats.md) | Display a live stream of container(s) resource usage  statistics |
+| [stop](stop.md) | Stop a running container                                   |
+| [top](top.md) | Display the running processes of a container                 |
+| [unpause](unpause.md) | Unpause all processes within a container             |
+| [update](update.md) | Update configuration of one or more containers         |
+| [wait](wait.md) | Block until a container stops, then print its exit code    |
 
 ### Hub and registry commands
 
-* [login](login.md)
-* [logout](logout.md)
-* [pull](pull.md)
-* [push](push.md)
-* [search](search.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [login](login.md) | Register or log in to a Docker registry                  |
+| [logout](logout.md) | Log out from a Docker registry                         |
+| [pull](pull.md) | Pull an image or a repository from a Docker registry       |
+| [push](push.md) | Push an image or a repository to a Docker registry         |
+| [search](search.md) | Search the Docker Hub for images                       |
 
 ### Network and connectivity commands
 
-* [network_connect](network_connect.md)
-* [network_create](network_create.md)
-* [network_disconnect](network_disconnect.md)
-* [network_inspect](network_inspect.md)
-* [network_ls](network_ls.md)
-* [network_rm](network_rm.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [network connect](network_connect.md) | Connect a container to a network     |
+| [network create](network_create.md) | Create a new network                   |
+| [network disconnect](network_disconnect.md) | Disconnect a container from a network |
+| [network inspect](network_inspect.md) | Display information about a network  |
+| [network ls](network_ls.md) | Lists all the networks the Engine `daemon` knows about |
+| [network rm](network_rm.md) | Removes one or more networks                   |
+
 
 ### Shared data volume commands
 
-* [volume_create](volume_create.md)
-* [volume_inspect](volume_inspect.md)
-* [volume_ls](volume_ls.md)
-* [volume_rm](volume_rm.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [volume create](volume_create.md) | Creates a new volume where containers can consume and store data |
+| [volume inspect](volume_inspect.md) | Display information about a volume     |
+| [volume ls](volume_ls.md) | Lists all the volumes Docker knows about         |
+| [volume rm](volume_rm.md) | Remove one or more volumes                       |
+
 
 ### Swarm node commands
 
-* [node_accept](node_accept.md)
-* [node_promote](node_promote.md)
-* [node_demote](node_demote.md)
-* [node_inspect](node_inspect.md)
-* [node_update](node_update.md)
-* [node_tasks](node_tasks.md)
-* [node_ls](node_ls.md)
-* [node_rm](node_rm.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [node accept](node_accept.md) | Accept a node into the swarm                 |
+| [node promote](node_promote.md) | Promote a node that is pending a promotion to manager |
+| [node demote](node_demote.md) | Demotes an existing manager so that it is no longer a manager |
+| [node inspect](node_inspect.md) | Inspect a node in the swarm                |
+| [node update](node_update.md) | Update attributes for a node                 |
+| [node tasks](node_tasks.md) | List tasks running on a node                   |
+| [node ls](node_ls.md) | List nodes in the swarm                              |
+| [node rm](node_rm.md) | Remove a node from the swarm                         |
 
 ### Swarm swarm commands
 
-* [swarm init](swarm_init.md)
-* [swarm join](swarm_join.md)
-* [swarm leave](swarm_leave.md)
-* [swarm update](swarm_update.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [swarm init](swarm_init.md) | Initialize a Swarm                             |
+| [swarm join](swarm_join.md) | Join a Swarm as a manager node or worker node  |
+| [swarm leave](swarm_leave.md) | Remove the current node from the swarm       |
+| [swarm update](swarm_update.md) | Update attributes of a swarm               |
 
 ### Swarm service commands
 
-* [service create](service_create.md)
-* [service inspect](service_inspect.md)
-* [service ls](service_ls.md)
-* [service rm](service_rm.md)
-* [service scale](service_scale.md)
-* [service tasks](service_tasks.md)
-* [service update](service_update.md)
+| Command | Description                                                        |
+|:--------|:-------------------------------------------------------------------|
+| [service create](service_create.md) | Create a new service                   |
+| [service inspect](service_inspect.md) | Inspect a service                    |
+| [service ls](service_ls.md) | List services in the swarm                     |
+| [service rm](service_rm.md) | Reemove a swervice from the swarm              |
+| [service scale](service_scale.md) | Set the number of replicas for the desired state of the service |
+| [service tasks](service_tasks.md) | List the tasks of a service              |
+| [service update](service_update.md)  | Update the attributes of a service    |

--- a/docs/reference/commandline/menu.md
+++ b/docs/reference/commandline/menu.md
@@ -1,0 +1,26 @@
+<!-- [metadata]>
++++
+title = "Command line reference"
+description = "Docker's CLI command description and usage"
+keywords = ["Docker, Docker documentation, CLI,  command line"]
+[menu.main]
+identifier= "smn_cli"
+parent = "engine_ref"
+weight=-75
++++
+<![end-metadata]-->
+
+
+
+# The Docker commands
+
+This section contains reference information on using Docker's command line
+client. Each command has a reference page along with samples. If you are
+unfamiliar with the command line, you should start by reading about how to
+[Use the Docker command line](cli.md).
+
+You start the Docker daemon with the command line. How you start the daemon
+affects your Docker containers. For that reason you should also make sure to
+read the [`dockerd`](dockerd.md) reference page.
+
+For a list of Docker commands see [Command line reference guide](index.md).

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -12,7 +12,7 @@ parent = "smn_cli"
 
     Usage:  docker network ls [OPTIONS]
 
-    Lists all the networks created by the user
+    List networks
       -f, --filter=[]       Filter output based on conditions provided
       --help                Print usage
       --no-trunc            Do not truncate the output
@@ -35,10 +35,10 @@ Use the `--no-trunc` option to display the full network id:
 ```bash
 docker network ls --no-trunc
 NETWORK ID                                                         NAME                DRIVER
-18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null                
-c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host                host                
-7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185   bridge              bridge              
-95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd   foo                 bridge    
+18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null
+c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host                host
+7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185   bridge              bridge
+95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd   foo                 bridge
 63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge
 ```
 
@@ -46,7 +46,7 @@ c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host         
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
-Multiple filter flags are combined as an `OR` filter. For example, 
+Multiple filter flags are combined as an `OR` filter. For example,
 `-f type=custom -f type=builtin` returns both `custom` and `builtin` networks.
 
 The currently supported filters are:
@@ -105,7 +105,7 @@ The following filter matches networks with the `usage` label regardless of its v
 ```bash
 $ docker network ls -f "label=usage"
 NETWORK ID          NAME                DRIVER
-db9db329f835        test1               bridge              
+db9db329f835        test1               bridge
 f6e212da9dfd        test2               bridge
 ```
 

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -14,7 +14,7 @@ parent = "smn_cli"
 
     Demote a node as manager in the swarm
 
-Demotes an existing Manager so that it is no longer a manager. This command targets a docker engine that is a manager in the swarm cluster.
+Demotes an existing manager so that it is no longer a manager. This command targets a docker engine that is a manager in the swarm cluster.
 
 
 ```bash

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -15,6 +15,7 @@ parent = "smn_cli"
 
     Display detailed information on one or more nodes
 
+
       -f, --format=       Format the output using the given go template.
       --help              Print usage
       -p, --pretty        Print the information in a human friendly format.

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -13,7 +13,7 @@ parent = "smn_cli"
 
     Usage:  docker swarm update [OPTIONS]
 
-    update the Swarm.
+    Update the Swarm.
 
     Options:
           --auto-accept value               Auto acceptance policy (worker, manager or none)


### PR DESCRIPTION
implement menu.md for Engine CLI docs. Put CLI links into a table with short description. correct node_inspect to refer to node instead of volume. Fix minor typos.

Signed-off-by: Charles Smith charles.smith@docker.com
