### PR TITLE
Change "rotate_worker_token" to "rotateWorkerToken"

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -67,11 +67,23 @@ func (sr *swarmRouter) updateCluster(ctx context.Context, w http.ResponseWriter,
 	}
 
 	var flags types.UpdateFlags
-	if r.URL.Query().Get("rotate_worker_token") == "true" {
-		flags.RotateWorkerToken = true
+
+	if value := r.URL.Query().Get("rotateWorkerToken"); value != "" {
+		rot, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for rotateWorkerToken: %s", value)
+		}
+
+		flags.RotateWorkerToken = rot
 	}
-	if r.URL.Query().Get("rotate_manager_token") == "true" {
-		flags.RotateManagerToken = true
+
+	if value := r.URL.Query().Get("rotateManagerToken"); value != "" {
+		rot, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for rotateManagerToken: %s", value)
+		}
+
+		flags.RotateManagerToken = rot
 	}
 
 	if err := sr.backend.Update(version, swarm, flags); err != nil {

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3755,8 +3755,8 @@ Update a Swarm
 
 - **version** – The version number of the swarm object being updated. This is
   required to avoid conflicting writes.
-- **rotate_worker_token** - Set to `true` to rotate the worker join token.
-- **rotate_manager_token** - Set to `true` to rotate the manager join token.
+- **rotateWorkerToken** - Set to `true` (or `1`) to rotate the worker join token.
+- **rotateManagerToken** - Set to `true` (or `1`) to rotate the manager join token.
 
 **Status codes**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3756,8 +3756,8 @@ Update a Swarm
 
 - **version** – The version number of the swarm object being updated. This is
   required to avoid conflicting writes.
-- **rotate_worker_token** - Set to `true` to rotate the worker join token.
-- **rotate_manager_token** - Set to `true` to rotate the manager join token.
+- **rotateWorkerToken** - Set to `true` (or `1`) to rotate the worker join token.
+- **rotateManagerToken** - Set to `true` (or `1`) to rotate the manager join token.
 
 **Status codes**:
 

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
-clone git github.com/docker/engine-api c977588a28fa81fbbb06c295e936853cef37cf27
+clone git github.com/docker/engine-api ebb728a1346926edc2ad9418f9b6045901810b20
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -270,7 +270,7 @@ func (d *SwarmDaemon) rotateTokens(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &sw), checker.IsNil)
 
-	url := fmt.Sprintf("/swarm/update?version=%d&rotate_worker_token=true&rotate_manager_token=true", sw.Version.Index)
+	url := fmt.Sprintf("/swarm/update?version=%d&rotateWorkerToken=true&rotateManagerToken=true", sw.Version.Index)
 	status, out, err = d.SockRequest("POST", url, sw.Spec)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))

--- a/vendor/src/github.com/docker/engine-api/client/swarm_update.go
+++ b/vendor/src/github.com/docker/engine-api/client/swarm_update.go
@@ -13,8 +13,8 @@ import (
 func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	query.Set("rotate_worker_token", fmt.Sprintf("%v", flags.RotateWorkerToken))
-	query.Set("rotate_manager_token", fmt.Sprintf("%v", flags.RotateManagerToken))
+	query.Set("rotateWorkerToken", fmt.Sprintf("%v", flags.RotateWorkerToken))
+	query.Set("rotateManagerToken", fmt.Sprintf("%v", flags.RotateManagerToken))
 	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/src/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/src/github.com/docker/engine-api/types/events/events.go
@@ -3,14 +3,16 @@ package events
 const (
 	// ContainerEventType is the event type that containers generate
 	ContainerEventType = "container"
-	// ImageEventType is the event type that images generate
-	ImageEventType = "image"
-	// VolumeEventType is the event type that volumes generate
-	VolumeEventType = "volume"
-	// NetworkEventType is the event type that networks generate
-	NetworkEventType = "network"
 	// DaemonEventType is the event type that daemon generate
 	DaemonEventType = "daemon"
+	// ImageEventType is the event type that images generate
+	ImageEventType = "image"
+	// NetworkEventType is the event type that networks generate
+	NetworkEventType = "network"
+	// PluginEventType is the event type that plugins generate
+	PluginEventType = "plugin"
+	// VolumeEventType is the event type that volumes generate
+	VolumeEventType = "volume"
 )
 
 // Actor describes something that generates events,

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -282,7 +282,7 @@ type ExecStartCheck struct {
 type HealthcheckResult struct {
 	Start    time.Time // Start is the time this check started
 	End      time.Time // End is the time this check ended
-	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=starting, else=error running probe
+	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=reserved (considered unhealthy), else=error running probe
 	Output   string    // Output from last check
 }
 


### PR DESCRIPTION
This renames the `rotate_xxx` flags to camelBack, for consistency with other API query-params, such as `detachKeys`, `noOverwriteDirNonDir`, and `fromImage` (we're not always consistent, but at least trying to :blush:).

Also makes this flag accept a wider range of boolean values ("0", "1", "true", "false"), and throw an error if an invalid value is passed.

Relates to https://github.com/docker/docker/pull/24823, and needs an API and vendor update in engine-api if we want to do the rename.

Either direction is fine with me, just opening for consideration

ping @aaronlehmann @tiborvass 
