### PR TITLE
Extend deprecation cycle to 3 releases by default

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -13,6 +13,9 @@ weight=80
 # Deprecated Engine Features
 
 The following list of features are deprecated in Engine.
+To learn more about Docker Engine's deprecation policy,
+see [Feature Deprecation Policy](index.md#feature-deprecation-policy).
+
 
 ### Three argument form in `docker import`
 **Deprecated In Release: [v0.6.7](https://github.com/docker/docker/releases/tag/v0.6.7)**
@@ -25,7 +28,7 @@ The `docker import` command format 'file|URL|- [REPOSITORY [TAG]]' is deprecated
 
 **Deprecated In Release: [v1.12.0](https://github.com/docker/docker/releases/)**
 
-**Target For Removal In Release: [v1.14.0](https://github.com/docker/docker/releases/)**
+**Target For Removal In Release: v1.15**
 
 The shorthand (`-h`) is less common than `--help` on Linux and cannot be used
 on all subcommands (due to it conflicting with, e.g. `-h` / `--hostname` on
@@ -35,14 +38,14 @@ on all subcommands (due to it conflicting with, e.g. `-h` / `--hostname` on
 ### `-e` and `--email` flags on `docker login`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
-**Target For Removal In Release: v1.13**
+**Target For Removal In Release: v1.14**
 
 The docker login command is removing the ability to automatically register for an account with the target registry if the given username doesn't exist. Due to this change, the email flag is no longer required, and will be deprecated.
 
 ### Separator (`:`) of `--security-opt` flag on `docker run`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
-**Target For Removal In Release: v1.13**
+**Target For Removal In Release: v1.14**
 
 The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consinstency with other similar flags, like `--storage-opt`.
 
@@ -88,7 +91,7 @@ Use `docker ps --filter=before=...` and `docker ps --filter=since=...` instead.
 
 **Deprecated in Release: [v1.12.0](https://github.com/docker/docker/releases/)**
 
-**Target For Removal In Release: v1.14**
+**Target For Removal In Release: v1.15**
 
 The `docker search --automated` and `docker search --stars` options are deprecated.
 Use `docker search --filter=is-automated=...` and `docker search --filter=stars=...` instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ on the separate [Release Notes page](https://docs.docker.com/release-notes)
 As changes are made to Docker there may be times when existing features
 will need to be removed or replaced with newer features. Before an existing
 feature is removed it will be labeled as "deprecated" within the documentation
-and will remain in Docker for, usually, at least 2 releases. After that time
+and will remain in Docker for, usually, at least 3 releases. After that time
 it may be removed.
 
 Users are expected to take note of the list of deprecated features each


### PR DESCRIPTION
At the moment docker's deprecation policy is 2 release cycles by default, which is around 5 months. This may not be enough for production environment and there is a need to extend the deprecation cycle to 3 releases (see #24494).

This fix updates the docs/deprecated.md and extend the deprecation cycle to 3 releases.

Fixes #24534

This fix is related to #24494.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
