### PR TITLE
test container state timeout with 200 milliseconds

### DIFF
--- a/container/state_test.go
+++ b/container/state_test.go
@@ -65,7 +65,7 @@ func TestStateTimeoutWait(t *testing.T) {
 	}()
 	select {
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("Stop callback doesn't fire in 100 milliseconds")
+		t.Fatal("Stop callback doesn't fire in 200 milliseconds")
 	case <-stopped:
 		t.Log("Stop callback fired")
 	}


### PR DESCRIPTION
It tests 200 milliseconds timeout, so fatal info should be 200.
