### PR TITLE
rename desired_state filter to desired-state

### DIFF
--- a/api/client/node/tasks.go
+++ b/api/client/node/tasks.go
@@ -55,10 +55,9 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 
 	filter := opts.filter.Value()
 	filter.Add("node", node.ID)
-	if !opts.all && !filter.Include("desired_state") {
-		filter.Add("desired_state", string(swarm.TaskStateRunning))
-		filter.Add("desired_state", string(swarm.TaskStateAccepted))
-
+	if !opts.all && !filter.Include("desired-state") {
+		filter.Add("desired-state", string(swarm.TaskStateRunning))
+		filter.Add("desired-state", string(swarm.TaskStateAccepted))
 	}
 
 	tasks, err := client.TaskList(

--- a/api/client/service/tasks.go
+++ b/api/client/service/tasks.go
@@ -51,9 +51,9 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 
 	filter := opts.filter.Value()
 	filter.Add("service", service.ID)
-	if !opts.all && !filter.Include("desired_state") {
-		filter.Add("desired_state", string(swarm.TaskStateRunning))
-		filter.Add("desired_state", string(swarm.TaskStateAccepted))
+	if !opts.all && !filter.Include("desired-state") {
+		filter.Add("desired-state", string(swarm.TaskStateRunning))
+		filter.Add("desired-state", string(swarm.TaskStateAccepted))
 	}
 
 	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})

--- a/api/client/stack/tasks.go
+++ b/api/client/stack/tasks.go
@@ -48,9 +48,9 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 
 	filter := opts.filter.Value()
 	filter.Add("label", labelNamespace+"="+opts.namespace)
-	if !opts.all && !filter.Include("desired_state") {
-		filter.Add("desired_state", string(swarm.TaskStateRunning))
-		filter.Add("desired_state", string(swarm.TaskStateAccepted))
+	if !opts.all && !filter.Include("desired-state") {
+		filter.Add("desired-state", string(swarm.TaskStateRunning))
+		filter.Add("desired-state", string(swarm.TaskStateAccepted))
 	}
 
 	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})

--- a/daemon/cluster/filters.go
+++ b/daemon/cluster/filters.go
@@ -68,7 +68,7 @@ func newListTasksFilters(filter filters.Args) (*swarmapi.ListTasksRequest_Filter
 		"label":         true,
 		"service":       true,
 		"node":          true,
-		"desired_state": true,
+		"desired-state": true,
 	}
 	if err := filter.Validate(accepted); err != nil {
 		return nil, err
@@ -81,11 +81,11 @@ func newListTasksFilters(filter filters.Args) (*swarmapi.ListTasksRequest_Filter
 		NodeIDs:    filter.Get("node"),
 	}
 
-	for _, s := range filter.Get("desired_state") {
+	for _, s := range filter.Get("desired-state") {
 		if state, ok := swarmapi.TaskState_value[strings.ToUpper(s)]; ok {
 			f.DesiredStates = append(f.DesiredStates, swarmapi.TaskState(state))
 		} else if s != "" {
-			return nil, fmt.Errorf("Invalid desired_state filter: '%s'", s)
+			return nil, fmt.Errorf("Invalid desired-state filter: '%s'", s)
 		}
 	}
 

--- a/docs/reference/commandline/node_tasks.md
+++ b/docs/reference/commandline/node_tasks.md
@@ -44,7 +44,7 @@ The currently supported filters are:
 * [name](#name)
 * [id](#id)
 * [label](#label)
-* [desired_state](#desired_state)
+* [desired-state](#desired-state)
 
 #### name
 
@@ -85,9 +85,9 @@ bg8c07zzg87di2mufeq51a2qp  redis.7  redis    redis:3.0.6  Running 9 minutes   Ru
 ```
 
 
-#### desired_state
+#### desired-state
 
-The `desired_state` filter can take the values `running` and `accepted`.
+The `desired-state` filter can take the values `running` and `accepted`.
 
 
 ## Related information

--- a/docs/reference/commandline/service_tasks.md
+++ b/docs/reference/commandline/service_tasks.md
@@ -60,7 +60,7 @@ The currently supported filters are:
 
 * [id](#id)
 * [name](#name)
-* [desired_state](#desired_state)
+* [desired-state](#desired-state)
 
 
 #### ID
@@ -85,9 +85,9 @@ ID                         NAME      SERVICE  IMAGE        DESIRED STATE  LAST S
 ```
 
 
-#### desired_state
+#### desired-state
 
-The `desired_state` filter can take the values `running` and `accepted`.
+The `desired-state` filter can take the values `running` and `accepted`.
 
 
 ## Related information


### PR DESCRIPTION
For consistency with other filters (such as "is-official"), this renames the desired_state filter to "desired-state".

as noted in https://github.com/docker/docker/pull/24120#issuecomment-229407458

this will conflict with https://github.com/docker/docker/pull/24125, once merged
