### PR TITLE
Windows: TestRunCleanupCmdOnEntrypoint for nanoserver

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1770,7 +1770,11 @@ func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 	out = strings.TrimSpace(out)
 	expected := "root"
 	if daemonPlatform == "windows" {
-		expected = `user manager\containeradministrator`
+		if WindowsBaseImage == "windowsservercore" {
+			expected = `user manager\containeradministrator`
+		} else {
+			expected = `ContainerAdministrator` // nanoserver
+		}
 	}
 	if out != expected {
 		c.Fatalf("Expected output %s, got %q", expected, out)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Another PR relating to https://github.com/docker/docker/pull/24853. On nanoserver, due to the APIs busybox uses, the result of `whoami` returns a differently formatted result. This allows this test to pass using both windowsservercore and nanoserver as the base image when running the integration-cli tests.

@thaJeztah :)
