### PR TITLE
docs: update Oracle support link

### DIFF
--- a/docs/installation/linux/oracle.md
+++ b/docs/installation/linux/oracle.md
@@ -202,7 +202,7 @@ use the btrfs storage engine on Oracle Linux 7.
 
 If you have a current Basic or Premier Support Subscription for Oracle Linux,
 you can report any issues you have with the installation of Docker via a Service
-Request at [My Oracle Support](http://support.oracle.com).
+Request at [My Oracle Support](https://support.oracle.com).
 
 If you do not have an Oracle Linux Support Subscription, you can use the [Oracle
 Linux


### PR DESCRIPTION
The non-https url results in a redirect to 

```
https://support.oracle.com/epmos/faces/MosIndex.jspx?......
```

which our link-checker didn't like (https://github.com/docker/docker/pull/22566#issuecomment-233127377).

The https link looks to be a direct link, and not resulting in a redirect, so updating the URL.

Docs CI error;

```
04:40:16 ERROR: (503) 1 links to (http://support.oracle.com)
04:40:16             link http://support.oracle.com on page engine/installation/linux/oracle.md
04:40:42 Skip
```

/cc @Djelibeybi @vdemeester 
