### PR TITLE
New seccomp json format

### DIFF
--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -32,7 +32,7 @@ func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
 		return nil
 	}
 	if c.SeccompProfile != "" {
-		profile, err = seccomp.LoadProfile(c.SeccompProfile)
+		profile, err = seccomp.LoadProfile(c.SeccompProfile, rs)
 		if err != nil {
 			return err
 		}

--- a/docs/security/seccomp.md
+++ b/docs/security/seccomp.md
@@ -40,24 +40,65 @@ compatibility. The default Docker profile (found [here](https://github.com/docke
 ```json
 {
 	"defaultAction": "SCMP_ACT_ERRNO",
-	"architectures": [
-		"SCMP_ARCH_X86_64",
-		"SCMP_ARCH_X86",
-		"SCMP_ARCH_X32"
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		...
 	],
 	"syscalls": [
 		{
-			"name": "accept",
+			"names": [
+				"accept",
+				"accept4",
+				"access",
+				"alarm",
+				"alarm",
+				"bind",
+				"brk",
+				...
+				"waitid",
+				"waitpid",
+				"write",
+				"writev"
+			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": []
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
 		},
 		{
-			"name": "accept4",
+			"names": [
+				"clone"
+			],
 			"action": "SCMP_ACT_ALLOW",
-			"args": []
+			"args": [
+				{
+					"index": 1,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "s390 parameter ordering for clone is different",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
 		},
 		...
-	]
 }
 ```
 

--- a/profiles/seccomp/default.json
+++ b/profiles/seccomp/default.json
@@ -1,828 +1,373 @@
 {
 	"defaultAction": "SCMP_ACT_ERRNO",
-	"architectures": [
-		"SCMP_ARCH_X86_64",
-		"SCMP_ARCH_X86",
-		"SCMP_ARCH_X32"
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		}
 	],
 	"syscalls": [
 		{
-			"name": "accept",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "accept4",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "access",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "alarm",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "bind",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "brk",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "capget",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "capset",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chdir",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chmod",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "clock_getres",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "clock_gettime",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "clock_nanosleep",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "close",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "connect",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "copy_file_range",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "creat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "dup",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "dup2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "dup3",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_create",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_create1",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_ctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_ctl_old",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_pwait",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_wait",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "epoll_wait_old",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "eventfd",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "eventfd2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "execve",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "execveat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "exit",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "exit_group",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "faccessat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fadvise64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fadvise64_64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fallocate",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fanotify_mark",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchdir",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchmod",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchmodat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fchownat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fcntl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fcntl64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fdatasync",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fgetxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "flistxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "flock",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fork",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fremovexattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fsetxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fstat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fstat64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fstatat64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fstatfs",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fstatfs64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "fsync",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ftruncate",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ftruncate64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "futex",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "futimesat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getcpu",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getcwd",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getdents",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getdents64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getegid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getegid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "geteuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "geteuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getgid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getgroups",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getgroups32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getitimer",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getpeername",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getpgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getpgrp",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getpid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getppid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getpriority",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getrandom",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getresgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getresgid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getresuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getresuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getrlimit",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "get_robust_list",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getrusage",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getsid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getsockname",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getsockopt",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "get_thread_area",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "gettid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "gettimeofday",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "getxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "inotify_add_watch",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "inotify_init",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "inotify_init1",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "inotify_rm_watch",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "io_cancel",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ioctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "io_destroy",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "io_getevents",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ioprio_get",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ioprio_set",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "io_setup",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "io_submit",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ipc",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "kill",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lchown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lchown32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lgetxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "link",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "linkat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "listen",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "listxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "llistxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "_llseek",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lremovexattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lseek",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lsetxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lstat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "lstat64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "madvise",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "memfd_create",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mincore",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mkdir",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mkdirat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mknod",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mknodat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mlock",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mlock2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mlockall",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mmap",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mmap2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mprotect",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mq_getsetattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mq_notify",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mq_open",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mq_timedreceive",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mq_timedsend",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mq_unlink",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "mremap",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "msgctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "msgget",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "msgrcv",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "msgsnd",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "msync",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "munlock",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "munlockall",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "munmap",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "nanosleep",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "newfstatat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "_newselect",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "open",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "openat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "pause",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "personality",
+			"names": [
+				"accept",
+				"accept4",
+				"access",
+				"alarm",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_getres",
+				"clock_gettime",
+				"clock_nanosleep",
+				"close",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"ipc",
+				"kill",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedsend",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"pause",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"prctl",
+				"pread64",
+				"preadv",
+				"prlimit64",
+				"pselect6",
+				"pwrite64",
+				"pwritev",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"syslog",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_settime",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_settime",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [
 				{
@@ -831,10 +376,15 @@
 					"valueTwo": 0,
 					"op": "SCMP_CMP_EQ"
 				}
-			]
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
 		},
 		{
-			"name": "personality",
+			"names": [
+				"personality"
+			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [
 				{
@@ -843,10 +393,15 @@
 					"valueTwo": 0,
 					"op": "SCMP_CMP_EQ"
 				}
-			]
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
 		},
 		{
-			"name": "personality",
+			"names": [
+				"personality"
+			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [
 				{
@@ -855,730 +410,120 @@
 					"valueTwo": 0,
 					"op": "SCMP_CMP_EQ"
 				}
-			]
-		},
-		{
-			"name": "pipe",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "pipe2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "poll",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ppoll",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "prctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "pread64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "preadv",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "prlimit64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "pselect6",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "pwrite64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "pwritev",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "read",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "readahead",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "readlink",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "readlinkat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "readv",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "recv",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "recvfrom",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "recvmmsg",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "recvmsg",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "remap_file_pages",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "removexattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rename",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "renameat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "renameat2",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "restart_syscall",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rmdir",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigaction",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigpending",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigprocmask",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigqueueinfo",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigreturn",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigsuspend",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_sigtimedwait",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "rt_tgsigqueueinfo",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_getaffinity",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_getattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_getparam",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_get_priority_max",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_get_priority_min",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_getscheduler",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_rr_get_interval",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_setaffinity",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_setattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_setparam",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_setscheduler",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sched_yield",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "seccomp",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "select",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "semctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "semget",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "semop",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "semtimedop",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "send",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sendfile",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sendfile64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sendmmsg",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sendmsg",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sendto",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setfsgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setfsgid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setfsuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setfsuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setgid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setgroups",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setgroups32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setitimer",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setpgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setpriority",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setregid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setregid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setresgid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setresgid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setresuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setresuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setreuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setreuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setrlimit",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "set_robust_list",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setsid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setsockopt",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "set_thread_area",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "set_tid_address",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setuid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setuid32",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "setxattr",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "shmat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "shmctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "shmdt",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "shmget",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "shutdown",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sigaltstack",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "signalfd",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "signalfd4",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sigreturn",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "socket",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "socketcall",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "socketpair",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "splice",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "stat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "stat64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "statfs",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "statfs64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "symlink",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "symlinkat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sync",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sync_file_range",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "syncfs",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "sysinfo",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "syslog",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "tee",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "tgkill",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "time",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timer_create",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timer_delete",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timerfd_create",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timerfd_gettime",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timerfd_settime",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timer_getoverrun",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timer_gettime",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "timer_settime",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "times",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "tkill",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "truncate",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "truncate64",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "ugetrlimit",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "umask",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "uname",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "unlink",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "unlinkat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "utime",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "utimensat",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "utimes",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "vfork",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "vmsplice",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "wait4",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "waitid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "waitpid",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "write",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "writev",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "arch_prctl",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "modify_ldt",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "chroot",
-			"action": "SCMP_ACT_ALLOW",
-			"args": []
-		},
-		{
-			"name": "clone",
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"breakpoint",
+				"cacheflush",
+				"set_tls"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"arm",
+					"arm64"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arch_prctl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"modify_ldt"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32",
+					"x86"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"bpf",
+				"clone",
+				"fanotify_init",
+				"lookup_dcookie",
+				"mount",
+				"name_to_handle_at",
+				"perf_event_open",
+				"setdomainname",
+				"sethostname",
+				"setns",
+				"umount",
+				"umount2",
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"clone"
+			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [
 				{
@@ -1587,7 +532,165 @@
 					"valueTwo": 0,
 					"op": "SCMP_CMP_MASKED_EQ"
 				}
-			]
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				],
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 1,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "s390 parameter ordering for clone is different",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"reboot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_BOOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"settimeofday",
+				"stime",
+				"adjtimex"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
 		}
 	]
 }

--- a/profiles/seccomp/generate.go
+++ b/profiles/seccomp/generate.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/oci"
 	"github.com/docker/docker/profiles/seccomp"
 )
 
@@ -21,10 +20,8 @@ func main() {
 	}
 	f := filepath.Join(wd, "default.json")
 
-	rs := oci.DefaultSpec()
-
 	// write the default profile to the file
-	b, err := json.MarshalIndent(seccomp.DefaultProfile(&rs), "", "\t")
+	b, err := json.MarshalIndent(seccomp.DefaultProfile(), "", "\t")
 	if err != nil {
 		panic(err)
 	}

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -4,30 +4,42 @@ package seccomp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
+	"github.com/docker/docker/pkg/stringutils"
 	"github.com/docker/engine-api/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	libseccomp "github.com/seccomp/libseccomp-golang"
 )
 
 //go:generate go run -tags 'seccomp' generate.go
 
 // GetDefaultProfile returns the default seccomp profile.
 func GetDefaultProfile(rs *specs.Spec) (*specs.Seccomp, error) {
-	return setupSeccomp(DefaultProfile(rs))
+	return setupSeccomp(DefaultProfile(), rs)
 }
 
 // LoadProfile takes a file path and decodes the seccomp profile.
-func LoadProfile(body string) (*specs.Seccomp, error) {
+func LoadProfile(body string, rs *specs.Spec) (*specs.Seccomp, error) {
 	var config types.Seccomp
 	if err := json.Unmarshal([]byte(body), &config); err != nil {
 		return nil, fmt.Errorf("Decoding seccomp profile failed: %v", err)
 	}
-
-	return setupSeccomp(&config)
+	return setupSeccomp(&config, rs)
 }
 
-func setupSeccomp(config *types.Seccomp) (newConfig *specs.Seccomp, err error) {
+var nativeToSeccomp = map[string]types.Arch{
+	"amd64":       types.ArchX86_64,
+	"arm64":       types.ArchAARCH64,
+	"mips64":      types.ArchMIPS64,
+	"mips64n32":   types.ArchMIPS64N32,
+	"mipsel64":    types.ArchMIPSEL64,
+	"mipsel64n32": types.ArchMIPSEL64N32,
+	"s390x":       types.ArchS390X,
+}
+
+func setupSeccomp(config *types.Seccomp, rs *specs.Spec) (*specs.Seccomp, error) {
 	if config == nil {
 		return nil, nil
 	}
@@ -37,38 +49,102 @@ func setupSeccomp(config *types.Seccomp) (newConfig *specs.Seccomp, err error) {
 		return nil, nil
 	}
 
-	newConfig = &specs.Seccomp{}
+	newConfig := &specs.Seccomp{}
+
+	var arch string
+	var native, err = libseccomp.GetNativeArch()
+	if err == nil {
+		arch = native.String()
+	}
+
+	if len(config.Architectures) != 0 && len(config.ArchMap) != 0 {
+		return nil, errors.New("'architectures' and 'archMap' were specified in the seccomp profile, use either 'architectures' or 'archMap'")
+	}
 
 	// if config.Architectures == 0 then libseccomp will figure out the architecture to use
-	if len(config.Architectures) > 0 {
-		for _, arch := range config.Architectures {
-			newConfig.Architectures = append(newConfig.Architectures, specs.Arch(arch))
+	if len(config.Architectures) != 0 {
+		for _, a := range config.Architectures {
+			newConfig.Architectures = append(newConfig.Architectures, specs.Arch(a))
+		}
+	}
+
+	if len(config.ArchMap) != 0 {
+		for _, a := range config.ArchMap {
+			seccompArch, ok := nativeToSeccomp[arch]
+			if ok {
+				if a.Arch == seccompArch {
+					newConfig.Architectures = append(newConfig.Architectures, specs.Arch(a.Arch))
+					for _, sa := range a.SubArches {
+						newConfig.Architectures = append(newConfig.Architectures, specs.Arch(sa))
+					}
+					break
+				}
+			}
 		}
 	}
 
 	newConfig.DefaultAction = specs.Action(config.DefaultAction)
 
-	// Loop through all syscall blocks and convert them to libcontainer format
+Loop:
+	// Loop through all syscall blocks and convert them to libcontainer format after filtering them
 	for _, call := range config.Syscalls {
-		newCall := specs.Syscall{
-			Name:   call.Name,
-			Action: specs.Action(call.Action),
-		}
-
-		// Loop through all the arguments of the syscall and convert them
-		for _, arg := range call.Args {
-			newArg := specs.Arg{
-				Index:    arg.Index,
-				Value:    arg.Value,
-				ValueTwo: arg.ValueTwo,
-				Op:       specs.Operator(arg.Op),
+		if len(call.Excludes.Arches) > 0 {
+			if stringutils.InSlice(call.Excludes.Arches, arch) {
+				continue Loop
 			}
-
-			newCall.Args = append(newCall.Args, newArg)
+		}
+		if len(call.Excludes.Caps) > 0 {
+			for _, c := range call.Excludes.Caps {
+				if stringutils.InSlice(rs.Process.Capabilities, c) {
+					continue Loop
+				}
+			}
+		}
+		if len(call.Includes.Arches) > 0 {
+			if !stringutils.InSlice(call.Includes.Arches, arch) {
+				continue Loop
+			}
+		}
+		if len(call.Includes.Caps) > 0 {
+			for _, c := range call.Includes.Caps {
+				if !stringutils.InSlice(rs.Process.Capabilities, c) {
+					continue Loop
+				}
+			}
 		}
 
-		newConfig.Syscalls = append(newConfig.Syscalls, newCall)
+		if call.Name != "" && len(call.Names) != 0 {
+			return nil, errors.New("'name' and 'names' were specified in the seccomp profile, use either 'name' or 'names'")
+		}
+
+		if call.Name != "" {
+			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall(call.Name, call.Action, call.Args))
+		}
+
+		for _, n := range call.Names {
+			newConfig.Syscalls = append(newConfig.Syscalls, createSpecsSyscall(n, call.Action, call.Args))
+		}
 	}
 
 	return newConfig, nil
+}
+
+func createSpecsSyscall(name string, action types.Action, args []*types.Arg) specs.Syscall {
+	newCall := specs.Syscall{
+		Name:   name,
+		Action: specs.Action(action),
+	}
+
+	// Loop through all the arguments of the syscall and convert them
+	for _, arg := range args {
+		newArg := specs.Arg{
+			Index:    arg.Index,
+			Value:    arg.Value,
+			ValueTwo: arg.ValueTwo,
+			Op:       specs.Operator(arg.Op),
+		}
+
+		newCall.Args = append(newCall.Args, newArg)
+	}
+	return newCall
 }

--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -6,858 +6,357 @@ import (
 	"syscall"
 
 	"github.com/docker/engine-api/types"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	libseccomp "github.com/seccomp/libseccomp-golang"
 )
 
-func arches() []types.Arch {
-	var native, err = libseccomp.GetNativeArch()
-	if err != nil {
-		return []types.Arch{}
-	}
-	var a = native.String()
-	switch a {
-	case "amd64":
-		return []types.Arch{types.ArchX86_64, types.ArchX86, types.ArchX32}
-	case "arm64":
-		return []types.Arch{types.ArchARM, types.ArchAARCH64}
-	case "mips64":
-		return []types.Arch{types.ArchMIPS, types.ArchMIPS64, types.ArchMIPS64N32}
-	case "mips64n32":
-		return []types.Arch{types.ArchMIPS, types.ArchMIPS64, types.ArchMIPS64N32}
-	case "mipsel64":
-		return []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64, types.ArchMIPSEL64N32}
-	case "mipsel64n32":
-		return []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64, types.ArchMIPSEL64N32}
-	case "s390x":
-		return []types.Arch{types.ArchS390, types.ArchS390X}
-	default:
-		return []types.Arch{}
+func arches() []types.Architecture {
+	return []types.Architecture{
+		{
+			Arch:      types.ArchX86_64,
+			SubArches: []types.Arch{types.ArchX86, types.ArchX32},
+		},
+		{
+			Arch:      types.ArchAARCH64,
+			SubArches: []types.Arch{types.ArchARM},
+		},
+		{
+			Arch:      types.ArchMIPS64,
+			SubArches: []types.Arch{types.ArchMIPS, types.ArchMIPS64N32},
+		},
+		{
+			Arch:      types.ArchMIPS64N32,
+			SubArches: []types.Arch{types.ArchMIPS, types.ArchMIPS64},
+		},
+		{
+			Arch:      types.ArchMIPSEL64,
+			SubArches: []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64N32},
+		},
+		{
+			Arch:      types.ArchMIPSEL64N32,
+			SubArches: []types.Arch{types.ArchMIPSEL, types.ArchMIPSEL64},
+		},
+		{
+			Arch:      types.ArchS390X,
+			SubArches: []types.Arch{types.ArchS390},
+		},
 	}
 }
 
 // DefaultProfile defines the whitelist for the default seccomp profile.
-func DefaultProfile(rs *specs.Spec) *types.Seccomp {
-
+func DefaultProfile() *types.Seccomp {
 	syscalls := []*types.Syscall{
 		{
-			Name:   "accept",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "accept4",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "access",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "alarm",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "bind",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "brk",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "capget",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "capset",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "chdir",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "chmod",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "chown",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "chown32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-
-		{
-			Name:   "clock_getres",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "clock_gettime",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "clock_nanosleep",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "close",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "connect",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "copy_file_range",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "creat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "dup",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "dup2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "dup3",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_create",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_create1",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_ctl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_ctl_old",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_pwait",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_wait",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "epoll_wait_old",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "eventfd",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "eventfd2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "execve",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "execveat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "exit",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "exit_group",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "faccessat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fadvise64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fadvise64_64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fallocate",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fanotify_mark",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fchdir",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fchmod",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fchmodat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fchown",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fchown32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fchownat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fcntl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fcntl64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fdatasync",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fgetxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "flistxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "flock",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fork",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fremovexattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fsetxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fstat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fstat64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fstatat64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fstatfs",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fstatfs64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "fsync",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ftruncate",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ftruncate64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "futex",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "futimesat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getcpu",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getcwd",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getdents",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getdents64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getegid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getegid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "geteuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "geteuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getgid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getgroups",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getgroups32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getitimer",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getpeername",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getpgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getpgrp",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getpid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getppid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getpriority",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getrandom",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getresgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getresgid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getresuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getresuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getrlimit",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "get_robust_list",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getrusage",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getsid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getsockname",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getsockopt",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "get_thread_area",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "gettid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "gettimeofday",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "getxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "inotify_add_watch",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "inotify_init",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "inotify_init1",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "inotify_rm_watch",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "io_cancel",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ioctl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "io_destroy",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "io_getevents",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ioprio_get",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ioprio_set",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "io_setup",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "io_submit",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ipc",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "kill",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lchown",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lchown32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lgetxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "link",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "linkat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "listen",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "listxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "llistxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "_llseek",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lremovexattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lseek",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lsetxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lstat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "lstat64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "madvise",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "memfd_create",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mincore",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mkdir",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mkdirat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mknod",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mknodat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mlock",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mlock2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mlockall",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mmap",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mmap2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mprotect",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mq_getsetattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mq_notify",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mq_open",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mq_timedreceive",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mq_timedsend",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mq_unlink",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "mremap",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "msgctl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "msgget",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "msgrcv",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "msgsnd",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "msync",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "munlock",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "munlockall",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "munmap",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "nanosleep",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "newfstatat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "_newselect",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "open",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "openat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "pause",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "personality",
+			Names: []string{
+				"accept",
+				"accept4",
+				"access",
+				"alarm",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_getres",
+				"clock_gettime",
+				"clock_nanosleep",
+				"close",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"ipc",
+				"kill",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedsend",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"pause",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"prctl",
+				"pread64",
+				"preadv",
+				"prlimit64",
+				"pselect6",
+				"pwrite64",
+				"pwritev",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"syslog",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_settime",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_settime",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+		},
+		{
+			Names:  []string{"personality"},
 			Action: types.ActAllow,
 			Args: []*types.Arg{
 				{
@@ -868,7 +367,7 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 			},
 		},
 		{
-			Name:   "personality",
+			Names:  []string{"personality"},
 			Action: types.ActAllow,
 			Args: []*types.Arg{
 				{
@@ -879,7 +378,7 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 			},
 		},
 		{
-			Name:   "personality",
+			Names:  []string{"personality"},
 			Action: types.ActAllow,
 			Args: []*types.Arg{
 				{
@@ -890,990 +389,214 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 			},
 		},
 		{
-			Name:   "pipe",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "pipe2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "poll",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ppoll",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "prctl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "pread64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "preadv",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "prlimit64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "pselect6",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "pwrite64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "pwritev",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "read",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "readahead",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "readlink",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "readlinkat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "readv",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "recv",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "recvfrom",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "recvmmsg",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "recvmsg",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "remap_file_pages",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "removexattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rename",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "renameat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "renameat2",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "restart_syscall",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rmdir",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigaction",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigpending",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigprocmask",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigqueueinfo",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigreturn",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigsuspend",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_sigtimedwait",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "rt_tgsigqueueinfo",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_getaffinity",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_getattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_getparam",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_get_priority_max",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_get_priority_min",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_getscheduler",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_rr_get_interval",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_setaffinity",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_setattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_setparam",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_setscheduler",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sched_yield",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "seccomp",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "select",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "semctl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "semget",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "semop",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "semtimedop",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "send",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sendfile",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sendfile64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sendmmsg",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sendmsg",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sendto",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setfsgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setfsgid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setfsuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setfsuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setgid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setgroups",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setgroups32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setitimer",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setpgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setpriority",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setregid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setregid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setresgid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setresgid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setresuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setresuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setreuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setreuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setrlimit",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "set_robust_list",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setsid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setsockopt",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "set_thread_area",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "set_tid_address",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setuid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setuid32",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "setxattr",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "shmat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "shmctl",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "shmdt",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "shmget",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "shutdown",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sigaltstack",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "signalfd",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "signalfd4",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sigreturn",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "socket",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "socketcall",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "socketpair",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "splice",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "stat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "stat64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "statfs",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "statfs64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "symlink",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "symlinkat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sync",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sync_file_range",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "syncfs",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "sysinfo",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "syslog",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "tee",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "tgkill",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "time",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timer_create",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timer_delete",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timerfd_create",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timerfd_gettime",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timerfd_settime",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timer_getoverrun",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timer_gettime",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "timer_settime",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "times",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "tkill",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "truncate",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "truncate64",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "ugetrlimit",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "umask",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "uname",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "unlink",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "unlinkat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "utime",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "utimensat",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "utimes",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "vfork",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "vmsplice",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "wait4",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "waitid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "waitpid",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "write",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-		{
-			Name:   "writev",
-			Action: types.ActAllow,
-			Args:   []*types.Arg{},
-		},
-	}
-
-	var sysCloneFlagsIndex uint
-	var arch string
-	var native, err = libseccomp.GetNativeArch()
-	if err == nil {
-		arch = native.String()
-	}
-	switch arch {
-	case "arm", "arm64":
-		syscalls = append(syscalls, []*types.Syscall{
-			{
-				Name:   "breakpoint",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+			Names: []string{
+				"breakpoint",
+				"cacheflush",
+				"set_tls",
 			},
-			{
-				Name:   "cacheflush",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Arches: []string{"arm", "arm64"},
 			},
-			{
-				Name:   "set_tls",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+		},
+		{
+			Names: []string{
+				"arch_prctl",
 			},
-		}...)
-	case "amd64", "x32":
-		syscalls = append(syscalls, []*types.Syscall{
-			{
-				Name:   "arch_prctl",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Arches: []string{"amd64", "x32"},
 			},
-		}...)
-		fallthrough
-	case "x86":
-		syscalls = append(syscalls, []*types.Syscall{
-			{
-				Name:   "modify_ldt",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+		},
+		{
+			Names: []string{
+				"modify_ldt",
 			},
-		}...)
-	case "s390", "s390x":
-		syscalls = append(syscalls, []*types.Syscall{
-			{
-				Name:   "s390_pci_mmio_read",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Arches: []string{"amd64", "x32", "x86"},
 			},
-			{
-				Name:   "s390_pci_mmio_write",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+		},
+		{
+			Names: []string{
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr",
 			},
-			{
-				Name:   "s390_runtime_instr",
-				Action: types.ActAllow,
-				Args:   []*types.Arg{},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Arches: []string{"s390", "s390x"},
 			},
-		}...)
-		/* Flags parameter of the clone syscall is the 2nd on s390 */
-		sysCloneFlagsIndex = 1
-	}
-
-	capSysAdmin := false
-
-	var cap string
-	for _, cap = range rs.Process.Capabilities {
-		switch cap {
-		case "CAP_DAC_READ_SEARCH":
-			syscalls = append(syscalls, []*types.Syscall{
+		},
+		{
+			Names: []string{
+				"open_by_handle_at",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_DAC_READ_SEARCH"},
+			},
+		},
+		{
+			Names: []string{
+				"bpf",
+				"clone",
+				"fanotify_init",
+				"lookup_dcookie",
+				"mount",
+				"name_to_handle_at",
+				"perf_event_open",
+				"setdomainname",
+				"sethostname",
+				"setns",
+				"umount",
+				"umount2",
+				"unshare",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			Names: []string{
+				"clone",
+			},
+			Action: types.ActAllow,
+			Args: []*types.Arg{
 				{
-					Name:   "open_by_handle_at",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_ADMIN":
-			capSysAdmin = true
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "bpf",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "clone",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "fanotify_init",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "lookup_dcookie",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "mount",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "name_to_handle_at",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "perf_event_open",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "setdomainname",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "sethostname",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "setns",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "umount",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "umount2",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "unshare",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_BOOT":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "reboot",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_CHROOT":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "chroot",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_MODULE":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "delete_module",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "init_module",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "finit_module",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "query_module",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_PACCT":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "acct",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_PTRACE":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "kcmp",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "process_vm_readv",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "process_vm_writev",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "ptrace",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_RAWIO":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "iopl",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "ioperm",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_TIME":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "settimeofday",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "stime",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
-					Name:   "adjtimex",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		case "CAP_SYS_TTY_CONFIG":
-			syscalls = append(syscalls, []*types.Syscall{
-				{
-					Name:   "vhangup",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-			}...)
-		}
-	}
-
-	if !capSysAdmin {
-		syscalls = append(syscalls, []*types.Syscall{
-			{
-				Name:   "clone",
-				Action: types.ActAllow,
-				Args: []*types.Arg{
-					{
-						Index:    sysCloneFlagsIndex,
-						Value:    syscall.CLONE_NEWNS | syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWUSER | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
-						ValueTwo: 0,
-						Op:       types.OpMaskedEqual,
-					},
+					Index:    0,
+					Value:    syscall.CLONE_NEWNS | syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWUSER | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
+					ValueTwo: 0,
+					Op:       types.OpMaskedEqual,
 				},
 			},
-		}...)
+			Excludes: types.Filter{
+				Caps:   []string{"CAP_SYS_ADMIN"},
+				Arches: []string{"s390", "s390x"},
+			},
+		},
+		{
+			Names: []string{
+				"clone",
+			},
+			Action: types.ActAllow,
+			Args: []*types.Arg{
+				{
+					Index:    1,
+					Value:    syscall.CLONE_NEWNS | syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWUSER | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
+					ValueTwo: 0,
+					Op:       types.OpMaskedEqual,
+				},
+			},
+			Comment: "s390 parameter ordering for clone is different",
+			Includes: types.Filter{
+				Arches: []string{"s390", "s390x"},
+			},
+			Excludes: types.Filter{
+				Caps: []string{"CAP_SYS_ADMIN"},
+			},
+		},
+		{
+			Names: []string{
+				"reboot",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_BOOT"},
+			},
+		},
+		{
+			Names: []string{
+				"chroot",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_CHROOT"},
+			},
+		},
+		{
+			Names: []string{
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_MODULE"},
+			},
+		},
+		{
+			Names: []string{
+				"acct",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_PACCT"},
+			},
+		},
+		{
+			Names: []string{
+				"kcmp",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_PTRACE"},
+			},
+		},
+		{
+			Names: []string{
+				"iopl",
+				"ioperm",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_RAWIO"},
+			},
+		},
+		{
+			Names: []string{
+				"settimeofday",
+				"stime",
+				"adjtimex",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_TIME"},
+			},
+		},
+		{
+			Names: []string{
+				"vhangup",
+			},
+			Action: types.ActAllow,
+			Args:   []*types.Arg{},
+			Includes: types.Filter{
+				Caps: []string{"CAP_SYS_TTY_CONFIG"},
+			},
+		},
 	}
 
 	return &types.Seccomp{
 		DefaultAction: types.ActErrno,
-		Architectures: arches(),
+		ArchMap:       arches(),
 		Syscalls:      syscalls,
 	}
 }

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -5,6 +5,8 @@ package seccomp
 import (
 	"io/ioutil"
 	"testing"
+
+	"github.com/docker/docker/oci"
 )
 
 func TestLoadProfile(t *testing.T) {
@@ -12,7 +14,8 @@ func TestLoadProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := LoadProfile(string(f)); err != nil {
+	rs := oci.DefaultSpec()
+	if _, err := LoadProfile(string(f), &rs); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -22,7 +25,8 @@ func TestLoadDefaultProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := LoadProfile(string(f)); err != nil {
+	rs := oci.DefaultSpec()
+	if _, err := LoadProfile(string(f), &rs); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
**\- What I did**

**Note that this change is fully backward compatible, people can still use the current seccomp profile json format**

I've modified the json seccomp profile format to be more expressive and to allow conditionals with filters. Syscall names can now also be grouped together if they have same action,args,includes,excludes. `includes` are ORed while `excludes` are `any of`. Conditionals can be expressed on architectures and capabilities also. See following examples of new format:

```
{
    "archMap": [{
        "architecture": "SCMP_ARCH_X86_64",
        "subArchitectures": [
            "SCMP_ARCH_X86",
            "SCMP_ARCH_X32"
        ]
    }],
    "syscalls": [{
        "names": [
            "accept",
            "accept4",
            "access",
            "alarm",
            "alarm",
            "bind",
            "brk",
            "capget",
            "capset",
            "chdir",
            "chmod"
        ],
        "action": "SCMP_ACT_ALLOW",
        "args": [],
        "comment": "this is a comment!",
        "includes": {},
        "excludes": {}
    }, {
        "names": [
            "iopl",
            "ioperm"
        ],
        "action": "SCMP_ACT_ALLOW",
        "args": [],
        "comment": "",
        "includes": {
            "caps": [
                "CAP_SYS_RAWIO"
            ]
        },
        "excludes": {}
    }, {
        "names": [
            "clone"
        ],
        "action": "SCMP_ACT_ALLOW",
        "args": [{
            "index": 1,
            "value": 2080505856,
            "valueTwo": 0,
            "op": "SCMP_CMP_MASKED_EQ"
        }],
        "comment": "",
        "includes": {
            "arches": [
                "s390",
                "s390x"
            ]
        },
        "excludes": {
            "caps": [
                "CAP_SYS_ADMIN"
            ]
        }
    }]
}
```

**\- How I did it**

vim

**\- How to verify it**

You can run containers with `--seccomp-profile=$DOCKERSRC/profiles/seccomp/default.json` and tweak it to verify seccomp rules are ok when running containers.

**\- Description for the changelog**

New seccomp json format

**\- A picture of a cute animal (not mandatory but encouraged)**

Following from https://github.com/docker/docker/pull/24221, this is a proposal about defining a new and more expressive (even if more verbose) seccomp json profile.

/cc @justincormack @jfrazelle @rhatdan @mheon @thaJeztah @LK4D4 

**TODO:**

_the stuff I've removed from this list should be done in a follow up or re-writing #24221_
- [x] re-generate `profiles/seccomp/default.json`
- [x] changes in docker/engine-api after design-review PR https://github.com/docker/engine-api/pull/313
- [x] add forward compatibility of the old json profile
- [ ] documentation
- [x] moar tests
- [ ] ~~hash based check to detect if running with Docker's default profile~~
- [ ] ~~docker info enhancement from #24221~~
- [ ] ~~teach the daemon to read from `/etc/docker/seccomp.json` https://github.com/docker/docker/pull/24221#issuecomment-231457809 instead of embedding the profile in code (might actually be still ok to override in daemon?)~~

**NOTE**: it's not as big as it seems, the actual files changed are just 7, the rest is syscall definitions and the json :smile_cat: 

Signed-off-by: Antonio Murdaca runcom@redhat.com
