### PR TITLE
Fix --filter=desired_state behaviour

### DIFF
--- a/api/client/node/tasks.go
+++ b/api/client/node/tasks.go
@@ -55,7 +55,7 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 
 	filter := opts.filter.Value()
 	filter.Add("node", node.ID)
-	if !opts.all {
+	if !opts.all && !filter.Include("desired_state") {
 		filter.Add("desired_state", string(swarm.TaskStateRunning))
 		filter.Add("desired_state", string(swarm.TaskStateAccepted))
 


### PR DESCRIPTION
Just like `docker service tasks`, we should add `desired_state` filters only in case there is no provided filters 🐈.

I'll add an integration tests at least in a follow-up PR :angel: 

Fixes #24117.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
