### PR TITLE
Kill and restart container returns 200 not 204 on OK

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -1090,7 +1090,7 @@ Restart the container `id`
 
 **Example response**:
 
-    HTTP/1.1 204 No Content
+    HTTP/1.1 200 No Content
 
 **Query parameters**:
 
@@ -1098,7 +1098,7 @@ Restart the container `id`
 
 **Status codes**:
 
--   **204** – no error
+-   **200** – OK
 -   **404** – no such container
 -   **500** – server error
 
@@ -1114,7 +1114,7 @@ Kill the container `id`
 
 **Example response**:
 
-    HTTP/1.1 204 No Content
+    HTTP/1.1 200 No Content
 
 **Query parameters**:
 
@@ -1123,7 +1123,7 @@ Kill the container `id`
 
 **Status codes**:
 
--   **204** – no error
+-   **200** – OK
 -   **404** – no such container
 -   **500** – server error
 


### PR DESCRIPTION
**\- What I did**
Working with 1.24 API scripts, tests are failing since documented return codes are not correct.

**\- How I did it**
Run my tests that tries to kill and restart a container.

**\- How to verify it**
Kill and restart a container via the API, inspect the http return codes.

**\- Description for the changelog**
The API returns 200 instead of the documented 204 for kill and restart container.
