### PR TITLE
Switch armhf Dockerfile to go1.6.2

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -65,7 +65,7 @@ RUN cd /usr/local/lvm2 \
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install Go
-ENV GO_VERSION 1.6.3
+ENV GO_VERSION 1.6.2
 RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
https://storage.googleapis.com/golang doesn't have a go1.6.3 build.

@thaJeztah 
