### PR TITLE
cli: service inspect - Null check for UpdateConfig

### DIFF
--- a/api/client/service/inspect.go
+++ b/api/client/service/inspect.go
@@ -117,12 +117,15 @@ func printService(out io.Writer, service swarm.Service) {
 	if service.Spec.TaskTemplate.Placement != nil && len(service.Spec.TaskTemplate.Placement.Constraints) > 0 {
 		ioutils.FprintfIfNotEmpty(out, " Constraints\t: %s\n", strings.Join(service.Spec.TaskTemplate.Placement.Constraints, ", "))
 	}
-	fmt.Fprintf(out, "UpdateConfig:\n")
-	fmt.Fprintf(out, " Parallelism:\t%d\n", service.Spec.UpdateConfig.Parallelism)
-	if service.Spec.UpdateConfig.Delay.Nanoseconds() > 0 {
-		fmt.Fprintf(out, " Delay:\t\t%s\n", service.Spec.UpdateConfig.Delay)
+	if service.Spec.UpdateConfig != nil {
+		fmt.Fprintf(out, "UpdateConfig:\n")
+		fmt.Fprintf(out, " Parallelism:\t%d\n", service.Spec.UpdateConfig.Parallelism)
+		if service.Spec.UpdateConfig.Delay.Nanoseconds() > 0 {
+			fmt.Fprintf(out, " Delay:\t\t%s\n", service.Spec.UpdateConfig.Delay)
+		}
+		fmt.Fprintf(out, " On failure:\t%s\n", service.Spec.UpdateConfig.FailureAction)
 	}
-	fmt.Fprintf(out, " On failure:\t%s\n", service.Spec.UpdateConfig.FailureAction)
+
 	fmt.Fprintf(out, "ContainerSpec:\n")
 	printContainerSpec(out, service.Spec.TaskTemplate.ContainerSpec)
 

--- a/api/client/service/inspect_test.go
+++ b/api/client/service/inspect_test.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/engine-api/types/swarm"
+)
+
+func TestPrettyPrintWithNoUpdateConfig(t *testing.T) {
+	b := new(bytes.Buffer)
+
+	endpointSpec := &swarm.EndpointSpec{
+		Mode: "vip",
+		Ports: []swarm.PortConfig{
+			{
+				Protocol:   swarm.PortConfigProtocolTCP,
+				TargetPort: 5000,
+			},
+		},
+	}
+
+	two := uint64(2)
+
+	s := swarm.Service{
+		ID: "de179gar9d0o7ltdybungplod",
+		Meta: swarm.Meta{
+			Version:   swarm.Version{Index: 315},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name:   "my_service",
+				Labels: map[string]string{"com.label": "foo"},
+			},
+			TaskTemplate: swarm.TaskSpec{
+				ContainerSpec: swarm.ContainerSpec{
+					Image: "foo/bar@sha256:this_is_a_test",
+				},
+			},
+			Mode: swarm.ServiceMode{
+				Replicated: &swarm.ReplicatedService{
+					Replicas: &two,
+				},
+			},
+			UpdateConfig: nil,
+			Networks: []swarm.NetworkAttachmentConfig{
+				{
+					Target:  "5vpyomhb6ievnk0i0o60gcnei",
+					Aliases: []string{"web"},
+				},
+			},
+			EndpointSpec: endpointSpec,
+		},
+		Endpoint: swarm.Endpoint{
+			Spec: *endpointSpec,
+			Ports: []swarm.PortConfig{
+				{
+					Protocol:      swarm.PortConfigProtocolTCP,
+					TargetPort:    5000,
+					PublishedPort: 30000,
+				},
+			},
+			VirtualIPs: []swarm.EndpointVirtualIP{
+				{
+					NetworkID: "6o4107cj2jx9tihgb0jyts6pj",
+					Addr:      "10.255.0.4/16",
+				},
+			},
+		},
+		UpdateStatus: swarm.UpdateStatus{
+			StartedAt:   time.Now(),
+			CompletedAt: time.Now(),
+		},
+	}
+
+	printService(b, s)
+	if strings.Contains(b.String(), "UpdateStatus") {
+		t.Fatal("Pretty print failed before parsing UpdateStatus")
+	}
+}


### PR DESCRIPTION
**\- What I did**

Added a null check  to make sure `UpdateConfig !=nil` before trying to print it's members

**\- How I did it**

Simple. It's a 1 line fix with a test.

**\- How to verify it**

You can run the unit test without the fix applied to observe the panic

**\- Description for the changelog**

<!--
Fix panic during `docker service inspect`
-->

![Cute dog](https://s-media-cache-ak0.pinimg.com/originals/16/8a/09/168a09cf7dc3a84437409300fba16658.jpg)

Fixes #25453

Signed-off-by: Dave Tucker dt@docker.com
