### PR TITLE
TestSwarmNodeListFilter: Wait for hostname to be populated

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -153,9 +153,16 @@ func (s *DockerSwarmSuite) TestSwarmServiceListFilter(c *check.C) {
 func (s *DockerSwarmSuite) TestSwarmNodeListFilter(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
-	out, err := d.Cmd("node", "inspect", "--format", "{{ .Description.Hostname }}", "self")
-	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+	var (
+		out string
+		err error
+	)
+	checkHostname := func(c *check.C) (interface{}, check.CommentInterface) {
+		out, err = d.Cmd("node", "inspect", "--format", "{{ .Description.Hostname }}", "self")
+		c.Assert(err, checker.IsNil)
+		return strings.TrimSpace(out), check.Commentf("output: %q", string(out))
+	}
+	waitAndAssert(c, defaultReconciliationTimeout, checkHostname, checker.Not(checker.Equals), "")
 	name := strings.TrimSpace(out)
 
 	filter := "name=" + name[:4]


### PR DESCRIPTION
An upcoming PR to swarmkit will batch node updates in the dispatcher to
address a scalability bottleneck. This means there may be up to a 100 ms
delay from the time a node registers to the time its hostname becomes
available in "docker node ls". Adjust TestSwarmNodeListFilter to use
waitAndAssert to wait for the hostname to show up.
