### PR TITLE
Refactoring for logrus formatting

### DIFF
--- a/daemon/discovery.go
+++ b/daemon/discovery.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/discovery"
 
 	// Register the libkv backends for discovery.
@@ -115,7 +115,7 @@ func (d *daemonDiscoveryReloader) advertiseHeartbeat(address string) {
 		select {
 		case <-d.ticker.C:
 			if err := d.backend.Register(address); err != nil {
-				log.Warnf("Registering as %q in discovery failed: %v", address, err)
+				logrus.Warnf("Registering as %q in discovery failed: %v", address, err)
 			} else {
 				if !ready {
 					close(d.readyCh)

--- a/daemon/graphdriver/driver_solaris.go
+++ b/daemon/graphdriver/driver_solaris.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"unsafe"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 const (
@@ -54,7 +54,7 @@ func Mounted(fsType FsMagic, mountPath string) (bool, error) {
 	// on Solaris buf.f_basetype contains ['z', 'f', 's', 0 ... ]
 	if (buf.f_basetype[0] != 122) || (buf.f_basetype[1] != 102) || (buf.f_basetype[2] != 115) ||
 		(buf.f_basetype[3] != 0) {
-		log.Debugf("[zfs] no zfs dataset found for rootdir '%s'", mountPath)
+		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", mountPath)
 		C.free(unsafe.Pointer(buf))
 		return false, ErrPrerequisites
 	}

--- a/daemon/graphdriver/zfs/zfs_solaris.go
+++ b/daemon/graphdriver/zfs/zfs_solaris.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"unsafe"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 )
 
@@ -32,7 +32,7 @@ func checkRootdirFs(rootdir string) error {
 	// on Solaris buf.f_basetype contains ['z', 'f', 's', 0 ... ]
 	if (buf.f_basetype[0] != 122) || (buf.f_basetype[1] != 102) || (buf.f_basetype[2] != 115) ||
 		(buf.f_basetype[3] != 0) {
-		log.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
+		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
 		C.free(unsafe.Pointer(buf))
 		return graphdriver.ErrPrerequisites
 	}

--- a/pkg/discovery/backends.go
+++ b/pkg/discovery/backends.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 var (
@@ -21,7 +21,7 @@ func Register(scheme string, d Backend) error {
 	if _, exists := backends[scheme]; exists {
 		return fmt.Errorf("scheme already registered %s", scheme)
 	}
-	log.WithField("name", scheme).Debug("Registering discovery service")
+	logrus.WithField("name", scheme).Debugf("Registering discovery service")
 	backends[scheme] = d
 	return nil
 }
@@ -98,7 +98,7 @@ func ParseAdvertise(advertise string) (string, error) {
 func New(rawurl string, heartbeat time.Duration, ttl time.Duration, clusterOpts map[string]string) (Backend, error) {
 	scheme, uri := parse(rawurl)
 	if backend, exists := backends[scheme]; exists {
-		log.WithFields(log.Fields{"name": scheme, "uri": uri}).Debug("Initializing discovery service")
+		logrus.WithFields(logrus.Fields{"name": scheme, "uri": uri}).Debugf("Initializing discovery service")
 		err := backend.Initialize(uri, heartbeat, ttl, clusterOpts)
 		return backend, err
 	}

--- a/pkg/discovery/kv/kv.go
+++ b/pkg/discovery/kv/kv.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/discovery"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/libkv"
@@ -73,7 +73,7 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 
 	var config *store.Config
 	if clusterOpts["kv.cacertfile"] != "" && clusterOpts["kv.certfile"] != "" && clusterOpts["kv.keyfile"] != "" {
-		log.Info("Initializing discovery with TLS")
+		logrus.Infof("Initializing discovery with TLS")
 		tlsConfig, err := tlsconfig.Client(tlsconfig.Options{
 			CAFile:   clusterOpts["kv.cacertfile"],
 			CertFile: clusterOpts["kv.certfile"],
@@ -93,7 +93,7 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 			TLS: tlsConfig,
 		}
 	} else {
-		log.Info("Initializing discovery without TLS")
+		logrus.Infof("Initializing discovery without TLS")
 	}
 
 	// Creates a new store, will ignore options given
@@ -112,7 +112,7 @@ func (s *Discovery) watchOnce(stopCh <-chan struct{}, watchCh <-chan []*store.KV
 				return true
 			}
 
-			log.WithField("discovery", s.backend).Debugf("Watch triggered with %d nodes", len(pairs))
+			logrus.WithField("discovery", s.backend).Debugf("Watch triggered with %d nodes", len(pairs))
 
 			// Convert `KVPair` into `discovery.Entry`.
 			addrs := make([]string, len(pairs))


### PR DESCRIPTION
I don't know full history. but i found most of source code use name of 'logrus' instead of 'log' when import module.
 and some older issue tried to remove some logrus funtion whcih w/o f.(#23459, #23461). 
 but i found some file not yet changed.
