### PR TITLE
Windows: Allow nanoserver image for CLI

### DIFF
--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -61,12 +61,13 @@ var (
 	// driver of the daemon. This is initialized in docker_utils by sending
 	// a version call to the daemon and examining the response header.
 	daemonStorageDriver string
+
+	// WindowsBaseImage is the name of the base image for Windows testing
+	// Environment variable WINDOWS_BASE_IMAGE can override this
+	WindowsBaseImage = "windowsservercore"
 )
 
 const (
-	// WindowsBaseImage is the name of the base image for Windows testing
-	WindowsBaseImage = "windowsservercore"
-
 	// DefaultImage is the name of the base image for the majority of tests that
 	// are run across suites
 	DefaultImage = "busybox"
@@ -128,4 +129,9 @@ func init() {
 	}
 	volumesConfigPath = dockerBasePath + "/volumes"
 	containerStoragePath = dockerBasePath + "/containers"
+
+	if len(os.Getenv("WINDOWS_BASE_IMAGE")) > 0 {
+		WindowsBaseImage = os.Getenv("WINDOWS_BASE_IMAGE")
+		fmt.Println("INFO: Windows Base image is ", WindowsBaseImage)
+	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@thaJeztah Hopefully a really simple PR to get in - this allows me to start the bring up of running the tests using nanoserver as the base image for integration tests on Windows through the use of an environment variable override.
