### PR TITLE
[Requires #343 to engine-api] Adds isolation to info

### DIFF
--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -214,6 +214,7 @@ func runInfo(dockerCli *client.DockerCli) error {
 	}
 
 	fmt.Fprintf(dockerCli.Out(), "Live Restore Enabled: %v\n", info.LiveRestoreEnabled)
+	fmt.Fprintf(dockerCli.Out(), "Default Isolation: %v\n", info.Isolation)
 
 	return nil
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -118,6 +118,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		NoProxy:            sockets.GetProxyEnv("no_proxy"),
 		SecurityOptions:    securityOptions,
 		LiveRestoreEnabled: daemon.configStore.LiveRestoreEnabled,
+		Isolation:          daemon.defaultIsolation,
 	}
 
 	// TODO Windows. Refactor this more once sysinfo is refactored into

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -60,7 +60,8 @@ clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://gith
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
-clone git github.com/docker/engine-api 3d1601b9d2436a70b0dfc045a23f6503d19195df
+# Temporary HACK
+clone git github.com/jhowardmsft/engine-api 0e80f8e3ab0e8df684239705201310fc9ac839d6
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/docker/engine-api/types/container"
 )
 
 var (
@@ -65,6 +66,9 @@ var (
 	// WindowsBaseImage is the name of the base image for Windows testing
 	// Environment variable WINDOWS_BASE_IMAGE can override this
 	WindowsBaseImage = "windowsservercore"
+
+	// isolation is the isolation mode of the daemon under test
+	isolation container.Isolation
 )
 
 const (

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -84,6 +84,7 @@ func init() {
 		volumesConfigPath = strings.Replace(volumesConfigPath, `\`, `/`, -1)
 		containerStoragePath = strings.Replace(containerStoragePath, `\`, `/`, -1)
 	}
+	isolation = info.Isolation
 }
 
 func convertBasesize(basesizeBytes int64) (int64, error) {

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -260,6 +260,7 @@ type Info struct {
 	// running when the daemon is shutdown or upon daemon start if
 	// running containers are detected
 	LiveRestoreEnabled bool
+	Isolation          container.Isolation
 }
 
 // PluginsInfo is a temp struct holding Plugins name


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This adds everything needed so that integration tests can be updated so that they know the isolation mode of the daemon under test so that they can take different actions between (on Windows) Window Server containers and Hyper-V containers.

Three commits:
- One (hacked pending https://github.com/docker/engine-api/pull/343 being merged into engine-api) that adds isolation to the `INFO` api call
- Second that updates the daemon population of the new field and the client outputting the new field
- Third that adds test infrastructure so that tests can now determine the isolation mode of the daemon and be updated accordingly.
