### PR TITLE
Add `self` to bash completion of `docker node inspect`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1966,7 +1966,7 @@ _docker_node_inspect() {
 			COMPREPLY=( $( compgen -W "--format -f --help --pretty" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_nodes
+			__docker_complete_nodes_plus_self
 	esac
 }
 


### PR DESCRIPTION
`docker node inspect --help` advertises the use of the special nodename `self`:

``` bash
root@270166cbebbc:~# docker node inspect --help

Usage:  docker node inspect [OPTIONS] self|NODE [NODE...]
```

This PR adds it to bash completion.

A minor improvement, does not have to go into 1.12.1.
