### PR TITLE
Add daemon flags for swarm join `--swarm-join`

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -42,6 +42,7 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
+	swarmtypes "github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-connections/tlsconfig"
 )
 
@@ -279,6 +280,18 @@ func (cli *DaemonCli) start() (err error) {
 		logrus.Fatalf("Error creating cluster component: %v", err)
 	}
 
+	if len(cli.Config.SwarmJoin) > 0 {
+		req := swarmtypes.JoinRequest{
+			RemoteAddrs:   cli.Config.SwarmJoin,
+			ListenAddr:    cli.Config.SwarmJoinOptions.ListenAddr,
+			AdvertiseAddr: cli.Config.SwarmJoinOptions.AdvertiseAddr,
+			JoinToken:     cli.Config.SwarmJoinOptions.Token,
+		}
+		if err := c.Join(req); err != nil {
+			logrus.Fatalf("Error joining swarm cluster: %v", err)
+		}
+	}
+
 	logrus.Info("Daemon has completed initialization")
 
 	logrus.WithFields(logrus.Fields{
@@ -443,4 +456,8 @@ func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config
 		handleAuthorization := authorization.NewMiddleware(authZPlugins)
 		s.UseMiddleware(handleAuthorization)
 	}
+}
+
+func joinCluster(c *cluster.Cluster) error {
+	return nil
 }


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #24087 to add a daemon flag `--swarm-join`, so that daemon could join a swarm cluster at startup. This should help with automation.

**\- How I did it**

Additional flags
`--swarm-join`
`--swarm-join-listen-addr`
`--swarm-join-advertise-addr`
`--swarm-join-token`

have been added.

**\- How to verify it**

An integration test has been added for test.

**\- Description for the changelog**

Add `--swarm-join`,  `--swarm-join-listen-addr`, `--swarm-join-advertise-addr`, `--swarm-join-token` so that docker daemon could join a swarm cluster at startup time.

**NOTE: This PR introduced multiple flags for docker daemon. The documentation will be updated if the naming of those flags are OK'ed.**

This fix fixes #24087.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
