### PR TITLE
fix the docker run --readonly example. rename '/icanwrite here' to '/…

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -224,7 +224,7 @@ will automatically create this directory on the host for you. In the
 example above, Docker will create the `/doesnt/exist`
 folder before starting your container.
 
-    $ docker run --read-only -v /icanwrite busybox touch /icanwrite here
+    $ docker run --read-only -v /icanwrite busybox touch /icanwrite/here
 
 Volumes can be used in combination with `--read-only` to control where
 a container writes files. The `--read-only` flag mounts the container's root


### PR DESCRIPTION
 docker version
Client:
 Version:      1.11.2
 API version:  1.23
 Go version:   go1.5.4
 Git commit:   b9f10c9
 Built:        Wed Jun  1 21:47:50 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.11.2
 API version:  1.23
 Go version:   go1.5.4
 Git commit:   b9f10c9
 Built:        Wed Jun  1 21:47:50 2016
 OS/Arch:      linux/amd64

when i run the cmd.
`docker run --read-only -v /icanwrite busybox touch /icanwrite here`
I get a erro.
touch: here: Read-only file syste
I think `touch /icanwrite here` cmd touch two files. one is '/icanwrite',one is 'here'.the file 'here' can't created in the rootfs.
so i changed  '/icanwrite here'  to  '/icanwrite/here'

Signed-off-by: Mei ChunTao mei.chuntao@zte.com.cn
