### PR TITLE
Fix swarm manager node fault tolerance table

### DIFF
--- a/docs/swarm/admin_guide.md
+++ b/docs/swarm/admin_guide.md
@@ -64,7 +64,7 @@ guaranteed if you encounter more than two network partitions.
 |      1       |     1      |         0         |
 |      2       |     2      |         0         |
 |    **3**     |     2      |       **1**       |
-|      4       |     3      |         2         |
+|      4       |     3      |         1         |
 |    **5**     |     3      |       **2**       |
 |      6       |     4      |         2         |
 |    **7**     |     4      |       **3**       |


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
In a cluster of 4 nodes, with a majority being 3 nodes, the fault
tolerance should be 1 node.

**\- How I did it**
Change single character in docs.

**\- How to verify it**
Subtraction. 4-3=1

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix swarm cluster node majority table in docs/swarm

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Adam Walz adam@adamwalz.net
