### PR TITLE
Prevent transparent decompression of 'x-gzip' content

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -41,7 +41,8 @@ func NewV2Repository(ctx context.Context, repoInfo *registry.RepositoryInfo, end
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     endpoint.TLSConfig,
 		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
-		DisableKeepAlives: true,
+		DisableKeepAlives:  true,
+		DisableCompression: true,
 	}
 
 	proxyDialer, err := sockets.DialerFromEnvironment(direct)


### PR DESCRIPTION
When fetching layer content, we want to ensure that we get back the content as-is with no modification in order to verify its checksum.

Go's http.Transport provides transparent decompression by adding 'x-gzip' to the list of accepted encodings, then decompressing it before returning it to the caller.

This can be turned off using the DisableCompression flag.

Doing so fixes #17595.

To verify this, store V2 API responses on e.g. an Apache httpd web server with default configuration, and try 'docker pull' from it.
