### PR TITLE
Update go-patricia to 2.2.5

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -53,7 +53,7 @@ clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 5cf931ef8f
 clone git github.com/mattn/go-shellwords v1.0.0
 clone git github.com/mattn/go-sqlite3 v1.1.0
-clone git github.com/tchap/go-patricia v2.2.4
+clone git github.com/tchap/go-patricia v2.2.5
 clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git

--- a/vendor/src/github.com/tchap/go-patricia/patricia/children.go
+++ b/vendor/src/github.com/tchap/go-patricia/patricia/children.go
@@ -70,9 +70,8 @@ func (list *sparseChildList) add(child *Trie) childList {
 func (list *sparseChildList) remove(b byte) {
 	for i, node := range list.children {
 		if node.prefix[0] == b {
-			list.children, list.children[len(list.children)-1] =
-				append(list.children[:i], list.children[i+1:]...),
-				nil
+			copy(list.children[i:], list.children[i+1:])
+			list.children = list.children[:len(list.children)-1]
 			return
 		}
 	}


### PR DESCRIPTION
Fixes an issue that showed up on gccgo and hence s390x.

Fix #25360

Signed-off-by: Justin Cormack justin.cormack@docker.com

cc @michael-holzheu

![rhino](https://cloud.githubusercontent.com/assets/482364/17497074/f60249ac-5db7-11e6-9509-8ed1e45a9572.jpg)
