### PR TITLE
Cleanup manpage container in build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ validate: build ## validate DCO, Seccomp profile generation, gofmt,\n./pkg/ isol
 
 manpages: ## Generate man pages from go source and markdown
 	docker build -t docker-manpage-dev -f "man/$(DOCKERFILE)" ./man
-	docker run \
+	docker run --rm \
 		-v $(PWD):/go/src/github.com/docker/docker/ \
 		docker-manpage-dev
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
I just added the `--rm` flag to the `docker run` command in order to automatically remove the
created container after it is finished.

**\- How to verify it**
Run a `make manpages` and after the command completes check with `docker ps -a` that there is no stopped container which uses the `docker-manage-dev` image.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

When running a `make manpages` the image `docker-manpage-dev` will be build and started to create
the man pages. But the container will not be deleted afterwards. So I propose to start it with
`docker run --rm ...`, otherwise we'll collect some trash.

```
$ docker ps -a
CONTAINER ID        IMAGE                COMMAND                  CREATED             STATUS                      PORTS               NAMES
e3d9f721d862        docker-manpage-dev   "man/generate.sh"        19 minutes ago      Exited (0) 16 minutes ago                       berserk_jang
5738a23fb682        docker-manpage-dev   "man/generate.sh"        9 hours ago         Exited (0) 9 hours ago                          boring_bartik
15490b5e63f7        docker-manpage-dev   "man/generate.sh"        10 hours ago        Exited (0) 10 hours ago                         lonely_joliot
```

Signed-off-by: Dieter Reuter dieter.reuter@me.com
