### PR TITLE
1.12.0 final cherry picks

### DIFF
--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -173,7 +173,9 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 	}()
 
 	r := strings.NewReader(testCase.dockerfile)
-	n, err := parser.Parse(r)
+	d := parser.Directive{}
+	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
+	n, err := parser.Parse(r, &d)
 
 	if err != nil {
 		t.Fatalf("Error when parsing Dockerfile: %s", err)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -427,7 +427,7 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 
 	// parse the ONBUILD triggers by invoking the parser
 	for _, step := range onBuildTriggers {
-		ast, err := parser.Parse(strings.NewReader(step))
+		ast, err := parser.Parse(strings.NewReader(step), &b.directive)
 		if err != nil {
 			return err
 		}
@@ -648,7 +648,7 @@ func (b *Builder) parseDockerfile() error {
 			return fmt.Errorf("The Dockerfile (%s) cannot be empty", b.options.Dockerfile)
 		}
 	}
-	b.dockerfile, err = parser.Parse(f)
+	b.dockerfile, err = parser.Parse(f, &b.directive)
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/parser/dumper/main.go
+++ b/builder/dockerfile/parser/dumper/main.go
@@ -22,7 +22,10 @@ func main() {
 			panic(err)
 		}
 
-		ast, err := parser.Parse(f)
+		d := parser.Directive{LookingForDirectives: true}
+		parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
+
+		ast, err := parser.Parse(f, &d)
 		if err != nil {
 			panic(err)
 		} else {

--- a/builder/dockerfile/parser/json_test.go
+++ b/builder/dockerfile/parser/json_test.go
@@ -28,7 +28,10 @@ var validJSONArraysOfStrings = map[string][]string{
 
 func TestJSONArraysOfStrings(t *testing.T) {
 	for json, expected := range validJSONArraysOfStrings {
-		if node, _, err := parseJSON(json); err != nil {
+		d := Directive{}
+		SetEscapeToken(DefaultEscapeToken, &d)
+
+		if node, _, err := parseJSON(json, &d); err != nil {
 			t.Fatalf("%q should be a valid JSON array of strings, but wasn't! (err: %q)", json, err)
 		} else {
 			i := 0
@@ -48,7 +51,10 @@ func TestJSONArraysOfStrings(t *testing.T) {
 		}
 	}
 	for _, json := range invalidJSONArraysOfStrings {
-		if _, _, err := parseJSON(json); err != errDockerfileNotStringArray {
+		d := Directive{}
+		SetEscapeToken(DefaultEscapeToken, &d)
+
+		if _, _, err := parseJSON(json, &d); err != errDockerfileNotStringArray {
 			t.Fatalf("%q should be an invalid JSON array of strings, but wasn't!", json)
 		}
 	}

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -36,18 +36,18 @@ type Node struct {
 	EndLine    int             // the line in the original dockerfile where the node ends
 }
 
+const defaultTokenEscape = "\\"
+
 var (
 	dispatch              map[string]func(string) (*Node, map[string]bool, error)
 	tokenWhitespace       = regexp.MustCompile(`[\t\v\f\r ]+`)
 	tokenLineContinuation *regexp.Regexp
-	tokenEscape           rune
+	tokenEscape           = rune(defaultTokenEscape[0])
 	tokenEscapeCommand    = regexp.MustCompile(`^#[ \t]*escape[ \t]*=[ \t]*(?P<escapechar>.).*$`)
 	tokenComment          = regexp.MustCompile(`^#.*$`)
 	lookingForDirectives  bool
 	directiveEscapeSeen   bool
 )
-
-const defaultTokenEscape = "\\"
 
 // setTokenEscape sets the default token for escaping characters in a Dockerfile.
 func setTokenEscape(s string) error {

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -121,11 +121,11 @@ func TestParseWords(t *testing.T) {
 	for _, test := range tests {
 		words := parseWords(test["input"][0])
 		if len(words) != len(test["expect"]) {
-			t.Fatalf("length check failed. input: %v, expect: %v, output: %v", test["input"][0], test["expect"], words)
+			t.Fatalf("length check failed. input: %v, expect: %q, output: %q", test["input"][0], test["expect"], words)
 		}
 		for i, word := range words {
 			if word != test["expect"][i] {
-				t.Fatalf("word check failed for word: %q. input: %v, expect: %v, output: %v", word, test["input"][0], test["expect"], words)
+				t.Fatalf("word check failed for word: %q. input: %q, expect: %q, output: %q", word, test["input"][0], test["expect"], words)
 			}
 		}
 	}

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -39,7 +39,9 @@ func TestTestNegative(t *testing.T) {
 			t.Fatalf("Dockerfile missing for %s: %v", dir, err)
 		}
 
-		_, err = Parse(df)
+		d := Directive{LookingForDirectives: true}
+		SetEscapeToken(DefaultEscapeToken, &d)
+		_, err = Parse(df, &d)
 		if err == nil {
 			t.Fatalf("No error parsing broken dockerfile for %s", dir)
 		}
@@ -59,7 +61,9 @@ func TestTestData(t *testing.T) {
 		}
 		defer df.Close()
 
-		ast, err := Parse(df)
+		d := Directive{LookingForDirectives: true}
+		SetEscapeToken(DefaultEscapeToken, &d)
+		ast, err := Parse(df, &d)
 		if err != nil {
 			t.Fatalf("Error parsing %s's dockerfile: %v", dir, err)
 		}
@@ -119,7 +123,9 @@ func TestParseWords(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		words := parseWords(test["input"][0])
+		d := Directive{LookingForDirectives: true}
+		SetEscapeToken(DefaultEscapeToken, &d)
+		words := parseWords(test["input"][0], &d)
 		if len(words) != len(test["expect"]) {
 			t.Fatalf("length check failed. input: %v, expect: %q, output: %q", test["input"][0], test["expect"], words)
 		}
@@ -138,7 +144,9 @@ func TestLineInformation(t *testing.T) {
 	}
 	defer df.Close()
 
-	ast, err := Parse(df)
+	d := Directive{LookingForDirectives: true}
+	SetEscapeToken(DefaultEscapeToken, &d)
+	ast, err := Parse(df, &d)
 	if err != nil {
 		t.Fatalf("Error parsing dockerfile %s: %v", testFileLineInfo, err)
 	}

--- a/builder/dockerfile/parser/utils.go
+++ b/builder/dockerfile/parser/utils.go
@@ -36,7 +36,7 @@ func (node *Node) Dump() string {
 
 // performs the dispatch based on the two primal strings, cmd and args. Please
 // look at the dispatch table in parser.go to see how these dispatchers work.
-func fullDispatch(cmd, args string) (*Node, map[string]bool, error) {
+func fullDispatch(cmd, args string, d *Directive) (*Node, map[string]bool, error) {
 	fn := dispatch[cmd]
 
 	// Ignore invalid Dockerfile instructions
@@ -44,7 +44,7 @@ func fullDispatch(cmd, args string) (*Node, map[string]bool, error) {
 		fn = parseIgnore
 	}
 
-	sexp, attrs, err := fn(args)
+	sexp, attrs, err := fn(args, d)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1817,7 +1817,6 @@ _docker_service_update() {
 _docker_swarm() {
 	local subcommands="
 		init
-		inspect
 		join
 		join-token
 		leave
@@ -1854,20 +1853,6 @@ _docker_swarm_init() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--advertise-addr --force-new-cluster --help --listen-addr" -- "$cur" ) )
-			;;
-	esac
-}
-
-_docker_swarm_inspect() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1741,6 +1741,7 @@ _docker_service_update() {
 
 	if [ "$subcommand" = "create" ] ; then
 		options_with_args="$options_with_args
+			--container-label
 			--mode
 		"
 
@@ -1754,6 +1755,8 @@ _docker_service_update() {
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
 			--arg
+			--container-label-add
+			--container-label-rm
 			--image
 		"
 

--- a/contrib/init/systemd/docker.service.rpm
+++ b/contrib/init/systemd/docker.service.rpm
@@ -2,7 +2,6 @@
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 After=network.target
-Requires=docker.socket
 
 [Service]
 Type=notify

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -199,6 +199,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 	upper := stringid.GenerateRandomID()
 	deleteFile := "file-remove.txt"
 	deleteFileContent := []byte("This file should get removed in upper!")
+	deleteDir := "var/lib"
 
 	if err := driver.Create(base, "", "", nil); err != nil {
 		t.Fatal(err)
@@ -212,6 +213,10 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
+	if err := addDirectory(driver, base, deleteDir); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := driver.Create(upper, base, "", nil); err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +225,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	if err := removeFile(driver, upper, deleteFile); err != nil {
+	if err := removeAll(driver, upper, deleteFile, deleteDir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,6 +274,10 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 	}
 
 	if err := checkFileRemoved(driver, diff, deleteFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkFileRemoved(driver, diff, deleteDir); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/daemon/graphdriver/graphtest/testutil.go
+++ b/daemon/graphdriver/graphtest/testutil.go
@@ -78,14 +78,29 @@ func addFile(drv graphdriver.Driver, layer, filename string, content []byte) err
 	return ioutil.WriteFile(path.Join(root, filename), content, 0755)
 }
 
-func removeFile(drv graphdriver.Driver, layer, filename string) error {
+func addDirectory(drv graphdriver.Driver, layer, dir string) error {
 	root, err := drv.Get(layer, "")
 	if err != nil {
 		return err
 	}
 	defer drv.Put(layer)
 
-	return os.Remove(path.Join(root, filename))
+	return os.MkdirAll(path.Join(root, dir), 0755)
+}
+
+func removeAll(drv graphdriver.Driver, layer string, names ...string) error {
+	root, err := drv.Get(layer, "")
+	if err != nil {
+		return err
+	}
+	defer drv.Put(layer)
+
+	for _, filename := range names {
+		if err := os.RemoveAll(path.Join(root, filename)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func checkFileRemoved(drv graphdriver.Driver, layer, filename string) error {

--- a/docs/swarm/swarm-tutorial/rolling-update.md
+++ b/docs/swarm/swarm-tutorial/rolling-update.md
@@ -29,7 +29,6 @@ update delay:
       --replicas 3 \
       --name redis \
       --update-delay 10s \
-      --update-parallelism 1 \
       redis:3.0.6
 
     0u6a4s31ybk7yw2wyvtikmu50
@@ -37,18 +36,21 @@ update delay:
 
     You configure the rolling update policy at service deployment time.
 
-    The `--update-parallelism` flag configures the number of service tasks that
-    the scheduler can update simultaneously. When updates to individual tasks
-    return a state of `RUNNING` or `FAILED`, the scheduler schedules another
-    task to update until all tasks are updated.
-
     The `--update-delay` flag configures the time delay between updates to a
-    service task or sets of tasks.
+    service task or sets of tasks. You can describe the time `T` as a
+    combination of the number of seconds `Ts`, minutes `Tm`, or hours `Th`. So
+    `10m30s` indicates a 10 minute 30 second delay.
 
-    You can describe the time `T` as a combination of the number of seconds
-    `Ts`, minutes `Tm`, or hours `Th`. So `10m30s` indicates a 10 minute 30
-    second delay.
+    By default the scheduler updates 1 task at a time. You can pass the
+    `--update-parallelism` flag to configure the maximum number of service tasks
+    that the scheduler updates simultaneously.
 
+    By default, when an update to an individual task returns a state of
+    `RUNNING`, the scheduler schedules another task to update until all tasks
+    are updated. If, at any time during an update a task returns `FAILED`, the
+    scheduler pauses the update. You can control the behavior using the
+    `--update-failure-action` flag for `docker service create` or
+    `docker service update`.
 
 3. Inspect the `redis` service:
 
@@ -77,13 +79,15 @@ applies the update to nodes according to the `UpdateConfig` policy:
     redis
     ```
 
-    The scheduler applies rolling updates as follows:
+    The scheduler applies rolling updates as follows by default:
 
-    * Stop the initial number of tasks according to `--update-parallelism`.
-    * Schedule updates for the stopped tasks.
-    * Start the containers for the updated tasks.
-    * After an update to a task completes, wait for the specified delay
-    period before stopping the next task.
+    * Stop the first task.
+    * Schedule update for the stopped task.
+    * Start the container for the updated task.
+    * If the update to a task returns `RUNNING`, wait for the
+    specified delay period then stop the next task.
+    * If, at any time during the update, a task returns `FAILED`, pause the
+    update.
 
 5. Run `docker service inspect --pretty redis` to see the new image in the
 desired state:

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -65,7 +65,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork c7dc6dc476a5f00f9b28efebe591347dd64264fc
+clone git github.com/docker/libnetwork 443b7be96fdf0ed8f65ec92953aa8df4f9a725dc
 clone git github.com/docker/go-events afb2b9f2c23f33ada1a22b03651775fdc65a5089
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -563,6 +563,8 @@ func (clnt *client) Restore(containerID string, options ...CreateOption) error {
 		clnt.remote.Lock()
 		return nil
 	}
+	// relock because of the defer
+	clnt.remote.Lock()
 
 	clnt.deleteContainer(containerID)
 

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -23,7 +23,8 @@ func (overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi os
 	// convert whiteouts to AUFS format
 	if fi.Mode()&os.ModeCharDevice != 0 && hdr.Devmajor == 0 && hdr.Devminor == 0 {
 		// we just rename the file and make it normal
-		hdr.Name = WhiteoutPrefix + hdr.Name
+		dir, filename := filepath.Split(hdr.Name)
+		hdr.Name = filepath.Join(dir, WhiteoutPrefix+filename)
 		hdr.Mode = 0600
 		hdr.Typeflag = tar.TypeReg
 		hdr.Size = 0

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -726,6 +726,12 @@ func (sb *sandbox) restoreOslSandbox() error {
 		joinInfo := ep.joinInfo
 		i := ep.iface
 		ep.Unlock()
+
+		if i == nil {
+			log.Errorf("error restoring endpoint %s for container %s", ep.Name(), sb.ContainerID())
+			continue
+		}
+
 		ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().Address(i.addr), sb.osSbox.InterfaceOptions().Routes(i.routes))
 		if i.addrv6 != nil && i.addrv6.IP.To16() != nil {
 			ifaceOptions = append(ifaceOptions, sb.osSbox.InterfaceOptions().AddressIPv6(i.addrv6))

--- a/vendor/src/github.com/docker/libnetwork/sandbox_store.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox_store.go
@@ -245,6 +245,10 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 					ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
 				}
 			}
+			if _, ok := activeSandboxes[sb.ID()]; ok && err != nil {
+				logrus.Errorf("failed to restore endpoint %s in %s for container %s due to %v", eps.Eid, eps.Nid, sb.ContainerID(), err)
+				continue
+			}
 			heap.Push(&sb.endpoints, ep)
 		}
 


### PR DESCRIPTION
Cherrypicks:
- [#25059](https://github.com/docker/docker/pull/25059)
  - 13c138e bash completion for container labels to `service {create,update}`
- [#25060](https://github.com/docker/docker/pull/25060)
  - 34d9a82 Remove bash completion for `docker swarm inspect`
- [#25068](https://github.com/docker/docker/pull/25068)
  - df167d3 Fix issue with test ordering for TestParseWords
- [#25094](https://github.com/docker/docker/pull/25094)
  - 3cddda3 Remove the Require on the socket for the rpm
- [#25086](https://github.com/docker/docker/pull/25086)
  - 5c05b84 Update diff apply test to check sub directories
  - 1c0f665 Fix files in subdirectories creating bad whiteout
- [#25080](https://github.com/docker/docker/pull/25080)
  - 755be79 Move directive out of globals
- [#25111](https://github.com/docker/docker/pull/25111)
  - c75de8e Fix daemon panic on restoring containers
- [#25010](https://github.com/docker/docker/pull/25010)
  - 6440cac update rolling update tutorial to reflect default parallelism and update on failure
- [#25131](https://github.com/docker/docker/pull/25131)
  - b1ae883 Vendoring libnetwork to fix #25109
