### PR TITLE
Cleanup API docs Markdown formatting and wording

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -127,129 +127,128 @@ Create a container
 
 **Example request**:
 
-      POST /containers/create HTTP/1.1
-        Content-Type: application/json
+    POST /containers/create HTTP/1.1
+    Content-Type: application/json
 
-        {
-             "Hostname": "",
-             "Domainname": "",
-             "User": "",
-             "AttachStdin": false,
-             "AttachStdout": true,
-             "AttachStderr": true,
-             "Tty": false,
-             "OpenStdin": false,
-             "StdinOnce": false,
-             "Env": [
-                     "FOO=bar",
-                     "BAZ=quux"
-             ],
-             "Cmd": [
-                     "date"
-             ],
-             "Entrypoint": null,
-             "Image": "ubuntu",
-             "Labels": {
-                     "com.example.vendor": "Acme",
-                     "com.example.license": "GPL",
-                     "com.example.version": "1.0"
-             },
-             "Volumes": {
-                     "/tmp": {}
-             },
-             "WorkingDir": "",
-             "NetworkDisabled": false,
-             "MacAddress": "12:34:56:78:9a:bc",
-             "ExposedPorts": {
-                     "22/tcp": {}
-             },
-             "HostConfig": {
-               "Binds": ["/tmp:/tmp"],
-               "Links": ["redis3:redis"],
-               "LxcConf": {"lxc.utsname":"docker"},
-               "Memory": 0,
-               "MemorySwap": 0,
-               "CpuShares": 512,
-               "CpusetCpus": "0,1",
-               "PidMode": "",
-               "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
-               "PublishAllPorts": false,
-               "Privileged": false,
-               "ReadonlyRootfs": false,
-               "Dns": ["8.8.8.8"],
-               "DnsSearch": [""],
-               "ExtraHosts": null,
-               "VolumesFrom": ["parent", "other:ro"],
-               "CapAdd": ["NET_ADMIN"],
-               "CapDrop": ["MKNOD"],
-               "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
-               "NetworkMode": "bridge",
-               "Devices": [],
-               "Ulimits": [{}],
-               "LogConfig": { "Type": "json-file", Config: {} },
-               "SecurityOpt": [],
-               "CgroupParent": ""
-            }
-        }
+    {
+           "Hostname": "",
+           "Domainname": "",
+           "User": "",
+           "AttachStdin": false,
+           "AttachStdout": true,
+           "AttachStderr": true,
+           "Tty": false,
+           "OpenStdin": false,
+           "StdinOnce": false,
+           "Env": [
+                   "FOO=bar",
+                   "BAZ=quux"
+           ],
+           "Cmd": [
+                   "date"
+           ],
+           "Entrypoint": null,
+           "Image": "ubuntu",
+           "Labels": {
+                   "com.example.vendor": "Acme",
+                   "com.example.license": "GPL",
+                   "com.example.version": "1.0"
+           },
+           "Volumes": {
+             "/volumes/data": {}
+           },
+           "WorkingDir": "",
+           "NetworkDisabled": false,
+           "MacAddress": "12:34:56:78:9a:bc",
+           "ExposedPorts": {
+                   "22/tcp": {}
+           },
+           "HostConfig": {
+             "Binds": ["/tmp:/tmp"],
+             "Links": ["redis3:redis"],
+             "LxcConf": {"lxc.utsname":"docker"},
+             "Memory": 0,
+             "MemorySwap": 0,
+             "CpuShares": 512,
+             "CpusetCpus": "0,1",
+             "PidMode": "",
+             "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
+             "PublishAllPorts": false,
+             "Privileged": false,
+             "ReadonlyRootfs": false,
+             "Dns": ["8.8.8.8"],
+             "DnsSearch": [""],
+             "ExtraHosts": null,
+             "VolumesFrom": ["parent", "other:ro"],
+             "CapAdd": ["NET_ADMIN"],
+             "CapDrop": ["MKNOD"],
+             "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
+             "NetworkMode": "bridge",
+             "Devices": [],
+             "Ulimits": [{}],
+             "LogConfig": { "Type": "json-file", "Config": {} },
+             "SecurityOpt": [],
+             "CgroupParent": ""
+          }
+      }
 
 **Example response**:
 
-        HTTP/1.1 201 Created
-        Content-Type: application/json
+      HTTP/1.1 201 Created
+      Content-Type: application/json
 
-        {
-             "Id":"e90e34656806",
-             "Warnings":[]
-        }
+      {
+           "Id":"e90e34656806",
+           "Warnings":[]
+      }
 
 **JSON parameters**:
 
--   **Hostname** - A string value containing the desired hostname to use for the
+-   **Hostname** - A string value containing the hostname to use for the
       container.
--   **Domainname** - A string value containing the desired domain name to use
+-   **Domainname** - A string value containing the domain name to use
       for the container.
--   **User** - A string value containing the user to use inside the container.
--   **AttachStdin** - Boolean value, attaches to stdin.
--   **AttachStdout** - Boolean value, attaches to stdout.
--   **AttachStderr** - Boolean value, attaches to stderr.
--   **Tty** - Boolean value, Attach standard streams to a tty, including stdin if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
--   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
+-   **User** - A string value specifying the user inside the container.
+-   **AttachStdin** - Boolean value, attaches to `stdin`.
+-   **AttachStdout** - Boolean value, attaches to `stdout`.
+-   **AttachStderr** - Boolean value, attaches to `stderr`.
+-   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
+-   **OpenStdin** - Boolean value, opens `stdin`,
+-   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
--   **Labels** - Adds a map of labels that to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
+-   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
--   **Entrypoint** - Set the entrypoint for the container a string or an array
-      of strings
--   **Image** - String value containing the image name to use for the container
--   **Volumes** – An object mapping mountpoint paths (strings) inside the
+-   **Entrypoint** - Set the entry point for the container as a string or an array
+      of strings.
+-   **Image** - A string specifying the image name to use for the container.
+-   **Volumes** - An object mapping mount point paths (strings) inside the
       container to empty objects.
