### PR TITLE
Don't automagically add "[OPTIONS]" to usage

### DIFF
--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -17,7 +17,7 @@ import (
 //
 // Usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
 func (cli *DockerCli) CmdExec(args ...string) error {
-	cmd := Cli.Subcmd("exec", []string{"CONTAINER COMMAND [ARG...]"}, Cli.DockerCommands["exec"].Description, true)
+	cmd := Cli.Subcmd("exec", []string{"[OPTIONS] CONTAINER COMMAND [ARG...]"}, Cli.DockerCommands["exec"].Description, true)
 	detachKeys := cmd.String([]string{"-detach-keys"}, "", "Override the key sequence for detaching a container")
 
 	execConfig, err := ParseExec(cmd, args)

--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -15,7 +15,7 @@ import (
 //
 // Usage: docker inspect [OPTIONS] CONTAINER|IMAGE|TASK [CONTAINER|IMAGE|TASK...]
 func (cli *DockerCli) CmdInspect(args ...string) error {
-	cmd := Cli.Subcmd("inspect", []string{"CONTAINER|IMAGE|TASK [CONTAINER|IMAGE|TASK...]"}, Cli.DockerCommands["inspect"].Description, true)
+	cmd := Cli.Subcmd("inspect", []string{"[OPTIONS] CONTAINER|IMAGE|TASK [CONTAINER|IMAGE|TASK...]"}, Cli.DockerCommands["inspect"].Description, true)
 	tmplStr := cmd.String([]string{"f", "-format"}, "", "Format the output using the given go template")
 	inspectType := cmd.String([]string{"-type"}, "", "Return JSON for specified type, (e.g image, container or task)")
 	size := cmd.Bool([]string{"s", "-size"}, false, "Display total file sizes if the type is container")

--- a/api/client/network/list.go
+++ b/api/client/network/list.go
@@ -31,7 +31,7 @@ func newListCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts listOptions
 
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Aliases: []string{"list"},
 		Short:   "List networks",
 		Args:    cli.NoArgs,

--- a/api/client/node/list.go
+++ b/api/client/node/list.go
@@ -28,7 +28,7 @@ func newListCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Aliases: []string{"list"},
 		Short:   "List nodes in the swarm",
 		Args:    cli.NoArgs,

--- a/api/client/plugin/install.go
+++ b/api/client/plugin/install.go
@@ -25,7 +25,7 @@ type pluginOptions struct {
 func newInstallCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var options pluginOptions
 	cmd := &cobra.Command{
-		Use:   "install PLUGIN",
+		Use:   "install [OPTIONS] PLUGIN",
 		Short: "Install a plugin",
 		Args:  cli.RequiresMinArgs(1), // TODO: allow for set args
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/client/service/list.go
+++ b/api/client/service/list.go
@@ -30,7 +30,7 @@ func newListCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Aliases: []string{"list"},
 		Short:   "List services",
 		Args:    cli.NoArgs,

--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -34,7 +34,7 @@ func newInitCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "init",
+		Use:   "init [OPTIONS]",
 		Short: "Initialize a Swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/client/swarm/leave.go
+++ b/api/client/swarm/leave.go
@@ -18,7 +18,7 @@ func newLeaveCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := leaveOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "leave",
+		Use:   "leave [OPTIONS]",
 		Short: "Leave a Swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/client/swarm/update.go
+++ b/api/client/swarm/update.go
@@ -16,7 +16,7 @@ func newUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := swarmOptions{autoAccept: NewAutoAcceptOption()}
 
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [OPTIONS]",
 		Short: "Update the Swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/client/volume/create.go
+++ b/api/client/volume/create.go
@@ -26,7 +26,7 @@ func newCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create",
+		Use:   "create [OPTIONS]",
 		Short: "Create a volume",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/api/client/volume/list.go
+++ b/api/client/volume/list.go
@@ -31,7 +31,7 @@ func newListCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts listOptions
 
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Aliases: []string{"list"},
 		Short:   "List volumes",
 		Args:    cli.NoArgs,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -155,11 +155,6 @@ func Subcmd(name string, synopses []string, description string, exitOnError bool
 	}
 
 	flags.ShortUsage = func() {
-		options := ""
-		if flags.FlagCountUndeprecated() > 0 {
-			options = " [OPTIONS]"
-		}
-
 		if len(synopses) == 0 {
 			synopses = []string{""}
 		}
@@ -176,7 +171,7 @@ func Subcmd(name string, synopses []string, description string, exitOnError bool
 				synopsis = " " + synopsis
 			}
 
-			fmt.Fprintf(flags.Out(), "\n%sdocker %s%s%s", lead, name, options, synopsis)
+			fmt.Fprintf(flags.Out(), "\n%sdocker %s%s", lead, name, synopsis)
 		}
 
 		fmt.Fprintf(flags.Out(), "\n\n%s\n", description)

--- a/cli/cobraadaptor/adaptor.go
+++ b/cli/cobraadaptor/adaptor.go
@@ -32,7 +32,7 @@ func NewCobraAdaptor(clientFlags *cliflags.ClientFlags) CobraAdaptor {
 	dockerCli := client.NewDockerCli(stdin, stdout, stderr, clientFlags)
 
 	var rootCmd = &cobra.Command{
-		Use:           "docker",
+		Use:           "docker [OPTIONS]",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -131,7 +131,7 @@ func (c CobraAdaptor) Command(name string) func(...string) error {
 	return nil
 }
 
-var usageTemplate = `Usage:	{{if not .HasSubCommands}}{{if .HasLocalFlags}}{{appendIfNotPresent .UseLine "[OPTIONS]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasSubCommands}}{{ .CommandPath}} COMMAND{{end}}
+var usageTemplate = `Usage:	{{if not .HasSubCommands}}{{.UseLine}}{{end}}{{if .HasSubCommands}}{{ .CommandPath}} COMMAND{{end}}
 
 {{with or .Long .Short }}{{. | trim}}{{end}}{{if gt .Aliases 0}}
 


### PR DESCRIPTION
This removes the logic to automatically add [OPTIONS] to the usage output.

The current logic was broken if a command only has deprecated or hidden flags, and in many cases put the [OPTIONS] in the wrong location.

Requiring the usage string to be set manually gives more predictable results, and shouldn't require much to maintain.
