### PR TITLE
Update systemd.md

### DIFF
--- a/docs/admin/systemd.md
+++ b/docs/admin/systemd.md
@@ -53,7 +53,7 @@ following:
     EnvironmentFile=-/etc/sysconfig/docker-storage
     EnvironmentFile=-/etc/sysconfig/docker-network
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// $OPTIONS \
+    ExecStart=/usr/bin/dockerd daemon -H unix:///var/run/docker.sock $OPTIONS \
               $DOCKER_STORAGE_OPTIONS \
               $DOCKER_NETWORK_OPTIONS \
               $BLOCK_REGISTRY \
@@ -90,7 +90,7 @@ In this example, we'll assume that your `docker.service` file looks something li
 
     [Service]
     Type=notify
-    ExecStart=/usr/bin/docker daemon -H fd://
+    ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker.sock
     LimitNOFILE=1048576
     LimitNPROC=1048576
     TasksMax=1048576
@@ -104,7 +104,7 @@ directory:
 
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --graph="/mnt/docker-data" --storage-driver=overlay
+    ExecStart=/usr/bin/docker daemon -H -H unix:///var/run/docker.sock --graph="/mnt/docker-data" --storage-driver=overlay
 
 You can also set other environment variables in this file, for example, the
 `HTTP_PROXY` environment variables described below.
@@ -114,7 +114,7 @@ by a new configuration as follows:
 
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --bip=172.17.42.1/16
+    ExecStart=/usr/bin/docker daemon -H unix:///var/run/docker.sock --bip=172.17.42.1/16
 
 If you fail to specify an empty configuration, Docker reports an error such as:
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1032,7 +1032,7 @@ func (s *DockerSuite) TestRunSeccompProfileDenyCloneUserns(c *check.C) {
 // TestRunSeccompUnconfinedCloneUserns checks that
 // 'docker run --security-opt seccomp=unconfined syscall-test' allows creating a userns.
 func (s *DockerSuite) TestRunSeccompUnconfinedCloneUserns(c *check.C) {
-	testRequires(c, SameHostDaemon, seccompEnabled, UserNamespaceInKernel, NotUserNamespace)
+	testRequires(c, SameHostDaemon, seccompEnabled, UserNamespaceInKernel, NotUserNamespace, unprivilegedUsernsClone)
 
 	// make sure running w privileged is ok
 	runCmd := exec.Command(dockerBinary, "run", "--security-opt", "seccomp=unconfined", "syscall-test", "userns-test", "id")

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -3,6 +3,9 @@
 package main
 
 import (
+	"io/ioutil"
+	"strings"
+
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
@@ -98,6 +101,16 @@ var (
 			return !SysInfo.BridgeNFCallIP6TablesDisabled
 		},
 		"Test requires that bridge-nf-call-ip6tables support be enabled in the daemon.",
+	}
+	unprivilegedUsernsClone = testRequirement{
+		func() bool {
+			content, err := ioutil.ReadFile("/proc/sys/kernel/unprivileged_userns_clone")
+			if err == nil && strings.Contains(string(content), "0") {
+				return false
+			}
+			return true
+		},
+		"Test cannot be run with 'sysctl kernel.unprivileged_userns_clone' = 0",
 	}
 )
 


### PR DESCRIPTION
"Docker 1.12 on CentOS no longer uses socket activation", and suggestion on removing -H fd://
 update doc
