### PR TITLE
Update docker load security docs

### DIFF
--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -120,13 +120,11 @@ certificates](https.md).
 
 The daemon is also potentially vulnerable to other inputs, such as image
 loading from either disk with 'docker load', or from the network with
-'docker pull'. This has been a focus of improvement in the community,
-especially for 'pull' security. While these overlap, it should be noted
-that 'docker load' is a mechanism for backup and restore and is not
-currently considered a secure mechanism for loading images. As of
-Docker 1.3.2, images are now extracted in a chrooted subprocess on
-Linux/Unix platforms, being the first-step in a wider effort toward
-privilege separation.
+'docker pull'. As of Docker 1.3.2, images are now extracted in a chrooted 
+subprocess on Linux/Unix platforms, being the first-step in a wider effort 
+toward privilege separation. As of Docker 1.10.0, all images are stored and 
+accessed by the cryptographic checksums of their contents, limiting the 
+possibility of an attacker causing a collision with an existing image.
 
 Eventually, it is expected that the Docker daemon will run restricted
 privileges, delegating operations well-audited sub-processes,


### PR DESCRIPTION
Previous comment was added in docker v1.5 and the original issues it is referring to do not apply anymore.

fixes #24779

@aaronlehmann 
