### PR TITLE
Add support to install Docker on raspbian/jessie

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -389,12 +389,10 @@ do_install() {
 			}
 
 			if [ "$lsb_dist" = "raspbian" ]; then
-				# overlay is preferred to use on Raspbian
-				if [ ! -f /etc/modules-load.d/docker.conf ]; then
-					# Load kernel module 'overlay' at boot time
-					( set -x; $sh_c "modprobe overlay" )
-					( set -x; $sh_c "echo overlay > /etc/modules-load.d/docker.conf" )
-				fi
+				# Create Raspbian specific systemd init file, use overlay by default
+				( set -x; $sh_c "mkdir -p /etc/systemd/system" )
+				( set -x; $sh_c "$curl https://raw.githubusercontent.com/docker/docker/master/contrib/init/systemd/docker.service > /etc/systemd/system/docker.service" )
+				( set -x; $sh_c "sed -i 's/dockerd/dockerd --storage-driver overlay/' /etc/systemd/system/docker.service" )
 			else
 				# aufs is preferred over devicemapper; try to ensure the driver is available.
 				if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -87,7 +87,7 @@ check_forked() {
 			Upstream release is '$lsb_dist' version '$dist_version'.
 			EOF
 		else
-			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ]; then
+			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
 				# We're Debian and don't even know it!
 				lsb_dist=debian
 				dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
@@ -129,10 +129,12 @@ do_install() {
 	case "$(uname -m)" in
 		*64)
 			;;
+		armv6l|armv7l)
+			;;
 		*)
 			cat >&2 <<-'EOF'
-			Error: you are not using a 64bit platform.
-			Docker currently only supports 64bit platforms.
+			Error: you are not using a 64bit platform or a Raspberry Pi (armv6l/armv7l).
+			Docker currently only supports 64bit platforms or a Raspberry Pi (armv6l/armv7l).
 			EOF
 			exit 1
 			;;
@@ -268,7 +270,7 @@ do_install() {
 			fi
 		;;
 
-		debian)
+		debian|raspbian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in
 				8)
@@ -375,7 +377,7 @@ do_install() {
 			exit 0
 			;;
 
-		ubuntu|debian)
+		ubuntu|debian|raspbian)
 			export DEBIAN_FRONTEND=noninteractive
 
 			did_apt_get_update=
@@ -386,24 +388,33 @@ do_install() {
 				fi
 			}
 
-			# aufs is preferred over devicemapper; try to ensure the driver is available.
-			if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
-				if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -qE '^ii|^hi' 2>/dev/null; then
-					kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
+			if [ "$lsb_dist" = "raspbian" ]; then
+				# overlay is preferred to use on Raspbian
+				if [ ! -f /etc/modules-load.d/docker.conf ]; then
+					# Load kernel module 'overlay' at boot time
+					( set -x; $sh_c "modprobe overlay" )
+					( set -x; $sh_c "echo overlay > /etc/modules-load.d/docker.conf" )
+				fi
+			else
+				# aufs is preferred over devicemapper; try to ensure the driver is available.
+				if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
+					if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -qE '^ii|^hi' 2>/dev/null; then
+						kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
 
-					apt_get_update
-					( set -x; $sh_c 'sleep 3; apt-get install -y -q '"$kern_extras" ) || true
+						apt_get_update
+						( set -x; $sh_c 'sleep 3; apt-get install -y -q '"$kern_extras" ) || true
 
-					if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
-						echo >&2 'Warning: tried to install '"$kern_extras"' (for AUFS)'
-						echo >&2 ' but we still have no AUFS.  Docker may not work. Proceeding anyways!'
+						if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
+							echo >&2 'Warning: tried to install '"$kern_extras"' (for AUFS)'
+							echo >&2 ' but we still have no AUFS.  Docker may not work. Proceeding anyways!'
+							( set -x; sleep 10 )
+						fi
+					else
+						echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
+						echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
+						echo >&2 ' linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.'
 						( set -x; sleep 10 )
 					fi
-				else
-					echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
-					echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
-					echo >&2 ' linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.'
-					( set -x; sleep 10 )
 				fi
 			fi
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -389,7 +389,7 @@ do_install() {
 			}
 
 			if [ "$lsb_dist" = "raspbian" ]; then
