### PR TITLE
fix plugins restart on docker restart

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -35,7 +35,7 @@ func (pm *Manager) Enable(name string) error {
 	if err != nil {
 		return err
 	}
-	if err := pm.enable(p); err != nil {
+	if err := pm.enable(p, false); err != nil {
 		return err
 	}
 	pm.pluginEventLogger(p.PluginObj.ID, name, "enable")

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -321,7 +321,7 @@ func (pm *Manager) init() error {
 
 			if requiresManualRestore {
 				// if liveRestore is not enabled, the plugin will be stopped now so we should enable it
-				if err := pm.enable(p); err != nil {
+				if err := pm.enable(p, true); err != nil {
 					logrus.Errorf("failed to enable plugin '%s': %s", p.Name(), err)
 				}
 			}

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -20,8 +20,8 @@ import (
 	"github.com/opencontainers/specs/specs-go"
 )
 
-func (pm *Manager) enable(p *plugin) error {
-	if p.PluginObj.Active {
+func (pm *Manager) enable(p *plugin, force bool) error {
+	if p.PluginObj.Active && !force {
 		return fmt.Errorf("plugin %s is already enabled", p.Name())
 	}
 	spec, err := pm.initSpec(p)

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -8,7 +8,7 @@ import (
 	"github.com/opencontainers/specs/specs-go"
 )
 
-func (pm *Manager) enable(p *plugin) error {
+func (pm *Manager) enable(p *plugin, force bool) error {
 	return fmt.Errorf("Not implemented")
 }
 


### PR DESCRIPTION
**\- What I did**

Installed a plugin, restarted docker a check if the plugin was running

**\- How I did it**

```
docker plugin install vieux/sshfs
sudo service docker restart
sudo docker-runc list
```

`p.PluginObj.Active` represent the desired state, not the actual state. so when docker is starting and the desired state is `Active` we need to force enable it.

**\- Description for the changelog**
fix plugins restart on docker restart

**\- A picture of a cute animal (not mandatory but encouraged)**
![maxresdefault](https://cloud.githubusercontent.com/assets/1032519/17534464/248cecb0-5e3e-11e6-96a2-9a8a354b96f8.jpg)

ping @tiborvass @anusha-ragunathan 
