### PR TITLE
API return network-list if no network-name or id is provided

### DIFF
--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -31,7 +31,8 @@ func (r *networkRouter) initRoutes() {
 	r.routes = []router.Route{
 		// GET
 		router.NewGetRoute("/networks", r.getNetworksList),
-		router.NewGetRoute("/networks/{id:.*}", r.getNetwork),
+		router.NewGetRoute("/networks/", r.getNetworksList),
+		router.NewGetRoute("/networks/{id:.+}", r.getNetwork),
 		// POST
 		router.NewPostRoute("/networks/create", r.postNetworkCreate),
 		router.NewPostRoute("/networks/{id:.*}/connect", r.postNetworkConnect),

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -59,6 +59,7 @@ func (daemon *Daemon) GetNetworkByID(partialID string) (libnetwork.Network, erro
 }
 
 // GetNetworkByName function returns a network for a given network name.
+// If no network name is given, the default network is returned.
 func (daemon *Daemon) GetNetworkByName(name string) (libnetwork.Network, error) {
 	c := daemon.netController
 	if c == nil {

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -125,6 +125,9 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now takes a `Mounts` field in `HostConfig` which replaces `Binds` and `Volumes`. *note*: `Binds` and `Volumes` are still available but are exclusive with `Mounts`
 * `POST /build` now performs a preliminary validation of the `Dockerfile` before starting the build, and returns an error if the syntax is incorrect. Note that this change is _unversioned_ and applied to all API versions.
 * `POST /build` accepts `cachefrom` parameter to specify images used for build cache.
+* `GET /networks/` endpoint now correctly returns a list of *all* networks,
+  instead of the default network if a trailing slash is provided, but no `name`
+  or `id`.
 
 ### v1.24 API changes
 


### PR DESCRIPTION
When calling the `/networks/` endpoint (with a trailing slash), the default network was returned.

This changes the endpoint to return the list of networks instead.

Also updated the description for GetNetworkByName to
explain that the "default" network is returned if
no name or id is provided.

closes https://github.com/docker/docker/issues/24595
