### PR TITLE
Add missing critical dependencies to deb

### DIFF
--- a/hack/make/.build-deb/control
+++ b/hack/make/.build-deb/control
@@ -9,7 +9,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-engine
 Architecture: linux-any
-Depends: iptables, ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
+Depends: iptables, linux-image-extra-virtual | dmsetup, ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
 Recommends: aufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,


### PR DESCRIPTION
**\- What I did**
Fixes #23347

**\- How I did it**
Add to package dependencies list "linux-image-extra-virtual" (this package add aufs support) OR "dmsetup".

**\- How to verify it**
Build and install deb package

**\- Description for the changelog**
Fixes #23347 installation process hangs

The installation process hangs if aufs support and dmsetup utility is absents. Issue fixes #23347
