### PR TITLE
make more pkgs support darwin

### DIFF
--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -13,7 +13,7 @@ func Self() string {
 	return "/proc/self/exe"
 }
 
-// Command returns *exec.Cmd which have Path as current binary. Also it setting
+// Command returns *exec.Cmd which has Path as current binary. Also it setting
 // SysProcAttr.Pdeathsig to SIGTERM.
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).

--- a/pkg/reexec/command_unix.go
+++ b/pkg/reexec/command_unix.go
@@ -1,4 +1,4 @@
-// +build freebsd solaris
+// +build freebsd solaris darwin
 
 package reexec
 
@@ -12,7 +12,7 @@ func Self() string {
 	return naiveSelf()
 }
 
-// Command returns *exec.Cmd which have Path as current binary.
+// Command returns *exec.Cmd which has Path as current binary.
 // For example if current binary is "docker" at "/usr/bin/", then cmd.Path will
 // be set to "/usr/bin/docker".
 func Command(args ...string) *exec.Cmd {

--- a/pkg/reexec/command_unsupported.go
+++ b/pkg/reexec/command_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows,!freebsd,!solaris
+// +build !linux,!windows,!freebsd,!solaris,!darwin
 
 package reexec
 
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 )
 
-// Command is unsupported on operating systems apart from Linux and Windows.
+// Command is unsupported on operating systems apart from Linux, Windows, Solaris and Darwin.
 func Command(args ...string) *exec.Cmd {
 	return nil
 }

--- a/pkg/reexec/command_windows.go
+++ b/pkg/reexec/command_windows.go
@@ -12,7 +12,7 @@ func Self() string {
 	return naiveSelf()
 }
 
-// Command returns *exec.Cmd which have Path as current binary.
+// Command returns *exec.Cmd which has Path as current binary.
 // For example if current binary is "docker.exe" at "C:\", then cmd.Path will
 // be set to "C:\docker.exe".
 func Command(args ...string) *exec.Cmd {

--- a/pkg/sysinfo/sysinfo_freebsd.go
+++ b/pkg/sysinfo/sysinfo_freebsd.go
@@ -1,7 +1,0 @@
-package sysinfo
-
-// New returns an empty SysInfo for freebsd for now.
-func New(quiet bool) *SysInfo {
-	sysInfo := &SysInfo{}
-	return sysInfo
-}

--- a/pkg/sysinfo/sysinfo_unix.go
+++ b/pkg/sysinfo/sysinfo_unix.go
@@ -1,0 +1,9 @@
+// +build !linux,!solaris,!windows
+
+package sysinfo
+
+// New returns an empty SysInfo for non linux nor solaris for now.
+func New(quiet bool) *SysInfo {
+	sysInfo := &SysInfo{}
+	return sysInfo
+}

--- a/pkg/sysinfo/sysinfo_windows.go
+++ b/pkg/sysinfo/sysinfo_windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package sysinfo
 
 // New returns an empty SysInfo for windows for now.

--- a/pkg/system/utimes_darwin.go
+++ b/pkg/system/utimes_darwin.go
@@ -1,8 +1,0 @@
-package system
-
-import "syscall"
-
-// LUtimesNano is not supported by darwin platform.
-func LUtimesNano(path string, ts []syscall.Timespec) error {
-	return ErrNotSupportedPlatform
-}

--- a/pkg/system/utimes_unsupported.go
+++ b/pkg/system/utimes_unsupported.go
@@ -1,10 +1,10 @@
-// +build !linux,!freebsd,!darwin
+// +build !linux,!freebsd
 
 package system
 
 import "syscall"
 
-// LUtimesNano is not supported on platforms other than linux, freebsd and darwin.
+// LUtimesNano is only supported on linux and freebsd.
 func LUtimesNano(path string, ts []syscall.Timespec) error {
 	return ErrNotSupportedPlatform
 }

--- a/pkg/term/term.go
+++ b/pkg/term/term.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Package term provides provides structures and helper functions to work with
+// Package term provides structures and helper functions to work with
 // terminal (state, sizes).
 package term
 


### PR DESCRIPTION
make more pkgs in docker support darwin and make them better

What I did:
1. make pkg/sysinfo support more unix including darwin
2. simplify utimes_unsupported
3. make pkg/reexec support darwin
4. fix some typos

Signed-off-by: allencloud allen.sun@daocloud.io
