### PR TITLE
wrong id when testing exists in daemon aufs

### DIFF
--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -550,7 +550,7 @@ func TestExists(t *testing.T) {
 	}
 
 	if d.Exists("none") {
-		t.Fatal("id name should not exist in the driver")
+		t.Fatal("id none should not exist in the driver")
 	}
 
 	if !d.Exists("1") {


### PR DESCRIPTION
Fatal info "id name" should be "id none"
