### PR TITLE
Fix untag without force while container running

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -76,7 +76,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		// first. We can only remove this reference if either force is
 		// true, there are multiple repository references to this
 		// image, or there are no containers using the given reference.
-		if !(force || len(repoRefs) > 1) {
+		if !force && isSingleReference(repoRefs) {
 			if container := daemon.getContainerUsingImage(imgID); container != nil {
 				// If we removed the repository reference then
 				// this image would remain "dangling" and since


### PR DESCRIPTION
With digests being added by default, all images have multiple references. The check for whether force is required to remove the reference should use the new check for single reference which accounts for digest references. This change restores pre-1.12 behavior and ensures images are not accidentally left dangling while a container is running.

Ping @aaronlehmann, thanks for catching this regression

I will look into adding an integration test for this case, I had thought the force flag tests was already covering this case.
