### PR TITLE
ppc64le: remove go SHA check

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -91,11 +91,9 @@ RUN set -x \
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.6.2
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GO_DOWNLOAD_SHA256 787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63f1bccc
 ENV GOROOT_BOOTSTRAP /usr/local
 
 RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-    && echo "$GO_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
     && tar -C /usr/src -xzf golang.tar.gz \
     && rm golang.tar.gz \
     && cd /usr/src/go/src && ./make.bash 2>&1


### PR DESCRIPTION
Makes it consistent with other Dockerfiles.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
