### PR TITLE
Add dummy '--force' flag for backwards compatibility

### DIFF
--- a/api/client/image/tag.go
+++ b/api/client/image/tag.go
@@ -30,6 +30,10 @@ func NewTagCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)
+	// TODO remove dummy '--force' / '-f' flag for 1.13. It's only there for backward compatibility
+	var forceTag bool
+	flags.BoolVarP(&forceTag, "force", "f", false, "Force the tagging even if there's a conflict")
+	flags.MarkDeprecated("force", "force tagging is now enabled by default. This flag will be removed in Docker 1.13")
 
 	return cmd
 }


### PR DESCRIPTION
The 'docker tag --force' flag was deprecated in docker 1.10 and removed in 1.12 through cbccb19212c186e5baf5e09b130a7fcc1d58df4c (https://github.com/docker/docker/pull/23090),
conform our two-release cycle deprecation policy.

However, we're currently discussing to update the deprecation policy, and extend it to _three_ release cycles (see https://github.com/docker/docker/pull/24572, and https://github.com/docker/docker/issues/24534)

This adds back a dummy '--force' flag to preserve backward compatibility for one more release, without adding back the actual functionality (not forced/forced).

closes https://github.com/docker/docker/issues/24494

**To test this**

pull an image:

```
docker pull hello-world
Using default tag: latest
latest: Pulling from library/hello-world
c04b14da8d14: Pull complete
Digest: sha256:0256e8a36e2070f7bf2d0b0763dbabdd67798512411de4cdcf9431a1feb60fd9
Status: Downloaded newer image for hello-world:latest
```

Tag it, using the `-f` or `--force` flag; a deprecation message should be printed, but the actual tagging succeed

``` bash
docker tag -f hello-world tag1
Flag --force has been deprecated, force tagging is now enabled by default. This flag will be removed in Docker 1.13
```

``` bash
docker tag --force hello-world tag3
Flag --force has been deprecated, force tagging is now enabled by default. This flag will be removed in Docker 1.13
```

Tagging without the `--force` flag should work as usual;

``` bash
docker tag hello-world tag3
```

The end result should be _three_ images (tags);

``` bash
docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
hello-world         latest              c54a2cc56cbb        2 weeks ago         1.848 kB
tag1                latest              c54a2cc56cbb        2 weeks ago         1.848 kB
tag2                latest              c54a2cc56cbb        2 weeks ago         1.848 kB
tag3                latest              c54a2cc56cbb        2 weeks ago         1.848 kB
```
