### PR TITLE
Add environment variable to ignore proxy settings

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -250,6 +250,9 @@ func newHTTPClient(host string, tlsOptions *tlsconfig.Options) (*http.Client, er
 	tr := &http.Transport{
 		TLSClientConfig: config,
 	}
+	if tmpStr := os.Getenv("DOCKER_DISABLE_PROXY"); tmpStr != "" {
+		tr.Proxy = nil
+	}
 	proto, addr, _, err := client.ParseHost(host)
 	if err != nil {
 		return nil, err

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -52,6 +52,7 @@ by the `docker` command line:
 * `DOCKER_CONTENT_TRUST_SERVER` The URL of the Notary server to use. This defaults
   to the same URL as the registry.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
+* `DOCKER_DISABLE_PROXY` Ignores proxy environment variables.
 
 Because Docker is developed using 'Go', you can also use any environment
 variables used by the 'Go' runtime. In particular, you may find these useful:


### PR DESCRIPTION
Add `DOCKER_DISABLE_PROXY` environment variable to ignore completely the proxy environment variables when using Docker CLI.
Useful for environments where your local applications may need proxy, but you need to manage a segmented docker environment. Unfortunately you can't specify network segments in `NO_PROXY` environment variable.

Signed-off-by: Denis Volpato Martins denisvm@gmail.com
