### PR TITLE
Move export from image commands to container commands

### DIFF
--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -39,7 +39,6 @@ read the [`dockerd`](dockerd.md) reference page.
 |:--------|:-------------------------------------------------------------------|
 | [build](build.md) |  Build an image from a Dockerfile                        |
 | [commit](commit.md) | Create a new image from a container's changes          |
-| [export](export.md) | Export a container's filesystem as a tar archive       |
 | [history](history.md) | Show the history of an image                         |
 | [images](images.md) | List images                                            |
 | [import](import.md) | Import the contents from a tarball to create a filesystem image |
@@ -58,6 +57,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [diff](diff.md) | Inspect changes on a container's filesystem                |
 | [events](events.md) | Get real time events from the server                   |
 | [exec](exec.md) | Run a command in a running container                       |
+| [export](export.md) | Export a container's filesystem as a tar archive       |
 | [kill](kill.md) | Kill a running container                                   |
 | [logs](logs.md) | Fetch the logs of a container                              |
 | [pause](pause.md) | Pause all processes within a container                   |


### PR DESCRIPTION
The export command operates on containers, not images, so it should be listed under the container commands, not the image commands.
