### PR TITLE
Change mount-types to lowercase

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -196,7 +196,7 @@ func (m *MountOpt) Set(value string) error {
 		key, value := parts[0], parts[1]
 		switch strings.ToLower(key) {
 		case "type":
-			mount.Type = swarm.MountType(strings.ToUpper(value))
+			mount.Type = swarm.MountType(strings.ToLower(value))
 		case "source":
 			mount.Source = value
 		case "target":
@@ -208,7 +208,7 @@ func (m *MountOpt) Set(value string) error {
 			}
 			mount.ReadOnly = ro
 		case "bind-propagation":
-			bindOptions().Propagation = swarm.MountPropagation(strings.ToUpper(value))
+			bindOptions().Propagation = swarm.MountPropagation(strings.ToLower(value))
 		case "volume-nocopy":
 			volumeOptions().NoCopy, err = strconv.ParseBool(value)
 			if err != nil {
@@ -240,10 +240,10 @@ func (m *MountOpt) Set(value string) error {
 		return fmt.Errorf("source is required when specifying volume-* options")
 	}
 
-	if mount.Type == swarm.MountType("BIND") && mount.VolumeOptions != nil {
+	if mount.Type == swarm.MountTypeBind && mount.VolumeOptions != nil {
 		return fmt.Errorf("cannot mix 'volume-*' options with mount type '%s'", swarm.MountTypeBind)
 	}
-	if mount.Type == swarm.MountType("VOLUME") && mount.BindOptions != nil {
+	if mount.Type == swarm.MountTypeVolume && mount.BindOptions != nil {
 		return fmt.Errorf("cannot mix 'bind-*' options with mount type '%s'", swarm.MountTypeVolume)
 	}
 

--- a/api/client/service/opts_test.go
+++ b/api/client/service/opts_test.go
@@ -61,18 +61,18 @@ func TestMountOptString(t *testing.T) {
 	mount := MountOpt{
 		values: []swarm.Mount{
 			{
-				Type:   swarm.MountType("BIND"),
+				Type:   swarm.MountTypeBind,
 				Source: "/home/path",
 				Target: "/target",
 			},
 			{
-				Type:   swarm.MountType("VOLUME"),
+				Type:   swarm.MountTypeVolume,
 				Source: "foo",
 				Target: "/target/foo",
 			},
 		},
 	}
-	expected := "BIND /home/path /target, VOLUME foo /target/foo"
+	expected := "bind /home/path /target, volume foo /target/foo"
 	assert.Equal(t, mount.String(), expected)
 }
 
@@ -83,7 +83,7 @@ func TestMountOptSetNoError(t *testing.T) {
 	mounts := mount.Value()
 	assert.Equal(t, len(mounts), 1)
 	assert.Equal(t, mounts[0], swarm.Mount{
-		Type:   swarm.MountType("BIND"),
+		Type:   swarm.MountTypeBind,
 		Source: "/foo",
 		Target: "/target",
 	})
@@ -96,22 +96,22 @@ func TestMountOptSetErrorNoType(t *testing.T) {
 
 func TestMountOptSetErrorNoTarget(t *testing.T) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=VOLUME,source=/foo"), "target is required")
+	assert.Error(t, mount.Set("type=volume,source=/foo"), "target is required")
 }
 
 func TestMountOptSetErrorInvalidKey(t *testing.T) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=VOLUME,bogus=foo"), "unexpected key 'bogus'")
+	assert.Error(t, mount.Set("type=volume,bogus=foo"), "unexpected key 'bogus'")
 }
 
 func TestMountOptSetErrorInvalidField(t *testing.T) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=VOLUME,bogus"), "invalid field 'bogus'")
+	assert.Error(t, mount.Set("type=volume,bogus"), "invalid field 'bogus'")
 }
 
 func TestMountOptSetErrorInvalidWritable(t *testing.T) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=VOLUME,readonly=no"), "invalid value for readonly: no")
+	assert.Error(t, mount.Set("type=volume,readonly=no"), "invalid value for readonly: no")
 }
 
 func TestMountOptDefaultEnableWritable(t *testing.T) {

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -90,8 +90,8 @@ func TestUpdateMounts(t *testing.T) {
 	flags.Set("mount-rm", "/toremove")
 
 	mounts := []swarm.Mount{
-		{Target: "/toremove", Type: swarm.MountType("BIND")},
-		{Target: "/tokeep", Type: swarm.MountType("BIND")},
+		{Target: "/toremove", Type: swarm.MountTypeBind},
+		{Target: "/tokeep", Type: swarm.MountTypeBind},
 	}
 
 	updateMounts(flags, &mounts)
@@ -122,7 +122,7 @@ func TestUpdatePorts(t *testing.T) {
 	flags.Set("publish-rm", "333/udp")
 
 	portConfigs := []swarm.PortConfig{
-		{TargetPort: 333, Protocol: swarm.PortConfigProtocol("udp")},
+		{TargetPort: 333, Protocol: swarm.PortConfigProtocolUDP},
 		{TargetPort: 555},
 	}
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3935,7 +3935,7 @@ Create a service
               "ReadOnly": true,
               "Source": "web-data",
               "Target": "/usr/share/nginx/html",
-              "Type": "VOLUME",
+              "Type": "volume",
               "VolumeOptions": {
                 "DriverConfig": {
                 },

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3936,7 +3936,7 @@ Create a service
               "ReadOnly": true,
               "Source": "web-data",
               "Target": "/usr/share/nginx/html",
-              "Type": "VOLUME",
+              "Type": "volume",
               "VolumeOptions": {
                 "DriverConfig": {
                 },

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -143,12 +143,12 @@ func (m *MountPoint) Path() string {
 // Type returns the type of mount point
 func (m *MountPoint) Type() string {
 	if m.Name != "" {
-		return "VOLUME"
+		return "volume"
 	}
 	if m.Source != "" {
-		return "BIND"
+		return "bind"
 	}
-	return "EPHEMERAL"
+	return "ephemeral"
 }
 
 // ParseVolumesFrom ensures that the supplied volumes-from is valid.


### PR DESCRIPTION
these values were changed to lowercase in
https://github.com/docker/engine-api/commit/690cb2d08cfcca31cd02e68b23915b75386beecd,
but not changed accordingly in docker/docker.

this changes the mounttypes to lowercase

fixes https://github.com/docker/docker/issues/24867
