### PR TITLE
Enable syslog driver for windows

### DIFF
--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -7,4 +7,5 @@ import (
 	_ "github.com/docker/docker/daemon/logger/etwlogs"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/splunk"
+	_ "github.com/docker/docker/daemon/logger/syslog"
 )

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -1,5 +1,3 @@
-// +build linux
-
 // Package syslog provides the logdriver for forwarding server logs to syslog endpoints.
 package syslog
 

--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -1,11 +1,10 @@
-// +build linux
-
 package syslog
 
 import (
-	syslog "github.com/RackSec/srslog"
 	"reflect"
 	"testing"
+
+	syslog "github.com/RackSec/srslog"
 )
 
 func functionMatches(expectedFun interface{}, actualFun interface{}) bool {

--- a/daemon/logger/syslog/syslog_unsupported.go
+++ b/daemon/logger/syslog/syslog_unsupported.go
@@ -1,3 +1,0 @@
-// +build !linux
-
-package syslog


### PR DESCRIPTION
**\- What I did**
Enabled syslog logging driver for windows. As described in #25689 
Closes #25689 

**\- How I did it**
Just changed build tags and added syslog to list of windows logging drivers

**\- How to verify it**
Windows doesn't have any native syslog server. To verify it you can:
1. go get gopkg.in/mcuadros/go-syslog.v2
2. create simple syslog server using this package, example: [gist](https://gist.github.com/mwieczorek/427bdf838e09c970f6fe2f3317bfeb8b)
3. build this simple syslog server
4. run .exe in cmd without any parameters
5. run new container:

```
docker run -it --log-driver=syslog --log-opt syslog-address=tcp://127.0.0.1:514 --log-opt syslog-format=rfc3164 windowsservercore cmd
```

In syslog server console window you should get something like this:

```
Microsoft Windows [Version 10.0.14300] facility:3 severity:6 tls_peer: timestamp:2016-08-15 22:32:00 -0700 PDT priority:30 client:127.0.0.1:50077]
map[hostname:127.0.0.1 tag: content:Aug 15 22:32:00 vagrant-2016 ecce3efd2691[3652]: (c) 2016 Microsoft Corporation. All rights reserved. facility:3 severity:6 client:127.0.0.1:50077 timestamp:2016-08-15 22:32:00 -0700 PDT tls_peer: priority:30]
map[priority:30 facility:3 severity:6 client:127.0.0.1:50077 tls_peer: timestamp:2016-08-15 22:32:01 -0700 PDT hostname:127.0.0.1 tag: content:Aug 15 22:32:00 vagrant-2016 ecce3efd2691[3652]:]

```

**\- Description for the changelog**
Enabled syslog as logging driver for windows containers.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Michal Wieczorek wieczorek-michal@wp.pl
