### PR TITLE
Vendoring libnetwork to remove stale xfrm states

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -65,7 +65,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 6a3feece4ede9473439f0c835a13e666dc2ab857
+clone git github.com/docker/libnetwork c7dc6dc476a5f00f9b28efebe591347dd64264fc
 clone git github.com/docker/go-events afb2b9f2c23f33ada1a22b03651775fdc65a5089
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/encryption.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/encryption.go
@@ -95,7 +95,7 @@ func (d *driver) checkEncryption(nid string, rIP net.IP, vxlanID uint32, isLocal
 	switch {
 	case isLocal:
 		if err := d.peerDbNetworkWalk(nid, func(pKey *peerKey, pEntry *peerEntry) bool {
-			if !lIP.Equal(pEntry.vtep) {
+			if !aIP.Equal(pEntry.vtep) {
 				nodes[pEntry.vtep.String()] = pEntry.vtep
 			}
 			return false
@@ -488,7 +488,7 @@ func updateNodeKey(lIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx,
 
 	if delIdx != -1 {
 		// -rSA0
-		programSA(rIP, lIP, spis[delIdx], nil, reverse, false)
+		programSA(lIP, rIP, spis[delIdx], nil, reverse, false)
 	}
 
 	if newIdx > -1 {


### PR DESCRIPTION
When using encrypted vxlan network, some of the xfrm states were left stale and this fix will clean them up.

This fix also filters out self advertise-addr rules.

Signed-off-by: Madhu Venugopal madhu@docker.com
