### PR TITLE
update go-units vendor to newest version

### DIFF
--- a/VENDORING.md
+++ b/VENDORING.md
@@ -20,7 +20,7 @@ Each repo should:
 github releases file.
 
 The goal here is for consuming repos to be able to use the tag version and
-changelog updates to determine whether the vendoring will cause any  breaking or
+changelog updates to determine whether the vendoring will cause any breaking or
 backward incompatible changes. This also means that repos can specify having
 dependency on a package of a specific version or greater up to the next major
 release, without encountering breaking changes.

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -119,7 +119,7 @@ You can also filter for a substring in a name as this shows:
 $ docker ps --filter "name=nostalgic"
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-715ebfcee040        busybox             "top"               3 seconds ago       Up 1 seconds                            i_am_nostalgic
+715ebfcee040        busybox             "top"               3 seconds ago       Up 1 second                             i_am_nostalgic
 9b6247364a03        busybox             "top"               7 minutes ago       Up 7 minutes                            nostalgic_stallman
 673394ef1d4c        busybox             "top"               38 minutes ago      Up 38 minutes                           nostalgic_shockley
 ```

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -58,7 +58,7 @@ clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
-clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
+clone git github.com/docker/go-units eb879ae3e2b84e2a142af415b679ddeda47ec71c
 clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
 
 clone git github.com/docker/engine-api 603ec41824c63d1e6498a22271987fa1f268c0c0

--- a/vendor/src/github.com/docker/go-units/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/go-units/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to go-units
+
+Want to hack on go-units? Awesome! Here are instructions to get you started.
+
+go-units is a part of the [Docker](https://www.docker.com) project, and follows
+the same rules and principles. If you're already familiar with the way
+Docker does things, you'll feel right at home.
+
+Otherwise, go read Docker's
+[contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md),
+[issue triaging](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md),
+[review process](https://github.com/docker/docker/blob/master/project/REVIEWING.md) and
+[branches and tags](https://github.com/docker/docker/blob/master/project/BRANCHES-AND-TAGS.md).
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/vendor/src/github.com/docker/go-units/MAINTAINERS
+++ b/vendor/src/github.com/docker/go-units/MAINTAINERS
@@ -1,0 +1,27 @@
+# go-connections maintainers file
+#
+# This file describes who runs the docker/go-connections project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"calavera",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+	[people.calavera]
+	Name = "David Calavera"
+	Email = "david.calavera@gmail.com"
+	GitHub = "calavera"

--- a/vendor/src/github.com/docker/go-units/README.md
+++ b/vendor/src/github.com/docker/go-units/README.md
@@ -8,6 +8,9 @@ go-units is a library to transform human friendly measurements into machine frie
 
 See the [docs in godoc](https://godoc.org/github.com/docker/go-units) for examples and documentation.
 
-## License
+## Copyright and license
 
-go-units is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full license text.
+Copyright © 2015 Docker, Inc.
+
+go-units is licensed under the Apache License, Version 2.0.
+See [LICENSE](LICENSE) for the full text of the license.

--- a/vendor/src/github.com/docker/go-units/duration.go
+++ b/vendor/src/github.com/docker/go-units/duration.go
@@ -12,6 +12,8 @@ import (
 func HumanDuration(d time.Duration) string {
 	if seconds := int(d.Seconds()); seconds < 1 {
 		return "Less than a second"
+	} else if seconds == 1 {
+		return "1 second"
 	} else if seconds < 60 {
 		return fmt.Sprintf("%d seconds", seconds)
 	} else if minutes := int(d.Minutes()); minutes == 1 {

--- a/vendor/src/github.com/docker/go-units/size.go
+++ b/vendor/src/github.com/docker/go-units/size.go
@@ -31,7 +31,7 @@ type unitMap map[string]int64
 var (
 	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
 	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
-	sizeRegex  = regexp.MustCompile(`^(\d+)([kKmMgGtTpP])?[bB]?$`)
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
 )
 
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
@@ -41,7 +41,8 @@ var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB",
 // using custom format.
 func CustomSize(format string, size float64, base float64, _map []string) string {
 	i := 0
-	for size >= base {
+	unitsLimit := len(_map) - 1
+	for size >= base && i < unitsLimit {
 		size = size / base
 		i++
 	}
@@ -77,19 +78,19 @@ func RAMInBytes(size string) (int64, error) {
 // Parses the human-readable size string into the amount it represents.
 func parseSize(sizeStr string, uMap unitMap) (int64, error) {
 	matches := sizeRegex.FindStringSubmatch(sizeStr)
-	if len(matches) != 3 {
+	if len(matches) != 4 {
 		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
 	}
 
-	size, err := strconv.ParseInt(matches[1], 10, 0)
+	size, err := strconv.ParseFloat(matches[1], 64)
 	if err != nil {
 		return -1, err
 	}
 
-	unitPrefix := strings.ToLower(matches[2])
+	unitPrefix := strings.ToLower(matches[3])
 	if mul, ok := uMap[unitPrefix]; ok {
-		size *= mul
+		size *= float64(mul)
 	}
 
-	return size, nil
+	return int64(size), nil
 }

--- a/vendor/src/github.com/docker/go-units/ulimit.go
+++ b/vendor/src/github.com/docker/go-units/ulimit.go
@@ -73,25 +73,34 @@ func ParseUlimit(val string) (*Ulimit, error) {
 		return nil, fmt.Errorf("invalid ulimit type: %s", parts[0])
 	}
 
-	limitVals := strings.SplitN(parts[1], ":", 2)
-	if len(limitVals) > 2 {
+	var (
+		soft int64
+		hard = &soft // default to soft in case no hard was set
+		temp int64
+		err  error
+	)
+	switch limitVals := strings.Split(parts[1], ":"); len(limitVals) {
+	case 2:
+		temp, err = strconv.ParseInt(limitVals[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		hard = &temp
+		fallthrough
+	case 1:
+		soft, err = strconv.ParseInt(limitVals[0], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	default:
 		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
 	}
 
-	soft, err := strconv.ParseInt(limitVals[0], 10, 64)
-	if err != nil {
-		return nil, err
+	if soft > *hard {
+		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
 	}
 
-	hard := soft // in case no hard was set
-	if len(limitVals) == 2 {
-		hard, err = strconv.ParseInt(limitVals[1], 10, 64)
-	}
-	if soft > hard {
-		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, hard)
-	}
-
-	return &Ulimit{Name: parts[0], Soft: soft, Hard: hard}, nil
+	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil
 }
 
 // GetRlimit returns the RLimit corresponding to Ulimit.


### PR DESCRIPTION
Hi, All, 

Here is my command display:

```
root@ubuntu:/var/lib/docker/network/files# docker service ps 7r
ID                         NAME                     IMAGE                          NODE    DESIRED STATE  CURRENT STATE                 ERROR
cn7c2iw54uvtja71qbuecqn9v  sleepy_montalcini.1      daocloud.io/daocloud/dao-2048  ubuntu  Running        Running 2 minutes ago
afh1u62mztc3bwdms0ez1nymj  sleepy_montalcini.2      daocloud.io/daocloud/dao-2048  ubuntu  Running        Running 57 seconds ago
8jq3hgz9jrs7k5clco2hst13x  sleepy_montalcini.3      daocloud.io/daocloud/dao-2048  ubuntu  Ready          Ready less than a second ago
b39454u00dihd1iiyy2ao8p71   \_ sleepy_montalcini.3  daocloud.io/daocloud/dao-2048  ubuntu  Shutdown       Failed 1 seconds ago          "starting container failed: fa…"
```

I found that in the task `b39454u00dihd1iiyy2ao8p71`'s current state, it shows `1 seconds ago` which seems a plural mistake.

This PR did:
1. fix plural display mistake in go-units(https://github.com/docker/go-units/pull/18)
2. remove one more space in VENDORING.md
3. update one doc to use `1 second` instead of `1 seconds`
