### PR TITLE
Make docker daemon and init script agree on pidfile location

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -22,9 +22,9 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-prog="dockerd"
+prog="docker"
 unshare=/usr/bin/unshare
-exec="/usr/bin/$prog"
+exec="/usr/bin/dockerd"
 pidfile="/var/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"
 logfile="/var/log/$prog"


### PR DESCRIPTION
**\- What I did**
Made docker daemon and init script agree on pidfile location

**\- How I did it**
Since the docker daemon has been renamed to dockerd, the init script now looks for
the pid file at /var/run/dockerd.pid, however, the docker daemon still writes the
pid file to /var/run/docker.pid by default so the init script thinks it fails to
start and cannot stop the service either.

This change makes the init script pass the --pidfile option to the docker daemon,
so the daemon and init script will always agree on the pid file location.

**\- How to verify it**
1. Build and install version 1.12.0-rc2 of the docker RPM for CentOS 6. (Also configure the prereqs for CentOS 6 installation: update kernel, iptables, etc)
2. Attempt to start the service, note that it times out and fails, but the service started successfully
3. Apply this patch, repeat previous steps, notice that the service starts and stops successfully.

**\- Description for the changelog**
Made docker daemon and init script agree on pidfile location now that the name of the daemon is dockerd.

Signed-off-by: Paul Furtado paulfurtado91@gmail.com
