### PR TITLE
nuke-graph-directory.sh: Improve subvolume search

### DIFF
--- a/contrib/nuke-graph-directory.sh
+++ b/contrib/nuke-graph-directory.sh
@@ -51,13 +51,10 @@ done
 
 # now, let's go destroy individual btrfs subvolumes, if any exist
 if command -v btrfs > /dev/null 2>&1; then
-	root="$(df "$dir" | awk 'NR>1 { print $NF }')"
-	root="${root%/}" # if root is "/", we want it to become ""
-	for subvol in $(btrfs subvolume list -o "$root/" 2>/dev/null | awk -F' path ' '{ print $2 }' | sort -r); do
-		subvolDir="$root/$subvol"
-		if dir_in_dir "$subvolDir" "$dir"; then
-			( set -x; btrfs subvolume delete "$subvolDir" )
-		fi
+	# Find btrfs subvolumes under $dir checking for inode 256
+	# Source: http://stackoverflow.com/a/32865333
+	for subvol in $(find "$dir" -type d -inum 256 | sort -r); do
+		( set -x; btrfs subvolume delete "$subvol" )
 	done
 fi
 


### PR DESCRIPTION
This change allows btrfs subvolumes to be found in additional system configurations. The old logic failed to correctly identify subvolumes when the root fs was mounted as a subvolume that was not the btrfs filesystem root.

Should also fix problems discussed recently in #7423

For reference, my system is mounted with the root filesystem as a btrfs subvolume named root. An excerpt of `btrfs subvolume list` is shown below. The current script tries to delete `/root/var/lib/docker/btrfs/subvolumes/...` which fails because of the /root/ at the beginning.

This change should be safer in that `find` will never go outside of the search directory as `btrfs subvolume list` was doing.

```
ID 9093 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/56cce85c15604d98da0bded7307511f9ee7589cbafe42ef1e8b23c5bbd0c5b48
ID 9094 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/e6fa3a93184391d1f316310a3e0a679e4778a742912f99738ff044cec24feeb5
ID 9095 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/606b386f540e415f3a7ba765aaa8f1c69d339600e4ad7e849d675097bdc6bdec
ID 9096 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/7d36c9e99386e369dd938132b4651ef0b6df9fadeabd95aac7e66939e8b4e7c4
ID 9097 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/596c7098712cb929c6a6d92bfb7c90b0383df60fc981380e989ff06b732342b1
ID 9098 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/3250152b04288d6c5705f7fdb7bc52be14a61fef7c38a1d1ec963244c5d48985
ID 9099 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/ffa3e9a09957609336cfe8e3b093d7cebeb178d2a04115755eb0df8d8892b8b4
ID 9100 gen 353259 top level 2870 path root/var/lib/docker/btrfs/subvolumes/c9b1d22d43eb601fd00b80960c18d305b7e2a1f10a99bdcc19473544db9f43b3
```

See also: http://stackoverflow.com/questions/25908149/how-to-test-if-location-is-a-btrfs-subvolume
