### PR TITLE
Remove mess words in installation doc

### DIFF
--- a/docs/installation/linux/ubuntulinux.md
+++ b/docs/installation/linux/ubuntulinux.md
@@ -142,27 +142,48 @@ For Ubuntu Precise, Docker requires the 3.13 kernel version. If your kernel
 version is older than 3.13, you must upgrade it. Refer to this table to see
 which packages are required for your environment:
 
-<style type="text/css"> .tg  {border-collapse:collapse;border-spacing:0;} .tg
-td{font-size:14px;padding:10px
-5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
-.tg-031{width:275px;font-family:monospace} </style> <table class="tg"> <tr> <td
-class="tg-031">linux-image-generic-lts-trusty</td> <td class="tg-031e">Generic
-Linux kernel image. This kernel has AUFS built in. This is required to run
-Docker.</td> </tr> <tr> <td class="tg-031">linux-headers-generic-lts-trusty</td>
-<td class="tg-031e">Allows packages such as ZFS and VirtualBox guest additions
-which depend on them. If you didn't install the headers for your existing
-kernel, then you can skip these headers for the"trusty" kernel. If you're
-unsure, you should include this package for safety.</td> </tr> <tr> <td
-class="tg-031">xserver-xorg-lts-trusty</td> <td class="tg-031e"
-rowspan="2">Optional in non-graphical environments without Unity/Xorg.
-<b>Required</b> when running Docker on machine with a graphical environment.
-<br>
-<br>To learn more about the reasons for these packages, read the installation
-instructions for backported kernels, specifically the <a
-href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack" target="_blank">LTS
-Enablement Stack</a> &mdash; refer to note 5 under each version.
-</td> </tr>
-<tr> <td class="tg-031">libgl1-mesa-glx-lts-trusty</td> </tr> </table> &nbsp;
+<table>
+  <thead>
+  <tr>
+    <th>Package</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><b style="white-space: nowrap">linux-image-generic-lts-trusty</b></td>
+    <td>
+      Generic Linux kernel image. This kernel has AUFS built in. This is
+      required to run Docker.
+    </td>
+  </tr>
+  <tr>
+    <td><b style="white-space: nowrap">linux-headers-generic-lts-trusty</b></td>
+    <td>
+      Allows packages such as ZFS and VirtualBox guest additions which depend
+      on them. If you didn't install the headers for your existing kernel, then
+      you can skip these headers for the"trusty" kernel. If you're unsure, you
+      should include this package for safety.
+    </td>
+  </tr>
+  <tr>
+    <td><b style="white-space: nowrap">xserver-xorg-lts-trusty</b></td>
+    <td rowspan="2">
+      Optional in non-graphical environments without Unity/Xorg.
+      <b>Required</b> when running Docker on machine with a graphical
+      environment.<br /><br />
+      To learn more about the reasons for these packages, read the installation
+      instructions for backported kernels, specifically the <a
+      href="https://wiki.ubuntu.com/Kernel/LTSEnablementStack"
+      target="_blank">LTS Enablement Stack</a> &mdash; refer to note 5 under each
+      version.
+    </td>
+  </tr>
+  <tr>
+    <td><b style="white-space: nowrap">libgl1-mesa-glx-lts-trusty</b></td>
+  </tr>
+  </tbody>
+</table>
 
 To upgrade your kernel and install the additional packages, do the following:
 


### PR DESCRIPTION
There are some mess words happened which is shown by the attached file.  Therefore, those redundant words should be removed in installation/linux/ubuntulinux.md

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn

![docker_doc_error](https://cloud.githubusercontent.com/assets/20082558/17693997/49984874-63d4-11e6-840f-9d0f26f22f6d.jpg)
[](url)
