### PR TITLE
Remove --command flag for service update

### DIFF
--- a/api/client/service/inspect.go
+++ b/api/client/service/inspect.go
@@ -153,9 +153,6 @@ func printService(out io.Writer, service swarm.Service) {
 
 func printContainerSpec(out io.Writer, containerSpec swarm.ContainerSpec) {
 	fmt.Fprintf(out, " Image:\t\t%s\n", containerSpec.Image)
-	if len(containerSpec.Command) > 0 {
-		fmt.Fprintf(out, " Command:\t%s\n", strings.Join(containerSpec.Command, " "))
-	}
 	if len(containerSpec.Args) > 0 {
 		fmt.Fprintf(out, " Args:\t\t%s\n", strings.Join(containerSpec.Args, " "))
 	}

--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -373,7 +373,6 @@ type serviceOptions struct {
 	name    string
 	labels  opts.ListOpts
 	image   string
-	command []string
 	args    []string
 	env     opts.ListOpts
 	workdir string
@@ -416,7 +415,6 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: swarm.ContainerSpec{
 				Image:           opts.image,
-				Command:         opts.command,
 				Args:            opts.args,
 				Env:             opts.env.GetAll(),
 				Dir:             opts.workdir,

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -31,7 +31,6 @@ func newUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.String("image", "", "Service image tag")
-	flags.StringSlice("command", []string{}, "Service command")
 	flags.StringSlice("arg", []string{}, "Service command args")
 	addServiceFlags(cmd, opts)
 	return cmd
@@ -141,7 +140,6 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 	updateString(flagName, &spec.Name)
 	updateLabels(flags, &spec.Labels)
 	updateString("image", &cspec.Image)
-	updateSlice("command", &cspec.Command)
 	updateSlice("arg", &cspec.Args)
 	updateListOpts("env", &cspec.Env)
 	updateString("workdir", &cspec.Dir)

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -7,20 +7,15 @@ import (
 	"github.com/docker/engine-api/types/swarm"
 )
 
-func TestUpdateServiceCommandAndArgs(t *testing.T) {
+func TestUpdateServiceArgs(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("command", "the")
-	flags.Set("command", "new")
-	flags.Set("command", "command")
 	flags.Set("arg", "the")
 	flags.Set("arg", "new args")
 
 	spec := &swarm.ServiceSpec{}
 	cspec := &spec.TaskTemplate.ContainerSpec
-	cspec.Command = []string{"old", "command"}
 	cspec.Args = []string{"old", "args"}
 
 	updateService(flags, spec)
-	assert.EqualStringSlice(t, cspec.Command, []string{"the", "new", "command"})
 	assert.EqualStringSlice(t, cspec.Args, []string{"the", "new args"})
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1736,7 +1736,6 @@ _docker_service_update() {
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
 			--arg
-			--command
 			--image
 		"
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1154,7 +1154,6 @@ __docker_service_subcommand() {
                 $opts_help \
                 $opts_create_update \
                 "($help)--arg=[Service command args]:arguments: _normal" \
-                "($help)--command=[Service command]:command: _command_names -e" \
                 "($help)--image=[Service image tag]:image:__docker_repositories" \
                 "($help -)1:service:__docker_complete_services" && ret=0
             ;;

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -18,7 +18,6 @@ Update a service
 
 Options:
       --arg value                    Service command args (default [])
-      --command value                Service command (default [])
       --constraint value             Placement constraints (default [])
       --endpoint-mode string         Endpoint mode (vip or dnsrr)
   -e, --env value                    Set environment variables (default [])


### PR DESCRIPTION
Fixes #24196

removing `--command` for now (for `1.12.0`) 🐹.

> After discussing with Solomon, let's not add `--entrypoint` nor `--command` to service create or update.
- Should we also remove `Command` from `ContainerSpec` in the `engine-api` for now ? (because with this PR, we can no more specify a `--command` with the command-line, but it's still possible using the API)
- [ ] I have to check docs too 👼

/cc @tiborvass @stevvooe @aaronlehmann @dnephin @tonistiigi @thaJeztah 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
