### PR TITLE
api/client/service: mount option defaults and aliases

### DIFF
--- a/api/client/service/opts_test.go
+++ b/api/client/service/opts_test.go
@@ -77,21 +77,33 @@ func TestMountOptString(t *testing.T) {
 }
 
 func TestMountOptSetNoError(t *testing.T) {
-	var mount MountOpt
-	assert.NilError(t, mount.Set("type=bind,target=/target,source=/foo"))
+	for _, testcase := range []string{
+		// tests several aliases that should have same result.
+		"type=bind,target=/target,source=/source",
+		"type=bind,src=/source,dst=/target",
+		"type=bind,name=/source,dst=/target",
+		"type=bind,name=/source,path=/target",
+	} {
+		var mount MountOpt
 
-	mounts := mount.Value()
-	assert.Equal(t, len(mounts), 1)
-	assert.Equal(t, mounts[0], swarm.Mount{
-		Type:   swarm.MountTypeBind,
-		Source: "/foo",
-		Target: "/target",
-	})
+		assert.NilError(t, mount.Set(testcase))
+
+		mounts := mount.Value()
+		assert.Equal(t, len(mounts), 1)
+		assert.Equal(t, mounts[0], swarm.Mount{
+			Type:   swarm.MountTypeBind,
+			Source: "/source",
+			Target: "/target",
+		})
+	}
 }
 
-func TestMountOptSetErrorNoType(t *testing.T) {
+// TestMountOptDefaultType ensures that a mount without the type defaults to a
+// volume mount.
+func TestMountOptDefaultType(t *testing.T) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("target=/target,source=/foo"), "type is required")
+	assert.NilError(t, mount.Set("target=/target,source=/foo"))
+	assert.Equal(t, mount.values[0].Type, swarm.MountTypeVolume)
 }
 
 func TestMountOptSetErrorNoTarget(t *testing.T) {
@@ -109,12 +121,13 @@ func TestMountOptSetErrorInvalidField(t *testing.T) {
 	assert.Error(t, mount.Set("type=volume,bogus"), "invalid field 'bogus'")
 }
 
-func TestMountOptSetErrorInvalidWritable(t *testing.T) {
+func TestMountOptSetErrorInvalidReadOnly(t *testing.T) {
 	var mount MountOpt
 	assert.Error(t, mount.Set("type=volume,readonly=no"), "invalid value for readonly: no")
+	assert.Error(t, mount.Set("type=volume,readonly=invalid"), "invalid value for readonly: invalid")
 }
 
-func TestMountOptDefaultEnableWritable(t *testing.T) {
+func TestMountOptDefaultEnableReadOnly(t *testing.T) {
 	var m MountOpt
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo"))
 	assert.Equal(t, m.values[0].ReadOnly, false)


### PR DESCRIPTION
Simplifies the mount option usage by providing common aliases for
`source` and `target`. The default mount type is now volume.

Implements the aliases and defaults proposed in #24190. Backwards compatible with existing `--mount` flag.

@tiborvass @aluzzardi @mgoelzer 

Signed-off-by: Stephen J Day stephen.day@docker.com
