### PR TITLE
docs: update reference docs for plugins

### DIFF
--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -24,26 +24,31 @@ Disables a plugin. The plugin must be installed before it can be disabled,
 see [`docker plugin install`](plugin_install.md).
 
 
-The following example shows that the `no-remove` plugin is currently installed
+The following example shows that the `no-remove` plugin is installed
 and active:
 
 ```bash
 $ docker plugin ls
-NAME        	            TAG			ACTIVE
-tiborvass/no-remove	    latest		true
+
+NAME                        TAG           ACTIVE
+tiborvass/no-remove         latest        true
 ```
+
 To disable the plugin, use the following command:
 
 ```bash
-$ docker plugin disable tiborvass/no-remove:latest
+$ docker plugin disable tiborvass/no-remove
+
+tiborvass/no-remove
 ```
 
 After the plugin is disabled, it appears as "inactive" in the list of plugins:
 
 ```bash
 $ docker plugin ls
-NAME			VERSION		ACTIVE
-tiborvass/no-remove	latest		false
+
+NAME                    VERSION           ACTIVE
+tiborvass/no-remove     latest            false
 ```
 
 ## Related information

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -24,26 +24,31 @@ Enables a plugin. The plugin must be installed before it can be enabled,
 see [`docker plugin install`](plugin_install.md).
 
 
-The following example shows that the `no-remove` plugin is currently installed,
+The following example shows that the `no-remove` plugin is installed,
 but disabled ("inactive"):
 
 ```bash
 $ docker plugin ls
-NAME                	VERSION             ACTIVE
-tiborvass/no-remove	latest              false
+
+NAME                    VERSION             ACTIVE
+tiborvass/no-remove     latest              false
 ```
