### PR TITLE
Do not default to external linking on arm, i386

### DIFF
--- a/hack/make/.binary
+++ b/hack/make/.binary
@@ -20,22 +20,6 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 	esac
 fi
 
-if [ "$(go env GOOS)" == "linux" ] ; then
-	case "$(go env GOARCH)" in
-		arm*|386)
-			# linking for Linux on arm or x86 needs external linking to avoid
-			# https://github.com/golang/go/issues/9510 until we move to Go 1.6
-			if [ "$IAMSTATIC" == "true" ] ; then
-				export EXTLDFLAGS_STATIC="$EXTLDFLAGS_STATIC -zmuldefs"
-				export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC -extldflags \"$EXTLDFLAGS_STATIC\""
-
-			else
-				export LDFLAGS="$LDFLAGS -extldflags -zmuldefs"
-			fi
-			;;
-	esac
-fi
-
 if [ "$IAMSTATIC" == "true" ] && [ "$(go env GOHOSTOS)" == "linux" ]; then
 	if  [ "${GOOS}/${GOARCH}" == "darwin/amd64" ]; then
 		export CGO_ENABLED=1


### PR DESCRIPTION
Reverts https://github.com/docker/docker/pull/18197

This was a workaround before Go 1.6, not required any more.

cc @nalind @Govinda-Fichtner

Signed-off-by: Justin Cormack justin.cormack@docker.com

![goofy-gopher](https://cloud.githubusercontent.com/assets/482364/16983495/ec843728-4e6c-11e6-83c6-411ab3496c8e.jpeg)
