### PR TITLE
Remove git conflict markers in docs/reference/commandline/swarm_join.md

### DIFF
--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -88,7 +88,6 @@ This flag is generally not necessary when joining an existing swarm.
 ### `--manager`
 
 Joins the node as a manager
->>>>>>> 22565e1... Split advertised address from listen address
 
 ### `--token string`
 


### PR DESCRIPTION
**\- What I did**

Remove git conflict markers in command line reference for swarm mode's `swarm join` command.

**\- Why I did it**

These probably were introduced in a merge or rebase conflict and should have been removed.
