### PR TITLE
Xfs quota for overlay

### DIFF
--- a/daemon/graphdriver/quota/projectquota.go
+++ b/daemon/graphdriver/quota/projectquota.go
@@ -99,7 +99,7 @@ func NewControl(basePath string) (*Control, error) {
 	//
 	// Get project id of parent dir as minimal id to be used by driver
 	//
-	minProjectID, err := getProjectID(basePath)
+	minProjectID, err := GetProjectID(basePath)
 	if err != nil {
 		return nil, err
 	}
@@ -222,8 +222,8 @@ func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	return nil
 }
 
-// getProjectID - get the project id of path on xfs
-func getProjectID(targetPath string) (uint32, error) {
+// GetProjectID - gets the project id of path on xfs
+func GetProjectID(targetPath string) (uint32, error) {
 	dir, err := openDir(targetPath)
 	if err != nil {
 		return 0, err
@@ -277,7 +277,7 @@ func (q *Control) findNextProjectID(home string) error {
 			continue
 		}
 		path := filepath.Join(home, file.Name())
-		projid, err := getProjectID(path)
+		projid, err := GetProjectID(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**\- What I did**
Apply xfs project quota for overlay storage driver.
Basically it's same work for #24771 Xfs quota PR but I applied to overlay instead of overlay2
I planed to improve this PR and apply overlay2 too but better PR (#24771) is already summited...

**\- How I did it**
Set xfs project quota to container's overlay storage root directory.
Use projectquota.go in #24771 and apply it to overlay driver.
The --storage-opt size=#(m/g) options to set a limit for containers.

**\- Known issues**
This quota only applied to container's upper layer and file changes which made by container itself.
XFS quota doesn't allow hardlink across quota boundries. so basic ApplyDiff() hardlink operation is changed.
- if source/destination directories are same quota boundries or no quota --> hardlink file
- if source/destination directories are different quota boundries --> copy file
XFS project id is not deleted when quota is deleted by overlay driver (ex. container rm).
And there's no way to figure out current project id is used in another place. 
So, If you want to create unique project id, set a project id to home directory of overlay for it. (use it to minimum project id for quota) 

**\- How to verify it**
  - basic operation
```bash
# mount | grep xfs
/dev/sda1 on / type xfs (rw,relatime,attr2,inode64,prjquota)

# dockerd -H 0.0.0.0:2375 --storage-driver=overlay -D &
albamc@albamc-laptop:~/dev/github/albamc/docker$ docker run -it --storage-opt size=200m ubuntu
root@1a58611ae018:/# df
Filesystem     1K-blocks      Used Available Use% Mounted on
overlay           204800         8    204792   1% /
tmpfs            3596008         0   3596008   0% /dev
tmpfs            3596008         0   3596008   0% /sys/fs/cgroup
/dev/sda1      234318044 185557116  48760928  80% /etc/hosts
shm                65536         0     65536   0% /dev/shm
tmpfs            3596008         0   3596008   0% /sys/firmware
root@1a58611ae018:/# dd if=/dev/zero of=/file bs=1024 count=102400000
dd: error writing '/file': No space left on device
204793+0 records in
204792+0 records out
209707008 bytes (210 MB, 200 MiB) copied, 0.905432 s, 232 MB/s
root@1a58611ae018:/# df
Filesystem     1K-blocks      Used Available Use% Mounted on
overlay           204800    204800         0 100% /
tmpfs            3596008         0   3596008   0% /dev
tmpfs            3596008         0   3596008   0% /sys/fs/cgroup
/dev/sda1      234318044 185761228  48556816  80% /etc/hosts
shm                65536         0     65536   0% /dev/shm
tmpfs            3596008         0   3596008   0% /sys/firmware
```
  - check for different quota boundries
```bash
#
# tests for different quota boundries (copy file)
#
# run container
albamc@albamc-laptop:~$ docker run -d --name qtest --storage-opt size=200m alpine ping www.naver.com
bf08c9969da3a05628ac54881e60a703790a35b5600a7c3815f0a882aae9cc65
# change container files
albamc@albamc-laptop:~$ docker exec -it qtest /bin/sh -c "echo blarblarblar > /blarblarblar"
# get lower-dir
albamc@albamc-laptop:~$ docker inspect qtest -f {{.GraphDriver.Data.LowerDir}}
/var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1/root
# set project quota to lower-dir
albamc@albamc-laptop:~$ sudo xfs_quota -x -c 'project -s -p /var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1 10000' / &> /dev/null
# commit container for calling ApplyDiff()
albamc@albamc-laptop:~$ docker commit qtest alpine:qset
sha256:1a5b0bd64c2838bb41ca5ff13de424edbc026c62ea4fd486b088403808407960
# get created image's root dir
albamc@albamc-laptop:~$ docker image inspect alpine:qset -f {{.GraphDriver.Data.RootDir}}
/var/lib/docker/overlay/268334faf34e0a0e2880bd314e32eccdd5acd5f31e5beaff31b2dbc986d8554f/root
# check inode number is different (copied)
albamc@albamc-laptop:~/dev/github/albamc/docker$ sudo stat /var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1/root/bin/busybox
  File: '/var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1/root/bin/busybox'
  Size: 805032    	Blocks: 1576       IO Block: 4096   일반 파일
Device: 801h/2049d	Inode: 6737775     Links: 3
...
albamc@albamc-laptop:~/dev/github/albamc/docker$ sudo stat /var/lib/docker/overlay/268334faf34e0a0e2880bd314e32eccdd5acd5f31e5beaff31b2dbc986d8554f/root/bin/busybox
  File: '/var/lib/docker/overlay/268334faf34e0a0e2880bd314e32eccdd5acd5f31e5beaff31b2dbc986d8554f/root/bin/busybox'
  Size: 805032    	Blocks: 1576       IO Block: 4096   일반 파일
Device: 801h/2049d	Inode: 406782300   Links: 1
...
# 
# tests for same quota boundries (or quota is not set)
#
# clear project quota
albamc@albamc-laptop:~$ sudo xfs_quota -x -c 'project -C -p /var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1 10000' / &> /dev/null
# change container files
albamc@albamc-laptop:~/dev/github/albamc/docker$ docker exec -it qtest /bin/sh -c "echo blarblarblar2 > /blarblarblar2"
# commit container for calling ApplyDiff()
albamc@albamc-laptop:~/dev/github/albamc/docker$ docker commit qtest alpine:qunset
sha256:813e7bca6da679d3ee7601e4b8541fcc7b3f586da0fb59d1171f8d1a385b1d0a
# get created image's root dir
albamc@albamc-laptop:~/dev/github/albamc/docker$ docker image inspect alpine:qunset -f {{.GraphDriver.Data.RootDir}}
/var/lib/docker/overlay/aa42873df47dc2812bcaeccefd635339562e91cceeb1b0e3ba17fe1ea6fc5b78/root
# check inode number is same (hardlink)
albamc@albamc-laptop:~/dev/github/albamc/docker$ sudo stat /var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1/root/bin/busybox
  File: '/var/lib/docker/overlay/2f2e66b0f66638ffd326d20fbec1dc54858daccea958a691d89a12ce81d14bd1/root/bin/busybox'
  Size: 805032    	Blocks: 1576       IO Block: 4096   일반 파일
Device: 801h/2049d	Inode: 6737775     Links: 3
...
albamc@albamc-laptop:~/dev/github/albamc/docker$ sudo stat /var/lib/docker/overlay/aa42873df47dc2812bcaeccefd635339562e91cceeb1b0e3ba17fe1ea6fc5b78/root/bin/busybox
  File: '/var/lib/docker/overlay/aa42873df47dc2812bcaeccefd635339562e91cceeb1b0e3ba17fe1ea6fc5b78/root/bin/busybox'
  Size: 805032    	Blocks: 1576       IO Block: 4096   일반 파일
Device: 801h/2049d	Inode: 6737775     Links: 3
...
```

**\- Description for the changelog**
apply xfs project quota for overlay over xfs

**\- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/3273537/16959406/e4325ec6-4e1f-11e6-8ac2-54372f63f028.png)

Signed-off-by: Jonghyun Lee albam.c@navercorp.com
