### PR TITLE
Add node remove "force" parameter to 1.25 API docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3551,6 +3551,11 @@ Remove a node [`id`] from the Swarm.
     Content-Length: 0
     Content-Type: text/plain; charset=utf-8
 
+**Query parameters**:
+
+-   **force** - 1/True/true or 0/False/false, Force remove an active node.
+        Default `false`.
+
 **Status codes**:
 
 -   **200** – no error


### PR DESCRIPTION
This parameter was documented for 1.24, but we forgot to add it to the 1.25 docs as well.

ping @sfsmithcha 
