### PR TITLE
Update swarm init task-history-limit docs

### DIFF
--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -23,7 +23,7 @@ Options:
       --force-new-cluster               Force create a new cluster from current state.
       --help                            Print usage
       --listen-addr value               Listen address (default 0.0.0.0:2377)
-      --task-history-limit int          Task history retention limit (default 10)
+      --task-history-limit int          Task history retention limit (default 5)
 ```
 
 Initialize a swarm cluster. The docker engine targeted by this command becomes a manager

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -21,7 +21,7 @@ Options:
       --dispatcher-heartbeat duration   Dispatcher heartbeat period (default 5s)
       --external-ca value               Specifications of one or more certificate signing endpoints
       --help                            Print usage
-      --task-history-limit int          Task history retention limit (default 10)
+      --task-history-limit int          Task history retention limit (default 5)
 ```
 
 Updates a swarm cluster with new parameter values. This command must target a manager node.


### PR DESCRIPTION
Follow-up of #24957, updates `swarm_init.md` and `swarm_update.md` with new default task retention limit 👼

/cc @thaJeztah @aaronlehmann @aluzzardi 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
