### PR TITLE
Dockerfile.s390x: Update glibc to proposed-updates 2.19-18+deb8u5

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -48,6 +48,15 @@ RUN apt-get update && apt-get install -y \
 	tar \
 	--no-install-recommends
 
+# glibc in Debian has a bug specific to s390x that won't be fixed until Debian 8.6 is released
+# - https://github.com/docker/docker/issues/24748
+# - https://sourceware.org/git/?p=glibc.git;a=commit;h=890b7a4b33d482b5c768ab47d70758b80227e9bc
+# - https://sourceware.org/git/?p=glibc.git;a=commit;h=2e807f29595eb5b1e5d0decc6e356a3562ecc58e
+RUN echo 'deb http://httpredir.debian.org/debian jessie-proposed-updates main' >> /etc/apt/sources.list.d/pu.list \
+	&& apt-get update \
+	&& apt-get install -y libc6 \
+	&& rm -rf /var/lib/apt/lists/*
+
 # install seccomp: the version shipped in jessie is too old
 ENV SECCOMP_VERSION 2.3.1
 RUN set -x \


### PR DESCRIPTION
The glibc of Debian Jessie contains the following two bugs:

 https://sourceware.org/git/?p=glibc.git;a=commit;h=890b7a4b33d482b5c768ab47d70758b80227e9bc
 https://sourceware.org/git/?p=glibc.git;a=commit;h=2e807f29595eb5b1e5d0decc6e356a3562ecc58e

The CI tests hang because the bugs affect the gccgo runtime of the
s390x/gcc images.

Now the fixes have been integrated to glibc 2.19-18+deb8u5 in
"proposed-updates" for Debian Jessie:

 https://anonscm.debian.org/cgit/pkg-glibc/glibc.git/log/?h=jessie
 https://release.debian.org/proposed-updates/stable.html

It is expected that the package should be part of the next stable point
release (8.6) in about one to two months from now.

In order to enable CI for s390x earlier, we now explicitely update
the glibc in Dockerfile.s390x to the proposed-updates version.

After Debian 8.6 is released we can remove this change again.

Closes #24748

Suggested-by: Tianon Gravi admwiggin@gmail.com
Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
