### PR TITLE
Let swarmkit to handle cluster defaults in `swarm init` if not specified

### DIFF
--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -39,7 +39,7 @@ type Spec struct {
 type OrchestrationConfig struct {
 	// TaskHistoryRetentionLimit is the number of historic tasks to keep per instance or
 	// node. If negative, never remove completed or failed tasks.
-	TaskHistoryRetentionLimit int64 `json:",omitempty"`
+	TaskHistoryRetentionLimit *int64 `json:",omitempty"`
 }
 
 // TaskDefaults parameterizes cluster-level task creation with default values.

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -59,7 +59,7 @@ func runInit(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts initOption
 		ListenAddr:      opts.listenAddr.String(),
 		AdvertiseAddr:   opts.advertiseAddr,
 		ForceNewCluster: opts.forceNewCluster,
-		Spec:            opts.swarmOptions.ToSpec(),
+		Spec:            opts.swarmOptions.ToSpec(flags),
 	}
 
 	nodeID, err := client.SwarmInit(ctx, req)

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -169,11 +169,20 @@ func addSwarmFlags(flags *pflag.FlagSet, opts *swarmOptions) {
 	flags.Var(&opts.externalCA, flagExternalCA, "Specifications of one or more certificate signing endpoints")
 }
 
-func (opts *swarmOptions) ToSpec() swarm.Spec {
+func (opts *swarmOptions) ToSpec(flags *pflag.FlagSet) swarm.Spec {
 	spec := swarm.Spec{}
-	spec.Orchestration.TaskHistoryRetentionLimit = opts.taskHistoryLimit
-	spec.Dispatcher.HeartbeatPeriod = opts.dispatcherHeartbeat
-	spec.CAConfig.NodeCertExpiry = opts.nodeCertExpiry
-	spec.CAConfig.ExternalCAs = opts.externalCA.Value()
+
+	if flags.Changed(flagTaskHistoryLimit) {
+		spec.Orchestration.TaskHistoryRetentionLimit = &opts.taskHistoryLimit
+	}
+	if flags.Changed(flagDispatcherHeartbeat) {
+		spec.Dispatcher.HeartbeatPeriod = opts.dispatcherHeartbeat
+	}
+	if flags.Changed(flagCertExpiry) {
+		spec.CAConfig.NodeCertExpiry = opts.nodeCertExpiry
+	}
+	if flags.Changed(flagExternalCA) {
+		spec.CAConfig.ExternalCAs = opts.externalCA.Value()
+	}
 	return spec
 }

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -58,7 +58,8 @@ func mergeSwarm(swarm *swarm.Swarm, flags *pflag.FlagSet) error {
 	spec := &swarm.Spec
 
 	if flags.Changed(flagTaskHistoryLimit) {
-		spec.Orchestration.TaskHistoryRetentionLimit, _ = flags.GetInt64(flagTaskHistoryLimit)
+		taskHistoryRetentionLimit, _ := flags.GetInt64(flagTaskHistoryLimit)
+		spec.Orchestration.TaskHistoryRetentionLimit = &taskHistoryRetentionLimit
 	}
 
 	if flags.Changed(flagDispatcherHeartbeat) {

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -107,7 +107,11 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			fmt.Fprintf(dockerCli.Out(), " Managers: %d\n", info.Swarm.Managers)
 			fmt.Fprintf(dockerCli.Out(), " Nodes: %d\n", info.Swarm.Nodes)
 			fmt.Fprintf(dockerCli.Out(), " Orchestration:\n")
-			fmt.Fprintf(dockerCli.Out(), "  Task History Retention Limit: %d\n", info.Swarm.Cluster.Spec.Orchestration.TaskHistoryRetentionLimit)
+			taskHistoryRetentionLimit := int64(0)
+			if info.Swarm.Cluster.Spec.Orchestration.TaskHistoryRetentionLimit != nil {
+				taskHistoryRetentionLimit = *info.Swarm.Cluster.Spec.Orchestration.TaskHistoryRetentionLimit
+			}
+			fmt.Fprintf(dockerCli.Out(), "  Task History Retention Limit: %d\n", taskHistoryRetentionLimit)
 			fmt.Fprintf(dockerCli.Out(), " Raft:\n")
 			fmt.Fprintf(dockerCli.Out(), "  Snapshot Interval: %d\n", info.Swarm.Cluster.Spec.Raft.SnapshotInterval)
 			fmt.Fprintf(dockerCli.Out(), "  Heartbeat Tick: %d\n", info.Swarm.Cluster.Spec.Raft.HeartbeatTick)


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #24958 where previously `docker swarm init` will automatically fill in all the default value (instead of letting swarmkit to handle the default).

**\- How I did it**

This fix update the `swarm init` so that initial value are passed only when a flag change has been detected.

In addition, ClusterSpec in engine-api has been updated to use pointers so that unchanged values could be detected.

**\- How to verify it**

Existing tests passed. In addition, manual tests has been done to verify with `1.13.0 client vs. 1.13.0 daemon` and `1.12.0 client vs. 1.13.0 daemon`

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

A pull request in engine-api will be created separately.

This fix fixes #24958.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
