### PR TITLE
Remove duplicate keys in labels of `docker info`

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -223,6 +223,21 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 		for _, attribute := range info.Labels {
 			fmt.Fprintf(dockerCli.Out(), " %s\n", attribute)
 		}
+		// TODO: Engine labels with duplicate keys has been deprecated in 1.13 and will be error out
+		// after 3 release cycles (1.16). For now, a WARNING will be generated. The following will
+		// be removed eventually.
+		labelMap := map[string]string{}
+		for _, label := range info.Labels {
+			stringSlice := strings.SplitN(label, "=", 2)
+			if len(stringSlice) > 1 {
+				// If there is a conflict we will throw out an warning
+				if v, ok := labelMap[stringSlice[0]]; ok && v != stringSlice[1] {
+					fmt.Fprintln(dockerCli.Err(), "WARNING: labels with duplicate keys and conflicting values have been deprecated")
+					break
+				}
+				labelMap[stringSlice[0]] = stringSlice[1]
+			}
+		}
 	}
 
 	ioutils.FprintfIfTrue(dockerCli.Out(), "Experimental: %v\n", info.ExperimentalBuild)

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -396,6 +396,23 @@ func loadDaemonCliConfig(opts daemonOptions) (*daemon.Config, error) {
 		return nil, err
 	}
 
+	// Labels of the docker engine used to allow multiple values associated with the same key.
+	// This is deprecated in 1.13, and, be removed after 3 release cycles.
+	// The following will check the conflict of labels, and report a warning for deprecation.
+	//
+	// TODO: After 3 release cycles (1.16) an error will be returned, and labels will be
+	// sanitized to consolidate duplicate key-value pairs (config.Labels = newLabels):
+	//
+	// newLabels, err := daemon.GetConflictFreeLabels(config.Labels)
+	// if err != nil {
+	//	return nil, err
+	// }
+	// config.Labels = newLabels
+	//
+	if _, err := daemon.GetConflictFreeLabels(config.Labels); err != nil {
+		logrus.Warnf("Engine labels with duplicate keys and conflicting values have been deprecated: %s", err)
+	}
+
 	// Regardless of whether the user sets it to true or false, if they
 	// specify TLSVerify at all then we need to turn on TLS
 	if config.IsValueSet(cliflags.FlagTLSVerify) {

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -26,6 +26,14 @@ see [Feature Deprecation Policy](index.md#feature-deprecation-policy).
 
 The daemon is moved to a separate binary (`dockerd`), and should be used instead.
 
+### Duplicate keys with conflicting values in engine labels
+**Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/)**
+
+**Target For Removal In Release: v1.16**
+
+Duplicate keys with conflicting values have been deprecated. A warning is displayed
+in the output, and an error will be returned in the future.
+
 ### Three argument form in `docker import`
 **Deprecated In Release: [v0.6.7](https://github.com/docker/docker/releases/tag/v0.6.7)**
 

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -219,3 +219,15 @@ func (s *DockerDaemonSuite) TestRegistryMirrors(c *check.C) {
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s", registryMirror1))
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s", registryMirror2))
 }
+
+// Test case for #24392
+func (s *DockerDaemonSuite) TestInfoLabels(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	err := s.d.Start("--label", `test.empty=`, "--label", `test.empty=`, "--label", `test.label="1"`, "--label", `test.label="2"`)
+	c.Assert(err, checker.IsNil)
+
+	out, err := s.d.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "WARNING: labels with duplicate keys and conflicting values have been deprecated")
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #24392 where labels with duplicate keys exist in `docker info`, which contradicts with the specifications in the docs.

The reason for duplicate keys is that labels are stored as slice of strings in the format of `A=B` (and the input/output).

**\- How I did it**

 This fix tries to address this issue by checking conflict labels when daemon started, and remove duplicate labels (K-V).

The existing `/info` API has not been changed.

**\- How to verify it**

An additional integration test has been added to cover the changes in this fix.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #24392.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
