### PR TITLE
Update some vendoring with tags

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -46,39 +46,39 @@ clone git github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 clone git github.com/Microsoft/hcsshim v0.3.6
 clone git github.com/Microsoft/go-winio v0.3.4
 clone git github.com/Sirupsen/logrus v0.10.0 # logrus is a common dependency among multiple deps
-clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
+clone git github.com/docker/libtrust c8d2b36d60a84f3fa7d5e5e355be64f0fbe0b481 # FIXME: Use a tagged version
 clone git github.com/go-check/check 03a4d9dcf2f92eae8e90ed42aa2656f63fdd0b14 https://github.com/cpuguy83/check.git
-clone git github.com/gorilla/context 14f550f51a
-clone git github.com/gorilla/mux e444e69cbd
+clone git github.com/gorilla/context v1.1
+clone git github.com/gorilla/mux v1.1
 clone git github.com/kr/pty 5cf931ef8f
 clone git github.com/mattn/go-shellwords v1.0.0
 clone git github.com/mattn/go-sqlite3 v1.1.0
 clone git github.com/tchap/go-patricia v2.1.0
-clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
+clone git github.com/vdemeester/shakers v0.1.0
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
-clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
-clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
-clone git github.com/docker/engine-api 62043eb79d581a32ea849645277023c550732e52
+clone git github.com/docker/go-units v0.3.1
+clone git github.com/docker/go-connections v0.2.1
+clone git github.com/docker/engine-api 62043eb79d581a32ea849645277023c550732e52 # FIXME: Use a tagged version
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 377a7337f2387cce3be1df7a4503446147b68ff1
-clone git github.com/docker/go-events 39718a26497694185f8fb58a7d6f31947f3dc42d
+clone git github.com/docker/libnetwork 377a7337f2387cce3be1df7a4503446147b68ff1 # FIXME: Use a tagged version
+clone git github.com/docker/go-events afb2b9f2c23f33ada1a22b03651775fdc65a5089 # FIXME: Use a tagged version
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 88ac4de0d1a0ca6def284b571342db3b777a4c37
 clone git github.com/hashicorp/go-multierror fcdddc395df1ddf4247c69bd436e84cfa0733f7e
 clone git github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
-clone git github.com/docker/libkv 7283ef27ed32fe267388510a91709b307bb9942c
+clone git github.com/docker/libkv v0.2.0
 clone git github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 clone git github.com/vishvananda/netlink 734d02c3e202f682c74b71314b2c61eec0170fd4
-clone git github.com/BurntSushi/toml f706d00e3de6abe700c994cdd545a1a4915af060
+clone git github.com/BurntSushi/toml v0.2.0
 clone git github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
-clone git github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
+clone git github.com/deckarep/golang-set v1.5
 clone git github.com/coreos/etcd v2.3.2
 fix_rewritten_imports github.com/coreos/etcd
 clone git github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
@@ -87,7 +87,7 @@ clone git github.com/boltdb/bolt v1.2.1
 clone git github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-clone git github.com/docker/distribution 5bbf65499960b184fe8e0f045397375e1a6722b8
+clone git github.com/docker/distribution v2.5.0-rc.1
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get go-zfs packages
@@ -99,7 +99,7 @@ clone git github.com/docker/notary v0.3.0
 
 clone git google.golang.org/grpc ab0be5212fb225475f2087566eded7da5d727960 https://github.com/grpc/grpc-go.git
 clone git github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
-clone git github.com/docker/go v1.5.1-1-1-gbaf439e
+clone git github.com/docker/go v1.5.1-1
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
 clone git github.com/opencontainers/runc cc29e3dded8e27ba8f65738f40d251c885030a28 # libcontainer
@@ -117,14 +117,14 @@ clone git github.com/Graylog2/go-gelf aab2f594e4585d43468ac57287b0dece9d806883
 clone git github.com/fluent/fluent-logger-golang v1.1.0
 # fluent-logger-golang deps
 clone git github.com/philhofer/fwd 899e4efba8eaa1fea74175308f3fae18ff3319fa
-clone git github.com/tinylib/msgp 75ee40d2601edf122ef667e2a07d600d4c44490c
+clone git github.com/tinylib/msgp 75ee40d2601edf122ef667e2a07d600d4c44490c # FIXME use v1.0-beta (but after 1.12 release)
 
 # fsnotify
 clone git gopkg.in/fsnotify.v1 v1.2.11
 
 # awslogs deps
 clone git github.com/aws/aws-sdk-go v1.1.30
-clone git github.com/go-ini/ini 060d7da055ba6ec5ea7a31f116332fe5efa04ce0
+clone git github.com/go-ini/ini 060d7da055ba6ec5ea7a31f116332fe5efa04ce0 # FIXME use v1.17.0 (but after 1.12 release)
 clone git github.com/jmespath/go-jmespath 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 
 # gcplogs deps
@@ -136,10 +136,10 @@ clone git google.golang.org/cloud dae7e3d993bc3812a2185af60552bb6b847e52a0 https
 clone git github.com/docker/docker-credential-helpers v0.3.0
 
 # containerd
-clone git github.com/docker/containerd 1b3a81545ca79456086dc2aa424357be98b962ee
+clone git github.com/docker/containerd 1b3a81545ca79456086dc2aa424357be98b962ee # FIXME: Use a tagged version
 
 # cluster
-clone git github.com/docker/swarmkit 036a4a1e934bd1bbb35c3ec7f85dea2ba6d4e336
+clone git github.com/docker/swarmkit 036a4a1e934bd1bbb35c3ec7f85dea2ba6d4e336 # FIXME: Use a tagged version
 clone git github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 clone git github.com/gogo/protobuf 43a2e0b1c32252bfbbdf81f7faa7a88fb3fa4028
 clone git github.com/cloudflare/cfssl b895b0549c0ff676f92cf09ba971ae02bb41367b
@@ -149,7 +149,7 @@ clone git github.com/mreiferson/go-httpclient 63fe23f7434723dc904c901043af07931f
 clone git github.com/hashicorp/go-memdb 98f52f52d7a476958fa9da671354d270c50661a7
 clone git github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
 clone git github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
-clone git github.com/coreos/pkg 2c77715c4df99b5420ffcae14ead08f52104065d
+clone git github.com/coreos/pkg v2
 clone git github.com/pivotal-golang/clock 3fd3c1944c59d9742e1cd333672181cd1a6f9fa0
 clone git github.com/prometheus/client_golang e51041b3fa41cece0dca035740ba6411905be473
 clone git github.com/beorn7/perks b965b613227fddccbfffe13eae360ed3fa822f8d
@@ -158,7 +158,7 @@ clone git github.com/prometheus/common ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
 clone git github.com/prometheus/procfs 454a56f35412459b5e684fd5ec0f9211b94f002a
 clone hg bitbucket.org/ww/goautoneg 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 clone git github.com/matttproud/golang_protobuf_extensions fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
-clone git github.com/pkg/errors 01fa4104b9c248c8945d14d9f128454d5b28d595
+clone git github.com/pkg/errors v0.7.0
 
 # cli
 clone git github.com/spf13/cobra 75205f23b3ea70dc7ae5e900d074e010c23c37e9 https://github.com/dnephin/cobra.git

--- a/vendor/src/github.com/BurntSushi/toml/README.md
+++ b/vendor/src/github.com/BurntSushi/toml/README.md
@@ -9,7 +9,7 @@ representations. (There is an example of this below.)
 Spec: https://github.com/mojombo/toml
 
 Compatible with TOML version
