### PR TITLE
better vendor.sh to break when fail in grep

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -19,7 +19,12 @@ case $# in
 	;;
 # If user passed arguments to the script
 1)
-	eval "$(grep -E "^clone [^ ]+ $1" "$0")"
+	path="$PWD/hack/vendor.sh"
+	if ! cloneGrep="$(grep -E "^clone [^ ]+ $1" "$path")"; then
+		echo >&2 "error: failed to find 'clone ... $1' in $path"
+		exit 1
+	fi
+	eval "$cloneGrep"
 	clean
 	exit 0
 	;;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
fixed #25520

this pr did:
1. exit when grep fails
2. make this script work in most workdir

Signed-off-by: allencloud allen.sun@daocloud.io
