### PR TITLE
Improve systemd service unit in *Automatically start containers*

### DIFF
--- a/docs/admin/host_integration.md
+++ b/docs/admin/host_integration.md
@@ -84,5 +84,6 @@ and removed when the service is stopped.
     [Service]
     ...
     ExecStart=/usr/bin/docker run --env foo=bar --name redis_server redis
-    ExecStop=/usr/bin/docker stop -t 2 redis_server ; /usr/bin/docker rm -f redis_server
+    ExecStop=/usr/bin/docker stop -t 2 redis_server
+    ExecStopPost=/usr/bin/docker rm -f redis_server
     ...


### PR DESCRIPTION
Using `ExecStopPost=` instead of `;` in the systemd unit given in the `host_integration.md` host, as recommended (/cc @paulmenzel).

Closes #23887 :angel: 

/cc @thaJeztah 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
