### PR TITLE
Fixing v2 registry restriction for non-linux platforms.

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -69,13 +69,13 @@ func NewDaemonCli() *DaemonCli {
 	daemonConfig.LogConfig.Config = make(map[string]string)
 	daemonConfig.ClusterOpts = make(map[string]string)
 
-	if runtime.GOOS != "linux" {
-		daemonConfig.V2Only = true
-	}
-
 	daemonConfig.InstallFlags(flag.CommandLine, presentInHelp)
 	configFile := flag.CommandLine.String([]string{daemonConfigFileFlag}, defaultDaemonConfigFile, "Daemon configuration file")
 	flag.CommandLine.Require(flag.Exact, 0)
+
+	if runtime.GOOS != "linux" {
+		daemonConfig.V2Only = true
+	}
 
 	return &DaemonCli{
 		Config:      daemonConfig,

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -267,7 +267,7 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	configFile := f.Name()
 	defer os.Remove(configFile)
 
-	f.Write([]byte(`{"registry-mirrors": ["https://mirrors.docker.com"], "insecure-registries": ["https://insecure.docker.com"], "disable-legacy-registry": true}`))
+	f.Write([]byte(`{"registry-mirrors": ["https://mirrors.docker.com"], "insecure-registries": ["https://insecure.docker.com"]}`))
 	f.Close()
 
 	loadedConfig, err := loadDaemonCliConfig(c, flags, common, configFile)
@@ -286,9 +286,5 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 	r := loadedConfig.InsecureRegistries
 	if len(r) != 1 {
 		t.Fatalf("expected 1 insecure registries, got %d", len(r))
-	}
-
-	if !loadedConfig.V2Only {
-		t.Fatal("expected disable-legacy-registry to be true, got false")
 	}
 }

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -169,6 +170,11 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, ima
 
 	putOptions := []distribution.ManifestServiceOption{distribution.WithTag(ref.Tag())}
 	if _, err = manSvc.Put(ctx, manifest, putOptions...); err != nil {
+		if runtime.GOOS == "windows" {
+			logrus.Warnf("failed to upload schema2 manifest: %v", err)
+			return err
+		}
+
 		logrus.Warnf("failed to upload schema2 manifest: %v - falling back to schema1", err)
 
 		manifestRef, err := distreference.WithTag(p.repo.Named(), ref.Tag())

--- a/registry/config.go
+++ b/registry/config.go
@@ -77,7 +77,7 @@ func (options *ServiceOptions) InstallCliFlags(cmd *flag.FlagSet, usageFn func(s
 	insecureRegistries := opts.NewNamedListOptsRef("insecure-registries", &options.InsecureRegistries, ValidateIndexName)
 	cmd.Var(insecureRegistries, []string{"-insecure-registry"}, usageFn("Enable insecure registry communication"))
 
-	cmd.BoolVar(&options.V2Only, []string{"-disable-legacy-registry"}, false, usageFn("Disable contacting legacy registries"))
+	options.installCliPlatformFlags(cmd, usageFn)
 }
 
 // newServiceConfig returns a new instance of ServiceConfig

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -2,6 +2,10 @@
 
 package registry
 
+import (
+	flag "github.com/docker/docker/pkg/mflag"
+)
+
 var (
 	// CertsDir is the directory where certificates are stored
 	CertsDir = "/etc/docker/certs.d"
@@ -13,4 +17,9 @@ var (
 // which contain those characters (such as : on Windows)
 func cleanPath(s string) string {
 	return s
+}
+
+// installCliPlatformFlags handles any platform specific flags for the service.
+func (options *ServiceOptions) installCliPlatformFlags(cmd *flag.FlagSet, usageFn func(string) string) {
+	cmd.BoolVar(&options.V2Only, []string{"-disable-legacy-registry"}, false, usageFn("Disable contacting legacy registries"))
 }

--- a/registry/config_windows.go
+++ b/registry/config_windows.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	flag "github.com/docker/docker/pkg/mflag"
 )
 
 // CertsDir is the directory where certificates are stored
@@ -15,4 +17,9 @@ var CertsDir = os.Getenv("programdata") + `\docker\certs.d`
 // which contain those characters (such as : on Windows)
 func cleanPath(s string) string {
 	return filepath.FromSlash(strings.Replace(s, ":", "", -1))
+}
+
+// installCliPlatformFlags handles any platform specific flags for the service.
+func (options *ServiceOptions) installCliPlatformFlags(cmd *flag.FlagSet, usageFn func(string) string) {
+	// No Windows specific flags.
 }


### PR DESCRIPTION
@jstarks @jhowardmsft 
This fixes the hard coded restriction for non-linux platforms to v2 registries.  Previously, the check was above the flag parsing, which would overwrite the hard coded value and prevent correct operation.  This change also removes the related daemon flag from Windows to avoid confusion, as it has no meaning when the value is going to always be hard coded to true.

The change also introduces a restriction to the schema fallback logic to avoid fallback to v1 schema if v2 fails, since Windows images have no history and would fail a v1 schema.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
