### PR TITLE
swarm: add log driver support for services

### DIFF
--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -28,6 +28,7 @@ func ServiceFromGRPC(s swarmapi.Service) types.Service {
 				Resources:     resourcesFromGRPC(s.Spec.Task.Resources),
 				RestartPolicy: restartPolicyFromGRPC(s.Spec.Task.Restart),
 				Placement:     placementFromGRPC(s.Spec.Task.Placement),
+				LogDriver:     driverFromGRPC(s.Spec.Task.LogDriver),
 			},
 
 			Networks:     networks,
@@ -86,6 +87,7 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 		},
 		Task: swarmapi.TaskSpec{
 			Resources: resourcesToGRPC(s.TaskTemplate.Resources),
+			LogDriver: driverToGRPC(s.TaskTemplate.LogDriver),
 		},
 		Networks: networks,
 	}
@@ -250,4 +252,26 @@ func placementFromGRPC(p *swarmapi.Placement) *types.Placement {
 	}
 
 	return r
+}
+
+func driverFromGRPC(p *swarmapi.Driver) *types.Driver {
+	if p == nil {
+		return nil
+	}
+
+	return &types.Driver{
+		Name:    p.Name,
+		Options: p.Options,
+	}
+}
+
+func driverToGRPC(p *types.Driver) *swarmapi.Driver {
+	if p == nil {
+		return nil
+	}
+
+	return &swarmapi.Driver{
+		Name:    p.Name,
+		Options: p.Options,
+	}
 }

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -22,6 +22,7 @@ func TaskFromGRPC(t swarmapi.Task) types.Task {
 			Resources:     resourcesFromGRPC(t.Spec.Resources),
 			RestartPolicy: restartPolicyFromGRPC(t.Spec.Restart),
 			Placement:     placementFromGRPC(t.Spec.Placement),
+			LogDriver:     driverFromGRPC(t.Spec.LogDriver),
 		},
 		Status: types.TaskStatus{
 			State:   types.TaskState(strings.ToLower(t.Status.State.String())),


### PR DESCRIPTION
Adds log driver support for service creation and update. Add flags
`--log-driver` and `--log-opt` to match `docker run`. Log drivers are
configured per service.

Addresses #23710. Closes #24319. ~~Requires #24459.~~

Reviewers:
- Please confirm changes are correct and consistent.
- UI is consistent with `docker run`.
- Identify areas that need additional changes

Left to do:
- [X] Configure log drivers on `docker service create`
- [X] Configure log drivers on `docker service update`
- [ ] Configure cluster default log driver on `docker swarm update` and `docker swarm init`
  - [ ] Fix field position (requires https://github.com/docker/swarmkit/pull/1185, https://github.com/docker/engine-api/pull/322)
- [x] Confirm inspect output displays log drivers
- [x] Confirm full data flow (need #24459)
- [ ] Command documentation

cc @thaJeztah @tiborvass @dnephin @aanand @jpetazzo 

Signed-off-by: Stephen J Day stephen.day@docker.com
