### PR TITLE
Add api for stats all containers

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -53,6 +53,7 @@ type monitorBackend interface {
 	ContainerInspect(name string, size bool, version string) (interface{}, error)
 	ContainerLogs(ctx context.Context, name string, config *backend.ContainerLogsConfig, started chan struct{}) error
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
+	ContainerStatsAll(ctx context.Context, config *backend.ContainerStatsAllConfig) error
 	ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error)
 
 	Containers(config *types.ContainerListOptions) ([]*types.Container, error)

--- a/api/server/router/container/container.go
+++ b/api/server/router/container/container.go
@@ -46,6 +46,7 @@ func (r *containerRouter) initRoutes() {
 		router.NewGetRoute("/containers/{name:.*}/changes", r.getContainersChanges),
 		router.NewGetRoute("/containers/{name:.*}/json", r.getContainersByName),
 		router.NewGetRoute("/containers/{name:.*}/top", r.getContainersTop),
+		router.Cancellable(router.NewGetRoute("/containers/-/stats", r.getContainersStatsAll)),
 		router.Cancellable(router.NewGetRoute("/containers/{name:.*}/logs", r.getContainersLogs)),
 		router.Cancellable(router.NewGetRoute("/containers/{name:.*}/stats", r.getContainersStats)),
 		router.NewGetRoute("/containers/{name:.*}/attach/ws", r.wsContainersAttach),

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -74,6 +74,29 @@ func (s *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 	return s.backend.ContainerStats(ctx, vars["name"], config)
 }
 
+func (s *containerRouter) getContainersStatsAll(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	stream := httputils.BoolValueOrDefault(r, "stream", true)
+	if !stream {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	all := httputils.BoolValueOrDefault(r, "all", false)
+
+	config := &backend.ContainerStatsAllConfig{
+		ContainerStatsConfig: backend.ContainerStatsConfig{
+			Stream:    stream,
+			OutStream: w,
+			Version:   string(httputils.VersionFromContext(ctx)),
+		},
+		All: all,
+	}
+
+	return s.backend.ContainerStatsAll(ctx, config)
+}
+
 func (s *containerRouter) getContainersLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -83,7 +83,10 @@ func (s *containerRouter) getContainersStatsAll(ctx context.Context, w http.Resp
 	if !stream {
 		w.Header().Set("Content-Type", "application/json")
 	}
-	all := httputils.BoolValueOrDefault(r, "all", false)
+	filter, err := filters.FromParam(r.Form.Get("filters"))
+	if err != nil {
+		return err
+	}
 
 	config := &backend.ContainerStatsAllConfig{
 		ContainerStatsConfig: backend.ContainerStatsConfig{
@@ -91,7 +94,7 @@ func (s *containerRouter) getContainersStatsAll(ctx context.Context, w http.Resp
 			OutStream: w,
 			Version:   string(httputils.VersionFromContext(ctx)),
 		},
-		All: all,
+		Filters: filter,
 	}
 
 	return s.backend.ContainerStatsAll(ctx, config)

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/streamformatter"
 )
 
@@ -44,7 +45,7 @@ type ContainerStatsConfig struct {
 // behavior of a backend.ContainerStatsAll() call.
 type ContainerStatsAllConfig struct {
 	ContainerStatsConfig
-	All bool
+	Filters filters.Args
 }
 
 // ExecInspect holds information about a running process started

--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -40,6 +40,13 @@ type ContainerStatsConfig struct {
 	Version   string
 }
 
+// ContainerStatsAllConfig holds information for configuring the runtime
+// behavior of a backend.ContainerStatsAll() call.
+type ContainerStatsAllConfig struct {
+	ContainerStatsConfig
+	All bool
+}
+
 // ExecInspect holds information about a running process started
 // with docker exec.
 type ExecInspect struct {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -256,6 +256,12 @@ type ResizeOptions struct {
 	Width  uint
 }
 
+// StatsAllOptions holds parameters to get stats of all containers
+type StatsAllOptions struct {
+	All    bool // get all including exited
+	Stream bool // stream the output
+}
+
 // VersionResponse holds version information for the client and the server
 type VersionResponse struct {
 	Client *Version

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -258,8 +258,8 @@ type ResizeOptions struct {
 
 // StatsAllOptions holds parameters to get stats of all containers
 type StatsAllOptions struct {
-	All    bool // get all including exited
-	Stream bool // stream the output
+	Filters filters.Args
+	Stream  bool // stream the output
 }
 
 // VersionResponse holds version information for the client and the server

--- a/api/types/stats.go
+++ b/api/types/stats.go
@@ -162,7 +162,7 @@ type Stats struct {
 
 	// Shared stats
 	CPUStats    CPUStats    `json:"cpu_stats,omitempty"`
-	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"` // "Pre"="Previous"
+	PreCPUStats *CPUStats   `json:"precpu_stats,omitempty"` // "Pre"="Previous"
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 }
 

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -91,8 +91,9 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		var errs []string
 		cStats.mu.Lock()
 		for _, c := range cStats.cs {
-			if err := c.GetError(); err != nil {
-				errs = append(errs, err.Error())
+			cErr := c.GetError()
+			if cErr != nil && cErr != errNotRunning {
+				errs = append(errs, cErr.Error())
 			}
 		}
 		cStats.mu.Unlock()

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -92,7 +92,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		cStats.mu.Lock()
 		for _, c := range cStats.cs {
 			cErr := c.GetError()
-			if cErr != nil && cErr != errNotRunning {
+			if cErr != nil {
 				errs = append(errs, cErr.Error())
 			}
 		}

--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/cli/command/formatter"
 	"github.com/docker/docker/client"
 	"golang.org/x/net/context"
@@ -96,9 +97,14 @@ func (s *stats) collectAll(ctx context.Context, cli client.APIClient, all, strea
 		}
 	}()
 
+	filter := filters.NewArgs()
+	if !all {
+		filter.Add("status", "running")
+	}
+
 	options := types.StatsAllOptions{
-		All:    all,
-		Stream: streamStats,
+		Filters: filter,
+		Stream:  streamStats,
 	}
 	response, err := cli.ContainerStatsAll(ctx, options)
 	if err != nil {

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -24,3 +24,23 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 	osType := getDockerOS(resp.header.Get("Server"))
 	return types.ContainerStats{Body: resp.body, OSType: osType}, err
 }
+
+// ContainerStatsAll returns near realtime stats for all containers.
+// It's up to the caller to close the io.ReadCloser returned.
+func (cli *Client) ContainerStatsAll(ctx context.Context, options types.StatsAllOptions) (types.ContainerStats, error) {
+	query := url.Values{}
+	query.Set("stream", "0")
+	if options.Stream {
+		query.Set("stream", "1")
+	}
+	if options.All {
+		query.Set("all", "1")
+	}
+
+	resp, err := cli.get(ctx, "/containers/-/stats", query, nil)
+	if err != nil {
+		return types.ContainerStats{}, err
+	}
+	osType := getDockerOS(resp.header.Get("Server"))
+	return types.ContainerStats{Body: resp.body, OSType: osType}, err
+}

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/net/context"
 )
 
@@ -33,8 +34,15 @@ func (cli *Client) ContainerStatsAll(ctx context.Context, options types.StatsAll
 	if options.Stream {
 		query.Set("stream", "1")
 	}
-	if options.All {
-		query.Set("all", "1")
+
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
+
+		if err != nil {
+			return types.ContainerStats{}, err
+		}
+
+		query.Set("filters", filterJSON)
 	}
 
 	resp, err := cli.get(ctx, "/containers/-/stats", query, nil)

--- a/client/interface.go
+++ b/client/interface.go
@@ -56,6 +56,7 @@ type ContainerAPIClient interface {
 	ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
+	ContainerStatsAll(ctx context.Context, options types.StatsAllOptions) (types.ContainerStats, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
 	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"golang.org/x/net/context"
@@ -12,6 +13,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/api/types/versions/v1p20"
 	"github.com/docker/docker/container"
@@ -204,12 +206,40 @@ func (daemon *Daemon) ContainerStatsAll(ctx context.Context, config *backend.Con
 				}
 			}
 
-			if config.All {
-				containers := daemon.List()
-				for _, cnt := range containers {
-					if _, ok := statsJSON[cnt.ID]; !ok {
-						statsJSON[cnt.ID] = &types.StatsJSON{}
-					}
+			// filter container
+			filterdCtrs, err := daemon.reduceStatsContainers(config.Filters)
+			if err != nil {
+				logrus.Errorf("can't filter containers: %v", err)
+				continue
+			}
+
+			survivedContainers := make(map[string]*types.Container)
+			for _, ctr := range filterdCtrs {
+				survivedContainers[ctr.ID] = ctr
+			}
+
+			// if container didn't survive from the filter, remove it!
+			var toDelete []string
+			for id := range statsJSON {
+				if _, ok := survivedContainers[id]; !ok {
+					toDelete = append(toDelete, id)
+				} else {
+					delete(survivedContainers, id)
+				}
+			}
+
+			// iterate the toDelete list, delete statsJSON with related id
+			for _, id := range toDelete {
+				delete(statsJSON, id)
+			}
+
+			// if we didn't get stats data for one survived container,
+			// this means that the container isn't in running state,
+			// we need to add an empty item for it in statsJSON
+			for id, ctr := range survivedContainers {
+				statsJSON[id] = &types.StatsJSON{
+					ID:   ctr.ID,
+					Name: strings.Join(ctr.Names, ","),
 				}
 			}
 			if err := enc.Encode(statsJSON); err != nil {
@@ -249,7 +279,28 @@ func (daemon *Daemon) GetContainerStatsAllRunning() map[string]*types.StatsJSON 
 			continue
 		}
 
+		stats.ID = cnt.ID
+		stats.Name = cnt.Name
 		allStats[cnt.ID] = stats
 	}
 	return allStats
+}
+
+func (daemon *Daemon) reduceStatsContainers(filter filters.Args) ([]*types.Container, error) {
+	config := &types.ContainerListOptions{
+		All:     true,
+		Size:    true,
+		Filters: filter,
+	}
+
+	return daemon.reduceContainers(config, daemon.transformContainer)
+}
+
+// transformContainer generates the container type expected by the docker ps command.
+func (daemon *Daemon) transformStatsContainer(container *container.Container, ctx *listContext) (*types.Container, error) {
+	// For stats data, we only care about its ID for next step filtering
+	newC := &types.Container{
+		ID: container.ID,
+	}
+	return newC, nil
 }

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -60,7 +60,7 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 
 			statsJSON, ok := allStats[container.ID]
 			if !ok || statsJSON == nil {
-				return fmt.Errorf("can't get stats data for %q", container.ID[:12])
+				return nil
 			}
 
 			// this is for backward compatibity with API Pre 1.21
@@ -326,7 +326,6 @@ func (daemon *Daemon) GetContainerStatsAllRunning() map[string]*types.StatsJSON 
 func (daemon *Daemon) reduceStatsContainers(filter filters.Args) ([]*types.Container, error) {
 	config := &types.ContainerListOptions{
 		All:     true,
-		Size:    true,
 		Filters: filter,
 	}
 

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -47,89 +46,41 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 		outStream = wf
 	}
 
-	var preCPUStats *types.CPUStats
-	var preRead time.Time
-	getStatJSON := func(v interface{}) *types.StatsJSON {
-		ss := v.(types.StatsJSON)
-		ss.Name = container.Name
-		ss.ID = container.ID
-		ss.PreCPUStats = preCPUStats
-		ss.PreRead = preRead
-		preCPUStats = &ss.CPUStats
-		preRead = ss.Read
-		return &ss
-	}
+	filters := filters.NewArgs()
+	filters.Add("id", container.ID)
+	statsChan, errChan := daemon.fetchAndFilterAllStats(ctx, config.Stream, filters)
 
 	enc := json.NewEncoder(outStream)
-
-	updates := daemon.subscribeToContainerStats(container)
-	defer daemon.unsubscribeToContainerStats(container, updates)
-
-	noStreamFirstFrame := true
 	for {
 		select {
-		case v, ok := <-updates:
+		case allStats, ok := <-statsChan:
 			if !ok {
 				return nil
 			}
 
-			var statsJSON interface{}
-			statsJSONPost120 := getStatJSON(v)
-			if versions.LessThan(apiVersion, "1.21") {
-				if runtime.GOOS == "windows" {
-					return errors.New("API versions pre v1.21 do not support stats on Windows")
-				}
-				var (
-					rxBytes   uint64
-					rxPackets uint64
-					rxErrors  uint64
-					rxDropped uint64
-					txBytes   uint64
-					txPackets uint64
-					txErrors  uint64
-					txDropped uint64
-				)
-				for _, v := range statsJSONPost120.Networks {
-					rxBytes += v.RxBytes
-					rxPackets += v.RxPackets
-					rxErrors += v.RxErrors
-					rxDropped += v.RxDropped
-					txBytes += v.TxBytes
-					txPackets += v.TxPackets
-					txErrors += v.TxErrors
-					txDropped += v.TxDropped
-				}
-				statsJSON = &v1p20.StatsJSON{
-					Stats: statsJSONPost120.Stats,
-					Network: types.NetworkStats{
-						RxBytes:   rxBytes,
-						RxPackets: rxPackets,
-						RxErrors:  rxErrors,
-						RxDropped: rxDropped,
-						TxBytes:   txBytes,
-						TxPackets: txPackets,
-						TxErrors:  txErrors,
-						TxDropped: txDropped,
-					},
-				}
-			} else {
-				statsJSON = statsJSONPost120
+			statsJSON, ok := allStats[container.ID]
+			if !ok || statsJSON == nil {
+				return fmt.Errorf("can't get stats data for %q", container.ID[:12])
 			}
 
-			if !config.Stream && noStreamFirstFrame {
-				// prime the cpu stats so they aren't 0 in the final output
-				noStreamFirstFrame = false
-				continue
-			}
-
-			if err := enc.Encode(statsJSON); err != nil {
+			// this is for backward compatibity with API Pre 1.21
+			json, err := daemon.transformNetworkStats(apiVersion, statsJSON)
+			if err != nil {
 				return err
 			}
 
+			// we have filtered the results by "id", now we only send the
+			// StatsJSON instead of map[string]StatsJSONComplex for backward compatibility
+			if err := enc.Encode(json); err != nil {
+				return err
+			}
 			if !config.Stream {
 				return nil
 			}
-		case <-ctx.Done():
+		case err := <-errChan:
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -173,86 +124,172 @@ func (daemon *Daemon) ContainerStatsAll(ctx context.Context, config *backend.Con
 
 	enc := json.NewEncoder(outStream)
 
-	updates := daemon.subscribeToContainerStatsAll()
-	defer daemon.unsubscribeToContainerStatsAll(updates)
+	statsChan, errChan := daemon.fetchAndFilterAllStats(ctx, config.Stream, config.Filters)
 
 	for {
 		select {
-		case v, ok := <-updates:
+		case allStats, ok := <-statsChan:
 			if !ok {
 				return nil
 			}
-
-			statsJSON, ok := v.(map[string]*types.StatsJSON)
-			if !ok {
-				// malformed data!
-				logrus.Errorf("receive malformed stats data")
-				continue
+			if err := enc.Encode(allStats); err != nil {
+				return err
 			}
-
-			var preCPUNotExits bool
 			if !config.Stream {
-				// prime the cpu stats so they aren't 0 in the final output
-				for _, ss := range statsJSON {
-					if ss.PreCPUStats == nil {
-						preCPUNotExits = true
-						break
+				return nil
+			}
+		case err := <-errChan:
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (daemon *Daemon) fetchAndFilterAllStats(ctx context.Context, stream bool, filters filters.Args) (chan map[string]*types.StatsJSON, chan error) {
+	statsChan := make(chan (map[string]*types.StatsJSON), 16)
+	errChan := make(chan error)
+
+	go func() {
+		updates := daemon.subscribeToContainerStatsAll()
+		defer daemon.unsubscribeToContainerStatsAll(updates)
+
+		defer close(statsChan)
+		for {
+			select {
+			case v, ok := <-updates:
+				if !ok {
+					errChan <- nil
+					return
+				}
+
+				origStatsJSON, ok := v.(map[string]*types.StatsJSON)
+				if !ok {
+					// malformed data!
+					logrus.Errorf("receive malformed stats data")
+					continue
+				}
+
+				// copy map to avoid concurrent write
+				statsJSON := make(map[string]*types.StatsJSON)
+				for k, v := range origStatsJSON {
+					statsJSON[k] = v
+				}
+
+				var preCPUNotExits bool
+				if !stream {
+					// prime the cpu stats so they aren't 0 in the final output
+					for _, ss := range statsJSON {
+						if ss.PreCPUStats == nil {
+							preCPUNotExits = true
+							break
+						}
+					}
+
+					// if there's stats without preCPUNotExits
+					if preCPUNotExits {
+						continue
 					}
 				}
 
-				// if there's stats without preCPUNotExits
-				if preCPUNotExits {
+				// filter container
+				filterdCtrs, err := daemon.reduceStatsContainers(filters)
+				if err != nil {
+					logrus.Errorf("can't filter containers: %v", err)
 					continue
 				}
-			}
 
-			// filter container
-			filterdCtrs, err := daemon.reduceStatsContainers(config.Filters)
-			if err != nil {
-				logrus.Errorf("can't filter containers: %v", err)
-				continue
-			}
-
-			survivedContainers := make(map[string]*types.Container)
-			for _, ctr := range filterdCtrs {
-				survivedContainers[ctr.ID] = ctr
-			}
-
-			// if container didn't survive from the filter, remove it!
-			var toDelete []string
-			for id := range statsJSON {
-				if _, ok := survivedContainers[id]; !ok {
-					toDelete = append(toDelete, id)
-				} else {
-					delete(survivedContainers, id)
+				survivedContainers := make(map[string]*types.Container)
+				for _, ctr := range filterdCtrs {
+					survivedContainers[ctr.ID] = ctr
 				}
-			}
 
-			// iterate the toDelete list, delete statsJSON with related id
-			for _, id := range toDelete {
-				delete(statsJSON, id)
-			}
-
-			// if we didn't get stats data for one survived container,
-			// this means that the container isn't in running state,
-			// we need to add an empty item for it in statsJSON
-			for id, ctr := range survivedContainers {
-				statsJSON[id] = &types.StatsJSON{
-					ID:   ctr.ID,
-					Name: strings.Join(ctr.Names, ","),
+				// if container didn't survive from the filter, remove it!
+				var toDelete []string
+				for id := range statsJSON {
+					if _, ok := survivedContainers[id]; !ok {
+						toDelete = append(toDelete, id)
+					} else {
+						delete(survivedContainers, id)
+					}
 				}
-			}
-			if err := enc.Encode(statsJSON); err != nil {
-				return err
-			}
 
-			if !config.Stream {
-				return nil
+				// iterate the toDelete list, delete statsJSON with related id
+				for _, id := range toDelete {
+					delete(statsJSON, id)
+				}
+
+				// if we didn't get stats data for one survived container,
+				// this means that the container isn't in running state,
+				// we need to add an empty item for it in statsJSON
+				for id, ctr := range survivedContainers {
+					statsJSON[id] = &types.StatsJSON{
+						ID:   ctr.ID,
+						Name: strings.Join(ctr.Names, ","),
+					}
+				}
+				statsChan <- statsJSON
+
+				if !stream {
+					errChan <- nil
+					return
+				}
+			case <-ctx.Done():
+				errChan <- nil
+				return
 			}
-		case <-ctx.Done():
-			return nil
 		}
+	}()
+	return statsChan, errChan
+}
+
+// transformNetworkStats is basically used for backward compatibility
+// it will transform new stats format into old format for old API
+func (daemon *Daemon) transformNetworkStats(version string, stats *types.StatsJSON) (interface{}, error) {
+	if versions.LessThan(version, "1.21") && runtime.GOOS == "windows" {
+		return nil, errors.New("API versions pre v1.21 do not support stats on Windows")
 	}
+
+	var statsJSON interface{}
+	if versions.LessThan(version, "1.21") {
+		var (
+			rxBytes   uint64
+			rxPackets uint64
+			rxErrors  uint64
+			rxDropped uint64
+			txBytes   uint64
+			txPackets uint64
+			txErrors  uint64
+			txDropped uint64
+		)
+		for _, v := range stats.Networks {
+			rxBytes += v.RxBytes
+			rxPackets += v.RxPackets
+			rxErrors += v.RxErrors
+			rxDropped += v.RxDropped
+			txBytes += v.TxBytes
+			txPackets += v.TxPackets
+			txErrors += v.TxErrors
+			txDropped += v.TxDropped
+		}
+		statsJSON = &v1p20.StatsJSON{
+			Stats: stats.Stats,
+			Network: types.NetworkStats{
+				RxBytes:   rxBytes,
+				RxPackets: rxPackets,
+				RxErrors:  rxErrors,
+				RxDropped: rxDropped,
+				TxBytes:   txBytes,
+				TxPackets: txPackets,
+				TxErrors:  txErrors,
+				TxDropped: txDropped,
+			},
+		}
+	} else {
+		statsJSON = stats
+	}
+
+	return statsJSON, nil
 }
 
 func (daemon *Daemon) subscribeToContainerStatsAll() chan interface{} {

--- a/daemon/stats_collector.go
+++ b/daemon/stats_collector.go
@@ -16,6 +16,8 @@ import (
 type statsSupervisor interface {
 	// GetContainerStats collects all the stats related to a container
 	GetContainerStats(container *container.Container) (*types.StatsJSON, error)
+	// GetContainerStatsAllRunning collects stats of all the running containers
+	GetContainerStatsAllRunning() map[string]*types.StatsJSON
 }
 
 // newStatsCollector returns a new statsCollector that collections
@@ -30,17 +32,19 @@ func (daemon *Daemon) newStatsCollector(interval time.Duration) *statsCollector 
 		bufReader:  bufio.NewReaderSize(nil, 128),
 	}
 	platformNewStatsCollector(s)
-	go s.run()
+	go s.runCollectorForSome()
+	go s.runCollectorForAllRunning()
 	return s
 }
 
 // statsCollector manages and provides container resource stats
 type statsCollector struct {
-	m          sync.Mutex
-	supervisor statsSupervisor
-	interval   time.Duration
-	publishers map[*container.Container]*pubsub.Publisher
-	bufReader  *bufio.Reader
+	m            sync.Mutex
+	supervisor   statsSupervisor
+	interval     time.Duration
+	publishers   map[*container.Container]*pubsub.Publisher
+	publisherAll *pubsub.Publisher
+	bufReader    *bufio.Reader
 
 	// The following fields are not set on Windows currently.
 	clockTicksPerSecond uint64
@@ -85,7 +89,41 @@ func (s *statsCollector) unsubscribe(c *container.Container, ch chan interface{}
 	s.m.Unlock()
 }
 
-func (s *statsCollector) run() {
+// collectAll start the event loop for collecting on all containers
+// it will return a channel for subscriber to receive on.
+func (s *statsCollector) collectAll() chan interface{} {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.publisherAll == nil {
+		s.publisherAll = pubsub.NewPublisher(100*time.Millisecond, 1024)
+	}
+	return s.publisherAll.Subscribe()
+}
+
+// stopCollectionAll closes the channels for all subscribers and removes
+// the container from metrics collection.
+func (s *statsCollector) stopCollectionAll() {
+	s.m.Lock()
+	if s.publisherAll != nil {
+		s.publisherAll.Close()
+		s.publisherAll = nil
+	}
+	s.m.Unlock()
+}
+
+// unsubscribeAll removes a specific subscriber from receiving updates for all container's stats.
+func (s *statsCollector) unsubscribeAll(ch chan interface{}) {
+	s.m.Lock()
+	if s.publisherAll != nil {
+		s.publisherAll.Evict(ch)
+		if s.publisherAll.Len() == 0 {
+			s.publisherAll = nil
+		}
+	}
+	s.m.Unlock()
+}
+
+func (s *statsCollector) runCollectorForSome() {
 	type publishersPair struct {
 		container *container.Container
 		publisher *pubsub.Publisher
@@ -128,5 +166,72 @@ func (s *statsCollector) run() {
 
 			pair.publisher.Publish(*stats)
 		}
+	}
+}
+
+func (s *statsCollector) runCollectorForAllRunning() {
+	// preCPUStats save CPUStats collected from last time
+	// if fails to collect during s.interval, clear it all
+	// we don't need any outdated data
+	preCPUStats := make(map[string]*types.CPUStats)
+	preRead := make(map[string]time.Time)
+	for range time.Tick(s.interval) {
+		if s.publisherAll == nil {
+			// no subscriber, preCPUStats is out of date
+			// clear it all
+			preCPUStats = nil
+			preRead = nil
+			continue
+		}
+
+		systemUsage, err := s.getSystemCPUUsage()
+		if err != nil {
+			logrus.Errorf("collecting system cpu usage: %v", err)
+			preCPUStats = nil
+			preRead = nil
+			continue
+		}
+
+		if preCPUStats == nil {
+			preCPUStats = make(map[string]*types.CPUStats)
+			preRead = make(map[string]time.Time)
+		}
+
+		pubResults := s.supervisor.GetContainerStatsAllRunning()
+
+		// remove outdated data from preCPUStats and preRead
+		for id := range preCPUStats {
+			if _, ok := pubResults[id]; !ok {
+				// if pubResults doesn't contains container with "id",
+				// remove it from preCPUStats. This can happen when container
+				// stops running
+				delete(preCPUStats, id)
+			}
+		}
+		for id := range preRead {
+			if _, ok := pubResults[id]; !ok {
+				delete(preRead, id)
+			}
+		}
+
+		for id, stats := range pubResults {
+			// FIXME: move to containerd
+			stats.CPUStats.SystemUsage = systemUsage
+			if _, ok := preCPUStats[id]; ok {
+				stats.PreCPUStats = preCPUStats[id]
+			}
+			preCPUStats[id] = &stats.CPUStats
+			if _, ok := preRead[id]; ok {
+				stats.PreRead = preRead[id]
+			}
+			preRead[id] = stats.Read
+		}
+
+		// publish results no matter it's empty or not
+		s.m.Lock()
+		if s.publisherAll != nil {
+			s.publisherAll.Publish(pubResults)
+		}
+		s.m.Unlock()
 	}
 }

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -215,7 +215,7 @@ func (s *DockerSuite) TestGetContainerStatsRmRunning(c *check.C) {
 	out, _ := runSleepingContainer(c)
 	id := strings.TrimSpace(out)
 
-	buf := &testutil.ChannelBuffer{make(chan []byte, 1)}
+	buf := &testutil.ChannelBuffer{make(chan []byte, 128)}
 	defer buf.Close()
 
 	_, body, err := request.SockRequestRaw("GET", "/containers/"+id+"/stats?stream=1", nil, "application/json", daemonHost())

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestApiStatsAllNoStreamGetCpu(c *check.C) {
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
 	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
 
-	var v map[string]*types.Stats
+	var v map[string]*types.StatsJSON
 	err = json.NewDecoder(body).Decode(&v)
 	c.Assert(err, checker.IsNil)
 	body.Close()

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -26,6 +26,7 @@ func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), checker.IsNil)
 
+	// test API "/containers/[name]/stats"
 	resp, body, err := request.SockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "", daemonHost())
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
@@ -60,6 +61,37 @@ func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
 	c.Assert(cpuPercent, check.Not(checker.Equals), 0.0, check.Commentf("docker stats with no-stream get cpu usage failed: was %v", cpuPercent))
 }
 
+func (s *DockerSuite) TestApiStatsAllNoStreamGetCpu(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
+
+	id := strings.TrimSpace(out)
+	c.Assert(waitRun(id), checker.IsNil)
+
+	// test API "/containers/-/stats"
+	resp, body, err := request.SockRequestRaw("GET", "/containers/-/stats?stream=false", nil, "", daemonHost())
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.StatusCode, checker.Equals, http.StatusOK)
+	c.Assert(resp.Header.Get("Content-Type"), checker.Equals, "application/json")
+
+	var v map[string]*types.Stats
+	err = json.NewDecoder(body).Decode(&v)
+	c.Assert(err, checker.IsNil)
+	body.Close()
+
+	ss, ok := v[id]
+	if !ok {
+		c.Fatalf("container %s should exists in stats result: %v", id[:12], v)
+	}
+
+	var cpuPercent = 0.0
+	cpuDelta := float64(ss.CPUStats.CPUUsage.TotalUsage - ss.PreCPUStats.CPUUsage.TotalUsage)
+	systemDelta := float64(ss.CPUStats.SystemUsage - ss.PreCPUStats.SystemUsage)
+	cpuPercent = (cpuDelta / systemDelta) * float64(len(ss.CPUStats.CPUUsage.PercpuUsage)) * 100.0
+
+	c.Assert(cpuPercent, check.Not(checker.Equals), 0.0, check.Commentf("docker stats with no-stream get cpu usage failed: was %v", cpuPercent))
+}
+
 func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1")
 	id := strings.TrimSpace(out)
@@ -81,6 +113,25 @@ func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 	body.Close()
 
 	t := time.After(30 * time.Second)
+	for {
+		select {
+		case <-t:
+			c.Assert(getGoRoutines(), checker.LessOrEqualThan, routines)
+			goto test_stats_all
+		default:
+			if n := getGoRoutines(); n <= routines {
+				goto test_stats_all
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+test_stats_all:
+	// `GET /containers/-/stats` should return the same
+	_, body, err = request.SockRequestRaw("GET", "/containers/-/stats", nil, "", daemonHost())
+	c.Assert(err, checker.IsNil)
+	body.Close()
+
 	for {
 		select {
 		case <-t:
@@ -110,18 +161,32 @@ func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 	contIP := findContainerIP(c, id, net)
 	numPings := 1
 
-	var preRxPackets uint64
-	var preTxPackets uint64
-	var postRxPackets uint64
-	var postTxPackets uint64
+	var (
+		preRxPackets  uint64
+		preTxPackets  uint64
+		postRxPackets uint64
+		postTxPackets uint64
+
+		preRxPacketsAll  uint64
+		preTxPacketsAll  uint64
+		postRxPacketsAll uint64
+		postTxPacketsAll uint64
+	)
 
 	// Get the container networking stats before and after pinging the container
+	// Get with API "/container/[name]/stats"
 	nwStatsPre := getNetworkStats(c, id)
 	for _, v := range nwStatsPre {
 		preRxPackets += v.RxPackets
 		preTxPackets += v.TxPackets
 	}
 
+	// Get with API "/containers/-/stats"
+	nwStatsPre = getNetworkStatsForAll(c, id)
+	for _, v := range nwStatsPre {
+		preRxPacketsAll += v.RxPackets
+		preTxPacketsAll += v.TxPackets
+	}
 	countParam := "-c"
 	if runtime.GOOS == "windows" {
 		countParam = "-n" // Ping count parameter is -n on Windows
@@ -142,10 +207,19 @@ func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 	}
 	c.Assert(err, checker.IsNil)
 	pingouts := string(pingout[:])
+
+	// Get post packets via "/containers/[name]/stats"
 	nwStatsPost := getNetworkStats(c, id)
 	for _, v := range nwStatsPost {
 		postRxPackets += v.RxPackets
 		postTxPackets += v.TxPackets
+	}
+
+	// Get post packets via "/containers/-/stats"
+	nwStatsPost = getNetworkStatsForAll(c, id)
+	for _, v := range nwStatsPost {
+		postRxPacketsAll += v.RxPackets
+		postTxPacketsAll += v.TxPackets
 	}
 
 	// Verify the stats contain at least the expected number of packets
@@ -160,6 +234,11 @@ func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 		check.Commentf("Reported less TxPackets than expected. Expected >= %d. Found %d. %s", expTxPkts, postTxPackets, pingouts))
 	c.Assert(postRxPackets, checker.GreaterOrEqualThan, expRxPkts,
 		check.Commentf("Reported less Txbytes than expected. Expected >= %d. Found %d. %s", expRxPkts, postRxPackets, pingouts))
+
+	c.Assert(postTxPacketsAll, checker.GreaterOrEqualThan, expTxPkts,
+		check.Commentf("Reported less TxPackets than expected. Expected >= %d. Found %d. %s", expTxPkts, postTxPacketsAll, pingouts))
+	c.Assert(postRxPacketsAll, checker.GreaterOrEqualThan, expRxPkts,
+		check.Commentf("Reported less Txbytes than expected. Expected >= %d. Found %d. %s", expRxPkts, postRxPacketsAll, pingouts))
 }
 
 func (s *DockerSuite) TestAPIStatsNetworkStatsVersioning(c *check.C) {
@@ -199,6 +278,23 @@ func getNetworkStats(c *check.C, id string) map[string]types.NetworkStats {
 	c.Assert(err, checker.IsNil)
 	body.Close()
 
+	return st.Networks
+}
+
+func getNetworkStatsForAll(c *check.C, id string) map[string]types.NetworkStats {
+	var stMap map[string]*types.StatsJSON
+
+	_, body, err := request.SockRequestRaw("GET", "/containers/-/stats?stream=false", nil, "", daemonHost())
+	c.Assert(err, checker.IsNil)
+
+	err = json.NewDecoder(body).Decode(&stMap)
+	c.Assert(err, checker.IsNil)
+	body.Close()
+
+	st, ok := stMap[id]
+	if !ok {
+		c.Fatalf("container %s not exits in stats result: %v", id, st)
+	}
 	return st.Networks
 }
 


### PR DESCRIPTION
Fixes #22052

Add a new API for docker stats all containers, and refactored docker
client to make use of new API.

There're some obvious benefits from this commit:
1. it saves lots of TCP connections when stats bundles of containers.
2. the client side is expected to gain higher performance due to less goroutine.
3. client codes are simpler and easier to maintain.

Signed-off-by: Zhang Wei zhangwei555@huawei.com

ping @runcom @thaJeztah 
/cc @vincentwoo @jeanpralo Is this what you want?

TODO:
- [x] api-tests and integration tests
- [ ] docs 
