### PR TITLE
TestDaemonDiscoveryBackendConfigReload behavior

### DIFF
--- a/integration-cli/daemon_unix.go
+++ b/integration-cli/daemon_unix.go
@@ -7,3 +7,7 @@ import "syscall"
 func signalDaemonDump(pid int) {
 	syscall.Kill(pid, syscall.SIGQUIT)
 }
+
+func signalDaemonReload(pid int) error {
+	return syscall.Kill(pid, syscall.SIGHUP)
+}

--- a/integration-cli/daemon_windows.go
+++ b/integration-cli/daemon_windows.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 	"syscall"
 	"unsafe"
@@ -39,4 +40,8 @@ func signalDaemonDump(pid int) {
 		return
 	}
 	pulseEvent(h2, procPulseEvent)
+}
+
+func signalDaemonReload(pid int) error {
+	return fmt.Errorf("daemon reload not supported")
 }


### PR DESCRIPTION
`TestDaemonDiscoveryBackendConfigReload` was doing some weird things
with files, creating a file (directly in `./integration-cli`), removing
it, then creating a new file in the same place with new data.
This is just weird, so fixed it to use a single file, file will go into
a temp dir so it doesn't pollute integration-cli.
Only reason I found this is because I saw the `test.json` sitting in integration-cli after a test run.

It was also blindly sending a SIGHUP to the daemon process then sleeping
for 3 seconds.  This is racey, and slow.
Change this to look for the daemon-reload event in the event stream.
Reload logic is moved to a separate function and blocks (w/ a timeout)
waiting for the reload event to fire.

Runtime of the test is now ~0.5s on my machine, where as it was a
minimum of 3s due to the `time.Sleep` before.
