### PR TITLE
daemon: add a flag to override the default seccomp profile

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -34,6 +34,7 @@ type Config struct {
 	Ulimits              map[string]*units.Ulimit `json:"default-ulimits,omitempty"`
 	Runtimes             map[string]types.Runtime `json:"runtimes,omitempty"`
 	DefaultRuntime       string                   `json:"default-runtime,omitempty"`
+	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -86,6 +87,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))
 	cmd.StringVar(&config.RemappedRoot, []string{"-userns-remap"}, "", usageFn("User/Group setting for user namespaces"))
 	cmd.StringVar(&config.ContainerdAddr, []string{"-containerd"}, "", usageFn("Path to containerd socket"))
+	cmd.StringVar(&config.SeccompProfile, []string{"-seccomp-profile"}, "", usageFn("Path to seccomp profile"))
 	cmd.BoolVar(&config.LiveRestore, []string{"-live-restore"}, false, usageFn("Enable live restore of docker when containers are still running"))
 	config.Runtimes = make(map[string]types.Runtime)
 	cmd.Var(runconfigopts.NewNamedRuntimeOpt("runtimes", &config.Runtimes, stockRuntimeName), []string{"-add-runtime"}, usageFn("Register an additional OCI compatible runtime"))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -89,6 +89,9 @@ type Daemon struct {
 	discoveryWatcher          discoveryReloader
 	root                      string
 	seccompEnabled            bool
+	seccompProfile            []byte
+	seccompProfilePath        string
+	seccompProfileWeak        bool
 	shutdown                  bool
 	uidMaps                   []idtools.IDMap
 	gidMaps                   []idtools.IDMap
@@ -459,6 +462,10 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 			}
 		}
 	}()
+
+	if err := d.setupDefaultSeccompProfile(); err != nil {
+		return nil, err
+	}
 
 	// Set the default isolation mode (only applicable on Windows)
 	if err := d.setDefaultIsolation(); err != nil {

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -27,6 +27,10 @@ const (
 	solarisMaxCPUShares  = 65535
 )
 
+func (daemon *Daemon) setupDefaultSeccompProfile() error {
+	return nil
+}
+
 func (daemon *Daemon) cleanupMountsByID(id string) error {
 	return nil
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -77,6 +77,10 @@ func (daemon *Daemon) getCgroupDriver() string {
 	return ""
 }
 
+func (daemon *Daemon) setupDefaultSeccompProfile() error {
+	return nil
+}
+
 // adaptContainerSettings is called during container creation to modify any
 // settings necessary in the HostConfig structure.
 func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConfig, adjustCPUShares bool) error {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"sync/atomic"
@@ -67,15 +68,22 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		}
 	})
 
-	var securityOptions []string
+	securityOptions := make(map[string][][2]string)
 	if sysInfo.AppArmor {
-		securityOptions = append(securityOptions, "apparmor")
+		securityOptions["apparmor"] = [][2]string{}
 	}
 	if sysInfo.Seccomp {
-		securityOptions = append(securityOptions, "seccomp")
+		profile := daemon.seccompProfilePath
+		if profile == "" {
+			profile = "default"
+		}
+		securityOptions["seccomp"] = [][2]string{
+			{"ProfileWeak", fmt.Sprintf("%v", daemon.seccompProfileWeak)},
+			{"Profile", profile},
+		}
 	}
 	if selinuxEnabled() {
-		securityOptions = append(securityOptions, "selinux")
+		securityOptions["selinux"] = [][2]string{}
 	}
 
 	v := &types.Info{

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -35,9 +35,16 @@ func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
 			return err
 		}
 	} else {
-		profile, err = seccomp.GetDefaultProfile(rs)
-		if err != nil {
-			return err
+		if daemon.seccompProfile != nil {
+			profile, err = seccomp.LoadProfile(string(daemon.seccompProfile))
+			if err != nil {
+				return err
+			}
+		} else {
+			profile, err = seccomp.GetDefaultProfile(rs)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -63,6 +63,7 @@ weight = -1
       --registry-mirror=[]                   Preferred Docker registry mirror
       -s, --storage-driver=""                Storage driver to use
       --selinux-enabled                      Enable selinux support
+      --seccomp-profile                      Path to seccomp profile
       --storage-opt=[]                       Set storage driver options
       --tls                                  Use TLS; implied by --tlsverify
       --tlscacert="~/.docker/ca.pem"         Trust certs signed only by this CA

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -11,5 +11,5 @@ func (s *DockerSuite) TestInfoSecurityOptions(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled, Apparmor, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "info")
-	c.Assert(out, checker.Contains, "Security Options: apparmor seccomp")
+	c.Assert(out, checker.Contains, "Security Options:\n apparmor\n seccomp\n  Profile: default\n")
 }

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -54,6 +54,7 @@ dockerd - Enable daemon mode
 [**--registry-mirror**[=*[]*]]
 [**-s**|**--storage-driver**[=*STORAGE-DRIVER*]]
 [**--selinux-enabled**]
+[**--seccomp-profile**[=*SECCOMP-PROFILE*]]
 [**--storage-opt**[=*[]*]]
 [**--tls**]
 [**--tlscacert**[=*~/.docker/ca.pem*]]
@@ -235,6 +236,9 @@ output otherwise.
 
 **--selinux-enabled**=*true*|*false*
   Enable selinux support. Default is false. SELinux does not presently support either of the overlay storage drivers.
+
+**--seccomp-profile**=""
+  Path to a json seccomp profile to be used as a default for containers.
 
 **--storage-opt**=[]
   Set storage driver options. See STORAGE DRIVER OPTIONS.

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -252,7 +252,7 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
-	SecurityOptions    []string
+	SecurityOptions    map[string][][2]string
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info


### PR DESCRIPTION
**\- What I did**

I've added a new daemon flag `--seccomp-profile=/path/to/seccomp.json` to be able to use a custom default seccomp profile instead of the docker's default. This will allow people to run by default with their own default seccomp profile instead of overriding the docker's default per container.

**\- How I did it**

Added a new daemon flag `--seccomp-profile=/path/to/seccomp.json`

**\- How to verify it**

You can run the daemon with `--seccomp-profile=$DOCKERSRC/profiles/seccomp/default.json` and tweak it to verify seccomp rules are ok when running containers.

**\- Description for the changelog**

Add a daemon flag to override the default seccomp profile

**\- A picture of a cute animal (not mandatory but encouraged)**

**TODO** (after design review)
- [x] integration tests
- [x] ~~command completion~~ _FOLLOW UP_ @albers @sdurrheimer
- [x] docs

/cc @rhatdan @mrunalp @jfrazelle @thaJeztah @LK4D4 @cpuguy83 @justincormack 

Signed-off-by: Antonio Murdaca runcom@redhat.com
