### PR TITLE
Fix a grammatical error in errClusterNetworkOnRun()'s error message.

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -328,7 +328,7 @@ func (daemon *Daemon) updateNetwork(container *container.Container) error {
 }
 
 func errClusterNetworkOnRun(n string) error {
-	return fmt.Errorf("swarm-scoped network (%s) is not compatible with `docker create` or `docker run`. This network can be only used docker service", n)
+	return fmt.Errorf("swarm-scoped network (%s) is not compatible with `docker create` or `docker run`. This network can only be used by a docker service", n)
 }
 
 // updateContainerNetworkSettings update the network settings


### PR DESCRIPTION
**\- What I did**
There was a grammatical error in the error message returned by `errClusterNetworkOnRun()`

**\- How I did it**
Fixed the grammatical error.

**\- How to verify it**
Attempting to run a container using a swarm overlay network will now show the grammatically correct error message.

**\- Description for the changelog**
Fixed a grammatically error in the error message returned by `errClusterNetworkOnRun()`
