### PR TITLE
Carry #25134: Remove join-tokens from the /info API

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -733,7 +733,10 @@ func (c *Cluster) Info() types.Info {
 		if err != nil {
 			info.Error = err.Error()
 		}
-		info.Cluster = swarm
+
+		// Strip JoinTokens
+		info.Cluster = swarm.ClusterInfo
+
 		if r, err := c.client.ListNodes(ctx, &swarmapi.ListNodesRequest{}); err == nil {
 			info.Nodes = len(r.Nodes)
 			for _, n := range r.Nodes {

--- a/daemon/cluster/convert/swarm.go
+++ b/daemon/cluster/convert/swarm.go
@@ -13,17 +13,19 @@ import (
 // SwarmFromGRPC converts a grpc Cluster to a Swarm.
 func SwarmFromGRPC(c swarmapi.Cluster) types.Swarm {
 	swarm := types.Swarm{
-		ID: c.ID,
-		Spec: types.Spec{
-			Orchestration: types.OrchestrationConfig{
-				TaskHistoryRetentionLimit: c.Spec.Orchestration.TaskHistoryRetentionLimit,
-			},
-			Raft: types.RaftConfig{
-				SnapshotInterval:           c.Spec.Raft.SnapshotInterval,
-				KeepOldSnapshots:           c.Spec.Raft.KeepOldSnapshots,
-				LogEntriesForSlowFollowers: c.Spec.Raft.LogEntriesForSlowFollowers,
-				HeartbeatTick:              c.Spec.Raft.HeartbeatTick,
-				ElectionTick:               c.Spec.Raft.ElectionTick,
+		ClusterInfo: types.ClusterInfo{
+			ID: c.ID,
+			Spec: types.Spec{
+				Orchestration: types.OrchestrationConfig{
+					TaskHistoryRetentionLimit: c.Spec.Orchestration.TaskHistoryRetentionLimit,
+				},
+				Raft: types.RaftConfig{
+					SnapshotInterval:           c.Spec.Raft.SnapshotInterval,
+					KeepOldSnapshots:           c.Spec.Raft.KeepOldSnapshots,
+					LogEntriesForSlowFollowers: c.Spec.Raft.LogEntriesForSlowFollowers,
+					HeartbeatTick:              c.Spec.Raft.HeartbeatTick,
+					ElectionTick:               c.Spec.Raft.ElectionTick,
+				},
 			},
 		},
 		JoinTokens: types.JoinTokens{

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,7 @@ clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
-clone git github.com/docker/engine-api a52656d77f09d394104c1639824eada038bfdb89
+clone git github.com/docker/engine-api 3d1601b9d2436a70b0dfc045a23f6503d19195df
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/vendor/src/github.com/docker/engine-api/types/swarm/swarm.go
+++ b/vendor/src/github.com/docker/engine-api/types/swarm/swarm.go
@@ -2,11 +2,17 @@ package swarm
 
 import "time"
 
-// Swarm represents a swarm.
-type Swarm struct {
+// ClusterInfo represents info about a the cluster for outputing in "info"
+// it contains the same information as "Swarm", but without the JoinTokens
+type ClusterInfo struct {
 	ID string
 	Meta
-	Spec       Spec
+	Spec Spec
+}
+
+// Swarm represents a swarm.
+type Swarm struct {
+	ClusterInfo
 	JoinTokens JoinTokens
 }
 
@@ -119,7 +125,7 @@ type Info struct {
 	Nodes          int
 	Managers       int
 
-	Cluster Swarm
+	Cluster ClusterInfo
 }
 
 // Peer represents a peer.

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -256,7 +256,10 @@ type Info struct {
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info
-	LiveRestore        bool
+	// LiveRestoreEnabled determines whether containers should be kept
+	// running when the daemon is shutdown or upon daemon start if
+	// running containers are detected
+	LiveRestoreEnabled bool
 }
 
 // PluginsInfo is a temp struct holding Plugins name


### PR DESCRIPTION
join-tokens are not needed for this endpoint, and should not be as part of /info

per https://github.com/docker/docker/pull/24492#issuecomment-235006362
