### PR TITLE
Uncomment the TasksMax val later in the deb build

### DIFF
--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -1,6 +1,8 @@
 #!/usr/bin/make -f
 
 VERSION = $(shell cat VERSION)
+SYSTEMD_VERSION := $(shell dpkg-query -W -f='$${Version}\n' systemd | cut -d- -f1)
+SYSTEMD_GT_227 := $(shell [ '$(SYSTEMD_VERSION)' ] && [ '$(SYSTEMD_VERSION)' -gt 227 ] && echo true )
 
 override_dh_gencontrol:
 	# if we're on Ubuntu, we need to Recommends: apparmor
@@ -32,6 +34,10 @@ override_dh_auto_install:
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-engine"
 	dh_installinit --name=docker
+ifeq (true, $(SYSTEMD_GT_227))
+	$(warning "Setting TasksMax=infinity")
+	sed -i -- 's/#TasksMax=infinity/TasksMax=infinity/' debian/docker-engine/lib/systemd/system/docker.service
+endif
 
 override_dh_installudev:
 	# match our existing priority


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**
1) 'make deb' 
2) install the xenial deb and make sure docker info doesn't show "unsupported", and that the service file has an uncommented TasksMax=infinity
3) install a debian deb and make sure the service file still has the commented-out #TasksMax=infinity

**\- Description for the changelog**

The original sed placement in e82830ecde02b3a607d5f3b470f2c4eff17c37e7 was creating packages with an "unsupported" tag in the package name.

Fixes #24197

**\- A picture of a cute animal (not mandatory but encouraged)**
![happy chimp](http://thewondrous.com/wp-content/uploads/2015/04/pics-of-funny-monkeys.jpg)

The original sed placement was creating packages with an
"unsupported" tag in the package name.

Fixes #24197

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
