### PR TITLE
Begin process of deprecating MAINTAINER

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,4 @@
 FROM docs/base:oss
-MAINTAINER Docker Docs <docs@docker.com>
-
 ENV PROJECT=engine
 # To get the git info for this repo
 COPY . /src

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -196,3 +196,7 @@ Since 1.9, Docker Content Trust Offline key has been renamed to Root key and the
 - DOCKER_CONTENT_TRUST_OFFLINE_PASSPHRASE is now named DOCKER_CONTENT_TRUST_ROOT_PASSPHRASE
 - DOCKER_CONTENT_TRUST_TAGGING_PASSPHRASE is now named DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE
 
+### `MAINTAINER` in Dockerfile
+**Deprecated In Release: v1.13.0**
+
+`MAINTAINER` was an early very limited form of `LABEL` which should be used instead.

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -486,13 +486,6 @@ before each new `FROM` command.
 assumes a `latest` by default. The builder returns an error if it cannot match
 the `tag` value.
 
-## MAINTAINER
-
-    MAINTAINER <name>
-
-The `MAINTAINER` instruction allows you to set the *Author* field of the
-generated images.
-
 ## RUN
 
 RUN has 2 forms:
@@ -686,6 +679,20 @@ To view an image's labels, use the `docker inspect` command.
         "multi.label2": "value2",
         "other": "value3"
     },
+
+## MAINTAINER (deprecated)
+
+    MAINTAINER <name>
+
+The `MAINTAINER` instruction sets the *Author* field of the generated images. 
+The `LABEL` instruction is a much more flexible version of this and you should use
+it instead, as it enables setting any metadata you require, and can be viewed
+easily, for example with `docker inspect`. To set a label corresponding to the
+`MAINTAINER` field you could use:
+
+    LABEL maintainer "SvenDowideit@home.org.au"
+
+This will then be visible from `docker inspect` with the other labels.
 
 ## EXPOSE
 
@@ -1676,8 +1683,6 @@ something more realistic, take a look at the list of [Dockerization examples](..
 # VERSION               0.0.1
 
 FROM      ubuntu
-MAINTAINER Victor Vieux <victor@docker.com>
-
 LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products" Version="1.0"
 RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
 ```

--- a/docs/tutorials/dockerimages.md
+++ b/docs/tutorials/dockerimages.md
@@ -265,7 +265,6 @@ building your own Sinatra image for your fictitious development team.
 
     # This is a comment
     FROM ubuntu:14.04
-    MAINTAINER Kate Smith <ksmith@example.com>
     RUN apt-get update && apt-get install -y ruby ruby-dev
     RUN gem install sinatra
 
@@ -277,7 +276,7 @@ is capitalized.
 > **Note:** You use `#` to indicate a comment
 
 The first instruction `FROM` tells Docker what the source of our image is, in
-this case you're basing our new image on an Ubuntu 14.04 image. The instruction uses the `MAINTAINER` instruction to specify who maintains the new image.
+this case you're basing our new image on an Ubuntu 14.04 image.
 
 Lastly, you've specified two `RUN` instructions. A `RUN` instruction executes
 a command inside the image, for example installing a package. Here you're
@@ -294,10 +293,7 @@ Now let's take our `Dockerfile` and use the `docker build` command to build an i
     Sending build context to Docker daemon
     Step 1 : FROM ubuntu:14.04
      ---> e54ca5efa2e9
-    Step 2 : MAINTAINER Kate Smith <ksmith@example.com>
-     ---> Using cache
-     ---> 851baf55332b
-    Step 3 : RUN apt-get update && apt-get install -y ruby ruby-dev
+    Step 2 : RUN apt-get update && apt-get install -y ruby ruby-dev
      ---> Running in 3a2558904e9b
     Selecting previously unselected package libasan0:amd64.
     (Reading database ... 11518 files and directories currently installed.)
@@ -432,7 +428,7 @@ Now let's take our `Dockerfile` and use the `docker build` command to build an i
     Running hooks in /etc/ca-certificates/update.d....done.
      ---> c55c31703134
     Removing intermediate container 3a2558904e9b
-    Step 4 : RUN gem install sinatra
+    Step 3 : RUN gem install sinatra
      ---> Running in 6b81cb6313e5
     unable to convert "\xC3" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII for README.rdoc, skipping
     unable to convert "\xC3" to UTF-8 in conversion from ASCII-8BIT to UTF-8 to US-ASCII for README.rdoc, skipping


### PR DESCRIPTION
This may take some time, but start by pointing people at
LABEL instead.

MAINTAINER predates general LABEL and has basically no tooling,
only allows a single item to be added, and is has been
unofficially deprecated for some time, with many images not
including it, but we have never specifically said that it
should be replaced by LABEL as a better more generic metadata
solution.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![badger badger badger](https://cloud.githubusercontent.com/assets/482364/17456782/900c7904-5be3-11e6-9e07-57c2e56fffce.jpg)

I would imagine that we would not remove support for some considerable time. One option would be to simply treat the `MAINTAINER` line as a noop in a few releases.

cc @thaJeztah @SvenDowideit  I picked a few places in the docs to remove it, but there are more, could add here.

closes https://github.com/docker/docker/issues/18921
