### PR TITLE
Changed SignalProcess to use new hcsshim API

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -324,7 +324,7 @@ func (clnt *client) SignalProcess(containerID string, processFriendlyName string
 
 	for _, p := range cont.processes {
 		if p.friendlyName == processFriendlyName {
-			return hcsshim.TerminateProcessInComputeSystem(containerID, p.systemPid)
+			return p.hcsProcess.Kill()
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Changed SignalProcess to no longer use the deprecated hcsshim TerminateProcessInContainer API.

This was merged into a bump branch for a previous release, and hence missed my PR changing all the calls to hcsshim to use the new API. The currently called API is deprecated.

Signed-off-by: Darren Stahl darst@microsoft.com