--   **WorkingDir** - A string value containing the working dir for commands to
+-   **WorkingDir** - A string specifying the working directory for commands to
       run in.
 -   **NetworkDisabled** - Boolean value, when true disables networking for the
       container
 -   **ExposedPorts** - An object mapping ports to an empty object in the form of:
       `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
 -   **HostConfig**
-    -   **Binds** – A list of volume bindings for this container. Each volume
-            binding is a string of the form `container_path` (to create a new
-            volume for the container), `host_path:container_path` (to bind-mount
-            a host path into the container), or `host_path:container_path:ro`
-            (to make the bind-mount read-only inside the container).
+    -   **Binds** – A list of volume bindings for this container. Each volume binding is a string in one of these forms:
+           + `container_path` to create a new volume for the container
+           + `host_path:container_path` to bind-mount a host path into the container
+           + `host_path:container_path:ro` to make the bind-mount read-only inside the container.
     -   **Links** - A list of links for the container. Each link entry should be
           in the form of `container_name:alias`.
-    -   **LxcConf** - LXC specific configurations. These configurations will only
+    -   **LxcConf** - LXC specific configurations. These configurations only
           work when using the `lxc` execution driver.
     -   **Memory** - Memory limit in bytes.
     -   **MemorySwap** - Total memory limit (memory + swap); set `-1` to enable unlimited swap.
           You must use this with `memory` and make the swap value larger than `memory`.
-    -   **CpuShares** - An integer value containing the CPU Shares for container
+    -   **CpuShares** - An integer value containing the container's CPU Shares
           (ie. the relative weight vs other containers).
-    -   **CpusetCpus** - String value containing the cgroups CpusetCpus to use.
+    -   **CpusetCpus** - String value containing the `cgroups CpusetCpus` to use.
     -   **PidMode** - Set the PID (Process) Namespace mode for the container;
           `"container:<name|id>"`: joins another container's PID namespace
           `"host"`: use the host's PID namespace inside the container
     -   **PortBindings** - A map of exposed container ports and the host port they
-          should map to. It should be specified in the form
+          should map to. A JSON object in the form
           `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`
           Take note that `port` is specified as a string and not an integer value.
     -   **PublishAllPorts** - Allocates a random host port for all of a container's
@@ -258,9 +257,9 @@ Create a container
           a boolean value.
     -   **ReadonlyRootfs** - Mount the container's root filesystem as read only.
           Specified as a boolean value.
-    -   **Dns** - A list of dns servers for the container to use.
+    -   **Dns** - A list of DNS servers for the container to use.
     -   **DnsSearch** - A list of DNS search domains
-    -   **ExtraHosts** - A list of hostnames/IP mappings to be added to the
+    -   **ExtraHosts** - A list of hostnames/IP mappings to add to the
         container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
     -   **VolumesFrom** - A list of volumes to inherit from another container.
           Specified in the form `<container name>[:<ro|rw>]`
@@ -276,19 +275,19 @@ Create a container
             is added before each restart to prevent flooding the server.
     -   **NetworkMode** - Sets the networking mode for the container. Supported
           values are: `bridge`, `host`, `none`, and `container:<name|id>`
-    -   **Devices** - A list of devices to add to the container specified in the
-          form
+    -   **Devices** - A list of devices to add to the container specified as a JSON object in the
+      form
           `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
-    -   **Ulimits** - A list of ulimits to be set in the container, specified as
+    -   **Ulimits** - A list of ulimits to set in the container, specified as
           `{ "Name": <name>, "Soft": <soft limit>, "Hard": <hard limit> }`, for example:
           `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard": 2048 }`
     -   **SecurityOpt**: A list of string values to customize labels for MLS
         systems, such as SELinux.
