### PR TITLE
Add bash completion for `docker node rm --force`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2019,7 +2019,7 @@ _docker_node_remove() {
 _docker_node_rm() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--force --help" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_nodes


### PR DESCRIPTION
Ref: #25159
Please schedule for 1.12.1 as the corresponding feature is present in that release.
Ping @sdurrheimer for zsh completion
