### PR TITLE
Fix daemon not cleaned up w/ live restore enabled

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -652,8 +652,12 @@ func (daemon *Daemon) Shutdown() error {
 	// Keep mounts and networking running on daemon shutdown if
 	// we are to keep containers running and restore them.
 	if daemon.configStore.LiveRestore {
-		return nil
+		// check if there are any running containers, if none we should do some cleanup
+		if ls, err := daemon.Containers(&types.ContainerListOptions{}); len(ls) != 0 || err != nil {
+			return nil
+		}
 	}
+
 	if daemon.containers != nil {
 		logrus.Debug("starting clean shutdown of all containers...")
 		daemon.containers.ApplyAll(func(c *container.Container) {


### PR DESCRIPTION
This patch makes sure daemon resources are cleaned up on shutdown if
there are no running containers.

Fixes #24350 
