### PR TITLE
Fix seccomp output in `docker info`

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -71,7 +71,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	if sysInfo.AppArmor {
 		securityOptions = append(securityOptions, "apparmor")
 	}
-	if sysInfo.Seccomp {
+	if sysInfo.Seccomp && supportsSeccomp {
 		securityOptions = append(securityOptions, "seccomp")
 	}
 	if selinuxEnabled() {

--- a/daemon/seccomp_disabled.go
+++ b/daemon/seccomp_disabled.go
@@ -1,4 +1,4 @@
-// +build !seccomp,!windows
+// +build linux,!seccomp
 
 package daemon
 
@@ -8,6 +8,8 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/opencontainers/specs/specs-go"
 )
+
+var supportsSeccomp = false
 
 func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
 	if c.SeccompProfile != "" && c.SeccompProfile != "unconfined" {

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opencontainers/specs/specs-go"
 )
 
+var supportsSeccomp = true
+
 func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
 	var profile *specs.Seccomp
 	var err error

--- a/daemon/seccomp_unsupported.go
+++ b/daemon/seccomp_unsupported.go
@@ -1,0 +1,5 @@
+// +build !linux
+
+package daemon
+
+var supportsSeccomp = false


### PR DESCRIPTION
This fix tries to address the issue raised in #24374 where `docker info` outputs seccomp support in Ubuntu 14.04 but the seccomp wass not actually supported.

The issue is that in the current docker implementation, seccomp support is only checked against the kernel by inspect `CONFIG_SECCOMP` and `CONFIG_SECCOMP_FILTER`. However, seccomp might not be enabled when building docker (through golang build flag).

This fix adds a `supportsSeccomp` boolean variable. The `supportsSeccomp` is only set to true when seccomp is enabled while building docker.

This fix fixes #24374.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
