### PR TITLE
Support `--group` in `docker service create`

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -399,6 +399,7 @@ type serviceOptions struct {
 	env             opts.ListOpts
 	workdir         string
 	user            string
+	groups          []string
 	mounts          MountOpt
 
 	resources resourceOptions
@@ -446,6 +447,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 				Labels:          runconfigopts.ConvertKVStringsToMap(opts.containerLabels.GetAll()),
 				Dir:             opts.workdir,
 				User:            opts.user,
+				Groups:          opts.groups,
 				Mounts:          opts.mounts.Value(),
 				StopGracePeriod: opts.stopGrace.Value(),
 			},
@@ -491,6 +493,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	flags.StringSliceVar(&opts.groups, flagGroupAdd, []string{}, "Add additional user groups to the container")
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")
@@ -528,6 +531,8 @@ const (
 	flagEnv                  = "env"
 	flagEnvRemove            = "env-rm"
 	flagEnvAdd               = "env-add"
+	flagGroupAdd             = "group-add"
+	flagGroupRemove          = "group-rm"
 	flagLabel                = "label"
 	flagLabelRemove          = "label-rm"
 	flagLabelAdd             = "label-add"

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -100,6 +100,23 @@ func TestUpdateEnvironmentWithDuplicateKeys(t *testing.T) {
 	assert.Equal(t, envs[0], "A=b")
 }
 
+func TestUpdateGroups(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("group-add", "wheel")
+	flags.Set("group-add", "docker")
+	flags.Set("group-rm", "root")
+	flags.Set("group-add", "foo")
+	flags.Set("group-rm", "docker")
+
+	groups := []string{"bar", "root"}
+
+	updateGroups(flags, &groups)
+	assert.Equal(t, len(groups), 3)
+	assert.Equal(t, groups[0], "bar")
+	assert.Equal(t, groups[1], "foo")
+	assert.Equal(t, groups[2], "wheel")
+}
+
 func TestUpdateMounts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("mount-add", "type=volume,target=/toadd")

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -19,6 +19,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 		Env:     c.Env,
 		Dir:     c.Dir,
 		User:    c.User,
+		Groups:  c.Groups,
 	}
 
 	// Mounts
@@ -67,6 +68,7 @@ func containerToGRPC(c types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		Env:     c.Env,
 		Dir:     c.Dir,
 		User:    c.User,
+		Groups:  c.Groups,
 	}
 
 	if c.StopGracePeriod != nil {

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -20,6 +20,7 @@ Options:
       --container-label value          Service container labels (default [])
       --endpoint-mode string           Endpoint mode (vip or dnsrr)
   -e, --env value                      Set environment variables (default [])
+      --group-add value                Add additional user groups to the container (default [])
       --help                           Print usage
   -l, --label value                    Service labels (default [])
       --limit-cpu value                Limit CPUs (default 0.000)

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -24,6 +24,8 @@ Options:
       --endpoint-mode string           Endpoint mode (vip or dnsrr)
       --env-add value                  Add or update environment variables (default [])
       --env-rm value                   Remove an environment variable (default [])
+      --group-add value                Add additional user groups to the container (default [])
+      --group-rm value                 Remove previously added user groups from the container (default [])
       --help                           Print usage
       --image string                   Service image tag
       --label-add value                Add or update service labels (default [])


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #25304 to support `--group` in `docker service create`.

**\- How I did it**

This fix adds `--group` to `docker service create`, and adds `Group []string` to ContainerSpec in engine-api and swarmkit for the needed changes.

The `Config` and `HostConfig` in container remain the same formats. The groups are appended to `HostConfig.GroupAdd` if needed.

**\- How to verify it**

An additional integration test has bee added.

**\- Description for the changelog**

Support `--group` in `docker service create`

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25304.

**NOTE: PRs for engine-api and swarmkit will be opened separately**

Signed-off-by: Yong Tang yong.tang.github@outlook.com
