### PR TITLE
[1.12.1] Remove --network-add and --network-rm flags from service update

### DIFF
--- a/api/client/service/opts.go
+++ b/api/client/service/opts.go
@@ -538,8 +538,6 @@ const (
 	flagMountAdd             = "mount-add"
 	flagName                 = "name"
 	flagNetwork              = "network"
-	flagNetworkRemove        = "network-rm"
-	flagNetworkAdd           = "network-add"
 	flagPublish              = "publish"
 	flagPublishRemove        = "publish-rm"
 	flagPublishAdd           = "publish-add"

--- a/api/client/service/update.go
+++ b/api/client/service/update.go
@@ -41,14 +41,12 @@ func newUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
 	flags.Var(newListOptsVar(), flagContainerLabelRemove, "Remove a container label by its key")
 	flags.Var(newListOptsVar(), flagMountRemove, "Remove a mount by its target path")
 	flags.Var(newListOptsVar(), flagPublishRemove, "Remove a published port by its target port")
-	flags.Var(newListOptsVar(), flagNetworkRemove, "Remove a network by name")
 	flags.Var(newListOptsVar(), flagConstraintRemove, "Remove a constraint")
 	flags.Var(&opts.labels, flagLabelAdd, "Add or update service labels")
 	flags.Var(&opts.containerLabels, flagContainerLabelAdd, "Add or update container labels")
 	flags.Var(&opts.env, flagEnvAdd, "Add or update environment variables")
 	flags.Var(&opts.mounts, flagMountAdd, "Add or update a mount on a service")
 	flags.StringSliceVar(&opts.constraints, flagConstraintAdd, []string{}, "Add or update placement constraints")
-	flags.StringSliceVar(&opts.networks, flagNetworkAdd, []string{}, "Add or update network attachments")
 	flags.Var(&opts.endpoint.ports, flagPublishAdd, "Add or update a published port")
 	return cmd
 }
@@ -203,7 +201,6 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 		updateString(flagUpdateFailureAction, &spec.UpdateConfig.FailureAction)
 	}
 
-	updateNetworks(flags, &spec.Networks)
 	if flags.Changed(flagEndpointMode) {
 		value, _ := flags.GetString(flagEndpointMode)
 		if spec.EndpointSpec == nil {
@@ -388,23 +385,6 @@ portLoop:
 func equalPort(targetPort nat.Port, port swarm.PortConfig) bool {
 	return (string(port.Protocol) == targetPort.Proto() &&
 		port.TargetPort == uint32(targetPort.Int()))
-}
-
-func updateNetworks(flags *pflag.FlagSet, attachments *[]swarm.NetworkAttachmentConfig) {
-	if flags.Changed(flagNetworkAdd) {
-		networks, _ := flags.GetStringSlice(flagNetworkAdd)
-		for _, network := range networks {
-			*attachments = append(*attachments, swarm.NetworkAttachmentConfig{Target: network})
-		}
-	}
-	toRemove := buildToRemoveSet(flags, flagNetworkRemove)
-	newNetworks := []swarm.NetworkAttachmentConfig{}
-	for _, network := range *attachments {
-		if _, exists := toRemove[network.Target]; !exists {
-			newNetworks = append(newNetworks, network)
-		}
-	}
-	*attachments = newNetworks
 }
 
 func updateReplicas(flags *pflag.FlagSet, serviceMode *swarm.ServiceMode) error {

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -100,22 +100,6 @@ func TestUpdateMounts(t *testing.T) {
 	assert.Equal(t, mounts[1].Target, "/toadd")
 }
 
-func TestUpdateNetworks(t *testing.T) {
-	flags := newUpdateCommand(nil).Flags()
-	flags.Set("network-add", "toadd")
-	flags.Set("network-rm", "toremove")
-
-	attachments := []swarm.NetworkAttachmentConfig{
-		{Target: "toremove", Aliases: []string{"foo"}},
-		{Target: "tokeep"},
-	}
-
-	updateNetworks(flags, &attachments)
-	assert.Equal(t, len(attachments), 2)
-	assert.Equal(t, attachments[0].Target, "tokeep")
-	assert.Equal(t, attachments[1].Target, "toadd")
-}
-
 func TestUpdatePorts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("publish-add", "1000:1000")

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -37,8 +37,6 @@ Options:
       --mount-add value                Add or update a mount on a service
       --mount-rm value                 Remove a mount by its target path (default [])
       --name string                    Service name
-      --network-add value              Add or update network attachments (default [])
-      --network-rm value               Remove a network by name (default [])
       --publish-add value              Add or update a published port (default [])
       --publish-rm value               Remove a published port by its target port (default [])
       --replicas value                 Number of tasks (default none)


### PR DESCRIPTION
These flags were not supported (daemon returns an error), and it was an
oversight. They were not present in completion scripts.

Signed-off-by: Tibor Vass tibor@docker.com
(cherry picked from commit 3a7e90c743f6fdccb8aecb9d6d9afd42232fa736)
Signed-off-by: Tibor Vass tibor@docker.com

Cherry picked from #25646
