### PR TITLE
Handle plugin shutdown when liveRestore is set.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -651,6 +651,9 @@ func (daemon *Daemon) Shutdown() error {
 	daemon.shutdown = true
 	// Keep mounts and networking running on daemon shutdown if
 	// we are to keep containers running and restore them.
+
+	pluginShutdown()
+
 	if daemon.configStore.LiveRestore && daemon.containers != nil {
 		// check if there are any running containers, if none we should do some cleanup
 		if ls, err := daemon.Containers(&types.ContainerListOptions{}); len(ls) != 0 || err != nil {
@@ -686,8 +689,6 @@ func (daemon *Daemon) Shutdown() error {
 			logrus.Errorf("Error during layer Store.Cleanup(): %v", err)
 		}
 	}
-
-	pluginShutdown()
 
 	if err := daemon.cleanupMounts(); err != nil {
 		return err

--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -74,8 +74,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithPluginDisabled(c *check.C) {
 	c.Assert(out, checker.Contains, "false")
 }
 
-// TestDaemonShutdownLiveRestoreWithPlugins leaves plugin running.
-func (s *DockerDaemonSuite) TestDaemonShutdownLiveRestoreWithPlugins(c *check.C) {
+// TestDaemonKillLiveRestoreWithPlugins SIGKILLs daemon started with --live-restore.
+// Plugins should continue to run.
+func (s *DockerDaemonSuite) TestDaemonKillLiveRestoreWithPlugins(c *check.C) {
 	if err := s.d.Start("--live-restore"); err != nil {
 		c.Fatalf("Could not start daemon: %v", err)
 	}
@@ -95,6 +96,37 @@ func (s *DockerDaemonSuite) TestDaemonShutdownLiveRestoreWithPlugins(c *check.C)
 	}()
 
 	if err := s.d.Kill(); err != nil {
+		c.Fatalf("Could not kill daemon: %v", err)
+	}
+
+	cmd := exec.Command("pgrep", "-f", "plugin-no-remove")
+	if out, ec, err := runCommandWithOutput(cmd); ec != 0 {
+		c.Fatalf("Expected exit code '0', got %d err: %v output: %s ", ec, err, out)
+	}
+}
+
+// TestDaemonShutdownLiveRestoreWithPlugins SIGTERMs daemon started with --live-restore.
+// Plugins should continue to run.
+func (s *DockerDaemonSuite) TestDaemonShutdownLiveRestoreWithPlugins(c *check.C) {
+	if err := s.d.Start("--live-restore"); err != nil {
+		c.Fatalf("Could not start daemon: %v", err)
+	}
+	if out, err := s.d.Cmd("plugin", "install", "--grant-all-permissions", pluginName); err != nil {
+		c.Fatalf("Could not install plugin: %v %s", err, out)
+	}
+	defer func() {
+		if err := s.d.Restart("--live-restore"); err != nil {
+			c.Fatalf("Could not restart daemon: %v", err)
+		}
+		if out, err := s.d.Cmd("plugin", "disable", pluginName); err != nil {
+			c.Fatalf("Could not disable plugin: %v %s", err, out)
+		}
+		if out, err := s.d.Cmd("plugin", "remove", pluginName); err != nil {
+			c.Fatalf("Could not remove plugin: %v %s", err, out)
+		}
+	}()
+
+	if err := s.d.cmd.Process.Signal(os.Interrupt); err != nil {
 		c.Fatalf("Could not kill daemon: %v", err)
 	}
 

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -319,7 +319,7 @@ func (pm *Manager) init() error {
 			if requiresManualRestore {
 				// if liveRestore is not enabled, the plugin will be stopped now so we should enable it
 				if err := pm.enable(p); err != nil {
-					logrus.Errorf("Error restoring plugin '%s': %s", p.Name(), err)
+					logrus.Errorf("Error enabling plugin '%s': %s", p.Name(), err)
 				}
 			}
 		}(p)


### PR DESCRIPTION
When daemon has liveRestore set, daemon shutdown should not shutdown
plugins. Fixes #24759

Signed-off-by: Anusha Ragunathan anusha@docker.com
