### PR TITLE
Improve systemd configuration for Raspbian/Jessie

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -389,10 +389,9 @@ do_install() {
 			}
 
 			if [ "$lsb_dist" = "raspbian" ]; then
-				# Create Raspbian specific systemd unit file, use overlay by default
-				( set -x; $sh_c "mkdir -p /etc/systemd/system" )
-				( set -x; $sh_c "$curl https://raw.githubusercontent.com/docker/docker/master/contrib/init/systemd/docker.service > /etc/systemd/system/docker.service" )
-				( set -x; $sh_c "sed -i 's/dockerd/dockerd --storage-driver overlay/' /etc/systemd/system/docker.service" )
+				# Create Raspbian specific systemd drop-in file, use overlay by default
+				( set -x; $sh_c "mkdir -p /etc/systemd/system/docker.service.d" )
+				( set -x; $sh_c "echo '[Service]\nExecStart=\nExecStart=/usr/bin/dockerd --storage-driver overlay -H fd://' > /etc/systemd/system/docker.service.d/overlay.conf" )
 			else
 				# aufs is preferred over devicemapper; try to ensure the driver is available.
 				if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
I improved the systemd configuration for Raspbian. Instead of curl'ing a complete copy of a systemd unit file I just use a systemd drop-in file to change the `ExecStart=` line only. This is IMO the recommended way to customise a systemd service.

**\- How to verify it**
Install the Docker Engine on Raspberry Pi running Raspbian/Jessie OS with the following command:

```
$ repo=testing curl -sSL https://github.com/d64/docker/raw/3c7ae431e08af7a53ebfe4fbb2eaf279fb3993b6/hack/install.sh | sh
```

As the result you should have the following file with this content created:

```
$ cat /etc/systemd/system/docker.service.d/overlay.conf
[Service]
ExecStart=
ExecStart=/usr/bin/dockerd --storage-driver overlay -H fd://
```

You can also check the correct systemd configuration with `systemctl cat docker.service`:

```
$ systemctl cat docker.service
# /lib/systemd/system/docker.service
[Unit]
Description=Docker Application Container Engine
Documentation=https://docs.docker.com
After=network.target docker.socket
Requires=docker.socket

[Service]
Type=notify
# the default is not to use systemd for cgroups because the delegate issues still
# exists and systemd currently does not support the cgroup feature set required
# for containers run by docker
ExecStart=/usr/bin/dockerd -H fd://
ExecReload=/bin/kill -s HUP $MAINPID
# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=infinity
LimitNPROC=infinity
LimitCORE=infinity
# Uncomment TasksMax if your systemd version supports it.
# Only systemd 226 and above support this version.
#TasksMax=infinity
TimeoutStartSec=0
# set delegate yes so that systemd does not reset the cgroups of docker containers
Delegate=yes
# kill only the docker process, not all processes in the cgroup
KillMode=process

[Install]
WantedBy=multi-user.target

# /etc/systemd/system/docker.service.d/overlay.conf
[Service]
ExecStart=
ExecStart=/usr/bin/dockerd --storage-driver overlay -H fd://
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Customise systemd configuration for Raspbian/Jessie with a drop-in file

Signed-off-by: Dieter Reuter dieter.reuter@me.com
