### PR TITLE
delete a useless variable

### DIFF
--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	errInvalidScope = errors.New("invalid scope")
 	errNoSuchVolume = errors.New("no such volume")
 )
 


### PR DESCRIPTION
Delete the variable `errInvalidScope`,  because it is not used in the codes.

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
