### PR TITLE
swarm/controller: allow cancellation to propagate

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -87,6 +87,11 @@ func (r *controller) Prepare(ctx context.Context) error {
 
 	if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" {
 		if err := r.adapter.pullImage(ctx); err != nil {
+			cause := errors.Cause(err)
+			if cause == context.Canceled || cause == context.DeadlineExceeded {
+				return err
+			}
+
 			// NOTE(stevvooe): We always try to pull the image to make sure we have
 			// the most up to date version. This will return an error, but we only
 			// log it. If the image truly doesn't exist, the create below will

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -40,7 +40,11 @@ type fallbackError struct {
 
 // Error renders the FallbackError as a string.
 func (f fallbackError) Error() string {
-	return f.err.Error()
+	return f.Cause().Error()
+}
+
+func (f fallbackError) Cause() error {
+	return f.err
 }
 
 // shouldV2Fallback returns true if this error is a reason to fall back to v1.


### PR DESCRIPTION
Ensure that cancellation of a pull propagates rather than continuing to
container creation. This ensures that the `Prepare` method is properly
re-entrant.

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @aluzzardi @aaronlehmann 

Addresses aspects of #24447.
