### PR TITLE
swarm: improve cli output on node promote/demote for unchanged role

### DIFF
--- a/api/client/node/demote.go
+++ b/api/client/node/demote.go
@@ -22,6 +22,10 @@ func newDemoteCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 func runDemote(dockerCli *client.DockerCli, nodes []string) error {
 	demote := func(node *swarm.Node) error {
+		if node.Spec.Role == swarm.NodeRoleWorker {
+			fmt.Fprintf(dockerCli.Out(), "Node %s is already a worker.\n", node.ID)
+			return errNoRoleChange
+		}
 		node.Spec.Role = swarm.NodeRoleWorker
 		return nil
 	}

--- a/api/client/node/promote.go
+++ b/api/client/node/promote.go
@@ -22,6 +22,10 @@ func newPromoteCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 func runPromote(dockerCli *client.DockerCli, nodes []string) error {
 	promote := func(node *swarm.Node) error {
+		if node.Spec.Role == swarm.NodeRoleManager {
+			fmt.Fprintf(dockerCli.Out(), "Node %s is already a manager.\n", node.ID)
+			return errNoRoleChange
+		}
 		node.Spec.Role = swarm.NodeRoleManager
 		return nil
 	}

--- a/api/client/node/update.go
+++ b/api/client/node/update.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/client"
@@ -11,6 +12,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
+)
+
+var (
+	errNoRoleChange = errors.New("role was already set to the requested value")
 )
 
 func newUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
@@ -53,6 +58,9 @@ func updateNodes(dockerCli *client.DockerCli, nodes []string, mergeNode func(nod
 
 		err = mergeNode(&node)
 		if err != nil {
+			if err == errNoRoleChange {
+				continue
+			}
 			return err
 		}
 		err = client.NodeUpdate(ctx, node.ID, node.Version, node.Spec)


### PR DESCRIPTION
As of now promoting (or demoting) a node that has its role
left unchanged will always print a successful message.

This PR fixes the issue by matching the behavior on swarmkit's
swarmctl command and printing a message when desired role is
the current role of the node.

As a result this also avoids calling update when it is not
necessary.
## 

_Note_: swarmkit normally treats this as an error case, but on docker's side we allow promotion and demotion on multiple node IDs so we just print the message that the node already has the role and continue to the next node in the list.

Putting this for _1.13_ as this is just a minor annoyance. Feel free to change if you think adding this to the current milestone makes more sense.

/cc @tonistiigi

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
