### PR TITLE
[carry 25174] 409 status code result to create service

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3980,6 +3980,7 @@ Create a service
 
 - **201** – no error
 - **406** – server error or node is not part of a swarm
+- **409** – name conflicts with an existing object
 
 JSON Parameters:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3980,6 +3980,7 @@ Create a service
 
 - **201** – no error
 - **406** – server error or node is not part of a swarm
+- **409** – name conflicts with an existing object
 
 JSON Parameters:
 


### PR DESCRIPTION
Added example 409 status code result to the create service endpoint.

carries https://github.com/docker/docker/pull/25174
closes https://github.com/docker/docker/pull/25174
