### PR TITLE
small nit: fix unmeaningful log

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -43,7 +43,6 @@ import (
 	"github.com/docker/docker/pkg/directory"
 	"github.com/docker/docker/pkg/idtools"
 	mountpk "github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/stringid"
 
 	"github.com/opencontainers/runc/libcontainer/label"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
@@ -492,7 +491,7 @@ func (a *Driver) Cleanup() error {
 
 	for _, m := range dirs {
 		if err := a.unmount(m); err != nil {
-			logrus.Debugf("aufs error unmounting %s: %s", stringid.TruncateID(m), err)
+			logrus.Debugf("aufs error unmounting %s: %s", m, err)
 		}
 	}
 	return mountpk.Unmount(a.root)


### PR DESCRIPTION
Truncated dir name can't give any useful information, print whole dir
name will.

Bad debug log is like this:

```
DEBU[2449] aufs error unmounting /var/lib/doc: no such file or directory 
DEBU[2449] aufs error unmounting /var/lib/doc: no such file or directory 
DEBU[2449] aufs error unmounting /var/lib/doc: no such file or directory 
DEBU[2449] aufs error unmounting /var/lib/doc: no such file or directory 
DEBU[2449] aufs error unmounting /var/lib/doc: no such file or directory
```

it fulfills log file but provides nothing meaningful.

ping @cpuguy83 , who last modified this line.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
