### PR TITLE
Allow v1 search to use v2 auth with identity token

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -87,7 +87,7 @@ clone git github.com/boltdb/bolt v1.2.1
 clone git github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-clone git github.com/docker/distribution 4e17ab5d319ac5b70b2769442947567a83386fbc
+clone git github.com/docker/distribution 07f32ac1831ed0fc71960b7da5d6bb83cb6881b5
 clone git github.com/vbatts/tar-split v0.9.11
 
 # get go-zfs packages

--- a/vendor/src/github.com/docker/distribution/registry/client/auth/session.go
+++ b/vendor/src/github.com/docker/distribution/registry/client/auth/session.go
@@ -72,15 +72,19 @@ type endpointAuthorizer struct {
 }
 
 func (ea *endpointAuthorizer) ModifyRequest(req *http.Request) error {
-	v2Root := strings.Index(req.URL.Path, "/v2/")
-	if v2Root == -1 {
+	pingPath := req.URL.Path
+	if v2Root := strings.Index(req.URL.Path, "/v2/"); v2Root != -1 {
+		pingPath = pingPath[:v2Root+4]
+	} else if v1Root := strings.Index(req.URL.Path, "/v1/"); v1Root != -1 {
+		pingPath = pingPath[:v1Root] + "/v2/"
+	} else {
 		return nil
 	}
 
 	ping := url.URL{
 		Host:   req.URL.Host,
 		Scheme: req.URL.Scheme,
-		Path:   req.URL.Path[:v2Root+4],
+		Path:   pingPath,
 	}
 
 	challenges, err := ea.challenges.GetChallenges(ping)
@@ -149,6 +153,19 @@ type RepositoryScope struct {
 // using the scope grammar
 func (rs RepositoryScope) String() string {
 	return fmt.Sprintf("repository:%s:%s", rs.Repository, strings.Join(rs.Actions, ","))
+}
+
+// RegistryScope represents a token scope for access
+// to resources in the registry.
+type RegistryScope struct {
+	Name    string
+	Actions []string
+}
+
+// String returns the string representation of the user
+// using the scope grammar
+func (rs RegistryScope) String() string {
+	return fmt.Sprintf("registry:%s:%s", rs.Name, strings.Join(rs.Actions, ","))
 }
 
 // TokenHandlerOptions is used to configure a new token handler


### PR DESCRIPTION
Updates the v1 search endpoint to also support v2 auth when an identity token is given. Only search v1 endpoint is supported since there is not v2 search currently defined to replace it.

Fixes #22379.
