### PR TITLE
Implement service integration tests

### DIFF
--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/swarm"
 	"github.com/go-check/check"
 )
@@ -129,6 +130,32 @@ func (d *SwarmDaemon) getService(c *check.C, id string) *swarm.Service {
 	c.Assert(json.Unmarshal(out, &service), checker.IsNil)
 	c.Assert(service.ID, checker.Equals, id)
 	return &service
+}
+
+func (d *SwarmDaemon) getServiceTasks(c *check.C, service string) []swarm.Task {
+	var tasks []swarm.Task
+
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("desired-state", "running")
+	filterArgs.Add("service", service)
+	filters, err := filters.ToParam(filterArgs)
+	c.Assert(err, checker.IsNil)
+
+	status, out, err := d.SockRequest("GET", "/tasks?filters="+filters, nil)
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(json.Unmarshal(out, &tasks), checker.IsNil)
+	return tasks
+}
+
+func (d *SwarmDaemon) getTask(c *check.C, id string) swarm.Task {
+	var task swarm.Task
+
+	status, out, err := d.SockRequest("GET", "/tasks/"+id, nil)
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(json.Unmarshal(out, &task), checker.IsNil)
+	return task
 }
 
 func (d *SwarmDaemon) updateService(c *check.C, service *swarm.Service, f ...serviceConstructor) {

--- a/integration-cli/daemon_swarm_hack.go
+++ b/integration-cli/daemon_swarm_hack.go
@@ -1,0 +1,20 @@
+package main
+
+import "github.com/go-check/check"
+
+func (s *DockerSwarmSuite) getDaemon(c *check.C, nodeID string) *SwarmDaemon {
+	s.daemonsLock.Lock()
+	defer s.daemonsLock.Unlock()
+	for _, d := range s.daemons {
+		if d.NodeID == nodeID {
+			return d
+		}
+	}
+	c.Fatalf("could not find node with id: %s", nodeID)
+	return nil
+}
+
+// nodeCmd executes a command on a given node via the normal docker socket
+func (s *DockerSwarmSuite) nodeCmd(c *check.C, id, cmd string, args ...string) (string, error) {
+	return s.getDaemon(c, id).Cmd(cmd, args...)
+}

--- a/integration-cli/docker_cli_service_create_hack_test.go
+++ b/integration-cli/docker_cli_service_create_hack_test.go
@@ -1,0 +1,45 @@
+// +build !windows
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/swarm"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+	out, err := d.Cmd("service", "create", "--mount", "type=volume,source=foo,target=/foo", "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	id := strings.TrimSpace(out)
+
+	var tasks []swarm.Task
+	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
+		tasks = d.getServiceTasks(c, id)
+		return len(tasks) > 0, nil
+	}, checker.Equals, true)
+
+	task := tasks[0]
+	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
+		if task.NodeID == "" || task.Status.ContainerStatus.ContainerID == "" {
+			task = d.getTask(c, task.ID)
+		}
+		return task.NodeID != "" && task.Status.ContainerStatus.ContainerID != "", nil
+	}, checker.Equals, true)
+
+	out, err = s.nodeCmd(c, task.NodeID, "inspect", "--format", "{{json .Mounts}}", task.Status.ContainerStatus.ContainerID)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	var mounts []types.MountPoint
+	c.Assert(json.Unmarshal([]byte(out), &mounts), checker.IsNil)
+	c.Assert(mounts, checker.HasLen, 1)
+
+	c.Assert(mounts[0].Name, checker.Equals, "foo")
+	c.Assert(mounts[0].Destination, checker.Equals, "/foo")
+	c.Assert(mounts[0].RW, checker.Equals, false)
+}


### PR DESCRIPTION
This is done in a hacky way as currently there is no better way (that I know of).
Uses known implementation details about how tasks are scheduled to be
able to operate on the underlying container.

The one test I added is actually exposing a bug (fixed by #23947). Once this is merged we should add more tests to ensure that resulting containers match expectations from a service spec.
I've intentionally put these tests and related helpers into files with `_hack_` in the name so once there is a better way, we can clean these up easily.

I would be worried about releasing 1.12 without more tests like this.
