### PR TITLE
Separate container struct access from container operations locking

### DIFF
--- a/container/monitor.go
+++ b/container/monitor.go
@@ -11,12 +11,7 @@ const (
 )
 
 // Reset puts a container into a state where it can be restarted again.
-func (container *Container) Reset(lock bool) {
-	if lock {
-		container.Lock()
-		defer container.Unlock()
-	}
-
+func (container *Container) Reset() {
 	if err := container.CloseStreams(); err != nil {
 		logrus.Errorf("%s: %s", container.ID, err)
 	}

--- a/container/state.go
+++ b/container/state.go
@@ -5,9 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/go-units"
+	"golang.org/x/net/context"
 )
 
 // State holds the current container state, and has methods to get and
@@ -180,6 +179,24 @@ func (s *State) IsRunning() bool {
 	return res
 }
 
+// IsDead returns whether the Dead flag is set. Dead is set when there was an error
+// during removal that halted the remove operation
+func (s *State) IsDead() bool {
+	s.Lock()
+	res := s.Dead
+	s.Unlock()
+	return res
+}
+
+// IsRemoving returns whether the RemovalInProgress flag is set.
+// RemovalInProgress is set while the container is being removed
+func (s *State) IsRemoving() bool {
+	s.Lock()
+	res := s.RemovalInProgress
+	s.Unlock()
+	return res
+}
+
 // GetPID holds the process id of a container.
 func (s *State) GetPID() int {
 	s.Lock()
@@ -259,7 +276,9 @@ func (s *State) SetRestarting(exitStatus *ExitStatus) {
 // know the error that occurred when container transits to another state
 // when inspecting it
 func (s *State) SetError(err error) {
+	s.Lock()
 	s.error = err.Error()
+	s.Unlock()
 }
 
 // IsPaused returns whether the container is paused or not.

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -9,7 +9,8 @@ func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
 		return nil, err
 	}
 
-	container.Lock()
-	defer container.Unlock()
+	// make sure the container isn't removed while we are working
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 	return container.RWLayer.Changes()
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/locker"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/registrar"
 	"github.com/docker/docker/pkg/signal"
@@ -100,6 +101,7 @@ type Daemon struct {
 	containerdRemote          libcontainerd.Remote
 	defaultIsolation          containertypes.Isolation // Default isolation mode on Windows
 	clusterProvider           cluster.Provider
+	opLock                    *locker.Locker // protect concurrent container operations
 }
 
 func (daemon *Daemon) restore() error {
@@ -613,6 +615,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 	d.nameIndex = registrar.NewRegistrar()
 	d.linkIndex = newLinkIndex()
 	d.containerdRemote = containerdRemote
+	d.opLock = locker.New()
 
 	go d.execCommandGC()
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -24,6 +24,9 @@ func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) 
 		return err
 	}
 
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
+
 	// Container state RemovalInProgress should be used to avoid races.
 	if inProgress := container.SetRemovalInProgress(); inProgress {
 		return nil

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/pkg/locker"
 	"github.com/docker/engine-api/types"
 	containertypes "github.com/docker/engine-api/types/container"
 )
@@ -19,6 +20,7 @@ func TestContainerDoubleDelete(t *testing.T) {
 	daemon := &Daemon{
 		repository: tmp,
 		root:       tmp,
+		opLock:     locker.New(),
 	}
 	daemon.containers = container.NewMemoryStore()
 

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -81,7 +81,10 @@ func (daemon *Daemon) killWithSignal(container *container.Container, sig int) er
 		return nil
 	}
 
-	if err := daemon.kill(container, sig); err != nil {
+	container.Unlock()
+	err := daemon.kill(container, sig)
+	container.Lock()
+	if err != nil {
 		err = fmt.Errorf("Cannot kill container %s: %s", container.ID, err)
 		// if container or process not exists, ignore the error
 		if strings.Contains(err.Error(), "container not found") ||

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -41,14 +41,16 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		c.Lock()
 		defer c.Unlock()
 		c.Wait()
-		c.Reset(false)
+		c.Reset()
 		c.SetStopped(platformConstructExitStatus(e))
 		attributes := map[string]string{
 			"exitCode": strconv.Itoa(int(e.ExitCode)),
 		}
 		daemon.updateHealthMonitor(c)
 		daemon.LogContainerEventWithAttributes(c, "die", attributes)
+		c.Unlock()
 		daemon.Cleanup(c)
+		c.Lock()
 		// FIXME: here is race condition between two RUN instructions in Dockerfile
 		// because they share same runconfig and change image. Must be fixed
 		// in builder/builder.go
@@ -59,7 +61,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 	case libcontainerd.StateRestart:
 		c.Lock()
 		defer c.Unlock()
-		c.Reset(false)
+		c.Reset()
 		c.RestartCount++
 		c.SetRestarting(platformConstructExitStatus(e))
 		attributes := map[string]string{
@@ -87,22 +89,25 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 			logrus.Warnf("Ignoring StateExitProcess for %v but no exec command found", e)
 		}
 	case libcontainerd.StateStart, libcontainerd.StateRestore:
-		// Container is already locked in this case
+		c.Lock()
+		defer c.Unlock()
 		c.SetRunning(int(e.Pid), e.State == libcontainerd.StateStart)
 		c.HasBeenManuallyStopped = false
 		if err := c.ToDisk(); err != nil {
-			c.Reset(false)
+			c.Reset()
 			return err
 		}
 		daemon.initHealthMonitor(c)
 		daemon.LogContainerEvent(c, "start")
 	case libcontainerd.StatePause:
-		// Container is already locked in this case
+		c.Lock()
+		defer c.Unlock()
 		c.Paused = true
 		daemon.updateHealthMonitor(c)
 		daemon.LogContainerEvent(c, "pause")
 	case libcontainerd.StateResume:
-		// Container is already locked in this case
+		c.Lock()
+		defer c.Unlock()
 		c.Paused = false
 		daemon.updateHealthMonitor(c)
 		daemon.LogContainerEvent(c, "unpause")
@@ -129,7 +134,7 @@ func (daemon *Daemon) AttachStreams(id string, iop libcontainerd.IOPipe) error {
 	} else {
 		s = c.StreamConfig
 		if err := daemon.StartLogging(c); err != nil {
-			c.Reset(false)
+			c.Reset()
 			return err
 		}
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -298,7 +298,9 @@ func (daemon *Daemon) UpdateContainerServiceConfig(containerName string, service
 		return err
 	}
 
+	container.Lock()
 	container.NetworkSettings.Service = serviceConfig
+	container.Unlock()
 	return nil
 }
 
@@ -310,6 +312,8 @@ func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName strin
 	if err != nil {
 		return err
 	}
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 	return daemon.ConnectToNetwork(container, networkName, endpointConfig)
 }
 
@@ -323,6 +327,8 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 		}
 		return err
 	}
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 	return daemon.DisconnectFromNetwork(container, network, force)
 }
 

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -23,6 +23,8 @@ func (daemon *Daemon) ContainerPause(name string) error {
 // containerPause pauses the container execution without stopping the process.
 // The execution can be resumed by calling containerUnpause.
 func (daemon *Daemon) containerPause(container *container.Container) error {
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 	container.Lock()
 	defer container.Unlock()
 

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -25,8 +25,6 @@ func (daemon *Daemon) ContainerPause(name string) error {
 func (daemon *Daemon) containerPause(container *container.Container) error {
 	daemon.opLock.Lock(container.ID)
 	defer daemon.opLock.Unlock(container.ID)
-	container.Lock()
-	defer container.Unlock()
 
 	// We cannot Pause the container which is not running
 	if !container.Running {

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -41,17 +41,21 @@ func (daemon *Daemon) containerRestart(container *container.Container, seconds i
 
 	// set AutoRemove flag to false before stop so the container won't be
 	// removed during restart process
+	container.Lock()
 	autoRemove := container.HostConfig.AutoRemove
-
 	container.HostConfig.AutoRemove = false
+	container.Unlock()
+
 	err := daemon.containerStop(container, seconds)
 	// restore AutoRemove irrespective of whether the stop worked or not
+	container.Lock()
 	container.HostConfig.AutoRemove = autoRemove
 	// containerStop will write HostConfig to disk, we shall restore AutoRemove
 	// in disk too
-	if toDiskErr := container.ToDiskLocking(); toDiskErr != nil {
+	if toDiskErr := container.ToDisk(); toDiskErr != nil {
 		logrus.Errorf("Write container to disk error: %v", toDiskErr)
 	}
+	container.Unlock()
 
 	if err != nil {
 		return err

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -18,6 +18,9 @@ func (daemon *Daemon) ContainerRestart(name string, seconds int) error {
 	if err != nil {
 		return err
 	}
+
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 	if err := daemon.containerRestart(container, seconds); err != nil {
 		return fmt.Errorf("Cannot restart container %s: %v", name, err)
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -24,6 +24,8 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 	if err != nil {
 		return err
 	}
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 
 	if container.IsPaused() {
 		return fmt.Errorf("Cannot start a paused container, try unpause instead.")
@@ -78,11 +80,6 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 		return err
 	}
 
-	return daemon.containerStart(container)
-}
-
-// Start starts a container
-func (daemon *Daemon) Start(container *container.Container) error {
 	return daemon.containerStart(container)
 }
 

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -12,8 +12,10 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 
 	// Ensure a runtime has been assigned to this container
 	if container.HostConfig.Runtime == "" {
+		container.Lock()
 		container.HostConfig.Runtime = stockRuntimeName
 		container.ToDisk()
+		container.Unlock()
 	}
 
 	rt := daemon.configStore.GetRuntime(container.HostConfig.Runtime)

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -25,6 +25,10 @@ func (daemon *Daemon) ContainerStop(name string, seconds int) error {
 		err := fmt.Errorf("Container %s is already stopped", name)
 		return errors.NewErrorWithStatusCode(err, http.StatusNotModified)
 	}
+
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
+
 	if err := daemon.containerStop(container, seconds); err != nil {
 		return fmt.Errorf("Cannot stop container %s: %v", name, err)
 	}

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -24,8 +24,6 @@ func (daemon *Daemon) ContainerUnpause(name string) error {
 func (daemon *Daemon) containerUnpause(container *container.Container) error {
 	daemon.opLock.Lock(container.ID)
 	defer daemon.opLock.Unlock(container.ID)
-	container.Lock()
-	defer container.Unlock()
 
 	// We cannot unpause the container which is not running
 	if !container.Running {

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -22,6 +22,8 @@ func (daemon *Daemon) ContainerUnpause(name string) error {
 
 // containerUnpause resumes the container execution after the container is paused.
 func (daemon *Daemon) containerUnpause(container *container.Container) error {
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
 	container.Lock()
 	defer container.Unlock()
 

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -46,6 +46,9 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 		return err
 	}
 
+	daemon.opLock.Lock(container.ID)
+	defer daemon.opLock.Unlock(container.ID)
+
 	restoreConfig := false
 	backupHostConfig := *container.HostConfig
 	defer func() {


### PR DESCRIPTION
Use a separate lock for daemon operations on a container (start, stop, kill, etc) compared things that just need access to the container struct (like reading or setting a field).

This prevents the daemon from becoming essentially frozen when something has gone wrong with a single container.
