### PR TITLE
Return an empty network list if nothing matches filter

### DIFF
--- a/api/server/router/network/filter.go
+++ b/api/server/router/network/filter.go
@@ -51,7 +51,7 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 		return nil, err
 	}
 
-	var displayNet []types.NetworkResource
+	displayNet := []types.NetworkResource{}
 	for _, nw := range nws {
 		if filter.Include("driver") {
 			if !filter.ExactMatch("driver", nw.Driver) {


### PR DESCRIPTION
Initializing the network list struct in order to return an empty list instead of a nil object 🐹.

Fixes #24063.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
