### PR TITLE
Align bash completions for `-e --env`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2441,7 +2441,7 @@ _docker_run() {
 			return
 			;;
 		--env|-e)
-			COMPREPLY=( $( compgen -e -- "$cur" ) )
+			COMPREPLY=( $( compgen -e -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;


### PR DESCRIPTION
This PR aligns the completions for `docker {run,create} {-e,--env}` to the newly added completion for `docker service {create,update} {-e,--env}`.
Now in all completions the names of environment variables will automatically have a `=` appended, which saves typing one char and clearly indicates that you should specify a value now.

There is a corresponding PR for `docker-compose` (https://github.com/docker/compose/pull/3711), which currently also uses the old behavior.
