### PR TITLE
Allow templating of AWS log stream name

### DIFF
--- a/docs/admin/logging/awslogs.md
+++ b/docs/admin/logging/awslogs.md
@@ -63,6 +63,19 @@ specified, the container ID is used as the log stream.
 > at a time.  Using the same log stream for multiple containers concurrently
 > can cause reduced logging performance.
 
+# awslogs-stream-template
+
+Specify a template to automatically generate the log stream name to use.  The
+template supports [logger.Context
+](https://godoc.org/github.com/docker/docker/daemon/logger#Context), so
+`awslogs-stream-template="{{ .ContainerID }}"` would be equivalent to the
+default behavior.
+
+> **Notes:**
+> Log streams within a given log group should only be used by one container
+> at a time.  Using the same log stream for multiple containers concurrently
+> can cause reduced logging performance.
+
 ## Credentials
 
 You must provide AWS credentials to the Docker daemon to use the `awslogs`


### PR DESCRIPTION
I ended up needing something similar to [17747](https://github.com/docker/docker/issues/17747) and drafted this guy up - it's a fairly straight-forward implementation, but let me know if I'm missing any style-wants/etc.

There's items it could probably use (strip ':'s from ImageId's comes to mind since they're forbidden by the CW logs API), but hopefully a good enough start for others as well.