-    -   **LogConfig** - Log configuration for the container, specified as
+    -   **LogConfig** - Log configuration for the container, specified as a JSON object in the form
           `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
           Available types: `json-file`, `syslog`, `journald`, `none`.
           `json-file` logging driver.
-    -   **CgroupParent** - Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+    -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
 
 **Query parameters**:
 
@@ -424,7 +423,7 @@ Return low-level information on the container `id`
 			"Paused": false,
 			"Pid": 0,
 			"Restarting": false,
-			"Running": false,
+			"Running": true,
 			"StartedAt": "2015-01-06T15:47:32.072697474Z"
 		},
 		"Volumes": {},
@@ -525,12 +524,12 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Query parameters**:
 
--   **follow** – 1/True/true or 0/False/false, return stream. Default false
--   **stdout** – 1/True/true or 0/False/false, show stdout log. Default false
--   **stderr** – 1/True/true or 0/False/false, show stderr log. Default false
+-   **follow** – 1/True/true or 0/False/false, return stream. Default `false`.
+-   **stdout** – 1/True/true or 0/False/false, show `stdout` log. Default `false`.
+-   **stderr** – 1/True/true or 0/False/false, show `stderr` log. Default `false`.
 -   **timestamps** – 1/True/true or 0/False/false, print timestamps for
-        every log line. Default false
--   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all
+        every log line. Default `false`.
+-   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all.
 
 **Status codes**:
 
@@ -612,79 +611,79 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-        GET /containers/redis1/stats HTTP/1.1
+    GET /containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
-        HTTP/1.1 200 OK
-        Content-Type: application/json
+      HTTP/1.1 200 OK
+      Content-Type: application/json
 
-        {
-           "read" : "2015-01-08T22:57:31.547920715Z",
-           "network" : {
-              "rx_dropped" : 0,
-              "rx_bytes" : 648,
-              "rx_errors" : 0,
-              "tx_packets" : 8,
-              "tx_dropped" : 0,
-              "rx_packets" : 8,
-              "tx_errors" : 0,
-              "tx_bytes" : 648
-           },
-           "memory_stats" : {
-              "stats" : {
-                 "total_pgmajfault" : 0,
-                 "cache" : 0,
-                 "mapped_file" : 0,
-                 "total_inactive_file" : 0,
-                 "pgpgout" : 414,
-                 "rss" : 6537216,
-                 "total_mapped_file" : 0,
-                 "writeback" : 0,
-                 "unevictable" : 0,
-                 "pgpgin" : 477,
-                 "total_unevictable" : 0,
-                 "pgmajfault" : 0,
-                 "total_rss" : 6537216,
-                 "total_rss_huge" : 6291456,
-                 "total_writeback" : 0,
-                 "total_inactive_anon" : 0,
-                 "rss_huge" : 6291456,
-                 "hierarchical_memory_limit" : 67108864,
-                 "total_pgfault" : 964,
-                 "total_active_file" : 0,
-                 "active_anon" : 6537216,
-                 "total_active_anon" : 6537216,
-                 "total_pgpgout" : 414,
-                 "total_cache" : 0,
-                 "inactive_anon" : 0,
-                 "active_file" : 0,
-                 "pgfault" : 964,
-                 "inactive_file" : 0,
-                 "total_pgpgin" : 477
-              },
-              "max_usage" : 6651904,
-              "usage" : 6537216,
-              "failcnt" : 0,
-              "limit" : 67108864
-           },
-           "blkio_stats" : {},
-           "cpu_stats" : {
-              "cpu_usage" : {
-                 "percpu_usage" : [
-                    16970827,
-                    1839451,
-                    7107380,
-                    10571290
-                 ],
-                 "usage_in_usermode" : 10000000,
-                 "total_usage" : 36488948,
-                 "usage_in_kernelmode" : 20000000
-              },
-              "system_cpu_usage" : 20091722000000000,
-              "throttling_data" : {}
-           }
-        }
+      {
+         "read" : "2015-01-08T22:57:31.547920715Z",
+         "network" : {
+            "rx_dropped" : 0,
+            "rx_bytes" : 648,
+            "rx_errors" : 0,
+            "tx_packets" : 8,
+            "tx_dropped" : 0,
+            "rx_packets" : 8,
+            "tx_errors" : 0,
+            "tx_bytes" : 648
+         },
+         "memory_stats" : {
+            "stats" : {
+               "total_pgmajfault" : 0,
+               "cache" : 0,
+               "mapped_file" : 0,
+               "total_inactive_file" : 0,
+               "pgpgout" : 414,
+               "rss" : 6537216,
+               "total_mapped_file" : 0,
+               "writeback" : 0,
+               "unevictable" : 0,
+               "pgpgin" : 477,
+               "total_unevictable" : 0,
+               "pgmajfault" : 0,
+               "total_rss" : 6537216,
+               "total_rss_huge" : 6291456,
+               "total_writeback" : 0,
+               "total_inactive_anon" : 0,
+               "rss_huge" : 6291456,
+               "hierarchical_memory_limit" : 67108864,
+               "total_pgfault" : 964,
+               "total_active_file" : 0,
+               "active_anon" : 6537216,
+               "total_active_anon" : 6537216,
+               "total_pgpgout" : 414,
+               "total_cache" : 0,
+               "inactive_anon" : 0,
+               "active_file" : 0,
+               "pgfault" : 964,
+               "inactive_file" : 0,
+               "total_pgpgin" : 477
+            },
+            "max_usage" : 6651904,
+            "usage" : 6537216,
+            "failcnt" : 0,
+            "limit" : 67108864
+         },
+         "blkio_stats" : {},
+         "cpu_stats" : {
+            "cpu_usage" : {
+               "percpu_usage" : [
+                  16970827,
+                  1839451,
+                  7107380,
+                  10571290
+               ],
+               "usage_in_usermode" : 10000000,
+               "total_usage" : 36488948,
+               "usage_in_kernelmode" : 20000000
+            },
+            "system_cpu_usage" : 20091722000000000,
+            "throttling_data" : {}
+         }
+      }
 
 **Status codes**:
 
@@ -1209,22 +1208,22 @@ or being killed.
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
--   **t** – repository name (and optionally a tag) to be applied to
-        the resulting image in case of success
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-		called `Dockerfile`.
--   **q** – suppress verbose build output
--   **nocache** – do not use the cache when building the image
--   **pull** - attempt to pull the image even if an older image exists locally
--   **rm** - remove intermediate containers after a successful build (default behavior)
--   **forcerm** - always remove intermediate containers (includes rm)
--   **memory** - set memory limit for build
+-   **t** – A name and optional tag to apply to the image in the `name:tag` format.
+        If you omit the `tag` the default `latest` value is assumed.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
+-   **q** – Suppress verbose build output.
+-   **nocache** – Do not use the cache when building the image.
+-   **pull** - Attempt to pull the image even if an older image exists locally.
+-   **rm** - Remove intermediate containers after a successful build (default behavior).
+-   **forcerm** - Always remove intermediate containers (includes `rm`).
+-   **memory** - Set memory limit for build.
 -   **memswap** - Total memory (memory + swap), `-1` to enable unlimited swap.
--   **cpushares** - CPU shares (relative weight)
--   **cpusetcpus** - CPUs in which to allow execution, e.g., `0-3`, `0,1`
+-   **cpushares** - CPU shares (relative weight).
+-   **cpusetcpus** - CPUs in which to allow execution (e.g., `0-3`, `0,1`).
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – base64-encoded ConfigFile object
@@ -1238,7 +1237,7 @@ or being killed.
 
 `POST /images/create`
 
-Create an image, either by pulling it from the registry or by importing it
+Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
@@ -1266,7 +1265,7 @@ a base64-encoded AuthConfig object.
 -   **repo** – Repository name.
 -   **tag** – Tag.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
@@ -1293,35 +1292,33 @@ Return low-level information on the image `name`
     Content-Type: application/json
 
     {
-         "Created": "2013-03-23T22:24:18.818426-07:00",
-         "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
-         "ContainerConfig":
-                 {
-                         "Hostname": "",
-                         "User": "",
-                         "AttachStdin": false,
-                         "AttachStdout": false,
-                         "AttachStderr": false,
-                         "PortSpecs": null,
-                         "Tty": true,
-                         "OpenStdin": true,
-                         "StdinOnce": false,
-                         "Env": null,
-                         "Cmd": ["/bin/bash"],
-                         "Dns": null,
-                         "Image": "ubuntu",
-                         "Labels": {
-                             "com.example.vendor": "Acme",
-                             "com.example.license": "GPL",
-                             "com.example.version": "1.0"
-                         },
-                         "Volumes": null,
-                         "VolumesFrom": "",
-                         "WorkingDir": ""
-                 },
-         "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-         "Parent": "27cf784147099545",
-         "Size": 6824592
+       "Created": "2013-03-23T22:24:18.818426-07:00",
+       "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+       "ContainerConfig": {
+          "Hostname": "",
+          "User": "",
+          "AttachStdin": false,
+          "AttachStdout": false,
+          "AttachStderr": false,
+          "Tty": true,
+          "OpenStdin": true,
+          "StdinOnce": false,
+          "Env": null,
+          "Cmd": ["/bin/bash"],
+          "Dns": null,
+          "Image": "ubuntu",
+          "Labels": {
+             "com.example.vendor": "Acme",
+             "com.example.license": "GPL",
+             "com.example.version": "1.0"
+          },
+          "Volumes": null,
+          "VolumesFrom": "",
+          "WorkingDir": ""
+       },
+       "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+       "Parent": "27cf784147099545",
+       "Size": 6824592
     }
 
 **Status codes**:
@@ -1346,16 +1343,16 @@ Return the history of the image `name`
     Content-Type: application/json
 
     [
-         {
-                 "Id": "b750fe79269d",
-                 "Created": 1364102658,
-                 "CreatedBy": "/bin/bash"
-         },
-         {
-                 "Id": "27cf78414709",
-                 "Created": 1364068391,
-                 "CreatedBy": ""
-         }
+        {
+            "Id": "b750fe79269d",
+            "Created": 1364102658,
+            "CreatedBy": "/bin/bash"
+        },
+        {
+            "Id": "27cf78414709",
+            "Created": 1364068391,
+            "CreatedBy": ""
+        }
     ]
 
 **Status codes**:
@@ -1384,9 +1381,9 @@ Push the image `name` on the registry
     {"error": "Invalid..."}
     ...
 
-If you wish to push an image on to a private registry, that image must already have been tagged
-into a repository which references that registry host name and port.  This repository name should
-then be used in the URL. This mirrors the flow of the CLI.
+If you wish to push an image on to a private registry, that image must already have a tag
+into a repository which references that registry `hostname` and `port`.  This repository name should
+then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
@@ -1397,10 +1394,9 @@ then be used in the URL. This mirrors the flow of the CLI.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
--   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
-        object.
+-   **X-Registry-Auth** – base64-encoded AuthConfig object.
 
 **Status codes**:
 
@@ -1490,25 +1486,25 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
     [
             {
-                "description": "",
+                "star_count": 12,
                 "is_official": false,
-                "is_automated": false,
                 "name": "wma55/u1210sshd",
-                "star_count": 0
+                "is_automated": false,
+                "description": ""
             },
             {
-                "description": "",
+                "star_count": 10,
                 "is_official": false,
-                "is_automated": false,
                 "name": "jdswinbank/sshd",
-                "star_count": 0
+                "is_automated": false,
+                "description": ""
             },
             {
-                "description": "",
+                "star_count": 18,
                 "is_official": false,
-                "is_automated": false,
                 "name": "vgauthier/sshd",
-                "star_count": 0
+                "is_automated": false,
+                "description": ""
             }
     ...
     ]
@@ -1536,8 +1532,8 @@ Get the default username and email
     Content-Type: application/json
 
     {
-         "username":" hannibal",
-         "password: "xxxx",
+         "username": "hannibal",
+         "password": "xxxx",
          "email": "hannibal@a-team.com",
          "serveraddress": "https://index.docker.io/v1/"
     }
@@ -1741,7 +1737,7 @@ Docker containers report the following events:
 
     create, destroy, die, exec_create, exec_start, export, kill, oom, pause, restart, start, stop, unpause
 
-and Docker images report:
+Docker images report the following events:
 
     untag, delete
 
@@ -1803,7 +1799,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images.
+### Get a tarball containing all images
 
 `GET /images/get`
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -218,7 +218,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -328,7 +328,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -437,7 +437,7 @@ Return low-level information on the container `id`
 			"Paused": false,
 			"Pid": 0,
 			"Restarting": false,
-			"Running": false,
+			"Running": true,
 			"StartedAt": "2015-01-06T15:47:32.072697474Z"
 		},
 		"Volumes": {},
@@ -1250,8 +1250,8 @@ or being killed.
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
--   **t** – Repository name (and optionally a tag) to be applied to
-        the resulting image in case of success.
+-   **t** – A name and optional tag to apply to the image in the `name:tag` format.
+        If you omit the `tag` the default `latest` value is assumed.
 -   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
         URI points to a single text file, the file's contents are placed into
         a file called `Dockerfile` and the image is built from that file. If
@@ -1271,7 +1271,7 @@ or being killed.
 -   **cpuperiod** - The length of a CPU period in microseconds.
 -   **cpuquota** - Microseconds of CPU time that the container can get in a CPU period.
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – base64-encoded ConfigFile object
@@ -1313,7 +1313,7 @@ a base64-encoded AuthConfig object.
 -   **repo** – Repository name.
 -   **tag** – Tag.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
@@ -1340,35 +1340,33 @@ Return low-level information on the image `name`
     Content-Type: application/json
 
     {
-         "Created": "2013-03-23T22:24:18.818426-07:00",
-         "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
-         "ContainerConfig":
-                 {
-                         "Hostname": "",
-                         "User": "",
-                         "AttachStdin": false,
-                         "AttachStdout": false,
-                         "AttachStderr": false,
-                         "PortSpecs": null,
-                         "Tty": true,
-                         "OpenStdin": true,
-                         "StdinOnce": false,
-                         "Env": null,
-                         "Cmd": ["/bin/bash"],
-                         "Dns": null,
-                         "Image": "ubuntu",
-                         "Labels": {
-                             "com.example.vendor": "Acme",
-                             "com.example.license": "GPL",
-                             "com.example.version": "1.0"
-                         },
-                         "Volumes": null,
-                         "VolumesFrom": "",
-                         "WorkingDir": ""
-                 },
-         "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-         "Parent": "27cf784147099545",
-         "Size": 6824592
+       "Created": "2013-03-23T22:24:18.818426-07:00",
+       "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+       "ContainerConfig": {
+          "Hostname": "",
+          "User": "",
+          "AttachStdin": false,
+          "AttachStdout": false,
+          "AttachStderr": false,
+          "Tty": true,
+          "OpenStdin": true,
+          "StdinOnce": false,
+          "Env": null,
+          "Cmd": ["/bin/bash"],
+          "Dns": null,
+          "Image": "ubuntu",
+          "Labels": {
+             "com.example.vendor": "Acme",
+             "com.example.license": "GPL",
+             "com.example.version": "1.0"
+          },
+          "Volumes": null,
+          "VolumesFrom": "",
+          "WorkingDir": ""
+       },
+       "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+       "Parent": "27cf784147099545",
+       "Size": 6824592
     }
 
 **Status codes**:
@@ -1464,10 +1462,9 @@ then be used in the URL. This duplicates the command line's flow.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
--   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
-        object.
+-   **X-Registry-Auth** – base64-encoded AuthConfig object.
 
 **Status codes**:
 
@@ -1565,7 +1562,7 @@ be deprecated and replaced by the `is_automated` property.
                 "name": "wma55/u1210sshd",
                 "is_trusted": false,
                 "is_automated": false,
-                "description": "",
+                "description": ""
             },
             {
                 "star_count": 10,
@@ -1573,7 +1570,7 @@ be deprecated and replaced by the `is_automated` property.
                 "name": "jdswinbank/sshd",
                 "is_trusted": false,
                 "is_automated": false,
-                "description": "",
+                "description": ""
             },
             {
                 "star_count": 18,
@@ -1581,7 +1578,7 @@ be deprecated and replaced by the `is_automated` property.
                 "name": "vgauthier/sshd",
                 "is_trusted": false,
                 "is_automated": false,
-                "description": "",
+                "description": ""
             }
     ...
     ]
@@ -1609,8 +1606,8 @@ Get the default username and email
     Content-Type: application/json
 
     {
-         "username":" hannibal",
-         "password: "xxxx",
+         "username": "hannibal",
+         "password": "xxxx",
          "email": "hannibal@a-team.com",
          "serveraddress": "https://index.docker.io/v1/"
     }
@@ -1822,7 +1819,7 @@ Docker containers report the following events:
 
     attach, commit, copy, create, destroy, die, exec_create, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause
 
-and Docker images report:
+Docker images report the following events:
 
     untag, delete
 
@@ -1884,7 +1881,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images.
+### Get a tarball containing all images
 
 `GET /images/get`
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -220,7 +220,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -332,7 +332,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -440,7 +440,7 @@ Return low-level information on the container `id`
 			"Paused": false,
 			"Pid": 0,
 			"Restarting": false,
-			"Running": false,
+			"Running": true,
 			"StartedAt": "2015-01-06T15:47:32.072697474Z"
 		},
 		"Mounts": [
@@ -1377,11 +1377,11 @@ or being killed.
 
 -   **dockerfile** - Path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
--   **t** – A repository name (and optionally a tag) to apply to
-        the resulting image in case of success.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-        called `Dockerfile`.
+-   **t** – A name and optional tag to apply to the image in the `name:tag` format.
+        If you omit the `tag` the default `latest` value is assumed.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1394,7 +1394,7 @@ or being killed.
 -   **cpuperiod** - The length of a CPU period in microseconds.
 -   **cpuquota** - Microseconds of CPU time that the container can get in a CPU period.
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
@@ -1457,7 +1457,7 @@ a base64-encoded AuthConfig object.
 -   **repo** – Repository name.
 -   **tag** – Tag.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
@@ -1484,34 +1484,33 @@ Return low-level information on the image `name`
     Content-Type: application/json
 
     {
-         "Created": "2013-03-23T22:24:18.818426-07:00",
-         "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
-         "ContainerConfig":
-                 {
-                         "Hostname": "",
-                         "User": "",
-                         "AttachStdin": false,
-                         "AttachStdout": false,
-                         "AttachStderr": false,
-                         "Tty": true,
-                         "OpenStdin": true,
-                         "StdinOnce": false,
-                         "Env": null,
-                         "Cmd": ["/bin/bash"],
-                         "Dns": null,
-                         "Image": "ubuntu",
-                         "Labels": {
-                             "com.example.vendor": "Acme",
-                             "com.example.license": "GPL",
-                             "com.example.version": "1.0"
-                         },
-                         "Volumes": null,
-                         "VolumesFrom": "",
-                         "WorkingDir": ""
-                 },
-         "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-         "Parent": "27cf784147099545",
-         "Size": 6824592
+       "Created": "2013-03-23T22:24:18.818426-07:00",
+       "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+       "ContainerConfig": {
+          "Hostname": "",
+          "User": "",
+          "AttachStdin": false,
+          "AttachStdout": false,
+          "AttachStderr": false,
+          "Tty": true,
+          "OpenStdin": true,
+          "StdinOnce": false,
+          "Env": null,
+          "Cmd": ["/bin/bash"],
+          "Dns": null,
+          "Image": "ubuntu",
+          "Labels": {
+             "com.example.vendor": "Acme",
+             "com.example.license": "GPL",
+             "com.example.version": "1.0"
+          },
+          "Volumes": null,
+          "VolumesFrom": "",
+          "WorkingDir": ""
+       },
+       "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+       "Parent": "27cf784147099545",
+       "Size": 6824592
     }
 
 **Status codes**:
@@ -1607,10 +1606,9 @@ then be used in the URL. This duplicates the command line's flow.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
--   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
-        object.
+-   **X-Registry-Auth** – base64-encoded AuthConfig object.
 
 **Status codes**:
 
@@ -1746,8 +1744,8 @@ Get the default username and email
     Content-Type: application/json
 
     {
-         "username":" hannibal",
-         "password: "xxxx",
+         "username": "hannibal",
+         "password": "xxxx",
          "email": "hannibal@a-team.com",
          "serveraddress": "https://index.docker.io/v1/"
     }
@@ -1966,7 +1964,7 @@ Docker containers report the following events:
 
     attach, commit, copy, create, destroy, die, exec_create, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause
 
-and Docker images report:
+Docker images report the following events:
 
     delete, import, pull, push, tag, untag
 
@@ -2028,7 +2026,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images.
+### Get a tarball containing all images
 
 `GET /images/get`
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -229,7 +229,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -350,7 +350,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -462,14 +462,14 @@ Return low-level information on the container `id`
 			"MacAddress": "",
 			"Networks": {
 				"bridge": {
-					"EndpointID": "",
-					"Gateway": "",
-					"IPAddress": "",
-					"IPPrefixLen": 0,
+					"EndpointID": "7587b82f0dada3656fda26588aee72630c6fab1536d36e394b2bfbcf898c971d",
+					"Gateway": "172.17.0.1",
+					"IPAddress": "172.17.0.2",
+					"IPPrefixLen": 16,
 					"IPv6Gateway": "",
 					"GlobalIPv6Address": "",
 					"GlobalIPv6PrefixLen": 0,
-					"MacAddress": ""
+					"MacAddress": "02:42:ac:12:00:02"
 				}
 			}
 		},
@@ -1458,9 +1458,9 @@ or being killed.
 -   **t** – A name and optional tag to apply to the image in the `name:tag` format.
         If you omit the `tag` the default `latest` value is assumed.
         You can provide one or more `t` parameters.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-        called `Dockerfile`.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1478,7 +1478,7 @@ or being killed.
         variable expansion in other Dockerfile instructions. This is not meant for
         passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
@@ -1545,7 +1545,7 @@ a base64-encoded AuthConfig object.
         an image.
 -   **tag** – Tag or digest.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object
 
@@ -1754,10 +1754,9 @@ then be used in the URL. This duplicates the command line's flow.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
--   **X-Registry-Auth** – Include a base64-encoded AuthConfig.
-        object.
+-   **X-Registry-Auth** – base64-encoded AuthConfig object.
 
 **Status codes**:
 
@@ -1893,8 +1892,8 @@ Get the default username and email
     Content-Type: application/json
 
     {
-         "username":" hannibal",
-         "password: "xxxx",
+         "username": "hannibal",
+         "password": "xxxx",
          "email": "hannibal@a-team.com",
          "serveraddress": "https://index.docker.io/v1/"
     }
@@ -2115,7 +2114,7 @@ Docker containers report the following events:
 
     attach, commit, copy, create, destroy, die, exec_create, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause
 
-and Docker images report:
+Docker images report the following events:
 
     delete, import, pull, push, tag, untag
 
@@ -2178,7 +2177,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 -   **200** – no error
 -   **500** – server error
 
-### Get a tarball containing all images.
+### Get a tarball containing all images
 
 `GET /images/get`
 
@@ -2438,36 +2437,36 @@ Return low-level information about the `exec` command `id`.
           "SecurityOpt" : null
         },
         "Image" : "5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5",
-        "NetworkSettings": {
-            "Bridge": "",
-            "SandboxID": "",
-            "HairpinMode": false,
-            "LinkLocalIPv6Address": "",
-            "LinkLocalIPv6PrefixLen": 0,
-            "Ports": null,
-            "SandboxKey": "",
-            "SecondaryIPAddresses": null,
-            "SecondaryIPv6Addresses": null,
-            "EndpointID": "",
-            "Gateway": "",
-            "GlobalIPv6Address": "",
-            "GlobalIPv6PrefixLen": 0,
-            "IPAddress": "",
-            "IPPrefixLen": 0,
-            "IPv6Gateway": "",
-            "MacAddress": "",
-            "Networks": {
-                "bridge": {
-                    "EndpointID": "",
-                    "Gateway": "",
-                    "IPAddress": "",
-                    "IPPrefixLen": 0,
-                    "IPv6Gateway": "",
-                    "GlobalIPv6Address": "",
-                    "GlobalIPv6PrefixLen": 0,
-                    "MacAddress": ""
-                }
+        "NetworkSettings" : {
+          "Bridge": "",
+          "SandboxID": "",
+          "HairpinMode": false,
+          "LinkLocalIPv6Address": "",
+          "LinkLocalIPv6PrefixLen": 0,
+          "Ports": null,
+          "SandboxKey": "",
+          "SecondaryIPAddresses": null,
+          "SecondaryIPv6Addresses": null,
+          "EndpointID": "",
+          "Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "IPAddress": "",
+          "IPPrefixLen": 0,
+          "IPv6Gateway": "",
+          "MacAddress": "",
+          "Networks": {
+            "bridge": {
+              "EndpointID": "",
+              "Gateway": "",
+              "IPAddress": "",
+              "IPPrefixLen": 0,
+              "IPv6Gateway": "",
+              "GlobalIPv6Address": "",
+              "GlobalIPv6PrefixLen": 0,
+              "MacAddress": ""
             }
+          }
         },
         "ResolvConfPath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/resolv.conf",
         "HostnamePath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/hostname",
@@ -2760,11 +2759,14 @@ Content-Type: application/json
   "Name":"isolated_nw",
   "Driver":"bridge",
   "IPAM":{
-    "Config":[{
-      "Subnet":"172.20.0.0/16",
-      "IPRange":"172.20.10.0/24",
-      "Gateway":"172.20.10.11"
-    }]
+    "Config":[
+      {
+        "Subnet":"172.20.0.0/16",
+        "IPRange":"172.20.10.0/24",
+        "Gateway":"172.20.10.11"
+      }
+    ]
+  }
 }
 ```
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -113,7 +113,6 @@ List containers
                                   }
                          }
                  }
