### PR TITLE
Delete unnecessary “If” statement 

### DIFF
--- a/cli/error.go
+++ b/cli/error.go
@@ -8,10 +8,6 @@ import "strings"
 type Errors []error
 
 func (errList Errors) Error() string {
-	if len(errList) < 1 {
-		return ""
-	}
-
 	out := make([]string, len(errList))
 	for i := range errList {
 		out[i] = errList[i].Error()

--- a/cli/errors_test.go
+++ b/cli/errors_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+    "testing"
+    "errors"
+)
+
+func TestTwoErrors(t *testing.T) {
+    var errorsList Errors
+    errorsList = append(errorsList, errors.New("Error1"))
+    errorsList = append(errorsList, errors.New("Error2"))
+
+    if errorsList.Error() != "Error1, Error2" {
+        t.Error(errorsList)
+    }
+}
+
+func TestEmptyErrors(t *testing.T) {
+    errorsList := make(Errors, 0)
+
+    if errorsList.Error() != "" {
+        t.Error(errorsList)
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Delete unnecessary “If” statement for method “Error()” in  file cli/error.go

**\- How I did it**

Delete unnecessary “If” statement for method “Error()” in  file cli/error.go

**\- How to verify it**

Add Two Tests in file  cli/errors_test.go

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

The function “Join()” in package strings define as:

```
   func Join(a []string, sep string) string {
            if len(a) == 0 {
        return ""
    }
    if len(a) == 1 {
        return a[0]
    }
    n := len(sep) * (len(a) - 1)
    for i := 0; i < len(a); i++ {
        n += len(a[i])
    }

    b := make([]byte, n)
    bp := copy(b, a[0])
    for _, s := range a[1:] {
        bp += copy(b[bp:], sep)
        bp += copy(b[bp:], s)
    }
    return string(b)
}
```

So, when invoke function "Join()" in package string, it is no need to worry about the length of "a []string"

**\- A picture of a cute animal (not mandatory but encouraged)**
![maomi](https://cloud.githubusercontent.com/assets/8731588/16610501/29c79632-438e-11e6-961f-117519c1a181.jpg)
