### PR TITLE
fix duplicated usage in docs

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -13,12 +13,6 @@ weight = -1
 # daemon
 
 ```markdown
-    Usage: dockerd [OPTIONS]
-
-    A self-sufficient runtime for containers.
-
-    Options:
-
 Usage: dockerd [OPTIONS]
 
 A self-sufficient runtime for containers.


### PR DESCRIPTION
this removes a copy/pasta whoopsie on my side, introduced in de64324109d2694b1525e62b5c0072267282a36c (https://github.com/docker/docker/pull/24705) :blush:
