### PR TITLE
When handling plugin exit, lookup plugins only during daemon shutdown.

### DIFF
--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -143,10 +143,12 @@ func (pm *Manager) disable(p *plugin) error {
 
 // Shutdown stops all plugins and called during daemon shutdown.
 func (pm *Manager) Shutdown() {
+	pm.Lock()
+	pm.shutdown = true
+	pm.Unlock()
+
 	pm.RLock()
 	defer pm.RUnlock()
-
-	pm.shutdown = true
 	for _, p := range pm.plugins {
 		if pm.liveRestore && p.PluginObj.Active {
 			logrus.Debug("Plugin active when liveRestore is set, skipping shutdown")
@@ -173,7 +175,6 @@ func (pm *Manager) Shutdown() {
 					}
 				}
 			}
-			close(p.exitChan)
 		}
 		if err := os.RemoveAll(p.runtimeSourcePath); err != nil {
 			logrus.Errorf("Remove plugin runtime failed with error: %v", err)


### PR DESCRIPTION
**\- What I did**
The main intent of handling plugin exit is for graceful shutdown
of plugins during daemon shutdown. So avoid plugin lookup during
plugin exits caused by other reasons (eg. force remove)

**\- How I did it**
By avoiding plugin lookup for cases other than daemon shutdown.

**\- How to verify it**
Before this change, `docker plugin remove --force` caused errors in daemon logs.
DEBU[0450] plugin state changed 3a510f2a39b3805bebb55f20f3bbd92971a9405b0a4bc94b45050a213324bd40 libcontainerd.StateInfo{CommonStateInfo:libcontainerd.CommonStateInfo{State:"exit", Pid:0x0, ExitCode:0x89, ProcessID:""}, OOMKilled:false}
ERRO[0450] libcontainerd: backend.StateChanged(): plugin "3a510f2a39b3805bebb55f20f3bbd92971a9405b0a4bc94b45050a213324bd40" not found

After this change, there are no errors.  

Signed-off-by: Anusha Ragunathan anusha@docker.com
