### PR TITLE
updates get started with swarm to use join-token

### DIFF
--- a/docs/swarm/swarm-tutorial/add-nodes.md
+++ b/docs/swarm/swarm-tutorial/add-nodes.md
@@ -23,24 +23,24 @@ This tutorial uses the name `worker1`.
 [Create a swarm](create-swarm.md) tutorial step to create a worker node joined to the existing swarm:
 
     ```bash
-    $ docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
-      --ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
+    $ docker swarm join \
+      --token  SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
       192.168.99.100:2377
+
+    This node joined a swarm as a worker.
     ```
 
-    If you don't have the command available, you can run the following command:
+    If you don't have the command available, you can run the following command
+    on a manager node to retrieve the join command for a worker:
 
     ```bash
-    docker swarm join --secret <SECRET> <MANAGER-IP>:<PORT>
+    $ docker swarm join-token worker
+
+    To add a worker to this swarm, run the following command:
+        docker swarm join \
+        --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
+        192.168.99.100:2377
     ```
-
-    Replace `<SECRET>` with the secret that was printed by `docker swarm init`
-    in the previous step. Replace `<MANAGER-IP>` with the address of the manager
-    node and `<PORT>` with the port where the manager listens.
-
-    The command generated from `docker swarm init` includes the `--ca-hash` to
-    securely identify the manager node according to its root CA. For the
-    tutorial, it is OK to join without it.
 
 3. Open a terminal and ssh into the machine where you want to run a second
 worker node. This tutorial uses the name `worker2`.
@@ -50,19 +50,21 @@ worker node. This tutorial uses the name `worker2`.
 joined to the existing swarm:
 
     ```bash
-    $ docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
-      --ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
+    $ docker swarm join \
+      --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
       192.168.99.100:2377
+
+    This node joined a swarm as a worker.
     ```
 
 5. Open a terminal and ssh into the machine where the manager node runs and run
 the `docker node ls` command to see the worker nodes:
 
     ```bash
-    ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
-    03g1y59jwfg7cf99w4lt0f662    worker2   Accepted    Ready   Active
-    9j68exjopxe7wfl6yuxml7a7j    worker1   Accepted    Ready   Active
-    dxn1zf6l61qsb1josjja83ngz *  manager1  Accepted    Ready   Active        Reachable       Yes
+    ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
+    03g1y59jwfg7cf99w4lt0f662    worker2   Ready   Active
+    9j68exjopxe7wfl6yuxml7a7j    worker1   Ready   Active
+    dxn1zf6l61qsb1josjja83ngz *  manager1  Ready   Active        Leader
     ```
 
     The `MANAGER` column identifies the manager nodes in the swarm. The empty

--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -31,29 +31,28 @@ node. For example, the tutorial uses a machine named `manager1`.
 
     ```bash
     $ docker swarm init --listen-addr 192.168.99.100:2377
-    No --secret provided. Generated random secret:
-      4ao565v9jsuogtq5t8s379ulb
-
-    Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a
-    manager.
+    Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a manager.
 
     To add a worker to this swarm, run the following command:
-      docker swarm join --secret 4ao565v9jsuogtq5t8s379ulb \
-      --ca-hash sha256:07ce22bd1a7619f2adc0d63bd110479a170e7c4e69df05b67a1aa2705c88ef09 \
-      192.168.99.100:2377
+        docker swarm join \
+        --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
+        192.168.99.100:2377
+
+    To add a manager to this swarm, run the following command:
+        docker swarm join \
+        --token SWMTKN-1-61ztec5kyafptydic6jfc1i33t37flcl4nuipzcusor96k7kby-5vy9t8u35tuqm7vh67lrz9xp6 \
+        192.168.99.100:2377
     ```
 
     The `--listen-addr` flag configures the manager node to listen on port
     `2377`. The other nodes in the swarm must be able to access the manager at
     the IP address.
 
-    The `--ca-hash` flag provides the identity of the root CA for the manager
-    node.
+    The output incudes the commands to join new nodes to the swarm. Nodes will
+    join as managers or workers depending on the value for the `--swarm-token`
+    flag.
 
-2. Save the output of `docker swarm init` that includes the command to join
-worker nodes to the swarm.
-
-3. Run `docker info` to view the current state of the swarm:
+2. Run `docker info` to view the current state of the swarm:
 
     ```bash
     $ docker info
@@ -68,17 +67,16 @@ worker nodes to the swarm.
       Is Manager: true
       Managers: 1
       Nodes: 1
-      CA Certificate Hash: sha256:b7986d3baeff2f5664dfe350eec32e2383539ec1a802ba541c4eb829056b5f61
       ...snip...
     ```
 
-4. Run the `docker node ls` command to view information about nodes:
+3. Run the `docker node ls` command to view information about nodes:
 
     ```bash
     $ docker node ls
 
-    ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY  MANAGER STATUS  LEADER
-    dxn1zf6l61qsb1josjja83ngz *  manager1  Accepted    Ready   Active        Reachable       Yes
+    ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
+    dxn1zf6l61qsb1josjja83ngz *  manager1  Ready   Active        Leader
 
     ```
 

--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -31,10 +31,10 @@ run your manager node. For example, the tutorial uses a machine named
     ```bash
     $ docker node ls
 
-    ID                           HOSTNAME  MEMBERSHIP  STATUS  AVAILABILITY     MANAGER STATUS  LEADER
-    1bcef6utixb0l0ca7gxuivsj0    worker2   Accepted    Ready   Active
-    38ciaotwjuritcdtn9npbnkuz    worker1   Accepted    Ready   Active
-    e216jshn25ckzbvmwlnh5jr3g *  manager1  Accepted    Ready   Active        Reachable       Yes
+    ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
+    1bcef6utixb0l0ca7gxuivsj0    worker2   Ready   Active
+    38ciaotwjuritcdtn9npbnkuz    worker1   Ready   Active
+    e216jshn25ckzbvmwlnh5jr3g *  manager1  Ready   Active        Leader
     ```
 
 2. If you aren't still running the `redis` service from the [rolling

--- a/docs/swarm/swarm-tutorial/index.md
+++ b/docs/swarm/swarm-tutorial/index.md
@@ -73,6 +73,9 @@ Verify that the Docker Engine daemon is running on each of the machines.
 The IP address must be assigned to an a network interface available to the host
 operating system. All nodes in the swarm must be able to access the manager at the IP address.
 
+Because other nodes contact the manager node on its IP address, you should use a
+fixed IP address.
+
 >**Tip**: You can run `ifconfig` on Linux or Mac OS X to see a list of the
 available network interfaces.
 

--- a/docs/swarm/swarm-tutorial/menu.md
+++ b/docs/swarm/swarm-tutorial/menu.md
@@ -1,7 +1,7 @@
 <!--[metadata]>
 +++
-title = "Get started with Swarm"
-description = "Getting started tutorial for Docker Swarm"
+title = "Get started with swarm mode"
+description = "Getting started tutorial for Docker swarm mode"
 keywords = ["cluster, swarm, tutorial"]
 advisory = "rc"
 [menu.main]


### PR DESCRIPTION
**\- What I did**
Updated the swarm tutorial to use the new `--join-token` syntax
**\- How I did it**
Updated output for `docker swarm init` in create-swarm.md. Updated commands for `swarm-join` in add-nodes.md.

Also cleaned up output of `docker node ls` where it exists.
![img_3225](https://cloud.githubusercontent.com/assets/2415653/17037434/c166cfb8-4f45-11e6-8c1b-d5e764bfb5e4.jpg)

Signed-off-by: Charles Smith charles.smith@docker.com
