### PR TITLE
Fix bash completion for `docker service {create,update} {-e,--env}`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1774,7 +1774,8 @@ _docker_service_update() {
 			return
 			;;
 		--env|-e)
-			COMPREPLY=( $( compgen -e -S = -- "$cur" ) )
+			# we do not append a "=" here because "-e VARNAME" is legal systax, too
+			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -2431,6 +2432,7 @@ _docker_run() {
 			return
 			;;
 		--env|-e)
+			# we do not append a "=" here because "-e VARNAME" is legal systax, too
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			__docker_nospace
 			return


### PR DESCRIPTION
The completions for `docker service {create,update} {-e,--env}` append an `=`.
This is inconsistent with the behavior for docker {run,create} {-e,--env}`, which does not append the`=`.

This PR aligns the new completion to the existing one and adds a comment why this variant was chosen (it's very tempting to re-add the `=`).
