### PR TITLE
Harmonize containerd commit used by all Dockerfile

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -195,7 +195,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 90f827ca1066b3b6584ce7450989b96b576b1baf
+ENV CONTAINERD_COMMIT 0ac3cd1be170d180b2baed755e8f0da547ceb267
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -200,7 +200,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 90f827ca1066b3b6584ce7450989b96b576b1baf
+ENV CONTAINERD_COMMIT 0ac3cd1be170d180b2baed755e8f0da547ceb267
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -85,7 +85,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 90f827ca1066b3b6584ce7450989b96b576b1baf
+ENV CONTAINERD_COMMIT 0ac3cd1be170d180b2baed755e8f0da547ceb267
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -213,7 +213,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 90f827ca1066b3b6584ce7450989b96b576b1baf
+ENV CONTAINERD_COMMIT 0ac3cd1be170d180b2baed755e8f0da547ceb267
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -208,7 +208,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 90f827ca1066b3b6584ce7450989b96b576b1baf
+ENV CONTAINERD_COMMIT 0ac3cd1be170d180b2baed755e8f0da547ceb267
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -68,7 +68,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 90f827ca1066b3b6584ce7450989b96b576b1baf
+ENV CONTAINERD_COMMIT 0ac3cd1be170d180b2baed755e8f0da547ceb267
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \


### PR DESCRIPTION
When #24648 was merged, only the main Dockerfile was updated with the
new containerd commit, this commit brings the other Dockerfile up to
speed.

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

Fixes #24863

![](https://s-media-cache-ak0.pinimg.com/564x/f9/61/a5/f961a5a1db7a1f1804a77e055f42c39b.jpg)
