### PR TITLE
Windows: Clear volume path for Hyper-V containers

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -81,6 +81,7 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 	}
 
 	if spec.Windows.HvRuntime != nil {
+		configuration.VolumePath = "" // Always empty for Hyper-V containers
 		configuration.HvPartition = true
 		configuration.HvRuntime = &hcsshim.HvRuntime{
 			ImagePath: spec.Windows.HvRuntime.ImagePath,


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Found internally, the following sequence was failing on the `start`. This probably should meet the 1.12 bar for cherry-picking.

```
docker run --isolation=hyperv --name test nanoserver ipconfig
docker commit test blah
docker start test
```

Fixes internal bug 8035051. 

Note writing a regression test is not possible currently as it only affects Hyper-V containers, and it's not possible to run anything except Windows Server containers under the current CI infrastructure.

@swernli.
