### PR TITLE
Added shutdown to desired-state docs for filter node/service ps

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4503,6 +4503,9 @@ List tasks
   - `id=<task id>`
   - `name=<task name>`
   - `service=<service name>`
+  - `node=<node id>`
+  - `label=key` or `label="key=value"`
+  - `desired-state=(running | shutdown | accepted)`
 
 **Status codes**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4503,6 +4503,9 @@ List tasks
   - `id=<task id>`
   - `name=<task name>`
   - `service=<service name>`
+  - `node=<node id>`
+  - `label=key` or `label="key=value"`
+  - `desired-state=(running | shutdown | accepted)`
 
 **Status codes**:
 

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -89,7 +89,7 @@ bg8c07zzg87di2mufeq51a2qp  redis.7  redis    redis:3.0.6  Running 9 minutes   Ru
 
 #### desired-state
 
-The `desired-state` filter can take the values `running` and `accepted`.
+The `desired-state` filter can take the values `running`, `shutdown`, and `accepted`.
 
 
 ## Related information

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -87,7 +87,7 @@ ID                         NAME      SERVICE  IMAGE        DESIRED STATE  LAST S
 
 #### desired-state
 
-The `desired-state` filter can take the values `running` and `accepted`.
+The `desired-state` filter can take the values `running`, `shutdown`, and `accepted`.
 
 
 ## Related information


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

added `shutdown` to filter docs for node/service ps `desired-state` filter option. 

It already worked so might as well document it!

```
$ docker service ps nginx --filter desired-state=shutdown
ID                         NAME     IMAGE         NODE  DESIRED STATE  CURRENT STATE            ERROR
7qd7h77ynhrxqlkzekf027rqg  nginx.1  nginx:latest  moby  Shutdown       Rejected 50 minutes ago  "failed to allocate gateway (1…"

$ docker node ps self --filter desired-state=shutdown
ID                         NAME     IMAGE         NODE  DESIRED STATE  CURRENT STATE            ERROR
7qd7h77ynhrxqlkzekf027rqg  nginx.1  nginx:latest  moby  Shutdown       Rejected 48 minutes ago  "failed to allocate gateway (1…"
```

**\- How I did it**

typed 👼 

**\- How to verify it**

checkout markdown docs

**\- Description for the changelog**

Updated node/service ps filter options to include shutdown.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Josh Horwitz horwitzja@gmail.com
