### PR TITLE
Windows: nanoserver TestBuildCmdShellArgsEscaped

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6947,10 +6947,9 @@ func (s *DockerSuite) TestBuildShellWindowsPowershell(c *check.C) {
 func (s *DockerSuite) TestBuildCmdShellArgsEscaped(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildcmdshellescaped"
-
 	_, err := buildImage(name, `
   FROM `+minimalBaseImage()+`
-  CMD "tasklist"
+  CMD "ipconfig"
   `, true)
 	if err != nil {
 		c.Fatal(err)
@@ -6963,7 +6962,7 @@ func (s *DockerSuite) TestBuildCmdShellArgsEscaped(c *check.C) {
 	dockerCmd(c, "wait", "inspectme")
 	res = inspectFieldJSON(c, name, "Config.Cmd")
 
-	if res != `["cmd","/S","/C","\"tasklist\""]` {
+	if res != `["cmd","/S","/C","\"ipconfig\""]` {
 		c.Fatalf("CMD was not escaped Config.Cmd: got %v", res)
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Final one (for now :innocent: ) relating to https://github.com/docker/docker/pull/24853. Tasklist isn't available in nanoserver either. Just use any parameter-less binary which is common between nanoserver and grown-up server. 

With this change and the others that have been merged, I've had a successful internal full CI pass using nanoserver, but not remotely close yet unfortunately for public use - a lot more work to do outside of docker.

@thaJeztah 
