### PR TITLE
Update docs in `docker service create/update` for flag `--user`

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -489,7 +489,7 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.StringVar(&opts.name, flagName, "", "Service name")
 
 	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
-	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID")
+	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -42,7 +42,7 @@ Options:
       --update-delay duration          Delay between updates
       --update-failure-action string   Action on update failure (pause|continue) (default "pause")
       --update-parallelism uint        Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
-  -u, --user string                    Username or UID
+  -u, --user string                    Username or UID (format: <name|uid>[:<group|gid>])
       --with-registry-auth             Send registry authentication details to Swarm agents
   -w, --workdir string                 Working directory inside the container
 ```

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -50,7 +50,7 @@ Options:
       --update-delay duration          Delay between updates
       --update-failure-action string   Action on update failure (pause|continue) (default "pause")
       --update-parallelism uint        Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
-  -u, --user string                    Username or UID
+  -u, --user string                    Username or UID (format: <name|uid>[:<group|gid>])
       --with-registry-auth             Send registry authentication details to Swarm agents
   -w, --workdir string                 Working directory inside the container
 ```


### PR DESCRIPTION
In `docker service create/update`, flag `--user` actually supports `uid:gid` (same as `docker run`). However, this is not reflected in the help and documentation yet.

This fix updates docs in `docker service create/update` to change the description to `Username or UID (format: <name|uid>[:<group|gid>])`.

The help message output has also been updated.

This fix is related to #25304.

cc @thaJeztah 

Signed-off-by: Yong Tang yong.tang.github@outlook.com
