### PR TITLE
Use spaces, not tabs, to format sample "swarm join" command

### DIFF
--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -56,7 +56,7 @@ func runInit(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts initOptions
 	// If no secret was specified, we create a random one
 	if !flags.Changed("secret") {
 		opts.secret = generateRandomSecret()
-		fmt.Fprintf(dockerCli.Out(), "No --secret provided. Generated random secret:\n\t%s\n\n", opts.secret)
+		fmt.Fprintf(dockerCli.Out(), "No --secret provided. Generated random secret:\n    %s\n\n", opts.secret)
 	}
 
 	req := swarm.InitRequest{
@@ -88,7 +88,7 @@ func runInit(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts initOptions
 		if opts.secret != "" {
 			secretArgs = "--secret " + opts.secret
 		}
-		fmt.Fprintf(dockerCli.Out(), "To add a worker to this swarm, run the following command:\n\tdocker swarm join %s \\\n\t--ca-hash %s \\\n\t%s\n", secretArgs, info.Swarm.CACertHash, node.ManagerStatus.Addr)
+		fmt.Fprintf(dockerCli.Out(), "To add a worker to this swarm, run the following command:\n    docker swarm join %s \\\n    --ca-hash %s \\\n    %s\n", secretArgs, info.Swarm.CACertHash, node.ManagerStatus.Addr)
 	}
 
 	return nil

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -35,14 +35,14 @@ in the newly created one node Swarm cluster.
 ```bash
 $ docker swarm init --listen-addr 192.168.99.121:2377
 No --secret provided. Generated random secret:
-	4ao565v9jsuogtq5t8s379ulb
+    4ao565v9jsuogtq5t8s379ulb
 
 Swarm initialized: current node (1ujecd0j9n3ro9i6628smdmth) is now a manager.
 
 To add a worker to this swarm, run the following command:
-	docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
-	--ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
-	192.168.99.121:2377
+    docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
+    --ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
+    192.168.99.121:2377
 $ docker node ls
 ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS          LEADER
 1ujecd0j9n3ro9i6628smdmth *  manager1  Accepted    Ready   Active        Reachable               Yes

--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -31,14 +31,14 @@ node. For example, the tutorial uses a machine named `manager1`.
     ```
     $ docker swarm init --listen-addr 192.168.99.100:2377
     No --secret provided. Generated random secret:
-	4ao565v9jsuogtq5t8s379ulb
+        4ao565v9jsuogtq5t8s379ulb
 
     Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a manager.
 
     To add a worker to this swarm, run the following command:
-	docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
-	--ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
-	192.168.99.100:2377
+        docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
+        --ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
+        192.168.99.100:2377
     ```
 
     The `--listen-addr` flag configures the manager node to listen on port


### PR DESCRIPTION
Using tabs here seems to cause copy/paste problems in some terminals.
Using spaces is safer.

Fixes #24609
