### PR TITLE
Fix some broken sourceforge.net links

### DIFF
--- a/docs/admin/b2d_volume_resize.md
+++ b/docs/admin/b2d_volume_resize.md
@@ -73,7 +73,7 @@ The `boot2docker` command reads its configuration from the `$BOOT2DOCKER_PROFILE
 
 This solution increases the volume size by first cloning it, then resizing it
 using a disk partitioning tool. We recommend
-[GParted](http://gparted.sourceforge.net/download.php/index.php). The tool comes
+[GParted](https://sourceforge.net/projects/gparted/files/). The tool comes
 as a bootable ISO, is a free download, and works well with VirtualBox.
 
 1. Stop Boot2Docker
@@ -102,7 +102,7 @@ as a bootable ISO, is a free download, and works well with VirtualBox.
 
 5. Download a disk partitioning tool ISO
 
-  To resize the volume, we'll use [GParted](http://gparted.sourceforge.net/download.php/).
+  To resize the volume, we'll use [GParted](https://sourceforge.net/projects/gparted/files/).
   Once you've downloaded the tool, add the ISO to the Boot2Docker VM IDE bus.
   You might need to create the bus before you can add the ISO.
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -572,7 +572,7 @@ The cache for `RUN` instructions can be invalidated by `ADD` instructions. See
   For systems that have recent aufs version (i.e., `dirperm1` mount option can
   be set), docker will attempt to fix the issue automatically by mounting
   the layers with `dirperm1` option. More details on `dirperm1` option can be
-  found at [`aufs` man page](http://aufs.sourceforge.net/aufs3/man.html)
+  found at [`aufs` man page](https://github.com/sfjro/aufs3-linux/tree/aufs3.18/Documentation/filesystems/aufs)
 
   If your system doesn't have support for `dirperm1`, the issue describes a workaround.
 

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -51,7 +51,7 @@ common Ethernet switch; no more, no less.
 How mature is the code providing kernel namespaces and private
 networking? Kernel namespaces were introduced [between kernel version
 2.6.15 and
-2.6.26](http://lxc.sourceforge.net/index.php/about/kernel-namespaces/).
+2.6.26](http://man7.org/linux/man-pages/man7/namespaces.7.html).
 This means that since July 2008 (date of the 2.6.26 release
 ), namespace code has been exercised and scrutinized on a large
 number of production systems. And there is more: the design and


### PR DESCRIPTION
Looks like there's issues with sourceforge project
pages. Given that sourceforge isn't really what
it used to be, trying to find alternative URLs
where possible.
