### PR TITLE
Update --update-parallelism docs

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -40,7 +40,7 @@ Options:
       --restart-window value         Window used to evaluate the restart policy (default none)
       --stop-grace-period value      Time to wait before force killing a container (default none)
       --update-delay duration        Delay between updates
-      --update-parallelism uint      Maximum number of tasks updated simultaneously
+      --update-parallelism uint      Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                  Username or UID
       --with-registry-auth           Send registry authentication details to Swarm agents
   -w, --workdir string               Working directory inside the container

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -47,7 +47,7 @@ Options:
       --restart-window value         Window used to evaluate the restart policy (default none)
       --stop-grace-period value      Time to wait before force killing a container (default none)
       --update-delay duration        Delay between updates
-      --update-parallelism uint      Maximum number of tasks updated simultaneously
+      --update-parallelism uint      Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                  Username or UID
       --with-registry-auth           Send registry authentication details to Swarm agents
   -w, --workdir string               Working directory inside the container

--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -41,7 +41,7 @@ run your manager node. For example, the tutorial uses a machine named
 update](rolling-update.md) tutorial, start it now:
 
     ```bash
-    $ docker service create --replicas 3 --name redis --update-delay 10s --update-parallelism 1 redis:3.0.6
+    $ docker service create --replicas 3 --name redis --update-delay 10s redis:3.0.6
 
     c5uo6kdmzpon37mgj9mwglcfw
     ```


### PR DESCRIPTION
Update documentation to account for the changes in #24952.

docs/swarm/swarm-tutorial/rolling-update.md doesn't need any changes,
but the CLI reference pages should show the current help text.
drain-node.md no longer needs to specify --update-parallelism 1 in its
example.

ping @stevvooe @sfsmithcha
