### PR TITLE
Move David to alumni

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -28,7 +28,6 @@
 		people = [
 			"aaronlehmann",
 			"aluzzardi",
-			"calavera",
 			"coolljt0725",
 			"cpuguy83",
 			"crosbymichael",
@@ -89,6 +88,15 @@
 	# Thank you!
 
 		people = [
+			# David Calavera contributed many features to Docker, such as an improved
+			# event system, dynamic configuration reloading, volume plugins, fancy
+			# new templating options, and an external client credential store. As a
+			# maintainer, David was release captain for Docker 1.8, and competing
+			# with Jess Frazelle to be "top dream killer".
+			# David is now doing amazing stuff as CTO for https://www.netlify.com,
+			# and tweets as @calavera.
+			"calavera",
+
 			# As a maintainer, Erik was responsible for the "builder", and
 			# started the first designs for the new networking model in
 			# Docker. Erik is now working on all kinds of plugins for Docker


### PR DESCRIPTION
Unfortunately, combining a job as CTO of a startup, and maintaining Docker is too much to combine, so David asked to be moved to the alumni section.

Thanks for all the awesome work on Docker!

And, because @calavera likes a good coffee :smile:

![i-like-my-coffee-cute-like-my-meerkat](https://cloud.githubusercontent.com/assets/1804568/17299190/92c67480-580d-11e6-91d5-1442552afc66.jpg)

ping @docker/core-engine-maintainers 
