### PR TITLE
add health check in docker build-in swarm mode

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -2,10 +2,13 @@ package executor
 
 import (
 	"io"
+	"time"
 
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/events"
+	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/libnetwork/cluster"
 	networktypes "github.com/docker/libnetwork/types"
@@ -33,4 +36,6 @@ type Backend interface {
 	SetNetworkBootstrapKeys([]*networktypes.EncryptionKey) error
 	SetClusterProvider(provider cluster.Provider)
 	IsSwarmCompatible() error
+	SubscribeToEvents(since, until time.Time, filter filters.Args) ([]events.Message, chan interface{})
+	UnsubscribeFromEvents(listener chan interface{})
 }

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/docker/reference"
 	"github.com/docker/engine-api/types"
 	enginecontainer "github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/events"
+	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -419,4 +421,12 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 	}
 
 	return clustertypes.NetworkCreateRequest{na.Network.ID, types.NetworkCreateRequest{Name: name, NetworkCreate: options}}, nil
+}
+
+func (c containerConfig) eventFilter() filters.Args {
+	filter := filters.NewArgs()
+	filter.Add("type", events.ContainerEventType)
+	filter.Add("name", c.name())
+	filter.Add("label", fmt.Sprintf("%v.task.id=%v", systemLabelPrefix, c.task.ID))
+	return filter
 }

--- a/daemon/cluster/executor/container/errors.go
+++ b/daemon/cluster/executor/container/errors.go
@@ -9,4 +9,7 @@ var (
 	// ErrContainerDestroyed returned when a container is prematurely destroyed
 	// during a wait call.
 	ErrContainerDestroyed = fmt.Errorf("dockerexec: container destroyed")
+
+	// ErrContainerUnhealthy returned if controller detects the health check failure
+	ErrContainerUnhealthy = fmt.Errorf("dockerexec: unhealthy container")
 )

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -1,0 +1,102 @@
+// +build !windows
+
+package container
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/daemon/events"
+	containertypes "github.com/docker/engine-api/types/container"
+	"github.com/docker/swarmkit/api"
+	"golang.org/x/net/context"
+)
+
+func TestHealthStates(t *testing.T) {
+
+	// set up environment: events, task, container ....
+	e := events.New()
+	_, l, _ := e.Subscribe()
+	defer e.Evict(l)
+
+	task := &api.Task{
+		ID:        "id",
+		ServiceID: "sid",
+		Spec: api.TaskSpec{
+			Runtime: &api.TaskSpec_Container{
+				Container: &api.ContainerSpec{
+					Image: "image_name",
+					Labels: map[string]string{
+						"com.docker.swarm.task.id": "id",
+					},
+				},
+			},
+		},
+		Annotations: api.Annotations{Name: "name"},
+	}
+
+	c := &container.Container{
+		CommonContainer: container.CommonContainer{
+			ID:   "id",
+			Name: "name",
+			Config: &containertypes.Config{
+				Image: "image_name",
+				Labels: map[string]string{
+					"com.docker.swarm.task.id": "id",
+				},
+			},
+		},
+	}
+
+	daemon := &daemon.Daemon{
+		EventsService: e,
+	}
+
+	controller, err := newController(daemon, task)
+	if err != nil {
+		t.Fatalf("create controller fail %v", err)
+	}
+
+	errChan := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// fire checkHealth
+	go func() {
+		err := controller.checkHealth(ctx)
+		select {
+		case errChan <- err:
+		case <-ctx.Done():
+		}
+	}()
+
+	// send an event and expect to get expectedErr
+	// if expectedErr is nil, shouldn't get any error
+	logAndExpect := func(msg string, expectedErr error) {
+		daemon.LogContainerEvent(c, msg)
+
+		timer := time.NewTimer(1 * time.Second)
+		defer timer.Stop()
+
+		select {
+		case err := <-errChan:
+			if err != expectedErr {
+				t.Fatalf("expect error %v, but get %v", expectedErr, err)
+			}
+		case <-timer.C:
+			if expectedErr != nil {
+				t.Fatalf("time limit exceeded, didn't get expected error")
+			}
+		}
+	}
+
+	// events that are ignored by checkHealth
+	logAndExpect("health_status: running", nil)
+	logAndExpect("health_status: healthy", nil)
+	logAndExpect("die", nil)
+
+	// unhealthy event will be caught by checkHealth
+	logAndExpect("health_status: unhealthy", ErrContainerUnhealthy)
+}


### PR DESCRIPTION
The approach is to listen on the event queue to monitor container's status. When unhealthy container is detected, it will be shutdown. And corresponding Error is returned to upper layer.

`SubscribeToEvents` is introduced to backend to implement `adapter.events`

@dongluochen @tonistiigi @stevvooe 
Signed-off-by: runshenzhu runshen.zhu@gmail.com
