### PR TITLE
Add target for `make run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ DOCKER_ENVS := \
 	-e DOCKER_GITCOMMIT \
 	-e DOCKER_GRAPHDRIVER=$(DOCKER_GRAPHDRIVER) \
 	-e DOCKER_INCREMENTAL_BINARY \
+	-e DOCKER_PORT \
 	-e DOCKER_REMAP_ROOT \
 	-e DOCKER_STORAGE_OPTS \
 	-e DOCKER_USERLANDPROXY \
@@ -43,8 +44,9 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 DOCKER_IMAGE := docker-dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
+DOCKER_PORT_FORWARD := $(if $(DOCKER_PORT),-p "$(DOCKER_PORT)",)
 
-DOCKER_FLAGS := docker run --rm -i --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT)
+DOCKER_FLAGS := docker run --rm -i --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT) $(DOCKER_PORT_FORWARD)
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -96,6 +98,9 @@ install: ## install the linux binaries
 
 rpm: build ## build the rpm packages
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary build-rpm
+
+run: build ## run the docker daemon in a container
+	$(DOCKER_RUN_DOCKER) sh -c "KEEPBUNDLE=1 hack/make.sh install-binary run"
 
 shell: build ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash

--- a/hack/make/run
+++ b/hack/make/run
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+rm -rf "$DEST"
+
+if ! command -v dockerd &> /dev/null; then
+	echo >&2 'error: binary-daemon or dynbinary-daemon must be run before run'
+	false
+fi
+
+DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
+
+# example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
+storage_params=""
+if [ -n "$DOCKER_STORAGE_OPTS" ]; then
+	IFS=','
+	for i in ${DOCKER_STORAGE_OPTS}; do
+		storage_params="--storage-opt $i $storage_params"
+	done
+	unset IFS
+fi
+
+
+listen_port=2375
+if [ -n "$DOCKER_PORT" ]; then
+	IFS=':' read -r -a ports <<< "$DOCKER_PORT"
+	listen_port="${ports[-1]}"
+fi
+
+extra_params=""
+if [ "$DOCKER_REMAP_ROOT" ]; then
+	extra_params="--userns-remap $DOCKER_REMAP_ROOT"
+fi
+
+args="--debug \
+	--host tcp://0.0.0.0:${listen_port} --host unix:///var/run/docker.sock \
+	--storage-driver "$DOCKER_GRAPHDRIVER" \
+	--userland-proxy="$DOCKER_USERLANDPROXY" \
+	$storage_params \
+	$extra_params"
+
+echo dockerd $args
+exec dockerd $args


### PR DESCRIPTION
`make run` allows you to fire up a daemon (in a container) just using
the existing built binaries. This allows for more rapid iteration
instead of dealing with firing up a shell just to start the daemon.

By default the daemon will listen on port 2375 on the default network
interface.

If a port forward is required to access the daemon, the user can set
`make DOCKER_PORT=2375 run` to get a port forward on a random port with
the daemon listening on port 2375, or `make DOCKER_PORT=2375:2375 run`
to get a daemon running with port 2375 forwarded to the daemon running
on 2375.

Note that the daemon is automatically configured to listen on whatever
port is set for the container side of the `DOCKER_PORT` port spec.

When running on docker4mac, the user must do the following:

```
$ make BINDDIR=. DOCKER_PORT=2375 run
```

This makes sure the binaries are loaded in the container and a port is
forwarded, since it is currently impossible to route traffic from the
mac directly to a container IP.

To get a fresh binary:

```
$ make BINDDIR=. DOCKER_PORT=2375 binary run
```

Signed-off-by: Brian Goff cpuguy83@gmail.com
