### PR TITLE
Windows: Added processor count option

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -86,11 +86,13 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	if c.HostConfig.NanoCPUs > 0 {
 		cpuPercent = uint8(c.HostConfig.NanoCPUs * 100 / int64(sysinfo.NumCPU()) / 1e9)
 	}
+	cpuCount := uint64(c.HostConfig.CPUCount)
 	memoryLimit := uint64(c.HostConfig.Memory)
 	s.Windows.Resources = &specs.WindowsResources{
 		CPU: &specs.WindowsCPUResources{
 			Percent: &cpuPercent,
 			Shares:  &cpuShares,
+			Count:   &cpuCount,
 		},
 		Memory: &specs.WindowsMemoryResources{
 			Limit: &memoryLimit,

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -166,6 +166,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /nodes` and `GET /node/(id or name)` now return `Addr` as part of a node's `Status`, which is the address that that node connects to the manager from.
 * The `HostConfig` field now includes `NanoCPUs` that represents CPU quota in units of 10<sup>-9</sup> CPUs.
 * `GET /info` now returns more structured information about security options.
+* The `HostConfig` field now includes `CpuCount` that represents the number of CPUs available for execution by the container. Windows daemon only.
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -303,6 +303,7 @@ Create a container
              "MemoryReservation": 0,
              "KernelMemory": 0,
              "NanoCPUs": 500000,
+             "CpuCount": 4,
              "CpuPercent": 80,
              "CpuShares": 512,
              "CpuPeriod": 100000,
@@ -427,7 +428,14 @@ Create a container
     -   **MemoryReservation** - Memory soft limit in bytes.
     -   **KernelMemory** - Kernel memory limit in bytes.
     -   **NanoCPUs** - CPU quota in units of 10<sup>-9</sup> CPUs.
-    -   **CpuPercent** - An integer value containing the usable percentage of the available CPUs. (Windows daemon only)
+    -   **CpuCount** - An integer value containing the number of usable CPUs.
+          Windows daemon only. On Windows Server containers,
+          the processor resource controls are mutually exclusive, the order of precedence
+          is CPUCount first, then CPUShares, and CPUPercent last.
+    -   **CpuPercent** - An integer value containing the usable percentage of
+          the available CPUs. Windows daemon only. On Windows Server containers,
+          the processor resource controls are mutually exclusive, the order of precedence
+          is CPUCount first, then CPUShares, and CPUPercent last.
     -   **CpuShares** - An integer value containing the container's CPU Shares
           (ie. the relative weight vs other containers).
     -   **CpuPeriod** - The length of a CPU period in microseconds.
@@ -623,6 +631,7 @@ Return low-level information on the container `id`
 			"ContainerIDFile": "",
 			"CpusetCpus": "",
 			"CpusetMems": "",
+			"CpuCount": 4,
 			"CpuPercent": 80,
 			"CpuShares": 0,
 			"CpuPeriod": 100000,

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -31,6 +31,9 @@ Options:
       --cap-drop value              Drop Linux capabilities (default [])
       --cgroup-parent string        Optional parent cgroup for the container
       --cidfile string              Write the container ID to the file
+      --cpu-count int               The number of CPUs available for execution by the container.
+                                    Windows daemon only. On Windows Server containers, this is
+                                    approximated as a percentage of total CPU usage.
       --cpu-percent int             CPU percent (Windows only)
       --cpu-period int              Limit CPU CFS (Completely Fair Scheduler) period
       --cpu-quota int               Limit CPU CFS (Completely Fair Scheduler) quota

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -29,7 +29,14 @@ Options:
       --cap-drop value              Drop Linux capabilities (default [])
       --cgroup-parent string        Optional parent cgroup for the container
       --cidfile string              Write the container ID to the file
-      --cpu-percent int             CPU percent (Windows only)
+      --cpu-count int               The number of CPUs available for execution by the container.
+                                    Windows daemon only. On Windows Server containers, this is
+                                    approximated as a percentage of total CPU usage.
+      --cpu-percent int             Limit percentage of CPU available for execution
+                                    by the container. Windows daemon only.
+                                    The processor resource controls are mutually
+                                    exclusive, the order of precedence is CPUCount
+                                    first, then CPUShares, and CPUPercent last.
       --cpu-period int              Limit CPU CFS (Completely Fair Scheduler) period
       --cpu-quota int               Limit CPU CFS (Completely Fair Scheduler) quota
   -c, --cpu-shares int              CPU shares (relative weight)

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -218,6 +218,18 @@ var (
 		},
 		"Test requires containers are not pausable.",
 	}
+	IsolationIsHyperv = testRequirement{
+		func() bool {
+			return daemonPlatform == "windows" && isolation == "hyperv"
+		},
+		"Test requires a Windows daemon running default isolation mode of hyperv.",
+	}
+	IsolationIsProcess = testRequirement{
+		func() bool {
+			return daemonPlatform == "windows" && isolation == "process"
+		},
+		"Test requires a Windows daemon running default isolation mode of process.",
+	}
 )
 
 // testRequires checks if the environment satisfies the requirements

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -110,6 +110,9 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 
 	if spec.Windows.Resources != nil {
 		if spec.Windows.Resources.CPU != nil {
+			if spec.Windows.Resources.CPU.Count != nil {
+				configuration.ProcessorCount = uint32(*spec.Windows.Resources.CPU.Count)
+			}
 			if spec.Windows.Resources.CPU.Shares != nil {
 				configuration.ProcessorWeight = uint64(*spec.Windows.Resources.CPU.Shares)
 			}

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -15,6 +15,8 @@ docker-create - Create a new container
 [**--cap-drop**[=*[]*]]
 [**--cgroup-parent**[=*CGROUP-PATH*]]
 [**--cidfile**[=*CIDFILE*]]
+[**--cpu-count**[=*0*]]
+[**--cpu-percent**[=*0*]]
 [**--cpu-period**[=*0*]]
 [**--cpu-quota**[=*0*]]
 [**--cpu-rt-period**[=*0*]]
@@ -123,6 +125,18 @@ The initial status of the container created with **docker create** is 'created'.
 
 **--cidfile**=""
    Write the container ID to the file
+
+**--cpu-count**=*0*
+    Limit the number of CPUs available for execution by the container.
+    
+    On Windows Server containers, this is approximated as a percentage of total CPU usage.
+
+    On Windows Server containers, the processor resource controls are mutually exclusive, the order of precedence is CPUCount first, then CPUShares, and CPUPercent last.
+
+**--cpu-percent**=*0*
+    Limit the percentage of CPU available for execution by a container running on a Windows daemon.
+
+    On Windows Server containers, the processor resource controls are mutually exclusive, the order of precedence is CPUCount first, then CPUShares, and CPUPercent last.
 
 **--cpu-period**=*0*
     Limit the CPU CFS (Completely Fair Scheduler) period

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -15,6 +15,8 @@ docker-run - Run a command in a new container
 [**--cap-drop**[=*[]*]]
 [**--cgroup-parent**[=*CGROUP-PATH*]]
 [**--cidfile**[=*CIDFILE*]]
+[**--cpu-count**[=*0*]]
+[**--cpu-percent**[=*0*]]
 [**--cpu-period**[=*0*]]
 [**--cpu-quota**[=*0*]]
 [**--cpu-rt-period**[=*0*]]
@@ -173,6 +175,18 @@ division of CPU shares:
 
 **--cidfile**=""
    Write the container ID to the file
+
+**--cpu-count**=*0*
+    Limit the number of CPUs available for execution by the container.
+    
+    On Windows Server containers, this is approximated as a percentage of total CPU usage.
+
+    On Windows Server containers, the processor resource controls are mutually exclusive, the order of precedence is CPUCount first, then CPUShares, and CPUPercent last.
+
+**--cpu-percent**=*0*
+    Limit the percentage of CPU available for execution by a container running on a Windows daemon.
+
+    On Windows Server containers, the processor resource controls are mutually exclusive, the order of precedence is CPUCount first, then CPUShares, and CPUPercent last.
 
 **--cpu-period**=*0*
    Limit the CPU CFS (Completely Fair Scheduler) period

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -73,6 +73,7 @@ type ContainerOptions struct {
 	kernelMemory       string
 	user               string
 	workingDir         string
+	cpuCount           int64
 	cpuShares          int64
 	cpuPercent         int64
 	cpuPeriod          int64
@@ -227,6 +228,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.StringVar(&copts.containerIDFile, "cidfile", "", "Write the container ID to the file")
 	flags.StringVar(&copts.cpusetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	flags.StringVar(&copts.cpusetMems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
+	flags.Int64Var(&copts.cpuCount, "cpu-count", 0, "CPU count (Windows only)")
 	flags.Int64Var(&copts.cpuPercent, "cpu-percent", 0, "CPU percent (Windows only)")
 	flags.Int64Var(&copts.cpuPeriod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period")
 	flags.Int64Var(&copts.cpuQuota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
@@ -529,6 +531,7 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		KernelMemory:         kernelMemory,
 		OomKillDisable:       &copts.oomKillDisable,
 		NanoCPUs:             copts.cpus.Value(),
+		CPUCount:             copts.cpuCount,
 		CPUPercent:           copts.cpuPercent,
 		CPUShares:            copts.cpuShares,
 		CPUPeriod:            copts.cpuPeriod,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Added --cpu-count flag to set the number of CPUs available to the container on Windows daemons

**\- How to verify it**

See added tests to confirm the hostconfig gets updated correctly. Manual confirmation that the JSON blob sent to hcsshim contains the correct values.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added flag --cpu-count to run, and create to control the number of CPUs available to the container on Windows daemons

**\- A picture of a cute animal (not mandatory but encouraged)**
![Rabbit!](http://rexrabbitsusa.com/wp-content/uploads/2015/03/Bunny-Wallpapers-bunny-rabbits-128637_1024_768.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
