### PR TITLE
Fix incorrect test comment

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -653,7 +653,7 @@ func (s *DockerSuite) TestEventsContainerRestart(c *check.C) {
 	// wait until test2 is auto removed.
 	waitTime := 10 * time.Second
 	if daemonPlatform == "windows" {
-		// nslookup isn't present in Windows busybox. Is built-in.
+		// Windows takes longer...
 		waitTime = 90 * time.Second
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes a completely incorrect comment which (I guess I am the culprit, haven't checked :innocent:) somehow slipped into the events tests.
