### PR TITLE
Add NoArm64 testRequires and skip Schema1RegistrySuite on arm64

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -80,7 +80,7 @@ type DockerSchema1RegistrySuite struct {
 }
 
 func (s *DockerSchema1RegistrySuite) SetUpTest(c *check.C) {
-	testRequires(c, DaemonIsLinux, RegistryHosting)
+	testRequires(c, DaemonIsLinux, RegistryHosting, NotArm64)
 	s.reg = setupRegistry(c, true, "", "")
 	s.d = NewDaemon(c)
 }

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -42,6 +42,10 @@ var (
 		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "arm" },
 		"Test requires a daemon not running on ARM",
 	}
+	NotArm64 = testRequirement{
+		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "arm64" },
+		"Test requires a daemon not running on arm64",
+	}
 	NotPpc64le = testRequirement{
 		func() bool { return os.Getenv("DOCKER_ENGINE_GOARCH") != "ppc64le" },
 		"Test requires a daemon not running on ppc64le",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

schema1 manifests is not working on ARM64, we should skip integration-cli
tests for schema1 manifests on ARM64.
https://github.com/docker/docker/blob/master/Dockerfile.aarch64#L108

Signed-off-by: Lei Jitang leijitang@huawei.com
