### PR TITLE
Install iproute2 and iputils-ping in Dockerfile.aarch64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -47,6 +47,8 @@ RUN apt-get update && apt-get install -y \
 	python-pip \
 	python-websocket \
 	gccgo \
+	iproute2 \
+	iputils-ping \
 	--no-install-recommends
 
 # Install armhf loader to use armv6 binaries on armv8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

ping and ip command are need in integration-cli test, but
they are missing in ubuntu:wily.

Signed-off-by: Lei Jitang leijitang@huawei.com
