### PR TITLE
Clarify API behavior when older versions are called.

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -37,7 +37,8 @@ default.
 
 The current version of the API is v1.24 which means calling `/info` is the same
 as calling `/v1.24/info`. To call an older version of the API use
-`/v1.23/info`.
+`/v1.23/info`. If a newer daemon is installed, new properties may be returned
+even when calling older versions of the API.
 
 Use the table below to find the API version for a Docker version:
 


### PR DESCRIPTION
Fixes #24632. 

**\- What I did**

Added a line explaining that calling older versions of the API might still result in new properties.

**\- How I did it**

Edited the markdown file of the documentation.

**\- How to verify it**

**\- Description for the changelog**

Clarify API behavior when older versions are called.

Signed-off-by: fonglh fonglh@gmail.com
