### PR TITLE
Support `-v` syntax on `service create`

### DIFF
--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -93,7 +93,7 @@ func (c *containerConfig) volumes() map[string]struct{} {
 
 	for _, mount := range c.spec().Mounts {
 		// pick off all the volume mounts.
-		if mount.Type != api.MountTypeVolume {
+		if mount.Type != api.MountTypeVolume || mount.Source != "" {
 			continue
 		}
 
@@ -165,7 +165,7 @@ func (c *containerConfig) bindMounts() []string {
 
 	for _, val := range c.spec().Mounts {
 		mask := getMountMask(&val)
-		if val.Type == api.MountTypeBind {
+		if val.Type == api.MountTypeBind || (val.Type == api.MountTypeVolume && val.Source != "") {
 			r = append(r, fmt.Sprintf("%s:%s:%s", val.Source, val.Target, mask))
 		}
 	}

--- a/pkg/multiplatform/path_test.go
+++ b/pkg/multiplatform/path_test.go
@@ -1,0 +1,25 @@
+package multiplatform
+
+import "testing"
+
+func TestIsAbsWindows(t *testing.T) {
+	if !IsAbsWindows(`c:\windows`) {
+		t.Fatal("windows path not abs")
+	}
+}
+
+func TestIsAbsUnix(t *testing.T) {
+	if !IsAbsUnix("/foo") {
+		t.Fatal("unix path not abs")
+	}
+}
+
+func TestVolumeNameWindows(t *testing.T) {
+	if VolumeNameWindows(`c:\windows`) != "c:" {
+		t.Fatal("no volume name")
+	}
+
+	if VolumeNameWindows("/foo") != "" {
+		t.Fatal("got volume name")
+	}
+}

--- a/pkg/multiplatform/unix_path.go
+++ b/pkg/multiplatform/unix_path.go
@@ -1,0 +1,9 @@
+package multiplatform
+
+import "strings"
+
+// IsAbsUnix reports whether the path is absolute.
+// This is taken from path/filepath
+func IsAbsUnix(path string) bool {
+	return strings.HasPrefix(path, "/")
+}

--- a/pkg/multiplatform/windows_path.go
+++ b/pkg/multiplatform/windows_path.go
@@ -1,0 +1,61 @@
+package multiplatform
+
+// volumeNameLenWindows returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+func volumeNameLenWindows(path string) int {
+	if len(path) < 2 {
+		return 0
+	}
+	// with drive letter
+	c := path[0]
+	if path[1] == ':' && ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z') {
+		return 2
+	}
+	// is it UNC
+	if l := len(path); l >= 5 && isSlash(path[0]) && isSlash(path[1]) &&
+		!isSlash(path[2]) && path[2] != '.' {
+		// first, leading `\\` and next shouldn't be `\`. its server name.
+		for n := 3; n < l-1; n++ {
+			// second, next '\' shouldn't be repeated.
+			if isSlash(path[n]) {
+				n++
+				// third, following something characters. its share name.
+				if !isSlash(path[n]) {
+					if path[n] == '.' {
+						break
+					}
+					for ; n < l; n++ {
+						if isSlash(path[n]) {
+							break
+						}
+					}
+					return n
+				}
+				break
+			}
+		}
+	}
+	return 0
+}
+
+// IsAbsWindows reports whether the path is absolute.
+func IsAbsWindows(path string) (b bool) {
+	l := volumeNameLenWindows(path)
+	if l == 0 {
+		return false
+	}
+	path = path[l:]
+	if path == "" {
+		return false
+	}
+	return isSlash(path[0])
+}
+
+func isSlash(c uint8) bool {
+	return c == '\\' || c == '/'
+}
+
+// VolumeNameWindows returns leading volume name
+func VolumeNameWindows(path string) string {
+	return path[:volumeNameLenWindows(path)]
+}


### PR DESCRIPTION
Also fixes issue with all volume mounts going into the container's
`config.Volumes`, which should only be used for anonymous volumes (all
others need to go into HostConfig.Bind).

Copies platform specific path parsing for Windows and Unix into a new
`multiplatform` package which the parser can use on any platform rather
than just the platform it was compiled for.

Parses the raw `-v` string in multiple phases using the multiplatform
parsing for each section.

ping @tiborvass @stevvooe @aaronlehmann 
Closes #23947
