### PR TITLE
Support HTTP health checks

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -536,8 +536,11 @@ func healthcheck(b *Builder, args []string, attributes map[string]bool, original
 			}
 
 			healthcheck.Test = strslice.StrSlice(append([]string{typ}, cmdSlice...))
+		case "HTTP":
+			httpSlice := handleJSONArgs(args, attributes)
+			healthcheck.Test = strslice.StrSlice(append([]string{typ}, httpSlice...))
 		default:
-			return fmt.Errorf("Unknown type %#v in HEALTHCHECK (try CMD)", typ)
+			return fmt.Errorf("Unknown type %#v in HEALTHCHECK (try CMD or HTTP)", typ)
 		}
 
 		interval, err := parseOptInterval(flInterval)

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -103,6 +103,7 @@ type containerOptions struct {
 	shmSize            string
 	noHealthcheck      bool
 	healthCmd          string
+	healthHTTP         string
 	healthInterval     time.Duration
 	healthTimeout      time.Duration
 	healthRetries      int
@@ -220,6 +221,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 
 	// Health-checking
 	flags.StringVar(&copts.healthCmd, "health-cmd", "", "Command to run to check health")
+	flags.StringVar(&copts.healthHTTP, "health-http", "", "Http address to to check health")
 	flags.DurationVar(&copts.healthInterval, "health-interval", 0, "Time between running the check (ns|us|ms|s|m|h) (default 0s)")
 	flags.IntVar(&copts.healthRetries, "health-retries", 0, "Consecutive failures needed to report unhealthy")
 	flags.DurationVar(&copts.healthTimeout, "health-timeout", 0, "Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)")
@@ -489,7 +491,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*container.Config, *c
 
 	// Healthcheck
 	var healthConfig *container.HealthConfig
-	haveHealthSettings := copts.healthCmd != "" ||
+	haveHealthSettings := copts.healthCmd != "" || copts.healthHTTP != "" ||
 		copts.healthInterval != 0 ||
 		copts.healthTimeout != 0 ||
 		copts.healthRetries != 0
@@ -503,6 +505,9 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*container.Config, *c
 		var probe strslice.StrSlice
 		if copts.healthCmd != "" {
 			args := []string{"CMD-SHELL", copts.healthCmd}
+			probe = strslice.StrSlice(args)
+		} else if copts.healthHTTP != "" {
+			args := []string{"HTTP", copts.healthHTTP}
 			probe = strslice.StrSlice(args)
 		}
 		if copts.healthInterval < 0 {

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
 	"runtime"
 	"strings"
 	"sync"
@@ -50,6 +52,37 @@ type probe interface {
 	// Perform one run of the check. Returns the exit code and an optional
 	// short diagnostic string.
 	run(context.Context, *Daemon, *container.Container) (*types.HealthcheckResult, error)
+}
+
+// httpProbe implements the "HTTP" probe type.
+type httpProbe struct {
+}
+
+func httpHealthcheck(address, endpoint string, timeout time.Duration) (*types.HealthcheckResult, error) {
+	client := http.Client{
+		Timeout: timeoutWithDefault(timeout, defaultProbeTimeout),
+	}
+	resp, err := client.Get(fmt.Sprintf("http://%s%s", address, endpoint))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	output := &limitedBuffer{}
+	if _, err := io.Copy(output, resp.Body); err != nil {
+		return nil, err
+	}
+
+	exitCode := 1
+	if 200 <= resp.StatusCode && resp.StatusCode < 300 {
+		exitCode = 0
+	}
+
+	return &types.HealthcheckResult{
+		End:      time.Now(),
+		ExitCode: exitCode,
+		Output:   output.String(),
+	}, nil
 }
 
 // cmdProbe implements the "CMD" probe type.
@@ -219,8 +252,10 @@ func getProbe(c *container.Container) probe {
 		return &cmdProbe{shell: false}
 	case "CMD-SHELL":
 		return &cmdProbe{shell: true}
+	case "HTTP":
+		return &httpProbe{}
 	default:
-		logrus.Warnf("Unknown healthcheck type '%s' (expected 'CMD') in container %s", config.Test[0], c.ID)
+		logrus.Warnf("Unknown healthcheck type '%s' (expected 'CMD' or HTTP) in container %s", config.Test[0], c.ID)
 		return nil
 	}
 }

--- a/daemon/health_http.go
+++ b/daemon/health_http.go
@@ -1,0 +1,39 @@
+// +build !linux
+
+package daemon
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/container"
+)
+
+func (p *httpProbe) run(ctx context.Context, d *Daemon, container *container.Container) (*types.HealthcheckResult, error) {
+	httpSlice := strslice.StrSlice(container.Config.Healthcheck.Test)[1:]
+
+	endpoint := "/"
+	if len(httpSlice) > 0 {
+		endpoint = httpSlice[0]
+	}
+
+	address := ""
+	if container.HostConfig.NetworkMode.IsHost() {
+		address = "127.0.0.1"
+	} else {
+		for _, n := range container.NetworkSettings.Networks {
+			if n.IPAddress != "" {
+				address = n.IPAddress
+				break
+			}
+		}
+	}
+	if address == "" {
+		return nil, fmt.Errorf("unable to find network with IP address")
+	}
+
+	return httpHealthcheck(address, endpoint, container.Config.Healthcheck.Timeout)
+}

