### PR TITLE
Sync API docs to older API versions

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -19,6 +19,8 @@ weight = 3
  - The API tends to be REST, but for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `STDOUT`,
    `STDIN` and `STDERR`.
+ - When the client API version is newer than the daemon's, these calls return an HTTP
+   `400 Bad Request` error message.
 
 # 2. Endpoints
 
@@ -32,69 +34,69 @@ List containers
 
 **Example request**:
 
-        GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        [
-             {
-                     "Id": "8dfafdbc3a40",
-                     "Names":["/boring_feynman"],
-                     "Image": "ubuntu:latest",
-                     "Command": "echo 1",
-                     "Created": 1367854155,
-                     "Status": "Exit 0",
-                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "Labels": {
-                             "com.example.vendor": "Acme",
-                             "com.example.license": "GPL",
-                             "com.example.version": "1.0"
-                     },
-                     "SizeRw": 12288,
-                     "SizeRootFs": 0
-             },
-             {
-                     "Id": "9cd87474be90",
-                     "Names":["/coolName"],
-                     "Image": "ubuntu:latest",
-                     "Command": "echo 222222",
-                     "Created": 1367854155,
-                     "Status": "Exit 0",
-                     "Ports": [],
-                     "Labels": {},
-                     "SizeRw": 12288,
-                     "SizeRootFs": 0
-             },
-             {
-                     "Id": "3176a2479c92",
-                     "Names":["/sleepy_dog"],
-                     "Image": "ubuntu:latest",
-                     "Command": "echo 3333333333333333",
-                     "Created": 1367854154,
-                     "Status": "Exit 0",
-                     "Ports":[],
-                     "Labels": {},
-                     "SizeRw":12288,
-                     "SizeRootFs":0
-             },
-             {
-                     "Id": "4cb07b47f9fb",
-                     "Names":["/running_cat"],
-                     "Image": "ubuntu:latest",
-                     "Command": "echo 444444444444444444444444444444444",
-                     "Created": 1367854152,
-                     "Status": "Exit 0",
-                     "Ports": [],
-                     "Labels": {},
-                     "SizeRw": 12288,
-                     "SizeRootFs": 0
-             }
-        ]
+    [
+         {
+                 "Id": "8dfafdbc3a40",
+                 "Names":["/boring_feynman"],
+                 "Image": "ubuntu:latest",
+                 "Command": "echo 1",
+                 "Created": 1367854155,
+                 "Status": "Exit 0",
+                 "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                 "Labels": {
+                         "com.example.vendor": "Acme",
+                         "com.example.license": "GPL",
+                         "com.example.version": "1.0"
+                 },
+                 "SizeRw": 12288,
+                 "SizeRootFs": 0
+         },
+         {
+                 "Id": "9cd87474be90",
+                 "Names":["/coolName"],
+                 "Image": "ubuntu:latest",
+                 "Command": "echo 222222",
+                 "Created": 1367854155,
+                 "Status": "Exit 0",
+                 "Ports": [],
+                 "Labels": {},
+                 "SizeRw": 12288,
+                 "SizeRootFs": 0
+         },
+         {
+                 "Id": "3176a2479c92",
+                 "Names":["/sleepy_dog"],
+                 "Image": "ubuntu:latest",
+                 "Command": "echo 3333333333333333",
+                 "Created": 1367854154,
+                 "Status": "Exit 0",
+                 "Ports":[],
+                 "Labels": {},
+                 "SizeRw":12288,
+                 "SizeRootFs":0
+         },
+         {
+                 "Id": "4cb07b47f9fb",
+                 "Names":["/running_cat"],
+                 "Image": "ubuntu:latest",
+                 "Command": "echo 444444444444444444444444444444444",
+                 "Created": 1367854152,
+                 "Status": "Exit 0",
+                 "Ports": [],
+                 "Labels": {},
+                 "SizeRw": 12288,
+                 "SizeRootFs": 0
+         }
+    ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, Show all containers.
         Only running containers are shown by default (i.e., this defaults to false)
@@ -106,12 +108,12 @@ Query Parameters:
         non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers
         sizes
--   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list. Available filters:
-  -   exited=&lt;int&gt; -- containers with exit code of &lt;int&gt;
-  -   status=(restarting|running|paused|exited)
-  -   label=`key` or `label="key=value"` of a container label
+-   **filters** - a JSON encoded value of the filters (a `map[string][]string`) to process on the containers list. Available filters:
+  -   `exited=<int>`; -- containers with exit code of  `<int>` ;
+  -   `status=`(`restarting`|`running`|`paused`|`exited`)
+  -   `label=key` or `label="key=value"` of a container label
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -125,7 +127,7 @@ Create a container
 
 **Example request**:
 
-        POST /containers/create HTTP/1.1
+      POST /containers/create HTTP/1.1
         Content-Type: application/json
 
         {
@@ -200,7 +202,7 @@ Create a container
              "Warnings":[]
         }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Hostname** - A string value containing the desired hostname to use for the
       container.
@@ -288,12 +290,12 @@ Json Parameters:
           `json-file` logging driver.
     -   **CgroupParent** - Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – Assign the specified name to the container. Must
     match `/?[a-zA-Z0-9_-]+`.
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -308,15 +310,14 @@ Status Codes:
 
 Return low-level information on the container `id`
 
-
 **Example request**:
 
-        GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
 	{
 		"AppArmorProfile": "",
@@ -430,7 +431,7 @@ Return low-level information on the container `id`
 		"VolumesRW": {}
 	}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -490,11 +491,11 @@ supported on Windows.
       ],
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **ps_args** – `ps` arguments to use (e.g., `aux`), defaults to `-ef`
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -504,25 +505,25 @@ Status Codes:
 
 `GET /containers/(id or name)/logs`
 
-Get stdout and stderr logs from the container ``id``
+Get `stdout` and `stderr` logs from the container ``id``
 
 > **Note**:
 > This endpoint works only for containers with the `json-file` or `journald` logging drivers.
 
 **Example request**:
 
-       GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
+     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
 
 **Example response**:
 
-       HTTP/1.1 101 UPGRADED
-       Content-Type: application/vnd.docker.raw-stream
-       Connection: Upgrade
-       Upgrade: tcp
+     HTTP/1.1 101 UPGRADED
+     Content-Type: application/vnd.docker.raw-stream
+     Connection: Upgrade
+     Upgrade: tcp
 
-       {{ STREAM }}
+     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default false
 -   **stdout** – 1/True/true or 0/False/false, show stdout log. Default false
@@ -531,7 +532,7 @@ Query Parameters:
         every log line. Default false
 -   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -546,27 +547,27 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-        GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        [
-             {
-                     "Path": "/dev",
-                     "Kind": 0
-             },
-             {
-                     "Path": "/dev/kmsg",
-                     "Kind": 1
-             },
-             {
-                     "Path": "/test",
-                     "Kind": 1
-             }
-        ]
+    [
+         {
+                 "Path": "/dev",
+                 "Kind": 0
+         },
+         {
+                 "Path": "/dev/kmsg",
+                 "Kind": 1
+         },
+         {
+                 "Path": "/test",
+                 "Kind": 1
+         }
+    ]
 
 Values for `Kind`:
 
@@ -574,7 +575,7 @@ Values for `Kind`:
 - `1`: Add
 - `2`: Delete
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -588,16 +589,16 @@ Export the contents of container `id`
 
 **Example request**:
 
-        GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/octet-stream
+    HTTP/1.1 200 OK
+    Content-Type: application/octet-stream
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -685,7 +686,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
            }
         }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -695,19 +696,24 @@ Status Codes:
 
 `POST /containers/(id or name)/resize?h=<height>&w=<width>`
 
-Resize the TTY for container with  `id`. The container must be restarted for the resize to take effect.
+Resize the TTY for container with  `id`. You must restart the container for the resize to take effect.
 
 **Example request**:
 
-        POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Length: 0
-        Content-Type: text/plain; charset=utf-8
+      HTTP/1.1 200 OK
+      Content-Length: 0
+      Content-Type: text/plain; charset=utf-8
 
-Status Codes:
+**Query parameters**:
+
+-   **h** – height of `tty` session
+-   **w** – width
+
+**Status codes**:
 
 -   **200** – no error
 -   **404** – No such container
@@ -725,13 +731,13 @@ Start the container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/start HTTP/1.1
+    POST /containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already started
@@ -746,17 +752,17 @@ Stop the container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already stopped
@@ -771,17 +777,17 @@ Restart the container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -795,18 +801,18 @@ Kill the container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/kill HTTP/1.1
+    POST /containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Query Parameters
+**Query parameters**:
 
--   **signal** - Signal to send to the container: integer or string like "SIGINT".
-        When not set, SIGKILL is assumed and the call will waits for the container to exit.
+-   **signal** - Signal to send to the container: integer or string like `SIGINT`.
+        When not set, `SIGKILL` is assumed and the call waits for the container to exit.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -820,17 +826,17 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-        POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – new name for the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -845,13 +851,13 @@ Pause the container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/pause HTTP/1.1
+    POST /containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -865,13 +871,13 @@ Unpause the container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -885,30 +891,30 @@ Attach to the container `id`
 
 **Example request**:
 
-        POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 101 UPGRADED
-        Content-Type: application/vnd.docker.raw-stream
-        Connection: Upgrade
-        Upgrade: tcp
+    HTTP/1.1 101 UPGRADED
+    Content-Type: application/vnd.docker.raw-stream
+    Connection: Upgrade
+    Upgrade: tcp
 
