### PR TITLE
Add activate/drain/pause node command

### DIFF
--- a/api/client/node/activate.go
+++ b/api/client/node/activate.go
@@ -1,0 +1,32 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/cli"
+	"github.com/docker/engine-api/types/swarm"
+	"github.com/spf13/cobra"
+)
+
+func newActivateCommand(dockerCli *client.DockerCli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "activate NODE [NODE...]",
+		Short: "Activate a node in the swarm",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runActivate(dockerCli, args)
+		},
+	}
+}
+
+func runActivate(dockerCli *client.DockerCli, nodes []string) error {
+	activate := func(node *swarm.Node) error {
+		node.Spec.Availability = swarm.NodeAvailabilityActive
+		return nil
+	}
+	success := func(nodeID string) {
+		fmt.Fprintf(dockerCli.Out(), "Node %s availability set to active.\n", nodeID)
+	}
+	return updateNodes(dockerCli, nodes, activate, success)
+}

--- a/api/client/node/cmd.go
+++ b/api/client/node/cmd.go
@@ -23,9 +23,12 @@ func NewNodeCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(
+		newActivateCommand(dockerCli),
 		newDemoteCommand(dockerCli),
+		newDrainCommand(dockerCli),
 		newInspectCommand(dockerCli),
 		newListCommand(dockerCli),
+		newPauseCommand(dockerCli),
 		newPromoteCommand(dockerCli),
 		newRemoveCommand(dockerCli),
 		newPSCommand(dockerCli),

--- a/api/client/node/drain.go
+++ b/api/client/node/drain.go
@@ -1,0 +1,32 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/cli"
+	"github.com/docker/engine-api/types/swarm"
+	"github.com/spf13/cobra"
+)
+
+func newDrainCommand(dockerCli *client.DockerCli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "drain NODE [NODE...]",
+		Short: "Drain a node in the swarm",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDrain(dockerCli, args)
+		},
+	}
+}
+
+func runDrain(dockerCli *client.DockerCli, nodes []string) error {
+	drain := func(node *swarm.Node) error {
+		node.Spec.Availability = swarm.NodeAvailabilityDrain
+		return nil
+	}
+	success := func(nodeID string) {
+		fmt.Fprintf(dockerCli.Out(), "Node %s availability set to drain.\n", nodeID)
+	}
+	return updateNodes(dockerCli, nodes, drain, success)
+}

--- a/api/client/node/pause.go
+++ b/api/client/node/pause.go
@@ -1,0 +1,32 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/cli"
+	"github.com/docker/engine-api/types/swarm"
+	"github.com/spf13/cobra"
+)
+
+func newPauseCommand(dockerCli *client.DockerCli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "pause NODE [NODE...]",
+		Short: "Pause a node in the swarm",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPause(dockerCli, args)
+		},
+	}
+}
+
+func runPause(dockerCli *client.DockerCli, nodes []string) error {
+	pause := func(node *swarm.Node) error {
+		node.Spec.Availability = swarm.NodeAvailabilityPause
+		return nil
+	}
+	success := func(nodeID string) {
+		fmt.Fprintf(dockerCli.Out(), "Node %s availability set to pause.\n", nodeID)
+	}
+	return updateNodes(dockerCli, nodes, pause, success)
+}

