### PR TITLE
Force input stream ANSI emulation for ConEmu.

### DIFF
--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -73,6 +73,7 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 
 	if os.Getenv("ConEmuANSI") == "ON" {
 		// The ConEmu terminal emulates ANSI on output streams well.
+		emulateStdin = true
 		emulateStdout = false
 		emulateStderr = false
 	}


### PR DESCRIPTION
Forces input stream ANSI emulation for ConEmu so arrow keys etc are read on docker run commands

Fixes #25475

![alt text](http://i.imgur.com/50QN6dO.jpg kitten)

Signed-off-by: Ron Williams ron.a.williams@gmail.com