-
          },
          {
                  "Id": "3176a2479c92",
@@ -148,7 +147,6 @@ List containers
                                   }
                          }
                  }
-
          },
          {
                  "Id": "4cb07b47f9fb",
@@ -183,7 +181,6 @@ List containers
                                   }
                          }
                  }
-
          }
     ]
 
@@ -335,7 +332,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -464,7 +461,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -1638,9 +1635,9 @@ or being killed.
 -   **t** – A name and optional tag to apply to the image in the `name:tag` format.
         If you omit the `tag` the default `latest` value is assumed.
         You can provide one or more `t` parameters.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-        called `Dockerfile`.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1659,7 +1656,7 @@ or being killed.
         passing secret values. [Read more about the buildargs instruction](../../reference/builder.md#arg)
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
@@ -1727,7 +1724,7 @@ a base64-encoded AuthConfig object.
         an image.
 -   **tag** – Tag or digest.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -1955,7 +1952,7 @@ The push is cancelled if the HTTP connection is closed.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -2110,8 +2107,8 @@ Get the default username and email
     Content-Type: application/json
 
     {
-         "username":" hannibal",
-         "password: "xxxx",
+         "username": "hannibal",
+         "password": "xxxx",
          "email": "hannibal@a-team.com",
          "serveraddress": "https://index.docker.io/v1/"
     }
@@ -2229,7 +2226,7 @@ Show the docker version information
     Content-Type: application/json
 
     {
-         "Version": "1.10.0-dev",
+         "Version": "1.10.0",
          "Os": "linux",
          "KernelVersion": "3.19.0-23-generic",
          "GoVersion": "go1.4.2",
@@ -2775,25 +2772,25 @@ Return low-level information about the `exec` command `id`.
     Content-Type: application/json
 
     {
-        "CanRemove": false,
-        "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
-        "DetachKeys": "",
-        "ExitCode": 2,
-        "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
-        "OpenStderr": true,
-        "OpenStdin": true,
-        "OpenStdout": true,
-        "ProcessConfig": {
-            "arguments": [
-                "-c",
-                "exit 2"
-            ],
-            "entrypoint": "sh",
-            "privileged": false,
-            "tty": true,
-            "user": "1000"
-        },
-        "Running": false
+      "CanRemove": false,
+      "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
+      "DetachKeys": "",
+      "ExitCode": 2,
+      "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
+      "OpenStderr": true,
+      "OpenStdin": true,
+      "OpenStdout": true,
+      "ProcessConfig": {
+        "arguments": [
+          "-c",
+          "exit 2"
+        ],
+        "entrypoint": "sh",
+        "privileged": false,
+        "tty": true,
+        "user": "1000"
+      },
+      "Running": false
     }
 
 **Status codes**:
@@ -3082,18 +3079,18 @@ Content-Type: application/json
   "Driver":"bridge",
   "IPAM":{
     "Config":[
-       {
-          "Subnet":"172.20.0.0/16",
-          "IPRange":"172.20.10.0/24",
-          "Gateway":"172.20.10.11"
-        },
-        {
-          "Subnet":"2001:db8:abcd::/64",
-          "Gateway":"2001:db8:abcd::1011"
-        }
+      {
+        "Subnet":"172.20.0.0/16",
+        "IPRange":"172.20.10.0/24",
+        "Gateway":"172.20.10.11"
+      },
+      {
+        "Subnet":"2001:db8:abcd::/64",
+        "Gateway":"2001:db8:abcd::1011"
+      }
     ],
     "Options": {
-        "foo": "bar"
+      "foo": "bar"
     }
   },
   "Internal":true

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -355,7 +355,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -487,7 +487,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -1668,9 +1668,9 @@ or being killed.
 -   **t** – A name and optional tag to apply to the image in the `name:tag` format.
         If you omit the `tag` the default `latest` value is assumed.
         You can provide one or more `t` parameters.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-        called `Dockerfile`.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1690,7 +1690,7 @@ or being killed.
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
@@ -1758,7 +1758,7 @@ a base64-encoded AuthConfig object.
         an image.
 -   **tag** – Tag or digest.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -1993,7 +1993,7 @@ The push is cancelled if the HTTP connection is closed.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -2274,7 +2274,7 @@ Show the docker version information
     Content-Type: application/json
 
     {
-         "Version": "1.10.0-dev",
+         "Version": "1.10.0",
          "Os": "linux",
          "KernelVersion": "3.19.0-23-generic",
          "GoVersion": "go1.4.2",
@@ -2846,25 +2846,25 @@ Return low-level information about the `exec` command `id`.
     Content-Type: application/json
 
     {
-        "CanRemove": false,
-        "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
-        "DetachKeys": "",
-        "ExitCode": 2,
-        "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
-        "OpenStderr": true,
-        "OpenStdin": true,
-        "OpenStdout": true,
-        "ProcessConfig": {
-            "arguments": [
-                "-c",
-                "exit 2"
-            ],
-            "entrypoint": "sh",
-            "privileged": false,
-            "tty": true,
-            "user": "1000"
-        },
-        "Running": false
+      "CanRemove": false,
+      "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
+      "DetachKeys": "",
+      "ExitCode": 2,
+      "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
+      "OpenStderr": true,
+      "OpenStdin": true,
+      "OpenStdout": true,
+      "ProcessConfig": {
+        "arguments": [
+          "-c",
+          "exit 2"
+        ],
+        "entrypoint": "sh",
+        "privileged": false,
+        "tty": true,
+        "user": "1000"
+      },
+      "Running": false
     }
 
 **Status codes**:
@@ -2924,7 +2924,7 @@ Create a volume
       "Labels": {
         "com.example.some-label": "some-value",
         "com.example.some-other-label": "some-other-value"
-      },
+      }
     }
 
 **Example response**:
@@ -2939,7 +2939,7 @@ Create a volume
       "Labels": {
         "com.example.some-label": "some-value",
         "com.example.some-other-label": "some-other-value"
-      },
+      }
     }
 
 **Status codes**:
