### PR TITLE
Don't retry push on an unknown repository

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -89,7 +89,7 @@ func retryOnError(err error) error {
 		}
 	case errcode.Error:
 		switch v.Code {
-		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied, errcode.ErrorCodeTooManyRequests:
+		case errcode.ErrorCodeUnauthorized, errcode.ErrorCodeUnsupported, errcode.ErrorCodeDenied, errcode.ErrorCodeTooManyRequests, v2.ErrorCodeNameUnknown:
 			return xfer.DoNotRetry{Err: err}
 		}
 	case *url.Error:


### PR DESCRIPTION
If the remote registry responds with a NAME_UNKNOWN error, treat this as
a fatal error and don't retry the push.

Tested against an ECR registry.

Fixes #24473
