### PR TITLE
Output external CAs in swarm mode with `docker info`

### DIFF
--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -98,6 +98,12 @@ func runInfo(dockerCli *client.DockerCli) error {
 			fmt.Fprintf(dockerCli.Out(), "  Heartbeat Period: %s\n", units.HumanDuration(time.Duration(info.Swarm.Cluster.Spec.Dispatcher.HeartbeatPeriod)))
 			fmt.Fprintf(dockerCli.Out(), " CA Configuration:\n")
 			fmt.Fprintf(dockerCli.Out(), "  Expiry Duration: %s\n", units.HumanDuration(info.Swarm.Cluster.Spec.CAConfig.NodeCertExpiry))
+			if len(info.Swarm.Cluster.Spec.CAConfig.ExternalCAs) > 0 {
+				fmt.Fprintf(dockerCli.Out(), "  External CAs:\n")
+				for _, entry := range info.Swarm.Cluster.Spec.CAConfig.ExternalCAs {
+					fmt.Fprintf(dockerCli.Out(), "    %s: %s\n", entry.Protocol, entry.URL)
+				}
+			}
 		}
 		fmt.Fprintf(dockerCli.Out(), " Node Address: %s\n", info.Swarm.NodeAddr)
 	}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #25195 where external CA configurations are not present in `docker info`.

**\- How I did it**

This fix adds the output of external CAs in `docker info` in swarm mode.

**\- How to verify it**

The test is done manually with:

```
docker run -p 8888:8888 -e CXFSSL_ADDRESS=0.0.0.0 -d fabric8/cfssl
docker swarm init --external-ca protocol=cfssl,url=http://172.17.0.2:8888
```

The `docker info` output:

```
 Managers: 1
 Nodes: 1
 Orchestration:
  Task History Retention Limit: 5
 Raft:
  Snapshot interval: 10000
  Heartbeat tick: 1
  Election tick: 3
 Dispatcher:
  Heartbeat period: 5 seconds
 CA configuration:
  Expiry duration: 3 months
  External CAs:
    cfssl: https://172.17.0.2:8888
```

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25195.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