-				# Create Raspbian specific systemd init file, use overlay by default
+				# Create Raspbian specific systemd unit file, use overlay by default
 				( set -x; $sh_c "mkdir -p /etc/systemd/system" )
 				( set -x; $sh_c "$curl https://raw.githubusercontent.com/docker/docker/master/contrib/init/systemd/docker.service > /etc/systemd/system/docker.service" )
 				( set -x; $sh_c "sed -i 's/dockerd/dockerd --storage-driver overlay/' /etc/systemd/system/docker.service" )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Adding support in `install.sh` to install the Docker Engine on a standard Raspberry Pi running a raspbian/jessie OS. Implements https://github.com/docker/docker/issues/24561.

**\- How I did it**
I just added the detection of the Raspbian OS in `install.sh` and select the correct osname. Since Raspbian has to support ARMv6 and ARMv7 we have to use `raspbian/jessie` instead of `debian/jessie` to classify the OS the right way. 

```
$ cat /etc/apt/sources.list.d/docker.list
deb [arch=armhf] https://apt.dockerproject.org/repo raspbian-jessie testing
```

**\- How to verify it**
Once the new Debian packages for raspbian/jessie are available in the standard Docker APT repository, you can easily test the installation process on a freshly installed Raspberry Pi. First download the Raspbian SD image from https://www.raspberrypi.org/downloads/raspbian/ and select RASPBIAN JESSIE (Desktop version) `2016-05-27-raspbian-jessie.zip` or RASPBIAN JESSIE LITE (Server version) `2016-05-27-raspbian-jessie-lite.zip`, flash a SD card with it and boot the Raspberry Pi.

Login to the Raspberry Pi with username=`pi` and password=`raspberry`, get the script `install.sh` and start the installation process:

```
$ repo=testing ./install.sh
```

**Note:** `repo` can be set to `main`, `testing` or `experimental` which basically selects the APT repo branch. For `repo=testing` the Debian package `docker-engine` will be fetched from 'https://apt.dockerproject.org/repo/dists/raspbian-jessie/testing/binary-armhf/'.

**\- Tested on a RASPBIAN JESSIE `2016-05-27-raspbian-jessie.zip` with Docker 1.12.0-rc4**
Edit: new output with overlay fs

```
pi@raspberrypi:~ $ sudo docker info
Containers: 0
 Running: 0
 Paused: 0
 Stopped: 0
Images: 0
Server Version: 1.12.0-rc4
Storage Driver: overlay
 Backing Filesystem: extfs
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: null bridge host overlay
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Security Options:
Kernel Version: 4.4.11-v7+
Operating System: Raspbian GNU/Linux 8 (jessie)
OSType: linux
Architecture: armv7l
CPUs: 4
Total Memory: 925.5 MiB
Name: raspberrypi
ID: SELH:KXHE:UXRL:FX5Z:ATGK:GFGM:6NIG:DFUO:4QQK:3P74:J7XE:BZVS
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Registry: https://index.docker.io/v1/
WARNING: No swap limit support
WARNING: No kernel memory limit support
WARNING: No cpu cfs quota support
WARNING: No cpu cfs period support
WARNING: No cpuset support
Insecure Registries:
 127.0.0.0/8
pi@raspberrypi:~ $
```

**\- Known Issues**
The Raspbian Linux kernel supports overlay filesystem by default and this should be the preferred storage driver to run Docker. Right now, the Docker Engine will be installed and is configured to use devmapper. As soon as we can configure options for dockerd `-s overlay` or `--storage-driver overlay` during the installation, we can easily switch to use overlay fs. This setting can be made in `/lib/systemd/system/docker.service` or `/etc/systemd/system/docker.service`, just modify the line 
`ExecStart=/usr/bin/dockerd -H fd://` to `ExecStart=/usr/bin/dockerd --storage-driver overlay -H fd://`.
Edit: this issue is fixed now, overlay is now used as default. I just deployed a Raspbian specific  `/etc/systemd/system/docker.service` file.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add feature to install the Docker Engine on a Raspberry Pi directly from http://get.docker.com.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Dieter Reuter dieter.reuter@me.com
