### PR TITLE
Fix AuthzPlugin URL fragment in docs

### DIFF
--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -141,11 +141,11 @@ docker: Error response from daemon: plugin PLUGIN_NAME failed with error: AuthZP
 In addition to Docker's standard plugin registration method, each plugin
 should implement the following two methods:
 
-* `/AuthzPlugin.AuthZReq` This authorize request method is called before the Docker daemon processes the client request.
+* `/AuthZPlugin.AuthZReq` This authorize request method is called before the Docker daemon processes the client request.
 
-* `/AuthzPlugin.AuthZRes` This authorize response method is called before the response is returned from Docker daemon to the client.
+* `/AuthZPlugin.AuthZRes` This authorize response method is called before the response is returned from Docker daemon to the client.
 
-#### /AuthzPlugin.AuthZReq
+#### /AuthZPlugin.AuthZReq
 
 **Request**:
 
@@ -169,7 +169,7 @@ should implement the following two methods:
     "Err":   "The error message if things go wrong"
 }
 ```
-#### /AuthzPlugin.AuthZRes
+#### /AuthZPlugin.AuthZRes
 
 **Request**:
 


### PR DESCRIPTION
These docs have AuthzPlugin with a lower case 'z'. What the plugin api is actually looking for is AuthZPlugin with an upper case 'Z'.

See https://github.com/docker/docker/blob/46e3a249a1971f8697ca338c9b02e27d36ddab12/pkg/authorization/api.go#L5-L8
