### PR TITLE
Don't set ulimits (nproc) for all init scripts

### DIFF
--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -13,7 +13,10 @@ start_pre() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
 
 	ulimit -n 1048576
-	ulimit -u 1048576
+
+	# Having non-zero limits causes performance problems due to accounting overhead
+	# in the kernel. We recommend using cgroups to do container-local accounting.
+	ulimit -u unlimited
 
 	return 0
 }

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,9 +11,9 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 # Uncomment TasksMax if your systemd version supports it.

--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -94,10 +94,13 @@ case "$1" in
 		chgrp docker "$DOCKER_LOGFILE"
 
 		ulimit -n 1048576
+
+		# Having non-zero limits causes performance problems due to accounting overhead
+		# in the kernel. We recommend using cgroups to do container-local accounting.
 		if [ "$BASH" ]; then
-			ulimit -u 1048576
+			ulimit -u unlimited
 		else
-			ulimit -p 1048576
+			ulimit -p unlimited
 		fi
 
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -2,8 +2,12 @@ description "Docker daemon"
 
 start on (filesystem and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
+
 limit nofile 524288 1048576
-limit nproc 524288 1048576
+
+# Having non-zero limits causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+limit nproc unlimited unlimited
 
 respawn
 


### PR DESCRIPTION
There is a not-insignificant performance overhead for all containers (if
containerd is a child of Docker, which is the current setup) if rlimits are
set on the main Docker daemon process (because the limits
propogate to all children).

We recommend using cgroups to do container-local accounting.

This applies the change added in 8db61095a3d0bcb0733580734ba5d54bc27a614d
to other init scripts.

relates to https://github.com/docker/docker/pull/24307

ping @justincormack @tianon @runcom @cyphar PTAL if this looks good to you; I didn't know the best way to verify/test this, but can try if you agree on this