-        {{ STREAM }}
+    {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
--   **logs** – 1/True/true or 0/False/false, return logs. Default false
+-   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
-        Default false
--   **stdin** – 1/True/true or 0/False/false, if stream=true, attach
-        to stdin. Default false
--   **stdout** – 1/True/true or 0/False/false, if logs=true, return
-        stdout log, if stream=true, attach to stdout. Default false
--   **stderr** – 1/True/true or 0/False/false, if logs=true, return
-        stderr log, if stream=true, attach to stderr. Default false
+        Default `false`.
+-   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
+        to `stdin`. Default `false`.
+-   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
+        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
+-   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
+        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -921,30 +927,30 @@ Status Codes:
     When using the TTY setting is enabled in
     [`POST /containers/create`
     ](#create-a-container),
-    the stream is the raw data from the process PTY and client's stdin.
+    the stream is the raw data from the process PTY and client's `stdin`.
     When the TTY is disabled, then the stream is multiplexed to separate
-    stdout and stderr.
+    `stdout` and `stderr`.
 
     The format is a **Header** and a **Payload** (frame).
 
     **HEADER**
 
-    The header will contain the information on which stream write the
-    stream (stdout or stderr). It also contain the size of the
-    associated frame encoded on the last 4 bytes (uint32).
+    The header contains the information which the stream writes (`stdout` or
+    `stderr`). It also contains the size of the associated frame encoded in the
+    last four bytes (`uint32`).
 
-    It is encoded on the first 8 bytes like this:
+    It is encoded on the first eight bytes like this:
 
         header := [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}
 
     `STREAM_TYPE` can be:
 
--   0: stdin (will be written on stdout)
--   1: stdout
--   2: stderr
+-   0: `stdin` (is written on `stdout`)
+-   1: `stdout`
+-   2: `stderr`
 
-    `SIZE1, SIZE2, SIZE3, SIZE4` are the 4 bytes of
-    the uint32 size encoded as big endian.
+    `SIZE1, SIZE2, SIZE3, SIZE4` are the four bytes of
+    the `uint32` size encoded as big endian.
 
     **PAYLOAD**
 
@@ -954,11 +960,11 @@ Status Codes:
 
     The simplest way to implement the Attach protocol is the following:
 
-    1.  Read 8 bytes
-    2.  chose stdout or stderr depending on the first byte
-    3.  Extract the frame size from the last 4 bytes
-    4.  Read the extracted size and output it on the correct output
-    5.  Goto 1
+    1.  Read eight bytes.
+    2.  Choose `stdout` or `stderr` depending on the first byte.
+    3.  Extract the frame size from the last four bytes.
+    4.  Read the extracted size and output it on the correct output.
+    5.  Goto 1.
 
 ### Attach to a container (websocket)
 
@@ -970,25 +976,25 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-        GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
-        {{ STREAM }}
+    {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
--   **logs** – 1/True/true or 0/False/false, return logs. Default false
+-   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
-        Default false
--   **stdin** – 1/True/true or 0/False/false, if stream=true, attach
-        to stdin. Default false
--   **stdout** – 1/True/true or 0/False/false, if logs=true, return
-        stdout log, if stream=true, attach to stdout. Default false
--   **stderr** – 1/True/true or 0/False/false, if logs=true, return
-        stderr log, if stream=true, attach to stderr. Default false
+        Default `false`.
+-   **stdin** – 1/True/true or 0/False/false, if `stream=true`, attach
+        to `stdin`. Default `false`.
+-   **stdout** – 1/True/true or 0/False/false, if `logs=true`, return
+        `stdout` log, if `stream=true`, attach to `stdout`. Default `false`.
+-   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
+        `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1003,16 +1009,16 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-        POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {"StatusCode": 0}
+    {"StatusCode": 0}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1026,20 +1032,20 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-        DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **v** – 1/True/true or 0/False/false, Remove the volumes
-        associated to the container. Default false
+        associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
-        Default false
+        Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **400** – bad parameter
@@ -1055,21 +1061,21 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-        POST /containers/4fa6e0f0c678/copy HTTP/1.1
-        Content-Type: application/json
+    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    Content-Type: application/json
 
-        {
-             "Resource": "test.txt"
-        }
+    {
+         "Resource": "test.txt"
+    }
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1083,63 +1089,63 @@ Status Codes:
 
 **Example request**:
 
-        GET /images/json?all=0 HTTP/1.1
+    GET /images/json?all=0 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        [
-          {
-             "RepoTags": [
-               "ubuntu:12.04",
-               "ubuntu:precise",
-               "ubuntu:latest"
-             ],
-             "Id": "8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c",
-             "Created": 1365714795,
-             "Size": 131506275,
-             "VirtualSize": 131506275
-          },
-          {
-             "RepoTags": [
-               "ubuntu:12.10",
-               "ubuntu:quantal"
-             ],
-             "ParentId": "27cf784147099545",
-             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Created": 1364102658,
-             "Size": 24653,
-             "VirtualSize": 180116135
-          }
-        ]
+    [
+      {
+         "RepoTags": [
+           "ubuntu:12.04",
+           "ubuntu:precise",
+           "ubuntu:latest"
+         ],
+         "Id": "8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c",
+         "Created": 1365714795,
+         "Size": 131506275,
+         "VirtualSize": 131506275
+      },
+      {
+         "RepoTags": [
+           "ubuntu:12.10",
+           "ubuntu:quantal"
+         ],
+         "ParentId": "27cf784147099545",
+         "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+         "Created": 1364102658,
+         "Size": 24653,
+         "VirtualSize": 180116135
+      }
+    ]
 
 **Example request, with digest information**:
 
-        GET /images/json?digests=1 HTTP/1.1
+    GET /images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        [
-          {
-            "Created": 1420064636,
-            "Id": "4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125",
-            "ParentId": "ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2",
-            "RepoDigests": [
-              "localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"
-            ],
-            "RepoTags": [
-              "localhost:5000/test/busybox:latest",
-              "playdate:latest"
-            ],
-            "Size": 0,
-            "VirtualSize": 2429728
-          }
-        ]
+    [
+      {
+        "Created": 1420064636,
+        "Id": "4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125",
+        "ParentId": "ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2",
+        "RepoDigests": [
+          "localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"
+        ],
+        "RepoTags": [
+          "localhost:5000/test/busybox:latest",
+          "playdate:latest"
+        ],
+        "Size": 0,
+        "VirtualSize": 2429728
+      }
+    ]
 
 The response shows a single image `Id` associated with two repositories
 (`RepoTags`): `localhost:5000/test/busybox`: and `playdate`. A caller can use
@@ -1155,12 +1161,12 @@ digest. You can reference this digest using the value:
 See the `docker run` and `docker build` commands for examples of digest and tag
 references on the command line.
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
-  -   dangling=true
-  -   label=`key` or `label="key=value"` of an image label
+-   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+  -   `dangling=true`
+  -   `label=key` or `label="key=value"` of an image label
 -   **filter** - only return images with the specified name
 
 ### Build image from a Dockerfile
@@ -1171,37 +1177,37 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-        POST /build HTTP/1.1
+    POST /build HTTP/1.1
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {"stream": "Step 1..."}
-        {"stream": "..."}
-        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
+    {"stream": "Step 1..."}
+    {"stream": "..."}
+    {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
-The input stream must be a tar archive compressed with one of the
-following algorithms: identity (no compression), gzip, bzip2, xz.
+The input stream must be a `tar` archive compressed with one of the
+following algorithms: `identity` (no compression), `gzip`, `bzip2`, `xz`.
 
 The archive must include a build instructions file, typically called
-`Dockerfile` at the root of the archive. The `dockerfile` parameter may be
-used to specify a different build instructions file by having its value be
+`Dockerfile` at the archive's root. The `dockerfile` parameter may be
+used to specify a different build instructions file. To do this, its value must be
 the path to the alternate build instructions file to use.
 
 The archive may include any number of other files,
-which will be accessible in the build context (See the [*ADD build
+which are accessible in the build context (See the [*ADD build
 command*](../../reference/builder.md#add)).
 
-The build will also be canceled if the client drops the connection by quitting
+The build is canceled if the client drops the connection by quitting
 or being killed.
 
-Query Parameters:
+**Query parameters**:
 
--   **dockerfile** - path within the build context to the Dockerfile. This is
+-   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
 -   **t** – repository name (and optionally a tag) to be applied to
         the resulting image in case of success
@@ -1220,10 +1226,10 @@ Query Parameters:
 
     Request Headers:
 
--   **Content-type** – should be set to `"application/tar"`.
+-   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – base64-encoded ConfigFile object
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1236,35 +1242,35 @@ Create an image, either by pulling it from the registry or by importing it
 
 **Example request**:
 
-        POST /images/create?fromImage=ubuntu HTTP/1.1
+    POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {"status": "Pulling..."}
-        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
-        {"error": "Invalid..."}
-        ...
+    {"status": "Pulling..."}
+    {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+    {"error": "Invalid..."}
+    ...
 
-    When using this endpoint to pull an image from the registry, the
-    `X-Registry-Auth` header can be used to include
-    a base64-encoded AuthConfig object.
+When using this endpoint to pull an image from the registry, the
+`X-Registry-Auth` header can be used to include
+a base64-encoded AuthConfig object.
 
-Query Parameters:
+**Query parameters**:
 
--   **fromImage** – name of the image to pull
--   **fromSrc** – source to import.  The value may be a URL from which the image
+-   **fromImage** – Name of the image to pull.
+-   **fromSrc** – Source to import.  The value may be a URL from which the image
         can be retrieved or `-` to read the image from the request body.
--   **repo** – repository
--   **tag** – tag
+-   **repo** – Repository name.
+-   **tag** – Tag.
 
     Request Headers:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1279,46 +1285,46 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/ubuntu/json HTTP/1.1
+    GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {
-             "Created": "2013-03-23T22:24:18.818426-07:00",
-             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
-             "ContainerConfig":
-                     {
-                             "Hostname": "",
-                             "User": "",
-                             "AttachStdin": false,
-                             "AttachStdout": false,
-                             "AttachStderr": false,
-                             "PortSpecs": null,
-                             "Tty": true,
-                             "OpenStdin": true,
-                             "StdinOnce": false,
-                             "Env": null,
-                             "Cmd": ["/bin/bash"],
-                             "Dns": null,
-                             "Image": "ubuntu",
-                             "Labels": {
-                                 "com.example.vendor": "Acme",
-                                 "com.example.license": "GPL",
-                                 "com.example.version": "1.0"
-                             },
-                             "Volumes": null,
-                             "VolumesFrom": "",
-                             "WorkingDir": ""
-                     },
-             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent": "27cf784147099545",
-             "Size": 6824592
-        }
+    {
+         "Created": "2013-03-23T22:24:18.818426-07:00",
+         "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+         "ContainerConfig":
+                 {
+                         "Hostname": "",
+                         "User": "",
+                         "AttachStdin": false,
+                         "AttachStdout": false,
+                         "AttachStderr": false,
+                         "PortSpecs": null,
+                         "Tty": true,
+                         "OpenStdin": true,
+                         "StdinOnce": false,
+                         "Env": null,
+                         "Cmd": ["/bin/bash"],
+                         "Dns": null,
+                         "Image": "ubuntu",
+                         "Labels": {
+                             "com.example.vendor": "Acme",
+                             "com.example.license": "GPL",
+                             "com.example.version": "1.0"
+                         },
+                         "Volumes": null,
+                         "VolumesFrom": "",
+                         "WorkingDir": ""
+                 },
+         "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+         "Parent": "27cf784147099545",
+         "Size": 6824592
+    }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1332,27 +1338,27 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/ubuntu/history HTTP/1.1
+    GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        [
-             {
-                     "Id": "b750fe79269d",
-                     "Created": 1364102658,
-                     "CreatedBy": "/bin/bash"
-             },
-             {
-                     "Id": "27cf78414709",
-                     "Created": 1364068391,
-                     "CreatedBy": ""
-             }
-        ]
+    [
+         {
+                 "Id": "b750fe79269d",
+                 "Created": 1364102658,
+                 "CreatedBy": "/bin/bash"
+         },
+         {
+                 "Id": "27cf78414709",
+                 "Created": 1364068391,
+                 "CreatedBy": ""
+         }
+    ]
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1366,37 +1372,37 @@ Push the image `name` on the registry
 
 **Example request**:
 
-        POST /images/test/push HTTP/1.1
+    POST /images/test/push HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {"status": "Pushing..."}
-        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
-        {"error": "Invalid..."}
-        ...
+    {"status": "Pushing..."}
+    {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+    {"error": "Invalid..."}
+    ...
 
-    If you wish to push an image on to a private registry, that image must already have been tagged
-    into a repository which references that registry host name and port.  This repository name should
-    then be used in the URL. This mirrors the flow of the CLI.
+If you wish to push an image on to a private registry, that image must already have been tagged
+into a repository which references that registry host name and port.  This repository name should
+then be used in the URL. This mirrors the flow of the CLI.
 
 **Example request**:
 
-        POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /images/registry.acme.com:5000/test/push HTTP/1.1
 
 
-Query Parameters:
+**Query parameters**:
 
--   **tag** – the tag to associate with the image on the registry, optional
+-   **tag** – The tag to associate with the image on the registry. This is optional.
 
 Request Headers:
 
--   **X-Registry-Auth** – include a base64-encoded AuthConfig
+-   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
         object.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1410,19 +1416,19 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-        POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 201 Created
+    HTTP/1.1 201 Created
 
-Query Parameters:
+**Query parameters**:
 
 -   **repo** – The repository to tag in
 -   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -1438,25 +1444,25 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-        DELETE /images/test HTTP/1.1
+    DELETE /images/test HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-type: application/json
+    HTTP/1.1 200 OK
+    Content-type: application/json
 
-        [
-         {"Untagged": "3e2f21a89f"},
-         {"Deleted": "3e2f21a89f"},
-         {"Deleted": "53b4f83ac9"}
-        ]
+    [
+     {"Untagged": "3e2f21a89f"},
+     {"Deleted": "3e2f21a89f"},
+     {"Deleted": "53b4f83ac9"}
+    ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **force** – 1/True/true or 0/False/false, default false
 -   **noprune** – 1/True/true or 0/False/false, default false
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1475,43 +1481,43 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-        GET /images/search?term=sshd HTTP/1.1
+    GET /images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        [
-                {
-                    "description": "",
-                    "is_official": false,
-                    "is_automated": false,
-                    "name": "wma55/u1210sshd",
-                    "star_count": 0
-                },
-                {
-                    "description": "",
-                    "is_official": false,
-                    "is_automated": false,
-                    "name": "jdswinbank/sshd",
-                    "star_count": 0
-                },
-                {
-                    "description": "",
-                    "is_official": false,
-                    "is_automated": false,
-                    "name": "vgauthier/sshd",
-                    "star_count": 0
-                }
-        ...
-        ]
+    [
+            {
+                "description": "",
+                "is_official": false,
+                "is_automated": false,
+                "name": "wma55/u1210sshd",
+                "star_count": 0
+            },
+            {
+                "description": "",
+                "is_official": false,
+                "is_automated": false,
+                "name": "jdswinbank/sshd",
+                "star_count": 0
+            },
+            {
+                "description": "",
+                "is_official": false,
+                "is_automated": false,
+                "name": "vgauthier/sshd",
+                "star_count": 0
+            }
+    ...
+    ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **term** – term to search
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1526,21 +1532,21 @@ Get the default username and email
 
 **Example request**:
 
-        POST /auth HTTP/1.1
-        Content-Type: application/json
+    POST /auth HTTP/1.1
+    Content-Type: application/json
 
-        {
-             "username":" hannibal",
-             "password: "xxxx",
-             "email": "hannibal@a-team.com",
-             "serveraddress": "https://index.docker.io/v1/"
-        }
+    {
+         "username":" hannibal",
+         "password: "xxxx",
+         "email": "hannibal@a-team.com",
+         "serveraddress": "https://index.docker.io/v1/"
+    }
 
 **Example response**:
 
-        HTTP/1.1 200 OK
+    HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **204** – no error
@@ -1554,59 +1560,59 @@ Display system-wide information
 
 **Example request**:
 
-        GET /info HTTP/1.1
+    GET /info HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {
-            "Containers": 11,
-            "Debug": 0,
-            "DockerRootDir": "/var/lib/docker",
-            "Driver": "btrfs",
-            "DriverStatus": [[""]],
-            "ExecutionDriver": "native-0.1",
-            "HttpProxy": "http://test:test@localhost:8080",
-            "HttpsProxy": "https://test:test@localhost:8080",
-            "ID": "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
-            "IPv4Forwarding": 1,
-            "Images": 16,
-            "IndexServerAddress": "https://index.docker.io/v1/",
-            "InitPath": "/usr/bin/docker",
-            "InitSha1": "",
-            "KernelVersion": "3.12.0-1-amd64",
-            "Labels": [
-                "storage=ssd"
-            ],
-            "MemTotal": 2099236864,
-            "MemoryLimit": 1,
-            "NCPU": 1,
-            "NEventsListener": 0,
-            "NFd": 11,
-            "NGoroutines": 21,
-            "Name": "prod-server-42",
-            "NoProxy": "9.81.1.160",
-            "OperatingSystem": "Boot2Docker",
-            "RegistryConfig": {
-                "IndexConfigs": {
-                    "docker.io": {
-                        "Mirrors": null,
-                        "Name": "docker.io",
-                        "Official": true,
-                        "Secure": true
-                    }
-                },
-                "InsecureRegistryCIDRs": [
-                    "127.0.0.0/8"
-                ]
+    {
+        "Containers": 11,
+        "Debug": 0,
+        "DockerRootDir": "/var/lib/docker",
+        "Driver": "btrfs",
+        "DriverStatus": [[""]],
+        "ExecutionDriver": "native-0.1",
+        "HttpProxy": "http://test:test@localhost:8080",
+        "HttpsProxy": "https://test:test@localhost:8080",
+        "ID": "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
+        "IPv4Forwarding": 1,
+        "Images": 16,
+        "IndexServerAddress": "https://index.docker.io/v1/",
+        "InitPath": "/usr/bin/docker",
+        "InitSha1": "",
+        "KernelVersion": "3.12.0-1-amd64",
+        "Labels": [
+            "storage=ssd"
+        ],
+        "MemTotal": 2099236864,
+        "MemoryLimit": 1,
+        "NCPU": 1,
+        "NEventsListener": 0,
+        "NFd": 11,
+        "NGoroutines": 21,
+        "Name": "prod-server-42",
+        "NoProxy": "9.81.1.160",
+        "OperatingSystem": "Boot2Docker",
+        "RegistryConfig": {
+            "IndexConfigs": {
+                "docker.io": {
+                    "Mirrors": null,
+                    "Name": "docker.io",
+                    "Official": true,
+                    "Secure": true
+                }
             },
-            "SwapLimit": 0,
-            "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
-        }
+            "InsecureRegistryCIDRs": [
+                "127.0.0.0/8"
+            ]
+        },
+        "SwapLimit": 0,
+        "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
+    }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1619,24 +1625,24 @@ Show the docker version information
 
 **Example request**:
 
-        GET /version HTTP/1.1
+    GET /version HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {
-             "Version": "1.5.0",
-             "Os": "linux",
-             "KernelVersion": "3.18.5-tinycore64",
-             "GoVersion": "go1.4.1",
-             "GitCommit": "a8a31ef",
-             "Arch": "amd64",
-             "ApiVersion": "1.18"
-        }
+    {
+         "Version": "1.5.0",
+         "Os": "linux",
+         "KernelVersion": "3.18.5-tinycore64",
+         "GoVersion": "go1.4.1",
+         "GitCommit": "a8a31ef",
+         "Arch": "amd64",
+         "ApiVersion": "1.18"
+    }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1649,16 +1655,16 @@ Ping the docker server
 
 **Example request**:
 
-        GET /_ping HTTP/1.1
+    GET /_ping HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: text/plain
+    HTTP/1.1 200 OK
+    Content-Type: text/plain
 
-        OK
+    OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -1671,46 +1677,46 @@ Create a new image from a container's changes
 
 **Example request**:
 
-        POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
-        Content-Type: application/json
+    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    Content-Type: application/json
 
-        {
-             "Hostname": "",
-             "Domainname": "",
-             "User": "",
-             "AttachStdin": false,
-             "AttachStdout": true,
-             "AttachStderr": true,
-             "PortSpecs": null,
-             "Tty": false,
-             "OpenStdin": false,
-             "StdinOnce": false,
-             "Env": null,
-             "Cmd": [
-                     "date"
-             ],
-             "Volumes": {
-                     "/tmp": {}
-             },
-             "WorkingDir": "",
-             "NetworkDisabled": false,
-             "ExposedPorts": {
-                     "22/tcp": {}
-             }
-        }
+    {
+         "Hostname": "",
+         "Domainname": "",
+         "User": "",
+         "AttachStdin": false,
+         "AttachStdout": true,
+         "AttachStderr": true,
+         "PortSpecs": null,
+         "Tty": false,
+         "OpenStdin": false,
+         "StdinOnce": false,
+         "Env": null,
+         "Cmd": [
+                 "date"
+         ],
+         "Volumes": {
+                 "/tmp": {}
+         },
+         "WorkingDir": "",
+         "NetworkDisabled": false,
+         "ExposedPorts": {
+                 "22/tcp": {}
+         }
+    }
 
 **Example response**:
 
-        HTTP/1.1 201 Created
-        Content-Type: application/json
+    HTTP/1.1 201 Created
+    Content-Type: application/json
 
-        {"Id": "596069db4bf5"}
+    {"Id": "596069db4bf5"}
 
-Json Parameters:
+**JSON parameters**:
 
 -  **config** - the container's configuration
 
-Query Parameters:
+**Query parameters**:
 
 -   **container** – source container
 -   **repo** – repository
@@ -1719,7 +1725,7 @@ Query Parameters:
 -   **author** – author (e.g., "John Hannibal Smith
     <[hannibal@a-team.com](mailto:hannibal%40a-team.com)>")
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -1732,38 +1738,38 @@ Status Codes:
 Get container events from docker, either in real time via streaming, or via
 polling (using since).
 
-Docker containers will report the following events:
+Docker containers report the following events:
 
     create, destroy, die, exec_create, exec_start, export, kill, oom, pause, restart, start, stop, unpause
 
-and Docker images will report:
+and Docker images report:
 
     untag, delete
 
 **Example request**:
 
-        GET /events?since=1374067924
+    GET /events?since=1374067924
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+    HTTP/1.1 200 OK
+    Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
+    {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+    {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+    {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+    {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
-Query Parameters:
+**Query parameters**:
 
--   **since** – timestamp used for polling
--   **until** – timestamp used for polling
--   **filters** – a json encoded value of the filters (a map[string][]string) to process on the event list. Available filters:
-  -   event=&lt;string&gt; -- event to filter
-  -   image=&lt;string&gt; -- image to filter
-  -   container=&lt;string&gt; -- container to filter
+-   **since** – Timestamp used for polling
+-   **until** – Timestamp used for polling
+-   **filters** – A json encoded value of the filters (a map[string][]string) to process on the event list. Available filters:
+  -   `container=<string>`; -- container to filter
+  -   `event=<string>`; -- event to filter
+  -   `image=<string>`; -- image to filter
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1784,16 +1790,16 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-        GET /images/ubuntu/get
+    GET /images/ubuntu/get
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
 
-        Binary data stream
+    Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1805,7 +1811,7 @@ Status Codes:
 Get a tarball containing all images and metadata for one or more repositories.
 
 For each value of the `names` parameter: if it is a specific name and tag (e.g.
-ubuntu:latest), then only that image (and its parents) are returned; if it is
+`ubuntu:latest`), then only that image (and its parents) are returned; if it is
 an image ID, similarly only that image (and its parents) are returned and there
 would be no names referenced in the 'repositories' file for this image ID.
 
@@ -1813,16 +1819,16 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-        GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
 
-        Binary data stream
+    Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1831,20 +1837,20 @@ Status Codes:
 
 `POST /images/load`
 
-Load a set of images and tags into the docker repository.
+Load a set of images and tags into a Docker repository.
 See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-        POST /images/load
+    POST /images/load
 
-        Tarball in body
+    Tarball in body
 
 **Example response**:
 
-        HTTP/1.1 200 OK
+    HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1852,16 +1858,16 @@ Status Codes:
 ### Image tarball format
 
 An image tarball contains one directory per image layer (named using its long ID),
-each containing three files:
+each containing these files:
 
-1. `VERSION`: currently `1.0` - the file format version
-2. `json`: detailed layer information, similar to `docker inspect layer_id`
-3. `layer.tar`: A tarfile containing the filesystem changes in this layer
+- `VERSION`: currently `1.0` - the file format version
+- `json`: detailed layer information, similar to `docker inspect layer_id`
+- `layer.tar`: A tarfile containing the filesystem changes in this layer
 
-The `layer.tar` file will contain `aufs` style `.wh..wh.aufs` files and directories
+The `layer.tar` file contains `aufs` style `.wh..wh.aufs` files and directories
 for storing attribute changes and deletions.
 
-If the tarball defines a repository, there will also be a `repositories` file at
+If the tarball defines a repository, the tarball should also include a `repositories` file at
 the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
@@ -1878,39 +1884,39 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-        POST /containers/e90e34656806/exec HTTP/1.1
-        Content-Type: application/json
+    POST /containers/e90e34656806/exec HTTP/1.1
+    Content-Type: application/json
 
-        {
-	     "AttachStdin": false,
-	     "AttachStdout": true,
-	     "AttachStderr": true,
-	     "Tty": false,
-	     "Cmd": [
+      {
+       "AttachStdin": false,
+       "AttachStdout": true,
+       "AttachStderr": true,
+       "Tty": false,
+       "Cmd": [
                      "date"
-             ],
-        }
+             ]
+      }
 
 **Example response**:
 
-        HTTP/1.1 201 Created
-        Content-Type: application/json
+    HTTP/1.1 201 Created
+    Content-Type: application/json
 
-        {
-             "Id": "f90e34656806",
-             "Warnings":[]
-        }
+    {
+         "Id": "f90e34656806",
+         "Warnings":[]
+    }
 
-Json Parameters:
+**JSON parameters**:
 
--   **AttachStdin** - Boolean value, attaches to stdin of the exec command.
--   **AttachStdout** - Boolean value, attaches to stdout of the exec command.
--   **AttachStderr** - Boolean value, attaches to stderr of the exec command.
--   **Tty** - Boolean value to allocate a pseudo-TTY
+-   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
+-   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
+-   **AttachStderr** - Boolean value, attaches to `stderr` of the `exec` command.
+-   **Tty** - Boolean value to allocate a pseudo-TTY.
 -   **Cmd** - Command to run specified as a string or an array of strings.
 
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -1919,33 +1925,33 @@ Status Codes:
 
 `POST /exec/(id)/start`
 
-Starts a previously set up exec instance `id`. If `detach` is true, this API
+Starts a previously set up `exec` instance `id`. If `detach` is true, this API
 returns after starting the `exec` command. Otherwise, this API sets up an
 interactive session with the `exec` command.
 
 **Example request**:
 
-        POST /exec/e90e34656806/start HTTP/1.1
-        Content-Type: application/json
+    POST /exec/e90e34656806/start HTTP/1.1
+    Content-Type: application/json
 
-        {
-	     "Detach": false,
-	     "Tty": false,
-        }
+    {
+     "Detach": false,
+     "Tty": false
+    }
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/vnd.docker.raw-stream
+    HTTP/1.1 200 OK
+    Content-Type: application/vnd.docker.raw-stream
 
-        {{ STREAM }}
+    {{ STREAM }}
 
-Json Parameters:
+**JSON parameters**:
 
--   **Detach** - Detach from the exec command
--   **Tty** - Boolean value to allocate a pseudo-TTY
+-   **Detach** - Detach from the `exec` command.
+-   **Tty** - Boolean value to allocate a pseudo-TTY.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -1957,25 +1963,25 @@ Status Codes:
 
 `POST /exec/(id)/resize`
 
-Resizes the tty session used by the exec command `id`.
-This API is valid only if `tty` was specified as part of creating and starting the exec command.
+Resizes the `tty` session used by the `exec` command `id`.  The unit is number of characters.
+This API is valid only if `tty` was specified as part of creating and starting the `exec` command.
 
 **Example request**:
 
-        POST /exec/e90e34656806/resize HTTP/1.1
-        Content-Type: text/plain
+    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    Content-Type: text/plain
 
 **Example response**:
 
-        HTTP/1.1 201 Created
-        Content-Type: text/plain
+    HTTP/1.1 201 Created
+    Content-Type: text/plain
 
-Query Parameters:
+**Query parameters**:
 
--   **h** – height of tty session
+-   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such exec instance
@@ -1984,102 +1990,102 @@ Status Codes:
 
 `GET /exec/(id)/json`
 
-Return low-level information about the exec command `id`.
+Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-        GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: plain/text
+    HTTP/1.1 200 OK
+    Content-Type: plain/text
 
-        {
-          "ID" : "11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39",
-          "Running" : false,
-          "ExitCode" : 2,
-          "ProcessConfig" : {
-            "privileged" : false,
-            "user" : "",
-            "tty" : false,
-            "entrypoint" : "sh",
-            "arguments" : [
-              "-c",
-              "exit 2"
-            ]
-          },
+    {
+      "ID" : "11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39",
+      "Running" : false,
+      "ExitCode" : 2,
+      "ProcessConfig" : {
+        "privileged" : false,
+        "user" : "",
+        "tty" : false,
+        "entrypoint" : "sh",
+        "arguments" : [
+          "-c",
+          "exit 2"
+        ]
+      },
+      "OpenStdin" : false,
+      "OpenStderr" : false,
+      "OpenStdout" : false,
+      "Container" : {
+        "State" : {
+          "Running" : true,
+          "Paused" : false,
+          "Restarting" : false,
+          "OOMKilled" : false,
+          "Pid" : 3650,
+          "ExitCode" : 0,
+          "Error" : "",
+          "StartedAt" : "2014-11-17T22:26:03.717657531Z",
+          "FinishedAt" : "0001-01-01T00:00:00Z"
+        },
+        "ID" : "8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c",
+        "Created" : "2014-11-17T22:26:03.626304998Z",
+        "Path" : "date",
+        "Args" : [],
+        "Config" : {
+          "Hostname" : "8f177a186b97",
+          "Domainname" : "",
+          "User" : "",
+          "AttachStdin" : false,
+          "AttachStdout" : false,
+          "AttachStderr" : false,
+          "PortSpecs": null,
+          "ExposedPorts" : null,
+          "Tty" : false,
           "OpenStdin" : false,
-          "OpenStderr" : false,
-          "OpenStdout" : false,
-          "Container" : {
-            "State" : {
-              "Running" : true,
-              "Paused" : false,
-              "Restarting" : false,
-              "OOMKilled" : false,
-              "Pid" : 3650,
-              "ExitCode" : 0,
-              "Error" : "",
-              "StartedAt" : "2014-11-17T22:26:03.717657531Z",
-              "FinishedAt" : "0001-01-01T00:00:00Z"
-            },
-            "ID" : "8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c",
-            "Created" : "2014-11-17T22:26:03.626304998Z",
-            "Path" : "date",
-            "Args" : [],
-            "Config" : {
-              "Hostname" : "8f177a186b97",
-              "Domainname" : "",
-              "User" : "",
-              "AttachStdin" : false,
-              "AttachStdout" : false,
-              "AttachStderr" : false,
-              "PortSpecs" : null,
-              "ExposedPorts" : null,
-              "Tty" : false,
-              "OpenStdin" : false,
-              "StdinOnce" : false,
-              "Env" : [ "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ],
-              "Cmd" : [
-                "date"
-              ],
-              "Image" : "ubuntu",
-              "Volumes" : null,
-              "WorkingDir" : "",
-              "Entrypoint" : null,
-              "NetworkDisabled" : false,
-              "MacAddress" : "",
-              "OnBuild" : null,
-              "SecurityOpt" : null
-            },
-            "Image" : "5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5",
-            "NetworkSettings" : {
-              "IPAddress" : "172.17.0.2",
-              "IPPrefixLen" : 16,
-              "MacAddress" : "02:42:ac:11:00:02",
-              "Gateway" : "172.17.42.1",
-              "Bridge" : "docker0",
-              "PortMapping" : null,
-              "Ports" : {}
-            },
-            "ResolvConfPath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/resolv.conf",
-            "HostnamePath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/hostname",
-            "HostsPath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/hosts",
-            "LogPath": "/var/lib/docker/containers/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b-json.log",
-            "Name" : "/test",
-            "Driver" : "aufs",
-            "ExecDriver" : "native-0.2",
-            "MountLabel" : "",
-            "ProcessLabel" : "",
-            "AppArmorProfile" : "",
-            "RestartCount" : 0,
-            "Volumes" : {},
-            "VolumesRW" : {}
-          }
-        }
+          "StdinOnce" : false,
+          "Env" : [ "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ],
+          "Cmd" : [
+            "date"
+          ],
+          "Image" : "ubuntu",
+          "Volumes" : null,
+          "WorkingDir" : "",
+          "Entrypoint" : null,
+          "NetworkDisabled" : false,
+          "MacAddress" : "",
+          "OnBuild" : null,
+          "SecurityOpt" : null
+        },
+        "Image" : "5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5",
+        "NetworkSettings" : {
+          "IPAddress" : "172.17.0.2",
+          "IPPrefixLen" : 16,
+          "MacAddress" : "02:42:ac:11:00:02",
+          "Gateway" : "172.17.42.1",
+          "Bridge" : "docker0",
+          "PortMapping" : null,
+          "Ports" : {}
+        },
+        "ResolvConfPath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/resolv.conf",
+        "HostnamePath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/hostname",
+        "HostsPath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/hosts",
+        "LogPath": "/var/lib/docker/containers/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b/1eb5fabf5a03807136561b3c00adcd2992b535d624d5e18b6cdc6a6844d9767b-json.log",
+        "Name" : "/test",
+        "Driver" : "aufs",
+        "ExecDriver" : "native-0.2",
+        "MountLabel" : "",
+        "ProcessLabel" : "",
+        "AppArmorProfile" : "",
+        "RestartCount" : 0,
+        "Volumes" : {},
+        "VolumesRW" : {}
+      }
+    }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2094,22 +2100,21 @@ As an example, the `docker run` command line makes the following API calls:
 - Create the container
 
 - If the status code is 404, it means the image doesn't exist:
-    - Try to pull it
-    - Then retry to create the container
+    - Try to pull it.
+    - Then, retry to create the container.
 
-- Start the container
+- Start the container.
 
 - If you are not in detached mode:
-- Attach to the container, using logs=1 (to have stdout and
-      stderr from the container's start) and stream=1
+- Attach to the container, using `logs=1` (to have `stdout` and
+      `stderr` from the container's start) and `stream=1`
 
-- If in detached mode or only stdin is attached:
-- Display the container's id
+- If in detached mode or only `stdin` is attached, display the container's id.
 
 ## 3.2 Hijacking
 
-In this version of the API, /attach, uses hijacking to transport stdin,
-stdout and stderr on the same socket.
+In this version of the API, `/attach`, uses hijacking to transport `stdin`,
+`stdout`, and `stderr` on the same socket.
 
 To hint potential proxies about connection hijacking, Docker client sends
 connection upgrade headers similarly to websocket.
@@ -2117,15 +2122,15 @@ connection upgrade headers similarly to websocket.
     Upgrade: tcp
     Connection: Upgrade
 
-When Docker daemon detects the `Upgrade` header, it will switch its status code
-from **200 OK** to **101 UPGRADED** and resend the same headers.
+When Docker daemon detects the `Upgrade` header, it switches its status code
+from **200 OK** to **101 UPGRADED** and resends the same headers.
 
 This might change in the future.
 
 ## 3.3 CORS Requests
 
 To set cross origin requests to the remote api please give values to
-"--api-cors-header" when running docker in daemon mode. Set * will allow all,
+`--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,
 default or blank means CORS disabled
 
     $ docker -d -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -96,7 +96,7 @@ List containers
          }
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, Show all containers.
         Only running containers are shown by default (i.e., this defaults to false)
@@ -113,7 +113,7 @@ Query Parameters:
   -   `status=`(`restarting`|`running`|`paused`|`exited`)
   -   `label=key` or `label="key=value"` of a container label
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -155,7 +155,7 @@ Create a container
                    "com.example.version": "1.0"
            },
            "Volumes": {
-                   "/tmp": {}
+             "/volumes/data": {}
            },
            "WorkingDir": "",
            "NetworkDisabled": false,
@@ -207,7 +207,7 @@ Create a container
            "Warnings":[]
       }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Hostname** - A string value containing the hostname to use for the
       container.
