### PR TITLE
Add format to stats

### DIFF
--- a/cli/command/container/stats_unit_test.go
+++ b/cli/command/container/stats_unit_test.go
@@ -1,35 +1,10 @@
 package container
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 )
-
-func TestDisplay(t *testing.T) {
-	c := &containerStats{
-		Name:             "app",
-		CPUPercentage:    30.0,
-		Memory:           100 * 1024 * 1024.0,
-		MemoryLimit:      2048 * 1024 * 1024.0,
-		MemoryPercentage: 100.0 / 2048.0 * 100.0,
-		NetworkRx:        100 * 1024 * 1024,
-		NetworkTx:        800 * 1024 * 1024,
-		BlockRead:        100 * 1024 * 1024,
-		BlockWrite:       800 * 1024 * 1024,
-		PidsCurrent:      1,
-	}
-	var b bytes.Buffer
-	if err := c.Display(&b); err != nil {
-		t.Fatalf("c.Display() gave error: %s", err)
-	}
-	got := b.String()
-	want := "app\t30.00%\t100 MiB / 2 GiB\t4.88%\t105 MB / 839 MB\t105 MB / 839 MB\t1\n"
-	if got != want {
-		t.Fatalf("c.Display() = %q, want %q", got, want)
-	}
-}
 
 func TestCalculBlockIO(t *testing.T) {
 	blkio := types.BlkioStats{

--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -1,0 +1,135 @@
+package formatter
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/docker/go-units"
+)
+
+const (
+	defaultStatsTableFormat    = "table {{.Container}}\t{{.CPUPrec}}\t{{.MemUsage}}\t{{.MemPrec}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}"
+	winDefaultStatsTableFormat = "table {{.Container}}\t{{.CPUPrec}}\t{{{.MemUsage}}\t{.NetIO}}\t{{.BlockIO}}"
+	emptyStatsTableFormat      = "Waiting for statistics..."
+
+	containerHeader  = "CONTAINER"
+	cpuPrecHeader    = "CPU %"
+	netIOHeader      = "NET I/O"
+	blockIOHeader    = "BLOCK I/O"
+	winMemPrecHeader = "PRIV WORKING SET"  // Used only on Window
+	memPrecHeader    = "MEM %"             // Used only on Linux
+	memUseHeader     = "MEM USAGE / LIMIT" // Used only on Linux
+	pidsHeader       = "PIDS"              // Used only on Linux
+)
+
+// ContainerStatsAttrs represents the statistics data collected from a container.
+type ContainerStatsAttrs struct {
+	Windows          bool
+	Name             string
+	CPUPercentage    float64
+	Memory           float64 // On Windows this is the private working set
+	MemoryLimit      float64 // Not used on Windows
+	MemoryPercentage float64 // Not used on Windows
+	NetworkRx        float64
+	NetworkTx        float64
+	BlockRead        float64
+	BlockWrite       float64
+	PidsCurrent      uint64 // Not used on Windows
+}
+
+// ContainerStats represents the containers statistics data.
+type ContainerStats struct {
+	Mu sync.RWMutex
+	ContainerStatsAttrs
+	Err error
+}
+
+// NewStatsFormat returns a format for rendering an CStatsContext
+func NewStatsFormat(source, osType string) Format {
+	if source == TableFormatKey {
+		if osType == "windows" {
+			return Format(winDefaultStatsTableFormat)
+		}
+		return Format(defaultStatsTableFormat)
+	}
+	return Format(source)
+}
+
+// NewContainerStats returns a new ContainerStats entity and sets in it the given name
+func NewContainerStats(name, osType string) *ContainerStats {
+	return &ContainerStats{
+		ContainerStatsAttrs: ContainerStatsAttrs{
+			Name:    name,
+			Windows: (osType == "windows"),
+		},
+	}
+}
+
+// ContainerStatsWrite renders the context for a list of containers statistics
+func ContainerStatsWrite(ctx Context, containerStats []*ContainerStats) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, cstats := range containerStats {
+			cstats.Mu.RLock()
+			cstatsAttrs := cstats.ContainerStatsAttrs
+			cstats.Mu.RUnlock()
+			containerStatsCtx := &containerStatsContext{
+				s: cstatsAttrs,
+			}
+			if err := format(containerStatsCtx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(&containerStatsContext{}, render)
+}
+
+type containerStatsContext struct {
+	HeaderContext
+	s ContainerStatsAttrs
+}
+
+func (c *containerStatsContext) Container() string {
+	c.AddHeader(containerHeader)
+	return c.s.Name
+}
+
+func (c *containerStatsContext) CPUPrec() string {
+	c.AddHeader(cpuPrecHeader)
+	return fmt.Sprintf("%.2f%%", c.s.CPUPercentage)
+}
+
+func (c *containerStatsContext) MemUsage() string {
+	c.AddHeader(memUseHeader)
+	if !c.s.Windows {
+		return fmt.Sprintf("%s / %s", units.BytesSize(c.s.Memory), units.BytesSize(c.s.MemoryLimit))
+	}
+	return fmt.Sprintf("-- / --")
+}
+
+func (c *containerStatsContext) MemPrec() string {
+	header := memPrecHeader
+	if c.s.Windows {
+		header = winMemPrecHeader
+	}
+	c.AddHeader(header)
+	return fmt.Sprintf("%.2f%%", c.s.MemoryPercentage)
+}
+
+func (c *containerStatsContext) NetIO() string {
+	c.AddHeader(netIOHeader)
+	return fmt.Sprintf("%s / %s", units.HumanSizeWithPrecision(c.s.NetworkRx, 3), units.HumanSizeWithPrecision(c.s.NetworkTx, 3))
+}
+
+func (c *containerStatsContext) BlockIO() string {
+	c.AddHeader(blockIOHeader)
+	return fmt.Sprintf("%s / %s", units.HumanSizeWithPrecision(c.s.BlockRead, 3), units.HumanSizeWithPrecision(c.s.BlockWrite, 3))
+}
+
+func (c *containerStatsContext) PIDs() string {
+	c.AddHeader(pidsHeader)
+	if !c.s.Windows {
+		return fmt.Sprintf("%d", c.s.PidsCurrent)
+	}
+	return fmt.Sprintf("-")
+}


### PR DESCRIPTION
**\- What I did**
I attempted to use the formatter API to display docker stats.
closes #20973 

**\- How I did it**
- Created types.ContainerStats, CStatsContext and containerStats structs
- Moved stats_helper's Display logic to CStatsContext's Write

**\- How to verify it**
`docker stats --format "{{.PIDs}}"`
