### PR TITLE
Gate name_to_handle_at by CAP_SYS_ADMIN not CAP_DAC_READ_SEARCH

### DIFF
--- a/profiles/seccomp/seccomp_default.go
+++ b/profiles/seccomp/seccomp_default.go
@@ -1668,11 +1668,6 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 		case "CAP_DAC_READ_SEARCH":
 			syscalls = append(syscalls, []*types.Syscall{
 				{
-					Name:   "name_to_handle_at",
-					Action: types.ActAllow,
-					Args:   []*types.Arg{},
-				},
-				{
 					Name:   "open_by_handle_at",
 					Action: types.ActAllow,
 					Args:   []*types.Arg{},
@@ -1703,6 +1698,11 @@ func DefaultProfile(rs *specs.Spec) *types.Seccomp {
 				},
 				{
 					Name:   "mount",
+					Action: types.ActAllow,
+					Args:   []*types.Arg{},
+				},
+				{
+					Name:   "name_to_handle_at",
 					Action: types.ActAllow,
 					Args:   []*types.Arg{},
 				},


### PR DESCRIPTION
Only open_by_handle_at requires CAP_DAC_READ_SEARCH.

This allows systemd to run with only `--cap-add SYS_ADMIN`
rather than having to also add `--cap-add DAC_READ_SEARCH`
as well which it does not really need.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![linux-attack-100528169-gallery](https://cloud.githubusercontent.com/assets/482364/17552118/d63d5280-5ef5-11e6-984b-9c501d2342f2.jpg)
