### PR TITLE
Update `--user`/`-u` flag in man page of `docker create`

### DIFF
--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -375,7 +375,12 @@ any options, the systems uses the following options:
 `rw,noexec,nosuid,nodev,size=65536k`.
 
 **-u**, **--user**=""
-   Username or UID
+   Sets the username or UID used and optionally the groupname or GID for the specified command.
+
+   The followings examples are all valid:
+   --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
+
+   Without this argument root user will be used in the container by default.
 
 **--ulimit**=[]
    Ulimit options


### PR DESCRIPTION
The `--user`/`-u` of the `docker create` is the same as `docker run`, which could take either `uid` or `uid:gid` format. However, the description in the man page of `docker create` is missing and may cause some confusions (comared with `docker run`).

This fix updates the man page of `docker create` so that it is consistent with the man page of `docker run`.

This fix is related to #25304.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
