### PR TITLE
Clear raft state file after every test

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -259,6 +259,11 @@ func (s *DockerSwarmSuite) TearDownTest(c *check.C) {
 	s.daemonsLock.Lock()
 	for _, d := range s.daemons {
 		d.Stop()
+		// raft state file is quite big (64MB) so remove it after every test
+		walDir := filepath.Join(d.root, "swarm/raft/wal")
+		if err := os.RemoveAll(walDir); err != nil {
+			c.Logf("error removing %v: %v", walDir, err)
+		}
 	}
 	s.daemons = nil
 	s.daemonsLock.Unlock()


### PR DESCRIPTION
New version of etcd creates a 64MB wal file by default. This is a likely cause for the rhel ci failures we've been seeing after the update was made as our tests create a lot of daemons. Real fix is to make this configurable as we probably don't care about that optimization for our use-case.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
