### PR TITLE
Better error on 'docker deploy' when not in Swarm mode

### DIFF
--- a/api/client/stack/deploy.go
+++ b/api/client/stack/deploy.go
@@ -52,6 +52,14 @@ func runDeploy(dockerCli *client.DockerCli, opts deployOptions) error {
 		return err
 	}
 
+	info, err := dockerCli.Client().Info(context.Background())
+	if err != nil {
+		return err
+	}
+	if !info.Swarm.ControlAvailable {
+		return fmt.Errorf("This node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again.")
+	}
+
 	networks := getUniqueNetworkNames(bundle.Services)
 	ctx := context.Background()
 


### PR DESCRIPTION
Without this, `docker deploy` fails at the network creation step with an unfriendly error:

``` console
$ docker deploy myapp
Loading bundle from myapp.dab
Creating network myapp_default
Error response from daemon: datastore for scope "global" is not initialized
```
