### PR TITLE
Status code 409 received when conflicting name when creating container

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -299,6 +299,7 @@ Status Codes:
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1043,6 +1044,7 @@ Status Codes:
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Copy files or folders from a container

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -310,6 +310,7 @@ Status Codes:
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1081,6 +1082,7 @@ Status Codes:
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Copy files or folders from a container

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -314,6 +314,7 @@ Status Codes:
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1090,6 +1091,7 @@ Status Codes:
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Copy files or folders from a container

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -333,6 +333,7 @@ Status Codes:
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1174,6 +1175,7 @@ Status Codes:
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Copy files or folders from a container

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -445,6 +445,7 @@ Status Codes:
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1351,6 +1352,7 @@ Status Codes:
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Copy files or folders from a container

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -468,6 +468,7 @@ Status Codes:
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1381,6 +1382,7 @@ Status Codes:
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Copy files or folders from a container

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -492,6 +492,7 @@ Create a container
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1408,6 +1409,7 @@ Remove the container `id` from the filesystem
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Retrieving information about files and folders in a container

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -493,6 +493,7 @@ Create a container
 -   **400** – bad parameter
 -   **404** – no such container
 -   **406** – impossible to attach (container not running)
+-   **409** – conflict
 -   **500** – server error
 
 ### Inspect a container
@@ -1409,6 +1410,7 @@ Remove the container `id` from the filesystem
 -   **204** – no error
 -   **400** – bad parameter
 -   **404** – no such container
+-   **409** – conflict
 -   **500** – server error
 
 ### Retrieving information about files and folders in a container


### PR DESCRIPTION
- What I did
  Scripting creating a container with name.
- How I did it
  Created one container using the script, ran script again and it failed, inspected status codes and reason.
- How to verify it
  Create a container, then try to create another using the api with the same name. Inspect status code and reason.
- Description for the changelog

When creating a container by name using the remote API and the name already exists it returns 409 Conflict.

Signed-off-by: Eivin Giske Skaaren eivin@sysmystic.com
