### PR TITLE
Fix issue with test ordering for TestParseWords

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -36,18 +36,18 @@ type Node struct {
 	EndLine    int             // the line in the original dockerfile where the node ends
 }
 
+const defaultTokenEscape = "\\"
+
 var (
 	dispatch              map[string]func(string) (*Node, map[string]bool, error)
 	tokenWhitespace       = regexp.MustCompile(`[\t\v\f\r ]+`)
 	tokenLineContinuation *regexp.Regexp
-	tokenEscape           rune
+	tokenEscape           = rune(defaultTokenEscape[0])
 	tokenEscapeCommand    = regexp.MustCompile(`^#[ \t]*escape[ \t]*=[ \t]*(?P<escapechar>.).*$`)
 	tokenComment          = regexp.MustCompile(`^#.*$`)
 	lookingForDirectives  bool
 	directiveEscapeSeen   bool
 )
-
-const defaultTokenEscape = "\\"
 
 // setTokenEscape sets the default token for escaping characters in a Dockerfile.
 func setTokenEscape(s string) error {

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -121,11 +121,11 @@ func TestParseWords(t *testing.T) {
 	for _, test := range tests {
 		words := parseWords(test["input"][0])
 		if len(words) != len(test["expect"]) {
-			t.Fatalf("length check failed. input: %v, expect: %v, output: %v", test["input"][0], test["expect"], words)
+			t.Fatalf("length check failed. input: %v, expect: %q, output: %q", test["input"][0], test["expect"], words)
 		}
 		for i, word := range words {
 			if word != test["expect"][i] {
-				t.Fatalf("word check failed for word: %q. input: %v, expect: %v, output: %v", word, test["input"][0], test["expect"], words)
+				t.Fatalf("word check failed for word: %q. input: %q, expect: %q, output: %q", word, test["input"][0], test["expect"], words)
 			}
 		}
 	}


### PR DESCRIPTION
`TestParseWords` needs to use the `tokenEscape` for one of the test
cases, but `tokenEscape` was not being set unless tests ran in a
specific order.
This sets a default value for `tokenEscape`... `\`... so that tests that
rely on this global are not affected by test ordering.

This is the simplest fix for these cases. Ideally the token should not
be set as a global but rather passed down, which is a much larger
change.
