### PR TITLE
Fix inspect network show gateway with mask

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -240,7 +240,7 @@ func buildIpamResources(r *types.NetworkResource, nwInfo libnetwork.NetworkInfo)
 		for _, ip4Info := range ipv4Info {
 			iData := network.IPAMConfig{}
 			iData.Subnet = ip4Info.IPAMData.Pool.String()
-			iData.Gateway = ip4Info.IPAMData.Gateway.String()
+			iData.Gateway = ip4Info.IPAMData.Gateway.IP.String()
 			r.IPAM.Config = append(r.IPAM.Config, iData)
 		}
 	}

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3115,7 +3115,7 @@ Content-Type: application/json
     "Config": [
       {
         "Subnet": "172.19.0.0/16",
-        "Gateway": "172.19.0.1/16"
+        "Gateway": "172.19.0.1"
       }
     ],
     "Options": {

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3115,7 +3115,7 @@ Content-Type: application/json
     "Config": [
       {
         "Subnet": "172.19.0.0/16",
-        "Gateway": "172.19.0.1/16"
+        "Gateway": "172.19.0.1"
       }
     ],
     "Options": {

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -102,7 +102,7 @@ $ docker network inspect simple-network
             "Config": [
                 {
                     "Subnet": "172.22.0.0/16",
-                    "Gateway": "172.22.0.1/16"
+                    "Gateway": "172.22.0.1"
                 }
             ]
         },

--- a/docs/tutorials/networkingcontainers.md
+++ b/docs/tutorials/networkingcontainers.md
@@ -183,7 +183,7 @@ If you inspect the network, you'll find that it has nothing in it.
                 "Config": [
                     {
                         "Subnet": "172.18.0.0/16",
-                        "Gateway": "172.18.0.1/16"
+                        "Gateway": "172.18.0.1"
                     }
                 ]
             },

--- a/docs/userguide/networking/dockernetworks.md
+++ b/docs/userguide/networking/dockernetworks.md
@@ -333,7 +333,7 @@ $ docker network inspect isolated_nw
             "Config": [
                 {
                     "Subnet": "172.21.0.0/16",
-                    "Gateway": "172.21.0.1/16"
+                    "Gateway": "172.21.0.1"
                 }
             ]
         },

--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -57,7 +57,7 @@ $ docker network inspect simple-network
             "Config": [
                 {
                     "Subnet": "172.22.0.0/16",
-                    "Gateway": "172.22.0.1/16"
+                    "Gateway": "172.22.0.1"
                 }
             ]
         },
@@ -153,7 +153,7 @@ $ docker network inspect my-network
             "Config": [
                 {
                     "Subnet": "172.23.0.0/16",
-                    "Gateway": "172.23.0.1/16"
+                    "Gateway": "172.23.0.1"
                 }
             ]
         },
@@ -223,7 +223,7 @@ $ docker network inspect isolated_nw
             "Config": [
                 {
                     "Subnet": "172.25.0.0/16",
-                    "Gateway": "172.25.0.1/16"
+                    "Gateway": "172.25.0.1"
                 }
             ]
         },
@@ -784,7 +784,7 @@ $ docker network inspect isolated_nw
             "Config": [
                 {
                     "Subnet": "172.21.0.0/16",
-                    "Gateway": "172.21.0.1/16"
+                    "Gateway": "172.21.0.1"
                 }
             ]
         },
@@ -895,7 +895,7 @@ docker network inspect isolated_nw
             "Config": [
                 {
                     "Subnet": "172.21.0.0/16",
-                    "Gateway": "172.21.0.1/16"
+                    "Gateway": "172.21.0.1"
                 }
             ]
         },

--- a/man/docker-network-inspect.1.md
+++ b/man/docker-network-inspect.1.md
@@ -91,7 +91,7 @@ $ docker network inspect simple-network
             "Config": [
                 {
                     "Subnet": "172.22.0.0/16",
-                    "Gateway": "172.22.0.1/16"
+                    "Gateway": "172.22.0.1"
                 }
             ]
         },


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fix inspect network show gateway with mask
the gateway supposed to be a ip only
When `docker network inspect` a network, the `Gateway` will has a mask 

```
 "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "172.18.0.0/16",
                    "Gateway": "172.18.0.1/16"
                }
            ]
        },

```

and then we restart the daemon and `docker network inspect` again, it's changed, the suffix mask gone

```
"IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "172.18.0.0/16",
                    "Gateway": "172.18.0.1"
                }
            ]
        },

```

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Lei Jitang leijitang@huawei.com
