### PR TITLE
Update the errNoManager() to conform to `swarm join-token`

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -625,7 +625,7 @@ func (c *Cluster) isActiveManager() bool {
 // Call with read lock.
 func (c *Cluster) errNoManager() error {
 	if c.node == nil {
-		return fmt.Errorf("This node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join --manager\" to connect this node to swarm and try again.")
+		return fmt.Errorf("This node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again.")
 	}
 	if c.node.Manager() != nil {
 		return fmt.Errorf("This node is not a swarm manager. Manager is being prepared or has trouble connecting to the cluster.")


### PR DESCRIPTION
In #24823, `swarm join` has been updated to take a `--token` flag and flag `--manager` has been removed. Though in errNoManager() the error message still use the old description.

This fix update the error message in errNoManager() and conforms to the current available flags.

This fix is related to #24823.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
