### PR TITLE
Add '--registry-auth' flag to docker service scale

### DIFF
--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -12,12 +12,13 @@ parent = "smn_cli"
 # service scale
 
 ```markdown
-Usage:  docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]
+Usage:  docker service scale [OPTIONS] SERVICE=REPLICAS [SERVICE=REPLICAS...]
 
 Scale one or multiple services
 
 Options:
-      --help   Print usage
+      --help            Print usage
+      --registry-auth   Send registry authentication details to Swarm agents
 ```
 
 ## Examples


### PR DESCRIPTION
**\- What I did**

When scaling a service that uses private images,
nodes that the new tasks land on need to
authenticate, otherwise they cannot pull the
image.

**\- How to verify it**
- create a swarm with at least two nodes
- on the manager node, log in to docker hub
- create a service that uses a private image, but set `--replicas=0`
- scale the service `docker service scale myservice=2`, and see that it fails
- scale the service back to `0` (`docker service scale myservice=0`)
- scale the service again, this time passing `--registry-auth`; `docker service scale --registry-auth myservice=2`
- verify that the service is deployed successfully, and tasks are running on both nodes

fixes https://github.com/docker/docker/issues/24894
