### PR TITLE
Test improvements to reduce time for long running tests

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -874,7 +874,7 @@ func (s *DockerSuite) TestContainerApiWait(c *check.C) {
 	if daemonPlatform == "windows" {
 		sleepCmd = "sleep"
 	}
-	dockerCmd(c, "run", "--name", name, "busybox", sleepCmd, "5")
+	dockerCmd(c, "run", "--name", name, "busybox", sleepCmd, "2")
 
 	status, body, err := sockRequest("POST", "/containers/"+name+"/wait", nil)
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -90,7 +90,7 @@ func (s *DockerSuite) TestApiStatsNetworkStats(c *check.C) {
 
 	// Retrieve the container address
 	contIP := findContainerIP(c, id, "bridge")
-	numPings := 4
+	numPings := 1
 
 	var preRxPackets uint64
 	var preTxPackets uint64

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -661,27 +661,6 @@ RUN ls -le /file`
 
 }
 
-func (s *DockerSuite) TestBuildSixtySteps(c *check.C) {
-	testRequires(c, DaemonIsLinux) // TODO Windows: This test passes on Windows,
-	// but currently adds a disproportionate amount of time for the value it has.
-	// Removing it from Windows CI for now, but this will be revisited in the
-	// TP5 timeframe when perf is better.
-	name := "foobuildsixtysteps"
-
-	ctx, err := fakeContext("FROM "+minimalBaseImage()+"\n"+strings.Repeat("ADD foo /\n", 60),
-		map[string]string{
-			"foo": "test1",
-		})
-	if err != nil {
-		c.Fatal(err)
-	}
-	defer ctx.Close()
-
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
-		c.Fatal(err)
-	}
-}
-
 func (s *DockerSuite) TestBuildAddSingleFileToRoot(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
 	name := "testaddimg"


### PR DESCRIPTION
This is just a small change to reduce the time some of the tests take.  It decreases the time around 20-30 seconds depending on run.  Small improvement but we have to start somewhere.

I'm just going through the tests logs and looking at the longer tests and seeing if they first make sense, if they are duplicated, and what we could change to make them faster without losing functionality. 
