### PR TITLE
Improve bash completion for `docker swarm {init,join} --{advertise,listen}-addr}`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -414,6 +414,20 @@ __docker_complete_resolved_hostname() {
 	COMPREPLY=( $(host 2>/dev/null "${cur%:}" | awk '/has address/ {print $4}') )
 }
 
+__docker_local_interfaces() {
+	command -v ip >/dev/null 2>&1 || return
+	ip addr show scope global 2>/dev/null | sed -n 's| \+inet \([0-9.]\+\).* \([^ ]\+\)|\1 \2|p'
+}
+
+__docker_complete_local_interfaces() {
+	local additional_interface
+	if [ "$1" = "--add" ] ; then
+		additional_interface="$2"
+	fi
+
+	COMPREPLY=( $( compgen -W "$(__docker_local_interfaces) $additional_interface" -- "$cur" ) )
+}
+
 __docker_complete_capabilities() {
 	# The list of capabilities is defined in types.go, ALL was added manually.
 	COMPREPLY=( $( compgen -W "
@@ -1836,15 +1850,21 @@ _docker_swarm() {
 
 _docker_swarm_init() {
 	case "$prev" in
-		--listen-addr)
-			if [[ $cur == *: ]] ; then
-				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
-			fi
-			return
-			;;
 		--advertise-addr)
 			if [[ $cur == *: ]] ; then
 				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
+			else
+				__docker_complete_local_interfaces
+				__docker_nospace
+			fi
+			return
+			;;
+		--listen-addr)
+			if [[ $cur == *: ]] ; then
+				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
+			else
+				__docker_complete_local_interfaces --add 0.0.0.0
+				__docker_nospace
 			fi
 			return
 			;;
@@ -1859,19 +1879,25 @@ _docker_swarm_init() {
 
 _docker_swarm_join() {
 	case "$prev" in
-		--token)
+		--advertise-addr)
+			if [[ $cur == *: ]] ; then
+				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
+			else
+				__docker_complete_local_interfaces
+				__docker_nospace
+			fi
 			return
 			;;
 		--listen-addr)
 			if [[ $cur == *: ]] ; then
 				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
+			else
+				__docker_complete_local_interfaces --add 0.0.0.0
+				__docker_nospace
 			fi
 			return
 			;;
-		--advertise-addr)
-			if [[ $cur == *: ]] ; then
-				COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )
-			fi
+		--token)
 			return
 			;;
 	esac


### PR DESCRIPTION
From `docker swarm join --help` (same for `init`):

``` bash
Options:
      --advertise-addr string   Advertised address (format: <ip|interface>[:port])
      --listen-addr value       Listen address (format: <ip|interface>[:port]) (default 0.0.0.0:2377)
```

This adds completion of interfaces and IPs to both options. For `--listen-addr` , `0.0.0.0` is also completed.

The data is gathered from the output of `ip host`. Special caution is taken for cases where this command might not be available, using the same idiom as in `__docker_complete_resolved_hostname()`.
Completion works in the `albers/bash-completion-mac` image, so we are probably safe with MacBooks here.

I also sorted the completions in `_docker_swarm_join()`.

_This is an improvement of existing functionality, no need to include in 1.12.1._

ping @sdurrheimer maybe you can reuse this in zsh completion.
