### PR TITLE
Specify a lower restart delay for swarm integration tests

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -757,13 +757,17 @@ func (s *DockerSwarmSuite) TestApiSwarmForceNewCluster(c *check.C) {
 }
 
 func simpleTestService(s *swarm.Service) {
-	var ureplicas uint64
-	ureplicas = 1
+	ureplicas := uint64(1)
+	restartDelay := time.Duration(100 * time.Millisecond)
+
 	s.Spec = swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: swarm.ContainerSpec{
 				Image:   "busybox:latest",
 				Command: []string{"/bin/top"},
+			},
+			RestartPolicy: &swarm.RestartPolicy{
+				Delay: &restartDelay,
 			},
 		},
 		Mode: swarm.ServiceMode{
@@ -776,13 +780,17 @@ func simpleTestService(s *swarm.Service) {
 }
 
 func serviceForUpdate(s *swarm.Service) {
-	var ureplicas uint64
-	ureplicas = 1
+	ureplicas := uint64(1)
+	restartDelay := time.Duration(100 * time.Millisecond)
+
 	s.Spec = swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: swarm.ContainerSpec{
 				Image:   "busybox:latest",
 				Command: []string{"/bin/top"},
+			},
+			RestartPolicy: &swarm.RestartPolicy{
+				Delay: &restartDelay,
 			},
 		},
 		Mode: swarm.ServiceMode{
@@ -792,7 +800,7 @@ func serviceForUpdate(s *swarm.Service) {
 		},
 		UpdateConfig: &swarm.UpdateConfig{
 			Parallelism:   2,
-			Delay:         8 * time.Second,
+			Delay:         4 * time.Second,
 			FailureAction: swarm.UpdateFailureActionContinue,
 		},
 	}


### PR DESCRIPTION
If no restart delay is specified for a swarm service, the default
restart delay is 5 seconds. This is a reasonable value for actual
deployments - one example of where it's useful is that if a bad image is
specified, the orchestrator will wait 5 seconds between attempts to
restart it instead of restarting it in a tight loop.

In integration tests, this 5 second delay is dead time. The tests run
faster if the delay is reduced. Set it to 100 ms to avoid the waste of
time.

This appears to speed up a few tests:

DockerSwarmSuite.TestApiSwarmForceNewCluster 37.241s -> 34.323s
DockerSwarmSuite.TestApiSwarmRestartCluster  22.038s -> 15.545s
DockerSwarmSuite.TestApiSwarmServicesMultipleAgents 24.456s -> 19.853s
DockerSwarmSuite.TestApiSwarmServicesStateReporting 19.240s -> 10.049s

...a small step towards making the Swarm integration tests run in a
reasonable amount of time.

Also, change the update delay for the rolling update test from 8 seconds to 4 seconds, which should be sufficient to differentiate between batches of updated tasks. This reduces the runtime for DockerSwarmSuite.TestApiSwarmServicesUpdate from 28s to 20s.
