### PR TITLE
healthcheck: do not interpret exit code 2 as "starting"

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -41,7 +41,6 @@ const (
 
 	exitStatusHealthy   = 0 // Container is healthy
 	exitStatusUnhealthy = 1 // Container is unhealthy
-	exitStatusStarting  = 2 // Container needs more time to start
 )
 
 // probe implementations know how to run a particular type of probe.
@@ -127,12 +126,10 @@ func handleProbeResult(d *Daemon, c *container.Container, result *types.Healthch
 	if result.ExitCode == exitStatusHealthy {
 		h.FailingStreak = 0
 		h.Status = types.Healthy
-	} else if result.ExitCode == exitStatusStarting && c.State.Health.Status == types.Starting {
-		// The container is not ready yet. Remain in the starting state.
 	} else {
 		// Failure (including invalid exit code)
 		h.FailingStreak++
-		if c.State.Health.FailingStreak >= retries {
+		if h.FailingStreak >= retries {
 			h.Status = types.Unhealthy
 		}
 		// Else we're starting or healthy. Stay in that state.

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -94,22 +94,6 @@ func TestHealthStates(t *testing.T) {
 	handleResult(c.State.StartedAt.Add(3*time.Second), 1)
 	expect("health_status: unhealthy")
 
-	// starting -> starting -> starting ->
-	// healthy -> starting (invalid transition)
-
-	reset(c)
-
-	handleResult(c.State.StartedAt.Add(20*time.Second), 2)
-	handleResult(c.State.StartedAt.Add(40*time.Second), 2)
-	if c.State.Health.Status != types.Starting {
-		t.Errorf("Expecting starting, but got %#v\n", c.State.Health.Status)
-	}
-
-	handleResult(c.State.StartedAt.Add(50*time.Second), 0)
-	expect("health_status: healthy")
-	handleResult(c.State.StartedAt.Add(60*time.Second), 2)
-	expect("health_status: unhealthy")
-
 	// Test retries
 
 	reset(c)

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1524,10 +1524,7 @@ The possible values are:
 
 - 0: success - the container is healthy and ready for use
 - 1: unhealthy - the container is not working correctly
-- 2: starting - the container is not ready for use yet, but is working correctly
-
-If the probe returns 2 ("starting") when the container has already moved out of the
-"starting" state then it is treated as "unhealthy" instead.
+- 2: reserved - do not use this exit code
 
 For example, to check every five minutes or so that a web-server is able to
 serve the site's main page within three seconds:


### PR DESCRIPTION
Instead reserve exit code 2 to be future proof, document that it should
not be used. Implementation-wise, it is considered as unhealthy, but
users should not rely on this as it may change in the future.

Signed-off-by: Tibor Vass tibor@docker.com

Fixes #24396 
