### PR TITLE
api/client/service: shorten to volume-opt

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -218,7 +218,7 @@ func (m *MountOpt) Set(value string) error {
 			setValueOnMap(volumeOptions().Labels, value)
 		case "volume-driver":
 			volumeOptions().DriverConfig.Name = value
-		case "volume-driver-opt":
+		case "volume-opt":
 			if volumeOptions().DriverConfig.Options == nil {
 				volumeOptions().DriverConfig.Options = make(map[string]string)
 			}


### PR DESCRIPTION
`volume-driver-opt` was too verbose for its own existence and the sanity
of those in the vicinity. The much better, sleeker `volume-opt` replaces
it. 7 bytes and a case of carpal tunnel syndrome are saved!

Signed-off-by: Stephen J Day stephen.day@docker.com
