### PR TITLE
Add documentation for stack commands

### DIFF
--- a/api/client/stack/opts.go
+++ b/api/client/stack/opts.go
@@ -12,9 +12,9 @@ import (
 )
 
 func addBundlefileFlag(opt *string, flags *pflag.FlagSet) {
-	flags.StringVarP(
+	flags.StringVar(
 		opt,
-		"bundle", "f", "",
+		"bundle", "",
 		"Path to a Distributed Application Bundle file (Default: STACK.dab)")
 }
 

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -1,0 +1,57 @@
+<!--[metadata]>
++++
+title = "deploy"
+description = "The deploy command description and usage"
+keywords = ["stack, deploy"]
+advisory = "experimental"
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# stack deploy (experimental)
+
+```markdown
+Usage:  docker deploy [OPTIONS] STACK
+
+Create and update a stack from a Distributed Application Bundle (DAB)
+
+Options:
+      --bundle string   Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --help            Print usage
+```
+
+Create and update a stack from a `dab` file. This command has to be
+run targeting a manager node.
+
+```bash
+$ docker deploy vossibility-stack
+Loading bundle from vossibility-stack.dab
+Creating service vossibility-stack_elasticsearch
+Creating service vossibility-stack_kibana
+Creating service vossibility-stack_logstash
+Creating service vossibility-stack_lookupd
+Creating service vossibility-stack_nsqd
+Creating service vossibility-stack_vossibility-collector
+```
+
+You can verify that the services were correctly created:
+
+```bash
+$ docker service ls
+ID            NAME                                     REPLICAS  IMAGE
+COMMAND
+29bv0vnlm903  vossibility-stack_lookupd                1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqlookupd
+4awt47624qwh  vossibility-stack_nsqd                   1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqd --data-path=/data --lookupd-tcp-address=lookupd:4160
+4tjx9biia6fs  vossibility-stack_elasticsearch          1 elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility-stack_kibana                 1 kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility-stack_logstash               1 logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe logstash -f /etc/logstash/conf.d/logstash.conf
+axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba --config /config/config.toml --debug
+```
+
+## Related information
+
+* [stack config](stack_config.md)
+* [stack deploy](stack_deploy.md)
+* [stack rm](stack_rm.md)
+* [stack tasks](stack_tasks.md)

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -1,0 +1,30 @@
+<!--[metadata]>
++++
+title = "stack config"
+description = "The stack config command description and usage"
+keywords = ["stack, config"]
+advisory = "experimental"
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# stack config (experimental)
+
+```markdown
+Usage:  docker stack config [OPTIONS] STACK
+
+Print the stack configuration
+
+Options:
+      --bundle string   Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --help            Print usage
+```
+
+Displays the configuration of a stack.
+
+## Related information
+
+* [stack deploy](stack_deploy.md)
+* [stack rm](stack_rm.md)
+* [stack tasks](stack_tasks.md)

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -1,0 +1,59 @@
+<!--[metadata]>
++++
+title = "stack deploy"
+description = "The stack deploy command description and usage"
+keywords = ["stack, deploy, up"]
+advisory = "experimental"
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# stack deploy (experimental)
+
+```markdown
+Usage:  docker stack deploy [OPTIONS] STACK
+
+Create and update a stack from a Distributed Application Bundle (DAB)
+
+Aliases:
+  deploy, up
+
+Options:
+      --bundle string   Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --help            Print usage
+```
+
+Create and update a stack from a `dab` file on the swarm. This command
+has to be run targeting a manager node.
+
+```bash
+$ docker stack deploy vossibility-stack
+Loading bundle from vossibility-stack.dab
+Creating service vossibility-stack_elasticsearch
+Creating service vossibility-stack_kibana
+Creating service vossibility-stack_logstash
+Creating service vossibility-stack_lookupd
+Creating service vossibility-stack_nsqd
+Creating service vossibility-stack_vossibility-collector
+```
+
+You can verify that the services were correctly created:
+
+```bash
+$ docker service ls
+ID            NAME                                     REPLICAS  IMAGE
+COMMAND
+29bv0vnlm903  vossibility-stack_lookupd                1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqlookupd
+4awt47624qwh  vossibility-stack_nsqd                   1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqd --data-path=/data --lookupd-tcp-address=lookupd:4160
+4tjx9biia6fs  vossibility-stack_elasticsearch          1 elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility-stack_kibana                 1 kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility-stack_logstash               1 logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe logstash -f /etc/logstash/conf.d/logstash.conf
+axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba --config /config/config.toml --debug
+```
+
+## Related information
+
+* [stack config](stack_config.md)
+* [stack rm](stack_rm.md)
+* [stack tasks](stack_tasks.md)

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -1,0 +1,33 @@
+<!--[metadata]>
++++
+title = "stack rm"
+description = "The stack rm command description and usage"
+keywords = ["stack, rm, remove, down"]
+advisory = "experimental"
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# stack rm (experimental)
+
+```markdown
+Usage:  docker stack rm STACK
+
+Remove the stack
+
+Aliases:
+  rm, remove, down
+
+Options:
+      --help   Print usage
+```
+
+Remove the stack from the swarm. This command has to be run targeting
+a manager node.
+
+## Related information
+
+* [stack config](stack_config.md)
+* [stack deploy](stack_deploy.md)
+* [stack tasks](stack_tasks.md)

--- a/docs/reference/commandline/stack_tasks.md
+++ b/docs/reference/commandline/stack_tasks.md
@@ -1,0 +1,46 @@
+<!--[metadata]>
++++
+title = "stack tasks"
+description = "The stack tasks command description and usage"
+keywords = ["stack, tasks"]
+advisory = "experimental"
+[menu.main]
+parent = "smn_cli"
++++
+<![end-metadata]-->
+
+# stack tasks (experimental)
+
+```markdown
+Usage:  docker stack tasks [OPTIONS] STACK
+
+List the tasks in the stack
+
+Options:
+  -a, --all            Display all tasks
+  -f, --filter value   Filter output based on conditions provided
+      --help           Print usage
+      --no-resolve     Do not map IDs to Names
+```
+
+Lists the tasks that are running as part of the specified stack. This
+command has to be run targeting a manager node.
+
+## Filtering
+
+The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
+is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
+Multiple filter flags are combined as an `OR` filter. For example,
+`-f name=redis.1 -f name=redis.7` returns both `redis.1` and `redis.7` tasks.
+
+The currently supported filters are:
+
+* [id](#id)
+* [name](#name)
+* [desired-state](#desired-state)
+
+## Related information
+
+* [stack config](stack_config.md)
+* [stack deploy](stack_deploy.md)
+* [stack rm](stack_rm.md)


### PR DESCRIPTION
We already document _experimental_ commands like `plugin` subcommands, adding some documentation for `stack` subcommands and for the `deploy` command.

Also removes the `-f` flags of bundle to follow the single-letter flags evaluation.
- [ ] Add more example on `tasks` subcommand (like what we do on `service tasks`).
- [ ] What to do about the short flag for `--bundle`.

/cc @thaJeztah @dnephin @aanand @tiborvass @icecrime 

Signed-off-by: Vincent Demeester vincent@sbr.pm
