### PR TITLE
Minor refactor and beter coverage for pkg/stringid

### DIFF
--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -29,11 +29,10 @@ func TruncateID(id string) string {
 	if i := strings.IndexRune(id, ':'); i >= 0 {
 		id = id[i+1:]
 	}
-	trimTo := shortLen
-	if len(id) < shortLen {
-		trimTo = len(id)
+	if len(id) > shortLen {
+		id = id[:shortLen]
 	}
-	return id[:trimTo]
+	return id
 }
 
 func generateID(crypto bool) string {
@@ -60,7 +59,6 @@ func generateID(crypto bool) string {
 // GenerateRandomID returns a unique id.
 func GenerateRandomID() string {
 	return generateID(true)
-
 }
 
 // GenerateNonCryptoID generates unique id without using cryptographically

--- a/pkg/stringid/stringid_test.go
+++ b/pkg/stringid/stringid_test.go
@@ -13,10 +13,26 @@ func TestGenerateRandomID(t *testing.T) {
 	}
 }
 
+func TestGenerateNonCryptoID(t *testing.T) {
+	id := GenerateNonCryptoID()
+
+	if len(id) != 64 {
+		t.Fatalf("Id returned is incorrect: %s", id)
+	}
+}
+
 func TestShortenId(t *testing.T) {
-	id := GenerateRandomID()
+	id := "90435eec5c4e124e741ef731e118be2fc799a68aba0466ec17717f24ce2ae6a2"
 	truncID := TruncateID(id)
-	if len(truncID) != 12 {
+	if truncID != "90435eec5c4e" {
+		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
+	}
+}
+
+func TestShortenSha256Id(t *testing.T) {
+	id := "sha256:4e38e38c8ce0b8d9041a9c4fefe786631d1416225e13b0bfe8cfa2321aec4bba"
+	truncID := TruncateID(id)
+	if truncID != "4e38e38c8ce0" {
 		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
 	}
 }


### PR DESCRIPTION
Mainly a nit I stumbled on; this slightly simplifies `TruncateID()` by only trimming the string if needed.

Also improved unit-tests for this package;
- Add a test for `GenerateNonCryptoID()`
- Add a test for shortening a sha-256 ID
- Make `TestShortenId()` more "unit", by using a fixed string, instead of calling `GenerateRandomID()`
