### PR TITLE
Windows: TestBuildWorkdirWindowsPath hard code fix

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6393,7 +6393,7 @@ func (s *DockerSuite) TestBuildWorkdirWindowsPath(c *check.C) {
 	name := "testbuildworkdirwindowspath"
 
 	_, err := buildImage(name, `
-	FROM windowsservercore
+	FROM `+WindowsBaseImage+`
 	RUN mkdir C:\\work
 	WORKDIR C:\\work
 	RUN if "%CD%" NEQ "C:\work" exit -1


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Relates to https://github.com/docker/docker/pull/24853 - one of the CLI tests has a hard-coded `windowsservercore` for the image name. Just use whatever is the configured base image instead to allow this test to run when using nanoserver.
