### PR TITLE
Return `application/json` for image/load API (quiet=1)

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -201,17 +201,14 @@ func (s *imageRouter) postImagesLoad(ctx context.Context, w http.ResponseWriter,
 	}
 	quiet := httputils.BoolValueOrDefault(r, "quiet", true)
 
-	if !quiet {
-		w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
 
-		output := ioutils.NewWriteFlusher(w)
-		defer output.Close()
-		if err := s.backend.LoadImage(r.Body, output, quiet); err != nil {
-			output.Write(streamformatter.NewJSONStreamFormatter().FormatError(err))
-		}
-		return nil
+	output := ioutils.NewWriteFlusher(w)
+	defer output.Close()
+	if err := s.backend.LoadImage(r.Body, output, quiet); err != nil {
+		output.Write(streamformatter.NewJSONStreamFormatter().FormatError(err))
 	}
-	return s.backend.LoadImage(r.Body, w, quiet)
+	return nil
 }
 
 func (s *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -30,8 +30,8 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 	)
 	if !quiet {
 		progressOutput = sf.NewProgressOutput(outStream, false)
-		outStream = &streamformatter.StdoutFormatter{Writer: outStream, StreamFormatter: streamformatter.NewJSONStreamFormatter()}
 	}
+	outStream = &streamformatter.StdoutFormatter{Writer: outStream, StreamFormatter: streamformatter.NewJSONStreamFormatter()}
 
 	tmpDir, err := ioutil.TempDir("", "docker-import-")
 	if err != nil {


### PR DESCRIPTION
**\- What I did**
This fix tries to address the issue raised in #25529 where the image/load API returns `application/json` for quiet=0 and `text/plain` for quite=1.

**\- How I did it**

This fix makes the change so that `application/json` is returned for both quiet=0 and quite=1.

**\- How to verify it**
This fix has been tested manually. In addition, old docker client has been tested to make sure the output is OK.

```
ubuntu@ubuntu:~/tmp$  curl -i --request POST  "http://127.0.0.1:2375/v1.25/images/load?quiet=0"  -H "Content-Type: application/x-tar" --data-binary @busybox.tar
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Content-Type: application/json
Server: Docker/1.13.0-dev (linux)
Date: Wed, 10 Aug 2016 00:48:23 GMT
Transfer-Encoding: chunked

{"stream":"Loaded image: busybox:latest\n"}
ubuntu@ubuntu:~/tmp$ curl -i --request POST  "http://127.0.0.1:2375/v1.25/images/load?quiet=1"  -H "Content-Type: application/x-tar" --data-binary @busybox.tar
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Content-Type: application/json
Server: Docker/1.13.0-dev (linux)
Date: Wed, 10 Aug 2016 00:48:44 GMT
Transfer-Encoding: chunked

{"stream":"Loaded image: busybox:latest\n"}
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.7.0 load < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.8.0 load < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.9.0 load < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.10.0 load < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.11.0/docker load < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.11.0/docker load -q < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.12.0/docker load < busybox.tar
Loaded image: busybox:latest
ubuntu@ubuntu:~/tmp$ sudo ./docker.1.12.0/docker load -q < busybox.tar
Loaded image: busybox:latest
```

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25529.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
