### PR TITLE
Clarify warning against using build-time variables for secrets

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1292,8 +1292,9 @@ subsequent line 3. The `USER` at line 4 evaluates to `what_user` as `user` is
 defined and the `what_user` value was passed on the command line. Prior to its definition by an
 `ARG` instruction, any use of a variable results in an empty string.
 
-> **Note:** It is not recommended to use build-time variables for
->  passing secrets like github keys, user credentials etc.
+> **Warning:** It is not recommended to use build-time variables for
+>  passing secrets like github keys, user credentials etc. Build-time variable
+>  values are visible to any user of the image with the `docker history` command.
 
 You can use an `ARG` or an `ENV` instruction to specify variables that are
 available to the `RUN` instruction. Environment variables defined using the

--- a/man/Dockerfile.5.md
+++ b/man/Dockerfile.5.md
@@ -376,8 +376,9 @@ A Dockerfile is similar to a Makefile.
   defined and the `what_user` value was passed on the command line. Prior to its definition by an
   `ARG` instruction, any use of a variable results in an empty string.
 
-  > **Note:** It is not recommended to use build-time variables for
-  >  passing secrets like github keys, user credentials etc.
+  > **Warning:** It is not recommended to use build-time variables for
+  >  passing secrets like github keys, user credentials etc. Build-time variable
+  >  values are visible to any user of the image with the `docker history` command.
 
   You can use an `ARG` or an `ENV` instruction to specify variables that are
   available to the `RUN` instruction. Environment variables defined using the


### PR DESCRIPTION
The current docs for the Dockerfile `ARG` instruction contain a note recommending against using build-time variables for passing secrets, but they don't explain _why_.

I've attempted to clarify the reasoning without going into too much detail, and I've upgraded the `Note` to a `Warning`.

Signed-off-by: Dave Henderson dhenderson@gmail.com
