### PR TITLE
fixed cut-and-paste error on description of Docker Toolbox

### DIFF
--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -34,7 +34,7 @@ If you have an earlier Windows system that doesn't meet the Docker for Windows r
 
 See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docker with Toolbox.
 
-The Docker Toolbox setup does not run Docker natively in OS X. Instead, it uses `docker-machine` to create and attach to a virtual machine (VM). This machine is a Linux VM that hosts Docker for you on your Mac.
+The Docker Toolbox setup does not run Docker natively on Windows. Instead, it uses `docker-machine` to create and attach to a virtual machine (VM). This machine is a Linux VM that hosts Docker for you on your Windows system.
 
 **Requirements**
 


### PR DESCRIPTION
**\- What I did**
Updated the description of Docker Toolbox for the Windows install doc. (There was a cut-and-paste error that referred to Mac OS X.)

Signed-off-by: Victoria Bialas victoria.bialas@docker.com
