### PR TITLE
Docker api inspect assert HostConfig

### DIFF
--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -97,7 +97,7 @@ func (s *DockerSuite) TestInspectApiContainerVolumeDriver(c *check.C) {
 	c.Assert(ok, checker.False, check.Commentf("Api version 1.21 expected to not include VolumeDriver in 'Config'"))
 
 	config, ok = inspectJSON["HostConfig"]
-	c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
+	c.Assert(ok, checker.True, check.Commentf("Unable to find 'HostConfig'"))
 	cfg = config.(map[string]interface{})
 	_, ok = cfg["VolumeDriver"]
 	c.Assert(ok, checker.True, check.Commentf("Api version 1.21 expected to include VolumeDriver in 'HostConfig'"))


### PR DESCRIPTION
when inspectJSON "inspectJSON", Docker api inspect should assert HostConfig not Config.

"Config" has been asserted:

```
config, ok := inspectJSON["Config"]
c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
```
