### PR TITLE
add ref docs for node label

### DIFF
--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -25,6 +25,38 @@ Options:
       --role string           Role of the node (worker/manager)
 ```
 
+### Add label metadata to a node
+
+Add metadata to a swarm node using node labels. You can specify a node label as
+a key with an empty value:
+
+``` bash
+$ docker node update --label-add foo worker1
+```
+
+To add multiple labels to a node, pass the `--label-add` flag for each label:
+
+``` bash
+$ docker node update --label-add foo --label-add bar worker1
+```
+
+When you [create a service](service_create.md),
+you can use node labels as a constraint. A constraint limits the nodes where the
+scheduler deploys tasks for a service.
+
+For example, to add a `type` label to identify nodes where the scheduler should
+deploy message queue service tasks:
+
+``` bash
+$ docker node update --label-add type=queue worker1
+```
+
+The labels you set for nodes using `docker node update` apply only to the node
+entity within the swarm. Do not confuse them with the docker daemon labels for
+[dockerd]( ../../userguide/labels-custom-metadata.md#daemon-labels).
+
+For more information about labels, refer to [apply custom
+metadata](../../userguide/labels-custom-metadata.md).
 
 ## Related information
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -131,7 +131,7 @@ $ docker service create \
 ```
 
 For more information about labels, refer to [apply custom
-metadata](../../userguide/labels-custom-metadata.md)
+metadata](../../userguide/labels-custom-metadata.md).
 
 ### Set service mode
 
@@ -162,7 +162,7 @@ follows:
 
 `engine.labels` apply to Docker Engine labels like operating system,
 drivers, etc. Swarm administrators add `node.labels` for operational purposes by
-using the `docker node update` command.
+using the [`docker node update`](node_update.md) command.
 
 For example, the following limits tasks for the redis service to nodes where the
 node type label equals queue:


### PR DESCRIPTION
adds examples for `--label-add`
Signed-off-by: Charles Smith charles.smith@docker.com
