### PR TITLE
Ignore socket rm errors on daemon suite teardown

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/cliconfig"
-	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/engine-api/types/swarm"
 	"github.com/go-check/check"
@@ -189,18 +188,18 @@ func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TearDownSuite(c *check.C) {
-	err := filepath.Walk(daemonSockRoot, func(path string, fi os.FileInfo, err error) error {
+	filepath.Walk(daemonSockRoot, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			// ignore errors here
+			// not cleaning up sockets is not really an error
+			return nil
 		}
 		if fi.Mode() == os.ModeSocket {
 			syscall.Unlink(path)
 		}
 		return nil
 	})
-	c.Assert(err, checker.IsNil, check.Commentf("error while cleaning up daemon sockets"))
-	err = os.RemoveAll(daemonSockRoot)
-	c.Assert(err, checker.IsNil, check.Commentf("could not cleanup daemon socket root"))
+	os.RemoveAll(daemonSockRoot)
 }
 
 const defaultSwarmPort = 2477


### PR DESCRIPTION
Errors here are not important and not really related to set success/failure.

This should fix windows CI: https://github.com/docker/docker/pull/25171#issuecomment-238965671
