### PR TITLE
Add missing docker-proxy into managed files in rpm spec

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -189,6 +189,7 @@ install -p -m 644 contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/shar
 /%{_bindir}/docker-containerd
 /%{_bindir}/docker-containerd-shim
 /%{_bindir}/docker-containerd-ctr
+/%{_bindir}/docker-proxy
 /%{_bindir}/docker-runc
 /%{_sysconfdir}/udev/rules.d/80-docker.rules
 %if 0%{?is_systemd}


### PR DESCRIPTION
This was missed in #23312 even though the other parts of
this were fixed.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![sleepy-puppy](https://cloud.githubusercontent.com/assets/482364/16688641/d4414822-4516-11e6-834f-71c7277d5f01.gif)
