### PR TITLE
fix deadlock when more than 1 plugin is installed

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -326,8 +326,8 @@ func (pm *Manager) init() error {
 				}
 			}
 		}(p)
-		group.Wait()
 	}
+	group.Wait()
 	return pm.save()
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fix plugins restore code when engine starts.

**\- A picture of a cute animal (not mandatory but encouraged)**
![4--animal-selfies--151222](https://cloud.githubusercontent.com/assets/1032519/17385293/9220b786-5996-11e6-9056-11429cc92815.jpg)

Signed-off-by: Victor Vieux vieux@docker.com
