### PR TITLE
daemon: ensure we set default options to stock runtime

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -579,7 +579,11 @@ func verifyDaemonSettings(config *Config) error {
 	if config.Runtimes == nil {
 		config.Runtimes = make(map[string]types.Runtime)
 	}
-	config.Runtimes[stockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+	stockRuntimeOpts := []string{}
+	if UsingSystemd(config) {
+		stockRuntimeOpts = append(stockRuntimeOpts, "--systemd-cgroup=true")
+	}
+	config.Runtimes[stockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary, Args: stockRuntimeOpts}
 
 	return nil
 }


### PR DESCRIPTION
**\- What I did**

Fix https://github.com/docker/docker/issues/24424
Make sure we set default stock runtime options in case we use systemd

**\- How I did it**

set stock runtime options

**\- How to verify it**

if you run w/o this patch and `--exec-opts native.cgroupdriver=systemd`  you'll get:

```
$ docker run fedora cat /proc/self/cgroup
11:perf_event:/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
10:memory:/system.slice/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
9:pids:/system.slice/docker.service/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
8:devices:/system.slice/docker.service/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
7:hugetlb:/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
6:blkio:/system.slice/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
5:freezer:/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
4:cpuset:/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
3:cpu,cpuacct:/system.slice/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
2:net_cls,net_prio:/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
1:name=systemd:/system.slice/docker.service/system.slice:docker:046f8702dd1dd72557f320bae3b77875cd7550799670ff06308ccd6f1f662a6b
```

and you can notice cgroup paths are incorrect (too many colons)

Running with this patch:

```
$ docker run fedora cat /proc/self/cgroup   
11:perf_event:/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
10:memory:/init.scope/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
9:pids:/init.scope/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
8:devices:/init.scope/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
7:hugetlb:/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
6:blkio:/init.scope/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
5:freezer:/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
4:cpuset:/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
3:cpu,cpuacct:/init.scope/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
2:net_cls,net_prio:/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
1:name=systemd:/system.slice/docker-28287451c5ac225e572a15a42f5e7e23bc820e49c293fe2debc95abf3cbb6374.scope
```

**\- Description for the changelog**

Ensure we set default options to stock runtime

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Antonio Murdaca runcom@redhat.com
