### PR TITLE
Allow service and node filter to be name in `tasks` subcommands 

### DIFF
--- a/api/client/node/cmd.go
+++ b/api/client/node/cmd.go
@@ -35,9 +35,10 @@ func NewNodeCommand(dockerCli *client.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func nodeReference(client apiclient.APIClient, ctx context.Context, ref string) (string, error) {
-	// The special value "self" for a node reference is mapped to the current
-	// node, hence the node ID is retrieved using the `/info` endpoint.
+// Reference return the reference of a node. The special value "self" for a node
+// reference is mapped to the current node, hence the node ID is retrieved using
+// the `/info` endpoint.
+func Reference(client apiclient.APIClient, ctx context.Context, ref string) (string, error) {
 	if ref == "self" {
 		info, err := client.Info(ctx)
 		if err != nil {

--- a/api/client/node/inspect.go
+++ b/api/client/node/inspect.go
@@ -45,7 +45,7 @@ func runInspect(dockerCli *client.DockerCli, opts inspectOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 	getRef := func(ref string) (interface{}, []byte, error) {
-		nodeRef, err := nodeReference(client, ctx, ref)
+		nodeRef, err := Reference(client, ctx, ref)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/api/client/node/tasks.go
+++ b/api/client/node/tasks.go
@@ -44,7 +44,7 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 
-	nodeRef, err := nodeReference(client, ctx, opts.nodeID)
+	nodeRef, err := Reference(client, ctx, opts.nodeID)
 	if err != nil {
 		return nil
 	}

--- a/api/client/service/tasks.go
+++ b/api/client/service/tasks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/api/client/idresolver"
+	"github.com/docker/docker/api/client/node"
 	"github.com/docker/docker/api/client/task"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
@@ -54,6 +55,18 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 	if !opts.all && !filter.Include("desired_state") {
 		filter.Add("desired_state", string(swarm.TaskStateRunning))
 		filter.Add("desired_state", string(swarm.TaskStateAccepted))
+	}
+
+	if filter.Include("node") {
+		nodeFilters := filter.Get("node")
+		for _, nodeFilter := range nodeFilters {
+			nodeReference, err := node.Reference(client, ctx, nodeFilter)
+			if err != nil {
+				return err
+			}
+			filter.Del("node", nodeFilter)
+			filter.Add("node", nodeReference)
+		}
 	}
 
 	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})

--- a/daemon/cluster/filters.go
+++ b/daemon/cluster/filters.go
@@ -61,7 +61,7 @@ func newListServicesFilters(filter filters.Args) (*swarmapi.ListServicesRequest_
 	}, nil
 }
 
-func newListTasksFilters(filter filters.Args) (*swarmapi.ListTasksRequest_Filters, error) {
+func newListTasksFilters(filter filters.Args, transformFunc func(filters.Args) error) (*swarmapi.ListTasksRequest_Filters, error) {
 	accepted := map[string]bool{
 		"name":          true,
 		"id":            true,
@@ -72,6 +72,11 @@ func newListTasksFilters(filter filters.Args) (*swarmapi.ListTasksRequest_Filter
 	}
 	if err := filter.Validate(accepted); err != nil {
 		return nil, err
+	}
+	if transformFunc != nil {
+		if err := transformFunc(filter); err != nil {
+			return nil, err
+		}
 	}
 	f := &swarmapi.ListTasksRequest_Filters{
 		Names:      filter.Get("name"),


### PR DESCRIPTION
Allow service and node filter to be name on `docker node tasks` and `docker service tasks` commands 🐅.

This changes is mainly server-side (between engine api and swarmkit). There is just a check in `api/client/service/tasks.go` to handle the special _self_ meaning.

This is an attempt to _partly_ fix #24163 and #24165 (it just _misses_ partial names, but this would require changes in `swarmkit` I think 🐳).

This is an alternative to a _client-side only_ change (see https://github.com/docker/docker/compare/master...vdemeester:tasks-filter-service-node-by-name).

/cc @aaronlehmann @cpuguy83 @stevvooe 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
