### PR TITLE
Add a new "is-task" ps filter

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2181,6 +2181,10 @@ _docker_ps() {
 			__docker_complete_container_ids
 			return
 			;;
+		is-task)
+			COMPREPLY=( $( compgen -W "true false" -- "${cur##*=}" ) )
+			return
+			;;
 		name)
 			cur="${cur##*=}"
 			__docker_complete_container_names

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -333,6 +333,9 @@ __docker_complete_ps_filters() {
             (id)
                 __docker_containers_ids && ret=0
                 ;;
+            (is-task)
+                _describe -t boolean-filter-opts "filter options" boolean_opts && ret=0
+                ;;
             (name)
                 __docker_containers_names && ret=0
                 ;;

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -36,6 +36,7 @@ var acceptedPsFilterTags = map[string]bool{
 	"since":     true,
 	"volume":    true,
 	"network":   true,
+	"is-task":   true,
 }
 
 // iterationAction represents possible outcomes happening during the container iteration.
@@ -79,11 +80,14 @@ type listContext struct {
 	exitAllowed []int
 
 	// beforeFilter is a filter to ignore containers that appear before the one given
-	// this is used for --filter=before= and --before=, the latter is deprecated.
 	beforeFilter *container.Container
 	// sinceFilter is a filter to stop the filtering when the iterator arrive to the given container
-	// this is used for --filter=since= and --since=, the latter is deprecated.
 	sinceFilter *container.Container
+
+	// taskFilter tells if we should filter based on wether a container is part of a task
+	taskFilter bool
+	// isTask tells us if the we should filter container that are a task (true) or not (false)
+	isTask bool
 	// ContainerListOptions is the filters set by the user
 	*types.ContainerListOptions
 }
@@ -241,6 +245,19 @@ func (daemon *Daemon) foldFilter(config *types.ContainerListOptions) (*listConte
 		return nil, err
 	}
 
+	var taskFilter, isTask bool
+	if psFilters.Include("is-task") {
+		if psFilters.ExactMatch("is-task", "true") {
+			taskFilter = true
+			isTask = true
+		} else if psFilters.ExactMatch("is-task", "false") {
+			taskFilter = true
+			isTask = false
+		} else {
+			return nil, fmt.Errorf("Invalid filter 'is-task=%s'", psFilters.Get("is-task"))
+		}
+	}
+
 	var beforeContFilter, sinceContFilter *container.Container
 
 	err = psFilters.WalkValues("before", func(value string) error {
@@ -286,6 +303,8 @@ func (daemon *Daemon) foldFilter(config *types.ContainerListOptions) (*listConte
 		exitAllowed:          filtExited,
 		beforeFilter:         beforeContFilter,
 		sinceFilter:          sinceContFilter,
+		taskFilter:           taskFilter,
+		isTask:               isTask,
 		ContainerListOptions: config,
 		names:                daemon.nameIndex.GetAll(),
 	}, nil
@@ -323,6 +342,12 @@ func includeContainerInList(container *container.Container, ctx *listContext) it
 	// Do not include container if the id doesn't match
 	if !ctx.filters.Match("id", container.ID) {
 		return excludeContainer
+	}
+
+	if ctx.taskFilter {
+		if ctx.isTask != container.Managed {
+			return excludeContainer
+		}
 	}
 
 	// Do not include container if any of the labels don't match

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -130,6 +130,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
   instead of the default network if a trailing slash is provided, but no `name`
   or `id`.
 * `DELETE /containers/(name)` endpoint now returns an error of `removal of container name is already in progress` with status code of 400, when container name is in a state of removal in progress.
+* `GET /containers/json` now supports a `is-task` filter to filter
+  containers that are tasks (part of a service in swarm mode).
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -229,6 +229,9 @@ List containers
   -   `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
   -   `label=key` or `label="key=value"` of a container label
   -   `isolation=`(`default`|`process`|`hyperv`)   (Windows daemon only)
+      `id=<ID>` a container's ID
+      `name=<name>` a container's name
+      `is-task=`(`true`|`false`)
   -   `ancestor`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
   -   `before`=(`<container id>` or `<container name>`)
   -   `since`=(`<container id>` or `<container name>`)

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -27,6 +27,7 @@ Options:
                         - since=(<container-name>|<container-id>)
                         - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>)
                           containers created from an image or a descendant.
+                        - is-task=(true|false)
       --format string   Pretty-print containers using a Go template
       --help            Print usage
   -n, --last int        Show n last created containers (includes all states) (default -1)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -136,6 +136,7 @@ func assertContainerList(out string, expected []string) bool {
 	return true
 }
 
+// FIXME(vdemeester) Move this into a unit test in daemon package
 func (s *DockerSuite) TestPsListContainersInvalidFilterName(c *check.C) {
 	out, _, err := dockerCmdWithError("ps", "-f", "invalidFilter=test")
 	c.Assert(err, checker.NotNil)

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -323,3 +323,33 @@ func (s *DockerSwarmSuite) TestSwarmTaskListFilter(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Not(checker.Contains), name)
 }
+
+func (s *DockerSwarmSuite) TestPsListContainersFilterIsTask(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	// Create a bare container
+	out, err := d.Cmd("run", "-d", "--name=bare-container", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+	bareID := strings.TrimSpace(out)[:12]
+	// Create a service
+	name := "busybox-top"
+	out, err = d.Cmd("service", "create", "--name", name, "busybox", "top")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+
+	// make sure task has been deployed.
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkServiceRunningTasks(c, name), checker.Equals, 1)
+
+	// Filter non-tasks
+	out, err = d.Cmd("ps", "-a", "-q", "--filter=is-task=false")
+	c.Assert(err, checker.IsNil)
+	psOut := strings.TrimSpace(out)
+	c.Assert(psOut, checker.Equals, bareID, check.Commentf("Expected id %s, got %s for is-task label, output %q", bareID, psOut, out))
+
+	// Filter tasks
+	out, err = d.Cmd("ps", "-a", "-q", "--filter=is-task=true")
+	c.Assert(err, checker.IsNil)
+	lines := strings.Split(strings.Trim(out, "\n "), "\n")
+	c.Assert(lines, checker.HasLen, 1)
+	c.Assert(lines[0], checker.Not(checker.Equals), bareID, check.Commentf("Expected not %s, but got it for is-task label, output %q", bareID, out))
+}

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -32,6 +32,7 @@ the running containers.
    - status=(created|restarting|running|paused|exited|dead)
    - name=<string> a container's name
    - id=<ID> a container's ID
+   - is-task=(true|false) - containers that are a task (part of a service managed by swarm)
    - before=(<container-name>|<container-id>)
    - since=(<container-name>|<container-id>)
    - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.


### PR DESCRIPTION
This is a _simple_ try at #24393 🐳. 

This PR add a `is-task` filter to `docker ps` to make it easier to list containers that are managed (started with swarm mode) and those who are not 👼.

The accepted values of this new `is-task` filters are : `true`, `false`.

``` bash
$ docker service create --replicas 3 --name toto busybox top
$ docker run -itd busybox sh
$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
6b285d27cb6b        busybox             "sh"                14 minutes ago      Up 14 minutes                           angry_albattani
0386186609e5        busybox:latest      "top"               14 minutes ago      Up 14 minutes                           toto.3.ecv0v800vjm5tczzqjjez4q9w
4d5f0bb784d0        busybox:latest      "top"               14 minutes ago      Up 14 minutes                           toto.2.7s1mw00ssx5pl4i938kya3zsi
d107a6069a97        busybox:latest      "top"               14 minutes ago      Up 14 minutes                           toto.1.46ppfac4ol5mlrh4q6cpsuy88
$ docker ps --filter=is-task=true
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
0386186609e5        busybox:latest      "top"               14 minutes ago      Up 14 minutes                           toto.3.ecv0v800vjm5tczzqjjez4q9w
4d5f0bb784d0        busybox:latest      "top"               14 minutes ago      Up 14 minutes                           toto.2.7s1mw00ssx5pl4i938kya3zsi
d107a6069a97        busybox:latest      "top"               14 minutes ago      Up 14 minutes                           toto.1.46ppfac4ol5mlrh4q6cpsuy88
$ docker ps --filter=is-task=true
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
6b285d27cb6b        busybox             "sh"                14 minutes ago      Up 14 minutes                           angry_albattani
$ docker ps --filter=is-task=wrong
Error response from daemon: Invalid filter 'is-task=[wrong]'
```

<del>As @thaJeztah said, "I'm completely open to suggestions w.r.t. naming; is "managed" the right term for this?" 👼</del>


If this pass design-review, I'll need to:
- [x] Add some tests
- [X] Update completion
- [x] Update documentation

Closes #24393 

/cc @thaJeztah @icecrime @stevvooe @aaronlehmann @dnephin 

Signed-off-by: Vincent Demeester vincent@sbr.pm
