### PR TITLE
Fixed typo: s/unqiue/unique/g

### DIFF
--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -126,7 +126,7 @@ name. This is called once per container start. If the same volume_name is reques
 more than once, the plugin may need to keep track of each new mount request and provision
 at the first mount request and deprovision at the last corresponding unmount request.
 
-`ID` is a unqiue ID for the caller that is requesting the mount.
+`ID` is a unique ID for the caller that is requesting the mount.
 
 **Response**:
 ```json
@@ -176,7 +176,7 @@ Indication that Docker no longer is using the named volume. This is called once
 per container stop.  Plugin may deduce that it is safe to deprovision it at
 this point.
 
-`ID` is a unqiue ID for the caller that is requesting the mount.
+`ID` is a unique ID for the caller that is requesting the mount.
 
 **Response**:
 ```json


### PR DESCRIPTION
This is a just a basic typo fix in the plugins_volume.md file
The `unique` word was incorrectly spelled. Twice.
Signed-off-by: Damien Nadé github@livna.org
