### PR TITLE
Fix Upstart post-start script when using multiple Unix sockets

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -58,7 +58,7 @@ post-start script
 	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
 		DOCKER_SOCKET=/var/run/docker.sock
 	else
-		DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)')
+		DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)' | sed 1q)
 	fi
 
 	if [ -n "$DOCKER_SOCKET" ]; then


### PR DESCRIPTION
Fixes #25223 

**\- What I did**

Fixed the problem that the script was looking for a non-existent socket composed of all the socket names joined by newlines.

**\- How I did it**

Added `sed 1q` to take the first line of output only.

**\- How to verify it**

Follow steps in #25223 

**\- Description for the changelog**

Fix Upstart post-start script when using multiple Unix sockets

**\- A picture of a cute animal (not mandatory but encouraged)**

![baby duck](http://www.maniacworld.com/baby-duck-feed-the-carp.jpg)
