### PR TITLE
docs: remove executiondriver from API 1.24 docs

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -116,6 +116,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 * `POST /containers/create` now takes `StorageOpt` field.
 * `GET /info` now returns `SecurityOptions` field, showing if `apparmor`, `seccomp`, or `selinux` is supported.
+* `GET /info` no longer returns the `ExecutionDriver` property. This property was no longer used after integration
+  with ContainerD in Docker 1.11.
 * `GET /networks` now supports filtering by `label` and `driver`.
 * `GET /containers/json` now supports filtering containers by `network` name or id.
 * `POST /containers/create` now takes `MaximumIOps` and `MaximumIOBps` fields. Windows daemon only.

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2198,7 +2198,6 @@ Display system-wide information
         "DockerRootDir": "/var/lib/docker",
         "Driver": "btrfs",
         "DriverStatus": [[""]],
-        "ExecutionDriver": "native-0.1",
         "ExperimentalBuild": false,
         "HttpProxy": "http://test:test@localhost:8080",
         "HttpsProxy": "https://test:test@localhost:8080",


### PR DESCRIPTION
the executiondriver property was removed in
880484992c360881dc57a3317b84d75300c358af, but docs
were only updated for the 1.25 API, not for 1.24

relates to https://github.com/docker/docker/pull/24501#issuecomment-232204337
