### PR TITLE
Add Andrew Wiles, Florence Nightingale, Thomas Edison to container na…

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -196,6 +196,9 @@ var (
 		// Annie Easley - She was a leading member of the team which developed software for the Centaur rocket stage and one of the first African-Americans in her field. https://en.wikipedia.org/wiki/Annie_Easley
 		"easley",
 
+		// Thomas Alva Edison, prolific inventor https://en.wikipedia.org/wiki/Thomas_Edison
+		"edison",
+
 		// Albert Einstein invented the general theory of relativity. https://en.wikipedia.org/wiki/Albert_Einstein
 		"einstein",
 
@@ -379,6 +382,9 @@ var (
 		// Isaac Newton invented classic mechanics and modern optics. https://en.wikipedia.org/wiki/Isaac_Newton
 		"newton",
 
+		// Florence Nightingale, more prominently known as a nurse, was also the first female member of the Royal Statistical Society and a pioneer in statistical graphics https://en.wikipedia.org/wiki/Florence_Nightingale#Statistics_and_sanitary_reform
+		"nightingale",
+
 		// Alfred Nobel - a Swedish chemist, engineer, innovator, and armaments manufacturer (inventor of dynamite) - https://en.wikipedia.org/wiki/Alfred_Nobel
 		"nobel",
 
@@ -501,6 +507,9 @@ var (
 
 		// Marlyn Wescoff - one of the original programmers of the ENIAC. https://en.wikipedia.org/wiki/ENIAC - https://en.wikipedia.org/wiki/Marlyn_Meltzer
 		"wescoff",
+
+		// Andrew Wiles - Notable British mathematician who proved the enigmatic Fermat's Last Theorem - https://en.wikipedia.org/wiki/Andrew_Wiles
+		"wiles",
 
 		// Roberta Williams, did pioneering work in graphical adventure games for personal computers, particularly the King's Quest series. https://en.wikipedia.org/wiki/Roberta_Williams
 		"williams",


### PR DESCRIPTION
**\- What I did**
I added names of three scientists to the pool of possible container names
Ran gofmt -s -w on modified file

**\- How I did it**
Modified the list of names to add each name, along with a comment.

**\- How to verify it**
Run the following command to generate an infinite stream of names

/go/src/github.com/docker/docker/pkg/namesgenerator/cmd/names-generator# sh -c "while true; do go run main.go; done;"

You should see the names of edison, nightingale, wiles come up

I noticed:
kickass_nightingale
elegant_edison
furious_wiles

**\- Description for the changelog**
Add Andrew Wiles, Florence Nightingale, Thomas Edison to container names

British mathematician Andrew Wiles is notable for solving Fermat's Last
Theorem. Florence Nightingale was the first female inducted into the
Royal Statistical Society. Thomas Alva Edison was a prolific inventor,
noted for inventing the incandescent light bulb, the phonograph and the
motion picture camera (among many other).

Signed-off-by: Shourya Sarcar shourya.sarcar@gmail.com
