### PR TITLE
Dockerfile's comments for "Run the test suite" are out of date becaus…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.

--- a/builder/dockerfile/parser/testfiles/docker/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/docker/Dockerfile
@@ -9,7 +9,7 @@
 # docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t docker bash
 #
 # # Run the test suite:
-# docker run --privileged docker hack/make.sh test
+# docker run --privileged docker hack/make.sh test-unit test-integration-cli test-docker-py
 #
 # # Publish a release:
 # docker run --privileged \


### PR DESCRIPTION
Hi,

There are incorrect comments at the beginning of Dockerfile*. I just submit a pull request. Could you please check if my change is right? 

issue:

``` bash
[root@CentOS7-01 ~]# docker run --rm --privileged docker-dev:v1-12-0 hack/make.sh test

/go/src/github.com/docker/docker/hack/make.sh: line 316: /go/src/github.com/docker/docker/hack/make/test: No such file or directory
---> Making bundle: test (in bundles/1.12.0-dev/test)
```

cause:

``` bash
[root@CentOS7-01 ~]# docker run --rm --privileged docker-dev:v1-12-0 ls -a hack/make | grep test
.ensure-nnp-test
.ensure-syscall-test
test-deb-install
test-docker-py
test-install-script
test-integration-cli
test-old-apt-repo
test-unit
validate-test
```
