### PR TITLE
Add fchmod and fchmodat to TestRunSeccompProfileDenyChmod

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -955,6 +955,14 @@ func (s *DockerSuite) TestRunSeccompProfileDenyChmod(c *check.C) {
 		{
 			"name": "chmod",
 			"action": "SCMP_ACT_ERRNO"
+		},
+		{
+			"name":"fchmod",
+			"action": "SCMP_ACT_ERRNO"
+		},
+		{
+			"name": "fchmodat",
+			"action":"SCMP_ACT_ERRNO"
 		}
 	]
 }`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

On arm64, chmod binary use syscall fchmodat, strace shows:

```
newfstatat(AT_FDCWD, "test", {st_mode=S_IFDIR|0755, st_size=4096, ...}, 0) = 0
fchmodat(AT_FDCWD, "test", 0644)        = 0
```

this will make test TestRunSeccompProfileDenyChmod on arm64 failed.

there are three syscall `chmod` `fchmod` and `fchmodat` to change the permissions of a file,
I think it's better to add all to this test.

ping @jfrazelle  @justincormack 
Signed-off-by: Lei Jitang leijitang@huawei.com
