### PR TITLE
TestRunSeccompUnconfinedCloneUserns: Check for unprivileged_userns_clone

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1032,7 +1032,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyCloneUserns(c *check.C) {
 // TestRunSeccompUnconfinedCloneUserns checks that
 // 'docker run --security-opt seccomp=unconfined syscall-test' allows creating a userns.
 func (s *DockerSuite) TestRunSeccompUnconfinedCloneUserns(c *check.C) {
-	testRequires(c, SameHostDaemon, seccompEnabled, UserNamespaceInKernel, NotUserNamespace)
+	testRequires(c, SameHostDaemon, seccompEnabled, UserNamespaceInKernel, NotUserNamespace, unprivilegedUsernsClone)
 
 	// make sure running w privileged is ok
 	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "syscall-test", "userns-test", "id")

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -3,6 +3,9 @@
 package main
 
 import (
+	"io/ioutil"
+	"strings"
+
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
@@ -98,6 +101,16 @@ var (
 			return !SysInfo.BridgeNFCallIP6TablesDisabled
 		},
 		"Test requires that bridge-nf-call-ip6tables support be enabled in the daemon.",
+	}
+	unprivilegedUsernsClone = testRequirement{
+		func() bool {
+			content, err := ioutil.ReadFile("/proc/sys/kernel/unprivileged_userns_clone")
+			if err == nil && strings.Contains(string(content), "0") {
+				return false
+			}
+			return true
+		},
+		"Test cannot be run with 'sysctl kernel.unprivileged_userns_clone' = 0",
 	}
 )
 


### PR DESCRIPTION
On Ubuntu and Debian there is a sysctl which allows to block
clone(CLONE_NEWUSER) via "sysctl kernel.unprivileged_userns_clone=0"
for unprivileged users that do not have CAP_SYS_ADMIN.

See: https://lists.ubuntu.com/archives/kernel-team/2016-January/067926.html

The DockerSuite.TestRunSeccompUnconfinedCloneUserns testcase fails if
"kernel.unprivileged_userns_clone" is set to 0:

```
 docker_cli_run_unix_test.go:1040:
    c.Fatalf("expected clone userns with --security-opt seccomp=unconfined
              to succeed, got %s: %v", out, err)
 ... Error: expected clone userns with --security-opt seccomp=unconfined
              to succeed, got clone failed: Operation not permitted
 : exit status 1
```

So add a check and skip the testcase if kernel.unprivileged_userns_clone exists and is 0.

Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
