### PR TITLE
Remove --network-add and --network-rm flags from service update

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -538,8 +538,6 @@ const (
 	flagMountAdd             = "mount-add"
 	flagName                 = "name"
 	flagNetwork              = "network"
-	flagNetworkRemove        = "network-rm"
-	flagNetworkAdd           = "network-add"
 	flagPublish              = "publish"
 	flagPublishRemove        = "publish-rm"
 	flagPublishAdd           = "publish-add"

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -115,22 +115,6 @@ func TestUpdateMounts(t *testing.T) {
 	assert.Equal(t, mounts[1].Target, "/toadd")
 }
 
-func TestUpdateNetworks(t *testing.T) {
-	flags := newUpdateCommand(nil).Flags()
-	flags.Set("network-add", "toadd")
-	flags.Set("network-rm", "toremove")
-
-	attachments := []swarm.NetworkAttachmentConfig{
-		{Target: "toremove", Aliases: []string{"foo"}},
-		{Target: "tokeep"},
-	}
-
-	updateNetworks(flags, &attachments)
-	assert.Equal(t, len(attachments), 2)
-	assert.Equal(t, attachments[0].Target, "tokeep")
-	assert.Equal(t, attachments[1].Target, "toadd")
-}
-
 func TestUpdatePorts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("publish-add", "1000:1000")

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -35,8 +35,6 @@ Options:
       --mount-add value                Add or update a mount on a service
       --mount-rm value                 Remove a mount by its target path (default [])
       --name string                    Service name
-      --network-add value              Add or update network attachments (default [])
-      --network-rm value               Remove a network by name (default [])
       --publish-add value              Add or update a published port (default [])
       --publish-rm value               Remove a published port by its target port (default [])
       --replicas value                 Number of tasks (default none)


### PR DESCRIPTION
These flags were not supported (daemon returns an error), and it was an
oversight. They were not present in completion scripts.

Signed-off-by: Tibor Vass tibor@docker.com
