### PR TITLE
Update docs so that log-opts takes map (`{}`) instead of `[]`

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1027,7 +1027,7 @@ This is a full example of the allowed configuration options on Linux:
 	"labels": [],
 	"live-restore": true,
 	"log-driver": "",
-	"log-opts": [],
+	"log-opts": {},
 	"mtu": 0,
 	"pidfile": "",
 	"graph": "",


### PR DESCRIPTION
This fix updates docs so that log-opts takes map (`{}`) instead of `[]`, as is defined in the impmenetation (`map[string]string`)

This fix fixes #22311.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
