### PR TITLE
Remove extraneous mount cli aliases

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -178,12 +178,11 @@ func (m *MountOpt) Set(value string) error {
 		key := strings.ToLower(parts[0])
 
 		if len(parts) == 1 {
-			if key == "readonly" || key == "ro" {
+			switch key {
+			case "readonly", "ro":
 				mount.ReadOnly = true
 				continue
-			}
-
-			if key == "volume-nocopy" {
+			case "volume-nocopy":
 				volumeOptions().NoCopy = true
 				continue
 			}
@@ -197,16 +196,15 @@ func (m *MountOpt) Set(value string) error {
 		switch key {
 		case "type":
 			mount.Type = swarm.MountType(strings.ToLower(value))
-		case "source", "name", "src":
+		case "source", "src":
 			mount.Source = value
-		case "target", "dst", "dest", "destination", "path":
+		case "target", "dst", "destination":
 			mount.Target = value
 		case "readonly", "ro":
-			ro, err := strconv.ParseBool(value)
+			mount.ReadOnly, err = strconv.ParseBool(value)
 			if err != nil {
-				return fmt.Errorf("invalid value for readonly: %s", value)
+				return fmt.Errorf("invalid value for %s: %s", key, value)
 			}
-			mount.ReadOnly = ro
 		case "bind-propagation":
 			bindOptions().Propagation = swarm.MountPropagation(strings.ToLower(value))
 		case "volume-nocopy":

--- a/api/client/service/opts_test.go
+++ b/api/client/service/opts_test.go
@@ -81,8 +81,8 @@ func TestMountOptSetNoError(t *testing.T) {
 		// tests several aliases that should have same result.
 		"type=bind,target=/target,source=/source",
 		"type=bind,src=/source,dst=/target",
-		"type=bind,name=/source,dst=/target",
-		"type=bind,name=/source,path=/target",
+		"type=bind,source=/source,dst=/target",
+		"type=bind,src=/source,target=/target",
 	} {
 		var mount MountOpt
 


### PR DESCRIPTION
Follow up to #24872

Adding too many aliases makes the UX worse. Let's just add a couple that are shorter than the original values.