@@ -226,7 +226,7 @@ Json Parameters:
 -   **Entrypoint** - Set the entry point for the container as a string or an array
       of strings.
 -   **Image** - A string specifying the image name to use for the container.
--   **Volumes** – An object mapping mount point paths (strings) inside the
+-   **Volumes** - An object mapping mount point paths (strings) inside the
       container to empty objects.
 -   **WorkingDir** - A string specifying the working directory for commands to
       run in.
@@ -296,15 +296,15 @@ Json Parameters:
     -   **LogConfig** - Log configuration for the container, specified as a JSON object in the form
           `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
           Available types: `json-file`, `syslog`, `journald`, `none`.
-	      `syslog` available options are: `address`.
-    -   **CgroupParent** - Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+          `syslog` available options are: `address`.
+    -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – Assign the specified name to the container. Must
     match `/?[a-zA-Z0-9_-]+`.
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -318,7 +318,6 @@ Status Codes:
 `GET /containers/(id or name)/json`
 
 Return low-level information on the container `id`
-
 
 **Example request**:
 
@@ -445,7 +444,7 @@ Return low-level information on the container `id`
 		"VolumesRW": {}
 	}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -505,11 +504,11 @@ supported on Windows.
       ],
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **ps_args** – `ps` arguments to use (e.g., `aux`), defaults to `-ef`
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -537,7 +536,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
      {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
 -   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
@@ -548,7 +547,7 @@ Query Parameters:
         every log line. Default `false`.
 -   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -591,7 +590,7 @@ Values for `Kind`:
 - `1`: Add
 - `2`: Delete
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -614,7 +613,7 @@ Export the contents of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -719,11 +718,11 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 The precpu_stats is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the “cpu_stats” field.
 
-Query Parameters:
+**Query parameters**:
 
 -   **stream** – 1/True/true or 0/False/false, pull stats once then disconnect. Default `true`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -745,7 +744,12 @@ Resize the TTY for container with  `id`. You must restart the container for the 
       Content-Length: 0
       Content-Type: text/plain; charset=utf-8
 
-Status Codes:
+**Query parameters**:
+
+-   **h** – height of `tty` session
+-   **w** – width
+
+**Status codes**:
 
 -   **200** – no error
 -   **404** – No such container
@@ -763,13 +767,13 @@ Start the container `id`
 
 **Example request**:
 
-     POST /containers/e90e34656806/start HTTP/1.1
+    POST /containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
-     HTTP/1.1 204 No Content
+    HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already started
@@ -790,11 +794,11 @@ Stop the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already stopped
@@ -815,11 +819,11 @@ Restart the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -839,12 +843,12 @@ Kill the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters
+**Query parameters**:
 
 -   **signal** - Signal to send to the container: integer or string like `SIGINT`.
         When not set, `SIGKILL` is assumed and the call waits for the container to exit.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -864,11 +868,11 @@ Rename the container `id` to a `new_name`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – new name for the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -889,7 +893,7 @@ Pause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -909,7 +913,7 @@ Unpause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -934,7 +938,7 @@ Attach to the container `id`
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
@@ -946,7 +950,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -1014,7 +1018,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
@@ -1026,7 +1030,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1050,7 +1054,7 @@ Block until container `id` stops, then returns the exit code
 
     {"StatusCode": 0}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1070,14 +1074,14 @@ Remove the container `id` from the filesystem
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **v** – 1/True/true or 0/False/false, Remove the volumes
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **400** – bad parameter
@@ -1107,7 +1111,7 @@ Copy files or folders of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1198,7 +1202,7 @@ digest. You can reference this digest using the value:
 See the `docker run` and `docker build` commands for examples of digest and tag
 references on the command line.
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, default false
 -   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
@@ -1242,10 +1246,10 @@ command*](../../reference/builder.md#add)).
 The build is canceled if the client drops the connection by quitting
 or being killed.
 
-Query Parameters:
+**Query parameters**:
 
--   **dockerfile** - Path within the build context to the `Dockerfile`. This is
-        ignored if `remote` is specified and points to an external `Dockerfile`.
+-   **dockerfile** - Path within the build context to the Dockerfile. This is
+        ignored if `remote` is specified and points to an individual filename.
 -   **t** – Repository name (and optionally a tag) to be applied to
         the resulting image in case of success.
 -   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
@@ -1272,7 +1276,7 @@ Query Parameters:
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – base64-encoded ConfigFile object
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1301,7 +1305,7 @@ When using this endpoint to pull an image from the registry, the
 `X-Registry-Auth` header can be used to include
 a base64-encoded AuthConfig object.
 
-Query Parameters:
+**Query parameters**:
 
 -   **fromImage** – Name of the image to pull.
 -   **fromSrc** – Source to import.  The value may be a URL from which the image
@@ -1313,7 +1317,7 @@ Query Parameters:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1367,7 +1371,7 @@ Return low-level information on the image `name`
          "Size": 6824592
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1421,7 +1425,7 @@ Return the history of the image `name`
         }
     ]
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1456,7 +1460,7 @@ then be used in the URL. This duplicates the command line's flow.
     POST /images/registry.acme.com:5000/test/push HTTP/1.1
 
 
-Query Parameters:
+**Query parameters**:
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
@@ -1465,7 +1469,7 @@ Request Headers:
 -   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
         object.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1485,13 +1489,13 @@ Tag the image `name` into a repository
 
     HTTP/1.1 201 Created
 
-Query Parameters:
+**Query parameters**:
 
 -   **repo** – The repository to tag in
 -   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -1520,12 +1524,12 @@ Remove the image `name` from the filesystem
      {"Deleted": "53b4f83ac9"}
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **force** – 1/True/true or 0/False/false, default false
 -   **noprune** – 1/True/true or 0/False/false, default false
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1554,39 +1558,39 @@ be deprecated and replaced by the `is_automated` property.
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-        [
-                {
-                    "star_count": 12,
-                    "is_official": false,
-                    "name": "wma55/u1210sshd",
-                    "is_trusted": false,
-                    "is_automated": false,
-                    "description": "",
-                },
-                {
-                    "star_count": 10,
-                    "is_official": false,
-                    "name": "jdswinbank/sshd",
-                    "is_trusted": false,
-                    "is_automated": false,
-                    "description": "",
-                },
-                {
-                    "star_count": 18,
-                    "is_official": false,
-                    "name": "vgauthier/sshd",
-                    "is_trusted": false,
-                    "is_automated": false,
-                    "description": "",
-                }
-        ...
-        ]
+    [
+            {
+                "star_count": 12,
+                "is_official": false,
+                "name": "wma55/u1210sshd",
+                "is_trusted": false,
+                "is_automated": false,
+                "description": "",
+            },
+            {
+                "star_count": 10,
+                "is_official": false,
+                "name": "jdswinbank/sshd",
+                "is_trusted": false,
+                "is_automated": false,
+                "description": "",
+            },
+            {
+                "star_count": 18,
+                "is_official": false,
+                "name": "vgauthier/sshd",
+                "is_trusted": false,
+                "is_automated": false,
+                "description": "",
+            }
+    ...
+    ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **term** – term to search
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1615,7 +1619,7 @@ Get the default username and email
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **204** – no error
@@ -1685,7 +1689,7 @@ Display system-wide information
         "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1715,7 +1719,7 @@ Show the docker version information
          "ApiVersion": "1.19"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1737,7 +1741,7 @@ Ping the docker server
 
     OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -1789,11 +1793,11 @@ Create a new image from a container's changes
 
     {"Id": "596069db4bf5"}
 
-Json Parameters:
+**JSON parameters**:
 
 -  **config** - the container's configuration
 
-Query Parameters:
+**Query parameters**:
 
 -   **container** – source container
 -   **repo** – repository
@@ -1802,7 +1806,7 @@ Query Parameters:
 -   **author** – author (e.g., "John Hannibal Smith
     <[hannibal@a-team.com](mailto:hannibal%40a-team.com)>")
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -1837,16 +1841,16 @@ and Docker images report:
     {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
     {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
-Query Parameters:
+**Query parameters**:
 
 -   **since** – Timestamp used for polling
 -   **until** – Timestamp used for polling
 -   **filters** – A json encoded value of the filters (a map[string][]string) to process on the event list. Available filters:
+  -   `container=<string>`; -- container to filter
   -   `event=<string>`; -- event to filter
   -   `image=<string>`; -- image to filter
-  -   `container=<string>`; -- container to filter
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1876,7 +1880,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1905,7 +1909,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1927,7 +1931,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1971,7 +1975,7 @@ Sets up an exec instance in a running container `id`
        "Tty": false,
        "Cmd": [
                      "date"
-             ],
+             ]
       }
 
 **Example response**:
@@ -1984,7 +1988,7 @@ Sets up an exec instance in a running container `id`
          "Warnings":[]
     }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
 -   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
@@ -1993,7 +1997,7 @@ Json Parameters:
 -   **Cmd** - Command to run specified as a string or an array of strings.
 
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2013,7 +2017,7 @@ interactive session with the `exec` command.
 
     {
      "Detach": false,
-     "Tty": false,
+     "Tty": false
     }
 
 **Example response**:
@@ -2023,12 +2027,12 @@ interactive session with the `exec` command.
 
     {{ STREAM }}
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Detach** - Detach from the `exec` command.
 -   **Tty** - Boolean value to allocate a pseudo-TTY.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2040,12 +2044,12 @@ Status Codes:
 
 `POST /exec/(id)/resize`
 
-Resizes the `tty` session used by the `exec` command `id`.
+Resizes the `tty` session used by the `exec` command `id`.  The unit is number of characters.
 This API is valid only if `tty` was specified as part of creating and starting the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize HTTP/1.1
+    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2053,12 +2057,12 @@ This API is valid only if `tty` was specified as part of creating and starting t
     HTTP/1.1 201 Created
     Content-Type: text/plain
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such exec instance
@@ -2162,7 +2166,7 @@ Return low-level information about the `exec` command `id`.
       }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -96,7 +96,7 @@ List containers
          }
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, Show all containers.
         Only running containers are shown by default (i.e., this defaults to false)
@@ -113,7 +113,7 @@ Query Parameters:
   -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`)
   -   `label=key` or `label="key=value"` of a container label
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -209,7 +209,7 @@ Create a container
            "Warnings":[]
       }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Hostname** - A string value containing the hostname to use for the
       container.
