### PR TITLE
Add new error to API docs

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -121,7 +121,7 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 	}
 
 	if nw.Info().Dynamic() {
-		return newNetworkForbiddenError("Operation not supported for swarm scoped networks")
+		return newNetworkForbiddenError("operation not supported for swarm scoped networks")
 	}
 
 	return n.backend.ConnectContainerToNetwork(connect.Container, nw.Name(), connect.EndpointConfig)
@@ -147,7 +147,7 @@ func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.Respon
 	}
 
 	if nw.Info().Dynamic() {
-		return newNetworkForbiddenError("Operation not supported for swarm scoped networks")
+		return newNetworkForbiddenError("operation not supported for swarm scoped networks")
 	}
 
 	return n.backend.DisconnectContainerFromNetwork(disconnect.Container, nw, disconnect.Force)

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3259,6 +3259,7 @@ Content-Type: application/json
 **Status codes**:
 
 - **200** - no error
+- **403** - operation not supported for swarm scoped networks
 - **404** - network or container is not found
 - **500** - Internal Server Error
 
@@ -3291,6 +3292,7 @@ Content-Type: application/json
 **Status codes**:
 
 - **200** - no error
+- **403** - operation not supported for swarm scoped networks
 - **404** - network or container not found
 - **500** - Internal Server Error
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3260,6 +3260,7 @@ Content-Type: application/json
 **Status codes**:
 
 - **200** - no error
+- **403** - operation not supported for swarm scoped networks
 - **404** - network or container is not found
 - **500** - Internal Server Error
 
@@ -3292,6 +3293,7 @@ Content-Type: application/json
 **Status codes**:
 
 - **200** - no error
+- **403** - operation not supported for swarm scoped networks
 - **404** - network or container not found
 - **500** - Internal Server Error
 


### PR DESCRIPTION
Commit cc493a52a46271df82dbebea26038502b85788b9 (https://github.com/docker/docker/pull/24988) added
a constraint to network connect/disconnect operations
on "Swarm scoped" networks.

This adds those errors to the API documentation. Also
changes the error to lowercase for consistency.
