### PR TITLE
Implement Basic Auth

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -959,7 +959,7 @@ _docker_daemon() {
 			return
 			;;
 		--cluster-store-opt)
-			COMPREPLY=( $( compgen -W "discovery.heartbeat discovery.ttl kv.cacertfile kv.certfile kv.keyfile kv.path" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "discovery.heartbeat discovery.ttl kv.cacertfile kv.certfile kv.keyfile kv.username kv.password kv.path" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1623,7 +1623,7 @@ __docker_subcommand() {
                     if compset -P '*='; then
                         _files && ret=0
                     else
-                        opts=('discovery.heartbeat' 'discovery.ttl' 'kv.cacertfile' 'kv.certfile' 'kv.keyfile' 'kv.path')
+                        opts=('discovery.heartbeat' 'discovery.ttl' 'kv.cacertfile' 'kv.certfile' 'kv.keyfile' 'kv.username' 'kv.password' 'kv.path')
                         _describe -t cluster-store-opts "Cluster Store Options" opts -qS "=" && ret=0
                     fi
                     ;;

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -784,6 +784,16 @@ The currently supported cluster store options are:
     private key is used as the client key for communication with the
     Key/Value store.
 
+*  `kv.username`
+
+    Specifies a username to be used for basic authentication with the Key/Value
+    store.
+
+*  `kv.password`
+
+    Specifies a password to be used for basic authentication with the Key/Value
+    store.
+
 *  `kv.path`
 
     Specifies the path in the Key/Value store. If not configured, the default value is 'docker/nodes'.

--- a/pkg/discovery/kv/kv.go
+++ b/pkg/discovery/kv/kv.go
@@ -92,8 +92,15 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 			// The actual TLS config that will be used
 			TLS: tlsConfig,
 		}
+	} else if (clusterOpts["kv.Username"] != "" && clusterOpts["kv.Password"] != "") {
+		log.Info("Initializing discovery with basic auth")
+		config = &stor.Config{
+			Username: clusterOpts["kv.Username"],
+			Password: clusterOpts["kv.Password"]
+		}
+
 	} else {
-		log.Info("Initializing discovery without TLS")
+		log.Info("Initializing discovery without authentication")
 	}
 
 	// Creates a new store, will ignore options given

--- a/pkg/discovery/kv/kv.go
+++ b/pkg/discovery/kv/kv.go
@@ -92,7 +92,7 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 			// The actual TLS config that will be used
 			TLS: tlsConfig,
 		}
-	} else if (clusterOpts["kv.username"] != "" && clusterOpts["kv.password"] != "") {
+	} else if clusterOpts["kv.username"] != "" && clusterOpts["kv.password"] != "" {
 		log.Info("Initializing discovery with basic auth")
 		config = &store.Config{
 			Username: clusterOpts["kv.username"],

--- a/pkg/discovery/kv/kv.go
+++ b/pkg/discovery/kv/kv.go
@@ -94,9 +94,9 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 		}
 	} else if (clusterOpts["kv.username"] != "" && clusterOpts["kv.password"] != "") {
 		log.Info("Initializing discovery with basic auth")
-		config = &stor.Config{
+		config = &store.Config{
 			Username: clusterOpts["kv.username"],
-			Password: clusterOpts["kv.password"]
+			Password: clusterOpts["kv.password"],
 		}
 
 	} else {

--- a/pkg/discovery/kv/kv.go
+++ b/pkg/discovery/kv/kv.go
@@ -92,11 +92,11 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 			// The actual TLS config that will be used
 			TLS: tlsConfig,
 		}
-	} else if (clusterOpts["kv.Username"] != "" && clusterOpts["kv.Password"] != "") {
+	} else if (clusterOpts["kv.username"] != "" && clusterOpts["kv.password"] != "") {
 		log.Info("Initializing discovery with basic auth")
 		config = &stor.Config{
-			Username: clusterOpts["kv.Username"],
-			Password: clusterOpts["kv.Password"]
+			Username: clusterOpts["kv.username"],
+			Password: clusterOpts["kv.password"]
 		}
 
 	} else {


### PR DESCRIPTION
**\- What I did**
Allow the use of Basic Authentication for key value stores which support Username/Password Auth.

**\- How I did it**
Passed Username and Password variables into the kv config object.  It looks like this feature was meant to be implemented earlier, but never finished, as it is referenced in several places:

[store.go](https://github.com/docker/docker/blob/14b5a50f0a95a2b8f3ed7ab7469bbab02189a09c/vendor/src/github.com/docker/libkv/store/store.go#L49)
[etcd.go](https://github.com/docker/swarm/blob/a4dda5bc973ef042dc98b9b63edf7510a644ac95/vendor/github.com/docker/libkv/store/etcd/etcd.go#L78)

**\- How to verify it**
1) Download and start ETCD
2) Enable ETCD Basic Authentication:

``` bash
etcdctl user add test;
# Above command will interactively prompt you for password
etcdctl auth enable;
```

3) Start Docker Daemon with `--cluster-store-opt kv.Username=test` and `--cluster-store-opt kv.Password=<YOUR_PASSWORD>` parameters.

4) Verify Docker created a record in ETCD using etcdctl

**\- Description for the changelog**
Added Basic Auth for Key/Value Discovery

**\- A picture of a cute animal (not mandatory but encouraged)**
![Penguins are adorable](http://i.dailymail.co.uk/i/pix/2015/12/13/08/2F477C6E00000578-3358025-image-a-2_1449997159358.jpg)
