### PR TITLE
Fixes #24022 - Adds container health support to docker ps filter/format

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -280,9 +280,10 @@ type HealthcheckResult struct {
 
 // Health states
 const (
-	Starting  = "starting"  // Starting indicates that the container is not yet ready
-	Healthy   = "healthy"   // Healthy indicates that the container is running correctly
-	Unhealthy = "unhealthy" // Unhealthy indicates that the container has a problem
+	NoHealthcheck = "none"      // Indicates there is no healthcheck
+	Starting      = "starting"  // Starting indicates that the container is not yet ready
+	Healthy       = "healthy"   // Healthy indicates that the container is running correctly
+	Unhealthy     = "unhealthy" // Unhealthy indicates that the container has a problem
 )
 
 // Health stores information about the container's healthcheck results

--- a/container/state.go
+++ b/container/state.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/go-units"
 )
 
@@ -78,6 +79,7 @@ func (s *State) String() string {
 		if h := s.Health; h != nil {
 			return fmt.Sprintf("Up %s (%s)", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)), h.String())
 		}
+
 		return fmt.Sprintf("Up %s", units.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
 	}
 
@@ -98,6 +100,23 @@ func (s *State) String() string {
 	}
 
 	return fmt.Sprintf("Exited (%d) %s ago", s.ExitCodeValue, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
+}
+
+// HealthString returns a single string to describe health status.
+func (s *State) HealthString() string {
+	if s.Health == nil {
+		return types.NoHealthcheck
+	}
+
+	return s.Health.String()
+}
+
+// IsValidHealthString checks if the provided string is a valid container health status or not.
+func IsValidHealthString(s string) bool {
+	return s == types.Starting ||
+		s == types.Healthy ||
+		s == types.Unhealthy ||
+		s == types.NoHealthcheck
 }
 
 // StateString returns a single string to describe state

--- a/container/state_test.go
+++ b/container/state_test.go
@@ -4,7 +4,29 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/api/types"
 )
+
+func TestIsValidHealthString(t *testing.T) {
+	contexts := []struct {
+		Health   string
+		Expected bool
+	}{
+		{types.Healthy, true},
+		{types.Unhealthy, true},
+		{types.Starting, true},
+		{types.NoHealthcheck, true},
+		{"fail", false},
+	}
+
+	for _, c := range contexts {
+		v := IsValidHealthString(c.Health)
+		if v != c.Expected {
+			t.Fatalf("Expected %t, but got %t", c.Expected, v)
+		}
+	}
+}
 
 func TestStateRunStop(t *testing.T) {
 	s := NewState()

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -136,6 +136,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/create` now takes `AutoRemove` in HostConfig, to enable auto-removal of the container on daemon side when the container's process exits.
 * `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.
 * `GET /containers/json` now accepts `removing` as a valid value for the `status` filter.
+* `GET /containers/json` now supports filtering containers by `health` status. 
 * `DELETE /volumes/(name)` now accepts a `force` query parameter to force removal of volumes that were already removed out of band by the volume driver plugin.
 * `POST /containers/create/` and `POST /containers/(name)/update` now validates restart policies.
 * `POST /containers/create` now validates IPAMConfig in NetworkingConfig, and returns error for invalid IPv4 and IPv6 addresses (`--ip` and `--ip6` in `docker create/run`).

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -241,7 +241,8 @@ List containers
   -   `since`=(`<container id>` or `<container name>`)
   -   `volume`=(`<volume name>` or `<mount point destination>`)
   -   `network`=(`<network id>` or `<network name>`)
-
+  -   `health`=(`starting`|`healthy`|`unhealthy`|`none`)
+ 
 **Status codes**:
 
 -   **200** – no error

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -33,6 +33,7 @@ Options:
                         - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>)
                           containers created from an image or a descendant.
                         - is-task=(true|false)