--- a/daemon/health_http_linux.go
+++ b/daemon/health_http_linux.go
@@ -1,0 +1,99 @@
+// +build linux
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/vishvananda/netns"
+)
+
+func init() {
+	reexec.Register("docker-healthcheck", reexecHealthcheck)
+}
+
+func reexecHealthcheck() {
+	if len(os.Args) < 4 {
+		logrus.Fatal("no endpoint or namespace path or timeout provided: %v", os.Args)
+	}
+	endpoint := os.Args[1]
+	sandboxKey := os.Args[2]
+	timeout, err := time.ParseDuration(os.Args[3])
+	if err != nil {
+		logrus.Fatalf("invalid timeout value: %s", err)
+	}
+
+	address := "127.0.0.1"
+
+	// Save the current network namespace
+	origns, err := netns.Get()
+	if err != nil {
+		logrus.Fatalf("unable to obtain current network namespace: %s", err)
+	}
+	defer origns.Close()
+
+	ns, err := netns.GetFromPath(sandboxKey)
+	if err != nil {
+		logrus.Fatalf("unable to get network namespace for %s: %s", sandboxKey, err)
+	}
+	defer ns.Close()
+
+	defer netns.Set(origns)
+	netns.Set(ns)
+
+	healthcheckResult, err := httpHealthcheck(address, endpoint, timeout)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	fmt.Fprint(os.Stdout, healthcheckResult.Output)
+	os.Exit(healthcheckResult.ExitCode)
+}
+
+func (p *httpProbe) run(ctx context.Context, d *Daemon, container *container.Container) (*types.HealthcheckResult, error) {
+	httpSlice := strslice.StrSlice(container.Config.Healthcheck.Test)[1:]
+
+	endpoint := "/"
+	if len(httpSlice) > 0 {
+		endpoint = httpSlice[0]
+	}
+
+	cmd := reexec.Command("docker-healthcheck", endpoint, container.NetworkSettings.SandboxKey, container.Config.Healthcheck.Timeout.String())
+	output := &limitedBuffer{}
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("healthcheck error on re-exec cmd: %v", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				return &types.HealthcheckResult{
+					End:      time.Now(),
+					ExitCode: status.ExitStatus(),
+					Output:   output.String(),
+				}, nil
+			}
+		}
+		return nil, fmt.Errorf("healthcheck re-exec error: %v: output: %s", err, output)
+	}
+
+	return &types.HealthcheckResult{
+		End:      time.Now(),
+		ExitCode: 0,
+		Output:   output.String(),
+	}, nil
+}

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-
 	"strconv"
 	"strings"
 	"time"
