### PR TITLE
Add a bundlefile example in the documentation

### DIFF
--- a/experimental/docker-stacks-and-bundles.md
+++ b/experimental/docker-stacks-and-bundles.md
@@ -182,3 +182,21 @@ A service has the following fields:
     </dd>
 </dl>
 
+The following is an example of bundlefile with two services:
+
+```json
+{
+	"Version": "0.1",
+	"Services": {
+		"redis": {
+			"Image": "redis@sha256:4b24131101fa0117bcaa18ac37055fffd9176aa1a240392bb8ea85e0be50f2ce",
+			"Networks": ["default"]
+		},
+		"web": {
+			"Image": "dockercloud/hello-world@sha256:fe79a2cfbd17eefc344fb8419420808df95a1e22d93b7f621a7399fd1e9dca1d",
+			"Networks": ["default"],
+			"User": "web"
+		}
+	}
+}
+```


### PR DESCRIPTION
While playing with the bundle/stack I found out that there is no example bundlefile in the documentation. Later I found an example from `api/client/bundlefile/bundlefile_test.go`.

In this fix a bundlefile example has been added to the documentation `docker-stacks-and-bundles.md`. This should help in case the user doesn't want to search inside the source code.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
