### PR TITLE
Fix panic when meminfo couldn't be read

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -51,6 +51,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	meminfo, err := system.ReadMemInfo()
 	if err != nil {
 		logrus.Errorf("Could not read system memory info: %v", err)
+		meminfo = &system.MemInfo{}
 	}
 
 	sysInfo := sysinfo.New(true)


### PR DESCRIPTION
Fixes panic reported by @abronan in https://github.com/docker/docker/pull/24516#issuecomment-232125090
