### PR TITLE
Revert tasksmax workaround to avoid unsupported bins

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -90,16 +90,6 @@ set -e
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN cp -aL hack/make/.build-deb debian
 			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
-		EOF
-		# Remove the following case-based substitution when none of these are supported, and the TasksMax value is uncommented in docker.service
-		case "$version" in
-		debian-jessie|debian-wheezy|ubuntu-precise|ubuntu-trusty|ubuntu-wily)
-			;;
-		*)
-			echo "RUN sed -i -- 's/#TasksMax=infinity/TasksMax=infinity/' contrib/init/systemd/docker.service" >> "$DEST/$version/Dockerfile.build"
-			;;
-		esac
-		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN dpkg-buildpackage -uc -us -I.git
 		EOF
 		tempImage="docker-temp/build-deb:$version"


### PR DESCRIPTION
This PR reverts PR #21628 and does no longer modify the git source tree for any OS until we come up with a better solution setting tasksmax differently for specific OS.

The modification of 21628 while building the binaries for each DEB package result in binaries with the "unsupported" tag if checked with `docker --version` or `docker version`.

**\- What I did**

I compiled all DEB packages with `make deb` for v1.12.0-rc2 and found out that some OS have unsupported binaries. So I reverted that commit that introduced the code change.

**\- How I did it**

```
git clone https://github.com/docker/docker
cd docker
git checkout v1.12.0-rc2
make deb
```

**\- How to verify it**

You can reproduce this problem by installing eg. the 1.12.0-rc2 DEB package on eg. ubuntu:xenial or debian:stretch with `curl -fsSL https://test.docker.com/ | sh`.

```
+ sh -c docker version
Client:
 Version:      1.12.0-rc2
 API version:  1.24
 Go version:   go1.6.2
 Git commit:   906eacd-unsupported
 Built:        Fri Jun 17 21:21:56 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.12.0-rc2
 API version:  1.24
 Go version:   go1.6.2
 Git commit:   906eacd-unsupported
 Built:        Fri Jun 17 21:21:56 2016
 OS/Arch:      linux/amd64

root@ubuntu-xenial:/home/ubuntu# 
```

The same steps with a debian/jessie64 Vagrant box shows clean binaries.

**\- Description for the changelog**

Revert tasksmax hack to avoid unsupported binaries in DEB packages.

**\- A picture of a cute animal (not mandatory but encouraged)**

![flop](https://cloud.githubusercontent.com/assets/207759/16441967/e0a36a90-3dce-11e6-9a06-20fee814ee60.jpg)

(mirrored image of 21628 :-) )

PS: You can't take a shortcut and remove some directories in the contrib/builder/deb/amd64 directory as this also leeds to a git code change and unsupported binaries.