+
 To enable the plugin, use the following command:
 
 ```bash
-$ docker plugin enable tiborvass/no-remove:latest
+$ docker plugin enable tiborvass/no-remove
+
+tiborvass/no-remove
 ```
 
 After the plugin is enabled, it appears as "active" in the list of plugins:
 
 ```bash
 $ docker plugin ls
-NAME                	VERSION             ACTIVE
-tiborvass/no-remove	latest              true
+
+NAME                    VERSION             ACTIVE
+tiborvass/no-remove     latest              true
 ```
 
 ## Related information

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -30,98 +30,109 @@ $ docker plugin inspect tiborvass/no-remove:latest
 ```
 ```JSON
 {
-    "Manifest": {
-        "ManifestVersion": "",
-        "Description": "A test plugin for Docker",
-        "Documentation": "https://docs.docker.com/engine/extend/plugins/",
-        "Entrypoint": [
-            "plugin-no-remove",
-            "/data"
-        ],
-        "Interface": {
-            "Types": [
-                "docker.volumedriver/1.0"
-            ],
-            "Socket": "plugins.sock"
-        },
-        "Network": {
-            "Type": "host"
-        },
-        "Capabilities": null,
-        "Mounts": [
-            {
-                "Name": "",
-                "Description": "",
-                "Settable": false,
-                "Source": "/data",
-                "Destination": "/data",
-                "Type": "bind",
-                "Options": [
-                    "shared",
-                    "rbind"
-                ]
-            },
-            {
-                "Name": "",
-                "Description": "",
-                "Settable": false,
-                "Source": null,
-                "Destination": "/foobar",
-                "Type": "tmpfs",
-                "Options": null
-            }
-        ],
-        "Devices": [
-            {
-                "Name": "device",
-                "Description": "a host device to mount",
-                "Settable": false,
-                "Path": null
-            }
-        ],
-        "Env": [
-            {
-                "Name": "DEBUG",
-                "Description": "If set, prints debug messages",
-                "Settable": false,
-                "Value": null
-            }
-        ],
-        "Args": [
-            {
-                "Name": "arg1",
-                "Description": "a command line argument",
-                "Settable": false,
-                "Value": null
-            }
+  "Id": "8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21",
+  "Name": "tiborvass/no-remove",
+  "Tag": "latest",
+  "Active": true,
+  "Config": {
+    "Mounts": [
+      {
+        "Name": "",
+        "Description": "",
+        "Settable": null,
+        "Source": "/data",
+        "Destination": "/data",
+        "Type": "bind",
+        "Options": [
+          "shared",
+          "rbind"
         ]
+      },
+      {
+        "Name": "",
+        "Description": "",
+        "Settable": null,
+        "Source": null,
+        "Destination": "/foobar",
+        "Type": "tmpfs",
+        "Options": null
+      }
+    ],
+    "Env": [
+      "DEBUG=1"
+    ],
+    "Args": null,
+    "Devices": null
+  },
+  "Manifest": {
+    "ManifestVersion": "v0",
+    "Description": "A test plugin for Docker",
+    "Documentation": "https://docs.docker.com/engine/extend/plugins/",
+    "Interface": {
+      "Types": [
+        "docker.volumedriver/1.0"
+      ],
+      "Socket": "plugins.sock"
     },
-    "Config": {
-        "Mounts": [
-            {
-                "Source": "/data",
-                "Destination": "/data",
-                "Type": "bind",
-                "Options": [
-                    "shared",
-                    "rbind"
-                ]
-            },
-            {
-                "Source": null,
-                "Destination": "/foobar",
-                "Type": "tmpfs",
-                "Options": null
-            }
-        ],
-        "Env": [],
-        "Args": [],
-        "Devices": null
+    "Entrypoint": [
+      "plugin-no-remove",
+      "/data"
+    ],
+    "Workdir": "",
+    "User": {
     },
-    "Active": true,
-    "Name": "tiborvass/no-remove",
-    "Tag": "latest",
-    "ID": "ac9d36b664921d61813254f7e9946f10e3cadbb676346539f1705fcaf039c01f"
+    "Network": {
+      "Type": "host"
+    },
+    "Capabilities": null,
+    "Mounts": [
+      {
+        "Name": "",
+        "Description": "",
+        "Settable": null,
+        "Source": "/data",
+        "Destination": "/data",
+        "Type": "bind",
+        "Options": [
+          "shared",
+          "rbind"
+        ]
+      },
+      {
+        "Name": "",
+        "Description": "",
+        "Settable": null,
+        "Source": null,
+        "Destination": "/foobar",
+        "Type": "tmpfs",
+        "Options": null
+      }
+    ],
+    "Devices": [
+      {
+        "Name": "device",
+        "Description": "a host device to mount",
+        "Settable": null,
+        "Path": "/dev/cpu_dma_latency"
+      }
+    ],
+    "Env": [
+      {
+        "Name": "DEBUG",
+        "Description": "If set, prints debug messages",
+        "Settable": null,
+        "Value": "1"
+      }
+    ],
+    "Args": {
+      "Name": "args",
+      "Description": "command line arguments",
+      "Settable": null,
+      "Value": [
+
+      ]
+    }
+  }
 }
 ```
 (output formatted for readability)

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -12,7 +12,7 @@ parent = "smn_cli"
 # plugin install (experimental)
 
 ```markdown
-Usage:  docker plugin install PLUGIN [OPTIONS]
+Usage:  docker plugin install [OPTIONS] PLUGIN
 
 Install a plugin
 
@@ -33,17 +33,21 @@ the plugin needs and enabling the plugin.
 
 ```bash
 $ docker plugin install tiborvass/no-remove
-Plugin "tiborvass/no-remove:latest" requested the following privileges:
- - Networking: host
- - Mounting host path: /data
+
+Plugin "tiborvass/no-remove" is requesting the following privileges:
+ - network: [host]
+ - mount: [/data]
+ - device: [/dev/cpu_dma_latency]
 Do you grant the above permissions? [y/N] y
+tiborvass/no-remove
 ```
 
 After the plugin is installed, it appears in the list of plugins:
 
 ```bash
 $ docker plugin ls
-NAME                	VERSION             ACTIVE
+
+NAME                  VERSION             ACTIVE
 tiborvass/no-remove   latest              true
 ```
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -30,8 +30,9 @@ Example output:
 
 ```bash
 $ docker plugin ls
-NAME                	VERSION             ACTIVE
-tiborvass/no-remove	latest              true
+
+NAME                  VERSION             ACTIVE
+tiborvass/no-remove   latest              true
 ```
 
 ## Related information

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -30,7 +30,9 @@ it.
 The following example disables and removes the `no-remove:latest` plugin;
 
 ```bash
-$ docker plugin disable tiborvass/no-remove:latest
+$ docker plugin disable tiborvass/no-remove
+no-remove:latest
+
 $ docker plugin rm tiborvass/no-remove:latest
 no-remove:latest
 ```


### PR DESCRIPTION
the output/response slightly changed in 340964db1c8f161a2ad156023eb47dcc93bf804b, and `:latest` is no longer required for various actions.

also replaced some tabs in the output, and changed them to spaces, to prevent
formatting / aligning issues in HTML

relates to https://github.com/docker/docker/pull/24692

/cc @sfsmithcha @anusha-ragunathan 
