### PR TITLE
Wait for the reader fifo opening to block

### DIFF
--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -225,8 +225,9 @@ func (ctr *container) discardFifos() {
 		f := ctr.fifo(i)
 		c := make(chan struct{})
 		go func() {
+			r := openReaderFromFifo(f)
 			close(c) // this channel is used to not close the writer too early, before readonly open has been called.
-			io.Copy(ioutil.Discard, openReaderFromFifo(f))
+			io.Copy(ioutil.Discard, r)
 		}()
 		<-c
 		closeReaderFifo(f) // avoid blocking permanently on open if there is no writer side

--- a/libcontainerd/process_linux.go
+++ b/libcontainerd/process_linux.go
@@ -79,7 +79,9 @@ func (r emptyReader) Read(b []byte) (int, error) {
 
 func openReaderFromFifo(fn string) io.Reader {
 	r, w := io.Pipe()
+	c := make(chan struct{})
 	go func() {
+		close(c)
 		stdoutf, err := os.OpenFile(fn, syscall.O_RDONLY, 0)
 		if err != nil {
 			r.CloseWithError(err)
@@ -90,6 +92,7 @@ func openReaderFromFifo(fn string) io.Reader {
 		w.Close()
 		stdoutf.Close()
 	}()
+	<-c // wait for the goroutine to get scheduled and syscall to block
 	return r
 }
 


### PR DESCRIPTION
Add https://github.com/docker/docker/pull/22313 for v1.12 branch. This was not included in master before because we hoped to have a better solution in containerd side but that seems to have slipped to `v1.13` now.

fixes #22124

@mlaventure @crosbymichael 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
