### PR TITLE
Add explicit support for macvlan networks to bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1445,7 +1445,7 @@ _docker_network_create() {
 			return
 			;;
 		--driver|-d)
-			local plugins=" $(__docker_plugins Network) "
+			local plugins="$(__docker_plugins Network) macvlan"
 			# remove drivers that allow one instance only
 			plugins=${plugins/ host / }
 			plugins=${plugins/ null / }


### PR DESCRIPTION
Bash completion grabs the available network drivers from the output of `docker info`.
Unfortionally, the `macvlan` network driver will not appear there unless a network was created using it, see https://github.com/docker/docker/issues/24798#issuecomment-234065721.

This PR explicitly adds this driver to the computed driver list so that it is always available.
Note that this is a workaround until the upcoming plugin system is available.

Please schedule for 1.12.0.
