### PR TITLE
exact match for name in "docker images"

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"path"
 	"sort"
 
 	"github.com/docker/docker/image"
@@ -141,7 +140,7 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
 					if ref.String() != filter {
 						continue
 					}
-				} else if matched, err := path.Match(filter, ref.Name()); !matched || err != nil { // name only match, FIXME: docs say exact
+				} else if ref.Name() != filter { // name only match
 					continue
 				}
 			}


### PR DESCRIPTION
**\- What I did**
I changed matching mechanism according to [docs](https://docs.docker.com/engine/reference/commandline/images/#/listing-images-by-name-and-tag).
**\- How I did it**
Changed `path.Match` to exact match (`==`) while searching by image name
**\- How to verify it**
`docker images` should not allow any wildcards ('*', '?' etc) according to documentation.

Test images:

```
$ docker images             
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
foo                 latest              30e40088812a        53 minutes ago      6.461 MB
bar                 latest              30e40088812a        53 minutes ago      6.461 MB
ext/bar             latest              30e40088812a        53 minutes ago      6.461 MB
```

Before change:

```
$ docker images *bar
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
bar                 latest              1c3a622dbb9b        7 minutes ago       6.461 MB
$ docker images fo*
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
foo                 latest              1c3a622dbb9b        7 minutes ago       6.461 MB
$ docker images ext/*
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
ext/bar             latest              1c3a622dbb9b        7 minutes ago       6.461 MB
```

After change:

```
$ docker images *bar
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
$ docker images fo*
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
$ docker images ext/* 
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
```

**\- Description for the changelog**
matching by name improvements in 'docker images $name'

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Adam Jędro jedroadam@gmail.com
