### PR TITLE
Vendoring libnetwork for 1.12.1-rc1

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -66,7 +66,7 @@ clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork f77a0c9f540536c37019cf64d09a9a932dd7b54b
+clone git github.com/docker/libnetwork 24f64a6f9e9cade70e3904df291fb321584b1b4e
 clone git github.com/docker/go-events afb2b9f2c23f33ada1a22b03651775fdc65a5089
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -567,7 +567,10 @@ func (sb *sandbox) ResolveName(name string, ipType int) ([]net.IP, bool) {
 	newList := []*endpoint{}
 	if !sb.controller.isDistributedControl() {
 		newList = append(newList, getDynamicNwEndpoints(epList)...)
-		newList = append(newList, getIngressNwEndpoint(epList))
+		ingressEP := getIngressNwEndpoint(epList)
+		if ingressEP != nil {
+			newList = append(newList, ingressEP)
+		}
 		newList = append(newList, getLocalNwEndpoints(epList)...)
 		epList = newList
 	}


### PR DESCRIPTION
Fix for a panic introduced by a [change](https://github.com/docker/libnetwork/pull/1389) in the pervious libnetwork vendor in.

Signed-off-by: Santhosh Manohar santhosh@docker.com
