### PR TITLE
Add missing --log-driver and --log-opt docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3926,33 +3926,68 @@ Create a service
     Content-Type: application/json
 
     {
-      "Name": "redis",
+      "Name": "web",
       "TaskTemplate": {
         "ContainerSpec": {
-          "Image": "redis"
+          "Image": "nginx:alpine",
+          "Mounts": [
+            {
+              "ReadOnly": true,
+              "Source": "web-data",
+              "Target": "/usr/share/nginx/html",
+              "Type": "VOLUME",
+              "VolumeOptions": {
+                "DriverConfig": {
+                },
+                "Labels": {
+                  "com.example.something": "something-value"
+                }
+              }
+            }
+          ],
+          "User": "33"
         },
+        "LogDriver": {
+          "Name": "json-file",
+          "Options": {
+            "max-file": "3",
+            "max-size": "10M"
+          }
+        },
+        "Placement": {},
         "Resources": {
-          "Limits": {},
-          "Reservations": {}
+          "Limits": {
+            "MemoryBytes": 104857600.0
+          },
+          "Reservations": {
+          }
         },
-        "RestartPolicy": {},
-        "Placement": {}
+        "RestartPolicy": {
+          "Condition": "on-failure",
+          "Delay": 10000000000.0,
+          "MaxAttempts": 10
+        }
       },
       "Mode": {
         "Replicated": {
-          "Replicas": 1
+          "Replicas": 4
         }
       },
       "UpdateConfig": {
-        "Parallelism": 1
+        "Delay": 30000000000.0,
+        "Parallelism": 2
       },
       "EndpointSpec": {
-        "ExposedPorts": [
+        "Ports": [
           {
             "Protocol": "tcp",
-            "Port": 6379
+            "PublishedPort": 8080,
+            "TargetPort": 80
           }
         ]
+      },
+      "Labels": {
+        "foo": "bar"
       }
     }
 
@@ -3986,8 +4021,8 @@ JSON Parameters:
         - **User** – A string value specifying the user inside the container.
         - **Labels** – A map of labels to associate with the service (e.g.,
           `{"key":"value"[,"key2":"value2"]}`).
-        - **Mounts** – Specification for mounts to be added to containers created as part of the new.
-          service.
+        - **Mounts** – Specification for mounts to be added to containers
+          created as part of the service.
             - **Target** – Container path.
             - **Source** – Mount source (e.g. a volume name, a host path).
             - **Type** – The mount type (`bind`, or `volume`).
@@ -4003,6 +4038,11 @@ JSON Parameters:
                   - **Options** - key/value map of driver specific options.
         - **StopGracePeriod** – Amount of time to wait for the container to terminate before
           forcefully killing it.
+    - **LogDriver** - Log configuration for containers created as part of the
+      service.
+        - **Name** - Name of the logging driver to use (`json-file`, `syslog`,
+          `journald`, `gelf`, `fluentd`, `awslogs`, `splunk`, `etwlogs`, `none`).
+        - **Options** - Driver-specific options.
     - **Resources** – Resource requirements which apply to each individual container created as part
       of the service.
         - **Limits** – Define resources limits.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3927,33 +3927,68 @@ Create a service
     Content-Type: application/json
 
     {
-      "Name": "redis",
+      "Name": "web",
       "TaskTemplate": {
         "ContainerSpec": {
-          "Image": "redis"
+          "Image": "nginx:alpine",
+          "Mounts": [
+            {
+              "ReadOnly": true,
+              "Source": "web-data",
+              "Target": "/usr/share/nginx/html",
+              "Type": "VOLUME",
+              "VolumeOptions": {
+                "DriverConfig": {
+                },
+                "Labels": {
+                  "com.example.something": "something-value"
+                }
+              }
+            }
+          ],
+          "User": "33"
         },
+        "LogDriver": {
+          "Name": "json-file",
+          "Options": {
+            "max-file": "3",
+            "max-size": "10M"
+          }
+        },
+        "Placement": {},
         "Resources": {
-          "Limits": {},
-          "Reservations": {}
+          "Limits": {
+            "MemoryBytes": 104857600.0
+          },
+          "Reservations": {
+          }
         },
-        "RestartPolicy": {},
-        "Placement": {}
+        "RestartPolicy": {
+          "Condition": "on-failure",
+          "Delay": 10000000000.0,
+          "MaxAttempts": 10
+        }
       },
       "Mode": {
         "Replicated": {
-          "Replicas": 1
+          "Replicas": 4
         }
       },
       "UpdateConfig": {
-        "Parallelism": 1
+        "Delay": 30000000000.0,
+        "Parallelism": 2
       },
       "EndpointSpec": {
-        "ExposedPorts": [
+        "Ports": [
           {
             "Protocol": "tcp",
-            "Port": 6379
+            "PublishedPort": 8080,
+            "TargetPort": 80
           }
         ]
+      },
+      "Labels": {
+        "foo": "bar"
       }
     }
 
@@ -3987,8 +4022,8 @@ JSON Parameters:
         - **User** – A string value specifying the user inside the container.
         - **Labels** – A map of labels to associate with the service (e.g.,
           `{"key":"value"[,"key2":"value2"]}`).
-        - **Mounts** – Specification for mounts to be added to containers created as part of the new.
-          service.
+        - **Mounts** – Specification for mounts to be added to containers
+          created as part of the service.
             - **Target** – Container path.
             - **Source** – Mount source (e.g. a volume name, a host path).
             - **Type** – The mount type (`bind`, or `volume`).
@@ -4004,6 +4039,11 @@ JSON Parameters:
                   - **Options** - key/value map of driver specific options.
         - **StopGracePeriod** – Amount of time to wait for the container to terminate before
           forcefully killing it.
+    - **LogDriver** - Log configuration for containers created as part of the
+      service.
+        - **Name** - Name of the logging driver to use (`json-file`, `syslog`,
+          `journald`, `gelf`, `fluentd`, `awslogs`, `splunk`, `etwlogs`, `none`).
+        - **Options** - Driver-specific options.
     - **Resources** – Resource requirements which apply to each individual container created as part
       of the service.
         - **Limits** – Define resources limits.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -24,6 +24,8 @@ Options:
   -l, --label value                  Service labels (default [])
       --limit-cpu value              Limit CPUs (default 0.000)
       --limit-memory value           Limit Memory (default 0 B)
+      --log-driver string            Logging driver for service
+      --log-opt value                Logging driver options (default [])
       --mode string                  Service mode (replicated or global) (default "replicated")
       --mount value                  Attach a mount to the service
       --name string                  Service name

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -29,6 +29,8 @@ Options:
       --label-rm value               Remove a label by its key (default [])
       --limit-cpu value              Limit CPUs (default 0.000)
       --limit-memory value           Limit Memory (default 0 B)
+      --log-driver string            Logging driver for service
+      --log-opt value                Logging driver options (default [])
       --mount-add value              Add or update a mount on a service
       --mount-rm value               Remove a mount by its target path (default [])
       --name string                  Service name


### PR DESCRIPTION
Adds (basic) documentation for "--log-driver" and "--log-opt" for services.

Also updated the API docs to include the new options, and generated a more complete JSON example.

relates to https://github.com/docker/docker/pull/24476
