### PR TITLE
pkg: integration: split cgroups strings correctly

### DIFF
--- a/pkg/integration/utils.go
+++ b/pkg/integration/utils.go
@@ -307,7 +307,7 @@ func ConsumeWithSpeed(reader io.Reader, chunkSize int, interval time.Duration, s
 func ParseCgroupPaths(procCgroupData string) map[string]string {
 	cgroupPaths := map[string]string{}
 	for _, line := range strings.Split(procCgroupData, "\n") {
-		parts := strings.Split(line, ":")
+		parts := strings.SplitN(line, ":", 3)
 		if len(parts) != 3 {
 			continue
 		}


### PR DESCRIPTION
/cc @vdemeester 

Basically in a cgroup patch there would be only at least 3 parts after splitting by ":"

Signed-off-by: Antonio Murdaca runcom@redhat.com
