### PR TITLE
Support multiple service IDs on "docker service ps"

### DIFF
--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -19,7 +19,7 @@ aliases: ["/engine/reference/commandline/service_tasks/"]
 ```Markdown
 Usage:  docker service ps [OPTIONS] SERVICE
 
-List the tasks of a service
+List the tasks of one or more services
 
 Options:
   -f, --filter filter   Filter output based on conditions provided
@@ -29,7 +29,7 @@ Options:
   -q, --quiet           Only display task IDs
 ```
 
-Lists the tasks that are running as part of the specified service. This command
+Lists the tasks that are running as part of the specified services. This command
 has to be run targeting a manager node.
 
 ## Examples


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #25228 to support multiple service IDs on `docker service ps`.

**\- How I did it**

Multiple IDs are allowed with `docker service ps ...`, and related documentation has been updated.

**\- How to verify it**

A test has been added to cover the changes.

**\- Description for the changelog**

Support multiple service IDs on "docker service ps"

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25228.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
