### PR TITLE
Hash some build time args when necessary

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -8,6 +8,8 @@ package dockerfile
 // package.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"runtime"
@@ -271,6 +273,21 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 	return b.commit("", b.runConfig.Cmd, fmt.Sprintf("WORKDIR %v", b.runConfig.WorkingDir))
 }
 
+func needsHash(key string) bool {
+	hashBuildArgs := []string{
+		"http_proxy",
+		"https_proxy",
+		"ftp_proxy",
+	}
+
+	for _, arg := range hashBuildArgs {
+		if strings.ToLower(key) == arg {
+			return true
+		}
+	}
+	return false
+}
+
 // RUN some command yo
 //
 // run a command and commit the image. Args are automatically prepended with
@@ -351,7 +368,23 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 	saveCmd := config.Cmd
 	if len(cmdBuildEnv) > 0 {
 		sort.Strings(cmdBuildEnv)
-		tmpEnv := append([]string{fmt.Sprintf("|%d", len(cmdBuildEnv))}, cmdBuildEnv...)
+		saveCmdBuildEnv := []string{}
+
+		for _, env := range cmdBuildEnv {
+			buildEnv := strings.SplitN(env, "=", 2)
+			k := buildEnv[0]
+			v := buildEnv[1]
+			// hash build time args if needed
+			if needsHash(k) {
+				hasher := sha256.New()
+				hasher.Write([]byte(v))
+				saveCmdBuildEnv = append(saveCmdBuildEnv, fmt.Sprintf("%s=%s", k, hex.EncodeToString(hasher.Sum(nil))))
+			} else {
+				saveCmdBuildEnv = append(saveCmdBuildEnv, env)
+			}
+		}
+
+		tmpEnv := append([]string{fmt.Sprintf("|%d", len(saveCmdBuildEnv))}, saveCmdBuildEnv...)
 		saveCmd = strslice.StrSlice(append(tmpEnv, saveCmd...))
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Hash some build time args in cache and history.

**\- How I did it**

Use sha256 to hash certain build time args when building a Dockerfile.

**\- How to verify it**

Use command
`docker build --build-arg http_proxy=http://account:password@server:port .` to build a image `imgName`.

Before this PR, you'll see the whole http_proxy info (account and password) from `docker history --no-trunc imgName`.

After this PR, you'll see `http_proxy=7c87f39bb182...` only hash number in arg value.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Some environments depend on proxys to connect to internet,
so we use `--build-arg` to pass `http_proxy` and
`https_proxy` envs to container when building a Dockerfile.
And it'll make images made in this way undistributable
because it contains proxy accounts and passwords in
`docker history`.

This patch hashes certain build args (currently only
`http_proxy`, `https_proxy` and `ftp_proxy`), so we can
keep these information private and don't have side
effects as the approach in #18702.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