@@ -2953,7 +2953,7 @@ Create a volume
 - **Driver** - Name of the volume driver to use. Defaults to `local` for the name.
 - **DriverOpts** - A mapping of driver options and values. These options are
     passed directly to the driver and are driver specific.
-- **Labels** - Labels to set on the volume, specified as a map: `{"key":"value" [,"key2":"value2"]}`
+- **Labels** - Labels to set on the volume, specified as a map: `{"key":"value","key2":"value2"}`
 
 ### Inspect a volume
 
@@ -2971,13 +2971,13 @@ Return low-level information on the volume `name`
     Content-Type: application/json
 
     {
-        "Name": "tardis",
-        "Driver": "local",
-        "Mountpoint": "/var/lib/docker/volumes/tardis/_data",
-        "Labels": {
-            "com.example.some-label": "some-value",
-            "com.example.some-other-label": "some-other-value"
-        }
+      "Name": "tardis",
+      "Driver": "local",
+      "Mountpoint": "/var/lib/docker/volumes/tardis/_data",
+      "Labels": {
+          "com.example.some-label": "some-value",
+          "com.example.some-other-label": "some-other-value"
+      }
     }
 
 **Status codes**:
@@ -3180,18 +3180,18 @@ Content-Type: application/json
   "EnableIPv6": true,
   "IPAM":{
     "Config":[
-       {
-          "Subnet":"172.20.0.0/16",
-          "IPRange":"172.20.10.0/24",
-          "Gateway":"172.20.10.11"
-        },
-        {
-          "Subnet":"2001:db8:abcd::/64",
-          "Gateway":"2001:db8:abcd::1011"
-        }
+      {
+        "Subnet":"172.20.0.0/16",
+        "IPRange":"172.20.10.0/24",
+        "Gateway":"172.20.10.11"
+      },
+      {
+        "Subnet":"2001:db8:abcd::/64",
+        "Gateway":"2001:db8:abcd::1011"
+      }
     ],
     "Options": {
-        "foo": "bar"
+      "foo": "bar"
     }
   },
   "Internal":true,

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -372,7 +372,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -512,7 +512,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -1669,9 +1669,9 @@ or being killed.
 -   **t** – A name and optional tag to apply to the image in the `name:tag` format.
         If you omit the `tag` the default `latest` value is assumed.
         You can provide one or more `t` parameters.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-        called `Dockerfile`.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1691,7 +1691,7 @@ or being killed.
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
@@ -1759,7 +1759,7 @@ a base64-encoded AuthConfig object.
         an image.
 -   **tag** – Tag or digest.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -1994,7 +1994,7 @@ The push is cancelled if the HTTP connection is closed.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -2427,7 +2427,7 @@ Docker daemon report the following event:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
