### PR TITLE
Update binary install docs with new contents of tgz

### DIFF
--- a/docs/installation/binaries.md
+++ b/docs/installation/binaries.md
@@ -130,11 +130,13 @@ directory named `docker` in your current location.
 $ tar -xvzf docker-latest.tgz
 
 docker/
-docker/docker-containerd-ctr
 docker/docker
 docker/docker-containerd
-docker/docker-runc
+docker/docker-containerd-ctr
 docker/docker-containerd-shim
+docker/docker-proxy
+docker/docker-runc
+docker/dockerd
 ```
 
 Engine requires these binaries to be installed in your host's `$PATH`.
@@ -154,7 +156,7 @@ $ mv docker/* /usr/bin/
 You can manually start the Engine in daemon mode using:
 
 ```bash
-$ sudo docker daemon &
+$ sudo dockerd &
 ```
 
 The GitHub repository provides samples of init-scripts you can use to control


### PR DESCRIPTION
This is now up to date with contents of 1.12 tgz

Also change usage to `dockerd` not `docker daemon`

Signed-off-by: Justin Cormack justin.cormack@docker.com

This is the docs adjustment for #23312 - I can't see anywhere else that needs to refer to the `docker-proxy` other than a mention in the changelog.

cc @thaJeztah 

![goatbook](https://cloud.githubusercontent.com/assets/482364/16687518/0cefa1f6-4511-11e6-80bc-ce0150a8a030.jpg)
