### PR TITLE
Replace `"workdir'` with const `flWorkdir`, same as other flags in `service create`

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -488,7 +488,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags := cmd.Flags()
 	flags.StringVar(&opts.name, flagName, "", "Service name")
 
-	flags.StringVarP(&opts.workdir, "workdir", "w", "", "Working directory inside the container")
+	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID")
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
@@ -555,6 +555,7 @@ const (
 	flagUpdateFailureAction  = "update-failure-action"
 	flagUpdateParallelism    = "update-parallelism"
 	flagUser                 = "user"
+	flagWorkdir              = "workdir"
 	flagRegistryAuth         = "with-registry-auth"
 	flagLogDriver            = "log-driver"
 	flagLogOpt               = "log-opt"

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -152,7 +152,7 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 	updateString("image", &cspec.Image)
 	updateStringToSlice(flags, "args", &cspec.Args)
 	updateEnvironment(flags, &cspec.Env)
-	updateString("workdir", &cspec.Dir)
+	updateString(flagWorkdir, &cspec.Dir)
 	updateString(flagUser, &cspec.User)
 	updateMounts(flags, &cspec.Mounts)
 


### PR DESCRIPTION
This is a minor fix that tries to replace `"workdir"` with const `flWorkdir` in `service create`.

Since `"workdir"` is the only string not defined as const in `func addServiceFlags()`, I think it makes sense to replace `"workdir"` with a const `flWorkdir` to be consistent.

The flag `"workdir"` in `service update` has also been replaced.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
