### PR TITLE
Fix issue reloading mount options on restart

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -88,7 +88,9 @@ func New(scope string, rootUID, rootGID int) (*Root, error) {
 			path:       r.DataPath(name),
 		}
 		r.volumes[name] = v
-		if b, err := ioutil.ReadFile(filepath.Join(name, "opts.json")); err == nil {
+		optsFilePath := filepath.Join(rootDirectory, name, "opts.json")
+		if b, err := ioutil.ReadFile(optsFilePath); err == nil {
+			v.opts = &optsConfig{}
 			if err := json.Unmarshal(b, v.opts); err != nil {
 				return nil, err
 			}

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"io/ioutil"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -245,5 +246,19 @@ func TestCreateWithOpts(t *testing.T) {
 	}
 	if !mounted {
 		t.Fatal("expected mount to still be active")
+	}
+
+	r, err = New(rootDir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v2, exists := r.volumes["test"]
+	if !exists {
+		t.Fatal("missing volume on restart")
+	}
+
+	if !reflect.DeepEqual(v.opts, v2.opts) {
+		t.Fatal("missing volume options on restart")
 	}
 }


### PR DESCRIPTION
On daemon restart the local volume driver will read options that it
persisted to disk, however it was reading an incorrect path, causing
volume options to be silently ignored after a daemon restart.

Fixes #25310 
