### PR TITLE
Fix the usage for `service rm` command

### DIFF
--- a/api/client/service/remove.go
+++ b/api/client/service/remove.go
@@ -13,7 +13,7 @@ import (
 func newRemoveCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:     "rm [OPTIONS] SERVICE",
+		Use:     "rm [OPTIONS] SERVICE [SERVICE...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove a service",
 		Args:    cli.RequiresMinArgs(1),


### PR DESCRIPTION
`service rm` command can accept multiple services.

Signed-off-by: Yi EungJun eungjun.yi@navercorp.com
