### PR TITLE
Use HOSTNAME in the output of `docker node ls`

### DIFF
--- a/api/client/node/list.go
+++ b/api/client/node/list.go
@@ -74,15 +74,11 @@ func printTable(out io.Writer, nodes []swarm.Node, info types.Info) {
 	// Ignore flushing errors
 	defer writer.Flush()
 
-	fmt.Fprintf(writer, listItemFmt, "ID", "NAME", "MEMBERSHIP", "STATUS", "AVAILABILITY", "MANAGER STATUS")
+	fmt.Fprintf(writer, listItemFmt, "ID", "HOSTNAME", "MEMBERSHIP", "STATUS", "AVAILABILITY", "MANAGER STATUS")
 	for _, node := range nodes {
-		name := node.Spec.Name
+		name := node.Description.Hostname
 		availability := string(node.Spec.Availability)
 		membership := string(node.Spec.Membership)
-
-		if name == "" {
-			name = node.Description.Hostname
-		}
 
 		reachability := ""
 		if node.ManagerStatus != nil {

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/pkg/integration/checker"
@@ -157,4 +158,14 @@ func (s *DockerSwarmSuite) TestSwarmIncompatibleDaemon(c *check.C) {
 	c.Assert(string(content), checker.Contains, "--live-restore daemon configuration is incompatible with swarm mode")
 	// restart for teardown
 	c.Assert(d.Start(), checker.IsNil)
+}
+
+// Test case for #24090
+func (s *DockerSwarmSuite) TestSwarmNodeListHostname(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	// The first line should contain "HOSTNAME"
+	out, err := d.Cmd("node", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.Split(out, "\n")[0], checker.Contains, "HOSTNAME")
 }


### PR DESCRIPTION
**\- What I did**

This fix tries to address an issue raised in #24090 where the title field of `docker node ls` use NAME instead of HOSTNAME. Yet the content of this field is actually hostname.

**\- How I did it**

The fix makes needed changes for the output of `docker node ls`.

**\- How to verify it**

An additional test has been added to cover the change in this fix.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #24090.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
