### PR TITLE
remove the second repeated line cli.api = api since api is a pointer

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -256,7 +256,6 @@ func (cli *DaemonCli) start() (err error) {
 	if err != nil {
 		return err
 	}
-	cli.api = api
 	signal.Trap(func() {
 		cli.stop()
 		<-stopc // wait for daemonCli.start() to return


### PR DESCRIPTION
Dear maintainers,
This PR is used to remove unused code when docker daemon starts. 
Because api server is a pointer and it is set to cli.api before, it doesn't need to be setted again.

Signed-off-by: yuzou zouyu7@huawei.com
