### PR TITLE
Fix bash completion for `docker swarm join --advertise-addr`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1878,7 +1878,7 @@ _docker_swarm_join() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--adveritse-addr --help --listen-addr --token" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--advertise-addr --help --listen-addr --token" -- "$cur" ) )
 			;;
 		*:)
 			COMPREPLY=( $( compgen -W "2377" -- "${cur##*:}" ) )


### PR DESCRIPTION
This fixes a typo in an option name that causes false completion of `docker swarm join --advertise-addr`.

Please include in 1.12.1 as this is about a new feature from 1.12.0.
