### PR TITLE
Fix a minor typo in swarm tutorial docs

### DIFF
--- a/docs/swarm/swarm-tutorial/delete-service.md
+++ b/docs/swarm/swarm-tutorial/delete-service.md
@@ -39,5 +39,5 @@ removed the service. The CLI returns a message that the service is not found:
 
 ## What's next?
 
-In the next step of the tutorial, you set up a new service and and apply a
+In the next step of the tutorial, you set up a new service and apply a
 [rolling update](rolling-update.md).


### PR DESCRIPTION
This fix fixes a minor typo in swarm tutorial's delete service docs.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
