### PR TITLE
fix overlay network example

### DIFF
--- a/docs/swarm/services.md
+++ b/docs/swarm/services.md
@@ -204,7 +204,7 @@ the overlay network:
 ```bash
 $ docker service create \
   --replicas 3 \
-  --network my-multi-host-network \
+  --network my-network \
   --name my-web \
   nginx
 


### PR DESCRIPTION
**\- What I did**
updates services.md to fix the network name in the example
Signed-off-by: Charles Smith charles.smith@docker.com
