### PR TITLE
Update vendored go-events

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -66,7 +66,7 @@ clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
 clone git github.com/docker/libnetwork 905d374c096ca1f3a9b75529e52518b7540179f3
-clone git github.com/docker/go-events 39718a26497694185f8fb58a7d6f31947f3dc42d
+clone git github.com/docker/go-events afb2b9f2c23f33ada1a22b03651775fdc65a5089
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b

--- a/vendor/src/github.com/docker/go-events/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/go-events/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Docker open source projects
+
+Want to hack on go-events? Awesome! Here are instructions to get you started.
+
+go-events is part of the [Docker](https://www.docker.com) project, and
+follows the same rules and principles. If you're already familiar with the way
+Docker does things, you'll feel right at home.
+
+Otherwise, go read Docker's
+[contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md),
+[issue triaging](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md),
+[review process](https://github.com/docker/docker/blob/master/project/REVIEWING.md) and
+[branches and tags](https://github.com/docker/docker/blob/master/project/BRANCHES-AND-TAGS.md).
+
+For an in-depth description of our contribution process, visit the
+contributors guide: [Understand how to contribute](https://docs.docker.com/opensource/workflow/make-a-contribution/)
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/vendor/src/github.com/docker/go-events/LICENSE
+++ b/vendor/src/github.com/docker/go-events/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/src/github.com/docker/go-events/MAINTAINERS
+++ b/vendor/src/github.com/docker/go-events/MAINTAINERS
@@ -1,0 +1,46 @@
+# go-events maintainers file
+#
+# This file describes who runs the docker/go-events project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"aaronlehmann",
+			"aluzzardi",
+			"lk4d4",
+			"stevvooe",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.aaronlehmann]
+	Name = "Aaron Lehmann"
+	Email = "aaron.lehmann@docker.com"
+	GitHub = "aaronlehmann"
+
+	[people.aluzzardi]
+	Name = "Andrea Luzzardi"
+	Email = "al@docker.com"
+	GitHub = "aluzzardi"
+
+	[people.lk4d4]
+	Name = "Alexander Morozov"
+	Email = "lk4d4@docker.com"
+	GitHub = "lk4d4"
+
+	[people.stevvooe]
+	Name = "Stephen Day"
+	Email = "stephen.day@docker.com"
+	GitHub = "stevvooe"

--- a/vendor/src/github.com/docker/go-events/README.md
+++ b/vendor/src/github.com/docker/go-events/README.md
@@ -110,3 +110,8 @@ Application behavior can be controlled by how `Write` behaves. The examples
 above are designed to queue the message and return as quickly as possible.
 Other implementations may block until the event is committed to durable
 storage.
+
+## Copyright and license
+
+Copyright © 2016 Docker, Inc. go-events is licensed under the Apache License,
+Version 2.0. See [LICENSE](LICENSE) for the full license text.

--- a/vendor/src/github.com/docker/go-events/channel.go
+++ b/vendor/src/github.com/docker/go-events/channel.go
@@ -10,7 +10,7 @@ type Channel struct {
 	closed chan struct{}
 }
 
-// NewChannel returns a channel. If buffer is non-zero, the channel is
+// NewChannel returns a channel. If buffer is zero, the channel is
 // unbuffered.
 func NewChannel(buffer int) *Channel {
 	return &Channel{

--- a/vendor/src/github.com/docker/go-events/queue.go
+++ b/vendor/src/github.com/docker/go-events/queue.go
@@ -72,10 +72,17 @@ func (eq *Queue) run() {
 		}
 
 		if err := eq.dst.Write(event); err != nil {
+			// TODO(aaronl): Dropping events could be bad depending
+			// on the application. We should have a way of
+			// communicating this condition. However, logging
+			// at a log level above debug may not be appropriate.
+			// Eventually, go-events should not use logrus at all,
+			// and should bubble up conditions like this through
+			// error values.
 			logrus.WithFields(logrus.Fields{
 				"event": event,
 				"sink":  eq.dst,
-			}).WithError(err).Warnf("eventqueue: dropped event")
+			}).WithError(err).Debug("eventqueue: dropped event")
 		}
 	}
 }


### PR DESCRIPTION
This is needed to suppress a log message about a harmless condition
which was previously logged at the WARNING log level with potentially
high frequency (https://github.com/docker/go-events/pull/11).
