### PR TITLE
Add unix socket for daemon access for privileged containers 

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -47,6 +47,7 @@ func New(cfg *Config) *Server {
 	}
 }
 
+// Config returns the server's configuration
 func (s *Server) Config() *Config {
 	return s.cfg
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -47,6 +47,10 @@ func New(cfg *Config) *Server {
 	}
 }
 
+func (s *Server) Config() *Config {
+	return s.cfg
+}
+
 // UseMiddleware appends a new middleware to the request chain.
 // This needs to be called before the API routes are configured.
 func (s *Server) UseMiddleware(m middleware.Middleware) {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -179,72 +179,15 @@ func (cli *DaemonCli) start() (err error) {
 		}()
 	}
 
-	serverConfig := &apiserver.Config{
-		Logging:     true,
-		SocketGroup: cli.Config.SocketGroup,
-		Version:     dockerversion.Version,
-		EnableCors:  cli.Config.EnableCors,
-		CorsHeaders: cli.Config.CorsHeaders,
-	}
-
-	if cli.Config.TLS {
-		tlsOptions := tlsconfig.Options{
-			CAFile:   cli.Config.CommonTLSOptions.CAFile,
-			CertFile: cli.Config.CommonTLSOptions.CertFile,
-			KeyFile:  cli.Config.CommonTLSOptions.KeyFile,
-		}
-
-		if cli.Config.TLSVerify {
-			// server requires and verifies client's certificate
-			tlsOptions.ClientAuth = tls.RequireAndVerifyClientCert
-		}
-		tlsConfig, err := tlsconfig.Server(tlsOptions)
-		if err != nil {
-			return err
-		}
-		serverConfig.TLSConfig = tlsConfig
-	}
-
 	if len(cli.Config.Hosts) == 0 {
 		cli.Config.Hosts = make([]string, 1)
 	}
