### PR TITLE
Add --oom-score-adjust to daemon

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -61,6 +61,7 @@ func (cli *DaemonCli) setupConfigReloadTrap() {
 func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 	opts := []libcontainerd.RemoteOption{
 		libcontainerd.WithDebugLog(cli.Config.Debug),
+		libcontainerd.WithOOMScore(cli.Config.OOMScoreAdjust),
 	}
 	if cli.Config.ContainerdAddr != "" {
 		opts = append(opts, libcontainerd.WithRemoteAddr(cli.Config.ContainerdAddr))

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -34,6 +34,7 @@ type Config struct {
 	Ulimits              map[string]*units.Ulimit `json:"default-ulimits,omitempty"`
 	Runtimes             map[string]types.Runtime `json:"runtimes,omitempty"`
 	DefaultRuntime       string                   `json:"default-runtime,omitempty"`
+	OOMScoreAdjust       int                      `json:"oom-score-adjust,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -90,6 +91,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	config.Runtimes = make(map[string]types.Runtime)
 	cmd.Var(runconfigopts.NewNamedRuntimeOpt("runtimes", &config.Runtimes, stockRuntimeName), []string{"-add-runtime"}, usageFn("Register an additional OCI compatible runtime"))
 	cmd.StringVar(&config.DefaultRuntime, []string{"-default-runtime"}, stockRuntimeName, usageFn("Default OCI runtime to be used"))
+	cmd.IntVar(&config.OOMScoreAdjust, []string{"-oom-score-adjust"}, -500, usageFn("Set the oom_score_adj for the daemon"))
 
 	config.attachExperimentalFlags(cmd, usageFn)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -434,7 +434,11 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 		}
 	}
 
-	if err = setupDaemonRoot(config, realRoot, rootUID, rootGID); err != nil {
+	if err := setupDaemonRoot(config, realRoot, rootUID, rootGID); err != nil {
+		return nil, err
+	}
+
+	if err := setupDaemonProcess(config); err != nil {
 		return nil, err
 	}
 

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -161,3 +161,7 @@ func (daemon *Daemon) setDefaultIsolation() error {
 func rootFSToAPIType(rootfs *image.RootFS) types.RootFS {
 	return types.RootFS{}
 }
+
+func setupDaemonProcess(config *Config) error {
+	return nil
+}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1139,3 +1139,19 @@ func rootFSToAPIType(rootfs *image.RootFS) types.RootFS {
 		Layers: layers,
 	}
 }
+
+// setupDaemonProcess sets various settings for the daemon's process
+func setupDaemonProcess(config *Config) error {
+	// setup the daemons oom_score_adj
+	return setupOOMScoreAdj(config.OOMScoreAdjust)
+}
+
+func setupOOMScoreAdj(score int) error {
+	f, err := os.OpenFile("/proc/self/oom_score_adj", os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(strconv.Itoa(score))
+	f.Close()
+	return err
+}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -431,3 +431,7 @@ func rootFSToAPIType(rootfs *image.RootFS) types.RootFS {
 		BaseLayer: rootfs.BaseLayer,
 	}
 }
+
+func setupDaemonProcess(config *Config) error {
+	return nil
+}

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -54,9 +54,10 @@ weight = -1
       --label=[]                             Set key=value labels to the daemon
       --log-driver="json-file"               Default driver for container logs
       --log-opt=[]                           Log driver specific options
-      --mtu=0                                Set the containers network MTU
       --max-concurrent-downloads=3           Set the max concurrent downloads for each pull
       --max-concurrent-uploads=5             Set the max concurrent uploads for each push
+      --mtu=0                                Set the containers network MTU
+      --oom-score-adjust=-500                Set the oom_score_adj for the daemon
       --disable-legacy-registry              Do not contact legacy registries
       -p, --pidfile="/var/run/docker.pid"    Path to use for daemon PID file
       --raw-logs                             Full timestamps without ANSI coloring
@@ -1057,6 +1058,7 @@ This is a full example of the allowed configuration options on Linux:
 	"insecure-registries": [],
 	"disable-legacy-registry": false,
 	"default-runtime": "runc",
+	"oom-score-adjust": -500,
 	"runtimes": {
 		"runc": {
 			"path": "runc"


### PR DESCRIPTION
This adds an `--oom-score-adjust` flag to the daemon so that the value
provided can be set for the docker daemon's process.  The default value
for the flag is -500.  This will allow the docker daemon to have a
less chance of being killed before containers do.  The default value for
processes is 0 with a min/max of -1000/1000.

-500 is a good middle ground because it is less than the default for
most processes and still not -1000 which basically means never kill this
process in an OOM condition on the host machine.  The only processes on
my machine that have a score less than -500 are dbus at -900 and sshd
and xfce( my window manager ) at -1000.  I don't think docker should be
set lower, by default, than dbus or sshd so that is why I chose -500.

Fixes #24027

Signed-off-by: Michael Crosby crosbymichael@gmail.com
