### PR TITLE
Syslog Driver: RFC 5425 Message Framing should be used only when protocol is TCP+TLS

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -105,7 +105,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		return nil, err
 	}
 
-	syslogFormatter, syslogFramer, err := parseLogFormat(ctx.Config["syslog-format"])
+	syslogFormatter, syslogFramer, err := parseLogFormat(ctx.Config["syslog-format"], proto)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 	if _, err := parseFacility(cfg["syslog-facility"]); err != nil {
 		return err
 	}
-	if _, _, err := parseLogFormat(cfg["syslog-format"]); err != nil {
+	if _, _, err := parseLogFormat(cfg["syslog-format"], ""); err != nil {
 		return err
 	}
 	return nil
@@ -241,16 +241,22 @@ func parseTLSConfig(cfg map[string]string) (*tls.Config, error) {
 	return tlsconfig.Client(opts)
 }
 
-func parseLogFormat(logFormat string) (syslog.Formatter, syslog.Framer, error) {
+func parseLogFormat(logFormat, proto string) (syslog.Formatter, syslog.Framer, error) {
 	switch logFormat {
 	case "":
 		return syslog.UnixFormatter, syslog.DefaultFramer, nil
 	case "rfc3164":
 		return syslog.RFC3164Formatter, syslog.DefaultFramer, nil
 	case "rfc5424":
-		return rfc5424formatterWithAppNameAsTag, syslog.RFC5425MessageLengthFramer, nil
+		if proto == secureProto {
+			return rfc5424formatterWithAppNameAsTag, syslog.RFC5425MessageLengthFramer, nil
+		}
+		return rfc5424formatterWithAppNameAsTag, syslog.DefaultFramer, nil
 	case "rfc5424micro":
-		return rfc5424microformatterWithAppNameAsTag, syslog.RFC5425MessageLengthFramer, nil
+		if proto == secureProto {
+			return rfc5424microformatterWithAppNameAsTag, syslog.RFC5425MessageLengthFramer, nil
+		}
+		return rfc5424microformatterWithAppNameAsTag, syslog.DefaultFramer, nil
 	default:
 		return nil, nil, errors.New("Invalid syslog format")
 	}

--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -13,31 +13,43 @@ func functionMatches(expectedFun interface{}, actualFun interface{}) bool {
 }
 
 func TestParseLogFormat(t *testing.T) {
-	formatter, framer, err := parseLogFormat("rfc5424")
+	formatter, framer, err := parseLogFormat("rfc5424", "udp")
+	if err != nil || !functionMatches(rfc5424formatterWithAppNameAsTag, formatter) ||
+		!functionMatches(syslog.DefaultFramer, framer) {
+		t.Fatal("Failed to parse rfc5424 format", err, formatter, framer)
+	}
+
+	formatter, framer, err = parseLogFormat("rfc5424", "tcp+tls")
 	if err != nil || !functionMatches(rfc5424formatterWithAppNameAsTag, formatter) ||
 		!functionMatches(syslog.RFC5425MessageLengthFramer, framer) {
 		t.Fatal("Failed to parse rfc5424 format", err, formatter, framer)
 	}
 
-	formatter, framer, err = parseLogFormat("rfc5424micro")
+	formatter, framer, err = parseLogFormat("rfc5424micro", "udp")
+	if err != nil || !functionMatches(rfc5424microformatterWithAppNameAsTag, formatter) ||
+		!functionMatches(syslog.DefaultFramer, framer) {
+		t.Fatal("Failed to parse rfc5424 (microsecond) format", err, formatter, framer)
+	}
+
+	formatter, framer, err = parseLogFormat("rfc5424micro", "tcp+tls")
 	if err != nil || !functionMatches(rfc5424microformatterWithAppNameAsTag, formatter) ||
 		!functionMatches(syslog.RFC5425MessageLengthFramer, framer) {
 		t.Fatal("Failed to parse rfc5424 (microsecond) format", err, formatter, framer)
 	}
 
-	formatter, framer, err = parseLogFormat("rfc3164")
+	formatter, framer, err = parseLogFormat("rfc3164", "")
 	if err != nil || !functionMatches(syslog.RFC3164Formatter, formatter) ||
 		!functionMatches(syslog.DefaultFramer, framer) {
 		t.Fatal("Failed to parse rfc3164 format", err, formatter, framer)
 	}
 
-	formatter, framer, err = parseLogFormat("")
+	formatter, framer, err = parseLogFormat("", "")
 	if err != nil || !functionMatches(syslog.UnixFormatter, formatter) ||
 		!functionMatches(syslog.DefaultFramer, framer) {
 		t.Fatal("Failed to parse empty format", err, formatter, framer)
 	}
 
-	formatter, framer, err = parseLogFormat("invalid")
+	formatter, framer, err = parseLogFormat("invalid", "")
 	if err == nil {
 		t.Fatal("Failed to parse invalid format", err, formatter, framer)
 	}


### PR DESCRIPTION
The current Syslog Driver, when using RFC 5424, inserts the Syslog message length at the first field of the Syslog Header. This message length is not part of [RFC 5424](https://tools.ietf.org/html/rfc5424#section-6), it is part of [RFC 5425](https://tools.ietf.org/html/rfc5425#section-4.3), and therefore, it should only be inserted when the Syslog protocol is `TLS`.

**\- What I did**
Use [RFC 5425 Message Framing](https://tools.ietf.org/html/rfc5425#section-4.3.1) only when protocol is TCP+TLS.

**\- How I did it**
Use the appropriate [Syslog Message Framer](https://github.com/RackSec/srslog/blob/master/framer.go) based on the Syslog protocol used.

**\- How to verify it**
1. Apply this patch and build the binaries.
2. Start the daemon and run a container using the syslog log driver: `--log-driver=syslog --log-opt syslog-address=tcp://<syslog address>:<syslog port> --log-opt syslog-format=rfc5424`.
3. Using a packet analyzer, check that the 1st field of the syslog message is the priority (`<priority>`) and not the message length.

**\- Description for the changelog**
Syslog Driver: RFC 5425 Message Framing should be used only when protocol is TCP+TLS

Signed-off-by: Ferran Rodenas frodenas@gmail.com