+                        - health=(starting|healthy|unhealthy|none)
       --format string   Pretty-print containers using a Go template
       --help            Print usage
   -n, --last int        Show n last created containers (includes all states) (default -1)
@@ -81,6 +82,7 @@ The currently supported filters are:
 * isolation (default|process|hyperv)   (Windows daemon only)
 * volume (volume name or mount point) - filters containers that mount volumes.
 * network (network id or name) - filters containers connected to the provided network
+* health (starting|healthy|unhealthy|none) - filters containers based on healthcheck status
 
 #### Label
 

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/integration/checker"
-	"github.com/go-check/check"
+
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
 )
 
 func waitForStatus(c *check.C, name string, prev string, expected string) {

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -38,6 +38,7 @@ the running containers.
    - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
    - volume=(<volume-name>|<mount-point-destination>)
    - network=(<network-name>|<network-id>) - containers connected to the provided network
+   - health=(starting|healthy|unhealthy|none) - filters containers based on healthcheck status
 
 **--format**="*TEMPLATE*"
    Pretty-print containers using a Go template.
@@ -141,3 +142,4 @@ June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 February 2015, updated by André Martins <martins@noironetworks.com>
+October 2016, updated by Josh Horwitz <horwitzja@gmail.com>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #24022

**\- What I did**

Added support in `docker ps` to filter by health status.

**\- How I did it**

Added `health` filter to `docker ps` with values of `no healthcheck`, `starting`, `healthy` and `unhealthy`. 

**\- How to verify it**
1. Run some containers with and without health checks to test the feature.

```
$ docker run -d tutum/hello-world
```

```
$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
cd9abd6b523f        tutum/hello-world   "/bin/sh -c 'php-fpm "   2 seconds ago       Up 1 seconds        80/tcp              sad_panini

$ docker ps --filter "health=healthy"
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES

$ docker ps --filter "health=unhealthy"
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES

$ docker ps --filter "health=no healthcheck"
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
d1b7678e816f        tutum/hello-world   "/bin/sh -c 'php-fpm "   2 minutes ago       Up 2 minutes        80/tcp              pedantic_cray
```

Now lets add a container with a passing & failing check health check to make it fun

```
$ docker run --name failing --health-cmd "cat etc" --health-interval 1s -d tutum/hello-world
$ docker run --name passing --health-cmd "ls etc" --health-interval 1s -d tutum/hello-world

$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS               NAMES
dc232283a140        tutum/hello-world   "/bin/sh -c 'php-f..."   34 seconds ago      Up 33 seconds (unhealthy)   80/tcp              failing
d802ddbaa28c        tutum/hello-world   "/bin/sh -c 'php-f..."   42 seconds ago      Up 41 seconds (healthy)     80/tcp              passing
6ba7c51e7530        tutum/hello-world   "/bin/sh -c 'php-f..."   2 minutes ago       Up 2 minutes                80/tcp              tender_heisenberg

$ docker ps --filter "health=healthy"
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                    PORTS               NAMES
d802ddbaa28c        tutum/hello-world   "/bin/sh -c 'php-f..."   56 seconds ago      Up 55 seconds (healthy)   80/tcp              passing

$ docker ps --health --filter "health=unhealthy"
CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS                          PORTS               NAMES
dc232283a140        tutum/hello-world   "/bin/sh -c 'php-f..."   About a minute ago   Up About a minute (unhealthy)   80/tcp              failing

$ docker ps --filter "health=no healthcheck"
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
6ba7c51e7530        tutum/hello-world   "/bin/sh -c 'php-f..."   3 minutes ago       Up 3 minutes        80/tcp              tender_heisenberg
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added container health support to docker ps filter

**\- A picture of a cute animal (not mandatory but encouraged)**

![cute animal](https://s-media-cache-ak0.pinimg.com/736x/36/74/57/367457b07e71ab1460359cf5c3126933.jpg)
Signed-off-by: Josh Horwitz horwitzja@gmail.com
