### PR TITLE
Fixes #24696 - Fixes Size showing 0 in formatted ps output

### DIFF
--- a/api/client/container/ps_test.go
+++ b/api/client/container/ps_test.go
@@ -1,0 +1,74 @@
+package container
+
+import "testing"
+
+func TestBuildContainerListOptions(t *testing.T) {
+
+	contexts := []struct {
+		psOpts          *psOptions
+		expectedAll     bool
+		expectedSize    bool
+		expectedLimit   int
+		expectedFilters map[string]string
+	}{
+		{
+			psOpts: &psOptions{
+				all:    true,
+				size:   true,
+				last:   5,
+				filter: []string{"foo=bar", "baz=foo"},
+			},
+			expectedAll:   true,
+			expectedSize:  true,
+			expectedLimit: 5,
+			expectedFilters: map[string]string{
+				"foo": "bar",
+				"baz": "foo",
+			},
+		},
+		{
+			psOpts: &psOptions{
+				all:     true,
+				size:    true,
+				last:    -1,
+				nLatest: true,
+			},
+			expectedAll:     true,
+			expectedSize:    true,
+			expectedLimit:   1,
+			expectedFilters: make(map[string]string),
+		},
+	}
+
+	for _, c := range contexts {
+		options, err := buildContainerListOptions(c.psOpts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if c.expectedAll != options.All {
+			t.Fatalf("Expected All to be %t but got %t", c.expectedAll, options.All)
+		}
+
+		if c.expectedSize != options.Size {
+			t.Fatalf("Expected Size to be %t but got %t", c.expectedSize, options.Size)
+		}
+
+		if c.expectedLimit != options.Limit {
+			t.Fatalf("Expected Limit to be %d but got %d", c.expectedLimit, options.Limit)
+		}
+
+		f := options.Filter
+
+		if f.Len() != len(c.expectedFilters) {
+			t.Fatalf("Expected %d filters but got %d", len(c.expectedFilters), f.Len())
+		}
+
+		for k, v := range c.expectedFilters {
+			f := options.Filter
+			if !f.ExactMatch(k, v) {
+				t.Fatalf("Expected filter with key %s to be %s but got %s", k, v, f.Get(k))
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #24696

**\- What I did**

Extended the preProcessor struct with types.Container so it won't fail on valid filter args. What was happening was the template.Execute call would fail early if anything but `{{.Status}}` was encountered first. This meant `--format "table {{.Size}}\t{{.Image}}"` worked but `--format "table {{.Image}}\t{{.Size}}` didn't. 

**\- How to verify it**

Prior to this fix:

```
$ docker ps --format "table {{.Image}}\t{{ .Size}}"
IMAGE               SIZE
tutum/hello-world   0 B
tutum/hello-world   0 B
c838763fde28        0 B

$ docker ps --format "table {{ .Size}}\t{{.Image}}"
SIZE                          IMAGE
114 B (virtual 17.79 MB)      tutum/hello-world
114 B (virtual 17.79 MB)      tutum/hello-world
161.5 MB (virtual 2.493 GB)   c838763fde28
```

After fix:

```
$ docker ps --format "table {{ .Size}}\t{{.Image}}"
SIZE                       IMAGE
2 B (virtual 182.8 MB)     nginx
114 B (virtual 17.79 MB)   tutum/hello-world

$ docker ps --format "table {{.Image}}\t{{.Size}}"
IMAGE               SIZE
nginx               2 B (virtual 182.8 MB)
tutum/hello-world   114 B (virtual 17.79 MB)
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed Size in formatted ps output

**\- A picture of a cute animal (not mandatory but encouraged)**
![cute animal](http://i.imgur.com/e49o75f.jpg)

Signed-off-by: Josh Horwitz horwitzja@gmail.com
