### PR TITLE
Send registry auth token for service deploy

### DIFF
--- a/api/client/stack/opts.go
+++ b/api/client/stack/opts.go
@@ -18,6 +18,10 @@ func addBundlefileFlag(opt *string, flags *pflag.FlagSet) {
 		"Path to a Distributed Application Bundle file (Default: STACK.dab)")
 }
 
+func addRegistryAuthFlag(opt *bool, flags *pflag.FlagSet) {
+	flags.BoolVar(opt, "registry-auth", false, "Send registry authentication details to Swarm agents")
+}
+
 func loadBundlefile(stderr io.Writer, namespace string, path string) (*bundlefile.Bundlefile, error) {
 	defaultPath := fmt.Sprintf("%s.dab", namespace)
 

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -19,6 +19,7 @@ Create and update a stack from a Distributed Application Bundle (DAB)
 Options:
       --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
       --help            Print usage
+      --registry-auth   Send registry authentication details to Swarm agents
 ```
 
 Create and update a stack from a `dab` file. This command has to be

--- a/experimental/docker-stacks-and-bundles.md
+++ b/experimental/docker-stacks-and-bundles.md
@@ -46,6 +46,7 @@ Create and update a stack
 Options:
       --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
       --help            Print usage
+      --registry-auth   Send registry authentication details to Swarm agents
 ```
 
 Let's deploy the stack created before:


### PR DESCRIPTION
Follow up to #23584 

This PR passes the registry auth token for `docker service deploy`.

cc @tiborvass @tonistiigi @aaronlehmann - it's not clear what the best way to set and retrieve the `--registry-auth` flag in this case. 