@@ -303,12 +303,12 @@ Json Parameters:
           `json-file` logging driver.
     -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – Assign the specified name to the container. Must
     match `/?[a-zA-Z0-9_-]+`.
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -322,7 +322,6 @@ Status Codes:
 `GET /containers/(id or name)/json`
 
 Return low-level information on the container `id`
-
 
 **Example request**:
 
@@ -454,7 +453,7 @@ Return low-level information on the container `id`
 		]
 	}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -514,11 +513,11 @@ supported on Windows.
       ],
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **ps_args** – `ps` arguments to use (e.g., `aux`), defaults to `-ef`
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -546,7 +545,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
      {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
 -   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
@@ -557,7 +556,7 @@ Query Parameters:
         every log line. Default `false`.
 -   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -600,7 +599,7 @@ Values for `Kind`:
 - `1`: Add
 - `2`: Delete
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -623,7 +622,7 @@ Export the contents of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -728,11 +727,11 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 The precpu_stats is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the “cpu_stats” field.
 
-Query Parameters:
+**Query parameters**:
 
 -   **stream** – 1/True/true or 0/False/false, pull stats once then disconnect. Default `true`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -754,7 +753,12 @@ Resize the TTY for container with  `id`. You must restart the container for the 
       Content-Length: 0
       Content-Type: text/plain; charset=utf-8
 
-Status Codes:
+**Query parameters**:
+
+-   **h** – height of `tty` session
+-   **w** – width
+
+**Status codes**:
 
 -   **200** – no error
 -   **404** – No such container
@@ -778,7 +782,7 @@ Start the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already started
@@ -799,11 +803,11 @@ Stop the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already stopped
@@ -824,11 +828,11 @@ Restart the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -848,12 +852,12 @@ Kill the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters
+**Query parameters**:
 
 -   **signal** - Signal to send to the container: integer or string like `SIGINT`.
         When not set, `SIGKILL` is assumed and the call waits for the container to exit.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -873,11 +877,11 @@ Rename the container `id` to a `new_name`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – new name for the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -898,7 +902,7 @@ Pause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -918,7 +922,7 @@ Unpause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -943,7 +947,7 @@ Attach to the container `id`
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
@@ -955,7 +959,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -1023,7 +1027,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
@@ -1035,7 +1039,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1059,7 +1063,7 @@ Block until container `id` stops, then returns the exit code
 
     {"StatusCode": 0}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1079,14 +1083,14 @@ Remove the container `id` from the filesystem
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **v** – 1/True/true or 0/False/false, Remove the volumes
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **400** – bad parameter
@@ -1118,7 +1122,7 @@ Copy files or folders of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1137,7 +1141,7 @@ following section.
 
 Get a tar archive of a resource in the filesystem of container `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - resource in the container's filesystem to archive. Required.
 
@@ -1148,39 +1152,41 @@ Query Parameters:
     indicates that only the contents of the **path** directory should be
     copied. A symlink is always resolved to its target.
 
-    **Note**: It is not possible to copy certain system files such as resources
-    under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
-    container.
+    > **Note**: It is not possible to copy certain system files such as resources
+    > under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
+    > container.
 
 **Example request**:
 
-        GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
-        X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
+    X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
 the archived resource. The above example value would decode to the following
 JSON object (whitespace added for readability):
 
-        {
-            "name": "root",
-            "size": 4096,
-            "mode": 2147484096,
-            "mtime": "2014-02-27T20:51:23Z",
-            "linkTarget": ""
-        }
+```json
+{
+    "name": "root",
+    "size": 4096,
+    "mode": 2147484096,
+    "mtime": "2014-02-27T20:51:23Z",
+    "linkTarget": ""
+}
+```
 
 A `HEAD` request can also be made to this endpoint if only this information is
 desired.
 
-Status Codes:
+**Status codes**:
 
 - **200** - success, returns archive of copied resource
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1199,7 +1205,7 @@ Status Codes:
 Upload a tar archive to be extracted to a path in the filesystem of container
 `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - path to a directory in the container
     to extract the archive's contents into. Required.
@@ -1212,16 +1218,16 @@ Query Parameters:
 
 **Example request**:
 
-        PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
-        Content-Type: application/x-tar
+    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    Content-Type: application/x-tar
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
 **Example response**:
 
-        HTTP/1.1 200 OK
+    HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** – the content was extracted successfully
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1323,7 +1329,7 @@ digest. You can reference this digest using the value:
 See the `docker run` and `docker build` commands for examples of digest and tag
 references on the command line.
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, default false
 -   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
@@ -1367,7 +1373,7 @@ command*](../../reference/builder.md#add)).
 The build is canceled if the client drops the connection by quitting
 or being killed.
 
-Query Parameters:
+**Query parameters**:
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
@@ -1375,7 +1381,7 @@ Query Parameters:
         the resulting image in case of success.
 -   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
         URI specifies a filename, the file's contents are placed into a file
-		called `Dockerfile`.
+        called `Dockerfile`.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1414,7 +1420,7 @@ Query Parameters:
     be specified with both a "https://" prefix and a "/v1/" suffix even
     though Docker will prefer to use the v2 registry API.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1443,7 +1449,7 @@ When using this endpoint to pull an image from the registry, the
 `X-Registry-Auth` header can be used to include
 a base64-encoded AuthConfig object.
 
-Query Parameters:
+**Query parameters**:
 
 -   **fromImage** – Name of the image to pull.
 -   **fromSrc** – Source to import.  The value may be a URL from which the image
@@ -1455,7 +1461,7 @@ Query Parameters:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1508,7 +1514,7 @@ Return low-level information on the image `name`
          "Size": 6824592
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1562,7 +1568,7 @@ Return the history of the image `name`
         }
     ]
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1597,7 +1603,7 @@ then be used in the URL. This duplicates the command line's flow.
     POST /images/registry.acme.com:5000/test/push HTTP/1.1
 
 
