### PR TITLE
[carry 24499] Remove "Yes"/"No" and use "true"/"false" consistently in `docker info`

### DIFF
--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -82,13 +82,11 @@ func runInfo(dockerCli *client.DockerCli) error {
 		if info.Swarm.Error != "" {
 			fmt.Fprintf(dockerCli.Out(), " Error: %v\n", info.Swarm.Error)
 		}
+		fmt.Fprintf(dockerCli.Out(), " IsManager: %v\n", info.Swarm.ControlAvailable)
 		if info.Swarm.ControlAvailable {
-			fmt.Fprintf(dockerCli.Out(), " IsManager: Yes\n")
 			fmt.Fprintf(dockerCli.Out(), " Managers: %d\n", info.Swarm.Managers)
 			fmt.Fprintf(dockerCli.Out(), " Nodes: %d\n", info.Swarm.Nodes)
 			ioutils.FprintfIfNotEmpty(dockerCli.Out(), " CACertHash: %s\n", info.Swarm.CACertHash)
-		} else {
-			fmt.Fprintf(dockerCli.Out(), " IsManager: No\n")
 		}
 	}
 

--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -82,11 +82,11 @@ func runInfo(dockerCli *client.DockerCli) error {
 		if info.Swarm.Error != "" {
 			fmt.Fprintf(dockerCli.Out(), " Error: %v\n", info.Swarm.Error)
 		}
-		fmt.Fprintf(dockerCli.Out(), " IsManager: %v\n", info.Swarm.ControlAvailable)
+		fmt.Fprintf(dockerCli.Out(), " Is Manager: %v\n", info.Swarm.ControlAvailable)
 		if info.Swarm.ControlAvailable {
 			fmt.Fprintf(dockerCli.Out(), " Managers: %d\n", info.Swarm.Managers)
 			fmt.Fprintf(dockerCli.Out(), " Nodes: %d\n", info.Swarm.Nodes)
-			ioutils.FprintfIfNotEmpty(dockerCli.Out(), " CACertHash: %s\n", info.Swarm.CACertHash)
+			ioutils.FprintfIfNotEmpty(dockerCli.Out(), " CA Certificate Hash: %s\n", info.Swarm.CACertHash)
 		}
 	}
 

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -56,7 +56,7 @@ storage driver and a node that is part of a 2 node Swarm cluster:
      Network: bridge null host overlay
     Swarm: 
      NodeID: 0gac67oclbxq7
-     IsManager: YES
+     Is Manager: true
      Managers: 2
      Nodes: 2
     Runtimes: default

--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -57,10 +57,10 @@ node. For example, the tutorial uses a machine named `manager1`.
      ...snip...
      Swarm: active
       NodeID: dxn1zf6l61qsb1josjja83ngz
-      IsManager: Yes
+      Is Manager: true
       Managers: 1
       Nodes: 1
-      CACertHash: sha256:b7986d3baeff2f5664dfe350eec32e2383539ec1a802ba541c4eb829056b5f61
+      CA Certificate Hash: sha256:b7986d3baeff2f5664dfe350eec32e2383539ec1a802ba541c4eb829056b5f61
      ...snip...
      ```
 


### PR DESCRIPTION
carry of #24499; makes labels more human readable, as suggested in https://github.com/docker/docker/pull/24499#issuecomment-231799725

closes #24499
