### PR TITLE
Windows: Block (v2) pulling Linux images

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -550,6 +550,11 @@ func (p *v2Puller) pullSchema2(ctx context.Context, ref reference.Named, mfst *s
 		if unmarshalledConfig.RootFS == nil {
 			return "", "", errors.New("image config has no rootfs section")
 		}
+		// https://github.com/docker/docker/issues/24766 - Err on the side of caution,
+		// explicitly blocking images intended for linux from the Windows daemon
+		if unmarshalledConfig.OS == "linux" {
+			return "", "", fmt.Errorf("image operating system %q cannot be used on this platform", unmarshalledConfig.OS)
+		}
 		downloadRootFS = *unmarshalledConfig.RootFS
 		downloadRootFS.DiffIDs = []layer.DiffID{}
 	} else {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes https://github.com/docker/docker/issues/24766. 

@jstarks @aaronlehmann @friism Deliberately on the permissive side, on Windows (which only uses the v2 registry), put a useful message up front before attempting to pull the layers that the image can't be used on the platform rather than an obscure error on the base layer.

See #24766 for an example of the 'before' experience. After this change:

```
PS E:\go\src\github.com\docker\docker> docker pull ubuntu
Using default tag: latest
latest: Pulling from library/ubuntu
image operating system "linux" cannot be used on this platform
```
