### PR TITLE
seccomp: do not add empty named syscalls

### DIFF
--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -50,6 +50,9 @@ func setupSeccomp(config *types.Seccomp) (newConfig *specs.Seccomp, err error) {
 
 	// Loop through all syscall blocks and convert them to libcontainer format
 	for _, call := range config.Syscalls {
+		if call.Name == "" {
+			continue
+		}
 		newCall := specs.Syscall{
 			Name:   call.Name,
 			Action: specs.Action(call.Action),


### PR DESCRIPTION
if you pass this seccomp json:

```
{
    "defaultAction": "SCMP_ACT_ALLOW",
    "syscalls": [
        {
            "action": "SCMP_ACT_ERRNO"
        },
    {
        "name": "chmod",
            "action": "SCMP_ACT_ERRNO"
    }
    ]
}
```

you'll get:

```
docker run --security-opt seccomp:test.json busybox chmod 777 . 
docker: Error response from daemon: oci runtime error: empty string is not a valid syscall.
```

I don't know if it's ok to skip empty named syscalls in the profile, in doubt, I opened this and I'm going to fix https://github.com/docker/docker/pull/24510 as well if we don't want them.

/cc @justincormack 

Signed-off-by: Antonio Murdaca runcom@redhat.com
