### PR TITLE
Add live restore to info

### DIFF
--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -212,5 +212,8 @@ func runInfo(dockerCli *client.DockerCli) error {
 			fmt.Fprintf(dockerCli.Out(), " %s/%d\n", registry.IP.String(), mask)
 		}
 	}
+
+	fmt.Fprintf(dockerCli.Out(), "Live Restore Enabled: %v\n", info.LiveRestoreEnabled)
+
 	return nil
 }

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -72,7 +72,7 @@ func (cli *DaemonCli) getPlatformRemoteOptions() []libcontainerd.RemoteOption {
 		args := []string{"--systemd-cgroup=true"}
 		opts = append(opts, libcontainerd.WithRuntimeArgs(args))
 	}
-	if cli.Config.LiveRestore {
+	if cli.Config.LiveRestoreEnabled {
 		opts = append(opts, libcontainerd.WithLiveRestore(true))
 	}
 	opts = append(opts, libcontainerd.WithRuntimePath(daemon.DefaultRuntimeBinary))

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -94,7 +94,10 @@ type CommonConfig struct {
 	TrustKeyPath         string              `json:"-"`
 	CorsHeaders          string              `json:"api-cors-header,omitempty"`
 	EnableCors           bool                `json:"api-enable-cors,omitempty"`
-	LiveRestore          bool                `json:"live-restore,omitempty"`
+
+	// LiveRestoreEnabled determines whether we should keep containers
+	// alive upon daemon shutdown/start
+	LiveRestoreEnabled bool `json:"live-restore,omitempty"`
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
 	// multihost networking (to store networks and endpoints information) and by the node discovery

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -87,7 +87,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))
 	cmd.StringVar(&config.RemappedRoot, []string{"-userns-remap"}, "", usageFn("User/Group setting for user namespaces"))
 	cmd.StringVar(&config.ContainerdAddr, []string{"-containerd"}, "", usageFn("Path to containerd socket"))
-	cmd.BoolVar(&config.LiveRestore, []string{"-live-restore"}, false, usageFn("Enable live restore of docker when containers are still running"))
+	cmd.BoolVar(&config.LiveRestoreEnabled, []string{"-live-restore"}, false, usageFn("Enable live restore of docker when containers are still running"))
 	config.Runtimes = make(map[string]types.Runtime)
 	cmd.Var(runconfigopts.NewNamedRuntimeOpt("runtimes", &config.Runtimes, stockRuntimeName), []string{"-add-runtime"}, usageFn("Register an additional OCI compatible runtime"))
 	cmd.StringVar(&config.DefaultRuntime, []string{"-default-runtime"}, stockRuntimeName, usageFn("Default OCI runtime for containers"))
@@ -133,7 +133,7 @@ func (config *Config) isSwarmCompatible() error {
 	if config.ClusterStore != "" || config.ClusterAdvertise != "" {
 		return fmt.Errorf("--cluster-store and --cluster-advertise daemon configurations are incompatible with swarm mode")
 	}
-	if config.LiveRestore {
+	if config.LiveRestoreEnabled {
 		return fmt.Errorf("--live-restore daemon configuration is incompatible with swarm mode")
 	}
 	return nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -658,7 +658,7 @@ func (daemon *Daemon) Shutdown() error {
 
 	pluginShutdown()
 
-	if daemon.configStore.LiveRestore && daemon.containers != nil {
+	if daemon.configStore.LiveRestoreEnabled && daemon.containers != nil {
 		// check if there are any running containers, if none we should do some cleanup
 		if ls, err := daemon.Containers(&types.ContainerListOptions{}); len(ls) != 0 || err != nil {
 			return nil
@@ -916,8 +916,8 @@ func (daemon *Daemon) Reload(config *Config) error {
 		daemon.configStore.Debug = config.Debug
 	}
 	if config.IsValueSet("live-restore") {
-		daemon.configStore.LiveRestore = config.LiveRestore
-		if err := daemon.containerdRemote.UpdateOptions(libcontainerd.WithLiveRestore(config.LiveRestore)); err != nil {
+		daemon.configStore.LiveRestoreEnabled = config.LiveRestoreEnabled
+		if err := daemon.containerdRemote.UpdateOptions(libcontainerd.WithLiveRestore(config.LiveRestoreEnabled)); err != nil {
 			return err
 		}
 
@@ -1076,7 +1076,7 @@ func (daemon *Daemon) networkOptions(dconfig *Config, activeSandboxes map[string
 	options = append(options, nwconfig.OptionLabels(dconfig.Labels))
 	options = append(options, driverOptions(dconfig)...)
 
-	if daemon.configStore != nil && daemon.configStore.LiveRestore && len(activeSandboxes) != 0 {
+	if daemon.configStore != nil && daemon.configStore.LiveRestoreEnabled && len(activeSandboxes) != 0 {
 		options = append(options, nwconfig.OptionActiveSandboxes(activeSandboxes))
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -951,6 +951,7 @@ func (daemon *Daemon) Reload(config *Config) error {
 
 	// We emit daemon reload event here with updatable configurations
 	attributes["debug"] = fmt.Sprintf("%t", daemon.configStore.Debug)
+	attributes["live-restore"] = fmt.Sprintf("%t", daemon.configStore.LiveRestoreEnabled)
 	attributes["cluster-store"] = daemon.configStore.ClusterStore
 	if daemon.configStore.ClusterOpts != nil {
 		opts, _ := json.Marshal(daemon.configStore.ClusterOpts)

--- a/daemon/daemon_experimental.go
+++ b/daemon/daemon_experimental.go
@@ -13,7 +13,7 @@ func (daemon *Daemon) verifyExperimentalContainerSettings(hostConfig *container.
 }
 
 func pluginInit(d *Daemon, cfg *Config, remote libcontainerd.Remote) error {
-	return plugin.Init(cfg.Root, remote, d.RegistryService, cfg.LiveRestore, d.LogPluginEvent)
+	return plugin.Init(cfg.Root, remote, d.RegistryService, cfg.LiveRestoreEnabled, d.LogPluginEvent)
 }
 
 func pluginShutdown() {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -117,6 +117,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		HTTPSProxy:         sockets.GetProxyEnv("https_proxy"),
 		NoProxy:            sockets.GetProxyEnv("no_proxy"),
 		SecurityOptions:    securityOptions,
+		LiveRestoreEnabled: daemon.configStore.LiveRestoreEnabled,
 	}
 
 	// TODO Windows. Refactor this more once sysinfo is refactored into

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -437,7 +437,7 @@ func (s *DockerDaemonSuite) TestDaemonEvents(c *check.C) {
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c))
 	c.Assert(err, checker.IsNil)
 
-	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, labels=[\"bar=foo\"], max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=runc:{docker-runc []})", daemonID, daemonName))
+	c.Assert(out, checker.Contains, fmt.Sprintf("daemon reload %s (cluster-advertise=, cluster-store=, cluster-store-opts={}, debug=true, default-runtime=runc, labels=[\"bar=foo\"], live-restore=false, max-concurrent-downloads=1, max-concurrent-uploads=5, name=%s, runtimes=runc:{docker-runc []})", daemonID, daemonName))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *check.C) {

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -33,6 +33,7 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Volume:",
 		"Network:",
 		"Security Options:",
+		"Live Restore Enabled:",
 	}
 
 	if DaemonIsLinux.Condition() {


### PR DESCRIPTION
This add the status of the `live-restore` settings to both `docker info` output and the `docker reload` event.
