### PR TITLE
Make release scripts architecture-agnostic and add ARM support

### DIFF
--- a/hack/make/release-deb
+++ b/hack/make/release-deb
@@ -14,9 +14,6 @@ set -e
 #
 # ... and so on and so forth for the builds created by hack/make/build-deb
 
-source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
-source "$(dirname "$BASH_SOURCE")/.detect-daemon-osarch"
-
 : ${DOCKER_RELEASE_DIR:=$DEST}
 : ${GPG_KEYID:=releasedocker}
 APTDIR=$DOCKER_RELEASE_DIR/apt/repo
@@ -25,7 +22,7 @@ APTDIR=$DOCKER_RELEASE_DIR/apt/repo
 mkdir -p "$APTDIR/conf" "$APTDIR/db" "$APTDIR/dists"
 
 # supported arches/sections
-arches=( amd64 i386 )
+arches=( amd64 i386 armhf )
 
 # Preserve existing components but don't add any non-existing ones
 for component in main testing experimental ; do
@@ -77,7 +74,7 @@ TreeDefault {
 };
 EOF
 
-for dir in contrib/builder/deb/${PACKAGE_ARCH}/*/; do
+for dir in bundles/$VERSION/build-deb/*/; do
 	version="$(basename "$dir")"
 	suite="${version//debootstrap-}"
 
@@ -98,12 +95,12 @@ APT::FTPArchive::Release::Architectures "${arches[*]}";
 EOF
 
 # release the debs
-for dir in contrib/builder/deb/${PACKAGE_ARCH}/*/; do
+for dir in bundles/$VERSION/build-deb/*/; do
 	version="$(basename "$dir")"
 	codename="${version//debootstrap-}"
 
 	tempdir="$(mktemp -d /tmp/tmp-docker-release-deb.XXXXXXXX)"
-	DEBFILE=( "bundles/$VERSION/build-deb/$version/docker-engine"*.deb )
+	DEBFILE=( "$dir/docker-engine"*.deb )
 
 	# add the deb for each component for the distro version into the
 	# pool (if it is not there already)
@@ -128,7 +125,9 @@ for dir in contrib/builder/deb/${PACKAGE_ARCH}/*/; do
 
 	# build the right directory structure, needed for apt-ftparchive
 	for arch in "${arches[@]}"; do
-		mkdir -p "$APTDIR/dists/$codename/$component/binary-$arch"
+		for c in "${components[@]}"; do
+			mkdir -p "$APTDIR/dists/$codename/$c/binary-$arch"
+		done
 	done
 
 	# update the filelist for this codename/component
@@ -139,7 +138,7 @@ done
 # run the apt-ftparchive commands so we can have pinning
 apt-ftparchive generate "$APTDIR/conf/apt-ftparchive.conf"
 
-for dir in contrib/builder/deb/${PACKAGE_ARCH}/*/; do
+for dir in bundles/$VERSION/build-deb/*/; do
 	version="$(basename "$dir")"
 	codename="${version//debootstrap-}"
 

--- a/hack/make/release-rpm
+++ b/hack/make/release-rpm
@@ -14,15 +14,9 @@ set -e
 #
 # ... and so on and so forth for the builds created by hack/make/build-rpm
 
-source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
-source "$(dirname "$BASH_SOURCE")/.detect-daemon-osarch"
-
 : ${DOCKER_RELEASE_DIR:=$DEST}
 YUMDIR=$DOCKER_RELEASE_DIR/yum/repo
 : ${GPG_KEYID:=releasedocker}
-
-# manage the repos for each distribution separately
-distros=( fedora centos opensuse oraclelinux )
 
 # get the release
 release="main"
@@ -35,44 +29,42 @@ if [ $DOCKER_EXPERIMENTAL ] || [[ "$VERSION" == *-dev ]] || [ -n "$(git status -
 	release="experimental"
 fi
 
-for distro in "${distros[@]}"; do
-	# Setup the yum repo
-	REPO=$YUMDIR/$release/$distro
+# Setup the yum repo
+for dir in bundles/$VERSION/build-rpm/*/; do
+	version="$(basename "$dir")"
+	suite="${version##*-}"
 
-	for dir in contrib/builder/rpm/${PACKAGE_ARCH}/$distro-*/; do
-		version="$(basename "$dir")"
-		suite="${version##*-}"
+	REPO=$YUMDIR/$release/$suite
 
-		# if the directory does not exist, initialize the yum repo
-		if [[ ! -d $REPO/$suite/Packages ]]; then
-			mkdir -p "$REPO/$suite/Packages"
+	# if the directory does not exist, initialize the yum repo
+	if [[ ! -d $REPO/$suite/Packages ]]; then
+		mkdir -p "$REPO/$suite/Packages"
 
-			createrepo --pretty "$REPO/$suite"
-		fi
+		createrepo --pretty "$REPO/$suite"
+	fi
 
-		# path to rpms
-		RPMFILE=( "bundles/$VERSION/build-rpm/$version/RPMS/"*"/docker-engine"*.rpm "bundles/$VERSION/build-rpm/$version/SRPMS/docker-engine"*.rpm )
+	# path to rpms
+	RPMFILE=( "bundles/$VERSION/build-rpm/$version/RPMS/"*"/docker-engine"*.rpm "bundles/$VERSION/build-rpm/$version/SRPMS/docker-engine"*.rpm )
 
-		# if we have a $GPG_PASSPHRASE we may as well
-		# sign the rpms before adding to repo
-		if [ ! -z $GPG_PASSPHRASE ]; then
-			# export our key to rpm import
-			gpg --armor --export "$GPG_KEYID" > /tmp/gpg
-			rpm --import /tmp/gpg
+	# if we have a $GPG_PASSPHRASE we may as well
+	# sign the rpms before adding to repo
+	if [ ! -z $GPG_PASSPHRASE ]; then
+		# export our key to rpm import
+		gpg --armor --export "$GPG_KEYID" > /tmp/gpg
+		rpm --import /tmp/gpg
 
-			# sign the rpms
-			echo "yes" | setsid rpm \
-				--define "_gpg_name $GPG_KEYID" \
-				--define "_signature gpg" \
-				--define "__gpg_check_password_cmd /bin/true" \
-				--define "__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --passphrase '$GPG_PASSPHRASE' --no-secmem-warning -u '%{_gpg_name}' --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}" \
-				--resign "${RPMFILE[@]}"
-		fi
+		# sign the rpms
+		echo "yes" | setsid rpm \
+			--define "_gpg_name $GPG_KEYID" \
+			--define "_signature gpg" \
+			--define "__gpg_check_password_cmd /bin/true" \
+			--define "__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --passphrase '$GPG_PASSPHRASE' --no-secmem-warning -u '%{_gpg_name}' --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}" \
+			--resign "${RPMFILE[@]}"
+	fi
 
-		# copy the rpms to the packages folder
-		cp "${RPMFILE[@]}" "$REPO/$suite/Packages"
+	# copy the rpms to the packages folder
+	cp "${RPMFILE[@]}" "$REPO/$suite/Packages"
 
-		# update the repo
-		createrepo --pretty --update "$REPO/$suite"
-	done
+	# update the repo
+	createrepo --pretty --update "$REPO/$suite"
 done


### PR DESCRIPTION
This patch allows to only release the packages that were built and are
present under the bundles/ directory instead of assuming packages exist
for all distros enumerated in the contrib/builder/ directory.

It also now adds support for armhf architecture for apt repositories.

Signed-off-by: Tibor Vass tibor@docker.com
