### PR TITLE
Dockerfile's comments for "Run the test suite" is out of date.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \

--- a/builder/dockerfile/parser/testfiles/docker/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/docker/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \


### PR DESCRIPTION
There is an error in Dockerfile's comments. If I follow the instruction, it will come out an error as below:

```
[root@CentOS7-01 ~]# docker run --rm --privileged docker-dev:v1-12-0 hack/make.sh test

/go/src/github.com/docker/docker/hack/make.sh: line 316: /go/src/github.com/docker/docker/hack/make/test: No such file or directory
---> Making bundle: test (in bundles/1.12.0-dev/test)
```

Cause is 'test' does not exist in hack/make directory:

```
[root@CentOS7-01 ~]# docker run --rm --privileged docker-dev:v1-12-0 ls -a hack/make | grep test
.ensure-nnp-test
.ensure-syscall-test
test-deb-install
test-docker-py
test-install-script
test-integration-cli
test-old-apt-repo
test-unit
validate-test
```
