### PR TITLE
Fix spelling in comments, strings and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -891,7 +891,7 @@ by another client (#15489)
 #### Security
 - Fix tar breakout vulnerability
 * Extractions are now sandboxed chroot
-- Security options are no longer committed to images
+- Security options are no longer comitted to images
 
 #### Runtime
 - Fix deadlock in `docker ps -f exited=1`
@@ -1317,7 +1317,7 @@ by another client (#15489)
 * Update issue filing instructions
 * Warn against the use of symlinks for Docker's storage folder
 * Replace the Firefox example with an IceWeasel example
-* Rewrite the PostgresSQL example using a Dockerfile and add more details to it
+* Rewrite the PostgreSQL example using a Dockerfile and add more details to it
 * Improve the OS X documentation
 
 #### Remote API

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -421,7 +421,7 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 		fmt.Fprintf(b.Stderr, "# Executing %d build %s...\n", nTriggers, word)
 	}
 
-	// Copy the ONBUILD triggers, and remove them from the config, since the config will be committed.
+	// Copy the ONBUILD triggers, and remove them from the config, since the config will be comitted.
 	onBuildTriggers := b.runConfig.OnBuild
 	b.runConfig.OnBuild = []string{}
 

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1031,7 +1031,7 @@ func getNetwork(ctx context.Context, c swarmapi.ControlClient, input string) (*s
 		}
 
 		if l := len(rl.Networks); l > 1 {
-			return nil, fmt.Errorf("network %s is ambigious (%d matches found)", input, l)
+			return nil, fmt.Errorf("network %s is ambiguous (%d matches found)", input, l)
 		}
 
 		return rl.Networks[0], nil

--- a/daemon/cluster/helpers.go
+++ b/daemon/cluster/helpers.go
@@ -42,7 +42,7 @@ func getNode(ctx context.Context, c swarmapi.ControlClient, input string) (*swar
 		}
 
 		if l := len(rl.Nodes); l > 1 {
-			return nil, fmt.Errorf("node %s is ambigious (%d matches found)", input, l)
+			return nil, fmt.Errorf("node %s is ambiguous (%d matches found)", input, l)
 		}
 
 		return rl.Nodes[0], nil
@@ -70,7 +70,7 @@ func getService(ctx context.Context, c swarmapi.ControlClient, input string) (*s
 		}
 
 		if l := len(rl.Services); l > 1 {
-			return nil, fmt.Errorf("service %s is ambigious (%d matches found)", input, l)
+			return nil, fmt.Errorf("service %s is ambiguous (%d matches found)", input, l)
 		}
 
 		return rl.Services[0], nil
@@ -99,7 +99,7 @@ func getTask(ctx context.Context, c swarmapi.ControlClient, input string) (*swar
 		}
 
 		if l := len(rl.Tasks); l > 1 {
-			return nil, fmt.Errorf("task %s is ambigious (%d matches found)", input, l)
+			return nil, fmt.Errorf("task %s is ambiguous (%d matches found)", input, l)
 		}
 
 		return rl.Tasks[0], nil

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -271,7 +271,7 @@ func getConflictFreeConfiguration(configFile string, flags *flag.FlagSet) (*Conf
 		}
 
 		// Override flag values to make sure the values set in the config file with nullable values, like `false`,
-		// are not overriden by default truthy values from the flags that were not explicitly set.
+		// are not overridden by default truthy values from the flags that were not explicitly set.
 		// See https://github.com/docker/docker/issues/20289 for an example.
 		//
 		// TODO: Rewrite configuration logic to avoid same issue with other nullable values, like numbers.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -367,7 +367,7 @@ func (daemon *Daemon) registerLink(parent, child *container.Container, alias str
 	return nil
 }
 
