### PR TITLE
remove "secrets" from completion scripts

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1832,24 +1832,17 @@ _docker_swarm() {
 
 _docker_swarm_init() {
 	case "$prev" in
-		--auto-accept)
-			COMPREPLY=( $( compgen -W "manager none worker" -- "$cur" ) )
-			return
-			;;
 		--listen-addr)
 			if [[ $cur == *: ]] ; then
 				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
 			fi
 			return
 			;;
-		--secret)
-			return
-			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--auto-accept --force-new-cluster --help --listen-addr --secret" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--force-new-cluster --help --listen-addr" -- "$cur" ) )
 			;;
 	esac
 }
@@ -1870,7 +1863,7 @@ _docker_swarm_inspect() {
 
 _docker_swarm_join() {
 	case "$prev" in
-		--ca-hash|--secret)
+		--token)
 			return
 			;;
 		--listen-addr)
@@ -1883,7 +1876,7 @@ _docker_swarm_join() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--ca-hash --help --listen-addr --manager --secret" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --listen-addr --token" -- "$cur" ) )
 			;;
 		*:)
 			COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
@@ -1901,25 +1894,20 @@ _docker_swarm_leave() {
 
 _docker_swarm_update() {
 	case "$prev" in
-		--auto-accept)
-			COMPREPLY=( $( compgen -W "manager none worker" -- "$cur" ) )
-			return
-			;;
-		--cert-expiry|--dispatcher-heartbeat|--secret|--task-history-limit)
+		--cert-expiry|--dispatcher-heartbeat|--task-history-limit)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--auto-accept --cert-expiry --dispatcher-heartbeat --help --secret --task-history-limit" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--cert-expiry --dispatcher-heartbeat --help --task-history-limit" -- "$cur" ) )
 			;;
 	esac
 }
 
 _docker_node() {
 	local subcommands="
-		accept
 		demote
 		inspect
 		ls list
@@ -1937,16 +1925,6 @@ _docker_node() {
 		*)
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
 			;;
-	esac
-}
-
-_docker_node_accept() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_nodes --id --filter membership=pending
 	esac
 }
 
@@ -2072,10 +2050,6 @@ _docker_node_update() {
 			COMPREPLY=( $( compgen -W "active drain pause" -- "$cur" ) )
 			return
 			;;
-		--membership)
-			COMPREPLY=( $( compgen -W "accepted rejected" -- "$cur" ) )
-			return
-			;;
 		--role)
 			COMPREPLY=( $( compgen -W "manager worker" -- "$cur" ) )
 			return
@@ -2087,7 +2061,7 @@ _docker_node_update() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--availability --help --label-add --label-rm --membership --role" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--availability --help --label-add --label-rm --role" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -782,7 +782,6 @@ __docker_complete_worker_nodes() {
 __docker_node_commands() {
     local -a _docker_node_subcommands
     _docker_node_subcommands=(
-        "accept:Accept a node in the swarm"
         "demote:Demote a node as manager in the swarm"
         "inspect:Display detailed information on one or more nodes"
         "ls:List nodes in the swarm"
@@ -802,7 +801,7 @@ __docker_node_subcommand() {
     opts_help=("(: -)--help[Print usage]")
 
     case "$words[1]" in
-        (accept|rm|remove)
+        (rm|remove)
              _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -)*:node:__docker_complete_pending_nodes" && ret=0
@@ -854,7 +853,6 @@ __docker_node_subcommand() {
                 "($help)--availability=[Availability of the node]:availability:(active pause drain)" \
                 "($help)*--label-add=[Add or update a node label]:key=value: " \
                 "($help)*--label-rm=[Remove a node label if exists]:label: " \
-                "($help)--membership=[Membership of the node]:membership:(accepted rejected)" \
                 "($help)--role=[Role of the node]:role:(manager worker)" \
                 "($help -)1:node:__docker_complete_nodes" && ret=0
             ;;
@@ -1205,11 +1203,9 @@ __docker_swarm_subcommand() {
         (init)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help)--auto-accept=[Acceptance policy]:policy:(manager none worker)" \
                 "($help)*--external-ca=[Specifications of one or more certificate signing endpoints]:endpoint: " \
                 "($help)--force-new-cluster[Force create a new cluster from current state]" \
-                "($help)--listen-addr[Listen address]:ip\:port: " \
-                "($help)--secret[Set secret value needed to accept nodes into cluster]:secret: " && ret=0
+                "($help)--listen-addr=[Listen address]:ip\:port: " && ret=0
             ;;
         (inspect)
             _arguments $(__docker_arguments) \
@@ -1219,10 +1215,8 @@ __docker_swarm_subcommand() {
         (join)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help)--ca-hash=[Hash of the Root Certificate Authority certificate used for trusted join]:hash: " \
-                "($help)--listen-addr[Listen address]:ip\:port: " \
-                "($help)--manager[Try joining as a manager]" \
-                "($help)--secret[Secret for node acceptance]:secret: " \
+                "($help)--listen-addr=[Listen address]:ip\:port: " \
+                "($help)--token=[Token for entry into the swarm]:secret: " \
                 "($help -):host\:port: " && ret=0
             ;;
         (leave)
@@ -1232,11 +1226,9 @@ __docker_swarm_subcommand() {
         (update)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help)--auto-accept=[Acceptance policy]:policy:(manager none worker)" \
                 "($help)--cert-expiry=[Validity period for node certificates]:duration: " \
                 "($help)--dispatcher-heartbeat=[Dispatcher heartbeat period]:duration: " \
-                "($help)--secret[Set secret value needed to accept nodes into cluster]:secret: " \
-                "($help)--task-history-limit[Task history retention limit]:limit: " && ret=0
+                "($help)--task-history-limit=[Task history retention limit]:limit: " && ret=0
             ;;
         (help)
             _arguments $(__docker_arguments) ":subcommand:__docker_network_commands" && ret=0


### PR DESCRIPTION
Swarm join has been changed in f5e1f6f6880391a5a3399023cf93a3c48502e57d (https://github.com/docker/docker/pull/24823), removing various options and the "node accept" command.

This removes the removed options from the completion scripts.

NOTE: a new command (`docker swarm join-token`) was also added, but is not part of this commit.

ping @albers @sdurrheimer PTAL