-Query Parameters:
+**Query parameters**:
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
@@ -1606,7 +1612,7 @@ Request Headers:
 -   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
         object.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1626,13 +1632,13 @@ Tag the image `name` into a repository
 
     HTTP/1.1 201 Created
 
-Query Parameters:
+**Query parameters**:
 
 -   **repo** – The repository to tag in
 -   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -1661,12 +1667,12 @@ Remove the image `name` from the filesystem
      {"Deleted": "53b4f83ac9"}
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **force** – 1/True/true or 0/False/false, default false
 -   **noprune** – 1/True/true or 0/False/false, default false
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1717,11 +1723,11 @@ Search for an image on [Docker Hub](https://hub.docker.com).
     ...
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **term** – term to search
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1750,7 +1756,7 @@ Get the default username and email
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **204** – no error
@@ -1820,7 +1826,7 @@ Display system-wide information
         "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1851,7 +1857,7 @@ Show the docker version information
          "Experimental": false
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1873,7 +1879,7 @@ Ping the docker server
 
     OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -1929,11 +1935,11 @@ Create a new image from a container's changes
 
     {"Id": "596069db4bf5"}
 
-Json Parameters:
+**JSON parameters**:
 
 -  **config** - the container's configuration
 
-Query Parameters:
+**Query parameters**:
 
 -   **container** – source container
 -   **repo** – repository
@@ -1944,7 +1950,7 @@ Query Parameters:
 -   **pause** – 1/True/true or 0/False/false, whether to pause the container before committing
 -   **changes** – Dockerfile instructions to apply while committing
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -1979,16 +1985,16 @@ and Docker images report:
     {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
     {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
-Query Parameters:
+**Query parameters**:
 
 -   **since** – Timestamp used for polling
 -   **until** – Timestamp used for polling
 -   **filters** – A json encoded value of the filters (a map[string][]string) to process on the event list. Available filters:
+  -   `container=<string>`; -- container to filter
   -   `event=<string>`; -- event to filter
   -   `image=<string>`; -- image to filter
-  -   `container=<string>`; -- container to filter
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2018,7 +2024,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2047,7 +2053,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2069,7 +2075,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2126,7 +2132,7 @@ Sets up an exec instance in a running container `id`
          "Warnings":[]
     }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
 -   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
@@ -2135,7 +2141,7 @@ Json Parameters:
 -   **Cmd** - Command to run specified as a string or an array of strings.
 
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2165,12 +2171,12 @@ interactive session with the `exec` command.
 
     {{ STREAM }}
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Detach** - Detach from the `exec` command.
 -   **Tty** - Boolean value to allocate a pseudo-TTY.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2195,12 +2201,12 @@ This API is valid only if `tty` was specified as part of creating and starting t
     HTTP/1.1 201 Created
     Content-Type: text/plain
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such exec instance
@@ -2302,7 +2308,7 @@ Return low-level information about the `exec` command `id`.
       }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -100,7 +100,7 @@ List containers
          }
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, Show all containers.
         Only running containers are shown by default (i.e., this defaults to false)