-    Server: Docker/1.10.0 (linux)
+    Server: Docker/1.11.0 (linux)
     Date: Fri, 29 Apr 2016 15:18:06 GMT
     Transfer-Encoding: chunked
 
@@ -2860,25 +2860,25 @@ Return low-level information about the `exec` command `id`.
     Content-Type: application/json
 
     {
-        "CanRemove": false,
-        "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
-        "DetachKeys": "",
-        "ExitCode": 2,
-        "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
-        "OpenStderr": true,
-        "OpenStdin": true,
-        "OpenStdout": true,
-        "ProcessConfig": {
-            "arguments": [
-                "-c",
-                "exit 2"
-            ],
-            "entrypoint": "sh",
-            "privileged": false,
-            "tty": true,
-            "user": "1000"
-        },
-        "Running": false
+      "CanRemove": false,
+      "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
+      "DetachKeys": "",
+      "ExitCode": 2,
+      "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
+      "OpenStderr": true,
+      "OpenStdin": true,
+      "OpenStdout": true,
+      "ProcessConfig": {
+        "arguments": [
+          "-c",
+          "exit 2"
+        ],
+        "entrypoint": "sh",
+        "privileged": false,
+        "tty": true,
+        "user": "1000"
+      },
+      "Running": false
     }
 
 **Status codes**:
