### PR TITLE
overlay2: close read end of pipe on mount exec

### DIFF
--- a/daemon/graphdriver/overlay2/mount.go
+++ b/daemon/graphdriver/overlay2/mount.go
@@ -32,12 +32,6 @@ type mountOptions struct {
 }
 
 func mountFrom(dir, device, target, mType, label string) error {
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		return fmt.Errorf("mountfrom pipe failure: %v", err)
-	}
-
 	options := &mountOptions{
 		Device: device,
 		Target: target,
@@ -47,7 +41,10 @@ func mountFrom(dir, device, target, mType, label string) error {
 	}
 
 	cmd := reexec.Command("docker-mountfrom", dir)
-	cmd.Stdin = r
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("mountfrom error on pipe creation: %v", err)
+	}
 
 	output := bytes.NewBuffer(nil)
 	cmd.Stdout = output


### PR DESCRIPTION
The read end of the pipe sent to the mount from exec call was left open by the parent causing fd leakage.
The fd eventually got cleaned up by garbage collection but could cause the process to hit the fd limit.

Fixes #23686
