### PR TITLE
api/client/service: default update parallelism to 1

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -16,11 +16,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// DefaultReplicas is the default replicas to use for a replicated service
-	DefaultReplicas uint64 = 1
-)
-
 type int64Value interface {
 	Value() int64
 }
@@ -501,7 +496,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.restartPolicy.maxAttempts, flagRestartMaxAttempts, "Maximum number of restarts before giving up")
 	flags.Var(&opts.restartPolicy.window, flagRestartWindow, "Window used to evaluate the restart policy")
 
-	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 0, "Maximum number of tasks updated simultaneously")
+	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 1, "Maximum number of tasks updated simultaneously (0 to update all at once)")
 	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates")
 
 	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, "", "Endpoint mode (vip or dnsrr)")


### PR DESCRIPTION
When updates happen, the current behavior is to kill all running
instances and dispatch new tasks. Common use cases for container updates
involve small numbers of containers, meaning the app will go down on
most updates. Setting parallelism to 1 ensures that at most one task
will go down during the update. Services with higher replica counts can
increase this number accordingly to meet their needs.

Partially addresses #24447.

cc @thaJeztah @tiborvass @aaronlehmann @aluzzardi 

Signed-off-by: Stephen J Day stephen.day@docker.com
