### PR TITLE
  fix volume driver deletions prevents recreation of volume issue.

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -260,7 +260,10 @@ func (s *VolumeStore) create(name, driverName string, opts, labels map[string]st
 		if v.DriverName() != driverName && driverName != "" && driverName != volume.DefaultDriverName {
 			return nil, errNameConflict
 		}
-		return v, nil
+		// check exist in driver
+		if driverName == "" || driverName == volume.DefaultDriverName {
+			return v, nil
+		}
 	}
 
 	// Since there isn't a specified driver name, let's see if any of the existing drivers have this volume name


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
fix a issue which volume driver deletions will cause recreation of volume failed.

**\- How I did it**

When creating a volume in docker, it will check the memory cache in docker, I just step over it and use "VolumeDriver.Get" API to check the volume status.

**\- How to verify it**
1.  docker volume create --name test -d convoy -o size=1
2. convoy delete test
3. docker volume ls   #  to check it does not exist.
4. docker volume create --name test -d convoy -o size=1  

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

  Signed-off-by:  Wentao Zhang zhangwentao234@huawei.com
