### PR TITLE
Restore missing ps example for killed containers

### DIFF
--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -138,6 +138,23 @@ ea09c3c82f6e        registry:latest   /srv/run.sh            2 weeks ago        
 48ee228c9464        fedora:20         bash                   2 weeks ago         Exited (0) 2 weeks ago                              tender_torvalds
 ```
 
+#### Killed containers
+
+You can use a filter to locate containers that exited with status of `137`
+meaning a `SIGKILL(9)` killed them.
+
+```bash
+$ docker ps -a --filter 'exited=137'
+CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES
+b3e1c0ed5bfe        ubuntu:latest       "sleep 1000"           12 seconds ago      Exited (137) 5 seconds ago                       grave_kowalevski
+a2eb5558d669        redis:latest        "/entrypoint.sh redi   2 hours ago         Exited (137) 2 hours ago                         sharp_lalande
+
+Any of these events result in a `137` status:
+
+* the `init` process of the container is killed manually
+* `docker kill` kills the container
+* Docker daemon restarts which kills all running containers
+
 #### Status
 
 The `status` filter matches containers by status. You can filter using


### PR DESCRIPTION
This example was added in b0b2f979c7c43e2975d5e39340c168da2da42d1d (https://github.com/docker/docker/pull/13907), but got lost during splitting up the cli.md docs into separate files; 561bfb268de3c674b04d48895b7e46ae890ef795 (https://github.com/docker/docker/pull/14189)

This restores the missing example.