@@ -37,7 +36,7 @@ func getHealth(c *check.C, name string) *types.Health {
 }
 
 func (s *DockerSuite) TestHealth(c *check.C) {
-	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
+	testRequires(c, DaemonIsLinux)
 
 	imageName := "testhealth"
 	buildImageSuccessfully(c, imageName, withDockerfile(`FROM busybox
@@ -141,4 +140,80 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 		"--format={{.Config.Healthcheck.Test}}", imageName)
 	c.Check(out, checker.Equals, "[CMD cat /my status]\n")
 
+}
+
+func (s *DockerSuite) TestHealthHttp(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	name := "healthcheck_http"
+	// Enable the checks from the CLI
+	_, _ = dockerCmd(c, "run", "-d", "--name", name,
+		"--health-interval=0.5s",
+		"--health-retries=3",
+		"--health-http=:8080/health",
+		"busybox", "sh", "-c", "echo -e \"HTTP/1.1 200 OK\n\nHealthCheck Successful\" > /status && while true ; do cat /status | nc -l -p 8080 ; done")
+	waitForHealthStatus(c, name, "starting", "healthy")
+	health := getHealth(c, name)
+	c.Check(health.Status, checker.Equals, "healthy")
+	c.Check(health.FailingStreak, checker.Equals, 0)
+	last := health.Log[len(health.Log)-1]
+	c.Check(last.ExitCode, checker.Equals, 0)
+	c.Check(last.Output, checker.Equals, "HealthCheck Successful\n")
+
+	// Fail the check
+	dockerCmd(c, "exec", name, "sh", "-c", "echo -e \"HTTP/1.1 500 Internal Server Error\n\nHealthCheck Failed\" > /status")
+	waitForHealthStatus(c, name, "healthy", "unhealthy")
+
+	health = getHealth(c, name)
+	c.Check(health.Status, checker.Equals, "unhealthy")
+	c.Check(health.FailingStreak >= 3, checker.Equals, true)
+	last = health.Log[len(health.Log)-1]
+	c.Check(last.ExitCode, checker.Equals, 1)
+	c.Check(last.Output, checker.Equals, "HealthCheck Failed\n")
+}
+
+func (s *DockerSuite) TestHealthHttpBuild(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	imageName := "testhealth"
+	_, err := buildImage(imageName,
+		`FROM busybox
+		STOPSIGNAL SIGKILL
+		HEALTHCHECK --interval=1s --timeout=30s \
+		  HTTP :8080/health`,
+		true)
+
+	c.Check(err, check.IsNil)
+
+	// No health status before starting
+	name := "healthcheck_http"
+	dockerCmd(c, "create", "--name", name, imageName, "sh", "-c", "echo -e \"HTTP/1.1 200 OK\n\nHealthCheck Successful\" > /status && while true ; do cat /status | nc -l -p 8080 ; done")
+	out, _ := dockerCmd(c, "ps", "-a", "--format={{.Status}}")
+	c.Check(out, checker.Equals, "Created\n")
+
+	// Inspect the options
+	out, _ = dockerCmd(c, "inspect", "--format", "timeout={{.Config.Healthcheck.Timeout}} "+
+		"interval={{.Config.Healthcheck.Interval}} "+
+		"retries={{.Config.Healthcheck.Retries}} "+
+		"test={{.Config.Healthcheck.Test}}", name)
+	c.Check(out, checker.Equals, "timeout=30s interval=1s retries=0 test=[HTTP :8080/health]\n")
+
+	// Start
+	dockerCmd(c, "start", name)
+	waitForHealthStatus(c, name, "starting", "healthy")
+
+	// Make it fail
+	dockerCmd(c, "exec", name, "rm", "/status")
+	waitForHealthStatus(c, name, "healthy", "unhealthy")
+
+	// Inspect the status
+	out, _ = dockerCmd(c, "inspect", "--format={{.State.Health.Status}}", name)
+	c.Check(out, checker.Equals, "unhealthy\n")
+
+	// Make it healthy again
+	dockerCmd(c, "exec", name, "sh", "-c", "echo -e \"HTTP/1.1 200 OK\n\nHealthCheck Successful\" > /status")
+	waitForHealthStatus(c, name, "unhealthy", "healthy")
+
+	// Remove container
+	dockerCmd(c, "rm", "-f", name)
 }


### PR DESCRIPTION
**\- What I did**

This fix is an attempt to address the proposal raised in #24111 to support HTTP health checks. (Suggestions/feedbacks are welcomed.)

**\- How I did it**

As is discussed in #24111, it is very common that the majority of the microservices are HTTP services and HTTP health check is very common for micro services.

At the moment this fix:
- Adds a `--health-http` to `docker run/create` to specify an HTTP based healthcheck.
- Adds `HTTP` in `HEALTHCHECK` of Dockerfiles to specify an HTTP based health check.
- HTTP response with `2xx` is treated as healthy (`0`), otherwise unhealthy (`1`).

The HTTP based healthcheck is defined in the format of:

```
--health-http [:port][/url]
HEALTHCHECK [:port][/url]
```

For example,

```
--health-http :8080/health
HEALTHCHECK /status
```

The default value is `/`.

The HTTP based healthcheck in this fix:
- In Linux mode, set the namespace to container network namespace
- In non-Linux mode, find an IP address associated with the container

**TODO**
- [ ] Documentation update

**\- How to verify it**

Several integration tests have been added to cover the changes in this fix.

**\- Description for the changelog**
Add `--health-http` to `docker run/create`, and `HTTP` in `HEALTHCHECK` of Dockerfiles to sepcify an HTTP based health check.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #24111.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
