### PR TITLE
Windows: Fix Invalid Handle errors in logs when exiting an interactive session

### DIFF
--- a/vendor/src/github.com/Microsoft/hcsshim/cgo.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/cgo.go
@@ -1,0 +1,7 @@
+package hcsshim
+
+import "C"
+
+// This import is needed to make the library compile as CGO because HCSSHIM
+// only works with CGO due to callbacks from HCS comming back from a C thread
+// which is not supported without CGO. See https://github.com/golang/go/issues/10973

--- a/vendor/src/github.com/Microsoft/hcsshim/errors.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/errors.go
@@ -4,12 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"syscall"
-
-	"github.com/Sirupsen/logrus"
 )
 
 var (
-	// ErrHandleClose is an error returned when the handle generating the notification being waited on has been closed
+	// ErrComputeSystemDoesNotExist is an error encountered when the container being operated on no longer exists
+	ErrComputeSystemDoesNotExist = syscall.Errno(0xc037010e)
+
+	// ErrElementNotFound is an error encountered when the object being referenced does not exist
+	ErrElementNotFound = syscall.Errno(0x490)
+
+	// ErrHandleClose is an error encountered when the handle generating the notification being waited on has been closed
 	ErrHandleClose = errors.New("hcsshim: the handle generating this notification has been closed")
 
 	// ErrInvalidNotificationType is an error encountered when an invalid notification type is used
@@ -21,21 +25,21 @@ var (
 	// ErrTimeout is an error encountered when waiting on a notification times out
 	ErrTimeout = errors.New("hcsshim: timeout waiting for notification")
 
-	// ErrUnexpectedContainerExit is the error returned when a container exits while waiting for
+	// ErrUnexpectedContainerExit is the error encountered when a container exits while waiting for
 	// a different expected notification
 	ErrUnexpectedContainerExit = errors.New("unexpected container exit")
 
-	// ErrUnexpectedProcessAbort is the error returned when communication with the compute service
+	// ErrUnexpectedProcessAbort is the error encountered when communication with the compute service
 	// is lost while waiting for a notification
 	ErrUnexpectedProcessAbort = errors.New("lost communication with compute service")
 
-	// ErrUnexpectedValue is an error returned when hcs returns an invalid value
+	// ErrUnexpectedValue is an error encountered when hcs returns an invalid value
 	ErrUnexpectedValue = errors.New("unexpected value returned from hcs")
 
-	// ErrVmcomputeAlreadyStopped is an error returned when a shutdown or terminate request is made on a stopped container
+	// ErrVmcomputeAlreadyStopped is an error encountered when a shutdown or terminate request is made on a stopped container
 	ErrVmcomputeAlreadyStopped = syscall.Errno(0xc0370110)
 
-	// ErrVmcomputeOperationPending is an error returned when the operation is being completed asynchronously
+	// ErrVmcomputeOperationPending is an error encountered when the operation is being completed asynchronously
 	ErrVmcomputeOperationPending = syscall.Errno(0xC0370103)
 )
 
@@ -53,23 +57,6 @@ type ContainerError struct {
 	Operation string
 	ExtraInfo string
 	Err       error
-}
-
-func isKnownError(err error) bool {
-	// Don't wrap errors created in hcsshim
-	if err == ErrHandleClose ||
-		err == ErrInvalidNotificationType ||
-		err == ErrInvalidProcessState ||
-		err == ErrTimeout ||
-		err == ErrUnexpectedContainerExit ||
-		err == ErrUnexpectedProcessAbort ||
-		err == ErrUnexpectedValue ||
-		err == ErrVmcomputeAlreadyStopped ||
-		err == ErrVmcomputeOperationPending {
-		return true
-	}
-
-	return false
 }
 
 func (e *ContainerError) Error() string {
@@ -99,14 +86,11 @@ func (e *ContainerError) Error() string {
 }
 
 func makeContainerError(container *container, operation string, extraInfo string, err error) error {
-	// Return known errors to the client
-	if isKnownError(err) {
+	// Don't double wrap errors
+	if _, ok := err.(*ContainerError); ok {
 		return err
 	}
-
-	// Log any unexpected errors
 	containerError := &ContainerError{Container: container, Operation: operation, ExtraInfo: extraInfo, Err: err}
-	logrus.Error(containerError)
 	return containerError
 }
 
@@ -129,21 +113,70 @@ func (e *ProcessError) Error() string {
 		s += " " + e.Operation
 	}
 
-	if e.Err != nil {
+	switch e.Err.(type) {
+	case nil:
+		break
+	case syscall.Errno:
 		s += fmt.Sprintf(" failed in Win32: %s (0x%x)", e.Err, win32FromError(e.Err))
+	default:
+		s += fmt.Sprintf(" failed: %s", e.Error())
 	}
 
 	return s
 }
 
 func makeProcessError(process *process, operation string, extraInfo string, err error) error {
-	// Return known errors to the client
-	if isKnownError(err) {
+	// Don't double wrap errors
+	if _, ok := err.(*ProcessError); ok {
 		return err
 	}
-
-	// Log any unexpected errors
 	processError := &ProcessError{Process: process, Operation: operation, ExtraInfo: extraInfo, Err: err}
-	logrus.Error(processError)
 	return processError
+}
+
+// IsNotExist checks if an error is caused by the Container or Process not existing.
+// Note: Currently, ErrElementNotFound can mean that a Process has either
+// already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
+// will currently return true when the error is ErrElementNotFound.
+func IsNotExist(err error) bool {
+	err = getInnerError(err)
+	return err == ErrComputeSystemDoesNotExist ||
+		err == ErrElementNotFound
+}
+
+// IsPending returns a boolean indicating whether the error is that
+// the requested operation is being completed in the background.
+func IsPending(err error) bool {
+	err = getInnerError(err)
+	return err == ErrVmcomputeOperationPending
+}
+
+// IsTimeout returns a boolean indicating whether the error is caused by
+// a timeout waiting for the operation to complete.
+func IsTimeout(err error) bool {
+	err = getInnerError(err)
+	return err == ErrTimeout
+}
+
+// IsAlreadyStopped returns a boolean indicating whether the error is caused by
+// a Container or Process being already stopped.
+// Note: Currently, ErrElementNotFound can mean that a Process has either
+// already exited, or does not exist. Both IsAlreadyStopped and IsNotExist
+// will currently return true when the error is ErrElementNotFound.
+func IsAlreadyStopped(err error) bool {
+	err = getInnerError(err)
+	return err == ErrVmcomputeAlreadyStopped ||
+		err == ErrElementNotFound
+}
+
+func getInnerError(err error) error {
+	switch pe := err.(type) {
+	case nil:
+		return nil
+	case *ContainerError:
+		err = pe.Err
+	case *ProcessError:
+		err = pe.Err
+	}
+	return err
 }

--- a/vendor/src/github.com/Microsoft/hcsshim/waithelper.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/waithelper.go
@@ -50,7 +50,7 @@ func waitForSingleObject(handle syscall.Handle, timeout uint32) (bool, error) {
 
 func processAsyncHcsResult(err error, resultp *uint16, callbackNumber uintptr, expectedNotification hcsNotification, timeout *time.Duration) error {
 	err = processHcsResult(err, resultp)
-	if err == ErrVmcomputeOperationPending {
+	if IsPending(err) {
 		return waitForNotification(callbackNumber, expectedNotification, timeout)
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes #24004

**\- What I did**

Fix Invalid Handle errors in logs when exiting an interactive session

**\- How I did it**

Open two handles to the process running in the container. One is used for the WaitExit, which is closed when the container exits, and one is used for getting the std handles and closing them when appropriate.

As of opening, this includes an update to hcsshim which requires some changes to error handling. This will be sent as a separate PR once it is merged in hcsshim.

**\- How to verify it**

Run `docker run -it --rm windowsservercore cmd` and `exit`. Pre patch, the daemon logs had an Invalid Handle error when closing the stdin pipe.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Darren Stahl darst@microsoft.com
