### PR TITLE
Forbid update restart policy of container with AutoRemove flag

### DIFF
--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -95,6 +95,9 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		return cli.StatusError{StatusCode: 125}
 	}
 
+	if hostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
+		return ErrConflictRestartPolicyAndAutoRemove
+	}
 	if hostConfig.OomKillDisable != nil && *hostConfig.OomKillDisable && hostConfig.Memory == 0 {
 		fmt.Fprintf(stderr, "WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.\n")
 	}
@@ -165,9 +168,6 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 			defer close(waitDisplayID)
 			fmt.Fprintf(stdout, "%s\n", createResponse.ID)
 		}()
-	}
-	if hostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
-		return ErrConflictRestartPolicyAndAutoRemove
 	}
 	attach := config.AttachStdin || config.AttachStdout || config.AttachStderr
 	if attach {

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -302,6 +302,9 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 
 	// update HostConfig of container
 	if hostConfig.RestartPolicy.Name != "" {
+		if container.HostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
+			return fmt.Errorf("Restart policy cannot be updated because AutoRemove is enabled for the container")
+		}
 		container.HostConfig.RestartPolicy = hostConfig.RestartPolicy
 	}
 

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -72,6 +72,9 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 	}
 	// update HostConfig of container
 	if hostConfig.RestartPolicy.Name != "" {
+		if container.HostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
+			return fmt.Errorf("Restart policy cannot be updated because AutoRemove is enabled for the container")
+		}
 		container.HostConfig.RestartPolicy = hostConfig.RestartPolicy
 	}
 	return nil

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -460,7 +460,7 @@ Create a container
             An ever increasing delay (double the previous delay, starting at 100mS)
             is added before each restart to prevent flooding the server.
     -   **AutoRemove** - Boolean value, set to `true` to automatically remove the container on daemon side
-            when the container's process exits.
+            when the container's process exits. Note that `RestartPolicy` other than `none` is exclusive to `AutoRemove`.
     -   **UsernsMode**  - Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
            supported values are: `host`.
     -   **NetworkMode** - Sets the networking mode for the container. Supported

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -107,3 +107,7 @@ To update restart policy for one or more containers:
 ```bash
 $ docker update --restart=on-failure:3 abebf7571666 hopeful_morse
 ```
+
+Note that if the container is started with "--rm" flag, you cannot update the restart
+policy for it. The `AutoRemove` and `RestartPolicy` are mutually exclusive for the
+container.

--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -29,3 +29,13 @@ func (s *DockerSuite) TestUpdateRestartPolicy(c *check.C) {
 	maximumRetryCount := inspectField(c, id, "HostConfig.RestartPolicy.MaximumRetryCount")
 	c.Assert(maximumRetryCount, checker.Equals, "5")
 }
+
+func (s *DockerSuite) TestUpdateRestartWithAutoRemoveFlag(c *check.C) {
+	out, _ := runSleepingContainer(c, "--rm")
+	id := strings.TrimSpace(out)
+
+	// update restart policy for an AutoRemove container
+	out, _, err := dockerCmdWithError("update", "--restart=always", id)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "Restart policy cannot be updated because AutoRemove is enabled for the container")
+}

--- a/man/docker-update.1.md
+++ b/man/docker-update.1.md
@@ -148,3 +148,7 @@ To update restart policy for one or more containers:
 ```bash
 $ docker update --restart=on-failure:3 abebf7571666 hopeful_morse
 ```
+
+Note that if the container is started with "--rm" flag, you cannot update the restart
+policy for it. The `AutoRemove` and `RestartPolicy` are mutually exclusive for the
+container.


### PR DESCRIPTION
"--restart" and "--rm" are conflict options, if a container is started
with AutoRemove flag, we should forbid the update action for its Restart
Policy.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
