### PR TITLE
Check for swarm-mode network conflict during create network

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -81,6 +81,10 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 		return err
 	}
 
+	if _, err := n.clusterProvider.GetNetwork(create.Name); err == nil {
+		return libnetwork.NetworkNameError(create.Name)
+	}
+
 	nw, err := n.backend.CreateNetwork(create)
 	if err != nil {
 		if _, ok := err.(libnetwork.ManagerRedirectError); !ok {

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -81,10 +81,6 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 		return err
 	}
 
-	if _, err := n.clusterProvider.GetNetwork(create.Name); err == nil {
-		return libnetwork.NetworkNameError(create.Name)
-	}
-
 	nw, err := n.backend.CreateNetwork(create)
 	if err != nil {
 		if _, ok := err.(libnetwork.ManagerRedirectError); !ok {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -292,10 +292,6 @@ func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, service
 	return nil
 }
 
-func errClusterNetworkConnect() error {
-	return fmt.Errorf("cannot connect or disconnect managed containers on a network")
-}
-
 // ConnectContainerToNetwork connects the given container to the given
 // network. If either cannot be found, an err is returned. If the
 // network cannot be set up, an err is returned.
@@ -303,9 +299,6 @@ func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName strin
 	container, err := daemon.GetContainer(containerName)
 	if err != nil {
 		return err
-	}
-	if container.Managed {
-		return errClusterNetworkConnect()
 	}
 	return daemon.ConnectToNetwork(container, networkName, endpointConfig)
 }
@@ -319,9 +312,6 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 			return daemon.ForceEndpointDelete(containerName, network)
 		}
 		return err
-	}
-	if container.Managed {
-		return errClusterNetworkConnect()
 	}
 	return daemon.DisconnectFromNetwork(container, network, force)
 }


### PR DESCRIPTION
Reverts https://github.com/docker/docker/pull/24158 which causes service create to fail if it is attached to multiple networks. We need to find another better way to handle the case of failing network connect/disconnect for managed containers.

Fixes #23983 
