### PR TITLE
Changed ArchLinux image maker script to support ARMV versions other than 7

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -63,11 +63,7 @@ case "$arch" in
 		sed "s/Architecture = armv/Architecture = armv${version}h/g" './mkimage-archarm-pacman.conf' > "${PACMAN_CONF}"
 		PACMAN_MIRRORLIST='Server = http://mirror.archlinuxarm.org/$arch/$repo'
 		PACMAN_EXTRA_PKGS='archlinuxarm-keyring'
-		if [ "$version" -lt 7 ]; then
-			EXPECT_TIMEOUT=1800 # Some armv6 based devices can be very slow (e.g. RPiv1)
-		else
-			EXPECT_TIMEOUT=120
-		fi
+		EXPECT_TIMEOUT=1800 # Most armv* based devices can be very slow (e.g. RPiv1)
 		ARCH_KEYRING=archlinuxarm
 		DOCKER_IMAGE_NAME="armv${version}h/archlinux"
 		;;

--- a/contrib/mkimage-archarm-pacman.conf
+++ b/contrib/mkimage-archarm-pacman.conf
@@ -19,7 +19,7 @@ HoldPkg     = pacman glibc
 #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
 #CleanMethod = KeepInstalled
 #UseDelta    = 0.7
-Architecture = armv7h
+Architecture = armv
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
 #IgnorePkg   =


### PR DESCRIPTION
Looks like the ArchLinux contrib script file `mkimage-arch.sh` only attempts to generate armv7h images, regardless of the ARM platform being used to build. If you're like me and trying to build ArchLinux images on a crusty old armv6 Raspberry Pi, then this isn't going to work.

This PR switches the generated image to the ARM architecture of the system being used to build instead, which [for `armv` is `armv6h` and `armv7h` for ArchLinux](http://co.us.mirror.archlinuxarm.org/).

Extras:
- The RPiv1 is... not very fast, so the timeout for `expect` was changed to 30 minutes for `armv6h` builds.
- Bad signatures can cause `expect` to hang for the duration of the timeout. Added a conditional to the `exact` block for handling those.
- Changed the generated image name from `archlinuxarm` to `armv<version>h/archlinux` to more appropriately match [Docker's multiplatform image system](https://integratedcode.us/2016/04/22/a-step-towards-multi-platform-docker-images/).

Signed-off-by: Dillon Dixon dillondixon@gmail.com
