### PR TITLE
Windows: Restore console mode on set mode failure

### DIFF
--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -44,9 +44,11 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 		if err = winterm.SetConsoleMode(fd, mode|enableVirtualTerminalInput); err != nil {
 			emulateStdin = true
 		} else {
-			winterm.SetConsoleMode(fd, mode)
 			vtInputSupported = true
 		}
+		// Unconditionally set the console mode back even on failure because SetConsoleMode
+		// remembers invalid bits on input handles.
+		winterm.SetConsoleMode(fd, mode)
 	}
 
 	fd = os.Stdout.Fd()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

SetConsoleMode() on input handles appears to remember invalid bits that were set, causing problems for other programs (such as xcopy.exe) trying to set the console mode after docker.exe has exited. Always restore the input console mode on set failure.

fixes #24880 

I think this is important to make into 1.12, as it causes very unintuitive errors on subsequent applications run after docker.exe.

**\- How I did it**

Restore console mode on both success and failure to set the virtual terminal bit.

**\- How to verify it**

On Windows 10 run:

With fix:

```
C:\Windows\system32>docker
...

C:\Windows\system32>xcopy
Invalid number of parameters
0 File(s) copied
```

Without fix:

```
C:\Windows\system32>docker
...

C:\Windows\system32>xcopy

(silently returns without attempting to copy)
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix bug that caused xcopy (and other applications) to fail after docker.exe was run #24880

/cc @jhowardmsft @jstarks 
