### PR TITLE
Add MountFlags=shared in systemd

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,6 +11,7 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
+MountFlags=shared
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
https://github.com/docker/docker/pull/22806 removed MountFlags in order to use `shared` as default value for systemd.

However via https://github.com/docker/docker/issues/25474 default MountFlags is `0` (maybe only in CentOS/7). 
It causes a problem that when using `df -h` or `statvfs()`, the command will failed since the docker volumes are mounted in `/etc/mtab` and can't be accessed without root permission. 

Especially this will cause a monitoring alert when using the tools such as `sensu`.

| docker.service file | systemctl show docker |
| :-: | :-: |
| No MountFlags | MountFlags=0 |
| MountFlags=shared | MountFlags=1048576 |
| MountFlags=slave | MountFlags=524288 |
| MountFlags=private | MountFlags=262144 |
