### PR TITLE
Revert "Add checking err for IsWindowsClient()"

### DIFF
--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -56,7 +56,7 @@ func GetOSVersion() OSVersion {
 func IsWindowsClient() bool {
 	osviex := &osVersionInfoEx{OSVersionInfoSize: 284}
 	r1, _, err := procGetVersionExW.Call(uintptr(unsafe.Pointer(osviex)))
-	if err != nil || r1 == 0 {
+	if r1 == 0 {
 		logrus.Warnf("GetVersionExW failed - assuming server SKU: %v", err)
 		return false
 	}


### PR DESCRIPTION
Reverts docker/docker#25066

@lixiaobing10051267 @jhowardmsft @jstarks This actually breaks the functionality. Unfortunately, on success err is non-nil, so on client machines, we now default to believing they are server:
`time="2016-08-01T17:02:38.920570000-07:00" level=warning msg="GetVersionExW failed - assuming server SKU: The operation completed successfully."`
This change needs to be reverted to fix functionality.
