### PR TITLE
Do not create /dev/fuse by default

### DIFF
--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -61,7 +61,6 @@ func (s *DockerSuite) TestDiffEnsureDefaultDevs(c *check.C) {
 		"A /dev/mqueue":  true,
 		"A /dev/kmsg":    true,
 		"A /dev/fd":      true,
-		"A /dev/fuse":    true,
 		"A /dev/ptmx":    true,
 		"A /dev/null":    true,
 		"A /dev/random":  true,

--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -104,17 +104,7 @@ func DefaultSpec() specs.Spec {
 		// null, zero, full, random, urandom, tty, console, and ptmx.
 		// ptmx is a bind-mount or symlink of the container's ptmx.
 		// See also: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-devices
-		Devices: []specs.Device{
-			{
-				Type:     "c",
-				Path:     "/dev/fuse",
-				Major:    10,
-				Minor:    229,
-				FileMode: fmPtr(0666),
-				UID:      u32Ptr(0),
-				GID:      u32Ptr(0),
-			},
-		},
+		Devices: []specs.Device{},
 		Resources: &specs.Resources{
 			Devices: []specs.DeviceCgroup{
 				{


### PR DESCRIPTION
This device is not required by the OCI spec.

The rationale for this was linked to docker/docker#2393

So a non functional /dev/fuse was created, and actual fuse use still is
required to add the device explicitly. However even old versions of the JVM
on Ubuntu 12.04 no longer require the fuse package, and this is all not
needed.

See also https://github.com/opencontainers/runc/pull/983 although this
change alone stops the fuse device being created.

Tested and does not change actual ability to use fuse.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![cute baby goat5](https://cloud.githubusercontent.com/assets/482364/17620640/a76ab43e-6085-11e6-85d8-faf725c0dcf0.png)