--- a/docs/reference/commandline/node_activate.md
+++ b/docs/reference/commandline/node_activate.md
@@ -1,0 +1,38 @@
+<!--[metadata]>
++++
+title = "node activate"
+description = "The node activate command description and usage"
+keywords = ["node, activate"]
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# node activate
+
+    Usage:  docker node activate NODE [NODE...]
+
+    Activate a node in the swarm
+
+This command marks a previously drained or paused node as active again
+so that it can start accepting tasks again.
+
+This command must be run on a manager node, but may activate any node
+in the swarm.
+
+```bash
+$ docker node activate <node name>
+```
+
+## Related information
+
+* [node accept](node_accept.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
+* [node inspect](node_inspect.md)
+* [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
+* [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -20,7 +20,10 @@ Options:
 
 ```
 
-Demotes an existing manager so that it is no longer a manager. This command targets a docker engine that is a manager in the swarm.
+Demotes an existing manager so that it is no longer a manager.
+
+This command must be run on a manager node, but may demote any node in
+the swarm.
 
 
 ```bash
@@ -29,4 +32,13 @@ $ docker node demote <node name>
 
 ## Related information
 
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node drain](node_drain.md)
+* [node inspect](node_inspect.md)
+* [node ls](node_ls.md)
+* [node pause](node_pause.md)
 * [node promote](node_promote.md)
+* [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_drain.md
+++ b/docs/reference/commandline/node_drain.md
@@ -1,0 +1,39 @@
+<!--[metadata]>
++++
+title = "node drain"
+description = "The node drain command description and usage"
+keywords = ["node, drain"]
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# node drain
+
+    Usage:  docker node drain NODE [NODE...]
+
+    Drain a node in the swarm
+
+This command marks a node as drained so that all tasks will be removed
+from this node, and no tasks will be assigned to it until it is
+reactivated (using `docker node activate`).
+
+This command must be run on a manager node, but may drain any node in
+the swarm.
+
+```bash
+$ docker node drain <node name>
+```
+
+## Related information
+
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node inspect](node_inspect.md)
+* [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
+* [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -119,7 +119,13 @@ Example output:
 
 ## Related information
 
-* [node update](node_update.md)
-* [node ps](node_ps.md)
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
 * [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
 * [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -89,7 +89,13 @@ ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
 
 ## Related information
 
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
 * [node inspect](node_inspect.md)
-* [node update](node_update.md)
-* [node ps](node_ps.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
 * [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_pause.md
+++ b/docs/reference/commandline/node_pause.md
@@ -1,0 +1,38 @@
+<!--[metadata]>
++++
+title = "node pause"
+description = "The node pause command description and usage"
+keywords = ["node, pause"]
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# node pause
+
+    Usage:  docker node pause NODE [NODE...]
+
+    Pause a node in the swarm
+
+This command marks a node as paused so that it doesn't accept any new
+tasks until it's been reactivated (using `docker node activate`).
+
+This command must be run on a manager node, but may pause any node in
+the swarm.
+
+```bash
+$ docker node pause <node name>
+```
+
+## Related information
+
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
+* [node inspect](node_inspect.md)
+* [node ls](node_ls.md)
+* [node promote](node_promote.md)
+* [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -19,8 +19,17 @@ Options:
       --help   Print usage
 ```
 
-Promotes a node to manager. This command targets a docker engine that is a manager in the swarm.
+Promotes a worker node to a manager. Becoming a manager means the node
+will be able to accept administrative commands for the swarm, and
+become one of the candidates when the swarm elects a leader. The node
+will continue to be assigned tasks unless it is paused with `docker
+node pause` or drained with `docker node drain`. Only specific, stable
+nodes should be promoted to managers, because a majority of leaders
+must be responsive for the swarm to be available. Generally, a swarm
+should be set up with either 1, 3, or 5 managers.
 
+This command must be run on a manager node, but may promote any node
+in the swarm.
 
 ```bash
 $ docker node promote <node name>
@@ -28,4 +37,13 @@ $ docker node promote <node name>
 
 ## Related information
 
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
 * [node demote](node_demote.md)
+* [node drain](node_drain.md)
+* [node inspect](node_inspect.md)
+* [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node rm](node_rm.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -94,7 +94,13 @@ The `desired-state` filter can take the values `running`, `shutdown`, and `accep
 
 ## Related information
 
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
 * [node inspect](node_inspect.md)
-* [node update](node_update.md)
 * [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
 * [node rm](node_rm.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -52,7 +52,13 @@ from the cluster.
 
 ## Related information
 
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
 * [node inspect](node_inspect.md)
-* [node update](node_update.md)
-* [node ps](node_ps.md)
 * [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
+* [node tasks](node_tasks.md)
+* [node update](node_update.md)

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -23,6 +23,15 @@ Options:
       --role string           Role of the node (worker/manager)
 ```
 
+This command is a *low-level* command to update membership, role and
+availability of a node. Each of these attributes can be updated using
+a simpler command such as `accept` for membership, `promote` or
+`demote` for role and `activate`, `drain` or `pause` for
+availability.
+
+This command must be run on a manager node, but may update any node in
+the swarm.
+
 ### Add label metadata to a node
 
 Add metadata to a swarm node using node labels. You can specify a node label as
@@ -56,9 +65,16 @@ entity within the swarm. Do not confuse them with the docker daemon labels for
 For more information about labels, refer to [apply custom
 metadata](../../userguide/labels-custom-metadata.md).
 
+
 ## Related information
 
+* [node accept](node_accept.md)
+* [node active](node_activate.md)
+* [node demote](node_demote.md)
+* [node drain](node_drain.md)
 * [node inspect](node_inspect.md)
-* [node ps](node_ps.md)
 * [node ls](node_ls.md)
+* [node pause](node_pause.md)
+* [node promote](node_promote.md)
 * [node rm](node_rm.md)
+* [node tasks](node_tasks.md)


### PR DESCRIPTION
Expose simple commands for node update to be more consistent with the current ones (`demote`/`promote`, `accept`/`reject`) 🐮.

Closes #24086

/cc @aluzzardi @aaronlehmann @cpuguy83 @dnephin 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
