### PR TITLE
Add --no-trunc to service/node/stack ps output

### DIFF
--- a/api/client/node/ps.go
+++ b/api/client/node/ps.go
@@ -15,6 +15,7 @@ import (
 type psOptions struct {
 	nodeID    string
 	noResolve bool
+	noTrunc   bool
 	filter    opts.FilterOpt
 }
 
@@ -31,6 +32,7 @@ func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
 
@@ -59,5 +61,5 @@ func runPS(dockerCli *client.DockerCli, opts psOptions) error {
 		return err
 	}
 
-	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve))
+	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), opts.noTrunc)
 }

--- a/api/client/service/ps.go
+++ b/api/client/service/ps.go
@@ -16,6 +16,7 @@ import (
 type psOptions struct {
 	serviceID string
 	noResolve bool
+	noTrunc   bool
 	filter    opts.FilterOpt
 }
 
@@ -32,6 +33,7 @@ func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
+	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
 
@@ -66,5 +68,5 @@ func runPS(dockerCli *client.DockerCli, opts psOptions) error {
 		return err
 	}
 
-	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve))
+	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), opts.noTrunc)
 }

--- a/api/client/stack/ps.go
+++ b/api/client/stack/ps.go
@@ -20,6 +20,7 @@ import (
 type psOptions struct {
 	all       bool
 	filter    opts.FilterOpt
+	noTrunc   bool
 	namespace string
 	noResolve bool
 }
@@ -38,6 +39,7 @@ func newPSCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.all, "all", "a", false, "Display all tasks")
+	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")
 	flags.BoolVar(&opts.noResolve, "no-resolve", false, "Do not map IDs to Names")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
 
@@ -66,5 +68,5 @@ func runPS(dockerCli *client.DockerCli, opts psOptions) error {
 		return nil
 	}
 
-	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve))
+	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), opts.noTrunc)
 }

--- a/api/client/task/print.go
+++ b/api/client/task/print.go
@@ -41,7 +41,7 @@ func (t tasksBySlot) Less(i, j int) bool {
 }
 
 // Print task information in a table format
-func Print(dockerCli *client.DockerCli, ctx context.Context, tasks []swarm.Task, resolver *idresolver.IDResolver) error {
+func Print(dockerCli *client.DockerCli, ctx context.Context, tasks []swarm.Task, resolver *idresolver.IDResolver, noTrunc bool) error {
 	sort.Stable(tasksBySlot(tasks))
 
 	writer := tabwriter.NewWriter(dockerCli.Out(), 0, 4, 2, ' ', 0)
@@ -75,7 +75,7 @@ func Print(dockerCli *client.DockerCli, ctx context.Context, tasks []swarm.Task,
 
 		// Trim and quote the error message.
 		taskErr := task.Status.Err
-		if len(taskErr) > maxErrLength {
+		if !noTrunc && len(taskErr) > maxErrLength {
 			taskErr = fmt.Sprintf("%s…", taskErr[:maxErrLength-1])
 		}
 		if len(taskErr) > 0 {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1704,7 +1704,7 @@ _docker_service_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve --no-trunc" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--filter|-f')
@@ -2076,7 +2076,7 @@ _docker_node_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve --no-trunc" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--filter|-f')

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -841,6 +841,7 @@ __docker_node_subcommand() {
                 "($help -a --all)"{-a,--all}"[Display all instances]" \
                 "($help)*"{-f=,--filter=}"[Provide filter values]:filter:->filter-options" \
                 "($help)--no-resolve[Do not map IDs to Names]" \
+                "($help)--no-trunc[Do not truncate output]" \
                 "($help -)1:node:__docker_complete_nodes" && ret=0
             case $state in
                 (filter-options)
@@ -1156,6 +1157,7 @@ __docker_service_subcommand() {
                 "($help -a --all)"{-a,--all}"[Display all tasks]" \
                 "($help)*"{-f=,--filter=}"[Provide filter values]:filter:->filter-options" \
                 "($help)--no-resolve[Do not map IDs to Names]" \
+                "($help)--no-trunc[Do not truncate output]" \
                 "($help -)1:service:__docker_complete_services" && ret=0
             case $state in
                 (filter-options)

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -21,6 +21,7 @@ Options:
   -f, --filter value   Filter output based on conditions provided
       --help           Print usage
       --no-resolve     Do not map IDs to Names
+      --no-trunc       Do not truncate output
 ```
 
 Lists all the tasks on a Node that Docker knows about. You can filter using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more information about available filter options.

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -21,6 +21,7 @@ Options:
   -f, --filter value   Filter output based on conditions provided
       --help           Print usage
       --no-resolve     Do not map IDs to Names
+      --no-trunc       Do not truncate output
 ```
 
 Lists the tasks that are running as part of the specified service. This command


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #25332

**\- What I did**

Added `--no-trunc` option like `docker ps` has to `docker service ps`, `docker node ps` and `docker stack ps`. Currently only errors were being truncated. 

**\- How I did it**

Added cli option to the 3 commands & check for it in `task.Print`

**\- How to verify it**

Create a service that has tasks that error out -> run `docker node ps self --no-trunc` to see the full error. 

```
$ docker swarm init
$ echo 'FROM busybox \
      HEALTHCHECK --interval=1s --timeout=1s CMD ls /foo \
     CMD top' | docker build -t test_none -

$ docker service create --name test test_none
1ktygqey58cgpz43p54tl35e3

$ docker node ps self
ID                         NAME        IMAGE      NODE          DESIRED STATE  CURRENT STATE         ERROR
4nb1pvcty3a7co574cg6kscaf  test.1      test_none  e96bbd330fee  Ready          Ready 1 seconds ago
7fjobb83ee0k3dmxfky0qalpd   \_ test.1  test_none  e96bbd330fee  Shutdown       Failed 2 seconds ago  "task: non-zero exit (137): do…"

$ docker node ps self --no-trunc
ID                         NAME        IMAGE      NODE          DESIRED STATE  CURRENT STATE           ERROR
4nb1pvcty3a7co574cg6kscaf  test.1      test_none  e96bbd330fee  Running        Starting 1 seconds ago
7fjobb83ee0k3dmxfky0qalpd   \_ test.1  test_none  e96bbd330fee  Shutdown       Failed 6 seconds ago    "task: non-zero exit (137): dockerexec: unhealthy container"

$ docker service ps test --no-trunc
ID                         NAME        IMAGE      NODE          DESIRED STATE  CURRENT STATE           ERROR
279eltuipxm8sbz19syl8a1o9  test.1      test_none  e96bbd330fee  Running        Starting 4 seconds ago
4nb1pvcty3a7co574cg6kscaf   \_ test.1  test_none  e96bbd330fee  Shutdown       Failed 9 seconds ago    "task: non-zero exit (137): dockerexec: unhealthy container"
7fjobb83ee0k3dmxfky0qalpd   \_ test.1  test_none  e96bbd330fee  Shutdown       Failed 28 seconds ago   "task: non-zero exit (137): dockerexec: unhealthy container"
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add --no-trunc to service/node/stack ps output

Signed-off-by: Josh Horwitz horwitzja@gmail.com
