### PR TITLE
Windows: Skip RunCidFileCleanupIfEmpty on RS1

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2034,6 +2034,14 @@ func (s *DockerSuite) TestRunBindMounts(c *check.C) {
 // Ensure that CIDFile gets deleted if it's empty
 // Perform this test by making `docker run` fail
 func (s *DockerSuite) TestRunCidFileCleanupIfEmpty(c *check.C) {
+	// Windows Server 2016 RS1 builds load the windowsservercore image from a tar rather than
+	// a .WIM file, and the tar layer has the default CMD set (same as the Linux ubuntu image),
+	// where-as the TP5 .WIM had a blank CMD. Hence this test is not applicable on RS1 or later
+	// builds as the command won't fail as it's not blank
+	if daemonPlatform == "windows" && windowsDaemonKV >= 14375 {
+		c.Skip("Not applicable on Windows RS1 or later builds")
+	}
+
 	tmpDir, err := ioutil.TempDir("", "TestRunCidFile")
 	if err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Same deal as https://github.com/docker/docker/pull/24056 due to changes in the Windows base images on RS1. Needed for 1.12 if Windows CI is to continue passing when the CI servers imminently get rolled forward to post TP5 (aka RS1) builds. @tiborvass 
