### PR TITLE
Fix restoring behavior when live-restore is not set

### DIFF
--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -343,7 +343,7 @@ func (clnt *client) newContainer(dir string, options ...CreateOption) *container
 	}
 	for _, option := range options {
 		if err := option.Apply(container); err != nil {
-			logrus.Error(err)
+			logrus.Errorf("libcontainerd: newContainer(): %v", err)
 		}
 	}
 	return container
@@ -391,7 +391,7 @@ func (clnt *client) restore(cont *containerd.Container, lastEvent *containerd.Ev
 	clnt.lock(cont.Id)
 	defer clnt.unlock(cont.Id)
 
-	logrus.Debugf("restore container %s state %s", cont.Id, cont.Status)
+	logrus.Debugf("libcontainerd: restore container %s state %s", cont.Id, cont.Status)
 
 	containerID := cont.Id
 	if _, err := clnt.getContainer(containerID); err == nil {
@@ -445,7 +445,7 @@ func (clnt *client) restore(cont *containerd.Container, lastEvent *containerd.Ev
 				}})
 		}
 
-		logrus.Warnf("unexpected backlog event: %#v", lastEvent)
+		logrus.Warnf("libcontainerd: unexpected backlog event: %#v", lastEvent)
 	}
 
 	return nil
@@ -526,7 +526,7 @@ func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 	// container is still alive
 	if clnt.liveRestore {
 		if err := clnt.restore(cont, ev, options...); err != nil {
-			logrus.Errorf("error restoring %s: %v", containerID, err)
+			logrus.Errorf("libcontainerd: error restoring %s: %v", containerID, err)
 		}
 		return nil
 	}
@@ -542,12 +542,12 @@ func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 	container.discardFifos()
 
 	if err := clnt.Signal(containerID, int(syscall.SIGTERM)); err != nil {
-		logrus.Errorf("error sending sigterm to %v: %v", containerID, err)
+		logrus.Errorf("libcontainerd: error sending sigterm to %v: %v", containerID, err)
 	}
 	select {
 	case <-time.After(10 * time.Second):
 		if err := clnt.Signal(containerID, int(syscall.SIGKILL)); err != nil {
-			logrus.Errorf("error sending sigkill to %v: %v", containerID, err)
+			logrus.Errorf("libcontainerd: error sending sigkill to %v: %v", containerID, err)
 		}
 		select {
 		case <-time.After(2 * time.Second):

--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -544,6 +544,8 @@ func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 	if err := clnt.Signal(containerID, int(syscall.SIGTERM)); err != nil {
 		logrus.Errorf("libcontainerd: error sending sigterm to %v: %v", containerID, err)
 	}
+	// Let the main loop handle the exit event
+	clnt.remote.Unlock()
 	select {
 	case <-time.After(10 * time.Second):
 		if err := clnt.Signal(containerID, int(syscall.SIGKILL)); err != nil {
@@ -552,9 +554,13 @@ func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 		select {
 		case <-time.After(2 * time.Second):
 		case <-w.wait():
+			// relock because of the defer
+			clnt.remote.Lock()
 			return nil
 		}
 	case <-w.wait():
+		// relock because of the defer
+		clnt.remote.Lock()
 		return nil
 	}
 

--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -141,7 +141,7 @@ func (r *remote) handleConnectionChange() {
 			break
 		}
 		state = s
-		logrus.Debugf("containerd connection state change: %v", s)
+		logrus.Debugf("libcontainerd: containerd connection state change: %v", s)
 
 		if r.daemonPid != -1 {
 			switch state {
@@ -155,7 +155,7 @@ func (r *remote) handleConnectionChange() {
 					}
 					<-r.daemonWaitCh
 					if err := r.runContainerdDaemon(); err != nil { //FIXME: Handle error
-						logrus.Errorf("error restarting containerd: %v", err)
+						logrus.Errorf("libcontainerd: error restarting containerd: %v", err)
 					}
 				} else {
 					state = grpc.Idle
@@ -290,12 +290,12 @@ func (r *remote) handleEventStream(events containerd.API_EventsClient) {
 				// ignore error if grpc remote connection is closed manually
 				return
 			}
-			logrus.Errorf("failed to receive event from containerd: %v", err)
+			logrus.Errorf("libcontainerd: failed to receive event from containerd: %v", err)
 			go r.startEventsMonitor()
 			return
 		}
 
-		logrus.Debugf("received containerd event: %#v", e)
+		logrus.Debugf("libcontainerd: received containerd event: %#v", e)
 
 		var container *container
 		var c *client
@@ -347,7 +347,7 @@ func (r *remote) runContainerdDaemon() error {
 			return err
 		}
 		if utils.IsProcessAlive(int(pid)) {
-			logrus.Infof("previous instance of containerd still alive (%d)", pid)
+			logrus.Infof("libcontainerd: previous instance of containerd still alive (%d)", pid)
 			r.daemonPid = int(pid)
 			return nil
 		}
@@ -385,7 +385,7 @@ func (r *remote) runContainerdDaemon() error {
 			args = append(args, "--runtime-args")
 			args = append(args, v)
 		}
-		logrus.Debugf("runContainerdDaemon: runtimeArgs: %s", args)
+		logrus.Debugf("libcontainerd: runContainerdDaemon: runtimeArgs: %s", args)
 	}
 
 	cmd := exec.Command(containerdBinary, args...)
@@ -403,7 +403,7 @@ func (r *remote) runContainerdDaemon() error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	logrus.Infof("New containerd process, pid: %d", cmd.Process.Pid)
+	logrus.Infof("libcontainerd: new containerd process, pid: %d", cmd.Process.Pid)
 	if err := setOOMScore(cmd.Process.Pid, r.oomScore); err != nil {
 		utils.KillProcess(cmd.Process.Pid)
 		return err


### PR DESCRIPTION
At the moment the daemon will not receive the "exit" event from `containerd` during the restore phase when `--live-restore` is not specified due to the event lock not being released after the kill signal has been sent.

This cause the starting time of the daemon after a crash/kill to be much longer than necessary.

This PR fixes the above problem.

I also took this opportunity to prepend `libcontainerd:` to all the relevant `logrus` call for faster debugging.
