### PR TITLE
Make `docker pull` detect plugin content and error out.

### DIFF
--- a/plugin/distribution/pull.go
+++ b/plugin/distribution/pull.go
@@ -143,7 +143,7 @@ func Pull(name string, rs registry.Service, metaheader http.Header, authConfig *
 		logrus.Debugf("pull.go: error in json.Unmarshal(): %v", err)
 		return nil, err
 	}
-	if m.Config.MediaType != MediaTypeConfig {
+	if m.Config.MediaType != schema2.MediaTypePluginConfig {
 		return nil, ErrUnsupportedMediaType
 	}
 

--- a/plugin/distribution/push.go
+++ b/plugin/distribution/push.go
@@ -79,9 +79,9 @@ func Push(name string, rs registry.Service, metaHeader http.Header, authConfig *
 			return "", err
 		}
 		f.Close()
-		mt := MediaTypeLayer
+		mt := schema2.MediaTypeLayer
 		if i == 0 {
-			mt = MediaTypeConfig
+			mt = schema2.MediaTypePluginConfig
 		}
 		// Commit completes the write process to the BlobService.
 		// The descriptor arg to Commit is called the "provisional" descriptor and

--- a/plugin/distribution/types.go
+++ b/plugin/distribution/types.go
@@ -10,10 +10,5 @@ var ErrUnsupportedRegistry = errors.New("only V2 repositories are supported for 
 // ErrUnsupportedMediaType indicates we are pulling content that's not a plugin
 var ErrUnsupportedMediaType = errors.New("content is not a plugin")
 
-// Plugin related media types
-const (
-	MediaTypeManifest = "application/vnd.docker.distribution.manifest.v2+json"
-	MediaTypeConfig   = "application/vnd.docker.plugin.v0+json"
-	MediaTypeLayer    = "application/vnd.docker.image.rootfs.diff.tar.gzip"
-	DefaultTag        = "latest"
-)
+// DefaultTag is the default tag for plugins
+const DefaultTag = "latest"


### PR DESCRIPTION
**\- What I did**
Make `docker pull` detect plugin mediatype and error out.
In this process, also add the plugin media type to distribution package.

**\- How I did it**
Detect using manifest config's mediatype.

**\- How to verify it**
docker pull tiborvass/no-remove fails; before this change it panics. 

Signed-off-by: Anusha Ragunathan anusha@docker.com

Fixes #23752
