### PR TITLE
make node ps default to self in swarm node

### DIFF
--- a/api/client/node/cmd.go
+++ b/api/client/node/cmd.go
@@ -28,7 +28,7 @@ func NewNodeCommand(dockerCli *client.DockerCli) *cobra.Command {
 		newListCommand(dockerCli),
 		newPromoteCommand(dockerCli),
 		newRemoveCommand(dockerCli),
-		newPSCommand(dockerCli),
+		newPsCommand(dockerCli),
 		newUpdateCommand(dockerCli),
 	)
 	return cmd

--- a/api/client/node/ps.go
+++ b/api/client/node/ps.go
@@ -19,16 +19,21 @@ type psOptions struct {
 	filter    opts.FilterOpt
 }
 
-func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
+func newPsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
-		Use:   "ps [OPTIONS] self|NODE",
-		Short: "List tasks running on a node",
-		Args:  cli.ExactArgs(1),
+		Use:   "ps [OPTIONS] [NODE]",
+		Short: "List tasks running on a node, defaults to current node",
+		Args:  cli.RequiresRangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.nodeID = args[0]
-			return runPS(dockerCli, opts)
+			opts.nodeID = "self"
+
+			if len(args) != 0 {
+				opts.nodeID = args[0]
+			}
+
+			return runPs(dockerCli, opts)
 		},
 	}
 	flags := cmd.Flags()
@@ -39,7 +44,7 @@ func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runPS(dockerCli *client.DockerCli, opts psOptions) error {
+func runPs(dockerCli *client.DockerCli, opts psOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 

--- a/api/client/service/cmd.go
+++ b/api/client/service/cmd.go
@@ -22,7 +22,7 @@ func NewServiceCommand(dockerCli *client.DockerCli) *cobra.Command {
 	cmd.AddCommand(
 		newCreateCommand(dockerCli),
 		newInspectCommand(dockerCli),
-		newPSCommand(dockerCli),
+		newPsCommand(dockerCli),
 		newListCommand(dockerCli),
 		newRemoveCommand(dockerCli),
 		newScaleCommand(dockerCli),

--- a/api/client/service/ps.go
+++ b/api/client/service/ps.go
@@ -20,7 +20,7 @@ type psOptions struct {
 	filter    opts.FilterOpt
 }
 
-func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
+func newPsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{

--- a/api/client/stack/cmd.go
+++ b/api/client/stack/cmd.go
@@ -25,7 +25,7 @@ func NewStackCommand(dockerCli *client.DockerCli) *cobra.Command {
 		newDeployCommand(dockerCli),
 		newRemoveCommand(dockerCli),
 		newServicesCommand(dockerCli),
-		newPSCommand(dockerCli),
+		newPsCommand(dockerCli),
 	)
 	return cmd
 }

--- a/api/client/stack/ps.go
+++ b/api/client/stack/ps.go
@@ -25,7 +25,7 @@ type psOptions struct {
 	noResolve bool
 }
 
-func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
+func newPsCommand(dockerCli *client.DockerCli) *cobra.Command {
 	opts := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -792,7 +792,7 @@ __docker_node_commands() {
         "ls:List nodes in the swarm"
         "promote:Promote a node as manager in the swarm"
         "rm:Remove one or more nodes from the swarm"
-        "ps:List tasks running on a node"
+        "ps:List tasks running on a node, defaults to current node"
         "update:Update a node"
     )
     _describe -t docker-node-commands "docker node command" _docker_node_subcommands

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -115,7 +115,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [node demote](node_demote.md) | Demotes an existing manager so that it is no longer a manager |
 | [node inspect](node_inspect.md) | Inspect a node in the swarm                |
 | [node update](node_update.md) | Update attributes for a node                 |
-| [node ps](node_ps.md) | List tasks running on a node                   |
+| [node ps](node_ps.md) | List tasks running on a node                         |
 | [node ls](node_ls.md) | List nodes in the swarm                              |
 | [node rm](node_rm.md) | Remove one or more nodes from the swarm                         |
 

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -12,9 +12,9 @@ parent = "smn_cli"
 # node ps
 
 ```markdown
-Usage:  docker node ps [OPTIONS] self|NODE
+Usage:  docker node ps [OPTIONS] [NODE]
 
-List tasks running on a node
+List tasks running on a node, defaults to current node.
 
 Options:
   -a, --all            Display all instances


### PR DESCRIPTION
**\- What I did**
1. change function name: `newPSCommand` into `newPsCommand`, `runPS` into `runPs` to keep consistency
2. make command `docker node ps` default to list tasks on itself. fix #25175
3. modify some related docs.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
