### PR TITLE
Fix regression on --link on bridge network

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -177,11 +177,12 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container) ([]lib
 	// Legacy Link feature is supported only for the default bridge network.
 	// return if this call to build join options is not for default bridge network
 	// Legacy Link is only supported by docker run --link
-	if _, ok := container.NetworkSettings.Networks[defaultNetName]; !container.HostConfig.NetworkMode.IsDefault() || !ok {
+	bridgeSettings, ok := container.NetworkSettings.Networks[defaultNetName]
+	if !ok {
 		return sboxOptions, nil
 	}
 
-	if container.NetworkSettings.Networks[defaultNetName].EndpointID == "" {
+	if bridgeSettings.EndpointID == "" {
 		return sboxOptions, nil
 	}
 
@@ -209,7 +210,6 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container) ([]lib
 		}
 	}
 
-	bridgeSettings := container.NetworkSettings.Networks[defaultNetName]
 	for alias, parent := range daemon.parents(container) {
 		if daemon.configStore.DisableBridge || !container.HostConfig.NetworkMode.IsPrivate() {
 			continue


### PR DESCRIPTION
Fixes #24944

```
$ docker run -d --name test busybox top
34e5809d1f8ae711623c12670facb168a06220cc10d1a5012619ab576a6afa6e
$ docker run --rm --link test busybox grep test /etc/hosts
172.17.0.2  test 34e5809d1f8a
$ docker run --rm --link test --net default busybox grep test /etc/hosts
172.17.0.2  test 34e5809d1f8a
$ docker run --rm --link test --net bridge busybox grep test /etc/hosts
172.17.0.2  test 34e5809d1f8a
$
```

Signed-off-by: Alessandro Boch aboch@docker.com
