### PR TITLE
make container kill debug log readable

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -55,7 +55,7 @@ func (daemon *Daemon) ContainerKill(name string, sig uint64) error {
 // or not running, or if there is a problem returned from the
 // underlying kill command.
 func (daemon *Daemon) killWithSignal(container *container.Container, sig int) error {
-	logrus.Debugf("Sending %d to %s", sig, container.ID)
+	logrus.Debugf("Sending kill signal %d to container %s", sig, container.ID)
 	container.Lock()
 	defer container.Unlock()
 


### PR DESCRIPTION
**\- What I did**
change container kill debug log to make it more readable.
As I found a log record of docker daemon:

```
time="2016-08-01T00:56:24.084768389+08:00" level=debug msg="Sending 15 to 5ceca1f092a0d7590c1865e16ccc37f7e653105b5f4948f54aa4ca8ee57e6410"
```

First, I was confusing, actually it is invoked by command `docker stop`.
I wish we could make the log clearer.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
