### PR TITLE
Func name wrong in notes of response.go

### DIFF
--- a/pkg/authorization/response.go
+++ b/pkg/authorization/response.go
@@ -35,7 +35,7 @@ type ResponseModifier interface {
 	// OverrideStatusCode replaces the status code of the HTTP reply
 	OverrideStatusCode(statusCode int)
 
-	// Flush flushes all data to the HTTP response
+	// FlushAll flushes all data to the HTTP response
 	FlushAll() error
 
 	// Hijacked indicates the response has been hijacked by the Docker daemon


### PR DESCRIPTION
In file "pkg\authorization\response.go", line #38, "// Flush flushes all data to the HTTP response", here "Flush" should be "FlushAll", thus consistent with line #39 "FlushAll() error".
