### PR TITLE
docker swarm join command has no flag '--swarm-token'

### DIFF
--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -46,7 +46,7 @@ node. For example, the tutorial uses a machine named `manager1`.
     to access the manager at the IP address.
 
     The output incudes the commands to join new nodes to the swarm. Nodes will
-    join as managers or workers depending on the value for the `--swarm-token`
+    join as managers or workers depending on the value for the `--token`
     flag.
 
 2. Run `docker info` to view the current state of the swarm:


### PR DESCRIPTION
'--swarm-token' should be ''--token', because docker swarm join like this:

```
    docker swarm join \
    --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
    192.168.99.100:2377
```
