### PR TITLE
swarmkit expects network-id for as target

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -725,6 +725,13 @@ func (c *Cluster) UpdateService(serviceID string, version uint64, spec types.Ser
 		return c.errNoManager()
 	}
 
+	ctx := c.getRequestContext()
+
+	err := populateNetworkID(ctx, c.client, &spec)
+	if err != nil {
+		return err
+	}
+
 	serviceSpec, err := convert.ServiceSpecToGRPC(spec)
 	if err != nil {
 		return err


### PR DESCRIPTION
For any operation that involves netwoks (other than network create),
swarmkit expects the target as network-id. Service update was using
network-name as the target and that caused #24452

Fixes #24452 

Signed-off-by: Madhu Venugopal madhu@docker.com
