### PR TITLE
Add install of virtual kernel extras for AUFS

### DIFF
--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -119,10 +119,10 @@ packages from the new repository:
 - Ubuntu Trusty 14.04 (LTS)
 
 For Ubuntu Trusty, Wily, and Xenial, it's recommended to install the
-`linux-image-extra` kernel package. The `linux-image-extra` package
+`linux-image-extra-*` kernel packages. The `linux-image-extra-*` packages
 allows you use the `aufs` storage driver.
 
-To install the `linux-image-extra` package for your kernel version:
+To install the `linux-image-extra-*` packages:
 
 1. Open a terminal on your Ubuntu host.
 
@@ -130,13 +130,11 @@ To install the `linux-image-extra` package for your kernel version:
 
         $ sudo apt-get update
 
-3. Install the recommended package.
+3. Install the recommended packages.
 
-        $ sudo apt-get install linux-image-extra-$(uname -r)
+        $ sudo apt-get install linux-image-extra-$(uname -r) linux-image-extra-virtual
 
 4. Go ahead and install Docker.
-
-If you are installing on Ubuntu 14.04 or 12.04, `apparmor` is required.  You can install it using: `apt-get install apparmor`
 
 #### Ubuntu Precise 12.04 (LTS)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Updated the Ubuntu 14.04 documentation to include the `linux-image-extra-virtual` package

**\- How I did it**
Vim...it's great.

**\- How to verify it**
Install docker, enjoy the fact that you can use AUFS even after upgrading your kernel

**\- Description for the changelog**
I modified docs; this matches what is done via the hack/install.sh script (https://github.com/docker/docker/blob/a6aea68c35a6d0c27d2c299aaeff6aecd9a451e8/hack/install.sh#L400)

**\- A picture of a cute animal (not mandatory but encouraged)**
![derpy_dog](https://cloud.githubusercontent.com/assets/414445/17587940/6d86e644-5f99-11e6-97e9-bb10f419f7d2.jpg)

Signed-off-by: Matt Bentley matt.bentley@docker.com
