### PR TITLE
Fix flaky TestSwarmNodeTaskListFilter by waiting for task fully deployed

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -177,6 +177,9 @@ func (s *DockerSwarmSuite) TestSwarmNodeTaskListFilter(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 
+	// make sure task has been deployed.
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 3)
+
 	filter := "name=redis-cluster"
 
 	out, err = d.Cmd("node", "tasks", "--filter", filter, "self")


### PR DESCRIPTION
This is an attempt to fix the flaky test of TestSwarmNodeTaskListFilter
in #25029.

Basically this fix adds a check to wait until 3 containers has already up,
before processing `node tasks ...`.

Fixes #25029.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
