### PR TITLE
Fix overlay2 sub directory whiteouts

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -199,6 +199,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 	upper := stringid.GenerateRandomID()
 	deleteFile := "file-remove.txt"
 	deleteFileContent := []byte("This file should get removed in upper!")
+	deleteDir := "var/lib"
 
 	if err := driver.Create(base, "", "", nil); err != nil {
 		t.Fatal(err)
@@ -212,6 +213,10 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
+	if err := addDirectory(driver, base, deleteDir); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := driver.Create(upper, base, "", nil); err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +225,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	if err := removeFile(driver, upper, deleteFile); err != nil {
+	if err := removeAll(driver, upper, deleteFile, deleteDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,6 +274,10 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 	}
 
 	if err := checkFileRemoved(driver, diff, deleteFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkFileRemoved(driver, diff, deleteDir); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/daemon/graphdriver/graphtest/testutil.go
+++ b/daemon/graphdriver/graphtest/testutil.go
@@ -78,14 +78,29 @@ func addFile(drv graphdriver.Driver, layer, filename string, content []byte) err
 	return ioutil.WriteFile(path.Join(root, filename), content, 0755)
 }
 
-func removeFile(drv graphdriver.Driver, layer, filename string) error {
+func addDirectory(drv graphdriver.Driver, layer, dir string) error {
 	root, err := drv.Get(layer, "")
 	if err != nil {
 		return err
 	}
 	defer drv.Put(layer)
 
-	return os.Remove(path.Join(root, filename))
+	return os.MkdirAll(path.Join(root, dir), 0755)
+}
+
+func removeAll(drv graphdriver.Driver, layer string, names ...string) error {
+	root, err := drv.Get(layer, "")
+	if err != nil {
+		return err
+	}
+	defer drv.Put(layer)
+
+	for _, filename := range names {
+		if err := os.RemoveAll(path.Join(root, filename)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func checkFileRemoved(drv graphdriver.Driver, layer, filename string) error {

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -23,7 +23,8 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os
 	// convert whiteouts to AUFS format
 	if fi.Mode()&os.ModeCharDevice != 0 && hdr.Devmajor == 0 && hdr.Devminor == 0 {
 		// we just rename the file and make it normal
-		hdr.Name = WhiteoutPrefix + hdr.Name
+		dir, filename := filepath.Split(hdr.Name)
+		hdr.Name = filepath.Join(dir, WhiteoutPrefix+filename)
 		hdr.Mode = 0600
 		hdr.Typeflag = tar.TypeReg
 		hdr.Size = 0


### PR DESCRIPTION
Sub directory whiteouts are not being properly created on diff for overlay2. This causes `docker commit` and `docker build` to create bad layers with ignored whiteouts and an extra aufs whiteout which is kept around. This change ensures the whiteout prefix is only set on the base file name.

Split into 2 commits, first commit adds unit test to demonstrate failure. Second commit has fix.

Closes #23863
