### PR TITLE
Change NAME to HOSTNAME in docs for `docker node ls`

### DIFF
--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -28,7 +28,7 @@ Lists all the nodes that the Docker Swarm manager knows about. You can filter us
 Example output:
 
     $ docker node ls
-    ID                           NAME           MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+    ID                           HOSTNAME        MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
     1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Accepted    Ready   Active
     38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Accepted    Ready   Active
     e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Accepted    Ready   Active        Reachable       Yes
@@ -52,7 +52,7 @@ The `name` filter matches on all or part of a node name.
 The following filter matches the node with a name equal to `swarm-master` string.
 
     $ docker node ls -f name=swarm-manager1
-    ID                           NAME            MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+    ID                           HOSTNAME        MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
     e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Accepted    Ready   Active        Reachable       Yes
 
 ### id
@@ -60,7 +60,7 @@ The following filter matches the node with a name equal to `swarm-master` string
 The `id` filter matches all or part of a node's id.
 
     $ docker node ls -f id=1
-    ID                         NAME           MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+    ID                         HOSTNAME       MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
     1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Accepted    Ready   Active
 
 
@@ -73,7 +73,7 @@ The following filter matches nodes with the `usage` label regardless of its valu
 
 ```bash
 $ docker node ls -f "label=foo"
-ID                         NAME           MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+ID                         HOSTNAME       MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
 1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Accepted    Ready   Active
 ```
 

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -31,7 +31,7 @@ in the newly created one node Swarm cluster.
 $ docker swarm init --listen-addr 192.168.99.121:2377
 Swarm initialized: current node (1ujecd0j9n3ro9i6628smdmth) is now a manager.
 $ docker node ls
-ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS          LEADER
+ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS          LEADER
 1ujecd0j9n3ro9i6628smdmth *  manager1  Accepted    Ready   Active        Reachable               Yes
 ```
 

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -30,7 +30,7 @@ targeted by this command becomes a `manager`. If it is not specified, it becomes
 $ docker swarm join --manager --listen-addr 192.168.99.122:2377 192.168.99.121:2377
 This node joined a Swarm as a manager.
 $ docker node ls
-ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
+ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
 dkp8vy1dq1kxleu9g4u78tlag *  manager2  Accepted    Ready   Active        Reachable
 dvfxp4zseq4s0rih1selh0d20    manager1  Accepted    Ready   Active        Reachable              Yes
 ```
@@ -41,7 +41,7 @@ dvfxp4zseq4s0rih1selh0d20    manager1  Accepted    Ready   Active        Reachab
 $ docker swarm join --listen-addr 192.168.99.123:2377 192.168.99.121:2377
 This node joined a Swarm as a worker.
 $ docker node ls
-ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
+ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
 7ln70fl22uw2dvjn2ft53m3q5    worker2   Accepted    Ready   Active
 dkp8vy1dq1kxleu9g4u78tlag    worker1   Accepted    Ready   Active        Reachable
 dvfxp4zseq4s0rih1selh0d20 *  manager1  Accepted    Ready   Active        Reachable              Yes

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -23,7 +23,7 @@ This command causes the node to leave the swarm.
 On a manager node:
 ```bash
 $ docker node ls
-ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
+ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
 7ln70fl22uw2dvjn2ft53m3q5    worker2   Accepted    Ready   Active
 dkp8vy1dq1kxleu9g4u78tlag    worker1   Accepted    Ready   Active        Reachable
 dvfxp4zseq4s0rih1selh0d20 *  manager1  Accepted    Ready   Active        Reachable              Yes
@@ -38,7 +38,7 @@ Node left the default swarm.
 On a manager node:
 ```bash
 $ docker node ls
-ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
+ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS         LEADER
 7ln70fl22uw2dvjn2ft53m3q5    worker2   Accepted    Down    Active
 dkp8vy1dq1kxleu9g4u78tlag    worker1   Accepted    Ready   Active        Reachable
 dvfxp4zseq4s0rih1selh0d20 *  manager1  Accepted    Ready   Active        Reachable              Yes

--- a/docs/swarm/swarm-tutorial/add-nodes.md
+++ b/docs/swarm/swarm-tutorial/add-nodes.md
@@ -50,7 +50,7 @@ the existing Swarm.
 the `docker node ls` command to see the worker nodes:
 
     ```bash
-    ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+    ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
     03g1y59jwfg7cf99w4lt0f662    worker2   Accepted    Ready   Active
     9j68exjopxe7wfl6yuxml7a7j    worker1   Accepted    Ready   Active
     dxn1zf6l61qsb1josjja83ngz *  manager1  Accepted    Ready   Active        Reachable       Yes

--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -62,7 +62,7 @@ node. For example, the tutorial uses a machine named `manager1`.
     ```
     $ docker node ls
 
-    ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
+    ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
     dxn1zf6l61qsb1josjja83ngz *  manager1  Accepted    Ready   Active        Reachable       Yes
 
     ```

--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -31,7 +31,7 @@ run your manager node. For example, the tutorial uses a machine named
     ```bash
     $ docker node ls
 
-    ID                           NAME      MEMBERSHIP  STATUS  AVAILABILITY     MANAGER STATUS  LEADER
+    ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY     MANAGER STATUS  LEADER
     1bcef6utixb0l0ca7gxuivsj0    worker2   Accepted    Ready   Active
     38ciaotwjuritcdtn9npbnkuz    worker1   Accepted    Ready   Active
     e216jshn25ckzbvmwlnh5jr3g *  manager1  Accepted    Ready   Active        Reachable       Yes


### PR DESCRIPTION
In #24159, the title field of `docker node ls` has been changed from NAME to HOSTNAME. However, in the docs the NAMEs are still used for the output of `docker node ls`.

This fix updates docs so that NAME field is changed to HOSTNAME for all `docker node ls`.

This fix is related to #24159 and #24090.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
