### PR TITLE
Close pipe after using pipe

### DIFF
--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -53,6 +53,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 			if err != nil {
 				c.Fatal(err)
 			}
+			defer out.Close()
 
 			if err := cmd.Start(); err != nil {
 				c.Fatal(err)


### PR DESCRIPTION
It should close pipe after using pipe in test case.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
