### PR TITLE
Add only legacy plugins to the legacy lookup map.

### DIFF
--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -83,6 +83,11 @@ func (p *Plugin) Client() *Client {
 	return p.client
 }
 
+// IsLegacy returns true for legacy plugins and false otherwise.
+func (p *Plugin) IsLegacy() bool {
+	return true
+}
+
 // NewLocalPlugin creates a new local plugin.
 func NewLocalPlugin(name, addr string) *Plugin {
 	return &Plugin{

--- a/plugin/interface.go
+++ b/plugin/interface.go
@@ -6,4 +6,5 @@ import "github.com/docker/docker/pkg/plugins"
 type Plugin interface {
 	Client() *plugins.Client
 	Name() string
+	IsLegacy() bool
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -54,6 +54,11 @@ func (p *plugin) Client() *plugins.Client {
 	return p.client
 }
 
+// IsLegacy returns true for legacy plugins and false otherwise.
+func (p *plugin) IsLegacy() bool {
+	return false
+}
+
 func (p *plugin) Name() string {
 	name := p.P.Name
 	if len(p.P.Tag) > 0 {

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -118,7 +118,9 @@ func lookup(name string) (volume.Driver, error) {
 		return nil, err
 	}
 
-	drivers.extensions[name] = d
+	if p.IsLegacy() {
+		drivers.extensions[name] = d
+	}
 	return d, nil
 }
 
@@ -174,7 +176,9 @@ func GetAllDrivers() ([]volume.Driver, error) {
 		}
 
 		ext = NewVolumeDriver(name, p.Client())
-		drivers.extensions[name] = ext
+		if p.IsLegacy() {
+			drivers.extensions[name] = ext
+		}
 		ds = append(ds, ext)
 	}
 	return ds, nil


### PR DESCRIPTION
Legacy plugin model maintained a map of plugins. This is
not used by the new model. Using this map in the new model
causes incorrect lookup of plugins. This change uses adds
a plugin to the map only if its legacy.

Testing:
Before this change, running the following sequence failed the second time due to the map not deleting the plugin object correctly. After this change, it works fine.

docker plugin install tiborvass/no-remove --grant-all-permissions
docker volume create -d tiborvass/no-remove
docker plugin disable
docker plugin remove

Signed-off-by: Anusha Ragunathan anusha@docker.com
