### PR TITLE
Fix plugin lock when restoring containers

### DIFF
--- a/pkg/locker/README.md
+++ b/pkg/locker/README.md
@@ -63,3 +63,23 @@ else is modfying it at the same time.
 Since name lock is already in place, no reads will occur while the modification
 is being performed.
 
+### CancelWithError
+
+CancelWithError manually set the error for the lock with the given name.
+Other goroutines who are waiting for the lock will get an error, instead of getting the lock.
+
+```go
+# In goroutine1
+locker.Lock("test")
+defer locker.Lock("test")
+locker.CancelWithError("test", errors.New("some error"))
+
+# In goroutine2, assuming that it runs after goroutine1 getting the lock
+if err := locker.Lock("test"); err != nil {
+  # goroutine1 called the CancelWithError when it was holding the lock,
+  # this Lock function will return that error, indicating that this lock action has been canceled.
+  # ... handle the error ...
+} else {
+  defer locker.Unlock("test")
+}
+```

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -92,7 +92,9 @@ func Unregister(name string) bool {
 // driver with the given name has not been registered it checks if
 // there is a VolumeDriver plugin available with the given name.
 func lookup(name string) (volume.Driver, error) {
-	drivers.driverLock.Lock(name)
+	if err := drivers.driverLock.Lock(name); err != nil {
+		return nil, fmt.Errorf("Error looking up volume plugin %s: %v", name, err)
+	}
 	defer drivers.driverLock.Unlock(name)
 
 	drivers.Lock()
@@ -104,6 +106,7 @@ func lookup(name string) (volume.Driver, error) {
 
 	p, err := plugin.LookupWithCapability(name, extName)
 	if err != nil {
+		drivers.driverLock.CancelWithError(name, err)
 		return nil, fmt.Errorf("Error looking up volume plugin %s: %v", name, err)
 	}
 

--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -309,16 +309,20 @@ func (s *VolumeStore) create(name, driverName string, opts, labels map[string]st
 // This makes sure there are no races between checking for the existence of a volume and adding a reference for it
 func (s *VolumeStore) GetWithRef(name, driverName, ref string) (volume.Volume, error) {
 	name = normaliseVolumeName(name)
-	s.locks.Lock(name)
+	if err := s.locks.Lock(name); err != nil {
+		return nil, &OpErr{Err: err, Name: name, Op: "get"}
+	}
 	defer s.locks.Unlock(name)
 
 	vd, err := volumedrivers.GetDriver(driverName)
 	if err != nil {
+		s.locks.CancelWithError(name, err)
 		return nil, &OpErr{Err: err, Name: name, Op: "get"}
 	}
 
 	v, err := vd.Get(name)
 	if err != nil {
+		s.locks.CancelWithError(name, err)
 		return nil, &OpErr{Err: err, Name: name, Op: "get"}
 	}
 


### PR DESCRIPTION
The problem occurs when starting `dockerd` with the containers using the
same unavailable plugin.
The containers are restored one-by-one, not asynchronous.
The dockerd needs to wait (N)*(8 secs) for restoring all the containers.
(N is the number of containers using the unavailable plugin.)
## How to reproduce

> Precondition: I have a `rbd-docker-plugin`, with a plugin name "rbd")

**Step 1.** Run the `rbd-docker-plugin` and the `dockerd`.
**Step 2.** Create 2 containers using plugin `rbd`.

```
docker create --name cont01 --volume-driver=rbd -v docker_volumes/web1:/aaa ubuntu:14.04     sleep 5
docker create --name cont02 --volume-driver=rbd -v docker_volumes/web1:/aaa ubuntu:14.04 sleep 5
```

**Step 3.** Stop `rbd-docker-plugin`.
**Step 4.** Restart `dockerd`. (Now dockerd is unable to connect plugin `rbd`)

Then, you will find the `dockerd` logs like this:

``` plain
WARN[0001] Unable to locate plugin: rbd, retrying in 1s
WARN[0002] Unable to locate plugin: rbd, retrying in 2s
WARN[0004] Unable to locate plugin: rbd, retrying in 4s
WARN[0008] Unable to locate plugin: rbd, retrying in 8s
ERRO[0016] get docker_volumes/web1: Error looking up volume plugin rbd: plugin not found
WARN[0016] Unable to locate plugin: rbd, retrying in 1s
WARN[0017] Unable to locate plugin: rbd, retrying in 2s
WARN[0019] Unable to locate plugin: rbd, retrying in 4s
WARN[0023] Unable to locate plugin: rbd, retrying in 8s
ERRO[0031] get docker_volumes/web1: Error looking up volume plugin rbd: plugin not found
```

Totally use 2 \* 16 seconds = 32 secs.
## Should be

Every container, who waits for the plugin, should start to wait at the same time, like this,

``` plain
WARN[0001] Unable to locate plugin: rbd, retrying in 1s
WARN[0002] Unable to locate plugin: rbd, retrying in 2s
WARN[0004] Unable to locate plugin: rbd, retrying in 4s
WARN[0008] Unable to locate plugin: rbd, retrying in 8s
ERRO[0016] get docker_volumes/web1: Error looking up volume plugin rbd: plugin not found
ERRO[0016] get docker_volumes/web1: Error looking up volume plugin rbd: plugin not found
```

Totally use 16 seconds.
## The cause

~~Though [daemon.prepareMountPoints(c)](https://github.com/docker/docker/blob/v1.12.0-rc4/daemon/daemon.go#L298-L303) runs in seperated goroutines,
containers are still initialized synchronously because it is blocked at
["GetWithRef"](https://github.com/docker/docker/blob/v1.12.0-rc4/volume/store/store.go#L319-L324).~~

When multiple goroutines call [`drivers.lookup`](https://github.com/docker/docker/blob/v1.12.0-rc4/volume/drivers/extpoint.go#L91-L123) for the same volume concurrently,
- There are 2 steps in `lookup` to initialize a volume driver.
  - **Step1.** Get the plugin by `plugin.LookupWithCapability(name, extName)`, put plugin into `storage.plugins[name]`
  - **Step2.** Put plugin into `drivers.extensions[name]`
- The wait loop (waits 16s) is in **Step1**. `lookup` holds a lock (for **Step1** + **Step2**) at the beginning, which is before **Step1**'s lock. So that the 2nd goroutine's **Step1** cannot go into its wait loop, Every goroutine's **Step1** becomes synchronous.
  - When the 2nd goroutine's **Step1** can run, it doesn't know this plugin with this "name" has failed before (in 1st goroutine)
  - The 2nd goroutine waits again, waits another 16s.
  - Totally, it becomes (N)*(16s).
## Here's the fixes
1. The 1st goroutine holds the lock
2. The 2nd, 3rd, ..., goroutines wait for the lock
3. If the 1st goroutine's **Step1** + **Step2** fails, it tells 2nd, 3rd, ..., other goroutines to return error, not to do **Step1** + **Step2** again.

~~Only after getting the volume driver successfully should the volume be locked by name.~~

~~There is no need to lock drivers when "lookup" a driver. Because
  ["lookup"](https://github.com/docker/docker/blob/v1.12.0-rc4/volume/drivers/extpoint.go#L91-L123) actually does a GetOrCreate thing. When it is doing
  [(pkg/plugins/plugins.go)get(name string)](https://github.com/docker/docker/blob/v1.12.0-rc4/pkg/plugins/plugins.go#L200-L202), there is already a lock to
  ensure the same plugin won't be registered twice. So we can remove
  the outer lock in "lookup". Nor, it will block the "prepareMountPoints".~~
