### PR TITLE
expose RemovalInProgress in StateString #25652

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -86,6 +86,10 @@ func (s *State) StateString() string {
 		return "running"
 	}
 
+	if s.RemovalInProgress {
+		return "removing"
+	}
+
 	if s.Dead {
 		return "dead"
 	}
@@ -101,6 +105,7 @@ func (s *State) StateString() string {
 func IsValidStateString(s string) bool {
 	if s != "paused" &&
 		s != "restarting" &&
+		s != "removing" &&
 		s != "running" &&
 		s != "dead" &&
 		s != "created" &&

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2182,7 +2182,7 @@ _docker_ps() {
 			return
 			;;
 		status)
-			COMPREPLY=( $( compgen -W "created dead exited paused restarting running" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "created dead exited paused restarting running removing" -- "${cur##*=}" ) )
 			return
 			;;
 		volume)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -340,7 +340,7 @@ __docker_complete_ps_filters() {
                 __docker_networks && ret=0
                 ;;
             (status)
-                status_opts=('created' 'dead' 'exited' 'paused' 'restarting' 'running')
+                status_opts=('created' 'dead' 'exited' 'paused' 'restarting' 'running' 'removing')
                 _describe -t status-filter-opts "Status Filter Options" status_opts && ret=0
                 ;;
             (volume)

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -117,6 +117,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
 * `POST /containers/create` now takes `AutoRemove` in HostConfig, to enable auto-removal of the container on daemon side when the container's process exits.
+* `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.
+* `GET /containers/json` now accepts `removing` as a valid value for the `status` filter.
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -226,7 +226,7 @@ List containers
         sizes
 -   **filters** - a JSON encoded value of the filters (a `map[string][]string`) to process on the containers list. Available filters:
   -   `exited=<int>`; -- containers with exit code of  `<int>` ;
-  -   `status=`(`created`|`restarting`|`running`|`paused`|`exited`|`dead`)
+  -   `status=`(`created`|`restarting`|`running`|`removing`|`paused`|`exited`|`dead`)
   -   `label=key` or `label="key=value"` of a container label
   -   `isolation=`(`default`|`process`|`hyperv`)   (Windows daemon only)
   -   `ancestor`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -20,7 +20,7 @@ Options:
   -f, --filter value    Filter output based on conditions provided (default [])
                         - exited=<int> an exit code of <int>
                         - label=<key> or label=<key>=<value>
-                        - status=(created|restarting|running|paused|exited)
+                        - status=(created|restarting|removing|running|paused|exited)
                         - name=<string> a container's name
                         - id=<ID> a container's ID
                         - before=(<container-name>|<container-id>)
@@ -68,7 +68,7 @@ The currently supported filters are:
 * label (`label=<key>` or `label=<key>=<value>`)
 * name (container's name)
 * exited (int - the code of exited containers. Only useful with `--all`)
-* status (created|restarting|running|paused|exited|dead)
+* status (created|restarting|running|removing|paused|exited|dead)
 * ancestor (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters containers that were created from the given image or a descendant.
 * before (container's id or name) - filters containers created before given id or name
 * since (container's id or name) - filters containers created since given id or name
@@ -158,7 +158,7 @@ Any of these events result in a `137` status:
 #### Status
 
 The `status` filter matches containers by status. You can filter using
-`created`, `restarting`, `running`, `paused`, `exited` and `dead`. For example,
+`created`, `restarting`, `running`, `removing`, `paused`, `exited` and `dead`. For example,
 to filter for `running` containers:
 
 ```bash


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

expose `RemovalInProgress` in `StateString`.

**\- How I did it**

see diff, it's just 4 lines

**\- How to verify it**
1. run this script in a separate terminal pane or via nohup:

```
while [ 1 ]
do
 docker inspect [container_to_remove] | grep removing
done
```
1. remove a running container via `docker rm` or docker API
2. there'll be output from the running shell script

**\- Description for the changelog**

`StateString` will now express `RemovalInProgress` state

**I didn't test this PR because it's so simple**
