### PR TITLE
Fixes /swarm/join endpoint documentation

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3663,7 +3663,7 @@ Join an existing new Swarm
 
     {
       "ListenAddr": "0.0.0.0:4500",
-      "RemoteAddr": "node1:4500",
+      "RemoteAddrs": ["node1:4500"],
       "Secret": "",
       "CACertHash": "",
       "Manager": false

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3664,7 +3664,7 @@ Join an existing new Swarm
 
     {
       "ListenAddr": "0.0.0.0:4500",
-      "RemoteAddr": "node1:4500",
+      "RemoteAddrs": ["node1:4500"],
       "Secret": "",
       "CACertHash": "",
       "Manager": false


### PR DESCRIPTION
The JSON payload given in the API documentation is wrong, fixing it 🐮.

Closes #24094 

/cc @thaJeztah @sfsmithcha 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
