### PR TITLE
Delete  redundant content of 'docs/extend/plugins.md'

### DIFF
--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -34,7 +34,7 @@ Follow the instructions in the plugin's documentation.
 The sections below provide an inexhaustive overview of available plugins.
 
 <style>
-#content tr td:first-child { white-space: nowrap;}
+#DocumentationText  tr td:first-child { white-space: nowrap;}
 </style>
 
 ### Network plugins


### PR DESCRIPTION
I think `#content tr td:first-child { white-space: nowrap;}` is redundant in the `docs/extend/plugins.md`, and should be deleted.  Source code is as follows:

```
<style>
#content tr td:first-child { white-space: nowrap;} 
</style>
```

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
