### PR TITLE
Add -a option to service/node ps to show not running tasks

### DIFF
--- a/api/client/node/inspect.go
+++ b/api/client/node/inspect.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/api/client/inspect"
-	"github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-units"
@@ -26,10 +25,13 @@ func newInspectCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
-		Use:   "inspect [OPTIONS] self|NODE [NODE...]",
-		Short: "Display detailed information on one or more nodes",
-		Args:  cli.RequiresMinArgs(1),
+		Use:   "inspect [OPTIONS] [NODE...]",
+		Short: "Display detailed information on one or more nodes (default to current node)",
+		Args:  nil,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				args = []string{"self"}
+			}
 			opts.nodeIds = args
 			return runInspect(dockerCli, opts)
 		},

--- a/api/client/service/ps.go
+++ b/api/client/service/ps.go
@@ -16,6 +16,7 @@ import (
 type psOptions struct {
 	serviceID string
 	noResolve bool
+	all       bool
 	filter    opts.FilterOpt
 }
 
@@ -32,6 +33,7 @@ func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	flags.BoolVarP(&opts.all, "all", "a", false, "Show all tasks (default shows tasks that are or will be running)")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
 
@@ -61,7 +63,12 @@ func runPS(dockerCli *client.DockerCli, opts psOptions) error {
 		}
 	}
 
-	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})
+	options := types.TaskListOptions{
+		Filter: filter,
+		All:    opts.all,
+	}
+
+	tasks, err := client.TaskList(ctx, options)
 	if err != nil {
 		return err
 	}

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -235,7 +235,12 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	tasks, err := sr.backend.GetTasks(basictypes.TaskListOptions{Filter: filter})
+	options := basictypes.TaskListOptions{
+		Filter: filter,
+		All:    httputils.BoolValue(r, "all"),
+	}
+
+	tasks, err := sr.backend.GetTasks(options)
 	if err != nil {
 		logrus.Errorf("Error getting tasks: %v", err)
 		return err

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1080,6 +1080,18 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 		return nil
 	}
 
+	if !options.All && !options.Filter.Include("desired-state") {
+		options.Filter.Add("desired-state", "running")
+	}
+
+	// if all was set then that trumps any other desired state filters
+	if options.All {
+		options.Filter.WalkValues("desired-state", func(value string) error {
+			options.Filter.Del("desired-state", value)
+			return nil
+		})
+	}
+
 	filters, err := newListTasksFilters(options.Filter, byName)
 	if err != nil {
 		return nil, err

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4498,6 +4498,9 @@ List tasks
 
 **Query parameters**:
 
+- **all** – 1/True/true or 0/False/false, Show all containers.
+    Only tasks that will be running or are currently running are shown by default(i.e., this defaults to false)
+
 - **filters** – a JSON encoded value of the filters (a `map[string][]string`) to process on the
   services list. Available filters:
   - `id=<task id>`

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4498,12 +4498,14 @@ List tasks
 
 **Query parameters**:
 
+- **all** – 1/True/true or 0/False/false, Show all containers.
+    Only tasks that will be running or are currently running are shown by default(i.e., this defaults to false)
+
 - **filters** – a JSON encoded value of the filters (a `map[string][]string`) to process on the
   services list. Available filters:
   - `id=<task id>`
   - `name=<task name>`
   - `service=<service name>`
-
 **Status codes**:
 
 - **200** – no error

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -11,9 +11,9 @@ parent = "smn_cli"
 # node inspect
 
 ```markdown
-Usage:  docker node inspect [OPTIONS] self|NODE [NODE...]
+Usage:  docker node inspect [OPTIONS] [NODE...]
 
-Display detailed information on one or more nodes
+Display detailed information on one or more nodes (default to current node)
 
 Options:
   -f, --format string   Format the output using the given go template

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -12,12 +12,12 @@ parent = "smn_cli"
 # node ps
 
 ```markdown
-Usage:  docker node ps [OPTIONS] self|NODE
+Usage:  docker node ps [OPTIONS] [NODE]
 
-List tasks running on a node
+List tasks running on a node (default to current node)
 
 Options:
-  -a, --all            Display all instances
+  -a, --all            Show all tasks (default shows tasks that are or will be running)
   -f, --filter value   Filter output based on conditions provided
       --help           Print usage
       --no-resolve     Do not map IDs to Names

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -17,7 +17,7 @@ Usage:	docker service ps [OPTIONS] SERVICE
 List the tasks of a service
 
 Options:
-  -a, --all            Display all tasks
+  -a, --all            Show all tasks (default shows tasks that are or will be running)
   -f, --filter value   Filter output based on conditions provided
       --help           Print usage
       --no-resolve     Do not map IDs to Names

--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/daemon/cluster/executor/container"
 	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/swarm"
 	"github.com/go-check/check"
 )
@@ -54,7 +55,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
 		out, _ := d.Cmd("inspect", "--format={{.State.Health.Status}}", containerID)
 		return strings.TrimSpace(out), nil
-	}, checker.Equals, "healthy")
+	}, checker.Equals, types.Healthy)
 
 	// make it fail
 	d.Cmd("exec", containerID, "rm", "/status")
@@ -62,7 +63,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
 		out, _ := d.Cmd("inspect", "--format={{.State.Health.Status}}", containerID)
 		return strings.TrimSpace(out), nil
-	}, checker.Equals, "unhealthy")
+	}, checker.Equals, types.Unhealthy)
 
 	// Task should be terminated
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {

--- a/vendor/src/github.com/docker/engine-api/client/task_list.go
+++ b/vendor/src/github.com/docker/engine-api/client/task_list.go
@@ -23,6 +23,10 @@ func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) 
 		query.Set("filters", filterJSON)
 	}
 
+	if options.All {
+		query.Set("all", "1")
+	}
+
 	resp, err := cli.get(ctx, "/tasks", query, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -283,4 +283,5 @@ type ServiceListOptions struct {
 // TaskListOptions holds parameters to list  tasks with.
 type TaskListOptions struct {
 	Filter filters.Args
+	All    bool
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #25180
closes #25196

**\- What I did**

Changed `service ps` and `node ps` to only show tasks that will be or are currently running instead of every task. This is more inline with how `docker ps` works with containers. I added an `-a` and `--all` flag to both commands to show all tasks.

Also changed `node inspect` & `node ps` to default to `self` if the node isn't specified. I kept the `self` support since the GA already went out (let me know if it's OK to kill).

**\- How I did it**

Followed how `docker ps` was done with `all=1` optional flag on the http endpoint for `/tasks`.

**\- How to verify it**

Look at tests. 

Run `docker service ps` & `docker node ps` on various nodes including `self` to ensure that only tasks are shown that are running or will be running w/o the `-a` flag. Also make sure that adding a filter w/o `-a` selected keeps your filter on `desired-state` (test for this). 

Run `docker node inspect` w/o the `self` flag to make sure it works (test for this). 

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed service/node ps from showing all tasks by default & removed self arg. 

Signed-off-by: Josh Horwitz horwitzja@gmail.com
