### PR TITLE
Status code 409 received when conflicting name when creating container

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -492,6 +492,7 @@ Create a container
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -493,6 +493,7 @@ Create a container
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container


### PR DESCRIPTION
**\- What I did**
Scripting creating a container with name.

**\- How I did it**
Created one container using the script, ran script again and it failed, inspected status codes and reason.

**\- How to verify it**
Create a container, then try to create another using the api with the same name. Inspect status code and reason.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

When creating a container by name using the remote API and the name already exists it returns 409 Conflict.
