### PR TITLE
Added optional flags to init gcp logger metadata

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -21,6 +21,9 @@ const (
 	logLabelsKey  = "labels"
 	logEnvKey     = "env"
 	logCmdKey     = "gcp-log-cmd"
+	logZoneKey    = "gcp-meta-zone"
+	logNameKey    = "gcp-meta-name"
+	logIDKey      = "gcp-meta-id"
 )
 
 var (
@@ -142,6 +145,12 @@ func New(ctx logger.Context) (logger.Logger, error) {
 			Name: instanceName,
 			ID:   instanceID,
 		}
+	} else if ctx.Config[logZoneKey] != "" || ctx.Config[logNameKey] != "" || ctx.Config[logIDKey] != "" {
+		l.instance = &instanceInfo{
+			Zone: ctx.Config[logZoneKey],
+			Name: ctx.Config[logNameKey],
+			ID:   ctx.Config[logIDKey],
+		}
 	}
 
 	// The logger "overflows" at a rate of 10,000 logs per second and this
@@ -163,7 +172,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 func ValidateLogOpts(cfg map[string]string) error {
 	for k := range cfg {
 		switch k {
-		case projectOptKey, logLabelsKey, logEnvKey, logCmdKey:
+		case projectOptKey, logLabelsKey, logEnvKey, logCmdKey, logZoneKey, logNameKey, logIDKey:
 		default:
 			return fmt.Errorf("%q is not a valid option for the gcplogs driver", k)
 		}

--- a/docs/admin/logging/gcplogs.md
+++ b/docs/admin/logging/gcplogs.md
@@ -37,6 +37,10 @@ The `--gcp-project` takes precedence over information discovered from the metada
 so a Docker daemon running in a Google Cloud Project can be overridden to log to a different
 Google Cloud Project using `--gcp-project`.
 
+Docker fetches the values for zone, instance name and instance id from Google
+Cloud metadata server. Those values can be provided via options if metadata
+server is not available. They will not override the values from metadata server.
+
 ## gcplogs options
 
 You can use the `--log-opt NAME=VALUE` flag to specify these additional Google
@@ -48,6 +52,9 @@ Cloud Logging driver options:
 | `gcp-log-cmd`               | optional | Whether to log the command that the container was started with. Defaults to false.                                                          |
 | `labels`                    | optional | Comma-separated list of keys of labels, which should be included in message, if these labels are specified for container.                   |
 | `env`                       | optional | Comma-separated list of keys of environment variables, which should be included in message, if these variables are specified for container. |
+| `gcp-meta-zone`             | optional | Zone name for the instance. |
+| `gcp-meta-name`             | optional | Instance name. |
+| `gcp-meta-id`               | optional | Instance ID. |
 
 If there is collision between `label` and `env` keys, the value of the `env`
 takes precedence. Both options add additional fields to the attributes of a
@@ -57,13 +64,22 @@ Below is an example of the logging options required to log to the default
 logging destination which is discovered by querying the GCE metadata server.
 
     docker run --log-driver=gcplogs \
-        --log-opt labels=location
-        --log-opt env=TEST
-        --log-opt gcp-log-cmd=true
-        --env "TEST=false"
-        --label location=west
+        --log-opt labels=location \
+        --log-opt env=TEST \
+        --log-opt gcp-log-cmd=true \
+        --env "TEST=false" \
+        --label location=west \
         your/application
 
 This configuration also directs the driver to include in the payload the label
 `location`, the environment variable `ENV`, and the command used to start the
 container.
+
+An example of the logging options for running outside of GCE (the daemon must be
+configured with GOOGLE_APPLICATION_CREDENTIALS):
+
+    docker run --log-driver=gcplogs \
+        --log-opt gcp-project=test-project
+        --log-opt gcp-meta-zone=west1 \
+        --log-opt gcp-meta-name=`hostname` \
+        your/application


### PR DESCRIPTION
**\- What I did**

Added `gcp-meta-zone`, `gcp-meta-name` and `gcp-meta-id` to gcplogs driver. If at least one of them is specified, docker will provide `instance` dict to the GCP logs if metadata server is not available, thus allowing to provide metadata from instances that aren't running on GCE.

**\- How to verify it**

Run the docker off GCE, providing auth details via `GOOGLE_APPLICATION_CREDENTIALS` and passing any of the relevant gcp logging options.

**\- Description for the changelog**

Added optional flags to init gcp logger metadata

**\- A picture of a cute animal (not mandatory but encouraged)**

![b4kr0](https://cloud.githubusercontent.com/assets/693/16804115/1251f5d2-4902-11e6-8c69-8392c7103305.jpg)

Signed-off-by: Vladimir Pouzanov farcaller@google.com
