### PR TITLE
Allow option to override kernel check in overlay2

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/docker/docker/pkg/directory"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/kernel"
 
 	"github.com/opencontainers/runc/libcontainer/label"
@@ -92,6 +94,10 @@ func init() {
 // If overlay filesystem is not supported on the host, graphdriver.ErrNotSupported is returned as error.
 // If a overlay filesystem is not supported over a existing filesystem then error graphdriver.ErrIncompatibleFS is returned.
 func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+	opts, err := parseOptions(options)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := supportsOverlay(); err != nil {
 		return nil, graphdriver.ErrNotSupported
@@ -103,7 +109,10 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 	if kernel.CompareKernelVersion(*v, kernel.VersionInfo{Kernel: 4, Major: 0, Minor: 0}) < 0 {
-		return nil, graphdriver.ErrNotSupported
+		if !opts.overrideKernelCheck {
+			return nil, graphdriver.ErrNotSupported
+		}
+		logrus.Warnf("Using pre-4.0.0 kernel for overlay2, mount failures may require kernel update")
 	}
 
 	fsMagic, err := graphdriver.GetFSMagic(home)
@@ -142,6 +151,31 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	return d, nil
+}
+
+type overlayOptions struct {
+	overrideKernelCheck bool
+}
+
+func parseOptions(options []string) (*overlayOptions, error) {
+	o := &overlayOptions{}
+	for _, option := range options {
+		key, val, err := parsers.ParseKeyValueOpt(option)
+		if err != nil {
+			return nil, err
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "overlay2.override_kernel_check":
+			o.overrideKernelCheck, err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("overlay2: Unknown option %s\n", key)
+		}
+	}
+	return o, nil
 }
 
 func supportsOverlay() error {

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -566,6 +566,17 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     Example use:
         $ docker daemon -s btrfs --storage-opt btrfs.min_space=10G
 
+#### Overlay2 options
+
+* `overlay2.override_kernel_check`
+
+    Overrides the Linux kernel version check allowing overlay2. Support for
+    specifying multiple lower directories needed by overlay2 was added to the
+    Linux kernel in 4.0.0. However some older kernel versions may be patched
+    to add multiple lower directory support for OverlayFS. This option should
+    only be used after verifying this support exists in the kernel. Applying
+    this option on a kernel without this support will cause failures on mount.
+
 ## Docker runtime execution options
 
 The Docker daemon relies on a


### PR DESCRIPTION
Add option to skip kernel check for older kernels which have been patched to support multiple lower directories in OverlayFS.

Fixes #24023
