### PR TITLE
service ls: Show tasks from nodes that are not down, not only "ready" nodes

### DIFF
--- a/api/client/service/list.go
+++ b/api/client/service/list.go
@@ -84,7 +84,7 @@ func runList(dockerCli *client.DockerCli, opts listOptions) error {
 func PrintNotQuiet(out io.Writer, services []swarm.Service, nodes []swarm.Node, tasks []swarm.Task) {
 	activeNodes := make(map[string]struct{})
 	for _, n := range nodes {
-		if n.Status.State == swarm.NodeStateReady {
+		if n.Status.State != swarm.NodeStateDown {
 			activeNodes[n.ID] = struct{}{}
 		}
 	}


### PR DESCRIPTION
Currently, the counter only shows tasks on READY nodes. It's more
correct to also count nodes in the other states except DOWN, because
the tasks assocated with those nodes are still assumed to be running for
orchestration purposes. One example of when this could matter is during
a leader failover when agents are in the process of reconnecting.

Fixes #25186

cc @dongluochen
