### PR TITLE
Windows: docker rm hangs as not trapping failed start in restart

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -249,7 +249,13 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 						}
 						logrus.Error(err)
 					} else {
-						ctr.client.Create(ctr.containerID, ctr.ociSpec, ctr.options...)
+						if err := ctr.client.Create(ctr.containerID, ctr.ociSpec, ctr.options...); err != nil {
+							si.State = StateExit
+							if err := ctr.client.backend.StateChanged(ctr.containerID, si); err != nil {
+								logrus.Error(err)
+							}
+							logrus.Error(err)
+						}
 					}
 				}()
 			}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Found while attempting to bring up CI internally using Hyper-V containers, but affects Windows Server Containers as well. Short story - if a container start fails during a container restart (such as was the case in Hyper-V containers due to a Windows bug separate to this PR), the engines monitor is never notified of a state change as the error wasn't being checked. This left the container in a restarting state. The result of this is that a subsequent `docker rm -vf` on the container causes an indefinite hang waiting on an HCS notification which will never arrive - it did earlier, just we swallowed it due to not checking the error.

Repro steps were:

```
# Works - Windows Server Containers
docker run -d --name=foo --restart=on-failure:3 busybox false
docker ps -a # Get the ID
docker rm -vf ID

# Fails - Hyper-V Containers
docker run -d --name=foo --restart=on-failure:3 --isolation=hyperv busybox false
docker ps -a # Get the ID
docker rm -vf ID
<---- HANG --->
```

@swernli @darrenstahlmsft 