-
-	api := apiserver.New(serverConfig)
-	cli.api = api
-
-	for i := 0; i < len(cli.Config.Hosts); i++ {
-		var err error
-		if cli.Config.Hosts[i], err = opts.ParseHost(cli.Config.TLS, cli.Config.Hosts[i]); err != nil {
-			return fmt.Errorf("error parsing -H %s : %v", cli.Config.Hosts[i], err)
-		}
-
-		protoAddr := cli.Config.Hosts[i]
-		protoAddrParts := strings.SplitN(protoAddr, "://", 2)
-		if len(protoAddrParts) != 2 {
-			return fmt.Errorf("bad format %s, expected PROTO://ADDR", protoAddr)
-		}
-
-		proto := protoAddrParts[0]
-		addr := protoAddrParts[1]
-
-		// It's a bad idea to bind to TCP without tlsverify.
-		if proto == "tcp" && (serverConfig.TLSConfig == nil || serverConfig.TLSConfig.ClientAuth != tls.RequireAndVerifyClientCert) {
-			logrus.Warn("[!] DON'T BIND ON ANY IP ADDRESS WITHOUT setting -tlsverify IF YOU DON'T KNOW WHAT YOU'RE DOING [!]")
-		}
-		ls, err := listeners.Init(proto, addr, serverConfig.SocketGroup, serverConfig.TLSConfig)
-		if err != nil {
-			return err
-		}
-		ls = wrapListeners(proto, ls)
-		// If we're binding to a TCP port, make sure that a container doesn't try to use it.
-		if proto == "tcp" {
-			if err := allocateDaemonPort(addr); err != nil {
-				return err
-			}
-		}
-		logrus.Debugf("Listener created for HTTP on %s (%s)", protoAddrParts[0], protoAddrParts[1])
-		api.Accept(protoAddrParts[1], ls...)
+	api, err := cli.newAPI(cli.Config.Hosts)
+	if err != nil {
+		return err
 	}
+	// set the default api on the client
+	cli.api = api
 
 	if err := migrateKey(); err != nil {
 		return err
@@ -287,7 +230,6 @@ func (cli *DaemonCli) start() (err error) {
 		"graphdriver": d.GraphDriverName(),
 	}).Info("Docker daemon")
 
-	cli.initMiddlewares(api, serverConfig)
 	initRouter(api, d, c)
 
 	cli.d = d
@@ -424,14 +366,14 @@ func initRouter(s *apiserver.Server, d *daemon.Daemon, c *cluster.Cluster) {
 	s.InitRouter(utils.IsDebugEnabled(), routers...)
 }
 
-func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config) {
-	v := cfg.Version
+func (cli *DaemonCli) initMiddlewares(s *apiserver.Server) {
+	v := s.Config().Version
 
 	vm := middleware.NewVersionMiddleware(v, api.DefaultVersion, api.MinVersion)
 	s.UseMiddleware(vm)
 
-	if cfg.EnableCors {
-		c := middleware.NewCORSMiddleware(cfg.CorsHeaders)
+	if s.Config().EnableCors {
+		c := middleware.NewCORSMiddleware(s.Config().CorsHeaders)
 		s.UseMiddleware(c)
 	}
 
@@ -443,4 +385,83 @@ func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config
 		handleAuthorization := authorization.NewMiddleware(authZPlugins)
 		s.UseMiddleware(handleAuthorization)
 	}
+}
+
+func (cli *DaemonCli) newTLSConfig() (*tls.Config, error) {
+	if !cli.Config.TLS {
+		return nil, nil
+	}
+	tlsOptions := tlsconfig.Options{
+		CAFile:   cli.Config.CommonTLSOptions.CAFile,
+		CertFile: cli.Config.CommonTLSOptions.CertFile,
+		KeyFile:  cli.Config.CommonTLSOptions.KeyFile,
+	}
+	if cli.Config.TLSVerify {
+		// server requires and verifies client's certificate
+		tlsOptions.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return tlsconfig.Server(tlsOptions)
+}
+
+func (cli *DaemonCli) newServerConfig(tls *tls.Config) *apiserver.Config {
+	return &apiserver.Config{
+		Logging:     true,
+		SocketGroup: cli.Config.SocketGroup,
+		Version:     dockerversion.Version,
+		EnableCors:  cli.Config.EnableCors,
+		CorsHeaders: cli.Config.CorsHeaders,
+		TLSConfig:   tls,
+	}
+}
+
+func (cli *DaemonCli) newAPI(hosts []string) (*apiserver.Server, error) {
+	tlsConfig, err := cli.newTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	var (
+		config = cli.newServerConfig(tlsConfig)
+		api    = apiserver.New(config)
+	)
+
+	for i := 0; i < len(hosts); i++ {
+		var err error
+		if hosts[i], err = opts.ParseHost(cli.Config.TLS, hosts[i]); err != nil {
+			return nil, fmt.Errorf("error parsing -H %s : %v", hosts[i], err)
+		}
+
+		protoAddrParts := strings.SplitN(hosts[i], "://", 2)
+		if len(protoAddrParts) != 2 {
+			return nil, fmt.Errorf("bad format %s, expected PROTO://ADDR", hosts[i])
+		}
+
+		var (
+			proto = protoAddrParts[0]
+			addr  = protoAddrParts[1]
+		)
+
+		// It's a bad idea to bind to TCP without tlsverify.
+		if proto == "tcp" &&
+			(config.TLSConfig == nil || config.TLSConfig.ClientAuth != tls.RequireAndVerifyClientCert) {
+			logrus.Warn("[!] DON'T BIND ON ANY IP ADDRESS WITHOUT setting -tlsverify IF YOU DON'T KNOW WHAT YOU'RE DOING [!]")
+		}
+
+		ls, err := listeners.Init(proto, addr, config.SocketGroup, config.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
+		ls = wrapListeners(proto, ls)
+
+		// If we're binding to a TCP port, make sure that a container doesn't try to use it.
+		if proto == "tcp" {
+			if err := allocateDaemonPort(addr); err != nil {
+				return nil, err
+			}
+		}
+		logrus.Debugf("Listener created for HTTP on %s (%s)", proto, addr)
+		api.Accept(addr, ls...)
+	}
+	cli.initMiddlewares(api)
+
+	return api, nil
 }

--- a/container/container.go
+++ b/container/container.go
@@ -87,13 +87,14 @@ type CommonContainer struct {
 	// logDriver for closing
 	LogDriver      logger.Logger  `json:"-"`
 	LogCopier      *logger.Copier `json:"-"`
+	ExecRoot       string         `json:"-"`
 	restartManager restartmanager.RestartManager
 	attachContext  *attachContext
 }
 
 // NewBaseContainer creates a new container with its
 // basic configuration.
-func NewBaseContainer(id, root string) *Container {
+func NewBaseContainer(id, root, execRoot string) *Container {
 	return &Container{
 		CommonContainer: CommonContainer{
 			ID:            id,
@@ -103,6 +104,7 @@ func NewBaseContainer(id, root string) *Container {
 			MountPoints:   make(map[string]*volume.MountPoint),
 			StreamConfig:  runconfig.NewStreamConfig(),
 			attachContext: &attachContext{},
+			ExecRoot:      execRoot,
 		},
 	}
 }

--- a/container/container_solaris.go
+++ b/container/container_solaris.go
@@ -78,6 +78,11 @@ func (container *Container) TmpfsMounts() []Mount {
 	return mounts
 }
 
+// IntrospectionMounts returns the list of mounts for introspection support
+func (container *Container) IntrospectionMounts() ([]Mount, error) {
+	return nil, nil
+}
+
 // cleanResourcePath cleans a resource path and prepares to combine with mnt path
 func cleanResourcePath(path string) string {
 	return filepath.Join(string(os.PathSeparator), path)

--- a/container/container_solaris.go
+++ b/container/container_solaris.go
@@ -79,8 +79,8 @@ func (container *Container) TmpfsMounts() []Mount {
 }
 
 // IntrospectionMounts returns the list of mounts for introspection support
-func (container *Container) IntrospectionMounts() ([]Mount, error) {
-	return nil, nil
+func (container *Container) IntrospectionMounts() []Mount {
+	return nil
 }
 
 // cleanResourcePath cleans a resource path and prepares to combine with mnt path

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/chrootarchive"
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/system"
@@ -409,26 +408,16 @@ func (container *Container) TmpfsMounts() []Mount {
 }
 
 // IntrospectionMounts returns the list of mounts for introspection support
-func (container *Container) IntrospectionMounts() ([]Mount, error) {
+func (container *Container) IntrospectionMounts() []Mount {
 	if !container.HostConfig.Privileged {
-		return nil, nil
-	}
-	path, err := os.Readlink(reexec.Self())
-	if err != nil {
-		return nil, err
+		return nil
 	}
 	return []Mount{
 		{
-			Source:      filepath.Join(filepath.Dir(path), "docker"),
-			Destination: "/usr/bin/docker",
-			Writable:    true,
+			Source:      filepath.Join(container.ExecRoot, "docker-introspection.sock"),
+			Destination: "/var/run/docker.sock",
 		},
-		{
-			Source:      "/run/docker-introspection.sock",
-			Destination: "/run/docker.sock",
-			Writable:    true,
-		},
-	}, nil
+	}
 }
 
 // cleanResourcePath cleans a resource path and prepares to combine with mnt path

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -58,6 +58,11 @@ func (container *Container) TmpfsMounts() []Mount {
 	return mounts
 }
 
+// IntrospectionMounts returns the list of mounts for introspection support
+func (container *Container) IntrospectionMounts() ([]Mount, error) {
+	return nil, nil
+}
+
 // UpdateContainer updates configuration of a container
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	container.Lock()

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -59,8 +59,8 @@ func (container *Container) TmpfsMounts() []Mount {
 }
 
 // IntrospectionMounts returns the list of mounts for introspection support
-func (container *Container) IntrospectionMounts() ([]Mount, error) {
-	return nil, nil
+func (container *Container) IntrospectionMounts() []Mount {
+	return nil
 }
 
 // UpdateContainer updates configuration of a container

--- a/container/memory_store_test.go
+++ b/container/memory_store_test.go
@@ -18,7 +18,7 @@ func TestNewMemoryStore(t *testing.T) {
 
 func TestAddContainers(t *testing.T) {
 	s := NewMemoryStore()
-	s.Add("id", NewBaseContainer("id", "root"))
+	s.Add("id", NewBaseContainer("id", "root", "/var/run"))
 	if s.Size() != 1 {
 		t.Fatalf("expected store size 1, got %v", s.Size())
 	}
@@ -26,7 +26,7 @@ func TestAddContainers(t *testing.T) {
 
 func TestGetContainer(t *testing.T) {
 	s := NewMemoryStore()
-	s.Add("id", NewBaseContainer("id", "root"))
+	s.Add("id", NewBaseContainer("id", "root", "/var/run"))
 	c := s.Get("id")
 	if c == nil {
 		t.Fatal("expected container to not be nil")
@@ -35,7 +35,7 @@ func TestGetContainer(t *testing.T) {
 
 func TestDeleteContainer(t *testing.T) {
 	s := NewMemoryStore()
-	s.Add("id", NewBaseContainer("id", "root"))
+	s.Add("id", NewBaseContainer("id", "root", "/var/run"))
 	s.Delete("id")
 	if c := s.Get("id"); c != nil {
 		t.Fatalf("expected container to be nil after removal, got %v", c)
@@ -49,9 +49,9 @@ func TestDeleteContainer(t *testing.T) {
 func TestListContainers(t *testing.T) {
 	s := NewMemoryStore()
 
-	cont := NewBaseContainer("id", "root")
+	cont := NewBaseContainer("id", "root", "/var/run")
 	cont.Created = time.Now()
-	cont2 := NewBaseContainer("id2", "root")
+	cont2 := NewBaseContainer("id2", "root", "/var/run")
 	cont2.Created = time.Now().Add(24 * time.Hour)
 
 	s.Add("id", cont)
@@ -69,8 +69,8 @@ func TestListContainers(t *testing.T) {
 func TestFirstContainer(t *testing.T) {
 	s := NewMemoryStore()
 
-	s.Add("id", NewBaseContainer("id", "root"))
-	s.Add("id2", NewBaseContainer("id2", "root"))
+	s.Add("id", NewBaseContainer("id", "root", "/var/run"))
+	s.Add("id2", NewBaseContainer("id2", "root", "/var/run"))
 
 	first := s.First(func(cont *Container) bool {
 		return cont.ID == "id2"
@@ -87,8 +87,8 @@ func TestFirstContainer(t *testing.T) {
 func TestApplyAllContainer(t *testing.T) {
 	s := NewMemoryStore()
 
-	s.Add("id", NewBaseContainer("id", "root"))
-	s.Add("id2", NewBaseContainer("id2", "root"))
+	s.Add("id", NewBaseContainer("id", "root", "/var/run"))
+	s.Add("id2", NewBaseContainer("id2", "root", "/var/run"))
 
 	s.ApplyAll(func(cont *Container) {
 		if cont.ID == "id2" {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -82,6 +82,7 @@ func (daemon *Daemon) load(id string) (*container.Container, error) {
 	if container.ID != id {
 		return container, fmt.Errorf("Container %s is stored at %s", container.ID, id)
 	}
+	container.ExecRoot = daemon.configStore.GetExecRoot()
 
 	return container, nil
 }
@@ -153,7 +154,7 @@ func (daemon *Daemon) GetByName(name string) (*container.Container, error) {
 // newBaseContainer creates a new container with its initial
 // configuration based on the root storage from the daemon.
 func (daemon *Daemon) newBaseContainer(id string) *container.Container {
-	return container.NewBaseContainer(id, daemon.containerRoot(id))
+	return container.NewBaseContainer(id, daemon.containerRoot(id), daemon.configStore.GetExecRoot())
 }
 
 func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint strslice.StrSlice, configCmd strslice.StrSlice) (string, []string) {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -120,8 +120,9 @@ func TestGetContainer(t *testing.T) {
 func initDaemonWithVolumeStore(tmp string) (*Daemon, error) {
 	var err error
 	daemon := &Daemon{
-		repository: tmp,
-		root:       tmp,
+		repository:  tmp,
+		root:        tmp,
+		configStore: &Config{},
 	}
 	daemon.volumes, err = store.New(tmp)
 	if err != nil {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -23,7 +23,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/user"
-	"github.com/opencontainers/specs/specs-go"
+	specs "github.com/opencontainers/specs/specs-go"
 )
 
 func setResources(s *specs.Spec, r containertypes.Resources) error {
@@ -663,6 +663,11 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	}
 	ms = append(ms, c.IpcMounts()...)
 	ms = append(ms, c.TmpfsMounts()...)
+	ims, err := c.IntrospectionMounts()
+	if err != nil {
+		return nil, err
+	}
+	ms = append(ms, ims...)
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {
 		return nil, fmt.Errorf("linux mounts: %v", err)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -663,11 +663,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	}
 	ms = append(ms, c.IpcMounts()...)
 	ms = append(ms, c.TmpfsMounts()...)
-	ims, err := c.IntrospectionMounts()
-	if err != nil {
-		return nil, err
-	}
-	ms = append(ms, ims...)
+	ms = append(ms, c.IntrospectionMounts()...)
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {
 		return nil, fmt.Errorf("linux mounts: %v", err)


### PR DESCRIPTION
This adds a separate socket for providing introspection to containers.
It is automatically added to all privileged containers as well as the
current copy of the docker client binary for use with the socket.

The socket will be placed in `/run/docker.sock`.  All linux
systems/images should have a symlink from `/var/run` to `/run`.

The introspection socket does not include the swarm/1.12 endpoints as
these require advanced authentication for use.  The consumers will get a
404 if they try to access a swarm endpoint.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
