### PR TITLE
Make MongoDB sample Dockerfile working again

### DIFF
--- a/docs/examples/mongodb/Dockerfile
+++ b/docs/examples/mongodb/Dockerfile
@@ -7,8 +7,9 @@ MAINTAINER Docker
 
 # Installation:
 # Import MongoDB public GPG key AND create a MongoDB list file
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-RUN echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+RUN echo "deb http://repo.mongodb.org/apt/ubuntu $(cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -d= -f2)/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+
 # Update apt-get sources AND install MongoDB
 RUN apt-get update && apt-get install -y mongodb-org
 


### PR DESCRIPTION
**Problem**
Current Dockerfile doesn't finish image build

**\- What I did**
Updated Dockerfile to reflect recent changes:
1. [MongoDB manual](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/) uses 3.2 repo version as of July'16, which also has a new key.
2.  Command `# lsb_release -sc`  doesn't work out of box on Docker image, as least on Ubuntu 16.04.

**\- How to verify it**
Just build an image with a standard command `docker build --tag mondogb_sample .`

**\- Description for the changelog**
Fixed mongodb sample Dockerfile 

**-Environment**
MacOS 10.10.5, Docker 1.12.0-rc2 
