### PR TITLE
You can force leave swarm

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4215,6 +4215,10 @@ Leave a swarm
     Content-Length: 0
     Content-Type: text/plain; charset=utf-8
 
+**Query parameters**:
+
+- **force** - Boolean (0/1, false/true). Force leave swarm, even if this is the last manager or that it will break the cluster.
+
 **Status codes**:
 
 - **200** – no error

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4240,6 +4240,10 @@ Leave a swarm
     Content-Length: 0
     Content-Type: text/plain; charset=utf-8
 
+**Query parameters**:
+
+- **force** - Boolean (0/1, false/true). Force leave swarm, even if this is the last manager or that it will break the cluster.
+
 **Status codes**:
 
 - **200** – no error


### PR DESCRIPTION
**\- What I did**
Tried to leave swarm via API. Was unable because it was the last manager. Added the force query param and it worked.

**\- How I did it**
POST /swarm/leave?force=1

**\- How to verify it**
Try to leave the swarm for the last manager without the force param, then with the force param.

**\- Description for the changelog**
It is possible to leave the swarm for the last manager when using the force param.

Signed-off-by: Eivin Giske Skaaren eivin@sysmystic.com
