### PR TITLE
Label containers with stack name when deploying stack/bundle

### DIFF
--- a/api/client/stack/deploy.go
+++ b/api/client/stack/deploy.go
@@ -168,6 +168,10 @@ func deployServices(
 					Command: service.Command,
 					Args:    service.Args,
 					Env:     service.Env,
+					// Service Labels will not be copied to Containers
+					// automatically during the deployment so we apply
+					// it here.
+					Labels: getStackLabels(namespace, nil),
 				},
 			},
 			EndpointSpec: &swarm.EndpointSpec{


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #24881 where the stack name is not visable when inspecting containers deployed through stacks.

**\- How I did it**

This fix adds `labelNamespace` (`com.docker.stack.namespace`) to containers at the client side so that the stack name label will show up after containers are deployed.

**\- How to verify it**

This fix is tested manually:
- Build the binary with `make DOCKER_EXPERIMENTAL=1`
- Create a bundle file and deploy with the `docker stack deploy`
- Verify that `com.docker.stack.namespace` has been set properly by checking contaners with `docker inspect <ContainerID>`

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #24881.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
