### PR TITLE
[bump-1.12.0] cli: `docker service|node|stack ps` instead of tasks

### DIFF
--- a/api/client/node/cmd.go
+++ b/api/client/node/cmd.go
@@ -28,7 +28,7 @@ func NewNodeCommand(dockerCli *client.DockerCli) *cobra.Command {
 		newListCommand(dockerCli),
 		newPromoteCommand(dockerCli),
 		newRemoveCommand(dockerCli),
-		newTasksCommand(dockerCli),
+		newPSCommand(dockerCli),
 		newUpdateCommand(dockerCli),
 	)
 	return cmd

--- a/api/client/service/cmd.go
+++ b/api/client/service/cmd.go
@@ -22,7 +22,7 @@ func NewServiceCommand(dockerCli *client.DockerCli) *cobra.Command {
 	cmd.AddCommand(
 		newCreateCommand(dockerCli),
 		newInspectCommand(dockerCli),
-		newTasksCommand(dockerCli),
+		newPSCommand(dockerCli),
 		newListCommand(dockerCli),
 		newRemoveCommand(dockerCli),
 		newScaleCommand(dockerCli),

--- a/api/client/stack/cmd.go
+++ b/api/client/stack/cmd.go
@@ -24,7 +24,7 @@ func NewStackCommand(dockerCli *client.DockerCli) *cobra.Command {
 		newConfigCommand(dockerCli),
 		newDeployCommand(dockerCli),
 		newRemoveCommand(dockerCli),
-		newTasksCommand(dockerCli),
+		newPSCommand(dockerCli),
 	)
 	return cmd
 }

--- a/api/client/stack/ps.go
+++ b/api/client/stack/ps.go
@@ -17,23 +17,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type tasksOptions struct {
+type psOptions struct {
 	all       bool
 	filter    opts.FilterOpt
 	namespace string
 	noResolve bool
 }
 
-func newTasksCommand(dockerCli *client.DockerCli) *cobra.Command {
-	opts := tasksOptions{filter: opts.NewFilterOpt()}
+func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
+	opts := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
-		Use:   "tasks [OPTIONS] STACK",
+		Use:   "ps [OPTIONS] STACK",
 		Short: "List the tasks in the stack",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.namespace = args[0]
-			return runTasks(dockerCli, opts)
+			return runPS(dockerCli, opts)
 		},
 	}
 	flags := cmd.Flags()
@@ -44,7 +44,7 @@ func newTasksCommand(dockerCli *client.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runTasks(dockerCli *client.DockerCli, opts tasksOptions) error {
+func runPS(dockerCli *client.DockerCli, opts psOptions) error {
 	namespace := opts.namespace
 	client := dockerCli.Client()
 	ctx := context.Background()

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1573,7 +1573,7 @@ _docker_service() {
 		ls list
 		rm remove
 		scale
-		tasks
+		ps
 		update
 	"
 	__docker_subcommands "$subcommands" && return
@@ -1667,7 +1667,7 @@ _docker_service_scale() {
 	esac
 }
 
-_docker_service_tasks() {
+_docker_service_ps() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		desired-state)
@@ -1941,7 +1941,7 @@ _docker_node() {
 		ls list
 		promote
 		rm remove
-		tasks
+		ps
 		update
 	"
 	__docker_subcommands "$subcommands" && return
@@ -2038,7 +2038,7 @@ _docker_node_rm() {
 	esac
 }
 
-_docker_node_tasks() {
+_docker_node_ps() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		desired-state)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -683,7 +683,7 @@ __docker_node_complete_ls_filters() {
     return ret
 }
 
-__docker_node_complete_tasks_filters() {
+__docker_node_complete_ps_filters() {
     [[ $PREFIX = -* ]] && return 1
     integer ret=1
 
@@ -788,7 +788,7 @@ __docker_node_commands() {
         "ls:List nodes in the swarm"
         "promote:Promote a node as manager in the swarm"
         "rm:Remove a node from the swarm"
-        "tasks:List tasks running on a node"
+        "ps:List tasks running on a node"
         "update:Update a node"
     )
     _describe -t docker-node-commands "docker node command" _docker_node_subcommands
@@ -835,7 +835,7 @@ __docker_node_subcommand() {
                 $opts_help \
                 "($help -)*:node:__docker_complete_worker_nodes" && ret=0
             ;;
-        (tasks)
+        (ps)
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Display all instances]" \
@@ -844,7 +844,7 @@ __docker_node_subcommand() {
                 "($help -)1:node:__docker_complete_nodes" && ret=0
             case $state in
                 (filter-options)
-                    __docker_node_complete_tasks_filters && ret=0
+                    __docker_node_complete_ps_filters && ret=0
                     ;;
             esac
             ;;
@@ -971,7 +971,7 @@ __docker_service_complete_ls_filters() {
     return ret
 }
 
-__docker_service_complete_tasks_filters() {
+__docker_service_complete_ps_filters() {
     [[ $PREFIX = -* ]] && return 1
     integer ret=1
 
@@ -1061,7 +1061,7 @@ __docker_service_commands() {
         "ls:List services"
         "rm:Remove a service"
         "scale:Scale one or multiple services"
-        "tasks:List the tasks of a service"
+        "ps:List the tasks of a service"
         "update:Update a service"
     )
     _describe -t docker-service-commands "docker service command" _docker_service_subcommands
@@ -1149,7 +1149,7 @@ __docker_service_subcommand() {
                     ;;
             esac
             ;;
-        (tasks)
+        (ps)
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -a --all)"{-a,--all}"[Display all tasks]" \
@@ -1158,7 +1158,7 @@ __docker_service_subcommand() {
                 "($help -)1:service:__docker_complete_services" && ret=0
             case $state in
                 (filter-options)
-                    __docker_service_complete_tasks_filters && ret=0
+                    __docker_service_complete_ps_filters && ret=0
                     ;;
             esac
             ;;

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -115,7 +115,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [node demote](node_demote.md) | Demotes an existing manager so that it is no longer a manager |
 | [node inspect](node_inspect.md) | Inspect a node in the swarm                |
 | [node update](node_update.md) | Update attributes for a node                 |
-| [node tasks](node_tasks.md) | List tasks running on a node                   |
+| [node ps](node_ps.md) | List tasks running on a node                   |
 | [node ls](node_ls.md) | List nodes in the swarm                              |
 | [node rm](node_rm.md) | Remove a node from the swarm                         |
 
@@ -138,5 +138,5 @@ read the [`dockerd`](dockerd.md) reference page.
 | [service ls](service_ls.md) | List services in the swarm                     |
 | [service rm](service_rm.md) | Reemove a swervice from the swarm              |
 | [service scale](service_scale.md) | Set the number of replicas for the desired state of the service |
-| [service tasks](service_tasks.md) | List the tasks of a service              |
+| [service ps](service_ps.md) | List the tasks of a service              |
 | [service update](service_update.md)  | Update the attributes of a service    |

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -122,6 +122,6 @@ Example output:
 ## Related information
 
 * [node update](node_update.md)
-* [node tasks](node_tasks.md)
+* [node ps](node_ps.md)
 * [node ls](node_ls.md)
 * [node rm](node_rm.md)

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -93,5 +93,5 @@ ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
 
 * [node inspect](node_inspect.md)
 * [node update](node_update.md)
-* [node tasks](node_tasks.md)
+* [node ps](node_ps.md)
 * [node rm](node_rm.md)

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -1,8 +1,9 @@
 <!--[metadata]>
 +++
-title = "node tasks"
-description = "The node tasks command description and usage"
-keywords = ["node, tasks"]
+title = "node ps"
+description = "The node ps command description and usage"
+keywords = ["node, tasks", "ps"]
+aliases = ["/engine/reference/commandline/node_tasks/"]
 [menu.main]
 parent = "smn_cli"
 +++
@@ -10,10 +11,10 @@ parent = "smn_cli"
 
 **Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
 
-# node tasks
+# node ps
 
 ```markdown
-Usage:  docker node tasks [OPTIONS] self|NODE
+Usage:  docker node ps [OPTIONS] self|NODE
 
 List tasks running on a node
 
@@ -28,7 +29,7 @@ Lists all the tasks on a Node that Docker knows about. You can filter using the 
 
 Example output:
 
-    $ docker node tasks swarm-manager1
+    $ docker node ps swarm-manager1
     ID                         NAME      SERVICE  IMAGE        LAST STATE          DESIRED STATE  NODE
     7q92v0nr1hcgts2amcjyqg3pq  redis.1   redis    redis:3.0.6  Running 5 hours     Running        swarm-manager1
     b465edgho06e318egmgjbqo4o  redis.6   redis    redis:3.0.6  Running 29 seconds  Running        swarm-manager1
@@ -55,7 +56,7 @@ The `name` filter matches on all or part of a task's name.
 
 The following filter matches all tasks with a name containing the `redis` string.
 
-    $ docker node tasks -f name=redis swarm-manager1
+    $ docker node ps -f name=redis swarm-manager1
     ID                         NAME      SERVICE  IMAGE        LAST STATE          DESIRED STATE  NODE
     7q92v0nr1hcgts2amcjyqg3pq  redis.1   redis    redis:3.0.6  Running 5 hours     Running        swarm-manager1
     b465edgho06e318egmgjbqo4o  redis.6   redis    redis:3.0.6  Running 29 seconds  Running        swarm-manager1
@@ -68,7 +69,7 @@ The following filter matches all tasks with a name containing the `redis` string
 
 The `id` filter matches a task's id.
 
-    $ docker node tasks -f id=bg8c07zzg87di2mufeq51a2qp swarm-manager1
+    $ docker node ps -f id=bg8c07zzg87di2mufeq51a2qp swarm-manager1
     ID                         NAME      SERVICE  IMAGE        LAST STATE             DESIRED STATE  NODE
     bg8c07zzg87di2mufeq51a2qp  redis.7   redis    redis:3.0.6  Running 5 seconds      Running        swarm-manager1
 
@@ -81,7 +82,7 @@ value.
 The following filter matches tasks with the `usage` label regardless of its value.
 
 ```bash
-$ docker node tasks -f "label=usage"
+$ docker node ps -f "label=usage"
 ID                         NAME     SERVICE  IMAGE        LAST STATE          DESIRED STATE  NODE
 b465edgho06e318egmgjbqo4o  redis.6  redis    redis:3.0.6  Running 10 minutes  Running        swarm-manager1
 bg8c07zzg87di2mufeq51a2qp  redis.7  redis    redis:3.0.6  Running 9 minutes   Running        swarm-manager1

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -37,5 +37,5 @@ Example output:
 
 * [node inspect](node_inspect.md)
 * [node update](node_update.md)
-* [node tasks](node_tasks.md)
+* [node ps](node_ps.md)
 * [node ls](node_ls.md)

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -61,6 +61,6 @@ metadata](../../userguide/labels-custom-metadata.md).
 ## Related information
 
 * [node inspect](node_inspect.md)
-* [node tasks](node_tasks.md)
+* [node ps](node_ps.md)
 * [node ls](node_ls.md)
 * [node rm](node_rm.md)

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -186,5 +186,5 @@ $ docker service create \
 * [service ls](service_ls.md)
 * [service rm](service_rm.md)
 * [service scale](service_scale.md)
-* [service tasks](service_tasks.md)
+* [service ps](service_ps.md)
 * [service update](service_update.md)

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -151,5 +151,5 @@ $ docker service inspect --format='{{.Spec.Mode.Replicated.Replicas}}' redis
 * [service ls](service_ls.md)
 * [service rm](service_rm.md)
 * [service scale](service_scale.md)
-* [service tasks](service_tasks.md)
+* [service ps](service_ps.md)
 * [service update](service_update.md)

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -106,5 +106,5 @@ ID            NAME   REPLICAS  IMAGE        COMMAND
 * [service inspect](service_inspect.md)
 * [service rm](service_rm.md)
 * [service scale](service_scale.md)
-* [service tasks](service_tasks.md)
+* [service ps](service_ps.md)
 * [service update](service_update.md)

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -1,8 +1,9 @@
 <!--[metadata]>
 +++
-title = "service tasks"
-description = "The service tasks command description and usage"
-keywords = ["service, tasks"]
+title = "service ps"
+description = "The service ps command description and usage"
+keywords = ["service, tasks", "ps"]
+aliases = ["/engine/reference/commandline/service_tasks/"]
 [menu.main]
 parent = "smn_cli"
 +++
@@ -10,10 +11,10 @@ parent = "smn_cli"
 
 **Warning:** this command is part of the Swarm management feature introduced in Docker 1.12, and might be subject to non backward-compatible changes.
 
-# service tasks
+# service ps
 
 ```Markdown
-Usage:	docker service tasks [OPTIONS] SERVICE
+Usage:	docker service ps [OPTIONS] SERVICE
 
 List the tasks of a service
 
@@ -35,7 +36,7 @@ has to be run targeting a manager node.
 The following command shows all the tasks that are part of the `redis` service:
 
 ```bash
-$ docker service tasks redis
+$ docker service ps redis
 ID                         NAME      SERVICE IMAGE        LAST STATE          DESIRED STATE  NODE
 0qihejybwf1x5vqi8lgzlgnpq  redis.1   redis   redis:3.0.6  Running 8 seconds   Running        manager1
 bk658fpbex0d57cqcwoe3jthu  redis.2   redis   redis:3.0.6  Running 9 seconds   Running        worker2
@@ -69,7 +70,7 @@ The currently supported filters are:
 The `id` filter matches on all or a prefix of a task's ID.
 
 ```bash
-$ docker service tasks -f "id=8" redis
+$ docker service ps -f "id=8" redis
 ID                         NAME      SERVICE  IMAGE        LAST STATE         DESIRED STATE  NODE
 8ryt076polmclyihzx67zsssj  redis.4   redis    redis:3.0.6  Running 4 minutes  Running        worker1
 8eaxrb2fqpbnv9x30vr06i6vt  redis.10  redis    redis:3.0.6  Running 4 minutes  Running        manager1
@@ -80,7 +81,7 @@ ID                         NAME      SERVICE  IMAGE        LAST STATE         DE
 The `name` filter matches on task names.
 
 ```bash
-$ docker service tasks -f "name=redis.1" redis
+$ docker service ps -f "name=redis.1" redis
 ID                         NAME      SERVICE  IMAGE        DESIRED STATE  LAST STATE         NODE
 0qihejybwf1x5vqi8lgzlgnpq  redis.1   redis    redis:3.0.6  Running        Running 8 seconds  manager1
 ```

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -47,5 +47,5 @@ ID            NAME   SCALE  IMAGE        COMMAND
 * [service inspect](service_inspect.md)
 * [service ls](service_ls.md)
 * [service scale](service_scale.md)
-* [service tasks](service_tasks.md)
+* [service ps](service_ps.md)
 * [service update](service_update.md)

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -76,5 +76,5 @@ ID            NAME      REPLICAS  IMAGE         COMMAND
 * [service inspect](service_inspect.md)
 * [service ls](service_ls.md)
 * [service rm](service_rm.md)
-* [service tasks](service_tasks.md)
+* [service ps](service_ps.md)
 * [service update](service_update.md)

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -73,6 +73,6 @@ $ docker service update --limit-cpu 2 redis
 
 * [service create](service_create.md)
 * [service inspect](service_inspect.md)
-* [service tasks](service_tasks.md)
+* [service ps](service_ps.md)
 * [service ls](service_ls.md)
 * [service rm](service_rm.md)

--- a/docs/swarm/index.md
+++ b/docs/swarm/index.md
@@ -88,5 +88,5 @@ roll-back a task to a previous version of the service.
     * [service ls](../reference/commandline/service_ls.md)
     * [service rm](../reference/commandline/service_rm.md)
     * [service scale](../reference/commandline/service_scale.md)
-    * [service tasks](../reference/commandline/service_tasks.md)
+    * [service ps](../reference/commandline/service_ps.md)
     * [service update](../reference/commandline/service_update.md)

--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -46,11 +46,11 @@ update](rolling-update.md) tutorial, start it now:
     c5uo6kdmzpon37mgj9mwglcfw
     ```
 
-4. Run `docker service tasks redis` to see how the Swarm manager assigned the
+4. Run `docker service ps redis` to see how the Swarm manager assigned the
 tasks to different nodes:
 
     ```bash
-    $ docker service tasks redis
+    $ docker service ps redis
 
     ID                         NAME     SERVICE  IMAGE        LAST STATE          DESIRED STATE  NODE
     7q92v0nr1hcgts2amcjyqg3pq  redis.1  redis    redis:3.0.6  Running 26 seconds  Running        manager1
@@ -85,11 +85,11 @@ had a task assigned to it:
 
     The drained node shows `Drain` for `AVAILABILITY`.
 
-7. Run `docker service tasks redis` to see how the Swarm manager updated the
+7. Run `docker service ps redis` to see how the Swarm manager updated the
 task assignments for the `redis` service:
 
     ```bash
-    $ docker service tasks redis
+    $ docker service ps redis
 
     ID                         NAME     SERVICE  IMAGE        LAST STATE              DESIRED STATE  NODE
     7q92v0nr1hcgts2amcjyqg3pq  redis.1  redis    redis:3.0.6  Running 4 minutes       Running        manager1

--- a/docs/swarm/swarm-tutorial/inspect-service.md
+++ b/docs/swarm/swarm-tutorial/inspect-service.md
@@ -92,11 +92,11 @@ about a service in an easily readable format.
     ]
     ```
 
-4. Run `docker service tasks <SERVICE-ID>` to see which nodes are running the
+4. Run `docker service ps <SERVICE-ID>` to see which nodes are running the
 service:
 
     ```
-    $ docker service tasks helloworld
+    $ docker service ps helloworld
 
     ID                         NAME          SERVICE     IMAGE   LAST STATE         DESIRED STATE  NODE
     8p1vev3fq5zm0mi8g0as41w35  helloworld.1  helloworld  alpine  Running 3 minutes  Running        worker2

--- a/docs/swarm/swarm-tutorial/rolling-update.md
+++ b/docs/swarm/swarm-tutorial/rolling-update.md
@@ -106,10 +106,34 @@ desired state:
     Resources:
     ```
 
-6. Run `docker service tasks <TASK-ID>` to watch the rolling update:
+    The output of `service inspect` shows if your update paused due to failure:
 
     ```bash
-    $ docker service tasks redis
+    $ docker service inspect --pretty redis
+
+    ID:             0u6a4s31ybk7yw2wyvtikmu50
+    Name:           redis
+    ...snip...
+    Update status:
+     State:      paused
+     Started:    11 seconds ago
+     Message:    update paused due to failure or early termination of task 9p7ith557h8ndf0ui9s0q951b
+    ...snip...
+    ```
+
+    To restart a paused update run `docker service update <SERVICE-ID>`. For example:
+
+    ```bash
+    docker service update redis
+    ```
+
+    To avoid repeating certain update failures, you may need to reconfigure the
+    service by passing flags to `docker service update`.
+
+6. Run `docker service ps <SERVICE-ID>` to watch the rolling update:
+
+    ```bash
+    $ docker service ps redis
 
     ID                         NAME     SERVICE  IMAGE        LAST STATE              DESIRED STATE  NODE
     dos1zffgeofhagnve8w864fco  redis.1  redis    redis:3.0.7  Running 37 seconds      Running        worker1

--- a/docs/swarm/swarm-tutorial/scale-service.md
+++ b/docs/swarm/swarm-tutorial/scale-service.md
@@ -14,7 +14,7 @@ weight=18
 # Scale the service in the swarm
 
 Once you have [deployed a service](deploy-service.md) to a swarm, you are ready
-to use the Docker CLI to scale the number of service tasks in
+to use the Docker CLI to scale the number of service ps in
 the swarm.
 
 1. If you haven't already, open a terminal and ssh into the machine where you
@@ -36,10 +36,10 @@ service running in the swarm:
     helloworld scaled to 5
     ```
 
-3. Run `docker service tasks <SERVICE-ID>` to see the updated task list:
+3. Run `docker service ps <SERVICE-ID>` to see the updated task list:
 
     ```
-    $ docker service tasks helloworld
+    $ docker service ps helloworld
 
     ID                         NAME          SERVICE     IMAGE   LAST STATE          DESIRED STATE  NODE
     8p1vev3fq5zm0mi8g0as41w35  helloworld.1  helloworld  alpine  Running 7 minutes   Running        worker2

--- a/integration-cli/docker_cli_stack_test.go
+++ b/integration-cli/docker_cli_stack_test.go
@@ -20,7 +20,7 @@ func (s *DockerSwarmSuite) TestStackRemove(c *check.C) {
 func (s *DockerSwarmSuite) TestStackTasks(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	stackArgs := append([]string{"tasks", "UNKNOWN_STACK"})
+	stackArgs := append([]string{"ps", "UNKNOWN_STACK"})
 
 	out, err := d.Cmd("stack", stackArgs...)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -179,13 +179,13 @@ func (s *DockerSwarmSuite) TestSwarmNodeTaskListFilter(c *check.C) {
 
 	filter := "name=redis-cluster"
 
-	out, err = d.Cmd("node", "tasks", "--filter", filter, "self")
+	out, err = d.Cmd("node", "ps", "--filter", filter, "self")
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, name+".1")
 	c.Assert(out, checker.Contains, name+".2")
 	c.Assert(out, checker.Contains, name+".3")
 
-	out, err = d.Cmd("node", "tasks", "--filter", "name=none", "self")
+	out, err = d.Cmd("node", "ps", "--filter", "name=none", "self")
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Not(checker.Contains), name+".1")
 	c.Assert(out, checker.Not(checker.Contains), name+".2")


### PR DESCRIPTION
#24816 against bump release branch.

cc @tiborvass 

Rather than conflict with the unexposed task model, change the names of
the object-oriented task display to `docker <object> ps`. The command
works identically to `docker service tasks`. This change is superficial.

This provides a more sensical docker experience while not trampling on
the task model that may be introduced as a top-level command at a later
date.

The following is an example of the display using `docker service ps`
with a service named `condescending_cori`:

```
$ docker service ps condescending_cori
ID                         NAME                  SERVICE             IMAGE   LAST STATE              DESIRED STATE  NODE
e2cd9vqb62qjk38lw65uoffd2  condescending_cori.1  condescending_cori  alpine  Running 13 minutes ago  Running        6c6d232a5d0e
```

The following shows the output for the node on which the command is
running:

``` console
$ docker node ps self
ID                         NAME                  SERVICE             IMAGE   LAST STATE              DESIRED STATE  NODE
b1tpbi43k1ibevg2e94bmqo0s  mad_kalam.1           mad_kalam           apline  Accepted 2 seconds ago  Accepted       6c6d232a5d0e
e2cd9vqb62qjk38lw65uoffd2  condescending_cori.1  condescending_cori  alpine  Running 12 minutes ago  Running        6c6d232a5d0e
4x609m5o0qyn0kgpzvf0ad8x5  furious_davinci.1     furious_davinci     redis   Running 32 minutes ago  Running        6c6d232a5d0e
```

Signed-off-by: Stephen J Day stephen.day@docker.com
(cherry picked from commit 0aa4e1e68973ede0c73f8a4356e2a17fc903f549)
