### PR TITLE
Enhancement: add --sort-by flag for images command

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/docker/distribution/reference"
@@ -24,6 +25,7 @@ const (
 type ImageContext struct {
 	Context
 	Digest bool
+	Sortby string
 }
 
 func isDangling(image types.ImageSummary) bool {
@@ -80,10 +82,14 @@ func ImageWrite(ctx ImageContext, images []types.ImageSummary) error {
 }
 
 func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subContext subContext) error) error {
+	imageSorter := &imageSorter{
+		imageCtxs: []*imageContext{},
+		by:        ctx.Sortby,
+	}
+
 	for _, image := range images {
-		images := []*imageContext{}
 		if isDangling(image) {
-			images = append(images, &imageContext{
+			imageSorter.imageCtxs = append(imageSorter.imageCtxs, &imageContext{
 				trunc:  ctx.Trunc,
 				i:      image,
 				repo:   "<none>",
@@ -128,7 +134,7 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 
 				for _, tag := range tags {
 					if len(digests) == 0 {
-						images = append(images, &imageContext{
+						imageSorter.imageCtxs = append(imageSorter.imageCtxs, &imageContext{
 							trunc:  ctx.Trunc,
 							i:      image,
 							repo:   repo,
@@ -139,7 +145,7 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 					}
 					// Display the digests for each tag
 					for _, dgst := range digests {
-						images = append(images, &imageContext{
+						imageSorter.imageCtxs = append(imageSorter.imageCtxs, &imageContext{
 							trunc:  ctx.Trunc,
 							i:      image,
 							repo:   repo,
@@ -156,7 +162,7 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 				// If digests are displayed, show row per digest
 				if ctx.Digest {
 					for _, dgst := range digests {
-						images = append(images, &imageContext{
+						imageSorter.imageCtxs = append(imageSorter.imageCtxs, &imageContext{
 							trunc:  ctx.Trunc,
 							i:      image,
 							repo:   repo,
@@ -165,7 +171,7 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 						})
 					}
 				} else {
-					images = append(images, &imageContext{
+					imageSorter.imageCtxs = append(imageSorter.imageCtxs, &imageContext{
 						trunc: ctx.Trunc,
 						i:     image,
 						repo:  repo,
@@ -174,10 +180,14 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 				}
 			}
 		}
-		for _, imageCtx := range images {
-			if err := format(imageCtx); err != nil {
-				return err
-			}
+	}
+
+	// sort image contexts
+	sort.Sort(imageSorter)
+
+	for _, imageCtx := range imageSorter.imageCtxs {
+		if err := format(imageCtx); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -181,9 +181,7 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 	}
 
 	bys := []string{}
-	if ctx.Sortby == "" {
-		bys = append(bys, "CreatedAt:desc")
-	} else {
+	if ctx.Sortby != "" {
 		bys = append(bys, strings.Split(ctx.Sortby, ",")...)
 	}
 
@@ -201,7 +199,9 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 		return err
 	}
 
-	sort.Sort(sorter)
+	if len(bys) != 0 {
+		sort.Sort(sorter)
+	}
 	for _, imageCtx := range sorter.data {
 		subContext := imageCtx.(imageContext)
 		if err := format(&subContext); err != nil {

--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -182,12 +182,21 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 
 	bys := []string{}
 	if ctx.Sortby == "" {
-		bys = append(bys, "Created:dsc")
+		bys = append(bys, "CreatedAt:desc")
 	} else {
 		bys = append(bys, strings.Split(ctx.Sortby, ",")...)
 	}
 
-	sorter, err := newGenericStructSorter(imageCtxs, bys)
+	// whitelist is a map of struct field name to new name
+	whitelist := map[string]string{
+		"Created": "CreatedAt",
+		"ID":      "",
+		"Size":    "",
+		"repo":    "Repository",
+		"tag":     "Tag",
+		"digest":  "Digest",
+	}
+	sorter, err := newGenericStructSorter(imageCtxs, bys, whitelist)
 	if err != nil {
 		return err
 	}

--- a/cli/command/formatter/sorter.go
+++ b/cli/command/formatter/sorter.go
@@ -1,71 +1,289 @@
 package formatter
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"time"
-
-	"github.com/docker/docker/api/types"
 )
 
-type imageSorter struct {
-	imageCtxs []*imageContext
-	images    []types.ImageSummary
-	by        string
+type genericStructSorter struct {
+	data     []interface{}
+	bys      []string
+	ordering []string
+	indexes  [][]int
 }
 
-func (sorter imageSorter) Len() int { return len(sorter.imageCtxs) }
-
-func (sorter imageSorter) Swap(i, j int) {
-	sorter.imageCtxs[i], sorter.imageCtxs[j] = sorter.imageCtxs[j], sorter.imageCtxs[i]
+func (s genericStructSorter) Len() int {
+	return len(s.data)
 }
 
-func (sorter imageSorter) Less(i, j int) bool {
-	ctxi := sorter.imageCtxs[i]
-	ctxj := sorter.imageCtxs[j]
-	sorter.by = strings.Trim(sorter.by, " ")
-	if len(sorter.by) == 0 {
-		sorter.by = "created:des"
+func (s genericStructSorter) Swap(i, j int) {
+	s.data[i], s.data[j] = s.data[j], s.data[i]
+}
+
+const (
+	ascendantKey  = "asc"
+	descendantKey = "dsc"
+)
+
+func validateType(i interface{}, j interface{}) error {
+	iType := reflect.TypeOf(i)
+	jType := reflect.TypeOf(j)
+	if iType.Kind() != reflect.Struct {
+		return fmt.Errorf("data must be of type struct")
 	}
-	switch sorter.by {
-	case "size":
-		fallthrough
-	case "size:asc":
-		return ctxi.i.Size <= ctxj.i.Size
-	case "size:des":
-		return ctxi.i.Size > ctxj.i.Size
-	case "repo":
-		fallthrough
-	case "repo:asc":
-		repoTagi := ctxi.repo + ctxi.tag
-		repoTagj := ctxj.repo + ctxj.tag
-		if strings.Compare(repoTagi, repoTagj) <= 0 {
-			return true
-		}
-		return false
-	case "repo:des":
-		repoTagi := ctxi.repo + ctxi.tag
-		repoTagj := ctxj.repo + ctxj.tag
-		if strings.Compare(repoTagi, repoTagj) > 0 {
-			return true
-		}
-		return false
-	case "created":
-		fallthrough
-	case "created:asc":
-		timei := time.Unix(int64(ctxi.i.Created), 0)
-		timej := time.Unix(int64(ctxj.i.Created), 0)
-		if timei.Before(timej) || timei.Equal(timej) {
-			return true
-		}
-		return false
-	case "created:des":
-		timei := time.Unix(int64(ctxi.i.Created), 0)
-		timej := time.Unix(int64(ctxj.i.Created), 0)
-		if timei.After(timej) {
-			return true
-		}
-		return false
+	if iType.PkgPath() != jType.PkgPath() || iType.Name() != jType.Name() || iType.Kind() != jType.Kind() {
+		return fmt.Errorf("data are not of the same type: (%v, %v, %v) != (%v, %v, %v)",
+			iType.PkgPath(), iType.Name(), iType.Kind(), jType.PkgPath(), jType.Name(), jType.Kind())
+	}
+	return nil
+}
+
+func findFieldIndex(t reflect.Type, name string, index *[]int) bool {
+	match := func(s string) bool {
+		return strings.EqualFold(s, name)
+	}
+	f, ok := t.FieldByNameFunc(match)
+	if ok {
+		*index = append(f.Index, *index...)
+		return true
 	}
 
+	for i := 0; i < t.NumField(); i++ {
+		nt := t.Field(i).Type
+		if t.Kind() == reflect.Ptr {
+			nt = nt.Elem()
+		}
+		if nt.Kind() == reflect.Struct {
+			ok = findFieldIndex(nt, name, index)
+			if ok {
+				*index = append(t.Field(i).Index, *index...)
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func newGenericStructSorter(data []interface{}, bys []string) (genericStructSorter, error) {
+	gs := genericStructSorter{}
+	if len(data) == 0 {
+		return gs, nil
+	}
+	if len(bys) == 0 {
+		return gs, fmt.Errorf("bys cannot be empty")
+	}
+	gs.data = data
+	gs.bys = bys
+	d := data[0]
+	for i := 1; i < len(data); i++ {
+		if err := validateType(d, data[i]); err != nil {
+			return gs, err
+		}
+	}
+	for idx, by := range bys {
+		parts := strings.Split(by, ":")
+		by = parts[0]
+		dir := ascendantKey
+		if len(parts) > 1 && (dir == ascendantKey || dir == descendantKey) {
+			dir = parts[1]
+		}
+		gs.bys[idx] = by
+		gs.ordering = append(gs.ordering, dir)
+
+		fieldIndex := []int{}
+		ok := findFieldIndex(reflect.TypeOf(d), by, &fieldIndex)
+		if !ok {
+			return gs, fmt.Errorf("field %s was not found in struct", by)
+		}
+		gs.indexes = append(gs.indexes, fieldIndex)
+	}
+
+	return gs, nil
+}
+
+func (s genericStructSorter) Less(i, j int) bool {
+	di := s.data[i]
+	dj := s.data[j]
+
+	diType := reflect.TypeOf(di)
+	diValue := reflect.ValueOf(di)
+
+	djType := reflect.TypeOf(dj)
+	djValue := reflect.ValueOf(dj)
+
+	lastByIdx := len(s.bys) - 1
+	for byIdx := range s.bys {
+		var (
+			diField, djField           reflect.StructField
+			diFieldValue, djFieldValue reflect.Value
+		)
+
+		diCurType := diType
+		diCurValue := diValue
+		djCurType := djType
+		djCurValue := djValue
+
+		for _, idx := range s.indexes[byIdx] {
+			diField = diCurType.Field(idx)
+			diFieldValue = diCurValue.Field(idx)
+
+			djField = djCurType.Field(idx)
+			djFieldValue = djCurValue.Field(idx)
+
+			if diField.Type.Kind() == reflect.Ptr {
+				if diFieldValue.IsNil() && djFieldValue.IsNil() {
+					return false
+				} else if diFieldValue.IsNil() || djFieldValue.IsNil() {
+					if diFieldValue.IsNil() {
+						return true
+					}
+					return false
+				}
+
+				diCurType = diField.Type.Elem()
+				diCurValue = diFieldValue.Elem()
+
+				djCurType = djField.Type.Elem()
+				djCurValue = djFieldValue.Elem()
+			} else {
+				diCurType = diField.Type
+				diCurValue = diFieldValue
+
+				djCurType = djField.Type
+				djCurValue = djFieldValue
+			}
+		}
+
+		dir := s.ordering[byIdx]
+		res := 0
+		switch diCurType.Kind() {
+		case reflect.String:
+			res = lessForString(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+		case reflect.Bool:
+			res = lessForBool(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			res = lessForInt(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			res = lessForUint(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+		case reflect.Float32, reflect.Float64:
+			res = lessForFloat(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+		default:
+			switch diCurType {
+			case reflect.TypeOf(time.Time{}):
+				res = lessForTime(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+			default:
+				panic(fmt.Sprintf("genericStructSorter: comparison of %v are not supported", diCurType.Kind()))
+			}
+		}
+
+		if res != 0 {
+			return res == -1
+		}
+	}
 	return true
+}
+
+func lessForString(i, j reflect.Value, asc, last bool) int {
+	vi, vj := i.String(), j.String()
+	if vi == vj && !last {
+		return 0
+	}
+	if asc {
+		if vi < vj {
+			return -1
+		}
+		return 1
+	}
+	if vi > vj {
+		return -1
+	}
+	return 1
+}
+
+func lessForBool(i, j reflect.Value, asc, last bool) int {
+	vi, vj := i.Bool(), j.Bool()
+	if vi == vj && !last {
+		return 0
+	}
+	if asc {
+		if !vi && vj {
+			return -1
+		}
+		return 1
+	}
+	if vi && !vj {
+		return -1
+	}
+	return 1
+}
+
+func lessForInt(i, j reflect.Value, asc, last bool) (ret int) {
+	vi, vj := i.Int(), j.Int()
+	if vi == vj && !last {
+		return 0
+	}
+	if asc {
+		if vi < vj {
+			return -1
+		}
+		return 1
+	}
+	if vi > vj {
+		return -1
+	}
+	return 1
+}
+
+func lessForUint(i, j reflect.Value, asc, last bool) int {
+	vi, vj := i.Uint(), j.Uint()
+	if vi == vj && !last {
+		return 0
+	}
+	if asc {
+		if vi < vj {
+			return -1
+		}
+		return 1
+	}
+	if vi > vj {
+		return -1
+	}
+	return 1
+}
+
+func lessForFloat(i, j reflect.Value, asc, last bool) int {
+	vi, vj := i.Float(), j.Float()
+	if vi == vj && !last {
+		return 0
+	}
+	if asc {
+		if vi < vj {
+			return -1
+		}
+		return 1
+	}
+	if vi > vj {
+		return -1
+	}
+	return 1
+}
+
+func lessForTime(i, j reflect.Value, asc, last bool) int {
+	vi, vj := i.Interface().(time.Time), j.Interface().(time.Time)
+	if vi.Equal(vj) && !last {
+		return 0
+	}
+	if asc {
+		if vi.Before(vj) {
+			return -1
+		}
+		return 1
+	}
+	if vi.After(vj) {
+		return -1
+	}
+	return 1
 }

--- a/cli/command/formatter/sorter.go
+++ b/cli/command/formatter/sorter.go
@@ -7,11 +7,20 @@ import (
 	"time"
 )
 
+const (
+	ascendantKey  = "asc"
+	descendantKey = "dsc"
+)
+
+type orderBy struct {
+	fieldName string // order by field with `fieldName` in struct
+	ordering  string // asc or dsc
+	index     []int  // index of field in struct
+}
+
 type genericStructSorter struct {
-	data     []interface{}
-	bys      []string
-	ordering []string
-	indexes  [][]int
+	data []interface{}
+	bys  []orderBy
 }
 
 func (s genericStructSorter) Len() int {
@@ -22,29 +31,36 @@ func (s genericStructSorter) Swap(i, j int) {
 	s.data[i], s.data[j] = s.data[j], s.data[i]
 }
 
-const (
-	ascendantKey  = "asc"
-	descendantKey = "dsc"
-)
-
-func validateType(i interface{}, j interface{}) error {
-	iType := reflect.TypeOf(i)
-	jType := reflect.TypeOf(j)
-	if iType.Kind() != reflect.Struct {
+// validate all the data are of same time
+func validateType(data []interface{}) error {
+	if len(data) == 0 {
+		return nil
+	}
+	baseType := reflect.TypeOf(data[0])
+	if baseType.Kind() != reflect.Struct {
 		return fmt.Errorf("data must be of type struct")
 	}
-	if iType.PkgPath() != jType.PkgPath() || iType.Name() != jType.Name() || iType.Kind() != jType.Kind() {
-		return fmt.Errorf("data are not of the same type: (%v, %v, %v) != (%v, %v, %v)",
-			iType.PkgPath(), iType.Name(), iType.Kind(), jType.PkgPath(), jType.Name(), jType.Kind())
+	for i := 1; i < len(data); i++ {
+		iType := reflect.TypeOf(data[i])
+		if iType.PkgPath() != baseType.PkgPath() || iType.Name() != baseType.Name() || iType.Kind() != baseType.Kind() {
+			return fmt.Errorf("data are not of the same type: (%v, %v, %v) != (%v, %v, %v)",
+				iType.PkgPath(), iType.Name(), iType.Kind(), baseType.PkgPath(), baseType.Name(), baseType.Kind())
+		}
 	}
 	return nil
 }
 
+// findFieldIndex find the first occurence of field with name "name"
+// if it's a nested field, return array of index
+// e.g. [2, 1, 1] means field[2][1][1]
 func findFieldIndex(t reflect.Type, name string, index *[]int) bool {
-	match := func(s string) bool {
-		return strings.EqualFold(s, name)
-	}
-	f, ok := t.FieldByNameFunc(match)
+	// TODO: use FieldByNameFunc to compare both lower and upper case
+	// It's weird that current implementation doesn't work!
+	// match := func(s string) bool {
+	//	 return strings.EqualFold(s, name)
+	// }
+	// f, ok := t.FieldByNameFunc(match)
+	f, ok := t.FieldByName(name)
 	if ok {
 		*index = append(f.Index, *index...)
 		return true
@@ -52,10 +68,11 @@ func findFieldIndex(t reflect.Type, name string, index *[]int) bool {
 
 	for i := 0; i < t.NumField(); i++ {
 		nt := t.Field(i).Type
-		if t.Kind() == reflect.Ptr {
+		if nt.Kind() == reflect.Ptr {
 			nt = nt.Elem()
 		}
-		if nt.Kind() == reflect.Struct {
+		// don't peek into time.Time{}
+		if nt.Kind() == reflect.Struct && nt != reflect.TypeOf(time.Time{}) {
 			ok = findFieldIndex(nt, name, index)
 			if ok {
 				*index = append(t.Field(i).Index, *index...)
@@ -75,30 +92,56 @@ func newGenericStructSorter(data []interface{}, bys []string) (genericStructSort
 	if len(bys) == 0 {
 		return gs, fmt.Errorf("bys cannot be empty")
 	}
-	gs.data = data
-	gs.bys = bys
-	d := data[0]
-	for i := 1; i < len(data); i++ {
-		if err := validateType(d, data[i]); err != nil {
-			return gs, err
-		}
+	if err := validateType(data); err != nil {
+		return gs, err
 	}
-	for idx, by := range bys {
-		parts := strings.Split(by, ":")
-		by = parts[0]
-		dir := ascendantKey
-		if len(parts) > 1 && (dir == ascendantKey || dir == descendantKey) {
-			dir = parts[1]
-		}
-		gs.bys[idx] = by
-		gs.ordering = append(gs.ordering, dir)
+	// scan and get the sortable fields
+	sortableFields := make(map[string]bool)
+	if err := getSortableFields(reflect.TypeOf(data[0]), sortableFields); err != nil {
+		return gs, fmt.Errorf("can't get sortable fields: %v", err)
+	}
 
-		fieldIndex := []int{}
-		ok := findFieldIndex(reflect.TypeOf(d), by, &fieldIndex)
-		if !ok {
-			return gs, fmt.Errorf("field %s was not found in struct", by)
+	gs.data = data
+	for _, by := range bys {
+		by = strings.TrimSpace(by)
+		parts := strings.Split(by, ":")
+		dir := ascendantKey // ascendant key is default
+		switch len(parts) {
+		case 2:
+			switch parts[1] {
+			case descendantKey:
+				dir = descendantKey
+			case ascendantKey, "": // if default, keep as ascendantKey
+			default: // doesn't support key other than "asc","dsc",""
+				return gs, fmt.Errorf("sort order %q not supported", parts[1])
+			}
+		case 1: // sort order not specified, keep default
+		default:
+			return gs, fmt.Errorf("malformed sort key: %q", by)
 		}
-		gs.indexes = append(gs.indexes, fieldIndex)
+		by = parts[0]
+		if _, ok := sortableFields[by]; !ok {
+			var keys []string
+			for k := range sortableFields {
+				keys = append(keys, k)
+			}
+			return gs, fmt.Errorf("can't sort by %q, it must be in [%s]", by, strings.Join(keys, ","))
+		}
+		fieldIndex := []int{}
+		ok := findFieldIndex(reflect.TypeOf(data[0]), by, &fieldIndex)
+		if !ok { // if by is in sortableFields, then this should never happen
+			var keys []string
+			for k := range sortableFields {
+				keys = append(keys, k)
+			}
+			return gs, fmt.Errorf("can't find field index of %q, supported fields are [%s]", by, strings.Join(keys, ","))
+		}
+		gs.bys = append(gs.bys, orderBy{
+			fieldName: by,
+			ordering:  dir,
+			index:     fieldIndex,
+		})
+
 	}
 
 	return gs, nil
@@ -108,25 +151,17 @@ func (s genericStructSorter) Less(i, j int) bool {
 	di := s.data[i]
 	dj := s.data[j]
 
-	diType := reflect.TypeOf(di)
-	diValue := reflect.ValueOf(di)
-
-	djType := reflect.TypeOf(dj)
-	djValue := reflect.ValueOf(dj)
-
-	lastByIdx := len(s.bys) - 1
-	for byIdx := range s.bys {
+	for _, orderBy := range s.bys {
 		var (
 			diField, djField           reflect.StructField
 			diFieldValue, djFieldValue reflect.Value
+			diCurType                  = reflect.TypeOf(di)
+			diCurValue                 = reflect.ValueOf(di)
+			djCurType                  = reflect.TypeOf(dj)
+			djCurValue                 = reflect.ValueOf(dj)
 		)
 
-		diCurType := diType
-		diCurValue := diValue
-		djCurType := djType
-		djCurValue := djValue
-
-		for _, idx := range s.indexes[byIdx] {
+		for _, idx := range orderBy.index {
 			diField = diCurType.Field(idx)
 			diFieldValue = diCurValue.Field(idx)
 
@@ -134,13 +169,14 @@ func (s genericStructSorter) Less(i, j int) bool {
 			djFieldValue = djCurValue.Field(idx)
 
 			if diField.Type.Kind() == reflect.Ptr {
-				if diFieldValue.IsNil() && djFieldValue.IsNil() {
+				// keep nil value before non-nil value
+				// Note: for Less() parameters, i is larger than j, e.g. i=1, j=0
+				// if djFieldValue(data[0]) is nil, return false to keep their positions
+				// or if djFieldValue(data[0]) isn't nil but diFieldValue(data[1]) is nil, return true to swap
+				if djFieldValue.IsNil() {
 					return false
-				} else if diFieldValue.IsNil() || djFieldValue.IsNil() {
-					if diFieldValue.IsNil() {
-						return true
-					}
-					return false
+				} else if diFieldValue.IsNil() {
+					return true
 				}
 
 				diCurType = diField.Type.Elem()
@@ -157,133 +193,133 @@ func (s genericStructSorter) Less(i, j int) bool {
 			}
 		}
 
-		dir := s.ordering[byIdx]
 		res := 0
 		switch diCurType.Kind() {
 		case reflect.String:
-			res = lessForString(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+			res = lessForString(diCurValue, djCurValue)
 		case reflect.Bool:
-			res = lessForBool(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+			res = lessForBool(diCurValue, djCurValue)
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			res = lessForInt(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+			res = lessForInt(diCurValue, djCurValue)
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			res = lessForUint(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+			res = lessForUint(diCurValue, djCurValue)
 		case reflect.Float32, reflect.Float64:
-			res = lessForFloat(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+			res = lessForFloat(diCurValue, djCurValue)
 		default:
 			switch diCurType {
 			case reflect.TypeOf(time.Time{}):
-				res = lessForTime(diCurValue, djCurValue, dir == ascendantKey, byIdx == lastByIdx)
+				res = lessForTime(diCurValue, djCurValue)
 			default:
-				panic(fmt.Sprintf("genericStructSorter: comparison of %v are not supported", diCurType.Kind()))
+				// panic(fmt.Sprintf("genericStructSorter: comparison of %v are not supported", diCurType.Kind()))
+				// TODO: find a reasonable logic
+				// if it's unsupported field, keep original positions
+				return false
 			}
 		}
 
 		if res != 0 {
-			return res == -1
+			if orderBy.ordering == ascendantKey {
+				return res == -1
+			}
+			return res == 1
 		}
 	}
-	return true
+
+	// equal values, return false to keep their postions
+	return false
 }
 
-func lessForString(i, j reflect.Value, asc, last bool) int {
+func lessForString(i, j reflect.Value) int {
 	vi, vj := i.String(), j.String()
-	if vi == vj && !last {
+	if vi == vj {
 		return 0
 	}
-	if asc {
-		if vi < vj {
-			return -1
-		}
-		return 1
-	}
-	if vi > vj {
+	if vi < vj {
 		return -1
 	}
 	return 1
 }
 
-func lessForBool(i, j reflect.Value, asc, last bool) int {
+func lessForBool(i, j reflect.Value) int {
 	vi, vj := i.Bool(), j.Bool()
-	if vi == vj && !last {
+	if vi == vj {
 		return 0
 	}
-	if asc {
-		if !vi && vj {
-			return -1
-		}
-		return 1
-	}
-	if vi && !vj {
+	if !vi && vj {
 		return -1
 	}
 	return 1
 }
 
-func lessForInt(i, j reflect.Value, asc, last bool) (ret int) {
+func lessForInt(i, j reflect.Value) (ret int) {
 	vi, vj := i.Int(), j.Int()
-	if vi == vj && !last {
+	if vi == vj {
 		return 0
 	}
-	if asc {
-		if vi < vj {
-			return -1
-		}
-		return 1
-	}
-	if vi > vj {
+	if vi < vj {
 		return -1
 	}
 	return 1
 }
 
-func lessForUint(i, j reflect.Value, asc, last bool) int {
+func lessForUint(i, j reflect.Value) int {
 	vi, vj := i.Uint(), j.Uint()
-	if vi == vj && !last {
+	if vi == vj {
 		return 0
 	}
-	if asc {
-		if vi < vj {
-			return -1
-		}
-		return 1
-	}
-	if vi > vj {
+	if vi < vj {
 		return -1
 	}
 	return 1
 }
 
-func lessForFloat(i, j reflect.Value, asc, last bool) int {
+func lessForFloat(i, j reflect.Value) int {
 	vi, vj := i.Float(), j.Float()
-	if vi == vj && !last {
+	if vi == vj {
 		return 0
 	}
-	if asc {
-		if vi < vj {
-			return -1
-		}
-		return 1
-	}
-	if vi > vj {
+	if vi < vj {
 		return -1
 	}
 	return 1
 }
 
-func lessForTime(i, j reflect.Value, asc, last bool) int {
+func lessForTime(i, j reflect.Value) int {
 	vi, vj := i.Interface().(time.Time), j.Interface().(time.Time)
-	if vi.Equal(vj) && !last {
+	if vi.Equal(vj) {
 		return 0
 	}
-	if asc {
-		if vi.Before(vj) {
-			return -1
-		}
-		return 1
-	}
-	if vi.After(vj) {
+	if vi.Before(vj) {
 		return -1
 	}
 	return 1
+}
+
+func getSortableFields(dataType reflect.Type, fields map[string]bool) error {
+	if dataType.Kind() != reflect.Struct {
+		return fmt.Errorf("data must be of type struct: %v", dataType)
+	}
+
+	for i := 0; i < dataType.NumField(); i++ {
+		structField := dataType.Field(i)
+		fieldType := structField.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		switch fieldType.Kind() {
+		case reflect.String, reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+			fields[structField.Name] = true
+		case reflect.Struct:
+			if fieldType == reflect.TypeOf(time.Time{}) {
+				fields[structField.Name] = true
+				continue
+			}
+			if err := getSortableFields(fieldType, fields); err != nil {
+				return err
+			}
+		default: //ignore other types
+		}
+	}
+
+	return nil
 }

--- a/cli/command/formatter/sorter.go
+++ b/cli/command/formatter/sorter.go
@@ -1,0 +1,71 @@
+package formatter
+
+import (
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types"
+)
+
+type imageSorter struct {
+	imageCtxs []*imageContext
+	images    []types.ImageSummary
+	by        string
+}
+
+func (sorter imageSorter) Len() int { return len(sorter.imageCtxs) }
+
+func (sorter imageSorter) Swap(i, j int) {
+	sorter.imageCtxs[i], sorter.imageCtxs[j] = sorter.imageCtxs[j], sorter.imageCtxs[i]
+}
+
+func (sorter imageSorter) Less(i, j int) bool {
+	ctxi := sorter.imageCtxs[i]
+	ctxj := sorter.imageCtxs[j]
+	sorter.by = strings.Trim(sorter.by, " ")
+	if len(sorter.by) == 0 {
+		sorter.by = "created:des"
+	}
+	switch sorter.by {
+	case "size":
+		fallthrough
+	case "size:asc":
+		return ctxi.i.Size <= ctxj.i.Size
+	case "size:des":
+		return ctxi.i.Size > ctxj.i.Size
+	case "repo":
+		fallthrough
+	case "repo:asc":
+		repoTagi := ctxi.repo + ctxi.tag
+		repoTagj := ctxj.repo + ctxj.tag
+		if strings.Compare(repoTagi, repoTagj) <= 0 {
+			return true
+		}
+		return false
+	case "repo:des":
+		repoTagi := ctxi.repo + ctxi.tag
+		repoTagj := ctxj.repo + ctxj.tag
+		if strings.Compare(repoTagi, repoTagj) > 0 {
+			return true
+		}
+		return false
+	case "created":
+		fallthrough
+	case "created:asc":
+		timei := time.Unix(int64(ctxi.i.Created), 0)
+		timej := time.Unix(int64(ctxj.i.Created), 0)
+		if timei.Before(timej) || timei.Equal(timej) {
+			return true
+		}
+		return false
+	case "created:des":
+		timei := time.Unix(int64(ctxi.i.Created), 0)
+		timej := time.Unix(int64(ctxj.i.Created), 0)
+		if timei.After(timej) {
+			return true
+		}
+		return false
+	}
+
+	return true
+}

--- a/cli/command/formatter/sorter_test.go
+++ b/cli/command/formatter/sorter_test.go
@@ -238,8 +238,8 @@ func TestGetSortableFields(t *testing.T) {
 		"t":              "Time",
 		"deepInnerValue": "DeepValue",
 	}
-	sortableFields := map[string]fieldIndex{}
-	if err := getSortableFields(reflect.TypeOf(cs), whitelist, nil, sortableFields); err != nil {
+	sortableFields, err := getSortableFields(reflect.TypeOf(cs), whitelist, nil)
+	if err != nil {
 		t.Fatalf("failed to get sortable fields: %v", err)
 	}
 

--- a/cli/command/formatter/sorter_test.go
+++ b/cli/command/formatter/sorter_test.go
@@ -22,7 +22,7 @@ func TestStringStructSorter(t *testing.T) {
 	whitelist := map[string]string{"S": ""}
 	gs, err := newGenericStructSorter(data, []string{"S"}, whitelist)
 	if err != nil {
-		t.Fatal("failed to create sorter:", err)
+		t.Fatal("failed to create sorter: ", err)
 	}
 
 	sort.Sort(gs)
@@ -47,7 +47,7 @@ func TestBoolStructSorter(t *testing.T) {
 	whitelist := map[string]string{"B": ""}
 	gs, err := newGenericStructSorter(data, []string{"B:desc"}, whitelist)
 	if err != nil {
-		t.Fatal("failed to create sorter:", err)
+		t.Fatal("failed to create sorter: ", err)
 	}
 
 	sort.Sort(gs)
@@ -72,7 +72,7 @@ func TestIntStructSorter(t *testing.T) {
 	whitelist := map[string]string{"I": ""}
 	gs, err := newGenericStructSorter(data, []string{"I:asc"}, whitelist)
 	if err != nil {
-		t.Fatal("failed to create sorter:", err)
+		t.Fatal("failed to create sorter: ", err)
 	}
 
 	sort.Sort(gs)
@@ -97,7 +97,7 @@ func TestUintStructSorter(t *testing.T) {
 	whitelist := map[string]string{"U": ""}
 	gs, err := newGenericStructSorter(data, []string{"U"}, whitelist)
 	if err != nil {
-		t.Fatal("failed to create sorter:", err)
+		t.Fatal("failed to create sorter: ", err)
 	}
 
 	sort.Sort(gs)
@@ -122,7 +122,7 @@ func TestFloatStructSorter(t *testing.T) {
 	whitelist := map[string]string{"F": ""}
 	gs, err := newGenericStructSorter(data, []string{"F"}, whitelist)
 	if err != nil {
-		t.Fatal("failed to create sorter:", err)
+		t.Fatal("failed to create sorter: ", err)
 	}
 
 	sort.Sort(gs)

--- a/cli/command/formatter/sorter_test.go
+++ b/cli/command/formatter/sorter_test.go
@@ -1,0 +1,160 @@
+package formatter
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestStringStructSorter(t *testing.T) {
+	type strStruct struct {
+		S string
+	}
+
+	expected := []interface{}{
+		strStruct{"a"}, strStruct{"b"}, strStruct{"c"}, strStruct{"z"},
+	}
+	data := []interface{}{
+		strStruct{"z"}, strStruct{"c"}, strStruct{"a"}, strStruct{"b"},
+	}
+
+	gs, err := newGenericStructSorter(data, []string{"S"})
+	if err != nil {
+		t.Fatal("failed to create sorter:", err)
+	}
+
+	sort.Sort(gs)
+
+	if !reflect.DeepEqual(gs.data, expected) {
+		t.Fatalf("sorting failed:\nexpected: %#v\ngot: %#v", expected, gs.data)
+	}
+}
+
+func TestBoolStructSorter(t *testing.T) {
+	type boolStruct struct {
+		B bool
+	}
+
+	expected := []interface{}{
+		boolStruct{true}, boolStruct{true}, boolStruct{false}, boolStruct{false},
+	}
+	data := []interface{}{
+		boolStruct{true}, boolStruct{false}, boolStruct{true}, boolStruct{false},
+	}
+
+	gs, err := newGenericStructSorter(data, []string{"B:dsc"})
+	if err != nil {
+		t.Fatal("failed to create sorter:", err)
+	}
+
+	sort.Sort(gs)
+
+	if !reflect.DeepEqual(gs.data, expected) {
+		t.Fatalf("sorting failed:\nexpected: %#v\ngot: %#v", expected, gs.data)
+	}
+}
+
+func TestIntStructSorter(t *testing.T) {
+	type intStruct struct {
+		I int
+	}
+
+	expected := []interface{}{
+		intStruct{-21}, intStruct{10}, intStruct{16}, intStruct{42},
+	}
+	data := []interface{}{
+		intStruct{42}, intStruct{16}, intStruct{-21}, intStruct{10},
+	}
+
+	gs, err := newGenericStructSorter(data, []string{"I:asc"})
+	if err != nil {
+		t.Fatal("failed to create sorter:", err)
+	}
+
+	sort.Sort(gs)
+
+	if !reflect.DeepEqual(gs.data, expected) {
+		t.Fatalf("sorting failed:\nexpected: %#v\ngot: %#v", expected, gs.data)
+	}
+}
+
+func TestUintStructSorter(t *testing.T) {
+	type uintStruct struct {
+		U uint
+	}
+
+	expected := []interface{}{
+		uintStruct{10}, uintStruct{16}, uintStruct{21}, uintStruct{42},
+	}
+	data := []interface{}{
+		uintStruct{42}, uintStruct{16}, uintStruct{21}, uintStruct{10},
+	}
+
+	gs, err := newGenericStructSorter(data, []string{"U"})
+	if err != nil {
+		t.Fatal("failed to create sorter:", err)
+	}
+
+	sort.Sort(gs)
+
+	if !reflect.DeepEqual(gs.data, expected) {
+		t.Fatalf("sorting failed:\nexpected: %#v\ngot: %#v", expected, gs.data)
+	}
+}
+
+func TestFloatStructSorter(t *testing.T) {
+	type floatStruct struct {
+		F float32
+	}
+
+	expected := []interface{}{
+		floatStruct{-16.8}, floatStruct{3.14}, floatStruct{10}, floatStruct{21.42},
+	}
+	data := []interface{}{
+		floatStruct{3.14}, floatStruct{-16.8}, floatStruct{21.42}, floatStruct{10},
+	}
+
+	gs, err := newGenericStructSorter(data, []string{"F"})
+	if err != nil {
+		t.Fatal("failed to create sorter:", err)
+	}
+
+	sort.Sort(gs)
+
+	if !reflect.DeepEqual(gs.data, expected) {
+		t.Fatalf("sorting failed:\nexpected: %#v\ngot: %#v", expected, gs.data)
+	}
+}
+
+func TestTimeStructSorter(t *testing.T) {
+	type timeStruct struct {
+		T time.Time
+	}
+
+	sc, _ := time.LoadLocation("America/Los_Angeles")
+
+	expected := []interface{}{
+		timeStruct{time.Date(1984, time.September, 27, 13, 0, 0, 0, time.UTC)},
+		timeStruct{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
+		timeStruct{time.Date(2013, time.March, 13, 13, 20, 0, 0, sc)},
+		timeStruct{time.Date(2015, time.December, 15, 9, 0, 0, 0, sc)},
+	}
+	data := []interface{}{
+		timeStruct{time.Date(2013, time.March, 13, 13, 20, 0, 0, sc)},
+		timeStruct{time.Date(1984, time.September, 27, 13, 0, 0, 0, time.UTC)},
+		timeStruct{time.Date(2015, time.December, 15, 9, 0, 0, 0, sc)},
+		timeStruct{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
+	}
+
+	gs, err := newGenericStructSorter(data, []string{"T"})
+	if err != nil {
+		t.Fatal("failed to create sorter:", err)
+	}
+
+	sort.Sort(gs)
+
+	if !reflect.DeepEqual(gs.data, expected) {
+		t.Fatalf("sorting failed:\nexpected: %#v\ngot: %#v", expected, gs.data)
+	}
+}

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -47,7 +47,7 @@ func NewImagesCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&opts.showDigests, "digests", false, "Show digests")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print images using a Go template")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
-	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]. e.g. \"ID:asc,CreatedAt:desc\"")
+	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]. For example, \"id:asc,createdat:desc\"")
 
 	return cmd
 }

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -20,6 +20,7 @@ type imagesOptions struct {
 	showDigests bool
 	format      string
 	filter      opts.FilterOpt
+	sortby      string
 }
 
 // NewImagesCommand creates a new `docker images` command
@@ -46,6 +47,7 @@ func NewImagesCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&opts.showDigests, "digests", false, "Show digests")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print images using a Go template")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
+	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]")
 
 	return cmd
 }
@@ -91,6 +93,7 @@ func runImages(dockerCli *command.DockerCli, opts imagesOptions) error {
 			Trunc:  !opts.noTrunc,
 		},
 		Digest: opts.showDigests,
+		Sortby: opts.sortby,
 	}
 	return formatter.ImageWrite(imageCtx, images)
 }

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -47,7 +47,7 @@ func NewImagesCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&opts.showDigests, "digests", false, "Show digests")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print images using a Go template")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
-	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]")
+	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]. E.g. \"ID:asc,Created:dsc\"")
 
 	return cmd
 }

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -47,7 +47,7 @@ func NewImagesCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVar(&opts.showDigests, "digests", false, "Show digests")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print images using a Go template")
 	flags.VarP(&opts.filter, "filter", "f", "Filter output based on conditions provided")
-	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]. E.g. \"ID:asc,Created:dsc\"")
+	flags.StringVar(&opts.sortby, "sort-by", "", "Customize list order, sort by field[:order]. e.g. \"ID:asc,CreatedAt:desc\"")
 
 	return cmd
 }

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -33,6 +33,7 @@ Options:
       --help            Print usage
       --no-trunc        Don't truncate output
   -q, --quiet           Only show numeric IDs
+      --sort-by string  Customize list order, sort by field[:order]. For example, "id:asc,createdat:desc"
 ```
 
 ## Description
@@ -342,4 +343,33 @@ b6fa739cedf5        committ                   latest
 746b819f315e        postgres                  9.3.5
 746b819f315e        postgres                  latest
 {% endraw %}
+```
+
+### Customize sort order
+
+To customize list orders, you can use `--sort-by` option, which takes the format
+of `field[:order]`. `field` is one or more of: "repository",
+"tag", "digest", "createdat", "id" and "size". `order` should be either `asc`(ascendant)
+or `desc`(descendant).
+The meaning of each `field` is described in the [`Formatting`](#formatting) section.
+
+If you specify an invalid `field` or `order` string, a hint will be printed, such as the following:
+
+```bash
+$ docker images --sort-by invalid
+unknown sort field: "invalid". Valid options are "repository, tag, digest, createdat, id, size"
+```
+
+To sort images by repository name in ascendant order, then by tags in descendant order
+if some have same repository names, run this command:
+
+```bash
+$ docker images --sort-by "repository:asc,tag:desc"
+
+REPOSITORY                  TAG                 IMAGE ID            CREATED             SIZE
+alpine                      3.4                 baa5d63471ea        4 months ago        4.8MB
+golang                      latest              a1b716bca9ae        17 months ago       585MB
+golang                      1.6.2               8ecba0e9bd48        7 months ago        754MB
+golang                      1.4                 41dd037540dd        12 months ago       563MB
+hello                       latest              1832e715399b        9 months ago        1.11MB
 ```

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -378,5 +378,5 @@ func (s *DockerSuite) TestImageSortBy(c *check.C) {
 	// test unsupported --sort-by value
 	_, _, err := dockerCmdWithError("images", "--sort-by", "repo:asc,tag:desc", "name*")
 	c.Assert(err, checker.NotNil)
-	c.Assert(err.Error(), checker.Contains, "can't sort by \"repo\"")
+	c.Assert(err.Error(), checker.Contains, "unknown sort field: \"repo\"")
 }

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -363,3 +363,20 @@ func (s *DockerSuite) TestImagesFormatDefaultFormat(c *check.C) {
 	out, _ = dockerCmd(c, "--config", d, "images", "-q", "myimage")
 	c.Assert(out, checker.Equals, imageID+"\n", check.Commentf("Expected to print only the image id, got %v\n", out))
 }
+
+func (s *DockerSuite) TestImageSortBy(c *check.C) {
+	dockerCmd(c, "tag", "busybox", "name1:v1")
+	dockerCmd(c, "tag", "busybox", "name1:v2")
+	dockerCmd(c, "tag", "busybox", "name0:v2")
+
+	imagesOut, _ := dockerCmd(c, "images", "--sort-by", "repo:asc,tag:dsc", "name*")
+	imgs := strings.Split(imagesOut, "\n")
+	c.Assert(imgs[1], checker.Contains, "name0               v2", check.Commentf("First image must be %s, got %s", "name0:v2", imgs[1]))
+	c.Assert(imgs[2], checker.Contains, "name1               v2", check.Commentf("First image must be %s, got %s", "name1:v2", imgs[2]))
+	c.Assert(imgs[3], checker.Contains, "name1               v1", check.Commentf("First image must be %s, got %s", "name1:v1", imgs[3]))
+
+	// test unsupported --sort-by value
+	_, _, err := dockerCmdWithError("images", "--sort-by", "fake:asc,tag:dsc", "name*")
+	c.Assert(err, checker.NotNil)
+	c.Assert(err.Error(), checker.Contains, "can't sort by \"fake\"")
+}

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -369,14 +369,14 @@ func (s *DockerSuite) TestImageSortBy(c *check.C) {
 	dockerCmd(c, "tag", "busybox", "name1:v2")
 	dockerCmd(c, "tag", "busybox", "name0:v2")
 
-	imagesOut, _ := dockerCmd(c, "images", "--sort-by", "repo:asc,tag:dsc", "name*")
+	imagesOut, _ := dockerCmd(c, "images", "--sort-by", "Repository:asc,tag:desc", "name*")
 	imgs := strings.Split(imagesOut, "\n")
 	c.Assert(imgs[1], checker.Contains, "name0               v2", check.Commentf("First image must be %s, got %s", "name0:v2", imgs[1]))
 	c.Assert(imgs[2], checker.Contains, "name1               v2", check.Commentf("First image must be %s, got %s", "name1:v2", imgs[2]))
 	c.Assert(imgs[3], checker.Contains, "name1               v1", check.Commentf("First image must be %s, got %s", "name1:v1", imgs[3]))
 
 	// test unsupported --sort-by value
-	_, _, err := dockerCmdWithError("images", "--sort-by", "fake:asc,tag:dsc", "name*")
+	_, _, err := dockerCmdWithError("images", "--sort-by", "repo:asc,tag:desc", "name*")
 	c.Assert(err, checker.NotNil)
-	c.Assert(err.Error(), checker.Contains, "can't sort by \"fake\"")
+	c.Assert(err.Error(), checker.Contains, "can't sort by \"repo\"")
 }

--- a/man/apt.conf
+++ b/man/apt.conf
@@ -1,0 +1,3 @@
+Acquire::http::proxy "http://z00280905:Huawei.12@proxyhk.huawei.com:8080/";
+Acquire::https::proxy "http://z00280905:Huawei.12@proxyhk.huawei.com:8080/";
+Acquire::ftp::proxy "http://z00280905:Huawei.12@proxyhk.huawei.com:8080/";

--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -115,3 +115,26 @@ Listing just the shortened image IDs. This can be useful for some automated
 tools.
 
     docker image ls -q
+
+## Custome sort order
+
+To customize list orders, you can use `--sort-by` option, which takes the format
+of `field[:order]`. `field` is one or more of: "repository",
+"tag", "digest", "createdat", "id" and "size". `order` is either `asc`(ascending)
+or `desc`(descending).
+
+If you specify an invalid `field` or `order` string, a hint will be printed, such as the following:
+
+    docker images --sort-by invalid
+    unknown sort field: "invalid". Valid options are "repository, tag, digest, createdat, id, size"
+
+To sort images by repository name in ascendant order, then by tags in descendant order
+if some have same repository names, run this command:
+
+    docker images --sort-by "repository:asc,tag:desc"
+    REPOSITORY                  TAG                 IMAGE ID            CREATED             SIZE
+    alpine                      3.4                 baa5d63471ea        4 months ago        4.8MB
+    golang                      latest              a1b716bca9ae        17 months ago       585MB
+    golang                      1.6.2               8ecba0e9bd48        7 months ago        754MB
+    golang                      1.4                 41dd037540dd        12 months ago       563MB
+    hello                       latest              1832e715399b        9 months ago        1.11MB


### PR DESCRIPTION
Part of #25609

Allow user to customize their favourite list order, user can choose to
sort images by e.g. "size" in "asc"/"des" order.

Usage: --sort-by field[:order]

Supported fields: repository, tag, digest, createdat, id, size

order can be either "asc" or "desc", which means sort in ascendant/desendant
orders, default is "asc" if not specified.

Sample Usage: "--sort-by size:desc"

Signed-off-by: Zhang Wei zhangwei555@huawei.com

This is more like a prototype, I'd like to hear more feedbacks before I started to write test cases. :smile: 
