### PR TITLE
Fix update memory without memoryswap

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -283,6 +283,11 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		cResources.CpusetMems = resources.CpusetMems
 	}
 	if resources.Memory != 0 {
+		// if memory limit smaller than already set memoryswap limit and doesn't
+		// update the memoryswap limit, then error out.
+		if resources.Memory > cResources.MemorySwap && resources.MemorySwap == 0 {
+			return fmt.Errorf("Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time")
+		}
 		cResources.Memory = resources.Memory
 	}
 	if resources.MemorySwap != 0 {

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -236,3 +236,17 @@ func (s *DockerSuite) TestUpdateStats(c *check.C) {
 	c.Assert(preMemLimit, checker.Equals, curMemLimit)
 
 }
+
+func (s *DockerSuite) TestUpdateMemoryWithSwapMemory(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	testRequires(c, memoryLimitSupport)
+	testRequires(c, swapMemorySupport)
+
+	name := "test-update-container"
+	dockerCmd(c, "run", "-d", "--name", name, "--memory", "300M", "busybox", "top")
+	out, _, err := dockerCmdWithError("update", "--memory", "800M", name)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Memory limit should be smaller than already set memoryswap limit")
+
+	dockerCmd(c, "update", "--memory", "800M", "--memory-swap", "1000M", name)
+}

--- a/man/docker-update.1.md
+++ b/man/docker-update.1.md
@@ -67,6 +67,12 @@ a running container with kernel memory initialized.
 **-m**, **--memory**=""
    Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
 
+   Note that the memory should be smaller than the already set swap memory limit.
+   If you want update a memory limit bigger than the already set swap memory limit,
+   you should update swap memory limit at the same time. If you don't set swap memory 
+   limit on docker create/run but only memory limit, the swap memory is double
+   the memory limit.
+
 **--memory-reservation**=""
    Memory soft limit (format: <number>[<unit>], where unit = b, k, m or g)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

fixes #25460 

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

The memory should always be smaller than memoryswap,
we should error out with message that user know how
to do rather than just an invalid argument error if
user update the memory limit bigger than already set
memory swap.

Signed-off-by: Lei Jitang leijitang@huawei.com
