### PR TITLE
incorrect response information for docker swarm init command

### DIFF
--- a/docs/swarm/swarm-tutorial/create-swarm.md
+++ b/docs/swarm/swarm-tutorial/create-swarm.md
@@ -40,7 +40,7 @@ node. For example, the tutorial uses a machine named `manager1`.
 
     To add a manager to this swarm, run the following command:
         docker swarm join \
-        --token SWMTKN-1-61ztec5kyafptydic6jfc1i33t37flcl4nuipzcusor96k7kby-5vy9t8u35tuqm7vh67lrz9xp6 \
+        --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-5vy9t8u35tuqm7vh67lrz9xp6 \
         192.168.99.100:2377
     ```
 


### PR DESCRIPTION
add manager token info should be part the same as worker.

```
$ docker swarm init --advertise-addr 192.168.99.100
Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a manager.

To add a worker to this swarm, run the following command:
    docker swarm join \
    --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
    192.168.99.100:2377

To add a manager to this swarm, run the following command:
    docker swarm join \
    --token SWMTKN-1-61ztec5kyafptydic6jfc1i33t37flcl4nuipzcusor96k7kby-5vy9t8u35tuqm7vh67lrz9xp6 \
    192.168.99.100:2377
```
