### PR TITLE
Windows: Stack dump to file

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -412,7 +412,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 
 	// set up SIGUSR1 handler on Unix-like systems, or a Win32 global event
 	// on Windows to dump Go routine stacks
-	setupDumpStackTrap()
+	setupDumpStackTrap(config.Root)
 
 	uidMaps, gidMaps, err := setupRemappedRoot(config)
 	if err != nil {

--- a/daemon/debugtrap_unix.go
+++ b/daemon/debugtrap_unix.go
@@ -10,12 +10,12 @@ import (
 	psignal "github.com/docker/docker/pkg/signal"
 )
 
-func setupDumpStackTrap() {
+func setupDumpStackTrap(_ string) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR1)
 	go func() {
 		for range c {
-			psignal.DumpStacks()
+			psignal.DumpStacks("")
 		}
 	}()
 }

--- a/daemon/debugtrap_unsupported.go
+++ b/daemon/debugtrap_unsupported.go
@@ -2,6 +2,6 @@
 
 package daemon
 
-func setupDumpStackTrap() {
+func setupDumpStackTrap(_ string) {
 	return
 }

--- a/daemon/debugtrap_windows.go
+++ b/daemon/debugtrap_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/pkg/system"
 )
 
-func setupDumpStackTrap() {
+func setupDumpStackTrap(root string) {
 	// Windows does not support signals like *nix systems. So instead of
 	// trapping on SIGUSR1 to dump stacks, we wait on a Win32 event to be
 	// signaled.
@@ -23,7 +23,7 @@ func setupDumpStackTrap() {
 			logrus.Debugf("Stackdump - waiting signal at %s", ev)
 			for {
 				syscall.WaitForSingleObject(h, syscall.INFINITE)
-				signal.DumpStacks()
+				signal.DumpStacks(root)
 			}
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This has been causing grief to multiple folks here trying to debug the daemon on Windows :imp:. Time to fix it :smiley_cat:...  On Windows (only), the daemon now always writes the goroutine stack dump to a file, in a format which can be directly `type`d from a command prompt, even if the daemon is running as a Windows service where the logs would otherwise be written to the event log. 

@swernli 
