### PR TITLE
refactor function getDockerOS() in file github.com/docker/docker/vend…

### DIFF
--- a/vendor/src/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/src/github.com/docker/engine-api/client/image_build.go
@@ -109,11 +109,10 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	return query, nil
 }
 
-func getDockerOS(serverHeader string) string {
-	var osType string
+func getDockerOS(serverHeader string) (osType string) {
 	matches := headerRegexp.FindStringSubmatch(serverHeader)
-	if len(matches) > 0 {
-		osType = matches[1]
+	if len(matches) < 2 {
+		return ""
 	}
-	return osType
+	return matches[1]
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
refactor function “getDockerOS()” in file github.com/docker/docker/vendor/src/github.com/docker/engine-api/client/image_build.go
**\- How I did it**
1. remove the local variable -- ”var osType string“
1. refactor the statement "if len(matches) > 0 {osType = matches[1]}", because of when len(matches) == 1 , it will throw exception (index out of range)

**\- How to verify it**
local unit test
![test](https://cloud.githubusercontent.com/assets/8731588/16827122/1c9b7446-49b6-11e6-8852-e562c181c03c.png)

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

refactor the statement "if len(matches) > 0 {osType = matches[1]}", because of when len(matches) == 1 , it will throw exception (index out of range). More Robust !!!

**\- A picture of a cute animal (not mandatory but encouraged)**

…or/src/github.com/docker/engine-api/client/image_build.go

Signed-off-by: yuanxiao yuan.xiao5@zte.com.cn
