### PR TITLE
Allow plugins to have multiple handlers

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	"github.com/docker/docker/errors"
+	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/network"
@@ -333,6 +334,11 @@ func (daemon *Daemon) GetNetworkDriverList() map[string]bool {
 	}
 	// TODO : Replace this with proper libnetwork API
 	pluginList["overlay"] = true
+
+	remotes, _ := plugins.GetAll("NetworkDriver")
+	for _, remote := range remotes {
+		pluginList[remote.Name()] = true
+	}
 
 	return pluginList
 }

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -727,6 +727,21 @@ func (s *DockerNetworkSuite) TestDockerNetworkDriverOptions(c *check.C) {
 
 }
 
+func (s *DockerNetworkSuite) TestDockerNetworkDriverInfo(c *check.C) {
+	dockerCmd(c, "network", "create", "-d", dummyNetworkDriver, "testinfo")
+	assertNwIsAvailable(c, "testinfo")
+
+	out, _ := dockerCmd(c, "info")
+	temp := strings.Split(out, "\n")
+	for _, s := range temp {
+		if strings.HasPrefix(strings.TrimSpace(s), "Network:") {
+			c.Assert(s, checker.Contains, dummyNetworkDriver)
+			return
+		}
+	}
+	c.Error("Failed to match on plugin name in docker info")
+
+}
 func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *check.C) {
 	testRequires(c, ExecSupport)
 	// On default bridge network built-in service discovery should not happen


### PR DESCRIPTION
Currently the plugins pkg allows a single handler. This assumption breaks down if there are mutiple listeners to a plugin of a certain Manifest such as NetworkDriver or IpamDriver when swarm-mode is enabled.

Fixes https://github.com/docker/docker/issues/23990

Signed-off-by: Madhu Venugopal madhu@docker.com
