### PR TITLE
Fixing support for nat to choose a subnet automatically

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -221,6 +221,18 @@ func (daemon *Daemon) initNetworkController(config *Config, activeSandboxes map[
 		return nil, err
 	}
 
+	defaultNetworkExists := false
+
+	if network, err := controller.NetworkByName(runconfig.DefaultDaemonNetworkMode().NetworkName()); err == nil {
+		options := network.Info().DriverOptions()
+		for _, v := range hnsresponse {
+			if options[winlibnetwork.HNSID] == v.Id {
+				defaultNetworkExists = true
+				break
+			}
+		}
+	}
+
 	// discover and add HNS networks to windows
 	// network that exist are removed and added again
 	for _, v := range hnsresponse {
@@ -237,6 +249,8 @@ func (daemon *Daemon) initNetworkController(config *Config, activeSandboxes map[
 		controller.WalkNetworks(s)
 		if n != nil {
 			v.Name = n.Name()
+			// This will not cause network delete from HNS as the network
+			// is not yet populated in the libnetwork windows driver
 			n.Delete()
 		}
 
@@ -254,10 +268,12 @@ func (daemon *Daemon) initNetworkController(config *Config, activeSandboxes map[
 		}
 
 		name := v.Name
-		// There is only one nat network supported in windows.
-		// If it exists with a different name add it as the default name
-		if runconfig.DefaultDaemonNetworkMode() == containertypes.NetworkMode(strings.ToLower(v.Type)) {
+
+		// If there is no nat network create one from the first NAT network
+		// encountered
+		if !defaultNetworkExists && runconfig.DefaultDaemonNetworkMode() == containertypes.NetworkMode(strings.ToLower(v.Type)) {
 			name = runconfig.DefaultDaemonNetworkMode().NetworkName()
+			defaultNetworkExists = true
 		}
 
 		v6Conf := []*libnetwork.IpamConf{}
@@ -292,26 +308,38 @@ func initBridgeDriver(controller libnetwork.NetworkController, config *Config) e
 		winlibnetwork.NetworkName: runconfig.DefaultDaemonNetworkMode().NetworkName(),
 	}
 
-	ipamV4Conf := libnetwork.IpamConf{}
-	if config.bridgeConfig.FixedCIDR == "" {
-		ipamV4Conf.PreferredPool = defaultNetworkSpace
+	var ipamOption libnetwork.NetworkOption
+	var subnetPrefix string
+
+	if config.bridgeConfig.FixedCIDR != "" {
+		subnetPrefix = config.bridgeConfig.FixedCIDR
 	} else {
-		ipamV4Conf.PreferredPool = config.bridgeConfig.FixedCIDR
+		// TP5 doesn't support properly detecting subnet
+		osv := system.GetOSVersion()
+		if osv.Build < 14360 {
+			subnetPrefix = defaultNetworkSpace
+		}
 	}
 
-	v4Conf := []*libnetwork.IpamConf{&ipamV4Conf}
-	v6Conf := []*libnetwork.IpamConf{}
+	if subnetPrefix != "" {
+		ipamV4Conf := libnetwork.IpamConf{}
+		ipamV4Conf.PreferredPool = subnetPrefix
+		v4Conf := []*libnetwork.IpamConf{&ipamV4Conf}
+		v6Conf := []*libnetwork.IpamConf{}
+		ipamOption = libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil)
+	}
 
 	_, err := controller.NewNetwork(string(runconfig.DefaultDaemonNetworkMode()), runconfig.DefaultDaemonNetworkMode().NetworkName(), "",
 		libnetwork.NetworkOptionGeneric(options.Generic{
 			netlabel.GenericData: netOption,
 		}),
-		libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil),
+		ipamOption,
 	)
 
 	if err != nil {
 		return fmt.Errorf("Error creating default network: %v", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Windows always created a NAT network with the subnet prefix of 172.16.0.0/12. This causes issues when the machine has an overlapping address already assigned to one of the interfaces. This PR enables HNS to choose a subnet if it is not specified by the daemon. This support was added in HNS post TP5 hence this feature is only enabled for post TP5 builds.
In addition to this we added support in HNS to have multiple NAT networks (to enable D4W). One of the NAT network is choosen as the default NAT network and we want to preserve it across network restart so that it always remains the default network.

**\- How I did it**

**\- How to verify it**
Validated to not cause any regression against TP5 and validated to work properly with RTM.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: msabansal sabansal@microsoft.com
