### PR TITLE
devmapper: prevent libdevmapper from deleting /dev/mapper/docker-xxx symbolic links in RemoveDeviceDeferred

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -358,6 +358,27 @@ func RemoveDeviceDeferred(name string) error {
 		return ErrTaskDeferredRemove
 	}
 
+	// set a task cookie and disable library fallback, or else libdevmapper will
+	// disable udev dm rules and delete the symlink under /dev/mapper by itself,
+	// even if the removal is deferred by the kernel.
+	var cookie uint
+	var flags uint16
+	flags = DmUdevDisableLibraryFallback
+	if err := task.setCookie(&cookie, flags); err != nil {
+		return fmt.Errorf("devicemapper: Can not set cookie: %s", err)
+	}
+
+	// libdevmapper and udev relies on System V semaphore for synchronization,
+	// semaphores created in `task.setCookie` will be cleaned up in `UdevWait`.
+	// So these two function call must come in pairs, otherwise semaphores will
+	// be leaked, and the  limit of number of semaphores defined in `/proc/sys/kernel/sem`
+	// will be reached, which will eventually make all follwing calls to 'task.SetCookie'
+	// fail.
+	// this call will not wait for the deferred removal's final executing, since no
+	// udev event will be generated, and the semaphore's value will not be incremented
+	// by udev, what UdevWait is just cleaning up the semaphore.
+	defer UdevWait(&cookie)
+
 	if err = task.run(); err != nil {
 		return fmt.Errorf("devicemapper: Error running RemoveDeviceDeferred %s", err)
 	}


### PR DESCRIPTION
**\- What I did**
Fixes #24671 by preventing libdevmapper from deleting `/dev/mapper/docker-xxxxx` links when `dm.use_deferred_remove` is enabled.

In the original implementation, libdevmapper will delete the symbolic link even if the device removal is deferred by the kernel, which will leave the device being exist but the symbolic link being lost, and docker will fail to activate and mount the device again.

By preventing libdevmapper from doing this, and leave all symlink handling to udev, `/dev/mapper/docker-xxx` link's lifecycle will always be synced with the corresponding `/dev/dm-x` device.

**\- How I did it**
I did it by set a dm task cookie and a `DmUdevDisableLibraryFallback` task flag, liddevmapper will check these two variables to see if it need to delete the symlink by itself([ref](https://git.fedorahosted.org/cgit/lvm2.git/tree/libdm/ioctl/libdm-iface.c#n2025)).

**\- How to verify it**
please refer to the **way to produce** section in #24671 

**\- Description for the changelog**
devicemapper: Fix the issue that device symlinks may get lost when `dm.use_deferred_removal` is enabled. [#24740](https://github.com/docker/docker/pull/24740)
