### PR TITLE
[Carry 24314] Make MongoDB sample Dockerfile working again

### DIFF
--- a/docs/examples/mongodb/Dockerfile
+++ b/docs/examples/mongodb/Dockerfile
@@ -1,14 +1,15 @@
 # Dockerizing MongoDB: Dockerfile for building MongoDB images
-# Based on ubuntu:latest, installs MongoDB following the instructions from:
+# Based on ubuntu:16.04, installs MongoDB following the instructions from:
 # http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
 
-FROM       ubuntu:latest
+FROM       ubuntu:16.04
 MAINTAINER Docker
 
 # Installation:
 # Import MongoDB public GPG key AND create a MongoDB list file
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-RUN echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+RUN echo "deb http://repo.mongodb.org/apt/ubuntu $(cat /etc/lsb-release | grep DISTRIB_CODENAME | cut -d= -f2)/mongodb-org/3.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+
 # Update apt-get sources AND install MongoDB
 RUN apt-get update && apt-get install -y mongodb-org
 


### PR DESCRIPTION
carry of https://github.com/docker/docker/pull/24314
closes https://github.com/docker/docker/pull/24314

There were couple issues in the previous version of this Dockerfile
1. [MongoDB manual](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/) uses 3.2 repo version as of July'16.
2.  Command `# lsb_release -sc`  doesn't work out of box, because of `bash: lsb_release: command not found`.
