### PR TITLE
Fix build deb for ARMv6

### DIFF
--- a/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -7,6 +7,7 @@ RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.6.3
+ENV GOARM 6
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
I re-enabled to compile the Docker Engine binaries for ARMv6. 

This fix just reverts parts of the commit https://github.com/docker/docker/commit/d59458c12d76d732e0ab564ea0e769323af6d3d6 which accidentally removed the important line https://github.com/docker/docker/commit/d59458c12d76d732e0ab564ea0e769323af6d3d6#diff-44614ac3316945fbfc01ecdd0d639904L6 and did induced this error.

**\- How I did it**
For this purpose it's essential to use the env variable `GOARM=6` when compiling GOLANG programs. This is done within a Dockerfile with a `ENV GOARM 6`.

**\- How to verify it**
Create the Debian package for `raspbian-jessie` with a `make deb` and install it on a Raspberry Pi 1 or a Raspberry Pi Zero, then the installation should run without errors and a `sudo docker version` should succeed as well.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix compiling binaries for ARMv6 for Raspbian/Jessie Debian package

Signed-off-by: Dieter Reuter dieter.reuter@me.com