@@ -117,7 +117,7 @@ Query Parameters:
   -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`)
   -   `label=key` or `label="key=value"` of a container label
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -219,7 +219,7 @@ Create a container
            "Warnings":[]
       }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Hostname** - A string value containing the hostname to use for the
       container.
@@ -322,12 +322,12 @@ Json Parameters:
     -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
     -   **VolumeDriver** - Driver that this container users to mount volumes.
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – Assign the specified name to the container. Must
     match `/?[a-zA-Z0-9_-]+`.
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -341,7 +341,6 @@ Status Codes:
 `GET /containers/(id or name)/json`
 
 Return low-level information on the container `id`
-
 
 **Example request**:
 
@@ -517,11 +516,11 @@ Return low-level information on the container `id`
     ....
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **size** – 1/True/true or 0/False/false, return container size information. Default is `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -581,11 +580,11 @@ supported on Windows.
       ],
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **ps_args** – `ps` arguments to use (e.g., `aux`), defaults to `-ef`
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -613,7 +612,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
      {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
 -   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
@@ -624,7 +623,7 @@ Query Parameters:
         every log line. Default `false`.
 -   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -667,7 +666,7 @@ Values for `Kind`:
 - `1`: Add
 - `2`: Delete
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -690,7 +689,7 @@ Export the contents of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -807,11 +806,11 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 The precpu_stats is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the “cpu_stats” field.
 
-Query Parameters:
+**Query parameters**:
 
 -   **stream** – 1/True/true or 0/False/false, pull stats once then disconnect. Default `true`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -833,12 +832,12 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
       Content-Length: 0
       Content-Type: text/plain; charset=utf-8
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – No such container
@@ -862,7 +861,7 @@ Start the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already started
@@ -883,11 +882,11 @@ Stop the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already stopped
@@ -908,11 +907,11 @@ Restart the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -932,12 +931,12 @@ Kill the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters
+**Query parameters**:
 
 -   **signal** - Signal to send to the container: integer or string like `SIGINT`.
         When not set, `SIGKILL` is assumed and the call waits for the container to exit.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -957,11 +956,11 @@ Rename the container `id` to a `new_name`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – new name for the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -982,7 +981,7 @@ Pause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1002,7 +1001,7 @@ Unpause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1027,7 +1026,7 @@ Attach to the container `id`
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
@@ -1039,7 +1038,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -1107,7 +1106,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **logs** – 1/True/true or 0/False/false, return logs. Default `false`.
 -   **stream** – 1/True/true or 0/False/false, return stream.
@@ -1119,7 +1118,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1143,7 +1142,7 @@ Block until container `id` stops, then returns the exit code
 
     {"StatusCode": 0}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1163,14 +1162,14 @@ Remove the container `id` from the filesystem
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **v** – 1/True/true or 0/False/false, Remove the volumes
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **400** – bad parameter
@@ -1202,7 +1201,7 @@ Copy files or folders of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1221,7 +1220,7 @@ following section.
 
 Get a tar archive of a resource in the filesystem of container `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - resource in the container's filesystem to archive. Required.
 
@@ -1232,39 +1231,41 @@ Query Parameters:
     indicates that only the contents of the **path** directory should be
     copied. A symlink is always resolved to its target.
 
-    **Note**: It is not possible to copy certain system files such as resources
-    under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
-    container.
+    > **Note**: It is not possible to copy certain system files such as resources
+    > under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
+    > container.
 
 **Example request**:
 
-        GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
-        X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
+    X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
 the archived resource. The above example value would decode to the following
 JSON object (whitespace added for readability):
 
-        {
-            "name": "root",
-            "size": 4096,
-            "mode": 2147484096,
-            "mtime": "2014-02-27T20:51:23Z",
-            "linkTarget": ""
-        }
+```json
+{
+    "name": "root",
+    "size": 4096,
+    "mode": 2147484096,
+    "mtime": "2014-02-27T20:51:23Z",
+    "linkTarget": ""
+}
+```
 
 A `HEAD` request can also be made to this endpoint if only this information is
 desired.
 
-Status Codes:
+**Status codes**:
 
 - **200** - success, returns archive of copied resource
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1283,7 +1284,7 @@ Status Codes:
 Upload a tar archive to be extracted to a path in the filesystem of container
 `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - path to a directory in the container
     to extract the archive's contents into. Required.
@@ -1305,7 +1306,7 @@ Query Parameters:
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** – the content was extracted successfully
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1407,7 +1408,7 @@ digest. You can reference this digest using the value:
 See the `docker run` and `docker build` commands for examples of digest and tag
 references on the command line.
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, default false
 -   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
@@ -1451,7 +1452,7 @@ command*](../../reference/builder.md#add)).
 The build is canceled if the client drops the connection by quitting
 or being killed.
 
-Query Parameters:
+**Query parameters**:
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
@@ -1460,7 +1461,7 @@ Query Parameters:
         You can provide one or more `t` parameters.
 -   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
         URI specifies a filename, the file's contents are placed into a file
-		called `Dockerfile`.
+        called `Dockerfile`.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1504,7 +1505,7 @@ Query Parameters:
     be specified with both a "https://" prefix and a "/v1/" suffix even
     though Docker will prefer to use the v2 registry API.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1533,7 +1534,7 @@ When using this endpoint to pull an image from the registry, the
 `X-Registry-Auth` header can be used to include
 a base64-encoded AuthConfig object.
 
-Query Parameters:
+**Query parameters**:
 
 -   **fromImage** – Name of the image to pull. The name may include a tag or
         digest. This parameter may only be used when pulling an image.
@@ -1549,7 +1550,7 @@ Query Parameters:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1661,7 +1662,7 @@ Return low-level information on the image `name`
        }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1715,7 +1716,7 @@ Return the history of the image `name`
         }
     ]
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1750,7 +1751,7 @@ then be used in the URL. This duplicates the command line's flow.
     POST /images/registry.acme.com:5000/test/push HTTP/1.1
 
 
-Query Parameters:
+**Query parameters**:
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
@@ -1759,7 +1760,7 @@ Request Headers:
 -   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
         object.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1779,13 +1780,13 @@ Tag the image `name` into a repository
 
     HTTP/1.1 201 Created
 
-Query Parameters:
+**Query parameters**:
 
 -   **repo** – The repository to tag in
 -   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -1814,12 +1815,12 @@ Remove the image `name` from the filesystem
      {"Deleted": "53b4f83ac9"}
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **force** – 1/True/true or 0/False/false, default false
 -   **noprune** – 1/True/true or 0/False/false, default false
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1870,11 +1871,11 @@ Search for an image on [Docker Hub](https://hub.docker.com).
     ...
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **term** – term to search
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1903,7 +1904,7 @@ Get the default username and email
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **204** – no error
@@ -1975,7 +1976,7 @@ Display system-wide information
         "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2006,7 +2007,7 @@ Show the docker version information
          "Experimental": false
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2028,7 +2029,7 @@ Ping the docker server
 
     OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2084,11 +2085,11 @@ Create a new image from a container's changes
 
     {"Id": "596069db4bf5"}
 
-Json Parameters:
+**JSON parameters**:
 
 -  **config** - the container's configuration
 
-Query Parameters:
+**Query parameters**:
 
 -   **container** – source container
 -   **repo** – repository
@@ -2099,7 +2100,7 @@ Query Parameters:
 -   **pause** – 1/True/true or 0/False/false, whether to pause the container before committing
 -   **changes** – Dockerfile instructions to apply while committing
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2134,7 +2135,7 @@ and Docker images report:
     {"status":"attach","id":"5745704abe9caa5","from":"busybox","time":1442421716,"timeNano":1442421716894759198}
     {"status":"start","id":"5745704abe9caa5","from":"busybox","time":1442421716,"timeNano":1442421716983607193}
 
-Query Parameters:
+**Query parameters**:
 
 -   **since** – Timestamp used for polling
 -   **until** – Timestamp used for polling
@@ -2144,7 +2145,7 @@ Query Parameters:
   -   `image=<string>`; -- image to filter
   -   `label=<string>`; -- image and container label to filter
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2174,7 +2175,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2203,7 +2204,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2225,7 +2226,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2282,7 +2283,7 @@ Sets up an exec instance in a running container `id`
          "Warnings":[]
     }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
 -   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
@@ -2291,7 +2292,7 @@ Json Parameters:
 -   **Cmd** - Command to run specified as a string or an array of strings.
 
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2323,12 +2324,12 @@ interactive session with the `exec` command.
 
     {{ STREAM }}
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Detach** - Detach from the `exec` command.
 -   **Tty** - Boolean value to allocate a pseudo-TTY.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2354,12 +2355,12 @@ This API is valid only if `tty` was specified as part of creating and starting t
     HTTP/1.1 201 Created
     Content-Type: text/plain
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such exec instance
@@ -2484,7 +2485,7 @@ Return low-level information about the `exec` command `id`.
       }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2515,11 +2516,11 @@ Status Codes:
       ]
     }
 
-Query Parameters:
+**Query parameters**:
 
 - **filters** - JSON encoded value of the filters (a `map[string][]string`) to process on the volumes list. There is one available filter: `dangling=true`
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2550,12 +2551,12 @@ Create a volume
       "Mountpoint": "/var/lib/docker/volumes/tardis"
     }
 
-Status Codes:
+**Status codes**:
 
 - **201** - no error
 - **500**  - server error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Name** - The new volume's name. If not specified, Docker generates a name.
 - **Driver** - Name of the volume driver to use. Defaults to `local` for the name.
@@ -2583,7 +2584,7 @@ Return low-level information on the volume `name`
       "Mountpoint": "/var/lib/docker/volumes/tardis"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **404** - no such volume
@@ -2603,7 +2604,7 @@ Instruct the driver to remove the volume (`name`).
 
     HTTP/1.1 204 No Content
 
-Status Codes
+**Status codes**:
 
 -   **204** - no error
 -   **404** - no such volume or volume driver
@@ -2684,13 +2685,11 @@ Content-Type: application/json
 ]
 ```
 
-
-
-Query Parameters:
+**Query parameters**:
 
 - **filters** - JSON encoded value of the filters (a `map[string][]string`) to process on the networks list. Available filters: `name=[network-names]` , `id=[network-ids]`
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2741,7 +2740,7 @@ Content-Type: application/json
 }
 ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **404** - network not found
@@ -2760,7 +2759,7 @@ Content-Type: application/json
 
 {
   "Name":"isolated_nw",
-  "Driver":"bridge"
+  "Driver":"bridge",
   "IPAM":{
     "Config":[{
       "Subnet":"172.20.0.0/16",
@@ -2782,13 +2781,13 @@ Content-Type: application/json
 }
 ```
 
-Status Codes:
+**Status codes**:
 
 - **201** - no error
 - **404** - plugin not found
 - **500** - server error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
 - **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
@@ -2817,13 +2816,13 @@ Content-Type: application/json
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** - no error
 - **404** - network or container is not found
 - **500** - Internal Server Error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **container** - container-id/name to be connected to the network
 
@@ -2848,13 +2847,13 @@ Content-Type: application/json
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** - no error
 - **404** - network or container not found
 - **500** - Internal Server Error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Container** - container-id/name to be disconnected from a network
 
@@ -2872,7 +2871,7 @@ Instruct the driver to remove the network (`id`).
 
     HTTP/1.1 200 OK
 
-Status Codes
+**Status codes**:
 
 -   **200** - no error
 -   **404** - no such network

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -187,7 +187,7 @@ List containers
          }
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, Show all containers.
         Only running containers are shown by default (i.e., this defaults to false)
