### PR TITLE
Reorder swarm commands

### DIFF
--- a/api/client/swarm/cmd.go
+++ b/api/client/swarm/cmd.go
@@ -22,10 +22,10 @@ func NewSwarmCommand(dockerCli *client.DockerCli) *cobra.Command {
 	cmd.AddCommand(
 		newInitCommand(dockerCli),
 		newJoinCommand(dockerCli),
+		newJoinTokenCommand(dockerCli),
 		newUpdateCommand(dockerCli),
 		newLeaveCommand(dockerCli),
 		newInspectCommand(dockerCli),
-		newJoinTokenCommand(dockerCli),
 	)
 	return cmd
 }


### PR DESCRIPTION
This way "join-token" appears next to "join" in the help output.

cc @tiborvass