@@ -2983,7 +2983,7 @@ Create a volume
 
 Refer to the [inspect a volume](#inspect-a-volume) section or details about the
 JSON fields returned in the response.
- 
+
 ### Inspect a volume
 
 `GET /volumes/(name)`
@@ -3000,17 +3000,17 @@ Return low-level information on the volume `name`
     Content-Type: application/json
 
     {
-        "Name": "tardis",
-        "Driver": "custom",
-        "Mountpoint": "/var/lib/docker/volumes/tardis/_data",
-        "Status": {
-          "hello": "world"
-        },
-        "Labels": {
-            "com.example.some-label": "some-value",
-            "com.example.some-other-label": "some-other-value"
-        },
-        "Scope": "local"
+      "Name": "tardis",
+      "Driver": "custom",
+      "Mountpoint": "/var/lib/docker/volumes/tardis/_data",
+      "Status": {
+        "hello": "world"
+      },
+      "Labels": {
+          "com.example.some-label": "some-value",
+          "com.example.some-other-label": "some-other-value"
+      },
+      "Scope": "local"
     }
 
 **Status codes**:
@@ -3232,18 +3232,18 @@ Content-Type: application/json
   "EnableIPv6": true,
   "IPAM":{
     "Config":[
-       {
-          "Subnet":"172.20.0.0/16",
-          "IPRange":"172.20.10.0/24",
-          "Gateway":"172.20.10.11"
-        },
-        {
-          "Subnet":"2001:db8:abcd::/64",
-          "Gateway":"2001:db8:abcd::1011"
-        }
+      {
+        "Subnet":"172.20.0.0/16",
+        "IPRange":"172.20.10.0/24",
+        "Gateway":"172.20.10.11"
+      },
+      {
+        "Subnet":"2001:db8:abcd::/64",
+        "Gateway":"2001:db8:abcd::1011"
+      }
     ],
     "Options": {
-        "foo": "bar"
+      "foo": "bar"
     }
   },
   "Internal":true,
@@ -4449,7 +4449,6 @@ List services
 
 ### Create a service
 
-
 `POST /services/create`
 
 Create a service. When using this endpoint to create a service using a private
@@ -4544,7 +4543,7 @@ image](#create-an-image) section for more details.
 - **406** – server error or node is not part of a swarm
 - **409** – name conflicts with an existing object
 
-JSON Parameters:
+**JSON Parameters**:
 
 - **Annotations** – Optional medata to associate with the service.
     - **Name** – User-defined name for the service.
@@ -4724,7 +4723,6 @@ Return information on the service `id`.
 
 ### Update a service
 
-
 `POST /services/(id or name)/update`
 
 Update a service. When using this endpoint to create a service using a
@@ -4772,9 +4770,9 @@ image](#create-an-image) section for more details.
 
 **Example response**:
 
-      HTTP/1.1 200 OK
-      Content-Length: 0
-      Content-Type: text/plain; charset=utf-8
+    HTTP/1.1 200 OK
+    Content-Length: 0
+    Content-Type: text/plain; charset=utf-8
 
 **JSON Parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -372,7 +372,7 @@ Create a container
 -   **AttachStdout** - Boolean value, attaches to `stdout`.
 -   **AttachStderr** - Boolean value, attaches to `stderr`.
 -   **Tty** - Boolean value, Attach standard streams to a `tty`, including `stdin` if it is not closed.
--   **OpenStdin** - Boolean value, opens stdin,
+-   **OpenStdin** - Boolean value, opens `stdin`,
 -   **StdinOnce** - Boolean value, close `stdin` after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `["VAR=value"[,"VAR2=value2"]]`
 -   **Labels** - Adds a map of labels to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
@@ -516,7 +516,7 @@ Return low-level information on the container `id`
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {
+	{
 		"AppArmorProfile": "",
 		"Args": [
 			"-c",
@@ -1674,9 +1674,9 @@ or being killed.
 -   **t** – A name and optional tag to apply to the image in the `name:tag` format.
         If you omit the `tag` the default `latest` value is assumed.
         You can provide one or more `t` parameters.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
-        URI specifies a filename, the file's contents are placed into a file
-        called `Dockerfile`.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.
@@ -1696,7 +1696,7 @@ or being killed.
 -   **shmsize** - Size of `/dev/shm` in bytes. The size must be greater than 0.  If omitted the system uses 64MB.
 -   **labels** – JSON map of string pairs for labels to set on the image.
 
-    Request Headers:
+**Request Headers**:
 
 -   **Content-type** – Set to `"application/tar"`.
 -   **X-Registry-Config** – A base64-url-safe-encoded Registry Auth Config JSON
@@ -1764,7 +1764,7 @@ a base64-encoded AuthConfig object.
         an image.
 -   **tag** – Tag or digest.
 
-    Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -1999,7 +1999,7 @@ The push is cancelled if the HTTP connection is closed.
 
 -   **tag** – The tag to associate with the image on the registry. This is optional.
 
-Request Headers:
+**Request Headers**:
 
 -   **X-Registry-Auth** – base64-encoded AuthConfig object, containing either login information, or a token
     - Credential based login:
@@ -2402,7 +2402,7 @@ Create a new image from a container's changes
 
 `GET /events`
 
-Get container events from docker, either in real time via streaming.
+Get container events from docker, in real time via streaming.
 
 Docker containers report the following events:
 
@@ -2432,7 +2432,7 @@ Docker daemon report the following event:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
-    Server: Docker/1.10.0 (linux)
+    Server: Docker/1.11.0 (linux)
     Date: Fri, 29 Apr 2016 15:18:06 GMT
     Transfer-Encoding: chunked
 
@@ -2865,25 +2865,25 @@ Return low-level information about the `exec` command `id`.
     Content-Type: application/json
 
     {
-        "CanRemove": false,
-        "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
-        "DetachKeys": "",
-        "ExitCode": 2,
-        "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
-        "OpenStderr": true,
-        "OpenStdin": true,
-        "OpenStdout": true,
-        "ProcessConfig": {
-            "arguments": [
-                "-c",
-                "exit 2"
-            ],
-            "entrypoint": "sh",
-            "privileged": false,
-            "tty": true,
-            "user": "1000"
-        },
-        "Running": false
+      "CanRemove": false,
+      "ContainerID": "b53ee82b53a40c7dca428523e34f741f3abc51d9f297a14ff874bf761b995126",
+      "DetachKeys": "",
+      "ExitCode": 2,
+      "ID": "f33bbfb39f5b142420f4759b2348913bd4a8d1a6d7fd56499cb41a1bb91d7b3b",
+      "OpenStderr": true,
+      "OpenStdin": true,
+      "OpenStdout": true,
+      "ProcessConfig": {
+        "arguments": [
+          "-c",
+          "exit 2"
+        ],
+        "entrypoint": "sh",
+        "privileged": false,
+        "tty": true,
+        "user": "1000"
+      },
+      "Running": false
     }
 
 **Status codes**:
@@ -2952,6 +2952,7 @@ Create a volume
         "com.example.some-label": "some-value",
         "com.example.some-other-label": "some-other-value"
       },
+      "Driver": "custom"
     }
 
 **Example response**:
@@ -3007,17 +3008,17 @@ Return low-level information on the volume `name`
     Content-Type: application/json
 
     {
-        "Name": "tardis",
-        "Driver": "custom",
-        "Status": {
-          "hello": "world"
-        },
-        "Mountpoint": "/var/lib/docker/volumes/tardis/_data",
-        "Labels": {
-            "com.example.some-label": "some-value",
-            "com.example.some-other-label": "some-other-value"
-        },
-        "Scope": "local"
+      "Name": "tardis",
+      "Driver": "custom",
+      "Mountpoint": "/var/lib/docker/volumes/tardis/_data",
+      "Status": {
+        "hello": "world"
+      },
+      "Labels": {
+          "com.example.some-label": "some-value",
+          "com.example.some-other-label": "some-other-value"
+      },
+      "Scope": "local"
     }
 
 **Status codes**:
@@ -3239,18 +3240,18 @@ Content-Type: application/json
   "EnableIPv6": true,
   "IPAM":{
     "Config":[
-       {
-          "Subnet":"172.20.0.0/16",
-          "IPRange":"172.20.10.0/24",
-          "Gateway":"172.20.10.11"
-        },
-        {
-          "Subnet":"2001:db8:abcd::/64",
-          "Gateway":"2001:db8:abcd::1011"
-        }
+      {
+        "Subnet":"172.20.0.0/16",
+        "IPRange":"172.20.10.0/24",
+        "Gateway":"172.20.10.11"
+      },
+      {
+        "Subnet":"2001:db8:abcd::/64",
+        "Gateway":"2001:db8:abcd::1011"
+      }
     ],
     "Options": {
-        "foo": "bar"
+      "foo": "bar"
     }
   },
   "Internal":true,
@@ -4473,7 +4474,6 @@ List services
 
 ### Create a service
 
-
 `POST /services/create`
 
 Create a service. When using this endpoint to create a service using a private
@@ -4568,7 +4568,7 @@ image](#create-an-image) section for more details.
 - **406** – server error or node is not part of a swarm
 - **409** – name conflicts with an existing object
 
-JSON Parameters:
+**JSON Parameters**:
 
 - **Annotations** – Optional medata to associate with the service.
     - **Name** – User-defined name for the service.
@@ -4748,7 +4748,6 @@ Return information on the service `id`.
 
 ### Update a service
 
-
 `POST /services/(id or name)/update`
 
 Update a service. When using this endpoint to create a service using a
@@ -4796,9 +4795,9 @@ image](#create-an-image) section for more details.
 
 **Example response**:
 
-      HTTP/1.1 200 OK
-      Content-Length: 0
-      Content-Type: text/plain; charset=utf-8
+    HTTP/1.1 200 OK
+    Content-Length: 0
+    Content-Type: text/plain; charset=utf-8
 
 **JSON Parameters**:
 


### PR DESCRIPTION
Synchronize formatting between versions, and update wording to be consistent.

There's a lot of whitespace changes due to indenting being changes, so best watched with `?w=1`;
https://github.com/docker/docker/pull/25704/files?w=1
