### PR TITLE
fix for: docker images library/<name> doesnt list any images

### DIFF
--- a/api/client/image/images.go
+++ b/api/client/image/images.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 type imagesOptions struct {
@@ -32,7 +33,12 @@ func NewImagesCommand(dockerCli *client.DockerCli) *cobra.Command {
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				opts.matchName = args[0]
+				// library/foo filters on foo, but library/ still filters on library/
+				if name := strings.TrimPrefix(args[0], "library/"); name != "" {
+					opts.matchName = name
+				} else {
+					opts.matchName = args[0]
+				}
 			}
 			return runImages(dockerCli, opts)
 		},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
fix for #11955
I know it might be not very useful, but I thnik we shoul keep the same semantics in `build` and `images` commands.
**\- How I did it**
remove 'library/' prefix if present
**\- How to verify it**
Prepare image:
`docker build -t library/xxx .`
or
`docker build -t xxx .`

List images:
`docker images library/xxx`
`docker images xxx`
Both commands should produce same output.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

`docker images` takes into account 'library/' prefix in image name when listing images

**\- A picture of a cute animal (not mandatory but encouraged)**
[sweet-cat.png]

Signed-off-by: Adam Jędro jedroadam@gmail.com
