### PR TITLE
Update API docs example for image load response

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -2673,14 +2673,14 @@ See the [image tarball format](#image-tarball-format) for more details.
 **Example response**:
 
 If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress 
-details are suppressed, and only a confirmation message is returned as plain text
-once the action completes.
+details are suppressed, and only a confirmation message is returned once the
+action completes.
 
     HTTP/1.1 200 OK
-    Content-Length: 29
-    Content-Type: text/plain; charset=utf-8
+    Content-Type: application/json
+    Transfer-Encoding: chunked
 
-    Loaded image: busybox:latest
+    {"stream":"Loaded image: busybox:latest\n"}
 
 **Query parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2686,14 +2686,14 @@ See the [image tarball format](#image-tarball-format) for more details.
 **Example response**:
 
 If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress 
-details are suppressed, and only a confirmation message is returned as plain text
-once the action completes.
+details are suppressed, and only a confirmation message is returned once the
+action completes.
 
     HTTP/1.1 200 OK
-    Content-Length: 29
-    Content-Type: text/plain; charset=utf-8
+    Content-Type: application/json
+    Transfer-Encoding: chunked
 
-    Loaded image: busybox:latest
+    {"stream":"Loaded image: busybox:latest\n"}
 
 **Query parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -2692,14 +2692,14 @@ See the [image tarball format](#image-tarball-format) for more details.
 **Example response**:
 
 If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress 
-details are suppressed, and only a confirmation message is returned as plain text
-once the action completes.
+details are suppressed, and only a confirmation message is returned once the
+action completes.
 
     HTTP/1.1 200 OK
-    Content-Length: 29
-    Content-Type: text/plain; charset=utf-8
+    Content-Type: application/json
+    Transfer-Encoding: chunked
 
-    Loaded image: busybox:latest
+    {"stream":"Loaded image: busybox:latest\n"}
 
 **Query parameters**:
 


### PR DESCRIPTION
Commit 353af0b3ecfe483568fd88754e432c92b0ec088b (https://github.com/docker/docker/pull/25557) updated
the `/image/load` endpoint to consistendly return
JSON, but did not update the associated documentation.

This updates the example response in the documentation
to match the actual response.

Since this fixed isn't versioned, I updated all versions of
the API docs since "?force" was added.
