### PR TITLE
Improve timestamp formatting

### DIFF
--- a/api/client/task/print.go
+++ b/api/client/task/print.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	psTaskItemFmt = "%s\t%s\t%s\t%s\t%s %s\t%s\t%s\n"
+	psTaskItemFmt = "%s\t%s\t%s\t%s\t%s %s ago\t%s\t%s\n"
 )
 
 type tasksBySlot []swarm.Task
@@ -69,7 +69,7 @@ func Print(dockerCli *client.DockerCli, ctx context.Context, tasks []swarm.Task,
 			serviceValue,
 			task.Spec.ContainerSpec.Image,
 			client.PrettyPrint(task.Status.State),
-			units.HumanDuration(time.Since(task.Status.Timestamp)),
+			strings.ToLower(units.HumanDuration(time.Since(task.Status.Timestamp))),
 			client.PrettyPrint(task.DesiredState),
 			nodeValue,
 		)


### PR DESCRIPTION
lowercase the output, to prevent "About" halfway,
and add "ago" to the output, as timestamps are always
in the past.

fixes https://github.com/docker/docker/issues/24252
