### PR TITLE
service tasks: Improve error reporting

### DIFF
--- a/api/client/node/tasks.go
+++ b/api/client/node/tasks.go
@@ -9,13 +9,11 @@ import (
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/swarm"
 	"github.com/spf13/cobra"
 )
 
 type tasksOptions struct {
 	nodeID    string
-	all       bool
 	noResolve bool
 	filter    opts.FilterOpt
 }
@@ -33,7 +31,6 @@ func newTasksCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.all, "all", "a", false, "Display all instances")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
 
@@ -55,11 +52,6 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 
 	filter := opts.filter.Value()
 	filter.Add("node", node.ID)
-	if !opts.all && !filter.Include("desired-state") {
-		filter.Add("desired-state", string(swarm.TaskStateRunning))
-		filter.Add("desired-state", string(swarm.TaskStateAccepted))
-	}
-
 	tasks, err := client.TaskList(
 		ctx,
 		types.TaskListOptions{Filter: filter})

--- a/api/client/service/tasks.go
+++ b/api/client/service/tasks.go
@@ -10,13 +10,11 @@ import (
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/opts"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/swarm"
 	"github.com/spf13/cobra"
 )
 
 type tasksOptions struct {
 	serviceID string
-	all       bool
 	noResolve bool
 	filter    opts.FilterOpt
 }
@@ -34,7 +32,6 @@ func newTasksCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.all, "all", "a", false, "Display all tasks")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
 
@@ -52,11 +49,6 @@ func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
 
 	filter := opts.filter.Value()
 	filter.Add("service", service.ID)
-	if !opts.all && !filter.Include("desired-state") {
-		filter.Add("desired-state", string(swarm.TaskStateRunning))
-		filter.Add("desired-state", string(swarm.TaskStateAccepted))
-	}
-
 	if filter.Include("node") {
 		nodeFilters := filter.Get("node")
 		for _, nodeFilter := range nodeFilters {


### PR DESCRIPTION
- Tasks will display all tasks (`-a` is the default and was removed)
- Nest tasks to help display history
- Display task errors inline

Example:

```
# docker service tasks vote
ID                         NAME        IMAGE           NODE          DESIRED STATE  CURRENT STATE            ERROR
bvojmk7wiwjswyb0ww1o8by9e  vote.1      instavote/vote  ce5a79de6642  Running        Running 15 minutes ago
amwhb0xwateq040lqwzu0qado   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Complete 30 minutes ago
14hd2jrgta2378ndoya2ddgug   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Complete 45 minutes ago
5kb6oq07oydo6i8oz50wtt7ir   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Failed 45 minutes ago    "starting container failed: oc…"
613cgiw1ajc4bwxbwa5h033it   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Shutdown 52 minutes ago
3vgj9c3ab7fphoughj041r144   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Failed 54 minutes ago    "task: non-zero exit (137)"
612ik4x1sgkgwmoed9riwc3je   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Failed 56 minutes ago    "task: non-zero exit (137)"
00oz0yso8xcjveycxpobh8afm   \_ vote.1  instavote/vote  ce5a79de6642  Shutdown       Failed 56 minutes ago    "task: non-zero exit (137)"
0hung96bc208fazmg19kuze6z  vote.2      instavote/vote  ce5a79de6642  Running        Running 15 minutes ago
d53beglz6wgp9rx4gz91sjr7c   \_ vote.2  instavote/vote  ce5a79de6642  Shutdown       Complete 30 minutes ago
e0sfqy2zrxi06xjizhhfr405h   \_ vote.2  instavote/vote  ce5a79de6642  Shutdown       Complete 45 minutes ago
ap2xcl5x2op6txl95zepntqno   \_ vote.2  instavote/vote  ce5a79de6642  Shutdown       Failed 45 minutes ago    "starting container failed: oc…"
8oiok9dfowzf2urglzggpzz9a   \_ vote.2  instavote/vote  ce5a79de6642  Shutdown       Shutdown 52 minutes ago
```

/cc @vieux @icecrime @stevvooe @aaronlehmann @mgoelzer 
