### PR TITLE
Modify func name in integration-cli

### DIFF
--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -59,9 +59,9 @@ func registerUserAgentHandler(reg *testRegistry, result *string) {
 	})
 }
 
-// TestUserAgentPassThroughOnPull verifies that when an image is pulled from
+// TestUserAgentPassThrough verifies that when an image is pulled from
 // a registry, the registry should see a User-Agent string of the form
-//   [docker engine UA] UptreamClientSTREAM-CLIENT([client UA])
+// [docker engine UA] UptreamClientSTREAM-CLIENT([client UA])
 func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
 	var (
 		buildUA string


### PR DESCRIPTION
Modify func namt from TestUserAgentPassThroughOnPull to TestUserAgentPassThrough.
PTAL

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
