### PR TITLE
make filter networks return [] instead of null when empty

### DIFF
--- a/api/server/router/network/filter.go
+++ b/api/server/router/network/filter.go
@@ -51,7 +51,7 @@ func filterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.N
 		return nil, err
 	}
 
-	var displayNet []types.NetworkResource
+	displayNet := []types.NetworkResource{}
 	for _, nw := range nws {
 		if filter.Include("driver") {
 			if !filter.ExactMatch("driver", nw.Driver) {


### PR DESCRIPTION
fix #24098 

When accessing API /networks with filter options and the response is empty, docker 1.12.0-rc2 and docker 1.11.2 return two different things: `[] and null`.

This PR make it return [] instead of null in docker 1.12.0-rc2 to make it consistent.

Signed-off-by: allencloud allen.sun@daocloud.io