-// SetClusterProvider sets a component for quering the current cluster state.
+// SetClusterProvider sets a component for querying the current cluster state.
 func (daemon *Daemon) SetClusterProvider(clusterProvider cluster.Provider) {
 	daemon.clusterProvider = clusterProvider
 	daemon.netController.SetClusterProvider(clusterProvider)

--- a/docs/admin/logging/gcplogs.md
+++ b/docs/admin/logging/gcplogs.md
@@ -34,7 +34,7 @@ Otherwise, the user must specify which project to log to using the `--gcp-projec
 log option and Docker will attempt to obtain credentials from the
 <a href="https://developers.google.com/identity/protocols/application-default-credentials" target="_blank">Google Application Default Credential</a>.
 The `--gcp-project` takes precedence over information discovered from the metadata server
-so a Docker daemon running in a Google Cloud Project can be overriden to log to a different
+so a Docker daemon running in a Google Cloud Project can be overridden to log to a different
 Google Cloud Project using `--gcp-project`.
 
 ## gcplogs options

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -155,7 +155,7 @@ option is ignored if the address protocol is not `tcp+tls`.
 is ignored if the address protocol is not `tcp+tls`.
 
 `syslog-tls-skip-verify` configures the TLS verification. This verification is
-enabled by default, but it can be overriden by setting this option to `true`.
+enabled by default, but it can be overridden by setting this option to `true`.
 This option is ignored if the address protocol is not `tcp+tls`.
 
 `tag` configures a string that is appended to the APP-NAME in the syslog

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -502,7 +502,7 @@ default is `/bin/sh -c` on Linux or `cmd /S /C` on Windows)
 - `RUN ["executable", "param1", "param2"]` (*exec* form)
 
 The `RUN` instruction will execute any commands in a new layer on top of the
-current image and commit the results. The resulting committed image will be
+current image and commit the results. The resulting comitted image will be
 used for the next step in the `Dockerfile`.
 
 Layering `RUN` instructions and generating commits conforms to the core
@@ -544,7 +544,7 @@ RUN /bin/bash -c 'source $HOME/.bashrc ; echo $HOME'
 >
 > **Note**:
 > In the *JSON* form, it is necessary to escape backslashes. This is
-> particularly relevant on Windows where the backslash is the path seperator.
+> particularly relevant on Windows where the backslash is the path separator.
 > The following line would otherwise be treated as *shell* form due to not
 > being valid JSON, and fail in an unexpected way:
 > `RUN ["c:\windows\system32\tasklist.exe"]`

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -49,7 +49,7 @@ This example displays images with a name containing 'busybox':
     ofayau/busybox-libc32            Busybox with 32 bits (and 64 bits) libs         1                    [OK]
     peelsky/zulu-openjdk-busybox                                                     1                    [OK]
     skomma/busybox-data              Docker image suitable for data volume cont...   1                    [OK]
-    elektritter/busybox-teamspeak    Leightweight teamspeak3 container based on...   1                    [OK]
+    elektritter/busybox-teamspeak    Lightweight teamspeak3 container based on...    1                    [OK]
     socketplane/busybox                                                              1                    [OK]
     oveits/docker-nginx-busybox      This is a tiny NginX docker image based on...   0                    [OK]
     ggtools/busybox-ubuntu           Busybox ubuntu version with extra goodies       0                    [OK]

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -38,7 +38,7 @@ ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER
 ### `--auto-accept value`
 
 This flag controls node acceptance into the cluster. By default, `worker` nodes are
-automatically accepted by the cluster. This can be changed by specifing what kinds of nodes
+automatically accepted by the cluster. This can be changed by specifying what kinds of nodes
 can be auto-accepted into the cluster. If auto-accept is not turned on, then
 [node accept](node_accept.md) can be used to explicitly accept a node into the cluster.
 

--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -312,7 +312,7 @@ assumes that the Docker daemon is in the `stopped` state.
 
 14. Configure the Docker daemon with specific devicemapper options.
 
-	There are two ways to do this. You can set options on the commmand line if you start the daemon there:
+	There are two ways to do this. You can set options on the command line if you start the daemon there:
 
 	```bash
 	--storage-driver=devicemapper --storage-opt=dm.thinpooldev=/dev/mapper/docker-thinpool --storage-opt dm.use_deferred_removal=true

--- a/experimental/vlan-networks.md
+++ b/experimental/vlan-networks.md
@@ -627,7 +627,7 @@ docker network  create  -d ipvlan \
 
 
 # Start a few of containers on the network (ipnet110) 
-# in seperate terminals and check connectivity
+# in separate terminals and check connectivity
 docker run --net=ipnet110 -it --rm alpine /bin/sh
 # Start a second container specifying the v6 address
 docker run --net=ipnet110 --ip6=2001:db8:abc6::10 -it --rm alpine /bin/sh

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# This script exists as backwards compatiblity for CI
+# This script exists as backwards compatibility for CI
 (
     DEST="${DEST}-client"
     ABS_DEST="${ABS_DEST}-client"

--- a/image/spec/v1.1.md
+++ b/image/spec/v1.1.md
@@ -573,7 +573,7 @@ these directories contains 3 files:
  * `json` - The legacy JSON metadata for an image layer. In this version of
     the image specification, layers don't have JSON metadata, but in
     [version 1](v1.md), they did. A file is created for each layer in the
-    v1 format for backward compatiblity.
+    v1 format for backward compatibility.
  * `layer.tar` - The Tar archive of the filesystem changeset for an image
    layer.
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1432,7 +1432,7 @@ func (s *DockerSuite) TestPostContainersCreateWithOomScoreAdjInvalidRange(c *che
 	}
 }
 
-// test case for #22210 where an emtpy container name caused panic.
+// test case for #22210 where an empty container name caused panic.
 func (s *DockerSuite) TestContainerApiDeleteWithEmptyName(c *check.C) {
 	status, out, err := sockRequest("DELETE", "/containers/", nil)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4915,7 +4915,7 @@ func (s *DockerSuite) TestBuildRenamedDockerfile(c *check.C) {
 	}
 
 	if expected := fmt.Sprintf("The Dockerfile (%s) must be within the build context (.)", nonDockerfileFile); !strings.Contains(out, expected) {
-		c.Fatalf("wrong error messsage:%v\nexpected to contain=%v", out, expected)
+		c.Fatalf("wrong error message:%v\nexpected to contain=%v", out, expected)
 	}
 
 	out, _, err = dockerCmdInDir(c, filepath.Join(ctx.Dir, "files"), "build", "-f", filepath.Join("..", "Dockerfile"), "-t", "test6", "..")

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -359,7 +359,7 @@ func (s *DockerExternalGraphdriverSuite) testExternalGraphDriver(name string, ex
 
 	out, err = s.d.Cmd("diff", "graphtest")
 	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(strings.Contains(out, "A /hello"), check.Equals, true, check.Commentf("diff ouput: %s", out))
+	c.Assert(strings.Contains(out, "A /hello"), check.Equals, true, check.Commentf("diff output: %s", out))
 
 	out, err = s.d.Cmd("rm", "-f", "graphtest")
 	c.Assert(err, check.IsNil, check.Commentf(out))

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1260,7 +1260,7 @@ func daemonTime(c *check.C) time.Time {
 	return dt
 }
 
-// daemonUnixTime returns the current time on the daemon host with nanoseconds precission.
+// daemonUnixTime returns the current time on the daemon host with nanoseconds precision.
 // It return the time formatted how the client sends timestamps to the server.
 func daemonUnixTime(c *check.C) string {
 	return parseEventTime(daemonTime(c))

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -86,7 +86,7 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 			ImagePath: spec.Windows.HvRuntime.ImagePath,
 		}
 
-		// Images with build verison < 14350 don't support running with clone, but
+		// Images with build version < 14350 don't support running with clone, but
 		// Windows cannot automatically detect this. Explicitly block cloning in this
 		// case.
 		if build := buildFromVersion(spec.Platform.OSVersion); build > 0 && build < 14350 {


### PR DESCRIPTION
Fix multiple minor spelling errors in comments, a few strings and in documentation. There are no functional changes.

Please apply the patch in whole or give feedback so I can update the patch. Do not attempt to apply this patch partially – rather give me a chance to make the patch perfect for you.

Signed-off-by: Otto Kekäläinen otto@seravo.fi
