### PR TITLE
rewrite inspectAll function to make code more readable

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -335,7 +335,7 @@ func setupRemappedRoot(config *Config) ([]idtools.IDMap, []idtools.IDMap, error)
 
 func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error {
 	config.Root = rootDir
-	// Create the root directory if it doesn't exists
+	// Create the root directory if it doesn't exist
 	if err := system.MkdirAll(config.Root, 0700); err != nil && !os.IsExist(err) {
 		return err
 	}


### PR DESCRIPTION
I found that function InspectAll in api/client is somewhat terrible.

What I did:
1. rewrite function inspectAll;
2. fix a typo 

Signed-off-by: allencloud allen.sun@daocloud.io
