### PR TITLE
Improve swarm join-token instructions

### DIFF
--- a/api/client/swarm/init.go
+++ b/api/client/swarm/init.go
@@ -72,5 +72,10 @@ func runInit(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts initOptions
 
 	fmt.Fprintf(dockerCli.Out(), "Swarm initialized: current node (%s) is now a manager.\n\n", nodeID)
 
-	return printJoinCommand(ctx, dockerCli, nodeID, true, true)
+	if err := printJoinCommand(ctx, dockerCli, nodeID, true, false); err != nil {
+		return err
+	}
+
+	fmt.Fprint(dockerCli.Out(), "To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.\n\n")
+	return nil
 }

--- a/api/client/swarm/opts.go
+++ b/api/client/swarm/opts.go
@@ -19,6 +19,8 @@ const (
 	flagDispatcherHeartbeat = "dispatcher-heartbeat"
 	flagListenAddr          = "listen-addr"
 	flagAdvertiseAddr       = "advertise-addr"
+	flagQuiet               = "quiet"
+	flagRotate              = "rotate"
 	flagToken               = "token"
 	flagTaskHistoryLimit    = "task-history-limit"
 	flagExternalCA          = "external-ca"

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -35,14 +35,12 @@ $ docker swarm init --advertise-addr 192.168.99.121
 Swarm initialized: current node (bvz81updecsj6wjz393c09vti) is now a manager.
 
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx \
     172.17.0.2:2377
 
-To add a manager to this swarm, run the following command:
-    docker swarm join \
-    --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2 \
-    172.17.0.2:2377
+To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
 ```
 
 `docker swarm init` generates two random tokens, a worker token and a manager token. When you join

--- a/docs/reference/commandline/swarm_join_token.md
+++ b/docs/reference/commandline/swarm_join_token.md
@@ -36,12 +36,14 @@ the swarm:
 ```bash
 $ docker swarm join-token worker
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx \
     172.17.0.2:2377
 
 $ docker swarm join-token manager
 To add a manager to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2 \
     172.17.0.2:2377
@@ -51,7 +53,10 @@ Use the `--rotate` flag to generate a new join token for the specified role:
 
 ```bash
 $ docker swarm join-token --rotate worker
+Succesfully rotated worker join token.
+
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-b30ljddcqhef9b9v4rs7mel7t \
     172.17.0.2:2377
@@ -63,6 +68,7 @@ The `-q` (or `--quiet`) flag only prints the token:
 
 ```bash
 $ docker swarm join-token -q worker
+
 SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-b30ljddcqhef9b9v4rs7mel7t
 ```
 

--- a/docs/swarm/join-nodes.md
+++ b/docs/swarm/join-nodes.md
@@ -43,6 +43,7 @@ following command on a manager node:
 $ docker swarm join-token worker
 
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
     192.168.99.100:2377
@@ -90,6 +91,7 @@ following command on a manager node:
 $ docker swarm join-token manager
 
 To add a manager to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-61ztec5kyafptydic6jfc1i33t37flcl4nuipzcusor96k7kby-5vy9t8u35tuqm7vh67lrz9xp6 \
     192.168.99.100:2377

--- a/docs/swarm/swarm-mode.md
+++ b/docs/swarm/swarm-mode.md
@@ -56,21 +56,19 @@ swarm.
 external to the swarm.
 
 The output for `docker swarm init` provides the connection command to use when
-you join new worker or manager nodes to the swarm:
+you join new worker nodes to the swarm:
 
 ```bash
 $ docker swarm init
 Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a manager.
 
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
     192.168.99.100:2377
 
-To add a manager to this swarm, run the following command:
-    docker swarm join \
-    --token SWMTKN-1-61ztec5kyafptydic6jfc1i33t37flcl4nuipzcusor96k7kby-5vy9t8u35tuqm7vh67lrz9xp6 \
-    192.168.99.100:2377
+To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
 ```
 
 ### Configure the advertise address
@@ -115,6 +113,7 @@ To retrieve the join command including the join token for worker nodes, run:
 $ docker swarm join-token worker
 
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
     192.168.99.100:2377
@@ -128,6 +127,7 @@ To view the join command and token for manager nodes, run:
 $ docker swarm join-token manager
 
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
     192.168.99.100:2377
@@ -167,6 +167,7 @@ nodes:
 $docker swarm join-token  --rotate worker
 
 To add a worker to this swarm, run the following command:
+
     docker swarm join \
     --token SWMTKN-1-2kscvs0zuymrsc9t0ocyy1rdns9dhaodvpl639j2bqx55uptag-ebmn5u927reawo27s3azntd44 \
     172.17.0.2:2377

--- a/docs/swarm/swarm-tutorial/add-nodes.md
+++ b/docs/swarm/swarm-tutorial/add-nodes.md
@@ -36,6 +36,7 @@ This tutorial uses the name `worker1`.
     $ docker swarm join-token worker
 
     To add a worker to this swarm, run the following command:
+
         docker swarm join \
         --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
         192.168.99.100:2377

--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -33,14 +33,12 @@ node. For example, the tutorial uses a machine named `manager1`.
     Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a manager.
 
     To add a worker to this swarm, run the following command:
+
         docker swarm join \
         --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
         192.168.99.100:2377
 
-    To add a manager to this swarm, run the following command:
-        docker swarm join \
-        --token SWMTKN-1-61ztec5kyafptydic6jfc1i33t37flcl4nuipzcusor96k7kby-5vy9t8u35tuqm7vh67lrz9xp6 \
-        192.168.99.100:2377
+    To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.
     ```
 
     The `--advertise-addr` flag configures the manager node to publish its


### PR DESCRIPTION
this change improves the instructions for
swarm join-token and swarm init;
- only print the join-token command for workers
  instead of for both managers and workers, to
  prevent users from copying the wrong command.
  An extra line is added to explain how to obtain
  the manager token.
- print a message that a token was rotated
  sucesfully if '--rotate' is used.
- add some extra white-space before / after
  the join commands, to make copy/pasting
  easier.

this change also does some refactoring of join-token;
- move flagname-constants together with other constants
- use variables for selected role ("worker" / "manager")
  to prevent checking for them multiple times, and to
  keep the "worker" / "manager" sting centralized
- add an extra blank line after "join-token" instructions
  this makes it easier to copy, and cleans up the
  code a tiny bit