@@ -205,7 +205,7 @@ Query Parameters:
   -   `label=key` or `label="key=value"` of a container label
   -   `isolation=`(`default`|`process`|`hyperv`)   (Windows daemon only)
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -324,7 +324,7 @@ Create a container
            "Warnings":[]
       }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Hostname** - A string value containing the hostname to use for the
       container.
@@ -435,12 +435,12 @@ Json Parameters:
     -   **VolumeDriver** - Driver that this container users to mount volumes.
     -   **ShmSize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – Assign the specified name to the container. Must
     match `/?[a-zA-Z0-9_-]+`.
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -454,7 +454,6 @@ Status Codes:
 `GET /containers/(id or name)/json`
 
 Return low-level information on the container `id`
-
 
 **Example request**:
 
@@ -501,8 +500,8 @@ Return low-level information on the container `id`
 			"Tty": false,
 			"User": "",
 			"Volumes": {
-                          "/volumes/data": {}
-                        },
+				"/volumes/data": {}
+			},
 			"WorkingDir": "",
 			"StopSignal": "SIGTERM"
 		},
@@ -643,11 +642,11 @@ Return low-level information on the container `id`
     ....
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **size** – 1/True/true or 0/False/false, return container size information. Default is `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -707,11 +706,11 @@ supported on Windows.
       ],
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **ps_args** – `ps` arguments to use (e.g., `aux`), defaults to `-ef`
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -739,7 +738,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
      {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
 -   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
@@ -750,7 +749,7 @@ Query Parameters:
         every log line. Default `false`.
 -   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -793,7 +792,7 @@ Values for `Kind`:
 - `1`: Add
 - `2`: Delete
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -816,7 +815,7 @@ Export the contents of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -933,11 +932,11 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 The precpu_stats is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the “cpu_stats” field.
 
-Query Parameters:
+**Query parameters**:
 
 -   **stream** – 1/True/true or 0/False/false, pull stats once then disconnect. Default `true`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -959,12 +958,12 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
       Content-Length: 0
       Content-Type: text/plain; charset=utf-8
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – No such container
@@ -988,13 +987,13 @@ Start the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already started
@@ -1015,11 +1014,11 @@ Stop the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already stopped
@@ -1040,11 +1039,11 @@ Restart the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1064,12 +1063,12 @@ Kill the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters
+**Query parameters**:
 
 -   **signal** - Signal to send to the container: integer or string like `SIGINT`.
         When not set, `SIGKILL` is assumed and the call waits for the container to exit.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1108,7 +1107,7 @@ Update resource configs of one or more containers.
            "Warnings": []
        }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1129,11 +1128,11 @@ Rename the container `id` to a `new_name`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – new name for the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1154,7 +1153,7 @@ Pause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1174,7 +1173,7 @@ Unpause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1199,7 +1198,7 @@ Attach to the container `id`
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
@@ -1214,7 +1213,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -1283,7 +1282,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
@@ -1298,7 +1297,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1322,7 +1321,7 @@ Block until container `id` stops, then returns the exit code
 
     {"StatusCode": 0}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1342,14 +1341,14 @@ Remove the container `id` from the filesystem
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **v** – 1/True/true or 0/False/false, Remove the volumes
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **400** – bad parameter
@@ -1381,7 +1380,7 @@ Copy files or folders of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1400,7 +1399,7 @@ following section.
 
 Get a tar archive of a resource in the filesystem of container `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - resource in the container's filesystem to archive. Required.
 
@@ -1411,39 +1410,41 @@ Query Parameters:
     indicates that only the contents of the **path** directory should be
     copied. A symlink is always resolved to its target.
 
-    **Note**: It is not possible to copy certain system files such as resources
-    under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
-    container.
+    > **Note**: It is not possible to copy certain system files such as resources
+    > under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
+    > container.
 
 **Example request**:
 
-        GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
-        X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
+    X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
 the archived resource. The above example value would decode to the following
 JSON object (whitespace added for readability):
 
-        {
-            "name": "root",
-            "size": 4096,
-            "mode": 2147484096,
-            "mtime": "2014-02-27T20:51:23Z",
-            "linkTarget": ""
-        }
+```json
+{
+    "name": "root",
+    "size": 4096,
+    "mode": 2147484096,
+    "mtime": "2014-02-27T20:51:23Z",
+    "linkTarget": ""
+}
+```
 
 A `HEAD` request can also be made to this endpoint if only this information is
 desired.
 
-Status Codes:
+**Status codes**:
 
 - **200** - success, returns archive of copied resource
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1462,7 +1463,7 @@ Status Codes:
 Upload a tar archive to be extracted to a path in the filesystem of container
 `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - path to a directory in the container
     to extract the archive's contents into. Required.
@@ -1484,7 +1485,7 @@ Query Parameters:
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** – the content was extracted successfully
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1586,7 +1587,7 @@ digest. You can reference this digest using the value:
 See the `docker run` and `docker build` commands for examples of digest and tag
 references on the command line.
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, default false
 -   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
@@ -1630,7 +1631,7 @@ command*](../../reference/builder.md#add)).
 The build is canceled if the client drops the connection by quitting
 or being killed.
 
-Query Parameters:
+**Query parameters**:
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
@@ -1639,7 +1640,7 @@ Query Parameters:
         You can provide one or more `t` parameters.
 -   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
         URI specifies a filename, the file's contents are placed into a file
-		called `Dockerfile`.
+        called `Dockerfile`.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1684,7 +1685,7 @@ Query Parameters:
     be specified with both a "https://" prefix and a "/v1/" suffix even
     though Docker will prefer to use the v2 registry API.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1713,7 +1714,7 @@ When using this endpoint to pull an image from the registry, the
 `X-Registry-Auth` header can be used to include
 a base64-encoded AuthConfig object.
 
-Query Parameters:
+**Query parameters**:
 
 -   **fromImage** – Name of the image to pull. The name may include a tag or
         digest. This parameter may only be used when pulling an image.
@@ -1747,7 +1748,7 @@ Query Parameters:
     }
         ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1859,7 +1860,7 @@ Return low-level information on the image `name`
        }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1913,7 +1914,7 @@ Return the history of the image `name`
         }
     ]
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1950,7 +1951,7 @@ The push is cancelled if the HTTP connection is closed.
     POST /images/registry.acme.com:5000/test/push HTTP/1.1
 
 
-Query Parameters:
+**Query parameters**:
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
@@ -1975,7 +1976,7 @@ Request Headers:
     }
         ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1995,13 +1996,13 @@ Tag the image `name` into a repository
 
     HTTP/1.1 201 Created
 
-Query Parameters:
+**Query parameters**:
 
 -   **repo** – The repository to tag in
 -   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -2030,12 +2031,12 @@ Remove the image `name` from the filesystem
      {"Deleted": "53b4f83ac9"}
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **force** – 1/True/true or 0/False/false, default false
 -   **noprune** – 1/True/true or 0/False/false, default false
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -2086,11 +2087,11 @@ Search for an image on [Docker Hub](https://hub.docker.com).
     ...
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **term** – term to search
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2119,7 +2120,7 @@ Get the default username and email
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **204** – no error
@@ -2207,7 +2208,7 @@ Display system-wide information
         "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2239,7 +2240,7 @@ Show the docker version information
          "Experimental": true
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2261,7 +2262,7 @@ Ping the docker server
 
     OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2317,11 +2318,11 @@ Create a new image from a container's changes
 
     {"Id": "596069db4bf5"}
 
-Json Parameters:
+**JSON parameters**:
 
 -  **config** - the container's configuration
 
-Query Parameters:
+**Query parameters**:
 
 -   **container** – source container
 -   **repo** – repository
@@ -2332,7 +2333,7 @@ Query Parameters:
 -   **pause** – 1/True/true or 0/False/false, whether to pause the container before committing
 -   **changes** – Dockerfile instructions to apply while committing
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2520,7 +2521,7 @@ Docker networks report the following events:
       "timeNano": 1461943105338056026
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **since** – Timestamp used for polling
 -   **until** – Timestamp used for polling
@@ -2533,7 +2534,7 @@ Query Parameters:
   -   `volume=<string>`; -- volume to filter
   -   `network=<string>`; -- network to filter
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2563,12 +2564,12 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images.
+### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2592,7 +2593,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2614,7 +2615,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2672,7 +2673,7 @@ Sets up an exec instance in a running container `id`
          "Warnings":[]
     }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
 -   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
@@ -2684,7 +2685,7 @@ Json Parameters:
 -   **Cmd** - Command to run specified as a string or an array of strings.
 
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2716,12 +2717,12 @@ interactive session with the `exec` command.
 
     {{ STREAM }}
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Detach** - Detach from the `exec` command.
 -   **Tty** - Boolean value to allocate a pseudo-TTY.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2747,12 +2748,12 @@ This API is valid only if `tty` was specified as part of creating and starting t
     HTTP/1.1 201 Created
     Content-Type: text/plain
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such exec instance
@@ -2794,7 +2795,7 @@ Return low-level information about the `exec` command `id`.
         "Running": false
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2826,11 +2827,11 @@ Status Codes:
       "Warnings": []
     }
 
-Query Parameters:
+**Query parameters**:
 
 - **filters** - JSON encoded value of the filters (a `map[string][]string`) to process on the volumes list. There is one available filter: `dangling=true`
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2861,12 +2862,12 @@ Create a volume
       "Mountpoint": "/var/lib/docker/volumes/tardis"
     }
 
-Status Codes:
+**Status codes**:
 
 - **201** - no error
 - **500**  - server error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Name** - The new volume's name. If not specified, Docker generates a name.
 - **Driver** - Name of the volume driver to use. Defaults to `local` for the name.
@@ -2894,7 +2895,7 @@ Return low-level information on the volume `name`
       "Mountpoint": "/var/lib/docker/volumes/tardis"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **404** - no such volume
@@ -2914,7 +2915,7 @@ Instruct the driver to remove the volume (`name`).
 
     HTTP/1.1 204 No Content
 
-Status Codes
+**Status codes**:
 
 -   **204** - no error
 -   **404** - no such volume or volume driver
@@ -2995,14 +2996,14 @@ Content-Type: application/json
 ]
 ```
 
-Query Parameters:
+**Query parameters**:
 
 - **filters** - JSON encoded network list filter. The filter value is one of:
-  -   `name=<network-name>` Matches all or part of a network name.
   -   `id=<network-id>` Matches all or part of a network id.
+  -   `name=<network-name>` Matches all or part of a network name.
   -   `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -3058,7 +3059,7 @@ Content-Type: application/json
 }
 ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **404** - network not found
@@ -3110,13 +3111,13 @@ Content-Type: application/json
 }
 ```
 
-Status Codes:
+**Status codes**:
 
 - **201** - no error
 - **404** - plugin not found
 - **500** - server error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
 - **Driver** - Name of the network driver plugin to use. Defaults to `bridge` driver
@@ -3151,13 +3152,13 @@ Content-Type: application/json
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** - no error
 - **404** - network or container is not found
 - **500** - Internal Server Error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **container** - container-id/name to be connected to the network
 
@@ -3183,13 +3184,13 @@ Content-Type: application/json
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** - no error
 - **404** - network or container not found
 - **500** - Internal Server Error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Container** - container-id/name to be disconnected from a network
 - **Force** - Force the container to disconnect from a network
@@ -3208,7 +3209,7 @@ Instruct the driver to remove the network (`id`).
 
     HTTP/1.1 200 OK
 
-Status Codes
+**Status codes**:
 
 -   **200** - no error
 -   **404** - no such network

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -202,7 +202,7 @@ List containers
          }
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, Show all containers.
         Only running containers are shown by default (i.e., this defaults to false)
@@ -224,7 +224,7 @@ Query Parameters:
   -   `since`=(`<container id>` or `<container name>`)
   -   `volume`=(`<volume name>` or `<mount point destination>`)
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -344,7 +344,7 @@ Create a container
            "Warnings":[]
       }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Hostname** - A string value containing the hostname to use for the
       container.
@@ -458,12 +458,12 @@ Json Parameters:
     -   **VolumeDriver** - Driver that this container users to mount volumes.
     -   **ShmSize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – Assign the specified name to the container. Must
     match `/?[a-zA-Z0-9_-]+`.
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -477,7 +477,6 @@ Status Codes:
 `GET /containers/(id or name)/json`
 
 Return low-level information on the container `id`
-
 
 **Example request**:
 
