### PR TITLE
[RFC] Rename --bundle to --file

### DIFF
--- a/api/client/stack/opts.go
+++ b/api/client/stack/opts.go
@@ -14,7 +14,7 @@ import (
 func addBundlefileFlag(opt *string, flags *pflag.FlagSet) {
 	flags.StringVar(
 		opt,
-		"bundle", "",
+		"file", "",
 		"Path to a Distributed Application Bundle file (Default: STACK.dab)")
 }
 
@@ -26,7 +26,7 @@ func loadBundlefile(stderr io.Writer, namespace string, path string) (*bundlefil
 	}
 	if _, err := os.Stat(path); err != nil {
 		return nil, fmt.Errorf(
-			"Bundle %s not found. Specify the path with -f or --bundle",
+			"Bundle %s not found. Specify the path with --file",
 			path)
 	}
 

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -17,7 +17,7 @@ Usage:  docker deploy [OPTIONS] STACK
 Create and update a stack from a Distributed Application Bundle (DAB)
 
 Options:
-      --bundle string   Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
       --help            Print usage
 ```
 

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -17,7 +17,7 @@ Usage:  docker stack config [OPTIONS] STACK
 Print the stack configuration
 
 Options:
-      --bundle string   Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
       --help            Print usage
 ```
 

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -20,7 +20,7 @@ Aliases:
   deploy, up
 
 Options:
-      --bundle string   Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
       --help            Print usage
 ```
 

--- a/experimental/docker-stacks-and-bundles.md
+++ b/experimental/docker-stacks-and-bundles.md
@@ -44,7 +44,7 @@ Usage:  docker deploy [OPTIONS] STACK
 Create and update a stack
 
 Options:
-  -f, --bundle string   Path to a bundle (Default: STACK.dab)
+      --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
       --help            Print usage
 ```
 


### PR DESCRIPTION
This renames the `--bundle` flag for docker (stack) deploy to be consistent with `docker build`, as came up in https://github.com/docker/docker/pull/24802/files#r71370938

Note that there's no shorthand '-f' added for now, because this may be confusing on `docker stack config`, which also takes a file, and for which we may want to have a `--format` flag in future.
