### PR TITLE
Remove unmatched bracket from _docker for zsh

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -705,7 +705,7 @@ __docker_nodes() {
 
     type=$1; shift
     filter=$1; shift
-    [[ $filter != "none") ]] && args=("-f $filter")
+    [[ $filter != "none" ]] && args=("-f $filter")
 
     lines=(${(f)"$(_call_program commands docker $docker_options node ls $args)"})
     # Parse header line to find columns


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fixed a dangling ')' in the zsh _docker completion script.

**\- How I did it**
...With my keyboard?

**\- How to verify it**
tab completion no longer explodes with a parse error in zsh.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed a zsh tab completion issue.

**\- A picture of a cute animal (not mandatory but encouraged)**
![Cutest animal EVAR](http://media.mnn.com/assets/images/2016/02/aye-aye.jpg.638x0_q80_crop-smart.jpg)
