### PR TITLE
Rename `--registry-auth` to `--with-registry-auth`

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -547,7 +547,7 @@ const (
 	flagUpdateDelay        = "update-delay"
 	flagUpdateParallelism  = "update-parallelism"
 	flagUser               = "user"
-	flagRegistryAuth       = "registry-auth"
+	flagRegistryAuth       = "with-registry-auth"
 	flagLogDriver          = "log-driver"
 	flagLogOpt             = "log-opt"
 )

--- a/api/client/stack/opts.go
+++ b/api/client/stack/opts.go
@@ -19,7 +19,7 @@ func addBundlefileFlag(opt *string, flags *pflag.FlagSet) {
 }
 
 func addRegistryAuthFlag(opt *bool, flags *pflag.FlagSet) {
-	flags.BoolVar(opt, "registry-auth", false, "Send registry authentication details to Swarm agents")
+	flags.BoolVar(opt, "with-registry-auth", false, "Send registry authentication details to Swarm agents")
 }
 
 func loadBundlefile(stderr io.Writer, namespace string, path string) (*bundlefile.Bundlefile, error) {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1733,7 +1733,7 @@ _docker_service_update() {
 
 	local boolean_options="
 		--help
-		--registry-auth
+		--with-registry-auth
 	"
 
 	__docker_complete_log_driver_options && return

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1087,7 +1087,6 @@ __docker_service_subcommand() {
         "($help)--name=[Service name]:name: "
         "($help)*--network=[Network attachments]:network: "
         "($help)*"{-p=,--publish=}"[Publish a port as a node port]:port: "
-        "($help)--registry-auth[Send registry authentication details to swarm agents]"
         "($help)--replicas=[Number of tasks]:replicas: "
         "($help)--reserve-cpu=[Reserve CPUs]:value: "
         "($help)--reserve-memory=[Reserve Memory]:value: "
@@ -1099,6 +1098,7 @@ __docker_service_subcommand() {
         "($help)--update-delay=[Delay between updates]:delay: "
         "($help)--update-parallelism=[Maximum number of tasks updated simultaneously]:number: "
         "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users"
+        "($help)--with-registry-auth[Send registry authentication details to swarm agents]"
         "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories"
     )
 

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -17,9 +17,9 @@ Usage:  docker deploy [OPTIONS] STACK
 Create and update a stack from a Distributed Application Bundle (DAB)
 
 Options:
-      --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
-      --help            Print usage
-      --registry-auth   Send registry authentication details to swarm agents
+      --file   string        Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --help                 Print usage
+      --with-registry-auth   Send registry authentication details to swarm agents
 ```
 
 Create and update a stack from a `dab` file. This command has to be

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -31,7 +31,6 @@ Options:
       --name string                  Service name
       --network value                Network attachments (default [])
   -p, --publish value                Publish a port as a node port (default [])
-      --registry-auth                Send registry authentication details to swarm agents
       --replicas value               Number of tasks (default none)
       --reserve-cpu value            Reserve CPUs (default 0.000)
       --reserve-memory value         Reserve Memory (default 0 B)
@@ -43,6 +42,7 @@ Options:
       --update-delay duration        Delay between updates
       --update-parallelism uint      Maximum number of tasks updated simultaneously
   -u, --user string                  Username or UID
+      --with-registry-auth           Send registry authentication details to Swarm agents
   -w, --workdir string               Working directory inside the container
 ```
 

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -38,7 +38,6 @@ Options:
       --network-rm value             Remove a network by name (default [])
       --publish-add value            Add or update a published port (default [])
       --publish-rm value             Remove a published port by its target port (default [])
-      --registry-auth                Send registry authentication details to swarm agents
       --replicas value               Number of tasks (default none)
       --reserve-cpu value            Reserve CPUs (default 0.000)
       --reserve-memory value         Reserve Memory (default 0 B)
@@ -50,6 +49,7 @@ Options:
       --update-delay duration        Delay between updates
       --update-parallelism uint      Maximum number of tasks updated simultaneously
   -u, --user string                  Username or UID
+      --with-registry-auth           Send registry authentication details to Swarm agents
   -w, --workdir string               Working directory inside the container
 ```
 

--- a/experimental/docker-stacks-and-bundles.md
+++ b/experimental/docker-stacks-and-bundles.md
@@ -44,9 +44,9 @@ Usage:  docker deploy [OPTIONS] STACK
 Create and update a stack
 
 Options:
-      --file   string   Path to a Distributed Application Bundle file (Default: STACK.dab)
-      --help            Print usage
-      --registry-auth   Send registry authentication details to Swarm agents
+      --file   string        Path to a Distributed Application Bundle file (Default: STACK.dab)
+      --help                 Print usage
+      --with-registry-auth   Send registry authentication details to Swarm agents
 ```
 
 Let's deploy the stack created before:


### PR DESCRIPTION
Closes #24875. 🐮

`--with-registry-auth` is more explicit.

Depends on #24700 as it introduces `--registry-auth` on `stack deploy` subcommand. I'll update and rebase once it's merged 👼.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
