### PR TITLE
fix a potential error in the `pkg/plugins/discovery.go`

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -45,7 +45,7 @@ func Scan() ([]string, error) {
 
 	for _, path := range specsPaths {
 		if err := filepath.Walk(path, func(p string, fi os.FileInfo, err error) error {
-			if err != nil || fi.IsDir() {
+			if err != nil || (fi != nil && fi.IsDir()) {
 				return nil
 			}
 			name := strings.TrimSuffix(fi.Name(), filepath.Ext(fi.Name()))


### PR DESCRIPTION
**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**
I modify  `if err != nil || fi.IsDir()` to  `if err != nil || (fi != nil && fi.IsDir())`

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
