### PR TITLE
Update bash completion for `docker service {create,update} {--mode,--…

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1710,7 +1710,6 @@ _docker_service_update() {
 		--label -l
 		--limit-cpu
 		--limit-memory
-		--mode
 		--mount -m
 		--name
 		--network
@@ -1733,6 +1732,18 @@ _docker_service_update() {
 		--help
 	"
 
+	if [ "$subcommand" = "create" ] ; then
+		options_with_args="$options_with_args
+			--mode
+		"
+
+		case "$prev" in
+			--mode)
+				COMPREPLY=( $( compgen -W "global replicated" -- "$cur" ) )
+				return
+				;;
+		esac
+	fi
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
 			--arg
@@ -1750,16 +1761,12 @@ _docker_service_update() {
 
 	case "$prev" in
 		--endpoint-mode)
-			COMPREPLY=( $( compgen -W "DNSRR VIP" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "dnsrr vip" -- "$cur" ) )
 			return
 			;;
 		--env|-e)
 			COMPREPLY=( $( compgen -e -S = -- "$cur" ) )
 			__docker_nospace
-			return
-			;;
-		--mode)
-			COMPREPLY=( $( compgen -W "global replicated" -- "$cur" ) )
 			return
 			;;
 		--network)


### PR DESCRIPTION
This adjusts bash completion to two changes I found in https://github.com/docker/docker/pull/24395/files#diff-521d74974f0707579c5c082ea5b3afebL23. (Sorry, don't know the implementing PRs.)
- `--mode` is no longer shared between `docker service create` and `docker service update`
- The completions for `--endpoint-mode` changed to lower case.
