### PR TITLE
Fix TestUpdateKernelMemoryUninitialized on new kernel version

### DIFF
--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -37,9 +37,9 @@ limits on a single container or on many. To specify more than one container,
 provide space-separated list of container names or IDs.
 
 With the exception of the `--kernel-memory` option, you can specify these
-options on a running or a stopped container. You can only update
-`--kernel-memory` on a stopped container or on a running container with
-kernel memory initialized.
+options on a running or a stopped container. On kernel version older than
+4.6, you can only update `--kernel-memory` on a stopped container or on
+a running container with kernel memory initialized.
 
 ## EXAMPLES
 
@@ -66,9 +66,10 @@ $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ### Update a container's kernel memory constraints
 
 You can update a container's kernel memory limit using the `--kernel-memory`
-option. This option can be updated on a running container only if the container
-was started with `--kernel-memory`. If the container was started *without*
-`--kernel-memory` you need to stop the container before updating kernel memory.
+option. On kernel version older than 4.6, this option can be updated on a
+running container only if the container was started with `--kernel-memory`.
+If the container was started *without* `--kernel-memory` you need to stop
+the container before updating kernel memory.
 
 For example, if you started a container with this command:
 
@@ -92,6 +93,8 @@ Update kernel memory of running container `test2` will fail. You need to stop
 the container before updating the `--kernel-memory` setting. The next time you
 start it, the container uses the new value.
 
+Kernel version newer than (include) 4.6 does not have this limitation, you
+can use `--kernel-memory` the same way as other options.
 
 ### Update a container's restart policy
 

--- a/man/docker-update.1.md
+++ b/man/docker-update.1.md
@@ -29,9 +29,9 @@ limits on a single container or on many. To specify more than one container,
 provide space-separated list of container names or IDs.
 
 With the exception of the **--kernel-memory** option, you can specify these
-options on a running or a stopped container. You can only update
-**--kernel-memory** on a stopped container or on a running container with
-kernel memory initialized.
+options on a running or a stopped container. On kernel version older than
+4.6, You can only update **--kernel-memory** on a stopped container or on
+a running container with kernel memory initialized.
 
 # OPTIONS
 
@@ -59,9 +59,10 @@ kernel memory initialized.
 **--kernel-memory**=""
    Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)
 
-   Note that you can not update kernel memory on a running container if the container
-   is started without kernel memory initialized, in this case, it can only be updated
-   after it's stopped. The new setting takes effect when the container is started.
+   Note that on kernel version older than 4.6, you can not update kernel memory on
+   a running container if the container is started without kernel memory initialized,
+   in this case, it can only be updated after it's stopped. The new setting takes
+   effect when the container is started.
 
 **-m**, **--memory**=""
    Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
@@ -100,9 +101,10 @@ $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ### Update a container's kernel memory constraints
 
 You can update a container's kernel memory limit using the **--kernel-memory**
-option. This option can be updated on a running container only if the container
-was started with **--kernel-memory**. If the container was started *without*
-**--kernel-memory** you need to stop the container before updating kernel memory.
+option. On kernel version older than 4.6, this option can be updated on a
+running container only if the container was started with **--kernel-memory**.
+If the container was started *without* **--kernel-memory** you need to stop
+the container before updating kernel memory.
 
 For example, if you started a container with this command:
 
@@ -125,6 +127,9 @@ $ docker run -dit --name test2 --memory 300M ubuntu bash
 Update kernel memory of running container `test2` will fail. You need to stop
 the container before updating the **--kernel-memory** setting. The next time you
 start it, the container uses the new value.
+
+Kernel version newer than (include) 4.6 does not have this limitation, you
+can use `--kernel-memory` the same way as other options.
 
 ### Update a container's restart policy
 

--- a/pkg/parsers/kernel/kernel_unix.go
+++ b/pkg/parsers/kernel/kernel_unix.go
@@ -6,6 +6,8 @@ package kernel
 
 import (
 	"bytes"
+
+	"github.com/Sirupsen/logrus"
 )
 
 // GetKernelVersion gets the current kernel version.
@@ -27,4 +29,17 @@ func GetKernelVersion() (*VersionInfo, error) {
 	release = release[:bytes.IndexByte(release, 0)]
 
 	return ParseRelease(string(release))
+}
+
+// CheckKernelVersion checks if current kernel is newer than (or equal to)
+// the given version.
+func CheckKernelVersion(k, major, minor int) bool {
+	if v, err := GetKernelVersion(); err != nil {
+		logrus.Warnf("error getting kernel version: %s", err)
+	} else {
+		if CompareKernelVersion(*v, VersionInfo{Kernel: k, Major: major, Minor: minor}) < 0 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Fixes: #25073

Update kernel memory on running containers without initialized
is forbidden only on kernel version older than 4.6.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
