### PR TITLE
Remove join-tokens from /info API

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -733,7 +733,14 @@ func (c *Cluster) Info() types.Info {
 		if err != nil {
 			info.Error = err.Error()
 		}
-		info.Cluster = swarm
+
+		// Strip JoinTokens
+		info.Cluster = types.SwarmInfo{
+			ID:   swarm.ID,
+			Meta: swarm.Meta,
+			Spec: swarm.Spec,
+		}
+
 		if r, err := c.client.ListNodes(ctx, &swarmapi.ListNodesRequest{}); err == nil {
 			info.Nodes = len(r.Nodes)
 			for _, n := range r.Nodes {

--- a/vendor/src/github.com/docker/engine-api/types/swarm/swarm.go
+++ b/vendor/src/github.com/docker/engine-api/types/swarm/swarm.go
@@ -10,6 +10,13 @@ type Swarm struct {
 	JoinTokens JoinTokens
 }
 
+// Swarm represents info about a swarm for outputing in "info"
+type SwarmInfo struct {
+	ID string
+	Meta
+	Spec Spec
+}
+
 // JoinTokens contains the tokens workers and managers need to join the swarm.
 type JoinTokens struct {
 	Worker  string
@@ -119,7 +126,7 @@ type Info struct {
 	Nodes          int
 	Managers       int
 
-	Cluster Swarm
+	Cluster SwarmInfo
 }
 
 // Peer represents a peer.


### PR DESCRIPTION
join-tokens are not needed for this endpoint, and should not be as part of /info

per https://github.com/docker/docker/pull/24492#issuecomment-235006362

ping @tiborvass if you still think this (or a better approach) is needed for 1.12, but feel free to close if not