@@ -666,11 +665,11 @@ Return low-level information on the container `id`
     ....
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **size** – 1/True/true or 0/False/false, return container size information. Default is `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -730,11 +729,11 @@ supported on Windows.
       ],
     }
 
-Query Parameters:
+**Query parameters**:
 
 -   **ps_args** – `ps` arguments to use (e.g., `aux`), defaults to `-ef`
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -762,7 +761,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
      {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
 -   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
@@ -773,7 +772,7 @@ Query Parameters:
         every log line. Default `false`.
 -   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -816,7 +815,7 @@ Values for `Kind`:
 - `1`: Add
 - `2`: Delete
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -839,7 +838,7 @@ Export the contents of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -959,11 +958,11 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 The precpu_stats is the cpu statistic of last read, which is used for calculating the cpu usage percent. It is not the exact copy of the “cpu_stats” field.
 
-Query Parameters:
+**Query parameters**:
 
 -   **stream** – 1/True/true or 0/False/false, pull stats once then disconnect. Default `true`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -985,12 +984,12 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
       Content-Length: 0
       Content-Type: text/plain; charset=utf-8
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – No such container
@@ -1014,13 +1013,13 @@ Start the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
         where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already started
@@ -1041,11 +1040,11 @@ Stop the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **304** – container already stopped
@@ -1066,11 +1065,11 @@ Restart the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **t** – number of seconds to wait before killing the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1090,12 +1089,12 @@ Kill the container `id`
 
     HTTP/1.1 204 No Content
 
-Query Parameters
+**Query parameters**:
 
 -   **signal** - Signal to send to the container: integer or string like `SIGINT`.
         When not set, `SIGKILL` is assumed and the call waits for the container to exit.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1138,7 +1137,7 @@ Update configuration of one or more containers.
            "Warnings": []
        }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1159,11 +1158,11 @@ Rename the container `id` to a `new_name`
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **name** – new name for the container
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1184,7 +1183,7 @@ Pause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1204,7 +1203,7 @@ Unpause the container `id`
 
     HTTP/1.1 204 No Content
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **404** – no such container
@@ -1229,7 +1228,7 @@ Attach to the container `id`
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
@@ -1244,7 +1243,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **101** – no error, hints proxy about hijacking
 -   **200** – no error, no upgrade header found
@@ -1313,7 +1312,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
     {{ STREAM }}
 
-Query Parameters:
+**Query parameters**:
 
 -   **detachKeys** – Override the key sequence for detaching a
         container. Format is a single character `[a-Z]` or `ctrl-<value>`
@@ -1328,7 +1327,7 @@ Query Parameters:
 -   **stderr** – 1/True/true or 0/False/false, if `logs=true`, return
         `stderr` log, if `stream=true`, attach to `stderr`. Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **400** – bad parameter
@@ -1352,7 +1351,7 @@ Block until container `id` stops, then returns the exit code
 
     {"StatusCode": 0}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1372,14 +1371,14 @@ Remove the container `id` from the filesystem
 
     HTTP/1.1 204 No Content
 
-Query Parameters:
+**Query parameters**:
 
 -   **v** – 1/True/true or 0/False/false, Remove the volumes
         associated to the container. Default `false`.
 -   **force** - 1/True/true or 0/False/false, Kill then remove the container.
         Default `false`.
 
-Status Codes:
+**Status codes**:
 
 -   **204** – no error
 -   **400** – bad parameter
@@ -1411,7 +1410,7 @@ Copy files or folders of container `id`
 
     {{ TAR STREAM }}
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such container
@@ -1430,7 +1429,7 @@ following section.
 
 Get a tar archive of a resource in the filesystem of container `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - resource in the container's filesystem to archive. Required.
 
@@ -1441,39 +1440,41 @@ Query Parameters:
     indicates that only the contents of the **path** directory should be
     copied. A symlink is always resolved to its target.
 
-    **Note**: It is not possible to copy certain system files such as resources
-    under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
-    container.
+    > **Note**: It is not possible to copy certain system files such as resources
+    > under `/proc`, `/sys`, `/dev`, and mounts created by the user in the
+    > container.
 
 **Example request**:
 
-        GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/x-tar
-        X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
+    HTTP/1.1 200 OK
+    Content-Type: application/x-tar
+    X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
-        {{ TAR STREAM }}
+    {{ TAR STREAM }}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
 the archived resource. The above example value would decode to the following
 JSON object (whitespace added for readability):
 
-        {
-            "name": "root",
-            "size": 4096,
-            "mode": 2147484096,
-            "mtime": "2014-02-27T20:51:23Z",
-            "linkTarget": ""
-        }
+```json
+{
+    "name": "root",
+    "size": 4096,
+    "mode": 2147484096,
+    "mtime": "2014-02-27T20:51:23Z",
+    "linkTarget": ""
+}
+```
 
 A `HEAD` request can also be made to this endpoint if only this information is
 desired.
 
-Status Codes:
+**Status codes**:
 
 - **200** - success, returns archive of copied resource
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1492,7 +1493,7 @@ Status Codes:
 Upload a tar archive to be extracted to a path in the filesystem of container
 `id`.
 
-Query Parameters:
+**Query parameters**:
 
 - **path** - path to a directory in the container
     to extract the archive's contents into. Required.
@@ -1514,7 +1515,7 @@ Query Parameters:
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** – the content was extracted successfully
 - **400** - client error, bad parameter, details in JSON response body, one of:
@@ -1616,7 +1617,7 @@ digest. You can reference this digest using the value:
 See the `docker run` and `docker build` commands for examples of digest and tag
 references on the command line.
 
-Query Parameters:
+**Query parameters**:
 
 -   **all** – 1/True/true or 0/False/false, default false
 -   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
@@ -1660,7 +1661,7 @@ command*](../../reference/builder.md#add)).
 The build is canceled if the client drops the connection by quitting
 or being killed.
 
-Query Parameters:
+**Query parameters**:
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
@@ -1715,7 +1716,7 @@ Query Parameters:
     be specified with both a "https://" prefix and a "/v1/" suffix even
     though Docker will prefer to use the v2 registry API.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1744,7 +1745,7 @@ When using this endpoint to pull an image from the registry, the
 `X-Registry-Auth` header can be used to include
 a base64-encoded AuthConfig object.
 
-Query Parameters:
+**Query parameters**:
 
 -   **fromImage** – Name of the image to pull. The name may include a tag or
         digest. This parameter may only be used when pulling an image.
@@ -1778,7 +1779,7 @@ Query Parameters:
     }
         ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -1897,7 +1898,7 @@ Return low-level information on the image `name`
        }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1951,7 +1952,7 @@ Return the history of the image `name`
         }
     ]
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -1988,7 +1989,7 @@ The push is cancelled if the HTTP connection is closed.
     POST /images/registry.acme.com:5000/test/push HTTP/1.1
 
 
-Query Parameters:
+**Query parameters**:
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
@@ -2013,7 +2014,7 @@ Request Headers:
     }
         ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -2033,13 +2034,13 @@ Tag the image `name` into a repository
 
     HTTP/1.1 201 Created
 
-Query Parameters:
+**Query parameters**:
 
 -   **repo** – The repository to tag in
 -   **force** – 1/True/true or 0/False/false, default false
 -   **tag** - The new tag name
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **400** – bad parameter
@@ -2068,12 +2069,12 @@ Remove the image `name` from the filesystem
      {"Deleted": "53b4f83ac9"}
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **force** – 1/True/true or 0/False/false, default false
 -   **noprune** – 1/True/true or 0/False/false, default false
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such image
@@ -2124,11 +2125,11 @@ Search for an image on [Docker Hub](https://hub.docker.com).
     ...
     ]
 
-Query Parameters:
+**Query parameters**:
 
 -   **term** – term to search
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2162,7 +2163,7 @@ if available, for accessing the registry without password.
          "IdentityToken": "9cbaf023786cd7..."
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **204** – no error
@@ -2252,7 +2253,7 @@ Display system-wide information
         "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2284,7 +2285,7 @@ Show the docker version information
          "Experimental": true
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2306,7 +2307,7 @@ Ping the docker server
 
     OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2362,11 +2363,11 @@ Create a new image from a container's changes
 
     {"Id": "596069db4bf5"}
 
-Json Parameters:
+**JSON parameters**:
 
 -  **config** - the container's configuration
 
-Query Parameters:
+**Query parameters**:
 
 -   **container** – source container
 -   **repo** – repository
@@ -2377,7 +2378,7 @@ Query Parameters:
 -   **pause** – 1/True/true or 0/False/false, whether to pause the container before committing
 -   **changes** – Dockerfile instructions to apply while committing
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2565,8 +2566,7 @@ Docker networks report the following events:
       "timeNano": 1461943105338056026
     }
 
-
-Query Parameters:
+**Query parameters**:
 
 -   **since** – Timestamp used for polling
 -   **until** – Timestamp used for polling
@@ -2579,7 +2579,7 @@ Query Parameters:
   -   `volume=<string>`; -- volume to filter
   -   `network=<string>`; -- network to filter
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2609,12 +2609,12 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images.
+### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2638,7 +2638,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     Binary data stream
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2660,7 +2660,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **500** – server error
@@ -2718,7 +2718,7 @@ Sets up an exec instance in a running container `id`
          "Warnings":[]
     }
 
-Json Parameters:
+**JSON parameters**:
 
 -   **AttachStdin** - Boolean value, attaches to `stdin` of the `exec` command.
 -   **AttachStdout** - Boolean value, attaches to `stdout` of the `exec` command.
@@ -2730,7 +2730,7 @@ Json Parameters:
 -   **Cmd** - Command to run specified as a string or an array of strings.
 
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such container
@@ -2762,12 +2762,12 @@ interactive session with the `exec` command.
 
     {{ STREAM }}
 
-Json Parameters:
+**JSON parameters**:
 
 -   **Detach** - Detach from the `exec` command.
 -   **Tty** - Boolean value to allocate a pseudo-TTY.
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2793,12 +2793,12 @@ This API is valid only if `tty` was specified as part of creating and starting t
     HTTP/1.1 201 Created
     Content-Type: text/plain
 
-Query Parameters:
+**Query parameters**:
 
 -   **h** – height of `tty` session
 -   **w** – width
 
-Status Codes:
+**Status codes**:
 
 -   **201** – no error
 -   **404** – no such exec instance
@@ -2840,7 +2840,7 @@ Return low-level information about the `exec` command `id`.
         "Running": false
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** – no error
 -   **404** – no such exec instance
@@ -2872,11 +2872,11 @@ Status Codes:
       "Warnings": []
     }
 
-Query Parameters:
+**Query parameters**:
 
 - **filters** - JSON encoded value of the filters (a `map[string][]string`) to process on the volumes list. There is one available filter: `dangling=true`
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -2915,12 +2915,12 @@ Create a volume
       },
     }
 
-Status Codes:
+**Status codes**:
 
 - **201** - no error
 - **500**  - server error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Name** - The new volume's name. If not specified, Docker generates a name.
 - **Driver** - Name of the volume driver to use. Defaults to `local` for the name.
@@ -2953,7 +2953,7 @@ Return low-level information on the volume `name`
         }
     }
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **404** - no such volume
@@ -2973,14 +2973,14 @@ Instruct the driver to remove the volume (`name`).
 
     HTTP/1.1 204 No Content
 
-Status Codes
+**Status codes**:
 
 -   **204** - no error
 -   **404** - no such volume or volume driver
 -   **409** - volume is in use and cannot be removed
 -   **500** - server error
 
-## 2.5 Networks
+## 3.5 Networks
 
 ### List networks
 
@@ -3060,14 +3060,14 @@ Content-Type: application/json
 ]
 ```
 
-Query Parameters:
+**Query parameters**:
 
 - **filters** - JSON encoded network list filter. The filter value is one of:
-  -   `name=<network-name>` Matches all or part of a network name.
   -   `id=<network-id>` Matches all or part of a network id.
+  -   `name=<network-name>` Matches all or part of a network name.
   -   `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **500** - server error
@@ -3129,7 +3129,7 @@ Content-Type: application/json
 }
 ```
 
-Status Codes:
+**Status codes**:
 
 -   **200** - no error
 -   **404** - network not found
@@ -3195,13 +3195,13 @@ Content-Type: application/json
 }
 ```
 
-Status Codes:
+**Status codes**:
 
 - **201** - no error
 - **404** - plugin not found
 - **500** - server error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Name** - The new network's name. this is a mandatory field
 - **CheckDuplicate** - Requests daemon to check for networks with same name
@@ -3239,13 +3239,13 @@ Content-Type: application/json
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** - no error
 - **404** - network or container is not found
 - **500** - Internal Server Error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **container** - container-id/name to be connected to the network
 
@@ -3271,13 +3271,13 @@ Content-Type: application/json
 
     HTTP/1.1 200 OK
 
-Status Codes:
+**Status codes**:
 
 - **200** - no error
 - **404** - network or container not found
 - **500** - Internal Server Error
 
-JSON Parameters:
+**JSON parameters**:
 
 - **Container** - container-id/name to be disconnected from a network
 - **Force** - Force the container to disconnect from a network
@@ -3296,7 +3296,7 @@ Instruct the driver to remove the network (`id`).
 
     HTTP/1.1 204 No Content
 
-Status Codes
+**Status codes**:
 
 -   **204** - no error
 -   **404** - no such network


### PR DESCRIPTION
Had this branch around somewhere; this synchronizes formatting changes, and some textual fixes to older versions of the API
