### PR TITLE
docs: correct the placement constraints `docker service` example

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -170,7 +170,8 @@ node type label equals queue:
 ```bash
 $ docker service create \
   --name redis_2 \
-  --constraint node.labels.type == queue
+  --constraint 'node.labels.type == queue' \
+  redis:3.0.6
 ```
 
 ## Related information


### PR DESCRIPTION
- the constraint expression needs to be quoted
- add an actual redis container to run so the command line works

Signed-off-by: Anil Madhavapeddy anil@docker.com
