### PR TITLE
Allow engine to run inside a user namespace

### DIFF
--- a/daemon/graphdriver/overlay/copy.go
+++ b/daemon/graphdriver/overlay/copy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/system"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 )
 
 type copyFlags int
@@ -105,6 +106,10 @@ func copyDir(srcDir, dstDir string, flags copyFlags) error {
 		case os.ModeNamedPipe:
 			fallthrough
 		case os.ModeSocket:
+			if rsystem.RunningInUserNS() {
+				// cannot create a device if running in user namespace
+				return nil
+			}
 			if err := syscall.Mkfifo(dstPath, stat.Mode); err != nil {
 				return err
 			}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -802,7 +802,7 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil)
+	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/docker/docker/pkg/system"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 )
 
 // fixVolumePathPrefix does platform specific processing to ensure that if
@@ -80,6 +81,11 @@ func minor(device uint64) uint64 {
 // handleTarTypeBlockCharFifo is an OS-specific helper function used by
 // createTarFile to handle the following types of header: Block; Char; Fifo
 func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
+	if rsystem.RunningInUserNS() {
+		// cannot create a device if running in user namespace
+		return nil
+	}
+
 	mode := uint32(hdr.Mode & 07777)
 	switch hdr.Typeflag {
 	case tar.TypeBlock:

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -111,7 +111,7 @@ func UnpackLayer(dest string, layer Reader, options *TarOptions) (size int64, er
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil); err != nil {
+				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS); err != nil {
 					return 0, err
 				}
 			}
@@ -219,7 +219,7 @@ func UnpackLayer(dest string, layer Reader, options *TarOptions) (size int64, er
 				}
 				srcHdr.Gid = xGID
 			}
-			if err := createTarFile(path, dest, srcHdr, srcData, true, nil); err != nil {
+			if err := createTarFile(path, dest, srcHdr, srcData, true, nil, options.InUserNS); err != nil {
 				return 0, err
 			}
 


### PR DESCRIPTION
Carry of PR #20902 

Allow the Docker daemon to run inside a user namespaced parent process.  Original patch by @hallyn; I've added a change to revert to "real" chroot when inside a userns that came about since the original patch.

I have tested this capability inside lxc running an ubuntu:xenial image with a binary built from this PR patchset.  To successfully run the Docker daemon I used the following command line:

```
dockerd -D -s vfs --oom-score-adjust=0
```

Inside a user namespace, writing to the oom_score_adj special proc file fails, and I can't get any backend driver to work outside of vfs.

I cannot run the Docker engine inside of a runc container with user namespaces enabled due to how the `/sys/fs/cgroups` mount is handled under runc. Therefore it is hard to write a test that integrates well with our CI system without requiring a working LXC setup until we solve this problem in runc.
