### PR TITLE
make `docker service --help` text for `--endpoint-mode` more consistent

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -469,7 +469,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates")
 
 	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")
-	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "", "Endpoint mode(Valid values: vip, dnsrr)")
+	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "", "Endpoint mode (vip or dnsrr)")
 	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
 
 	flags.BoolVar(&opts.registryAuth, flagRegistryAuth, false, "Send registry authentication details to Swarm agents")

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -18,7 +18,7 @@ Create a new service
 
 Options:
       --constraint value             Placement constraints (default [])
-      --endpoint-mode string         Endpoint mode(Valid values: VIP, DNSRR)
+      --endpoint-mode string         Endpoint mode (vip or dnsrr)
   -e, --env value                    Set environment variables (default [])
       --help                         Print usage
   -l, --label value                  Service labels (default [])

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -20,7 +20,7 @@ Options:
       --arg value                    Service command args (default [])
       --command value                Service command (default [])
       --constraint value             Placement constraints (default [])
-      --endpoint-mode string         Endpoint mode(Valid values: VIP, DNSRR)
+      --endpoint-mode string         Endpoint mode (vip or dnsrr)
   -e, --env value                    Set environment variables (default [])
       --help                         Print usage
       --image string                 Service image tag


### PR DESCRIPTION
Previously:

```
      --constraint value             Placement constraints (default [])
      --endpoint-mode string         Endpoint mode(Valid values: vip, dnsrr)
<snip>
      --restart-condition string     Restart when condition is met (none, on_failure, or any)
```

Now:

```
      --constraint value             Placement constraints (default [])
      --endpoint-mode string         Endpoint mode (vip or dnsrr)
<snip>
      --restart-condition string     Restart when condition is met (none, on_failure, or any)
```

Signed-off-by: Anil Madhavapeddy anil@docker.com
