### PR TITLE
image spec: Correct set of acceptable characters in tags

### DIFF
--- a/image/spec/v1.1.md
+++ b/image/spec/v1.1.md
@@ -87,7 +87,8 @@ This specification uses the following terms:
     <dd>
         A tag serves to map a descriptive, user-given name to any single image
         ID. Tag values are limited to the set of characters
-        <code>[a-zA-Z_0-9]</code>.
+        <code>[a-zA-Z0-9_.-]</code>, except they may not start with a <code>.</code>
+        or <code>-</code> character. Tags are limited to 127 characters.
     </dd>
     <dt>
         Repository


### PR DESCRIPTION
The image spec did not match the regexp that validates tags. It
neglected to mention that period and dash characters are allowed in
tags, as long as they are not the first character. It also did not
mention the length limit for tags.

Fixes #24289
