### PR TITLE
Don't consider lxcbr0 in IP address autodetection

### DIFF
--- a/daemon/cluster/listen_addr.go
+++ b/daemon/cluster/listen_addr.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 )
 
 var (
@@ -14,6 +15,9 @@ var (
 	errBadListenAddr           = errors.New("listen address must be an IP address or network interface (with optional port number)")
 	errBadAdvertiseAddr        = errors.New("advertise address must be an IP address or network interface (with optional port number)")
 	errBadDefaultAdvertiseAddr = errors.New("default advertise address must be an IP address or network interface (without a port number)")
+	ignoreInterfacePrefixes    = []string{
+		"lxcbr",
+	}
 )
 
 func resolveListenAddr(specifiedAddr string) (string, string, error) {
@@ -169,6 +173,12 @@ ifaceLoop:
 		// Skip inactive interfaces and loopback interfaces
 		if (intf.Flags&net.FlagUp == 0) || (intf.Flags&net.FlagLoopback) != 0 {
 			continue
+		}
+
+		for _, prefix := range ignoreInterfacePrefixes {
+			if strings.HasPrefix(intf.Name, prefix) {
+				continue ifaceLoop
+			}
 		}
 
 		addrs, err := intf.Addrs()


### PR DESCRIPTION
@aluzzardi found that many cloud systems have a lxcbr0 interface (with
an IP address) by default. The IP address on this interface is generally
not the correct one for swarm mode to use as a default advertise
address. Exclude it from the interfaces we consider when doing automatic
address detection, to avoid spurious "could not choose an IP address"
errors. It's still possible to use this interface or its address by
specifying it explicitly.

Opening this for discussion. Not completely sure if we want to ignore interfaces by name for the purposes of autodetection, or whether lxcbr\* is a safe one to ignore.

cc @mavenugo @aboch
