### PR TITLE
fix validation of non-existing bind-mount source

### DIFF
--- a/daemon/cluster/executor/container/validate.go
+++ b/daemon/cluster/executor/container/validate.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/docker/swarmkit/api"
@@ -22,6 +23,9 @@ func validateMounts(mounts []api.Mount) error {
 		case api.MountTypeBind:
 			if !filepath.IsAbs(mount.Source) {
 				return fmt.Errorf("invalid bind mount source, must be an absolute path: %s", mount.Source)
+			}
+			if _, err := os.Stat(mount.Source); os.IsNotExist(err) {
+				return fmt.Errorf("invalid bind mount source, source path not found: %s", mount.Source)
 			}
 		case api.MountTypeVolume:
 			if filepath.IsAbs(mount.Source) {


### PR DESCRIPTION
Unlike `docker run -v..`, `docker service create --mount` does not allow bind-mounting non-existing host paths.

This adds validation for the specified `source`, and produces an error if the path is not found on the host.

fixes https://github.com/docker/docker/issues/25484
