### PR TITLE
fix stdout and stderr in api client

### DIFF
--- a/api/client/network/remove.go
+++ b/api/client/network/remove.go
@@ -33,7 +33,7 @@ func runRemove(dockerCli *client.DockerCli, networks []string) error {
 			status = 1
 			continue
 		}
-		fmt.Fprintf(dockerCli.Err(), "%s\n", name)
+		fmt.Fprintf(dockerCli.Out(), "%s\n", name)
 	}
 
 	if status != 0 {

--- a/api/client/registry/logout.go
+++ b/api/client/registry/logout.go
@@ -45,7 +45,7 @@ func runLogout(dockerCli *client.DockerCli, serverAddress string) error {
 
 	fmt.Fprintf(dockerCli.Out(), "Remove login credentials for %s\n", serverAddress)
 	if err := client.EraseCredentials(dockerCli.ConfigFile(), serverAddress); err != nil {
-		fmt.Fprintf(dockerCli.Out(), "WARNING: could not erase credentials: %v\n", err)
+		fmt.Fprintf(dockerCli.Err(), "WARNING: could not erase credentials: %v\n", err)
 	}
 
 	return nil

--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -56,6 +56,8 @@ func runInit(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts initOptions
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Swarm initialized: current node (%s) is now a manager.\n", nodeID)
+
+	fmt.Fprintf(dockerCli.Out(), "Swarm initialized: current node (%s) is now a manager.\n", nodeID)
+
 	return nil
 }

--- a/api/client/swarm/update.go
+++ b/api/client/swarm/update.go
@@ -47,7 +47,8 @@ func runUpdate(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts swarmOpti
 		return err
 	}
 
-	fmt.Println("Swarm updated.")
+	fmt.Fprintln(dockerCli.Out(), "Swarm updated.")
+
 	return nil
 }
 

--- a/api/client/volume/remove.go
+++ b/api/client/volume/remove.go
@@ -33,7 +33,7 @@ func runRemove(dockerCli *client.DockerCli, volumes []string) error {
 			status = 1
 			continue
 		}
-		fmt.Fprintf(dockerCli.Err(), "%s\n", name)
+		fmt.Fprintf(dockerCli.Out(), "%s\n", name)
 	}
 
 	if status != 0 {


### PR DESCRIPTION
This PR did:
Write more specific code when dealing api client stdout and stderr:
1. fix misuse of `dockerCli.Err()`;
2. use dockerCli to receive data instead of `fmt.Println`;

Signed-off-by: allencloud allen.sun@daocloud.io
