### PR TITLE
rewording and changes in 1.12.1 changelog for 1.12.1-GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,60 +7,11 @@ be found.
 
 ## 1.12.1 (2016-08-16)
 
-### Client
-
-* Add `Join at` information in `node inspect --pretty` [#25512](https://github.com/docker/docker/pull/25512)
-- Fix a crash on `service inspect` [#25454](https://github.com/docker/docker/pull/25454)
-- Fix issue preventing `service update --env-add` to work as intended [#25427](https://github.com/docker/docker/pull/25427)
-- Fix issue preventing `service update --publish-add` to work as intended [#25428](https://github.com/docker/docker/pull/25428)
-
-### Contrib
-
-+ Official ARM installation for Debian Jessie, Ubuntu Trusty, and Raspbian Jessie [#24815](https://github.com/docker/docker/pull/24815) [#25591](https://github.com/docker/docker/pull/25637)
-- Add selinux policy per distro/version, fixing issue preventing successful installation on Fedora 24 [#25334](https://github.com/docker/docker/pull/25334)
-* Add Oracle Linux distro specific selinux policy [#25593](https://github.com/docker/docker/pull/25593)
-
-### Networking
-
-- Fix issue preventing containers to be accessed by hostname with Docker overlay driver in Swarm Mode [#25603](https://github.com/docker/docker/pull/25603) [#25648](https://github.com/docker/docker/pull/25648)
-- Fix random network issues on service with published port [#25603](https://github.com/docker/docker/pull/25603)
-- Fix unreliable inter-service communication after scaling down and up [#25603](https://github.com/docker/docker/pull/25603)
-- Fix issue where removing all tasks on a node and adding it back breaks connectivity with other services [#25603](https://github.com/docker/docker/pull/25603)
-
-### Plugins (experimental)
-
-* Make daemon events listen for plugin lifecycle events [#24760](https://github.com/docker/docker/pull/24760)
-* Check for plugin state before enabling plugin [#25033](https://github.com/docker/docker/pull/25033)
-- Remove plugin root from filesystem on `plugin rm` [#25187](https://github.com/docker/docker/pull/25187)
-- Prevent deadlock when more than one plugin is installed [#25384](https://github.com/docker/docker/pull/25384)
-
-### Runtime
-
-* Mask join tokens in daemon logs [#25346](https://github.com/docker/docker/pull/25346)
-* `docker ps --filter` now orders the result by creation time [#25387](https://github.com/docker/docker/pull/25387)
-* Add `/proc/timer_list` to the masked paths list to prevent information leak from the host [#25630](https://github.com/docker/docker/pull/25630)
-- Fix various crashes [#25053](https://github.com/docker/docker/pull/25053)
-
-### Security
-
-* Allow systemd to run with only `--cap-add SYS_ADMIN` rather than having to also add `--cap-add DAC_READ_SEARCH` [#25567](https://github.com/docker/docker/pull/25567)
-
-### Volume
-
-- Persist local volume options after a daemon restart [#25316](https://github.com/docker/docker/pull/25316)
-- Fix an issue where the mount ID was not returned on volume unmount [#25333](https://github.com/docker/docker/pull/25333)
-- Fix an issue where a volume mount could inadvertently create a bind mount [#25309](https://github.com/docker/docker/pull/25309)
-- `service --mount type=bind,...` now errors out if source path does not exist [#25494](https://github.com/docker/docker/pull/25494)
-
-## 1.12.0 (2016-07-28)
-
-
-**IMPORTANT**:
-
-Docker 1.12.0 ships with an updated systemd unit file for rpm based installs
-(which includes RHEL, Fedora, CentOS, and Oracle Linux 7). When upgrading from
-an older version of docker, the upgrade process may not automatically install
-the updated version of the unit file, or fail to start the docker service if;
+**IMPORTANT**: Docker 1.12 ships with an updated systemd unit file for rpm
+based installs (which includes RHEL, Fedora, CentOS, and Oracle Linux 7). When
+upgrading from an older version of docker, the upgrade process may not
+automatically install the updated version of the unit file, or fail to start
+the docker service if;
 
 - the systemd unit file (`/usr/lib/systemd/system/docker.service`) contains local changes, or
 - a systemd drop-in file is present, and contains `-H fd://` in the `ExecStart` directive
@@ -76,7 +27,82 @@ or
 To resolve this:
 
 - Backup the current version of the unit file, and replace the file with the
-  version that ships with docker 1.12 (https://raw.githubusercontent.com/docker/docker/v1.12.0/contrib/init/systemd/docker.service.rpm)
+  [version that ships with docker 1.12](https://raw.githubusercontent.com/docker/docker/v1.12.0/contrib/init/systemd/docker.service.rpm)
+- Remove the `Requires=docker.socket` directive from the `/usr/lib/systemd/system/docker.service` file if present
+- Remove `-H fd://` from the `ExecStart` directive (both in the main unit file, and in any drop-in files present).
+
+After making those changes, run `sudo systemctl daemon-reload`, and `sudo
+systemctl restart docker` to reload changes and (re)start the docker daemon.
+
+
+### Client
+
+* Add `Joined at` information in `node inspect --pretty` [#25512](https://github.com/docker/docker/pull/25512)
+- Fix a crash on `service inspect` [#25454](https://github.com/docker/docker/pull/25454)
+- Fix issue preventing `service update --env-add` to work as intended [#25427](https://github.com/docker/docker/pull/25427)
+- Fix issue preventing `service update --publish-add` to work as intended [#25428](https://github.com/docker/docker/pull/25428)
+
+### Contrib
+
++ Official ARM installation for Debian Jessie, Ubuntu Trusty, and Raspbian Jessie [#24815](https://github.com/docker/docker/pull/24815) [#25591](https://github.com/docker/docker/pull/25637)
+- Add selinux policy per distro/version, fixing issue preventing successful installation on Fedora 24, and Oracle Linux [#25334](https://github.com/docker/docker/pull/25334) [#25593](https://github.com/docker/docker/pull/25593)
+
+### Networking
+
+- Fix issue that prevented containers to be accessed by hostname with Docker overlay driver in Swarm Mode [#25603](https://github.com/docker/docker/pull/25603) [#25648](https://github.com/docker/docker/pull/25648)
+- Fix random network issues on service with published port [#25603](https://github.com/docker/docker/pull/25603)
+- Fix unreliable inter-service communication after scaling down and up [#25603](https://github.com/docker/docker/pull/25603)
+- Fix issue where removing all tasks on a node and adding them back breaks connectivity with other services [#25603](https://github.com/docker/docker/pull/25603)
+
+### Plugins (experimental)
+
+* Make daemon events listen for plugin lifecycle events [#24760](https://github.com/docker/docker/pull/24760)
+* Check for plugin state before enabling plugin [#25033](https://github.com/docker/docker/pull/25033)
+- Remove plugin root from filesystem on `plugin rm` [#25187](https://github.com/docker/docker/pull/25187)
+- Prevent deadlock when more than one plugin is installed [#25384](https://github.com/docker/docker/pull/25384)
+
+### Runtime
+
+* Mask join tokens in daemon logs [#25346](https://github.com/docker/docker/pull/25346)
+- Fix `docker ps --filter` causing the results to no longer be sorted by creation time [#25387](https://github.com/docker/docker/pull/25387)
+- Fix various crashes [#25053](https://github.com/docker/docker/pull/25053)
+
+### Security
+
+* Add `/proc/timer_list` to the masked paths list to prevent information leak from the host [#25630](https://github.com/docker/docker/pull/25630)
+* Allow systemd to run with only `--cap-add SYS_ADMIN` rather than having to also add `--cap-add DAC_READ_SEARCH` or disabling seccomp filtering [#25567](https://github.com/docker/docker/pull/25567)
+
+### Volume
+
+- Persist local volume options after a daemon restart [#25316](https://github.com/docker/docker/pull/25316)
+- Fix an issue where the mount ID was not returned on volume unmount [#25333](https://github.com/docker/docker/pull/25333)
+- Fix an issue where a volume mount could inadvertently create a bind mount [#25309](https://github.com/docker/docker/pull/25309)
+- `docker service create --mount type=bind,...` now correctly validates if the source path exists, instead of creating it [#25494](https://github.com/docker/docker/pull/25494)
+
+## 1.12.0 (2016-07-28)
+
+
+**IMPORTANT**: Docker 1.12.0 ships with an updated systemd unit file for rpm
+based installs (which includes RHEL, Fedora, CentOS, and Oracle Linux 7). When
+upgrading from an older version of docker, the upgrade process may not
+automatically install the updated version of the unit file, or fail to start
+the docker service if;
+
+- the systemd unit file (`/usr/lib/systemd/system/docker.service`) contains local changes, or
+- a systemd drop-in file is present, and contains `-H fd://` in the `ExecStart` directive
+
+Starting the docker service will produce an error:
+
+    Failed to start docker.service: Unit docker.socket failed to load: No such file or directory.
+
+or
+
+    no sockets found via socket activation: make sure the service was started by systemd.
+
+To resolve this:
+
+- Backup the current version of the unit file, and replace the file with the
+  [version that ships with docker 1.12](https://raw.githubusercontent.com/docker/docker/v1.12.0/contrib/init/systemd/docker.service.rpm)
 - Remove the `Requires=docker.socket` directive from the `/usr/lib/systemd/system/docker.service` file if present
 - Remove `-H fd://` from the `ExecStart` directive (both in the main unit file, and in any drop-in files present).
 


### PR DESCRIPTION
- Repeats the warning about the systemd unit file
- Move the `/proc/timer_list` change to the "security" section
- Some minor rewording / changes

I titled this "WIP" so that we can update this if we find other changes that need to be included

/cc @tiborvass 
