### PR TITLE
Enhancement: allow parallel stop, pause, unpause

### DIFF
--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -34,8 +34,9 @@ func runPause(dockerCli *command.DockerCli, opts *pauseOptions) error {
 	ctx := context.Background()
 
 	var errs []string
+	errChan := parallelOperation(ctx, opts.containers, dockerCli.Client().ContainerPause)
 	for _, container := range opts.containers {
-		if err := dockerCli.Client().ContainerPause(ctx, container); err != nil {
+		if err := <-errChan; err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(dockerCli.Out(), "%s\n", container)

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -35,8 +35,9 @@ func runUnpause(dockerCli *command.DockerCli, opts *unpauseOptions) error {
 	ctx := context.Background()
 
 	var errs []string
+	errChan := parallelOperation(ctx, opts.containers, dockerCli.Client().ContainerUnpause)
 	for _, container := range opts.containers {
-		if err := dockerCli.Client().ContainerUnpause(ctx, container); err != nil {
+		if err := <-errChan; err != nil {
 			errs = append(errs, err.Error())
 		} else {
 			fmt.Fprintf(dockerCli.Out(), "%s\n", container)


### PR DESCRIPTION
Fixes #24724

Stop multiple containers in parallel to speed up stop process, allow
maximum 50 parallel stops.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
