### PR TITLE
Update `service ps` output format in swarm tutorial to match 1.12.0

### DIFF
--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -90,10 +90,11 @@ task assignments for the `redis` service:
     ```bash
     $ docker service ps redis
 
-    ID                         NAME     SERVICE  IMAGE        LAST STATE              DESIRED STATE  NODE
-    7q92v0nr1hcgts2amcjyqg3pq  redis.1  redis    redis:3.0.6  Running 4 minutes       Running        manager1
-    b4hovzed7id8irg1to42egue8  redis.2  redis    redis:3.0.6  Running About a minute  Running        worker2
-    9bg7cezvedmkgg6c8yzvbhwsd  redis.3  redis    redis:3.0.6  Running 4 minutes       Running        worker2
+    ID                         NAME          IMAGE        NODE      DESIRED STATE  CURRENT STATE           ERROR
+    7q92v0nr1hcgts2amcjyqg3pq  redis.1       redis:3.0.6  manager1  Running        Running 4 minutes
+    b4hovzed7id8irg1to42egue8  redis.2       redis:3.0.6  worker2   Running        Running About a minute
+    7h2l8h3q3wqy5f66hlv9ddmi6   \_ redis.2   redis:3.0.6  worker1   Shutdown       Shutdown 2 minutes ago
+    9bg7cezvedmkgg6c8yzvbhwsd  redis.3       redis:3.0.6  worker2   Running        Running 4 minutes
     ```
 
     The Swarm manager maintains the desired state by ending the task on a node

--- a/docs/swarm/swarm-tutorial/rolling-update.md
+++ b/docs/swarm/swarm-tutorial/rolling-update.md
@@ -138,10 +138,13 @@ desired state:
     ```bash
     $ docker service ps redis
 
-    ID                         NAME     SERVICE  IMAGE        LAST STATE              DESIRED STATE  NODE
-    dos1zffgeofhagnve8w864fco  redis.1  redis    redis:3.0.7  Running 37 seconds      Running        worker1
-    9l3i4j85517skba5o7tn5m8g0  redis.2  redis    redis:3.0.7  Running About a minute  Running        worker2
-    egiuiqpzrdbxks3wxgn8qib1g  redis.3  redis    redis:3.0.7  Running 48 seconds      Running        worker1
+    ID                         NAME         IMAGE        NODE       DESIRED STATE  CURRENT STATE            ERROR
+    dos1zffgeofhagnve8w864fco  redis.1      redis:3.0.7  worker1    Running        Running 37 seconds
+    88rdo6pa52ki8oqx6dogf04fh   \_ redis.1  redis:3.0.6  worker2    Shutdown       Shutdown 56 seconds ago
+    9l3i4j85517skba5o7tn5m8g0  redis.2      redis:3.0.7  worker2    Running        Running About a minute
+    66k185wilg8ele7ntu8f6nj6i   \_ redis.2  redis:3.0.6  worker1    Shutdown       Shutdown 2 minutes ago
+    egiuiqpzrdbxks3wxgn8qib1g  redis.3      redis:3.0.7  worker1    Running        Running 48 seconds
+    ctzktfddb2tepkr45qcmqln04   \_ redis.3  redis:3.0.6  mmanager1  Shutdown       Shutdown 2 minutes ago
     ```
 
     Before Swarm updates all of the tasks, you can see that some are running


### PR DESCRIPTION
**\- What I did**

These changes update the example output for `docker service ps` in the
swarm tutorial's rolling update and node draining sections to match that
produced by 1.12.0. shutdown tasks are listed and the column order and
naming has changed.

**\- How I did it**

The new output was generated by following the tutorial on a swarm of 3 nodes created with Docker Machine's vbox driver.

**\- How to verify it**

Follow the tutorial :)

**\- Description for the changelog**

Update `service ps` output format in swarm tutorial to match 1.12.0

**\- A picture of a cute animal (not mandatory but encouraged)**

Sure! How about this cc-by-nc [polar bear by Michael Linden?](https://www.flickr.com/photos/mjlinden/5493474800)

![Polar bear twitching nose](https://c1.staticflickr.com/6/5051/5493474800_f1c88cde72_b.jpg)
