### PR TITLE
Fix missing newline in service inspect --pretty

### DIFF
--- a/api/client/service/inspect.go
+++ b/api/client/service/inspect.go
@@ -149,6 +149,7 @@ func printService(out io.Writer, service swarm.Service) {
 		for _, n := range service.Spec.Networks {
 			fmt.Fprintf(out, " %s", n.Target)
 		}
+		fmt.Fprintln(out, "")
 	}
 
 	if len(service.Endpoint.Ports) > 0 {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Fixed a missing newline that was making `docker service inspect --pretty` ugly. Printing off networks was not adding a newline, so whatever was printed next was just being mashed onto the end. Usually, this was the word "Ports".

**\- How I did it**

Added an empty println after all networks are printed, so that the next thing printed prints on the next line.

**\- How to verify it**

Create a service with published ports and a network, mark well how the word `Ports` is printed on the line after `Networks: somenetworks`.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Made `docker service inspect --pretty` pretty again.

**\- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/2367858/17344171/15018c5c-58b6-11e6-82e1-a3e716c390f0.png)

Signed-off-by: Drew Erny drew.erny@docker.com
