### PR TITLE
Fix daemon tests.

### DIFF
--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -19,6 +19,15 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithPluginEnabled(c *check.C) {
 		c.Fatalf("Could not install plugin: %v %s", err, out)
 	}
 
+	defer func() {
+		if out, err := s.d.Cmd("plugin", "disable", pluginName); err != nil {
+			c.Fatalf("Could not disable plugin: %v %s", err, out)
+		}
+		if out, err := s.d.Cmd("plugin", "remove", pluginName); err != nil {
+			c.Fatalf("Could not remove plugin: %v %s", err, out)
+		}
+	}()
+
 	if err := s.d.Restart(); err != nil {
 		c.Fatalf("Could not restart daemon: %v", err)
 	}
@@ -40,6 +49,12 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithPluginDisabled(c *check.C) {
 	if out, err := s.d.Cmd("plugin", "install", "--grant-all-permissions", pluginName, "--disable"); err != nil {
 		c.Fatalf("Could not install plugin: %v %s", err, out)
 	}
+
+	defer func() {
+		if out, err := s.d.Cmd("plugin", "remove", pluginName); err != nil {
+			c.Fatalf("Could not remove plugin: %v %s", err, out)
+		}
+	}()
 
 	if err := s.d.Restart(); err != nil {
 		c.Fatalf("Could not restart daemon: %v", err)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2106,6 +2106,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check
 	}
 	cid = strings.TrimSpace(cid)
 
+	pid, err := s.d.Cmd("inspect", "-f", "{{.State.Pid}}", cid)
+	t.Assert(err, check.IsNil)
+	pid = strings.TrimSpace(pid)
+
 	// Kill the daemon
 	if err := s.d.Kill(); err != nil {
 		t.Fatal(err)
@@ -2119,10 +2123,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithKilledRunningContainer(t *check
 
 	// Give time to containerd to process the command if we don't
 	// the exit event might be received after we do the inspect
-	pidCmd := exec.Command("pidof", "top")
+	pidCmd := exec.Command("kill", "-0", pid)
 	_, ec, _ := runCommandWithOutput(pidCmd)
 	for ec == 0 {
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 		_, ec, _ = runCommandWithOutput(pidCmd)
 	}
 
@@ -2200,6 +2204,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *che
 	}
 	cid = strings.TrimSpace(cid)
 
+	pid, err := s.d.Cmd("inspect", "-f", "{{.State.Pid}}", cid)
+	t.Assert(err, check.IsNil)
+	pid = strings.TrimSpace(pid)
+
 	// pause the container
 	if _, err := s.d.Cmd("pause", cid); err != nil {
 		t.Fatal(cid, err)
@@ -2218,10 +2226,10 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithUnpausedRunningContainer(t *che
 
 	// Give time to containerd to process the command if we don't
 	// the resume event might be received after we do the inspect
-	pidCmd := exec.Command("pidof", "top")
+	pidCmd := exec.Command("kill", "-0", pid)
 	_, ec, _ := runCommandWithOutput(pidCmd)
 	for ec == 0 {
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 		_, ec, _ = runCommandWithOutput(pidCmd)
 	}
 


### PR DESCRIPTION
Fix two test issues:
- pidof is not available in PATH on some systems while using Jenkins (rhel, centos).
  Use kill -0 instead.
- Cleanup after plugin test. This is a stop gap fix. The right way to
  fix this, is to shutdown the plugin on daemon shutdown path (except
  for the live-restore case). This will be done in a follow up PR.

Signed-off-by: Anusha Ragunathan anusha@docker.com
