### PR TITLE
Remove docker.socket from rpm based systems

### DIFF
--- a/contrib/init/systemd/docker.service.rpm
+++ b/contrib/init/systemd/docker.service.rpm
@@ -1,0 +1,29 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network.target
+Requires=docker.socket
+
+[Service]
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/bin/dockerd
+ExecReload=/bin/kill -s HUP $MAINPID
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+#TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/installation/linux/fedora.md
+++ b/docs/installation/linux/fedora.md
@@ -60,9 +60,9 @@ There are two ways to install Docker Engine.  You can install with the `dnf` pac
 
         $ sudo dnf install docker-engine
 
-5. Enable the socket and service.
+5. Enable the service.
 
-		$ sudo systemctl enable docker.socket docker.service
+		$ sudo systemctl enable docker.service
 
 6. Start the Docker daemon.
 
@@ -113,9 +113,9 @@ There are two ways to install Docker Engine.  You can install with the `dnf` pac
 
 	This script adds the `docker.repo` repository and installs Docker.
 
-4. Enable the socket and service.
+4. Enable the service.
 
-		$ sudo systemctl enable docker.socket docker.service
+		$ sudo systemctl enable docker.service
 
 5. Start the Docker daemon.
 

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -147,8 +147,7 @@ install -d $RPM_BUILD_ROOT/%{_initddir}
 
 %if 0%{?is_systemd}
 install -d $RPM_BUILD_ROOT/%{_unitdir}
-install -p -m 644 contrib/init/systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
-install -p -m 644 contrib/init/systemd/docker.socket $RPM_BUILD_ROOT/%{_unitdir}/docker.socket
+install -p -m 644 contrib/init/systemd/docker.service.rpm $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 %else
 install -p -m 644 contrib/init/sysvinit-redhat/docker.sysconfig $RPM_BUILD_ROOT/etc/sysconfig/docker
 install -p -m 755 contrib/init/sysvinit-redhat/docker $RPM_BUILD_ROOT/%{_initddir}/docker
@@ -194,7 +193,6 @@ install -p -m 644 contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/shar
 /%{_sysconfdir}/udev/rules.d/80-docker.rules
 %if 0%{?is_systemd}
 /%{_unitdir}/docker.service
-/%{_unitdir}/docker.socket
 %else
 %config(noreplace,missingok) /etc/sysconfig/docker
 /%{_initddir}/docker


### PR DESCRIPTION
Fixes #23981

The selinux issue we are seeing in the report is related to the socket
file for docker and nothing else. By removing the socket docker starts
up correctly.

However, there is another motivation for removing socket activation from
docker's systemd files and that is because when you have daemons running
with --restart always whenever you have a host reboot those daemons
will not be started again because the docker daemon is not started by
systemd until a request comes into the docker API.

Leave it for deb based systems because everything is working correctly
for both socket activation and starting normally at boot.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
