### PR TITLE
Check for plugin state before enabling plugin.

### DIFF
--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -68,3 +68,24 @@ func (s *DockerSuite) TestPluginInstallImage(c *check.C) {
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, "content is not a plugin")
 }
+
+func (s *DockerSuite) TestPluginEnableDisableNegative(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
+	out, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", pName)
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Contains, pName)
+
+	out, _, err = dockerCmdWithError("plugin", "enable", pName)
+	c.Assert(err, checker.NotNil)
+	c.Assert(strings.TrimSpace(out), checker.Contains, "already enabled")
+
+	_, _, err = dockerCmdWithError("plugin", "disable", pName)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err = dockerCmdWithError("plugin", "disable", pName)
+	c.Assert(err, checker.NotNil)
+	c.Assert(strings.TrimSpace(out), checker.Contains, "already disabled")
+
+	_, _, err = dockerCmdWithError("plugin", "remove", pName)
+	c.Assert(err, checker.IsNil)
+}


### PR DESCRIPTION
This prevents unnecessary API call to containerd.

Signed-off-by: Anusha Ragunathan anusha@docker.com
