### PR TITLE
Use "on-failure" for both containers and services

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -476,7 +476,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 	flags.Var(&opts.replicas, flagReplicas, "Number of tasks")
 
-	flags.StringVar(&opts.restartPolicy.condition, flagRestartCondition, "", "Restart when condition is met (none, on_failure, or any)")
+	flags.StringVar(&opts.restartPolicy.condition, flagRestartCondition, "", "Restart when condition is met (none, on-failure, or any)")
 	flags.Var(&opts.restartPolicy.delay, flagRestartDelay, "Delay between restart attempts")
 	flags.Var(&opts.restartPolicy.maxAttempts, flagRestartMaxAttempts, "Maximum number of restarts before giving up")
 	flags.Var(&opts.restartPolicy.window, flagRestartWindow, "Window used to evaluate the restart policy")

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1701,7 +1701,7 @@ _docker_service_update() {
 			return
 			;;
 		--restart-condition)
-			COMPREPLY=( $( compgen -W "any none on_failure" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "any none on-failure" -- "$cur" ) )
 			return
 			;;
 		--user|-u)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1079,7 +1079,7 @@ __docker_service_subcommand() {
         "($help)--replicas=[Number of tasks]:replicas: "
         "($help)--reserve-cpu=[Reserve CPUs]:value: "
         "($help)--reserve-memory=[Reserve Memory]:value: "
-        "($help)--restart-condition=[Restart when condition is met]:mode:(any none on_failure)"
+        "($help)--restart-condition=[Restart when condition is met]:mode:(any none on-failure)"
         "($help)--restart-delay=[Delay between restart attempts]:delay: "
         "($help)--restart-max-attempts=[Maximum number of restarts before giving up]:max-attempts: "
         "($help)--restart-window=[Window used to evaluate the restart policy]:window: "

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -219,7 +219,8 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 	var rp *swarmapi.RestartPolicy
 	if p != nil {
 		rp = &swarmapi.RestartPolicy{}
-		if condition, ok := swarmapi.RestartPolicy_RestartCondition_value[strings.ToUpper(string(p.Condition))]; ok {
+		sanatizedCondition := strings.ToUpper(strings.Replace(string(p.Condition), "-", "_", -1))
+		if condition, ok := swarmapi.RestartPolicy_RestartCondition_value[sanatizedCondition]; ok {
 			rp.Condition = swarmapi.RestartPolicy_RestartCondition(condition)
 		} else if string(p.Condition) == "" {
 			rp.Condition = swarmapi.RestartOnAny

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4007,7 +4007,7 @@ JSON Parameters:
             - **Memory** – Memory reservation
     - **RestartPolicy** – Specification for the restart policy which applies to containers created
       as part of this service.
-        - **Condition** – Condition for restart (`none`, `on_failure`, or `any`).
+        - **Condition** – Condition for restart (`none`, `on-failure`, or `any`).
         - **Delay** – Delay between restart attempts.
         - **Attempts** – Maximum attempts to restart a given container before giving up (default value
           is 0, which is ignored).
@@ -4225,7 +4225,7 @@ Update the service `id`.
             - **Memory** – Memory reservation
     - **RestartPolicy** – Specification for the restart policy which applies to containers created
       as part of this service.
-        - **Condition** – Condition for restart (`none`, `on_failure`, or `any`).
+        - **Condition** – Condition for restart (`none`, `on-failure`, or `any`).
         - **Delay** – Delay between restart attempts.
         - **Attempts** – Maximum attempts to restart a given container before giving up (default value
           is 0, which is ignored).

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4008,7 +4008,7 @@ JSON Parameters:
             - **Memory** – Memory reservation
     - **RestartPolicy** – Specification for the restart policy which applies to containers created
       as part of this service.
-        - **Condition** – Condition for restart (`none`, `on_failure`, or `any`).
+        - **Condition** – Condition for restart (`none`, `on-failure`, or `any`).
         - **Delay** – Delay between restart attempts.
         - **Attempts** – Maximum attempts to restart a given container before giving up (default value
           is 0, which is ignored).
@@ -4226,7 +4226,7 @@ Update the service `id`.
             - **Memory** – Memory reservation
     - **RestartPolicy** – Specification for the restart policy which applies to containers created
       as part of this service.
-        - **Condition** – Condition for restart (`none`, `on_failure`, or `any`).
+        - **Condition** – Condition for restart (`none`, `on-failure`, or `any`).
         - **Delay** – Delay between restart attempts.
         - **Attempts** – Maximum attempts to restart a given container before giving up (default value
           is 0, which is ignored).

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -32,7 +32,7 @@ Options:
       --replicas value               Number of tasks (default none)
       --reserve-cpu value            Reserve CPUs (default 0.000)
       --reserve-memory value         Reserve Memory (default 0 B)
-      --restart-condition string     Restart when condition is met (none, on_failure, or any)
+      --restart-condition string     Restart when condition is met (none, on-failure, or any)
       --restart-delay value          Delay between restart attempts (default none)
       --restart-max-attempts value   Maximum number of restarts before giving up (default none)
       --restart-window value         Window used to evaluate the restart policy (default none)

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -35,7 +35,7 @@ Options:
       --replicas value               Number of tasks (default none)
       --reserve-cpu value            Reserve CPUs (default 0.000)
       --reserve-memory value         Reserve Memory (default 0 B)
-      --restart-condition string     Restart when condition is met (none, on_failure, or any)
+      --restart-condition string     Restart when condition is met (none, on-failure, or any)
       --restart-delay value          Delay between restart attempts (default none)
       --restart-max-attempts value   Maximum number of restarts before giving up (default none)
       --restart-window value         Window used to evaluate the restart policy (default none)

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
-clone git github.com/docker/engine-api 139c221fcbe6e67dfac3c8807870e7136884a45b
+clone git github.com/docker/engine-api 1d247454d4307fb1ddf10d09fd2996394b085904
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -308,8 +308,8 @@ type HostConfig struct {
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container
 	ShmSize         int64             // Total shm memory usage
-	Sysctls         map[string]string `json:",omitempty"`        // List of Namespaced sysctls used for the container
-	Runtime         string            `json:"runtime,omitempty"` // Runtime to use with this container
+	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
+	Runtime         string            `json:",omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
 	ConsoleSize [2]int    // Initial console size

--- a/vendor/src/github.com/docker/engine-api/types/swarm/network.go
+++ b/vendor/src/github.com/docker/engine-api/types/swarm/network.go
@@ -67,13 +67,13 @@ type NetworkSpec struct {
 	IPAMOptions         *IPAMOptions `json:",omitempty"`
 }
 
-// NetworkAttachmentConfig represents the configuration of a network attachement.
+// NetworkAttachmentConfig represents the configuration of a network attachment.
 type NetworkAttachmentConfig struct {
 	Target  string   `json:",omitempty"`
 	Aliases []string `json:",omitempty"`
 }
 
-// NetworkAttachment represents a network attchement.
+// NetworkAttachment represents a network attachment.
 type NetworkAttachment struct {
 	Network   Network  `json:",omitempty"`
 	Addresses []string `json:",omitempty"`

--- a/vendor/src/github.com/docker/engine-api/types/swarm/swarm.go
+++ b/vendor/src/github.com/docker/engine-api/types/swarm/swarm.go
@@ -18,6 +18,14 @@ type Spec struct {
 	Raft             RaftConfig          `json:",omitempty"`
 	Dispatcher       DispatcherConfig    `json:",omitempty"`
 	CAConfig         CAConfig            `json:",omitempty"`
+
+	// DefaultLogDriver sets the log driver to use at task creation time if
+	// unspecified by a task.
+	//
+	// Updating this value will only have an affect on new tasks. Old tasks
+	// will continue use their previously configured log driver until
+	// recreated.
+	DefaultLogDriver *Driver `json:",omitempty"`
 }
 
 // AcceptancePolicy represents the list of policies.

--- a/vendor/src/github.com/docker/engine-api/types/swarm/task.go
+++ b/vendor/src/github.com/docker/engine-api/types/swarm/task.go
@@ -93,7 +93,7 @@ const (
 	// RestartPolicyConditionNone NONE
 	RestartPolicyConditionNone RestartPolicyCondition = "none"
 	// RestartPolicyConditionOnFailure ON_FAILURE
-	RestartPolicyConditionOnFailure RestartPolicyCondition = "on_failure"
+	RestartPolicyConditionOnFailure RestartPolicyCondition = "on-failure"
 	// RestartPolicyConditionAny ANY
 	RestartPolicyConditionAny RestartPolicyCondition = "any"
 )

--- a/vendor/src/github.com/docker/engine-api/types/swarm/task.go
+++ b/vendor/src/github.com/docker/engine-api/types/swarm/task.go
@@ -54,6 +54,11 @@ type TaskSpec struct {
 	Resources     *ResourceRequirements `json:",omitempty"`
 	RestartPolicy *RestartPolicy        `json:",omitempty"`
 	Placement     *Placement            `json:",omitempty"`
+
+	// LogDriver specifies the LogDriver to use for tasks created from this
+	// spec. If not present, the one on cluster default on swarm.Spec will be
+	// used, finally falling back to the engine default if not specified.
+	LogDriver *Driver `json:",omitempty"`
 }
 
 // Resources represents resources (CPU/Memory).

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -444,12 +444,12 @@ type VolumeCreateRequest struct {
 // NetworkResource is the body of the "get network" http response message
 type NetworkResource struct {
 	Name       string                      // Name is the requested name of the network
-	ID         string                      `json:"Id"` // ID uniquely indentifies a network on a single machine
+	ID         string                      `json:"Id"` // ID uniquely identifies a network on a single machine
 	Scope      string                      // Scope describes the level at which the network exists (e.g. `global` for cluster-wide or `local` for machine level)
 	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
 	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
 	IPAM       network.IPAM                // IPAM is the network's IP Address Management
-	Internal   bool                        // Internal respresents if the network is used internal only
+	Internal   bool                        // Internal represents if the network is used internal only
 	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
 	Options    map[string]string           // Options holds the network specific options to use for when creating the network
 	Labels     map[string]string           // Labels holds metadata specific to the network being created


### PR DESCRIPTION
Make it so `service` `--restart-condition` flag takes `on-failure` to be consistent with `run`/`create` flag 🐳.

I believe protobuf enum cannot have a dash `-` in their _name_, so I updated `restartPolicyToGRPC` to transform `on-failure` to `ON_FAILURE` as required for SwarmKit. Maybe I'm wrong ? @stevvooe @aaronlehmann 

I'll create a PR in `engine-api` to update the struct if this changes is ok :wink:.

Closes #24356 

/cc @thaJeztah @icecrime @tiborvass 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
