### PR TITLE
Dockerfile: update osx cross toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN cd /usr/local/lvm2 \
 
 # Configure the container for OSX cross compilation
 ENV OSX_SDK MacOSX10.11.sdk
-ENV OSX_CROSS_COMMIT 8aa9b71a394905e6c5f4b59e2b97b87a004658a4
+ENV OSX_CROSS_COMMIT a9317c18a3a457ca0a657f08cc4d0d43c6cf8953
 RUN set -x \
 	&& export OSXCROSS_PATH="/osxcross" \
 	&& git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \


### PR DESCRIPTION
Playing around with osx cross compilation I've modified the commit hash to get a newer version (current master) because if failed in a Fedora container with the stack below (which is totally unrelated). I think it's good to update that from time to time (the previous commit was from January)

```
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:96:42: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline const T *increment(const void *p, ptrdiff_t offset)
                                         ^~~~~~~~~
                                         std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:100:30: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline T *increment(void *p, ptrdiff_t offset)
                             ^~~~~~~~~
                             std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:103:45: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline const void *increment(const void *p, ptrdiff_t offset)
                                            ^~~~~~~~~
                                            std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:106:33: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline void *increment(void *p, ptrdiff_t offset)
                                ^~~~~~~~~
                                std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:110:42: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline const T *increment(const void *p, ptrdiff_t offset, size_t alignment)
                                         ^~~~~~~~~
                                         std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:114:30: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline T *increment(void *p, ptrdiff_t offset, size_t alignment)
                             ^~~~~~~~~
                             std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:117:45: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline const void *increment(const void *p, ptrdiff_t offset, size_t alignment)
                                            ^~~~~~~~~
                                            std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:120:33: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline void *increment(void *p, ptrdiff_t offset, size_t alignment)
                                ^~~~~~~~~
                                std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:123:8: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline ptrdiff_t difference(const void *p1, const void *p2)
       ^~~~~~~~~
       std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-redhat-linux/6.1.1/../../../../include/c++/6.1.1/x86_64-redhat-linux/bits/c++config.h:2089:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
9 errors generated.
make[4]: *** [code-sign-blobs/ld-blob.o] Error 1
Makefile:613: recipe for target 'code-sign-blobs/ld-blob.o' failed
make[4]: *** Waiting for unfinished jobs....
make[4]: Leaving directory '/osxcross/build/cctools-877.5-ld64-253.3_4f8ad51/cctools/ld64/src/ld'
Makefile:631: recipe for target 'all-recursive' failed
make[3]: Leaving directory '/osxcross/build/cctools-877.5-ld64-253.3_4f8ad51/cctools/ld64/src/ld'
make[3]: *** [all-recursive] Error 1
Makefile:378: recipe for target 'all-recursive' failed
make[2]: Leaving directory '/osxcross/build/cctools-877.5-ld64-253.3_4f8ad51/cctools/ld64/src'
Makefile:379: recipe for target 'all-recursive' failed
make[1]: Leaving directory '/osxcross/build/cctools-877.5-ld64-253.3_4f8ad51/cctools/ld64'
make[2]: *** [all-recursive] Error 1
make[1]: *** [all-recursive] Error 1
Makefile:411: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1

exiting with abnormal exit code (2)
run 'OCDEBUG=1 ./build.sh' to enable debug messages
removing stale locks...
if it is happening the first time, then just re-run the script

The command '/bin/sh -c set -x  && export OSXCROSS_PATH="/osxcross"     && git clone https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH    && ( cd $OSXCROSS_PATH && git checkout -q $OSX_CROSS_COMMIT)    && curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz"  && UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh' returned a non-zero code: 2
Makefile:68: recipe for target 'build' failed
make: *** [build] Error 2
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
