### PR TITLE
Return an empty services list if no services are running

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -654,7 +654,7 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 		return nil, err
 	}
 
-	var services []types.Service
+	services := []types.Service{}
 
 	for _, service := range r.Services {
 		services = append(services, convert.ServiceFromGRPC(*service))

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -212,6 +212,16 @@ func (d *SwarmDaemon) listNodes(c *check.C) []swarm.Node {
 	return nodes
 }
 
+func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
+	status, out, err := d.SockRequest("GET", "/services", nil)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+
+	services := []swarm.Service{}
+	c.Assert(json.Unmarshal(out, &services), checker.IsNil)
+	return services
+}
+
 func (d *SwarmDaemon) updateSwarm(c *check.C, f ...specConstructor) {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -294,6 +294,15 @@ func (s *DockerSwarmSuite) TestApiSwarmPromoteDemote(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, d2.checkControlAvailable, checker.True)
 }
 
+func (s *DockerSwarmSuite) TestApiSwarmServicesEmptyList(c *check.C) {
+	testRequires(c, Network)
+	d := s.AddDaemon(c, true, true)
+
+	services := d.listServices(c)
+	c.Assert(services, checker.NotNil)
+	c.Assert(len(services), checker.Equals, 0, check.Commentf("services: %#v", services))
+}
+
 func (s *DockerSwarmSuite) TestApiSwarmServicesCreate(c *check.C) {
 	testRequires(c, Network)
 	d := s.AddDaemon(c, true, true)


### PR DESCRIPTION
Initializing the services list in order to return an empty list instead of a nil object.

Fixes #24526 

Signed-off-by: Ralf Sippl ralf.sippl@gmail.com
