### PR TITLE
modifed d4mac and d4win download links to stable for v1.12

### DIFF
--- a/docs/getstarted/step_one.md
+++ b/docs/getstarted/step_one.md
@@ -27,7 +27,7 @@ weight = 1
 
 Docker for Mac is our newest offering for the Mac. It runs as a native Mac application and uses <a href="https://github.com/mist64/xhyve/" target="_blank">xhyve</a> to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-<a class="button" href="https://download.docker.com/mac/beta/Docker.dmg">Get Docker for Mac</a>
+<a class="button" href="https://download.docker.com/mac/stable/Docker.dmg">Get Docker for Mac</a>
 
 **Requirements**
 
@@ -49,7 +49,7 @@ See [Docker Toolbox Overview](/toolbox/overview.md) for help on installing Docke
 
 Docker for Windows is our newest offering for PCs. It runs as a native Windows application and uses Hyper-V to virtualize the Docker Engine environment and Linux kernel-specific features for the Docker daemon.
 
-<a class="button" href="https://download.docker.com/win/beta/InstallDocker.msi">Get Docker for Windows</a>
+<a class="button" href="https://download.docker.com/win/stable/InstallDocker.msi">Get Docker for Windows</a>
 
 **Requirements**
 


### PR DESCRIPTION
cherry-pick #25156 into 1.12.0

@tiborvass this is currently thought to be the last docs change that must go out in 1.12.0 ga

if you are able to add it to your bump_v1.12.0 branch and thus the 1.12.0 release tag, that would be awesome :)
