### PR TITLE
Add IPVLAN and DUMMY to check-config.sh

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -183,7 +183,7 @@ flags=(
 	DEVPTS_MULTIPLE_INSTANCES
 	CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG
 	KEYS
-	MACVLAN VETH BRIDGE BRIDGE_NETFILTER
+	VETH BRIDGE BRIDGE_NETFILTER
 	NF_NAT_IPV4 IP_NF_FILTER IP_NF_TARGET_MASQUERADE
 	NETFILTER_XT_MATCH_{ADDRTYPE,CONNTRACK}
 	NF_NAT NF_NAT_NEEDED
@@ -252,6 +252,10 @@ echo '- Network Drivers:'
 	check_flags VXLAN | sed 's/^/  /'
 	echo '  Optional (for secure networks):'
 	check_flags XFRM_ALGO XFRM_USER | sed 's/^/  /'
+	echo '- "'$(wrap_color 'ipvlan' blue)'":'
+	check_flags IPVLAN | sed 's/^/  /'
+	echo '- "'$(wrap_color 'macvlan' blue)'":'
+	check_flags MACVLAN DUMMY | sed 's/^/  /'
 } | sed 's/^/  /'
 
 echo '- Storage Drivers:'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

This commit add DUMMY and IPVLAN to check-config.sh
because they are need for ipvlan and macvlan network
driver.
ping @mavenugo 

Signed-off-by: Lei Jitang leijitang@huawei.com
