### PR TITLE
modifed d4mac and d4win download links to stable for v1.12

### DIFF
--- a/docs/getstarted/step_one.md
+++ b/docs/getstarted/step_one.md
@@ -27,7 +27,7 @@ weight = 1
 
 Docker for Mac is our newest offering for the Mac. It runs as a native Mac application and uses <a href="https://github.com/mist64/xhyve/" target="_blank">xhyve</a> to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-<a class="button" href="https://download.docker.com/mac/beta/Docker.dmg">Get Docker for Mac</a>
+<a class="button" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac</a>
 
 **Requirements**
 
@@ -49,7 +49,7 @@ See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docke
 
 Docker for Windows is our newest offering for PCs. It runs as a native Windows application and uses Hyper-V to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-<a class="button" href="https://download.docker.com/win/beta/InstallDocker.msi">Get Docker for Windows</a>
+<a class="button" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows</a>
 
 **Requirements**
 


### PR DESCRIPTION
Modified the Docker for Mac and Docker for Windows download links to point to `stable` instead of `beta` in preparation for v1.12 publishing of docs tomorrow.

Signed-off-by: Victoria Bialas victoria.bialas@docker.com
