### PR TITLE
Remove use of exec-root in plugins due to socket pathname limits.

### DIFF
--- a/cmd/dockerd/daemon_plugin_support.go
+++ b/cmd/dockerd/daemon_plugin_support.go
@@ -10,5 +10,5 @@ import (
 )
 
 func pluginInit(config *daemon.Config, remote libcontainerd.Remote, rs registry.Service) error {
-	return plugin.Init(config.Root, config.ExecRoot, remote, rs, config.LiveRestore)
+	return plugin.Init(config.Root, remote, rs, config.LiveRestore)
 }

--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -3,11 +3,14 @@
 package main
 
 import (
-	"github.com/docker/docker/pkg/integration/checker"
-	"github.com/go-check/check"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
 )
 
 var pluginName = "tiborvass/no-remove"
@@ -132,4 +135,54 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *check.C) {
 	if out, ec, err := runCommandWithOutput(cmd); ec != 1 {
 		c.Fatalf("Expected exit code '1', got %d err: %v output: %s ", ec, err, out)
 	}
+}
+
+// TestVolumePlugin tests volume creation using a plugin.
+func (s *DockerDaemonSuite) TestVolumePlugin(c *check.C) {
+	volName := "plugin-volume"
+	volRoot := "/data"
+	destDir := "/tmp/data/"
+	destFile := "foo"
+
+	if err := s.d.Start(); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	out, err := s.d.Cmd("plugin", "install", pluginName, "--grant-all-permissions")
+	if err != nil {
+		c.Fatalf("Could not install plugin: %v %s", err, out)
+	}
+	defer func() {
+		if out, err := s.d.Cmd("plugin", "disable", pluginName); err != nil {
+			c.Fatalf("Could not disable plugin: %v %s", err, out)
+		}
+		if out, err := s.d.Cmd("plugin", "remove", pluginName); err != nil {
+			c.Fatalf("Could not remove plugin: %v %s", err, out)
+		}
+	}()
+
+	out, err = s.d.Cmd("volume", "create", "-d", pluginName, "--name", volName)
+	if err != nil {
+		c.Fatalf("Could not create volume: %v %s", err, out)
+	}
+	defer func() {
+		if out, err := s.d.Cmd("volume", "remove", volName); err != nil {
+			c.Fatalf("Could not remove volume: %v %s", err, out)
+		}
+	}()
+
+	mountPoint, err := s.d.Cmd("volume", "inspect", volName, "--format", "{{.Mountpoint}}")
+	if err != nil {
+		c.Fatalf("Could not inspect volume: %v %s", err, mountPoint)
+	}
+	mountPoint = strings.TrimSpace(mountPoint)
+
+	out, err = s.d.Cmd("run", "--rm", "-v", volName+":"+destDir, "busybox", "touch", destDir+destFile)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	path := filepath.Join(mountPoint, destFile)
+	_, err = os.Lstat(path)
+	c.Assert(err, checker.IsNil)
+
+	// tiborvass/no-remove is a volume plugin that persists data on disk at /data,
+	// even after the volume is removed. So perform an explicit filesystem cleanup.
+	os.RemoveAll(volRoot)
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -109,22 +109,15 @@ func GetManager() *Manager {
 
 // Init (was NewManager) instantiates the singleton Manager.
 // TODO: revert this to NewManager once we get rid of all the singletons.
-func Init(root, execRoot string, remote libcontainerd.Remote, rs registry.Service, liveRestore bool) (err error) {
+func Init(root string, remote libcontainerd.Remote, rs registry.Service, liveRestore bool) (err error) {
 	if manager != nil {
 		return nil
 	}
 
 	root = filepath.Join(root, "plugins")
-	execRoot = filepath.Join(execRoot, "plugins")
-	for _, dir := range []string{root, execRoot} {
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			return err
-		}
-	}
-
 	manager = &Manager{
 		libRoot:         root,
-		runRoot:         execRoot,
+		runRoot:         "/run/docker",
 		plugins:         make(map[string]*plugin),
 		nameToID:        make(map[string]string),
 		handlers:        make(map[string]func(string, *plugins.Client)),

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -36,8 +36,6 @@ func (pm *Manager) enable(p *plugin) error {
 		return err
 	}
 
-	//TODO: check net.Dial
-
 	pm.Lock() // fixme: lock single record
 	p.P.Active = true
 	pm.save()


### PR DESCRIPTION
Unix socket pathnames are limited to 108 bytes. As a result, we need to be careful in not using exec-root as the parent directory for pluginID (which is already 64 bytes), since it can result in socket path names longer than 108 bytes. Use /tmp instead. Before this change, setting:
- dockerd --exec-root=/go/src/github.com/do passes
- dockerd --exec-root=/go/src/github.com/doc fails
  After this change, there's no failure.

Also, write a volume plugins test to verify that the plugins socket responds.

Signed-off-by: Anusha Ragunathan anusha@docker.com
