### PR TITLE
Fix calculation of relative path for symlink on docker save

### DIFF
--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -307,7 +307,7 @@ func (s *saveSession) saveLayer(id layer.ChainID, legacyImg image.V1Image, creat
 	defer layer.ReleaseAndLog(s.ls, l)
 
 	if oldPath, exists := s.diffIDPaths[l.DiffID()]; exists {
-		relPath, err := filepath.Rel(layerPath, oldPath)
+		relPath, err := filepath.Rel(outDir, oldPath)
 		if err != nil {
 			return distribution.Descriptor{}, err
 		}


### PR DESCRIPTION
Relative paths are now calculated from a base path rather than from the file path, which gets treated as a directory. Symlinks will now properly point to the file as `../<layer dir>/layer.tar` rather the incorrect `../../<layer dir>/layer.tar`.

Fixes #24951
