### PR TITLE
update "image delete" error to match actual behavior

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -375,7 +375,7 @@ func (daemon *Daemon) checkImageDeleteConflict(imgID image.ID, mask conflictType
 	if mask&conflictActiveReference != 0 && len(daemon.referenceStore.References(imgID)) > 0 {
 		return &imageDeleteConflict{
 			imgID:   imgID,
-			message: "image is referenced in one or more repositories",
+			message: "image is referenced in multiple repositories",
 		}
 	}
 

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -134,7 +134,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 	// rmi tagged in multiple repos should have failed without force
 	c.Assert(err, checker.NotNil)
 	// rmi tagged in multiple repos should have failed without force
-	c.Assert(out, checker.Contains, "(must be forced) - image is referenced in one or more repositories", check.Commentf("out: %s; err: %v;", out, err))
+	c.Assert(out, checker.Contains, "(must be forced) - image is referenced in multiple repositories", check.Commentf("out: %s; err: %v;", out, err))
 
 	dockerCmd(c, "rmi", "-f", imgID)
 	{


### PR DESCRIPTION
The error message;

```
unable to delete .... (must be forced) - image is referenced in one or more repositories
```

Looks to be incorrect

Given the following images:

```
docker images | grep 2d36b1c0ea40
registry                           2                                     2d36b1c0ea40        7 weeks ago         171.2 MB
registry                           2.4.1                                 2d36b1c0ea40        7 weeks ago         171.2 MB
```

Removing the image by _id_ fails:

```
docker rmi 2d36b1c0ea40
Error response from daemon: conflict: unable to delete 2d36b1c0ea40 (must be forced) - image is referenced in one or more repositories
```

However, after untagging one image:

```
docker rmi registry:2
Untagged: registry:2
```

Removing the image works:

```
docker rmi 2d36b1c0ea40
Untagged: registry:2.4.1
Deleted: sha256:2d36b1c0ea40159adc8b36f7563f1d7a6d443384fe2611e8b393c1cb3ae2e6ad
Deleted: sha256:7abfddbf4e61927307b6646010845eeb7513ecc6541f33ea6103b2493e36aa4e
Deleted: sha256:f512d7699dbb2994fe15d30ee1d404e57b58c3c310617b4471db649680b4cfa0
Deleted: sha256:7291e34714908270aeda93f1dc681485f9734d41314e2fdc6c11f32ffa782a21
Deleted: sha256:548f6562929484f3d78267e4b1e31dcfeb9f303059668888b4423ce5501c7fbc
Deleted: sha256:afe56b46629e6d8e0bfc36fed13395a7cfa2bd83b58bb489976ef13553eff20b
Deleted: sha256:cf0c3bd5d6a0a14ebf96cc7d3df79a37774a70f3086273e09da71a86fe74fec2
Deleted: sha256:c5fdaf8b055f544d0211043e687905315c3a0b71c1c08df07e473dd0a30e43c8

docker images | grep 2d36b1c0ea40
<empty>
```

This changes the error message to reflect that behavior
