### PR TITLE
fix typo creats into creates in comments

### DIFF
--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -23,7 +23,7 @@ type attachOptions struct {
 	container string
 }
 
-// NewAttachCommand creats a new cobra.Command for `docker attach`
+// NewAttachCommand creates a new cobra.Command for `docker attach`
 func NewAttachCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts attachOptions
 

--- a/api/client/container/commit.go
+++ b/api/client/container/commit.go
@@ -25,7 +25,7 @@ type commitOptions struct {
 	config  string
 }
 
-// NewCommitCommand creats a new cobra.Command for `docker commit`
+// NewCommitCommand creates a new cobra.Command for `docker commit`
 func NewCommitCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts commitOptions
 

--- a/api/client/container/create.go
+++ b/api/client/container/create.go
@@ -26,7 +26,7 @@ type createOptions struct {
 	name string
 }
 
-// NewCreateCommand creats a new cobra.Command for `docker create`
+// NewCreateCommand creates a new cobra.Command for `docker create`
 func NewCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts createOptions
 	var copts *runconfigopts.ContainerOptions

--- a/api/client/container/kill.go
+++ b/api/client/container/kill.go
@@ -17,7 +17,7 @@ type killOptions struct {
 	containers []string
 }
 
-// NewKillCommand creats a new cobra.Command for `docker kill`
+// NewKillCommand creates a new cobra.Command for `docker kill`
 func NewKillCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts killOptions
 

--- a/api/client/container/logs.go
+++ b/api/client/container/logs.go
@@ -28,7 +28,7 @@ type logsOptions struct {
 	container string
 }
 
-// NewLogsCommand creats a new cobra.Command for `docker logs`
+// NewLogsCommand creates a new cobra.Command for `docker logs`
 func NewLogsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts logsOptions
 

--- a/api/client/container/pause.go
+++ b/api/client/container/pause.go
@@ -15,7 +15,7 @@ type pauseOptions struct {
 	containers []string
 }
 
-// NewPauseCommand creats a new cobra.Command for `docker pause`
+// NewPauseCommand creates a new cobra.Command for `docker pause`
 func NewPauseCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts pauseOptions
 

--- a/api/client/container/port.go
+++ b/api/client/container/port.go
@@ -18,7 +18,7 @@ type portOptions struct {
 	port string
 }
 
-// NewPortCommand creats a new cobra.Command for `docker port`
+// NewPortCommand creates a new cobra.Command for `docker port`
 func NewPortCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts portOptions
 

--- a/api/client/container/rename.go
+++ b/api/client/container/rename.go
@@ -16,7 +16,7 @@ type renameOptions struct {
 	newName string
 }
 
-// NewRenameCommand creats a new cobra.Command for `docker rename`
+// NewRenameCommand creates a new cobra.Command for `docker rename`
 func NewRenameCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts renameOptions
 

--- a/api/client/container/start.go
+++ b/api/client/container/start.go
@@ -24,7 +24,7 @@ type startOptions struct {
 	containers []string
 }
 
-// NewStartCommand creats a new cobra.Command for `docker start`
+// NewStartCommand creates a new cobra.Command for `docker start`
 func NewStartCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts startOptions
 

--- a/api/client/container/stats.go
+++ b/api/client/container/stats.go
@@ -27,7 +27,7 @@ type statsOptions struct {
 	containers []string
 }
 
-// NewStatsCommand creats a new cobra.Command for `docker stats`
+// NewStatsCommand creates a new cobra.Command for `docker stats`
 func NewStatsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts statsOptions
 

--- a/api/client/container/stop.go
+++ b/api/client/container/stop.go
@@ -18,7 +18,7 @@ type stopOptions struct {
 	containers []string
 }
 
-// NewStopCommand creats a new cobra.Command for `docker stop`
+// NewStopCommand creates a new cobra.Command for `docker stop`
 func NewStopCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts stopOptions
 

--- a/api/client/container/unpause.go
+++ b/api/client/container/unpause.go
@@ -15,7 +15,7 @@ type unpauseOptions struct {
 	containers []string
 }
 
-// NewUnpauseCommand creats a new cobra.Command for `docker unpause`
+// NewUnpauseCommand creates a new cobra.Command for `docker unpause`
 func NewUnpauseCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts unpauseOptions
 

--- a/api/client/container/update.go
+++ b/api/client/container/update.go
@@ -32,7 +32,7 @@ type updateOptions struct {
 	containers []string
 }
 
-// NewUpdateCommand creats a new cobra.Command for `docker update`
+// NewUpdateCommand creates a new cobra.Command for `docker update`
 func NewUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts updateOptions
 

--- a/api/client/system/events.go
+++ b/api/client/system/events.go
@@ -24,7 +24,7 @@ type eventsOptions struct {
 	filter []string
 }
 
-// NewEventsCommand creats a new cobra.Command for `docker events`
+// NewEventsCommand creates a new cobra.Command for `docker events`
 func NewEventsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts eventsOptions
 

--- a/api/client/system/version.go
+++ b/api/client/system/version.go
@@ -37,7 +37,7 @@ type versionOptions struct {
 	format string
 }
 
-// NewVersionCommand creats a new cobra.Command for `docker version`
+// NewVersionCommand creates a new cobra.Command for `docker version`
 func NewVersionCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts versionOptions
 


### PR DESCRIPTION
fix typo creats into creates in comments

Signed-off-by: allencloud allen.sun@daocloud.io
