### PR TITLE
fix config load error with default ulimits

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -45,6 +45,7 @@ var flatOptions = map[string]bool{
 	"cluster-store-opts": true,
 	"log-opts":           true,
 	"runtimes":           true,
+	"default-ulimits":    true,
 }
 
 // LogConfig represents the default log configuration.

--- a/daemon/config_test.go
+++ b/daemon/config_test.go
@@ -11,41 +11,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func TestDaemonConfigurationMerge(t *testing.T) {
-	f, err := ioutil.TempFile("", "docker-config-")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	configFile := f.Name()
-	f.Write([]byte(`{"debug": true}`))
-	f.Close()
-
-	c := &Config{
-		CommonConfig: CommonConfig{
-			AutoRestart: true,
-			LogConfig: LogConfig{
-				Type:   "syslog",
-				Config: map[string]string{"tag": "test"},
-			},
-		},
-	}
-
-	cc, err := MergeDaemonConfigurations(c, nil, configFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cc.Debug {
-		t.Fatalf("expected %v, got %v\n", true, cc.Debug)
-	}
-	if !cc.AutoRestart {
-		t.Fatalf("expected %v, got %v\n", true, cc.AutoRestart)
-	}
-	if cc.LogConfig.Type != "syslog" {
-		t.Fatalf("expected syslog config, got %q\n", cc.LogConfig)
-	}
-}
-
 func TestDaemonConfigurationNotFound(t *testing.T) {
 	_, err := MergeDaemonConfigurations(&Config{}, nil, "/tmp/foo-bar-baz-docker")
 	if err == nil || !os.IsNotExist(err) {

--- a/daemon/config_unix_test.go
+++ b/daemon/config_unix_test.go
@@ -1,0 +1,80 @@
+// +build !windows
+
+package daemon
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestDaemonConfigurationMerge(t *testing.T) {
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+
+	f.Write([]byte(`
+		{
+			"debug": true,
+			"default-ulimits": {
+				"nofile": {
+					"Name": "nofile",
+					"Hard": 2048,
+					"Soft": 1024
+				}
+			},
+			"log-opts": {
+				"tag": "test_tag"
+			}
+		}`))
+
+	f.Close()
+
+	c := &Config{
+		CommonConfig: CommonConfig{
+			AutoRestart: true,
+			LogConfig: LogConfig{
+				Type:   "syslog",
+				Config: map[string]string{"tag": "test"},
+			},
+		},
+	}
+
+	cc, err := MergeDaemonConfigurations(c, nil, configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cc.Debug {
+		t.Fatalf("expected %v, got %v\n", true, cc.Debug)
+	}
+	if !cc.AutoRestart {
+		t.Fatalf("expected %v, got %v\n", true, cc.AutoRestart)
+	}
+	if cc.LogConfig.Type != "syslog" {
+		t.Fatalf("expected syslog config, got %q\n", cc.LogConfig)
+	}
+
+	if configValue, OK := cc.LogConfig.Config["tag"]; !OK {
+		t.Fatal("expected syslog config attributes, got nil\n")
+	} else {
+		if configValue != "test_tag" {
+			t.Fatalf("expected syslog config attributes 'tag=test_tag', got 'tag=%s'\n", configValue)
+		}
+	}
+
+	if cc.Ulimits == nil {
+		t.Fatal("expected default ulimit config, got nil\n")
+	} else {
+		if _, OK := cc.Ulimits["nofile"]; OK {
+			if cc.Ulimits["nofile"].Name != "nofile" ||
+				cc.Ulimits["nofile"].Hard != 2048 ||
+				cc.Ulimits["nofile"].Soft != 1024 {
+				t.Fatalf("expected default ulimit name, hard and soft are nofile, 2048, 1024, got %s, %d, %d\n", cc.Ulimits["nofile"].Name, cc.Ulimits["nofile"].Hard, cc.Ulimits["nofile"].Soft)
+			}
+		} else {
+			t.Fatal("expected default ulimit name nofile, got nil\n")
+		}
+	}
+}

--- a/daemon/config_windows_test.go
+++ b/daemon/config_windows_test.go
@@ -1,0 +1,59 @@
+// +build windows
+
+package daemon
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestDaemonConfigurationMerge(t *testing.T) {
+	f, err := ioutil.TempFile("", "docker-config-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := f.Name()
+
+	f.Write([]byte(`
+		{
+			"debug": true,
+			"log-opts": {
+				"tag": "test_tag"
+			}
+		}`))
+
+	f.Close()
+
+	c := &Config{
+		CommonConfig: CommonConfig{
+			AutoRestart: true,
+			LogConfig: LogConfig{
+				Type:   "syslog",
+				Config: map[string]string{"tag": "test"},
+			},
+		},
+	}
+
+	cc, err := MergeDaemonConfigurations(c, nil, configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cc.Debug {
+		t.Fatalf("expected %v, got %v\n", true, cc.Debug)
+	}
+	if !cc.AutoRestart {
+		t.Fatalf("expected %v, got %v\n", true, cc.AutoRestart)
+	}
+	if cc.LogConfig.Type != "syslog" {
+		t.Fatalf("expected syslog config, got %q\n", cc.LogConfig)
+	}
+
+	if configValue, OK := cc.LogConfig.Config["tag"]; !OK {
+		t.Fatal("expected syslog config attributes, got nil\n")
+	} else {
+		if configValue != "test_tag" {
+			t.Fatalf("expected syslog config attributes 'tag=test_tag', got 'tag=%s'\n", configValue)
+		}
+	}
+}


### PR DESCRIPTION
fixes #25560 and #22309

There is one problem in each issue above:
1. `default-ulimits` may have a recursive map structures

**\- How I did it**:
1. in `flatOptions`, add `default-ulimits`
2. add unit test to cover this.

**\- How to verify it**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