-[v0.2.0](https://github.com/mojombo/toml/blob/master/versions/toml-v0.2.0.md)
+[v0.2.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.2.0.md)
 
 Documentation: http://godoc.org/github.com/BurntSushi/toml
 

--- a/vendor/src/github.com/BurntSushi/toml/decode.go
+++ b/vendor/src/github.com/BurntSushi/toml/decode.go
@@ -225,6 +225,9 @@ func (md *MetaData) unify(data interface{}, rv reflect.Value) error {
 func (md *MetaData) unifyStruct(mapping interface{}, rv reflect.Value) error {
 	tmap, ok := mapping.(map[string]interface{})
 	if !ok {
+		if mapping == nil {
+			return nil
+		}
 		return mismatch(rv, "map", mapping)
 	}
 
@@ -267,6 +270,9 @@ func (md *MetaData) unifyStruct(mapping interface{}, rv reflect.Value) error {
 func (md *MetaData) unifyMap(mapping interface{}, rv reflect.Value) error {
 	tmap, ok := mapping.(map[string]interface{})
 	if !ok {
+		if tmap == nil {
+			return nil
+		}
 		return badtype("map", mapping)
 	}
 	if rv.IsNil() {
@@ -292,6 +298,9 @@ func (md *MetaData) unifyMap(mapping interface{}, rv reflect.Value) error {
 func (md *MetaData) unifyArray(data interface{}, rv reflect.Value) error {
 	datav := reflect.ValueOf(data)
 	if datav.Kind() != reflect.Slice {
+		if !datav.IsValid() {
+			return nil
+		}
 		return badtype("slice", data)
 	}
 	sliceLen := datav.Len()
@@ -305,12 +314,16 @@ func (md *MetaData) unifyArray(data interface{}, rv reflect.Value) error {
 func (md *MetaData) unifySlice(data interface{}, rv reflect.Value) error {
 	datav := reflect.ValueOf(data)
 	if datav.Kind() != reflect.Slice {
+		if !datav.IsValid() {
+			return nil
+		}
 		return badtype("slice", data)
 	}
-	sliceLen := datav.Len()
-	if rv.IsNil() {
-		rv.Set(reflect.MakeSlice(rv.Type(), sliceLen, sliceLen))
+	n := datav.Len()
+	if rv.IsNil() || rv.Cap() < n {
+		rv.Set(reflect.MakeSlice(rv.Type(), n, n))
 	}
+	rv.SetLen(n)
 	return md.unifySliceArray(datav, rv)
 }
 

--- a/vendor/src/github.com/BurntSushi/toml/lex.go
+++ b/vendor/src/github.com/BurntSushi/toml/lex.go
@@ -272,8 +272,6 @@ func lexTableNameStart(lx *lexer) stateFn {
 		lx.ignore()
 		lx.push(lexTableNameEnd)
 		return lexValue // reuse string lexing
-	case isWhitespace(r):
-		return lexTableNameStart
 	default:
 		return lexBareTableName
 	}
@@ -560,7 +558,6 @@ func lexMultilineRawString(lx *lexer) stateFn {
 func lexMultilineStringEscape(lx *lexer) stateFn {
 	// Handle the special case first:
 	if isNL(lx.next()) {
-		lx.next()
 		return lexMultilineString
 	} else {
 		lx.backup()

--- a/vendor/src/github.com/BurntSushi/toml/type_fields.go
+++ b/vendor/src/github.com/BurntSushi/toml/type_fields.go
@@ -92,10 +92,10 @@ func typeFields(t reflect.Type) []field {
 			// Scan f.typ for fields to include.
 			for i := 0; i < f.typ.NumField(); i++ {
 				sf := f.typ.Field(i)
-				if sf.PkgPath != "" { // unexported
+				if sf.PkgPath != "" && !sf.Anonymous { // unexported
 					continue
 				}
-				name := sf.Tag.Get("toml")
+				name, _ := getOptions(sf.Tag.Get("toml"))
 				if name == "-" {
 					continue
 				}

--- a/vendor/src/github.com/coreos/pkg/capnslog/formatters.go
+++ b/vendor/src/github.com/coreos/pkg/capnslog/formatters.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"log"
 	"runtime"
 	"strings"
 	"time"
@@ -28,7 +29,7 @@ type Formatter interface {
 	Flush()
 }
 
-func NewStringFormatter(w io.Writer) *StringFormatter {
+func NewStringFormatter(w io.Writer) Formatter {
 	return &StringFormatter{
 		w: bufio.NewWriter(w),
 	}
@@ -103,4 +104,54 @@ func (c *PrettyFormatter) Format(pkg string, l LogLevel, depth int, entries ...i
 
 func (c *PrettyFormatter) Flush() {
 	c.w.Flush()
+}
+
+// LogFormatter emulates the form of the traditional built-in logger.
+type LogFormatter struct {
+	logger *log.Logger
+	prefix string
+}
+
+// NewLogFormatter is a helper to produce a new LogFormatter struct. It uses the
+// golang log package to actually do the logging work so that logs look similar.
+func NewLogFormatter(w io.Writer, prefix string, flag int) Formatter {
+	return &LogFormatter{
+		logger: log.New(w, "", flag), // don't use prefix here
+		prefix: prefix,               // save it instead
+	}
+}
+
+// Format builds a log message for the LogFormatter. The LogLevel is ignored.
+func (lf *LogFormatter) Format(pkg string, _ LogLevel, _ int, entries ...interface{}) {
+	str := fmt.Sprint(entries...)
+	prefix := lf.prefix
+	if pkg != "" {
+		prefix = fmt.Sprintf("%s%s: ", prefix, pkg)
+	}
+	lf.logger.Output(5, fmt.Sprintf("%s%v", prefix, str)) // call depth is 5
+}
+
+// Flush is included so that the interface is complete, but is a no-op.
+func (lf *LogFormatter) Flush() {
+	// noop
+}
+
+// NilFormatter is a no-op log formatter that does nothing.
+type NilFormatter struct {
+}
+
+// NewNilFormatter is a helper to produce a new LogFormatter struct. It logs no
+// messages so that you can cause part of your logging to be silent.
+func NewNilFormatter() Formatter {
+	return &NilFormatter{}
+}
+
+// Format does nothing.
+func (_ *NilFormatter) Format(_ string, _ LogLevel, _ int, _ ...interface{}) {
+	// noop
+}
+
+// Flush is included so that the interface is complete, but is a no-op.
+func (_ *NilFormatter) Flush() {
+	// noop
 }

--- a/vendor/src/github.com/coreos/pkg/capnslog/pkg_logger.go
+++ b/vendor/src/github.com/coreos/pkg/capnslog/pkg_logger.go
@@ -27,17 +27,19 @@ type PackageLogger struct {
 const calldepth = 2
 
 func (p *PackageLogger) internalLog(depth int, inLevel LogLevel, entries ...interface{}) {
+	logger.Lock()
+	defer logger.Unlock()
 	if inLevel != CRITICAL && p.level < inLevel {
 		return
 	}
-	logger.Lock()
-	defer logger.Unlock()
 	if logger.formatter != nil {
 		logger.formatter.Format(p.pkg, inLevel, depth+1, entries...)
 	}
 }
 
 func (p *PackageLogger) LevelAt(l LogLevel) bool {
+	logger.Lock()
+	defer logger.Unlock()
 	return p.level >= l
 }
 
@@ -58,7 +60,7 @@ func (p *PackageLogger) Println(args ...interface{}) {
 }
 
 func (p *PackageLogger) Printf(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
+	p.Logf(INFO, format, args...)
 }
 
 func (p *PackageLogger) Print(args ...interface{}) {
@@ -80,8 +82,7 @@ func (p *PackageLogger) Panic(args ...interface{}) {
 }
 
 func (p *PackageLogger) Fatalf(format string, args ...interface{}) {
-	s := fmt.Sprintf(format, args...)
-	p.internalLog(calldepth, CRITICAL, s)
+	p.Logf(CRITICAL, format, args...)
 	os.Exit(1)
 }
 
@@ -94,7 +95,7 @@ func (p *PackageLogger) Fatal(args ...interface{}) {
 // Error Functions
 
 func (p *PackageLogger) Errorf(format string, args ...interface{}) {
-	p.internalLog(calldepth, ERROR, fmt.Sprintf(format, args...))
+	p.Logf(ERROR, format, args...)
 }
 
 func (p *PackageLogger) Error(entries ...interface{}) {
@@ -104,7 +105,7 @@ func (p *PackageLogger) Error(entries ...interface{}) {
 // Warning Functions
 
 func (p *PackageLogger) Warningf(format string, args ...interface{}) {
-	p.internalLog(calldepth, WARNING, fmt.Sprintf(format, args...))
+	p.Logf(WARNING, format, args...)
 }
 
 func (p *PackageLogger) Warning(entries ...interface{}) {
@@ -114,7 +115,7 @@ func (p *PackageLogger) Warning(entries ...interface{}) {
 // Notice Functions
 
 func (p *PackageLogger) Noticef(format string, args ...interface{}) {
-	p.internalLog(calldepth, NOTICE, fmt.Sprintf(format, args...))
+	p.Logf(NOTICE, format, args...)
 }
 
 func (p *PackageLogger) Notice(entries ...interface{}) {
@@ -124,7 +125,7 @@ func (p *PackageLogger) Notice(entries ...interface{}) {
 // Info Functions
 
 func (p *PackageLogger) Infof(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
+	p.Logf(INFO, format, args...)
 }
 
 func (p *PackageLogger) Info(entries ...interface{}) {
@@ -134,20 +135,32 @@ func (p *PackageLogger) Info(entries ...interface{}) {
 // Debug Functions
 
 func (p *PackageLogger) Debugf(format string, args ...interface{}) {
-	p.internalLog(calldepth, DEBUG, fmt.Sprintf(format, args...))
+	if p.level < DEBUG {
+		return
+	}
+	p.Logf(DEBUG, format, args...)
 }
 
 func (p *PackageLogger) Debug(entries ...interface{}) {
+	if p.level < DEBUG {
+		return
+	}
 	p.internalLog(calldepth, DEBUG, entries...)
 }
 
 // Trace Functions
 
 func (p *PackageLogger) Tracef(format string, args ...interface{}) {
-	p.internalLog(calldepth, TRACE, fmt.Sprintf(format, args...))
+	if p.level < TRACE {
+		return
+	}
+	p.Logf(TRACE, format, args...)
 }
 
 func (p *PackageLogger) Trace(entries ...interface{}) {
+	if p.level < TRACE {
+		return
+	}
 	p.internalLog(calldepth, TRACE, entries...)
 }
 

--- a/vendor/src/github.com/deckarep/golang-set/README.md
+++ b/vendor/src/github.com/deckarep/golang-set/README.md
@@ -22,7 +22,7 @@ I have to give some credit for helping seed the idea with this post on [stackove
 
 ## Features (as of 9/22/2014)
 
-* a CartesionProduct() method has been added with unit-tests: [Read more about the cartesion product](http://en.wikipedia.org/wiki/Cartesian_product)
+* a CartesianProduct() method has been added with unit-tests: [Read more about the cartesian product](http://en.wikipedia.org/wiki/Cartesian_product)
 
 ## Features (as of 9/15/2014)
 

--- a/vendor/src/github.com/docker/distribution/.mailmap
+++ b/vendor/src/github.com/docker/distribution/.mailmap
@@ -14,3 +14,5 @@ Sven Dowideit <SvenDowideit@home.org.au> Sven Dowideit <SvenDowideit@users.norep
 Vincent Giersch <vincent.giersch@ovh.net> Vincent Giersch <vincent@giersch.fr>
 davidli <wenquan.li@hp.com> davidli <wenquan.li@hpe.com>
 Omer Cohen <git@omer.io> Omer Cohen <git@omerc.net>
+Eric Yang <windfarer@gmail.com> Eric Yang <Windfarer@users.noreply.github.com>
+Nikita Tarasov <nikita@mygento.ru> Nikita <luckyraul@users.noreply.github.com>

--- a/vendor/src/github.com/docker/distribution/AUTHORS
+++ b/vendor/src/github.com/docker/distribution/AUTHORS
@@ -6,6 +6,8 @@ Adrian Mouat <adrian.mouat@gmail.com>
 Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>
 Alex Chan <alex.chan@metaswitch.com>
 Alex Elman <aelman@indeed.com>
+Alexey Gladkov <gladkov.alexey@gmail.com>
+allencloud <allen.sun@daocloud.io>
 amitshukla <ashukla73@hotmail.com>
 Amy Lindburg <amy.lindburg@docker.com>
 Andrew Hsu <andrewhsu@acm.org>
@@ -30,6 +32,7 @@ Brian Bland <brian.bland@docker.com>
 burnettk <burnettk@gmail.com>
 Carson A <ca@carsonoid.net>
 Chris Dillon <squarism@gmail.com>
+cyli <cyli@twistedmatrix.com>
 Daisuke Fujita <dtanshi45@gmail.com>
 Daniel Huhn <daniel@danielhuhn.de>
 Darren Shepherd <darren@rancher.com>
@@ -52,6 +55,7 @@ Felix Yan <felixonmars@archlinux.org>
 Florentin Raud <florentin.raud@gmail.com>
 Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 gabriell nascimento <gabriell@bluesoft.com.br>
+Gleb Schukin <gschukin@ptsecurity.com>
 harche <p.harshal@gmail.com>
 Henri Gomez <henri.gomez@gmail.com>
 Hu Keping <hukeping@huawei.com>
@@ -72,6 +76,7 @@ Jonathan Boulle <jonathanboulle@gmail.com>
 Jordan Liggitt <jliggitt@redhat.com>
 Josh Hawn <josh.hawn@docker.com>
 Julien Fernandez <julien.fernandez@gmail.com>
+Ke Xu <leonhartx.k@gmail.com>
 Keerthan Mala <kmala@engineyard.com>
 Kelsey Hightower <kelsey.hightower@gmail.com>
 Kenneth Lim <kennethlimcp@gmail.com>
@@ -94,6 +99,7 @@ moxiegirl <mary@docker.com>
 Nathan Sullivan <nathan@nightsys.net>
 nevermosby <robolwq@qq.com>
 Nghia Tran <tcnghia@gmail.com>
+Nikita Tarasov <nikita@mygento.ru>
 Nuutti Kotivuori <nuutti.kotivuori@poplatek.fi>
 Oilbeater <liumengxinfly@gmail.com>
 Olivier Gambier <olivier@docker.com>
@@ -137,4 +143,5 @@ xg.song <xg.song@venusource.com>
 xiekeyang <xiekeyang@huawei.com>
 Yann ROBERT <yann.robert@anantaplex.fr>
 yuzou <zouyu7@huawei.com>
+zhouhaibing089 <zhouhaibing089@gmail.com>
 姜继忠 <jizhong.jiangjz@alibaba-inc.com>

--- a/vendor/src/github.com/docker/distribution/CHANGELOG.md
+++ b/vendor/src/github.com/docker/distribution/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 2.5.0 (2016-06-14)
+
+### Storage
+- Ensure uploads directory is cleaned after upload is commited
+- Add ability to cap concurrent operations in filesystem driver
+- S3: Add 'us-gov-west-1' to the valid region list
+- Swift: Handle ceph not returning Last-Modified header for HEAD requests
+- Add redirect middleware
+
+#### Registry
+- Add support for blobAccessController middleware
+- Add support for layers from foreign sources
+- Remove signature store
+- Add support for Let's Encrypt
+- Correct yaml key names in configuration
+
+#### Client
+- Add option to get content digest from manifest get
+
+#### Spec
+- Update the auth spec scope grammar to reflect the fact that hostnames are optionally supported
+- Clarify API documentation around catalog fetch behavior
+
+### API
+- Support returning HTTP 429 (Too Many Requests)
+
+### Documentation
+- Update auth documentation examples to show "expires in" as int
+
+### Docker Image
+- Use Alpine Linux as base image
+
+

--- a/vendor/src/github.com/docker/distribution/README.md
+++ b/vendor/src/github.com/docker/distribution/README.md
@@ -83,7 +83,7 @@ created. For more information see [docker/migrator]
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute
 issues, fixes, and patches to this project. If you are contributing code, see
-the instructions for [building a development environment](docs/building.md).
+the instructions for [building a development environment](docs/recipes/building.md).
 
 ## Support
 

--- a/vendor/src/github.com/docker/distribution/ROADMAP.md
+++ b/vendor/src/github.com/docker/distribution/ROADMAP.md
@@ -156,7 +156,7 @@ full and understand the problems behind deletes.
 While, at first glance, implementing deleting seems simple, there are a number
 mitigating factors that make many solutions not ideal or even pathological in
 the context of a registry. The following paragraph discuss the background and
-approaches that could be applied to a arrive at a solution.
+approaches that could be applied to arrive at a solution.
 
 The goal of deletes in any system is to remove unused or unneeded data. Only
 data requested for deletion should be removed and no other data. Removing

--- a/vendor/src/github.com/docker/distribution/blobs.go
+++ b/vendor/src/github.com/docker/distribution/blobs.go
@@ -127,6 +127,11 @@ type BlobDescriptorService interface {
 	Clear(ctx context.Context, dgst digest.Digest) error
 }
 
+// BlobDescriptorServiceFactory creates middleware for BlobDescriptorService.
+type BlobDescriptorServiceFactory interface {
+	BlobAccessController(svc BlobDescriptorService) BlobDescriptorService
+}
+
 // ReadSeekCloser is the primary reader type for blob data, combining
 // io.ReadSeeker with io.Closer.
 type ReadSeekCloser interface {

--- a/vendor/src/github.com/docker/distribution/manifests.go
+++ b/vendor/src/github.com/docker/distribution/manifests.go
@@ -61,12 +61,6 @@ type ManifestEnumerator interface {
 	Enumerate(ctx context.Context, ingester func(digest.Digest) error) error
 }
 
-// SignaturesGetter provides an interface for getting the signatures of a schema1 manifest. If the digest
-// referred to is not a schema1 manifest, an error should be returned.
-type SignaturesGetter interface {
-	GetSignatures(ctx context.Context, manifestDigest digest.Digest) ([]digest.Digest, error)
-}
-
 // Describable is an interface for descriptors
 type Describable interface {
 	Descriptor() Descriptor

--- a/vendor/src/github.com/docker/distribution/registry/api/errcode/register.go
+++ b/vendor/src/github.com/docker/distribution/registry/api/errcode/register.go
@@ -71,10 +71,7 @@ var (
 		Message: "too many requests",
 		Description: `Returned when a client attempts to contact a
 		service too many times`,
-		// FIXME: go1.5 doesn't export http.StatusTooManyRequests while
-		// go1.6 does. Update the hardcoded value to the constant once
-		// Docker updates golang version to 1.6.
-		HTTPStatusCode: 429,
+		HTTPStatusCode: http.StatusTooManyRequests,
 	})
 )
 

--- a/vendor/src/github.com/docker/distribution/registry/api/v2/descriptors.go
+++ b/vendor/src/github.com/docker/distribution/registry/api/v2/descriptors.go
@@ -1497,8 +1497,8 @@ var routeDescriptors = []RouteDescriptor{
 				Description: "Retrieve a sorted, json list of repositories available in the registry.",
 				Requests: []RequestDescriptor{
 					{
-						Name:        "Catalog Fetch Complete",
-						Description: "Request an unabridged list of repositories available.",
+						Name:        "Catalog Fetch",
+						Description: "Request an unabridged list of repositories available.  The implementation may impose a maximum limit and return a partial set with pagination links.",
 						Successes: []ResponseDescriptor{
 							{
 								Description: "Returns the unabridged list of repositories as a json response.",

--- a/vendor/src/github.com/docker/distribution/registry/client/errors.go
+++ b/vendor/src/github.com/docker/distribution/registry/client/errors.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 )
 
-// ErrNoErrorsInBody is returned when a HTTP response body parses to an empty
+// ErrNoErrorsInBody is returned when an HTTP response body parses to an empty
 // errcode.Errors slice.
 var ErrNoErrorsInBody = errors.New("no error details found in HTTP response body")
 
@@ -54,10 +54,7 @@ func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
 		switch statusCode {
 		case http.StatusUnauthorized:
 			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
-		// FIXME: go1.5 doesn't export http.StatusTooManyRequests while
-		// go1.6 does. Update the hardcoded value to the constant once
-		// Docker updates golang version to 1.6.
-		case 429:
+		case http.StatusTooManyRequests:
 			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
 		default:
 			return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)

--- a/vendor/src/github.com/docker/go-events/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/go-events/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Docker open source projects
+
+Want to hack on go-events? Awesome! Here are instructions to get you started.
+
+go-events is part of the [Docker](https://www.docker.com) project, and
+follows the same rules and principles. If you're already familiar with the way
+Docker does things, you'll feel right at home.
+
+Otherwise, go read Docker's
+[contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md),
+[issue triaging](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md),
+[review process](https://github.com/docker/docker/blob/master/project/REVIEWING.md) and
+[branches and tags](https://github.com/docker/docker/blob/master/project/BRANCHES-AND-TAGS.md).
+
+For an in-depth description of our contribution process, visit the
+contributors guide: [Understand how to contribute](https://docs.docker.com/opensource/workflow/make-a-contribution/)
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/vendor/src/github.com/docker/go-events/LICENSE
+++ b/vendor/src/github.com/docker/go-events/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/src/github.com/docker/go-events/MAINTAINERS
+++ b/vendor/src/github.com/docker/go-events/MAINTAINERS
@@ -1,6 +1,6 @@
-# Distribution maintainers file
+# go-events maintainers file
 #
-# This file describes who runs the docker/distribution project and how.
+# This file describes who runs the docker/go-events project and how.
 # This is a living document - if you see something out of date or missing, speak up!
 #
 # It is structured to be consumable by both humans and programs.
@@ -12,10 +12,8 @@
 	[Org."Core maintainers"]
 		people = [
 			"aaronlehmann",
-			"dmcgowan",
-			"dmp42",
-			"richardscothern",
-			"shykes",
+			"aluzzardi",
+			"lk4d4",
 			"stevvooe",
 		]
 
@@ -32,25 +30,15 @@
 	Email = "aaron.lehmann@docker.com"
 	GitHub = "aaronlehmann"
 
-	[people.dmcgowan]
-	Name = "Derek McGowan"
-	Email = "derek@mcgstyle.net"
-	GitHub = "dmcgowan"
+	[people.aluzzardi]
+	Name = "Andrea Luzzardi"
+	Email = "al@docker.com"
+	GitHub = "aluzzardi"
 
-	[people.dmp42]
-	Name = "Olivier Gambier"
-	Email = "olivier@docker.com"
-	GitHub = "dmp42"
-
-	[people.richardscothern]
-	Name = "Richard Scothern"
-	Email = "richard.scothern@gmail.com"
-	GitHub = "richardscothern"
-
-	[people.shykes]
-	Name = "Solomon Hykes"
-	Email = "solomon@docker.com"
-	GitHub = "shykes"
+	[people.lk4d4]
+	Name = "Alexander Morozov"
+	Email = "lk4d4@docker.com"
+	GitHub = "lk4d4"
 
 	[people.stevvooe]
 	Name = "Stephen Day"

--- a/vendor/src/github.com/docker/go-events/README.md
+++ b/vendor/src/github.com/docker/go-events/README.md
@@ -110,3 +110,8 @@ Application behavior can be controlled by how `Write` behaves. The examples
 above are designed to queue the message and return as quickly as possible.
 Other implementations may block until the event is committed to durable
 storage.
+
+## Copyright and license
+
+Copyright © 2016 Docker, Inc. go-events is licensed under the Apache License,
+Version 2.0. See [LICENSE](LICENSE) for the full license text.

--- a/vendor/src/github.com/docker/go-events/channel.go
+++ b/vendor/src/github.com/docker/go-events/channel.go
@@ -10,7 +10,7 @@ type Channel struct {
 	closed chan struct{}
 }
 
-// NewChannel returns a channel. If buffer is non-zero, the channel is
+// NewChannel returns a channel. If buffer is zero, the channel is
 // unbuffered.
 func NewChannel(buffer int) *Channel {
 	return &Channel{

--- a/vendor/src/github.com/docker/go-events/queue.go
+++ b/vendor/src/github.com/docker/go-events/queue.go
@@ -72,10 +72,17 @@ func (eq *Queue) run() {
 		}
 
 		if err := eq.dst.Write(event); err != nil {
+			// TODO(aaronl): Dropping events could be bad depending
+			// on the application. We should have a way of
+			// communicating this condition. However, logging
+			// at a log level above debug may not be appropriate.
+			// Eventually, go-events should not use logrus at all,
+			// and should bubble up conditions like this through
+			// error values.
 			logrus.WithFields(logrus.Fields{
 				"event": event,
 				"sink":  eq.dst,
-			}).WithError(err).Warnf("eventqueue: dropped event")
+			}).WithError(err).Debug("eventqueue: dropped event")
 		}
 	}
 }

--- a/vendor/src/github.com/docker/go-units/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/go-units/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to go-units
+
+Want to hack on go-units? Awesome! Here are instructions to get you started.
+
+go-units is a part of the [Docker](https://www.docker.com) project, and follows
+the same rules and principles. If you're already familiar with the way
+Docker does things, you'll feel right at home.
+
+Otherwise, go read Docker's
+[contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md),
+[issue triaging](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md),
+[review process](https://github.com/docker/docker/blob/master/project/REVIEWING.md) and
+[branches and tags](https://github.com/docker/docker/blob/master/project/BRANCHES-AND-TAGS.md).
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/vendor/src/github.com/docker/go-units/MAINTAINERS
+++ b/vendor/src/github.com/docker/go-units/MAINTAINERS
@@ -1,0 +1,27 @@
+# go-connections maintainers file
+#
+# This file describes who runs the docker/go-connections project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"calavera",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+	[people.calavera]
+	Name = "David Calavera"
+	Email = "david.calavera@gmail.com"
+	GitHub = "calavera"

--- a/vendor/src/github.com/docker/go-units/README.md
+++ b/vendor/src/github.com/docker/go-units/README.md
@@ -8,6 +8,9 @@ go-units is a library to transform human friendly measurements into machine frie
 
 See the [docs in godoc](https://godoc.org/github.com/docker/go-units) for examples and documentation.
 
-## License
+## Copyright and license
 
-go-units is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.
+Copyright © 2015 Docker, Inc.
+
+go-units is licensed under the Apache License, Version 2.0.
+See [LICENSE](LICENSE) for the full text of the license.

--- a/vendor/src/github.com/docker/go-units/size.go
+++ b/vendor/src/github.com/docker/go-units/size.go
@@ -31,7 +31,7 @@ type unitMap map[string]int64
 var (
 	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
 	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
-	sizeRegex  = regexp.MustCompile(`^(\d+)([kKmMgGtTpP])?[bB]?$`)
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
 )
 
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
@@ -41,7 +41,8 @@ var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB",
 // using custom format.
 func CustomSize(format string, size float64, base float64, _map []string) string {
 	i := 0
-	for size >= base {
+	unitsLimit := len(_map) - 1
+	for size >= base && i < unitsLimit {
 		size = size / base
 		i++
 	}
@@ -77,19 +78,19 @@ func RAMInBytes(size string) (int64, error) {
 // Parses the human-readable size string into the amount it represents.
 func parseSize(sizeStr string, uMap unitMap) (int64, error) {
 	matches := sizeRegex.FindStringSubmatch(sizeStr)
-	if len(matches) != 3 {
+	if len(matches) != 4 {
 		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
 	}
 
-	size, err := strconv.ParseInt(matches[1], 10, 0)
+	size, err := strconv.ParseFloat(matches[1], 64)
 	if err != nil {
 		return -1, err
 	}
 
-	unitPrefix := strings.ToLower(matches[2])
+	unitPrefix := strings.ToLower(matches[3])
 	if mul, ok := uMap[unitPrefix]; ok {
-		size *= mul
+		size *= float64(mul)
 	}
 
-	return size, nil
+	return int64(size), nil
 }

--- a/vendor/src/github.com/docker/go-units/ulimit.go
+++ b/vendor/src/github.com/docker/go-units/ulimit.go
@@ -73,25 +73,34 @@ func ParseUlimit(val string) (*Ulimit, error) {
 		return nil, fmt.Errorf("invalid ulimit type: %s", parts[0])
 	}
 
-	limitVals := strings.SplitN(parts[1], ":", 2)
-	if len(limitVals) > 2 {
+	var (
+		soft int64
+		hard = &soft // default to soft in case no hard was set
+		temp int64
+		err  error
+	)
+	switch limitVals := strings.Split(parts[1], ":"); len(limitVals) {
+	case 2:
+		temp, err = strconv.ParseInt(limitVals[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		hard = &temp
+		fallthrough
+	case 1:
+		soft, err = strconv.ParseInt(limitVals[0], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	default:
 		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
 	}
 
-	soft, err := strconv.ParseInt(limitVals[0], 10, 64)
-	if err != nil {
-		return nil, err
+	if soft > *hard {
+		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
 	}
 
-	hard := soft // in case no hard was set
-	if len(limitVals) == 2 {
-		hard, err = strconv.ParseInt(limitVals[1], 10, 64)
-	}
-	if soft > hard {
-		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, hard)
-	}
-
-	return &Ulimit{Name: parts[0], Soft: soft, Hard: hard}, nil
+	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil
 }
 
 // GetRlimit returns the RLimit corresponding to Ulimit.

--- a/vendor/src/github.com/docker/libtrust/util.go
+++ b/vendor/src/github.com/docker/libtrust/util.go
@@ -152,7 +152,7 @@ func NewIdentityAuthTLSClientConfig(dockerUrl string, trustUnknownHosts bool, ro
 }
 
 // joseBase64UrlEncode encodes the given data using the standard base64 url
-// encoding format but with all trailing '=' characters ommitted in accordance
+// encoding format but with all trailing '=' characters omitted in accordance
 // with the jose specification.
 // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31#section-2
 func joseBase64UrlEncode(b []byte) string {

--- a/vendor/src/github.com/gorilla/context/.travis.yml
+++ b/vendor/src/github.com/gorilla/context/.travis.yml
@@ -1,7 +1,19 @@
 language: go
+sudo: false
 
-go:
-  - 1.0
-  - 1.1
-  - 1.2
-  - tip
+matrix:
+  include:
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: tip
+
+install:
+  - go get golang.org/x/tools/cmd/vet
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/vendor/src/github.com/gorilla/mux/.travis.yml
+++ b/vendor/src/github.com/gorilla/mux/.travis.yml
@@ -1,7 +1,20 @@
 language: go
+sudo: false
 
-go:
-  - 1.0
-  - 1.1
-  - 1.2
-  - tip
+matrix:
+  include:
+    - go: 1.2
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: tip
+
+install:
+  - go get golang.org/x/tools/cmd/vet
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/vendor/src/github.com/gorilla/mux/README.md
+++ b/vendor/src/github.com/gorilla/mux/README.md
@@ -1,7 +1,242 @@
 mux
 ===
-[![Build Status](https://travis-ci.org/gorilla/mux.png?branch=master)](https://travis-ci.org/gorilla/mux)
+[![GoDoc](https://godoc.org/github.com/gorilla/mux?status.svg)](https://godoc.org/github.com/gorilla/mux)
+[![Build Status](https://travis-ci.org/gorilla/mux.svg?branch=master)](https://travis-ci.org/gorilla/mux)
 
-gorilla/mux is a powerful URL router and dispatcher.
+http://www.gorillatoolkit.org/pkg/mux
 
-Read the full documentation here: http://www.gorillatoolkit.org/pkg/mux
+Package `gorilla/mux` implements a request router and dispatcher.
+
+The name mux stands for "HTTP request multiplexer". Like the standard `http.ServeMux`, `mux.Router` matches incoming requests against a list of registered routes and calls a handler for the route that matches the URL or other conditions. The main features are:
+
+* Requests can be matched based on URL host, path, path prefix, schemes, header and query values, HTTP methods or using custom matchers.
+* URL hosts and paths can have variables with an optional regular expression.
+* Registered URLs can be built, or "reversed", which helps maintaining references to resources.
+* Routes can be used as subrouters: nested routes are only tested if the parent route matches. This is useful to define groups of routes that share common conditions like a host, a path prefix or other repeated attributes. As a bonus, this optimizes request matching.
+* It implements the `http.Handler` interface so it is compatible with the standard `http.ServeMux`.
+
+Let's start registering a couple of URL paths and handlers:
+
+```go
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/", HomeHandler)
+	r.HandleFunc("/products", ProductsHandler)
+	r.HandleFunc("/articles", ArticlesHandler)
+	http.Handle("/", r)
+}
+```
+
+Here we register three routes mapping URL paths to handlers. This is equivalent to how `http.HandleFunc()` works: if an incoming request URL matches one of the paths, the corresponding handler is called passing (`http.ResponseWriter`, `*http.Request`) as parameters.
+
+Paths can have variables. They are defined using the format `{name}` or `{name:pattern}`. If a regular expression pattern is not defined, the matched variable will be anything until the next slash. For example:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/products/{key}", ProductHandler)
+r.HandleFunc("/articles/{category}/", ArticlesCategoryHandler)
+r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
+```
+
+The names are used to create a map of route variables which can be retrieved calling `mux.Vars()`:
+
+```go
+vars := mux.Vars(request)
+category := vars["category"]
+```
+
+And this is all you need to know about the basic usage. More advanced options are explained below.
+
+Routes can also be restricted to a domain or subdomain. Just define a host pattern to be matched. They can also have variables:
+
+```go
+r := mux.NewRouter()
+// Only matches if domain is "www.example.com".
+r.Host("www.example.com")
+// Matches a dynamic subdomain.
+r.Host("{subdomain:[a-z]+}.domain.com")
+```
+
+There are several other matchers that can be added. To match path prefixes:
+
+```go
+r.PathPrefix("/products/")
+```
+
+...or HTTP methods:
+
+```go
+r.Methods("GET", "POST")
+```
+
+...or URL schemes:
+
+```go
+r.Schemes("https")
+```
+
+...or header values:
+
+```go
+r.Headers("X-Requested-With", "XMLHttpRequest")
+```
+
+...or query values:
+
+```go
+r.Queries("key", "value")
+```
+
+...or to use a custom matcher function:
+
+```go
+r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
+	return r.ProtoMajor == 0
+})
+```
+
+...and finally, it is possible to combine several matchers in a single route:
+
+```go
+r.HandleFunc("/products", ProductsHandler).
+  Host("www.example.com").
+  Methods("GET").
+  Schemes("http")
+```
+
+Setting the same matching conditions again and again can be boring, so we have a way to group several routes that share the same requirements. We call it "subrouting".
+
+For example, let's say we have several URLs that should only match when the host is `www.example.com`. Create a route for that host and get a "subrouter" from it:
+
+```go
+r := mux.NewRouter()
+s := r.Host("www.example.com").Subrouter()
+```
+
+Then register routes in the subrouter:
+
+```go
+s.HandleFunc("/products/", ProductsHandler)
+s.HandleFunc("/products/{key}", ProductHandler)
+s.HandleFunc("/articles/{category}/{id:[0-9]+}"), ArticleHandler)
+```
+
+The three URL paths we registered above will only be tested if the domain is `www.example.com`, because the subrouter is tested first. This is not only convenient, but also optimizes request matching. You can create subrouters combining any attribute matchers accepted by a route.
+
+Subrouters can be used to create domain or path "namespaces": you define subrouters in a central place and then parts of the app can register its paths relatively to a given subrouter.
+
+There's one more thing about subroutes. When a subrouter has a path prefix, the inner routes use it as base for their paths:
+
+```go
+r := mux.NewRouter()
+s := r.PathPrefix("/products").Subrouter()
+// "/products/"
+s.HandleFunc("/", ProductsHandler)
+// "/products/{key}/"
+s.HandleFunc("/{key}/", ProductHandler)
+// "/products/{key}/details"
+s.HandleFunc("/{key}/details", ProductDetailsHandler)
+```
+
+Now let's see how to build registered URLs.
+
+Routes can be named. All routes that define a name can have their URLs built, or "reversed". We define a name calling `Name()` on a route. For example:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+  Name("article")
+```
+
+To build a URL, get the route and call the `URL()` method, passing a sequence of key/value pairs for the route variables. For the previous route, we would do:
+
+```go
+url, err := r.Get("article").URL("category", "technology", "id", "42")
+```
+
+...and the result will be a `url.URL` with the following path:
+
+```
+"/articles/technology/42"
+```
+
+This also works for host variables:
+
+```go
+r := mux.NewRouter()
+r.Host("{subdomain}.domain.com").
+  Path("/articles/{category}/{id:[0-9]+}").
+  HandlerFunc(ArticleHandler).
+  Name("article")
+
+// url.String() will be "http://news.domain.com/articles/technology/42"
+url, err := r.Get("article").URL("subdomain", "news",
+                                 "category", "technology",
+                                 "id", "42")
+```
+
+All variables defined in the route are required, and their values must conform to the corresponding patterns. These requirements guarantee that a generated URL will always match a registered route -- the only exception is for explicitly defined "build-only" routes which never match.
+
+Regex support also exists for matching Headers within a route. For example, we could do:
+
+```go
+r.HeadersRegexp("Content-Type", "application/(text|json)")
+```
+
+...and the route will match both requests with a Content-Type of `application/json` as well as `application/text`
+
+There's also a way to build only the URL host or path for a route: use the methods `URLHost()` or `URLPath()` instead. For the previous route, we would do:
+
+```go
+// "http://news.domain.com/"
+host, err := r.Get("article").URLHost("subdomain", "news")
+
+// "/articles/technology/42"
+path, err := r.Get("article").URLPath("category", "technology", "id", "42")
+```
+
+And if you use subrouters, host and path defined separately can be built as well:
+
+```go
+r := mux.NewRouter()
+s := r.Host("{subdomain}.domain.com").Subrouter()
+s.Path("/articles/{category}/{id:[0-9]+}").
+  HandlerFunc(ArticleHandler).
+  Name("article")
+
+// "http://news.domain.com/articles/technology/42"
+url, err := r.Get("article").URL("subdomain", "news",
+                                 "category", "technology",
+                                 "id", "42")
+```
+
+## Full Example
+
+Here's a complete, runnable example of a small `mux` based server:
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func YourHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Gorilla!\n"))
+}
+
+func main() {
+	r := mux.NewRouter()
+	// Routes consist of a path and a handler function.
+	r.HandleFunc("/", YourHandler)
+
+	// Bind to a port and pass our router in
+	http.ListenAndServe(":8000", r)
+}
+```
+
+## License
+
+BSD licensed. See the LICENSE file for details.

--- a/vendor/src/github.com/gorilla/mux/doc.go
+++ b/vendor/src/github.com/gorilla/mux/doc.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package gorilla/mux implements a request router and dispatcher.
+Package mux implements a request router and dispatcher.
 
 The name mux stands for "HTTP request multiplexer". Like the standard
 http.ServeMux, mux.Router matches incoming requests against a list of
@@ -60,8 +60,8 @@ Routes can also be restricted to a domain or subdomain. Just define a host
 pattern to be matched. They can also have variables:
 
 	r := mux.NewRouter()
-	// Only matches if domain is "www.domain.com".
-	r.Host("www.domain.com")
+	// Only matches if domain is "www.example.com".
+	r.Host("www.example.com")
 	// Matches a dynamic subdomain.
 	r.Host("{subdomain:[a-z]+}.domain.com")
 
@@ -89,12 +89,12 @@ There are several other matchers that can be added. To match path prefixes:
 
 	r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
 		return r.ProtoMajor == 0
-    })
+	})
 
 ...and finally, it is possible to combine several matchers in a single route:
 
 	r.HandleFunc("/products", ProductsHandler).
-	  Host("www.domain.com").
+	  Host("www.example.com").
 	  Methods("GET").
 	  Schemes("http")
 
@@ -103,11 +103,11 @@ a way to group several routes that share the same requirements.
 We call it "subrouting".
 
 For example, let's say we have several URLs that should only match when the
-host is "www.domain.com". Create a route for that host and get a "subrouter"
+host is "www.example.com". Create a route for that host and get a "subrouter"
 from it:
 
 	r := mux.NewRouter()
-	s := r.Host("www.domain.com").Subrouter()
+	s := r.Host("www.example.com").Subrouter()
 
 Then register routes in the subrouter:
 
@@ -116,7 +116,7 @@ Then register routes in the subrouter:
 	s.HandleFunc("/articles/{category}/{id:[0-9]+}"), ArticleHandler)
 
 The three URL paths we registered above will only be tested if the domain is
-"www.domain.com", because the subrouter is tested first. This is not
+"www.example.com", because the subrouter is tested first. This is not
 only convenient, but also optimizes request matching. You can create
 subrouters combining any attribute matchers accepted by a route.
 
@@ -164,13 +164,20 @@ This also works for host variables:
 
 	// url.String() will be "http://news.domain.com/articles/technology/42"
 	url, err := r.Get("article").URL("subdomain", "news",
-									 "category", "technology",
-									 "id", "42")
+	                                 "category", "technology",
+	                                 "id", "42")
 
 All variables defined in the route are required, and their values must
 conform to the corresponding patterns. These requirements guarantee that a
 generated URL will always match a registered route -- the only exception is
 for explicitly defined "build-only" routes which never match.
+
+Regex support also exists for matching Headers within a route. For example, we could do:
+
+	r.HeadersRegexp("Content-Type", "application/(text|json)")
+
+...and the route will match both requests with a Content-Type of `application/json` as well as
+`application/text`
 
 There's also a way to build only the URL host or path for a route:
 use the methods URLHost() or URLPath() instead. For the previous route,
@@ -193,7 +200,7 @@ as well:
 
 	// "http://news.domain.com/articles/technology/42"
 	url, err := r.Get("article").URL("subdomain", "news",
-									 "category", "technology",
-									 "id", "42")
+	                                 "category", "technology",
+	                                 "id", "42")
 */
 package mux

--- a/vendor/src/github.com/gorilla/mux/regexp.go
+++ b/vendor/src/github.com/gorilla/mux/regexp.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -34,8 +35,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	// Now let's parse it.
 	defaultPattern := "[^/]+"
 	if matchQuery {
-		defaultPattern = "[^?&]+"
-		matchPrefix = true
+		defaultPattern = "[^?&]*"
 	} else if matchHost {
 		defaultPattern = "[^.]+"
 		matchPrefix = false
@@ -53,9 +53,7 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	varsN := make([]string, len(idxs)/2)
 	varsR := make([]*regexp.Regexp, len(idxs)/2)
 	pattern := bytes.NewBufferString("")
-	if !matchQuery {
-		pattern.WriteByte('^')
-	}
+	pattern.WriteByte('^')
 	reverse := bytes.NewBufferString("")
 	var end int
 	var err error
@@ -75,9 +73,11 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 				tpl[idxs[i]:end])
 		}
 		// Build the regexp pattern.
-		fmt.Fprintf(pattern, "%s(%s)", regexp.QuoteMeta(raw), patt)
+		fmt.Fprintf(pattern, "%s(?P<%s>%s)", regexp.QuoteMeta(raw), varGroupName(i/2), patt)
+
 		// Build the reverse template.
 		fmt.Fprintf(reverse, "%s%%s", raw)
+
 		// Append variable name and compiled pattern.
 		varsN[i/2] = name
 		varsR[i/2], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
@@ -90,6 +90,12 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	pattern.WriteString(regexp.QuoteMeta(raw))
 	if strictSlash {
 		pattern.WriteString("[/]?")
+	}
+	if matchQuery {
+		// Add the default pattern if the query value is empty
+		if queryVal := strings.SplitN(template, "=", 2)[1]; queryVal == "" {
+			pattern.WriteString(defaultPattern)
+		}
 	}
 	if !matchPrefix {
 		pattern.WriteByte('$')
@@ -141,20 +147,17 @@ type routeRegexp struct {
 func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 	if !r.matchHost {
 		if r.matchQuery {
-			return r.regexp.MatchString(req.URL.RawQuery)
-		} else {
-			return r.regexp.MatchString(req.URL.Path)
+			return r.matchQueryString(req)
 		}
+
+		return r.regexp.MatchString(req.URL.Path)
 	}
+
 	return r.regexp.MatchString(getHost(req))
 }
 
 // url builds a URL part using the given values.
-func (r *routeRegexp) url(pairs ...string) (string, error) {
-	values, err := mapFromPairs(pairs...)
-	if err != nil {
-		return "", err
-	}
+func (r *routeRegexp) url(values map[string]string) (string, error) {
 	urlValues := make([]interface{}, len(r.varsN))
 	for k, v := range r.varsN {
 		value, ok := values[v]
@@ -179,11 +182,31 @@ func (r *routeRegexp) url(pairs ...string) (string, error) {
 	return rv, nil
 }
 
+// getURLQuery returns a single query parameter from a request URL.
+// For a URL with foo=bar&baz=ding, we return only the relevant key
+// value pair for the routeRegexp.
+func (r *routeRegexp) getURLQuery(req *http.Request) string {
+	if !r.matchQuery {
+		return ""
+	}
+	templateKey := strings.SplitN(r.template, "=", 2)[0]
+	for key, vals := range req.URL.Query() {
+		if key == templateKey && len(vals) > 0 {
+			return key + "=" + vals[0]
+		}
+	}
+	return ""
+}
+
+func (r *routeRegexp) matchQueryString(req *http.Request) bool {
+	return r.regexp.MatchString(r.getURLQuery(req))
+}
+
 // braceIndices returns the first level curly brace indices from a string.
 // It returns an error in case of unbalanced braces.
 func braceIndices(s string) ([]int, error) {
 	var level, idx int
-	idxs := make([]int, 0)
+	var idxs []int
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '{':
@@ -204,6 +227,11 @@ func braceIndices(s string) ([]int, error) {
 	return idxs, nil
 }
 
+// varGroupName builds a capturing group name for the indexed variable.
+func varGroupName(idx int) string {
+	return "v" + strconv.Itoa(idx)
+}
+
 // ----------------------------------------------------------------------------
 // routeRegexpGroup
 // ----------------------------------------------------------------------------
@@ -219,20 +247,17 @@ type routeRegexpGroup struct {
 func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) {
 	// Store host variables.
 	if v.host != nil {
-		hostVars := v.host.regexp.FindStringSubmatch(getHost(req))
-		if hostVars != nil {
-			for k, v := range v.host.varsN {
-				m.Vars[v] = hostVars[k+1]
-			}
+		host := getHost(req)
+		matches := v.host.regexp.FindStringSubmatchIndex(host)
+		if len(matches) > 0 {
+			extractVars(host, matches, v.host.varsN, m.Vars)
 		}
 	}
 	// Store path variables.
 	if v.path != nil {
-		pathVars := v.path.regexp.FindStringSubmatch(req.URL.Path)
-		if pathVars != nil {
-			for k, v := range v.path.varsN {
-				m.Vars[v] = pathVars[k+1]
-			}
+		matches := v.path.regexp.FindStringSubmatchIndex(req.URL.Path)
+		if len(matches) > 0 {
+			extractVars(req.URL.Path, matches, v.path.varsN, m.Vars)
 			// Check if we should redirect.
 			if v.path.strictSlash {
 				p1 := strings.HasSuffix(req.URL.Path, "/")
@@ -250,13 +275,11 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 		}
 	}
 	// Store query string variables.
-	rawQuery := req.URL.RawQuery
 	for _, q := range v.queries {
-		queryVars := q.regexp.FindStringSubmatch(rawQuery)
-		if queryVars != nil {
-			for k, v := range q.varsN {
-				m.Vars[v] = queryVars[k+1]
-			}
+		queryURL := q.getURLQuery(req)
+		matches := q.regexp.FindStringSubmatchIndex(queryURL)
+		if len(matches) > 0 {
+			extractVars(queryURL, matches, q.varsN, m.Vars)
 		}
 	}
 }
@@ -273,4 +296,17 @@ func getHost(r *http.Request) string {
 	}
 	return host
 
+}
+
+func extractVars(input string, matches []int, names []string, output map[string]string) {
+	matchesCount := 0
+	prevEnd := -1
+	for i := 2; i < len(matches) && matchesCount < len(names); i += 2 {
+		if prevEnd < matches[i+1] {
+			value := input[matches[i]:matches[i+1]]
+			output[names[matchesCount]] = value
+			prevEnd = matches[i+1]
+			matchesCount++
+		}
+	}
 }

--- a/vendor/src/github.com/gorilla/mux/route.go
+++ b/vendor/src/github.com/gorilla/mux/route.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -31,6 +32,8 @@ type Route struct {
 	name string
 	// Error resulted from building a route.
 	err error
+
+	buildVarsFunc BuildVarsFunc
 }
 
 // Match matches the route against the request.
@@ -186,7 +189,7 @@ func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery 
 type headerMatcher map[string]string
 
 func (m headerMatcher) Match(r *http.Request, match *RouteMatch) bool {
-	return matchMap(m, r.Header, true)
+	return matchMapWithString(m, r.Header, true)
 }
 
 // Headers adds a matcher for request header values.
@@ -197,13 +200,37 @@ func (m headerMatcher) Match(r *http.Request, match *RouteMatch) bool {
 //               "X-Requested-With", "XMLHttpRequest")
 //
 // The above route will only match if both request header values match.
-//
-// It the value is an empty string, it will match any value if the key is set.
+// If the value is an empty string, it will match any value if the key is set.
 func (r *Route) Headers(pairs ...string) *Route {
 	if r.err == nil {
 		var headers map[string]string
-		headers, r.err = mapFromPairs(pairs...)
+		headers, r.err = mapFromPairsToString(pairs...)
 		return r.addMatcher(headerMatcher(headers))
+	}
+	return r
+}
+
+// headerRegexMatcher matches the request against the route given a regex for the header
+type headerRegexMatcher map[string]*regexp.Regexp
+
+func (m headerRegexMatcher) Match(r *http.Request, match *RouteMatch) bool {
+	return matchMapWithRegex(m, r.Header, true)
+}
+
+// HeadersRegexp accepts a sequence of key/value pairs, where the value has regex
+// support. For example:
+//
+//     r := mux.NewRouter()
+//     r.HeadersRegexp("Content-Type", "application/(text|json)",
+//               "X-Requested-With", "XMLHttpRequest")
+//
+// The above route will only match if both the request header matches both regular expressions.
+// It the value is an empty string, it will match any value if the key is set.
+func (r *Route) HeadersRegexp(pairs ...string) *Route {
+	if r.err == nil {
+		var headers map[string]*regexp.Regexp
+		headers, r.err = mapFromPairsToRegex(pairs...)
+		return r.addMatcher(headerRegexMatcher(headers))
 	}
 	return r
 }
@@ -212,7 +239,7 @@ func (r *Route) Headers(pairs ...string) *Route {
 
 // Host adds a matcher for the URL host.
 // It accepts a template with zero or more URL variables enclosed by {}.
-// Variables can define an optional regexp pattern to me matched:
+// Variables can define an optional regexp pattern to be matched:
 //
 // - {name} matches anything until the next dot.
 //
@@ -221,7 +248,7 @@ func (r *Route) Headers(pairs ...string) *Route {
 // For example:
 //
 //     r := mux.NewRouter()
-//     r.Host("www.domain.com")
+//     r.Host("www.example.com")
 //     r.Host("{subdomain}.domain.com")
 //     r.Host("{subdomain:[a-z]+}.domain.com")
 //
@@ -237,6 +264,7 @@ func (r *Route) Host(tpl string) *Route {
 // MatcherFunc is the function signature used by custom matchers.
 type MatcherFunc func(*http.Request, *RouteMatch) bool
 
+// Match returns the match for a given request.
 func (m MatcherFunc) Match(r *http.Request, match *RouteMatch) bool {
 	return m(r, match)
 }
@@ -270,7 +298,7 @@ func (r *Route) Methods(methods ...string) *Route {
 // Path adds a matcher for the URL path.
 // It accepts a template with zero or more URL variables enclosed by {}. The
 // template must start with a "/".
-// Variables can define an optional regexp pattern to me matched:
+// Variables can define an optional regexp pattern to be matched:
 //
 // - {name} matches anything until the next slash.
 //
@@ -321,7 +349,7 @@ func (r *Route) PathPrefix(tpl string) *Route {
 //
 // It the value is an empty string, it will match any value if the key is set.
 //
-// Variables can define an optional regexp pattern to me matched:
+// Variables can define an optional regexp pattern to be matched:
 //
 // - {name} matches anything until the next slash.
 //
@@ -334,7 +362,7 @@ func (r *Route) Queries(pairs ...string) *Route {
 		return nil
 	}
 	for i := 0; i < length; i += 2 {
-		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], false, true, true); r.err != nil {
+		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], false, false, true); r.err != nil {
 			return r
 		}
 	}
@@ -360,6 +388,19 @@ func (r *Route) Schemes(schemes ...string) *Route {
 	return r.addMatcher(schemeMatcher(schemes))
 }
 
+// BuildVarsFunc --------------------------------------------------------------
+
+// BuildVarsFunc is the function signature used by custom build variable
+// functions (which can modify route variables before a route's URL is built).
+type BuildVarsFunc func(map[string]string) map[string]string
+
+// BuildVarsFunc adds a custom function to be used to modify build variables
+// before a route's URL is built.
+func (r *Route) BuildVarsFunc(f BuildVarsFunc) *Route {
+	r.buildVarsFunc = f
+	return r
+}
+
 // Subrouter ------------------------------------------------------------------
 
 // Subrouter creates a subrouter for the route.
@@ -367,7 +408,7 @@ func (r *Route) Schemes(schemes ...string) *Route {
 // It will test the inner routes only if the parent route matched. For example:
 //
 //     r := mux.NewRouter()
-//     s := r.Host("www.domain.com").Subrouter()
+//     s := r.Host("www.example.com").Subrouter()
 //     s.HandleFunc("/products/", ProductsHandler)
 //     s.HandleFunc("/products/{key}", ProductHandler)
 //     s.HandleFunc("/articles/{category}/{id:[0-9]+}"), ArticleHandler)
@@ -422,17 +463,20 @@ func (r *Route) URL(pairs ...string) (*url.URL, error) {
 	if r.regexp == nil {
 		return nil, errors.New("mux: route doesn't have a host or path")
 	}
+	values, err := r.prepareVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
 	var scheme, host, path string
-	var err error
 	if r.regexp.host != nil {
 		// Set a default scheme.
 		scheme = "http"
-		if host, err = r.regexp.host.url(pairs...); err != nil {
+		if host, err = r.regexp.host.url(values); err != nil {
 			return nil, err
 		}
 	}
 	if r.regexp.path != nil {
-		if path, err = r.regexp.path.url(pairs...); err != nil {
+		if path, err = r.regexp.path.url(values); err != nil {
 			return nil, err
 		}
 	}
@@ -453,7 +497,11 @@ func (r *Route) URLHost(pairs ...string) (*url.URL, error) {
 	if r.regexp == nil || r.regexp.host == nil {
 		return nil, errors.New("mux: route doesn't have a host")
 	}
-	host, err := r.regexp.host.url(pairs...)
+	values, err := r.prepareVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	host, err := r.regexp.host.url(values)
 	if err != nil {
 		return nil, err
 	}
@@ -473,13 +521,67 @@ func (r *Route) URLPath(pairs ...string) (*url.URL, error) {
 	if r.regexp == nil || r.regexp.path == nil {
 		return nil, errors.New("mux: route doesn't have a path")
 	}
-	path, err := r.regexp.path.url(pairs...)
+	values, err := r.prepareVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	path, err := r.regexp.path.url(values)
 	if err != nil {
 		return nil, err
 	}
 	return &url.URL{
 		Path: path,
 	}, nil
+}
+
+// GetPathTemplate returns the template used to build the
+// route match.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define a path.
+func (r *Route) GetPathTemplate() (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.regexp == nil || r.regexp.path == nil {
+		return "", errors.New("mux: route doesn't have a path")
+	}
+	return r.regexp.path.template, nil
+}
+
+// GetHostTemplate returns the template used to build the
+// route match.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define a host.
+func (r *Route) GetHostTemplate() (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.regexp == nil || r.regexp.host == nil {
+		return "", errors.New("mux: route doesn't have a host")
+	}
+	return r.regexp.host.template, nil
+}
+
+// prepareVars converts the route variable pairs into a map. If the route has a
+// BuildVarsFunc, it is invoked.
+func (r *Route) prepareVars(pairs ...string) (map[string]string, error) {
+	m, err := mapFromPairsToString(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	return r.buildVars(m), nil
+}
+
+func (r *Route) buildVars(m map[string]string) map[string]string {
+	if r.parent != nil {
+		m = r.parent.buildVars(m)
+	}
+	if r.buildVarsFunc != nil {
+		m = r.buildVarsFunc(m)
+	}
+	return m
 }
 
 // ----------------------------------------------------------------------------
@@ -490,6 +592,7 @@ func (r *Route) URLPath(pairs ...string) (*url.URL, error) {
 type parentRoute interface {
 	getNamedRoutes() map[string]*Route
 	getRegexpGroup() *routeRegexpGroup
+	buildVars(map[string]string) map[string]string
 }
 
 // getNamedRoutes returns the map where named routes are registered.


### PR DESCRIPTION
Following the [vendoring policy](https://github.com/docker/docker/blob/master/VENDORING.md), I tried to update a bit of vendoring with `tagged` versions 👼.
- [ ] Make sure the actual changes do not add regression (otherwise I'll add back the hash and add a comment)
- [ ] Few `docker/*` project need to have tag version (added a `FIXME` and created some issues about it in the corresponding repositories)
- Some tagged version imply probably too much changes (`github.com/go-ini/ini` +2500 or `github.com/tinylib/msgp`), I added a comment to update them but I feel it's too late for it to be update for `v1.12.0`

I'm putting `1.12.0` milestone on it but feel free to remove it if you feel it's not needed or risky :wink:.

/cc @tiborvass @icecrime @anusha-ragunathan @thaJeztah 

Signed-off-by: Vincent Demeester vincent@sbr.pm
