### PR TITLE
daemon: no map[string]bool from GetNetworkDriverList

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -175,12 +175,7 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 	var pluginsInfo types.PluginsInfo
 
 	pluginsInfo.Volume = volumedrivers.GetDriverList()
-
-	networkDriverList := daemon.GetNetworkDriverList()
-	for nd := range networkDriverList {
-		pluginsInfo.Network = append(pluginsInfo.Network, nd)
-	}
-
+	pluginsInfo.Network = daemon.GetNetworkDriverList()
 	pluginsInfo.Authorization = daemon.configStore.AuthorizationPlugins
 
 	return pluginsInfo

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -328,21 +329,25 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 
 // GetNetworkDriverList returns the list of plugins drivers
 // registered for network.
-func (daemon *Daemon) GetNetworkDriverList() map[string]bool {
-	pluginList := make(map[string]bool)
+func (daemon *Daemon) GetNetworkDriverList() []string {
+	pluginList := []string{}
+	pluginMap := make(map[string]bool)
 
 	if !daemon.NetworkControllerEnabled() {
 		return nil
 	}
-	c := daemon.netController
-	networks := c.Networks()
+	networks := daemon.netController.Networks()
 
 	for _, network := range networks {
-		driver := network.Type()
-		pluginList[driver] = true
+		if !pluginMap[network.Type()] {
+			pluginList = append(pluginList, network.Type())
+			pluginMap[network.Type()] = true
+		}
 	}
 	// TODO : Replace this with proper libnetwork API
-	pluginList["overlay"] = true
+	pluginList = append(pluginList, "overlay")
+
+	sort.Strings(pluginList)
 
 	return pluginList
 }


### PR DESCRIPTION
No user of `GetNetworkDriverList` needs to access the map by key.
The only user of `GetNetworkDriverList` is in `docker info` and with a map
the network list is always flipping because loop is not deterministic.
Fix this by returning a string slice which instead is.

Signed-off-by: Antonio Murdaca runcom@redhat.com
