### PR TITLE
Treat HEALTHCHECK NONE the same as not setting a healthcheck

### DIFF
--- a/container/health.go
+++ b/container/health.go
@@ -13,9 +13,12 @@ type Health struct {
 
 // String returns a human-readable description of the health-check state
 func (s *Health) String() string {
+	// This happens when the container is being shutdown and the monitor has stopped
+	// or the monitor has yet to be setup.
 	if s.stop == nil {
-		return "no healthcheck"
+		return types.Unhealthy
 	}
+
 	switch s.Status {
 	case types.Starting:
 		return "health: starting"

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -203,6 +203,7 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 }
 
 // Get a suitable probe implementation for the container's healthcheck configuration.
+// Nil will be returned if no healthcheck was configured or NONE was set.
 func getProbe(c *container.Container) probe {
 	config := c.Config.Healthcheck
 	if config == nil || len(config.Test) == 0 {
@@ -244,7 +245,8 @@ func (d *Daemon) updateHealthMonitor(c *container.Container) {
 // two instances at once.
 // Called with c locked.
 func (d *Daemon) initHealthMonitor(c *container.Container) {
-	if c.Config.Healthcheck == nil {
+	// If no healthcheck is setup then don't init the monitor
+	if getProbe(c) == nil {
 		return
 	}
 
@@ -254,7 +256,6 @@ func (d *Daemon) initHealthMonitor(c *container.Container) {
 	if c.State.Health == nil {
 		h := &container.Health{}
 		h.Status = types.Starting
-		h.FailingStreak = 0
 		c.State.Health = h
 	}
 

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -17,6 +17,28 @@ func reset(c *container.Container) {
 	c.State.Health.Status = types.Starting
 }
 
+func TestNoneHealthcheck(t *testing.T) {
+	c := &container.Container{
+		CommonContainer: container.CommonContainer{
+			ID:   "container_id",
+			Name: "container_name",
+			Config: &containertypes.Config{
+				Image: "image_name",
+				Healthcheck: &containertypes.HealthConfig{
+					Test: []string{"NONE"},
+				},
+			},
+			State: &container.State{},
+		},
+	}
+	daemon := &Daemon{}
+
+	daemon.initHealthMonitor(c)
+	if c.State.Health != nil {
+		t.Errorf("Expecting Health to be nil, but was not")
+	}
+}
+
 func TestHealthStates(t *testing.T) {
 	e := events.New()
 	_, l, _ := e.Subscribe()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #24903

**\- What I did**

Treat `HEALTHCHECK NONE` the same as not setting a healthcheck at all. Removed `no healthcheck` from Health string and means it's not showed in the `docker ps` output either. 

**\- How I did it**

If there is no healthcheck probe then don't create/init health check monitoring. Before this PR docker would init the healthcheck monitor for a `HEALTHCHECK NONE` which resulted in the `State.Health.Status` value always being `starting` since it didn't have a probe to update in monitor goroutine. Now, when you set `HEALTHCHECK NONE` the `Health` struct will be nil just like it is when you don't set a healthcheck at all. 

**\- How to verify it**

Create an image w/o a health check. 

```
echo 'FROM busybox
HEALTHCHECK NONE
CMD top' | docker build -t test_none -

docker run -d test_none
```

Then run `docker ps` and you shouldn't see `(no healthcheck)` in the status column. 

```
CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS                               PORTS               NAMES
9767aa9caf61        test_none:latest    "/bin/sh -c top"    About a minute ago   Up About a minute (no healthcheck)                       test_none.1.04n8jw9670vzy3o5pc41wlqni
```

Create another image with either a passing or failing healthcheck (one below fails). You still should see the transition from `starting` -> `unhealthy`. Before this PR it would show `no healthcheck` during the transition from failing the last check -> killing the container because of how the healthcheck was initialized. Now it will show `unhealthy` since the container is being killed. 

```
echo 'FROM busybox
HEALTHCHECK --interval=5s --timeout=1s --retries=3 CMD ls /foo
CMD top' | docker build -t test -

$ docker service create --replicas 1 --name test test

$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                      PORTS               NAMES
f0d335cd81a2        test:latest         "/bin/sh -c top"    26 seconds ago      Up 25 seconds (unhealthy)                       test.1.axy6yvk16ximd3u6gib2sjb1t
d77e1605440f        test_none           "/bin/sh -c top"    4 minutes ago       Up 4 minutes                                    grave_curran
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Treat HEALTHCHECK NONE the same as not setting a healthcheck. 

Signed-off-by: Josh Horwitz horwitzja@gmail.com
