### PR TITLE
Fix inconsistent fields for resource settings on service for API docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4006,11 +4006,11 @@ JSON Parameters:
     - **Resources** – Resource requirements which apply to each individual container created as part
       of the service.
         - **Limits** – Define resources limits.
-            - **CPU** – CPU limit
-            - **Memory** – Memory limit
+            - **NanoCPUs** – CPU limit in units of 10<sup>-9</sup> CPU shares.
+            - **MemoryBytes** – Memory limit in Bytes.
         - **Reservation** – Define resources reservation.
-            - **CPU** – CPU reservation
-            - **Memory** – Memory reservation
+            - **NanoCPUs** – CPU reservation in units of 10<sup>-9</sup> CPU shares.
+            - **MemoryBytes** – Memory reservation in Bytes.
     - **RestartPolicy** – Specification for the restart policy which applies to containers created
       as part of this service.
         - **Condition** – Condition for restart (`none`, `on-failure`, or `any`).

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4007,11 +4007,11 @@ JSON Parameters:
     - **Resources** – Resource requirements which apply to each individual container created as part
       of the service.
         - **Limits** – Define resources limits.
-            - **CPU** – CPU limit
-            - **Memory** – Memory limit
+            - **NanoCPUs** – CPU limit in units of 10<sup>-9</sup> CPU shares.
+            - **MemoryBytes** – Memory limit in Bytes.
         - **Reservation** – Define resources reservation.
-            - **CPU** – CPU reservation
-            - **Memory** – Memory reservation
+            - **NanoCPUs** – CPU reservation in units of 10<sup>-9</sup> CPU shares.
+            - **MemoryBytes** – Memory reservation in Bytes.
     - **RestartPolicy** – Specification for the restart policy which applies to containers created
       as part of this service.
         - **Condition** – Condition for restart (`none`, `on-failure`, or `any`).


### PR DESCRIPTION
In API docs, `CPU` and `Memory` were used for resource settings on services. The actual settings should be `NanoCPUs` and `MemoryBytes`.

This fix address the inconsistent fields between API docs and actual settings.

This fix fixes #24058.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
