### PR TITLE
make pkg pidfile support darwin

### DIFF
--- a/pkg/pidfile/pidfile_darwin.go
+++ b/pkg/pidfile/pidfile_darwin.go
@@ -1,0 +1,18 @@
+// +build darwin
+
+package pidfile
+
+import (
+	"syscall"
+)
+
+func processExists(pid int) bool {
+	// OS X does not have a proc filesystem.
+	// Use kill -0 pid to judge if the process exists.
+	err := syscall.Kill(pid, 0)
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/pidfile/pidfile_unix.go
+++ b/pkg/pidfile/pidfile_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!darwin
 
 package pidfile
 


### PR DESCRIPTION
make pkg pidfile support darwin, as in OSX there is no proc filesystem.  While in `pkg/pidfile/pidfile_unix.go`, it will use `proc`.

This PR can finish a part of work described in #22470

Signed-off-by: allencloud allen.sun@daocloud.io
