### PR TITLE
integration-cli: fix --net=none tests

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -18,6 +18,7 @@ import (
 var defaultReconciliationTimeout = 30 * time.Second
 
 func (s *DockerSwarmSuite) TestApiSwarmInit(c *check.C) {
+	testRequires(c, Network)
 	// todo: should find a better way to verify that components are running than /info
 	d1 := s.AddDaemon(c, true, true)
 	info, err := d1.info()
@@ -69,9 +70,11 @@ func (s *DockerSwarmSuite) TestApiSwarmInit(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmManualAcceptance(c *check.C) {
+	testRequires(c, Network)
 	s.testAPISwarmManualAcceptance(c, "")
 }
 func (s *DockerSwarmSuite) TestApiSwarmManualAcceptanceSecret(c *check.C) {
+	testRequires(c, Network)
 	s.testAPISwarmManualAcceptance(c, "foobaz")
 }
 
@@ -129,6 +132,7 @@ func (s *DockerSwarmSuite) testAPISwarmManualAcceptance(c *check.C, secret strin
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmSecretAcceptance(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, false, false)
 	secret := "foobar"
 	c.Assert(d1.Init(swarm.InitRequest{
@@ -236,6 +240,7 @@ func (s *DockerSwarmSuite) TestApiSwarmSecretAcceptance(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmCAHash(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, false, false)
 	err := d2.Join(swarm.JoinRequest{CACertHash: "foobar", RemoteAddrs: []string{d1.listenAddr}})
@@ -247,6 +252,7 @@ func (s *DockerSwarmSuite) TestApiSwarmCAHash(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmPromoteDemote(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, false, false)
 	c.Assert(d1.Init(swarm.InitRequest{
 		Spec: swarm.Spec{
@@ -332,6 +338,7 @@ func (s *DockerSwarmSuite) TestApiSwarmPromoteDemote(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmServicesCreate(c *check.C) {
+	testRequires(c, Network)
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -348,6 +355,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesCreate(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmServicesMultipleAgents(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
@@ -376,6 +384,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesMultipleAgents(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmServicesCreateGlobal(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
@@ -394,6 +403,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesCreateGlobal(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmServicesStateReporting(c *check.C) {
+	testRequires(c, Network)
 	testRequires(c, SameHostDaemon)
 	testRequires(c, DaemonIsLinux)
 
@@ -468,6 +478,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesStateReporting(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmRaftQuorum(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, true)
 	d3 := s.AddDaemon(c, true, true)
@@ -497,6 +508,7 @@ func (s *DockerSwarmSuite) TestApiSwarmRaftQuorum(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmListNodes(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
@@ -516,6 +528,7 @@ loop0:
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmNodeUpdate(c *check.C) {
+	testRequires(c, Network)
 	d := s.AddDaemon(c, true, true)
 
 	nodes := d.listNodes(c)
@@ -529,6 +542,7 @@ func (s *DockerSwarmSuite) TestApiSwarmNodeUpdate(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmNodeDrainPause(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 
@@ -583,6 +597,7 @@ func (s *DockerSwarmSuite) TestApiSwarmNodeDrainPause(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmLeaveRemovesContainer(c *check.C) {
+	testRequires(c, Network)
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -666,6 +681,7 @@ func (s *DockerSwarmSuite) TestApiSwarmRestoreOnPendingJoin(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmManagerRestore(c *check.C) {
+	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -695,6 +711,7 @@ func (s *DockerSwarmSuite) TestApiSwarmManagerRestore(c *check.C) {
 }
 
 func (s *DockerSwarmSuite) TestApiSwarmScaleNoRollingUpdate(c *check.C) {
+	testRequires(c, Network)
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2


### PR DESCRIPTION
Example:

```
21:28:01 [d68573521] waiting for daemon to start
21:28:01 [d68573521] daemon started
21:28:01 docker_api_swarm_test.go:163:
21:28:01     c.Assert(d1.Init(map[string]bool{"worker": true}, ""),
checker.IsNil)
21:28:01 ... value *errors.errorString =
&errors.errorString{s:"initializing swarm: invalid statuscode 500,
\"{\\\"message\\\":\\\"could not determine local IP address: dial udp
8.8.8.8:53: connect: network is unreachable\\\"}\\n\"} ("initializing
swarm: invalid statuscode 500, \"{\\\"message\\\":\\\"could not
determine local IP address: dial udp 8.8.8.8:53: connect: network is
unreachable\\\"}\\n\"")
21:28:01
21:28:01 [d68573521] exiting daemon"}
```

Signed-off-by: Antonio Murdaca runcom@redhat.com
