### PR TITLE
optimize a print in `volume/volume.go`

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -154,7 +154,7 @@ func (m *MountPoint) Type() string {
 // ParseVolumesFrom ensures that the supplied volumes-from is valid.
 func ParseVolumesFrom(spec string) (string, string, error) {
 	if len(spec) == 0 {
-		return "", "", fmt.Errorf("malformed volumes-from specification: %s", spec)
+		return "", "", fmt.Errorf("volumes-from specification cannot be an empty string")
 	}
 
 	specParts := strings.SplitN(spec, ":", 2)


### PR DESCRIPTION
Optimize a print in `volume/volume.go`.

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
