### PR TITLE
rewrite GetNetworkDriverList in info and network

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -176,10 +176,7 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 
 	pluginsInfo.Volume = volumedrivers.GetDriverList()
 
-	networkDriverList := daemon.GetNetworkDriverList()
-	for nd := range networkDriverList {
-		pluginsInfo.Network = append(pluginsInfo.Network, nd)
-	}
+	pluginsInfo.Network = daemon.GetNetworkDriverList()
 
 	pluginsInfo.Authorization = daemon.configStore.AuthorizationPlugins
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -328,8 +328,8 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 
 // GetNetworkDriverList returns the list of plugins drivers
 // registered for network.
-func (daemon *Daemon) GetNetworkDriverList() map[string]bool {
-	pluginList := make(map[string]bool)
+func (daemon *Daemon) GetNetworkDriverList() []string {
+	var pluginList []string
 
 	if !daemon.NetworkControllerEnabled() {
 		return nil
@@ -339,10 +339,10 @@ func (daemon *Daemon) GetNetworkDriverList() map[string]bool {
 
 	for _, network := range networks {
 		driver := network.Type()
-		pluginList[driver] = true
+		pluginList = append(pluginList, driver)
 	}
 	// TODO : Replace this with proper libnetwork API
-	pluginList["overlay"] = true
+	pluginList = append(pluginList, "overlay")
 
 	return pluginList
 }


### PR DESCRIPTION
Simplify code in GetNetworkDriverList:
1. make GetNetworkDriverList return an array instead of map, since in the caller in info.go, no need for the value of map;
2. just assign to pluginsInfo.Network without convert. 

Signed-off-by: allencloud allen.sun@daocloud.io
