### PR TITLE
[carry 25344] deal with firewalld/docker startup issues

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target docker.socket
+After=network.target docker.socket firewalld.service
 Requires=docker.socket
 
 [Service]

--- a/contrib/init/systemd/docker.service.rpm
+++ b/contrib/init/systemd/docker.service.rpm
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target
+After=network.target firewalld.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
carry of https://github.com/docker/docker/pull/25344

closes https://github.com/docker/docker/pull/25344
fixes https://github.com/docker/docker/issues/16137

added the firewalld.service symbol in the After line docker
will always start after firewalld, thus eliminating the issue
of firewall blocking all mapped traffic.
