### PR TITLE
zfs: call mount.MakePrivate

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -99,6 +99,9 @@ func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdri
 		return nil, fmt.Errorf("BUG: zfs get all -t filesystem -rHp '%s' should contain '%s'", options.fsName, options.fsName)
 	}
 
+	if err := mount.MakePrivate(base); err != nil {
+		return nil, err
+	}
 	d := &Driver{
 		dataset:          rootDataset,
 		options:          options,


### PR DESCRIPTION
**\- What I did**
Fix ZFS issue #24008

**\- How I did it**
By calling `mount.MakePrivate` int `zfs.Init()`

**\- How to verify it**
Described in #24008 

```
$ cat > Dockerfile << EOF
FROM debian:jessie
COPY test.txt /test.txt
EOF
$ cat > test.txt << EOF
test
EOF
$ docker build -t timwolla/test .
```

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
