### PR TITLE
Add `--env-file` flag to `docker create service`

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -32,6 +32,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.VarP(&opts.labels, flagLabel, "l", "Service labels")
 	flags.Var(&opts.containerLabels, flagContainerLabel, "Container labels")
 	flags.VarP(&opts.env, flagEnv, "e", "Set environment variables")
+	flags.Var(&opts.envFile, flagEnvFile, "Read in a file of environment variables")
 	flags.Var(&opts.mounts, flagMount, "Attach a mount to the service")
 	flags.StringSliceVar(&opts.constraints, flagConstraint, []string{}, "Placement constraints")
 	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -25,6 +25,7 @@ Options:
       --container-label value            Service container labels (default [])
       --endpoint-mode string             Endpoint mode (vip or dnsrr)
   -e, --env value                        Set environment variables (default [])
+      --env-file value                   Read in a file of environment variables (default [])
       --group-add value                  Add additional user groups to the container (default [])
       --help                             Print usage
   -l, --label value                      Service labels (default [])

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -567,4 +568,23 @@ func (s *DockerSwarmSuite) TestSwarmNetworkPlugin(c *check.C) {
 	out, err = d.Cmd("service", "inspect", "--format", "{{range .Spec.Networks}}{{.Target}}{{end}}", name)
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "foo")
+}
+
+// Test case for #24712
+func (s *DockerSwarmSuite) TestSwarmServiceEnvFile(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	path := filepath.Join(d.folder, "env.txt")
+	err := ioutil.WriteFile(path, []byte("VAR1=A\nVAR2=A\n"), 0644)
+	c.Assert(err, checker.IsNil)
+
+	name := "worker"
+	out, err := d.Cmd("service", "create", "--env-file", path, "--env", "VAR1=B", "--env", "VAR1=C", "--env", "VAR2=", "--env", "VAR2", "--name", name, "busybox", "top")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+
+	// The complete env is [VAR1=A VAR2=A VAR1=B VAR1=C VAR2= VAR2] and duplicates will be removed => [VAR1=C VAR2]
+	out, err = d.Cmd("inspect", "--format", "{{ .Spec.TaskTemplate.ContainerSpec.Env }}", name)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "[VAR1=C VAR2]")
 }

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -427,13 +427,13 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	}
 
 	// collect all the environment variables for the container
-	envVariables, err := readKVStrings(copts.envFile.GetAll(), copts.env.GetAll())
+	envVariables, err := ReadKVStrings(copts.envFile.GetAll(), copts.env.GetAll())
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	// collect all the labels for the container
-	labels, err := readKVStrings(copts.labelsFile.GetAll(), copts.labels.GetAll())
+	labels, err := ReadKVStrings(copts.labelsFile.GetAll(), copts.labels.GetAll())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -663,9 +663,9 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 	return config, hostConfig, networkingConfig, nil
 }
 
-// reads a file of line terminated key=value pairs, and overrides any keys
+// ReadKVStrings reads a file of line terminated key=value pairs, and overrides any keys
 // present in the file with additional pairs specified in the override parameter
-func readKVStrings(files []string, override []string) ([]string, error) {
+func ReadKVStrings(files []string, override []string) ([]string, error) {
 	envVariables := []string{}
 	for _, ef := range files {
 		parsedVars, err := ParseEnvFile(ef)


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue in #24712 and add `--env-file` file to `docker create service`.

**\- How I did it**

The flag has been added and related documentation has been updated.

**\- How to verify it**

An additional integration has been added.

**\- Description for the changelog**

Add `--env-file` flag to `docker create service`.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #24712.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
