### PR TITLE
check-config: Don't check DEVPTS_MULTIPLE_INSTANCES for kernel upper than 4.7

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -126,6 +126,32 @@ check_distro_userns() {
 	fi
 }
 
+kernel_version_ge()
+{
+	local target_version="$1"
+
+	local config_version
+	config_version=$(zgrep '^# Linux/.* Kernel Configuration$' "$CONFIG" | cut -d' ' -f3)
+	[[ "$config_version" ]] || {
+		echo "WARNING: $FUNCNAME: get config_version failed"
+		return 1
+	}
+
+	local lower_version
+	if echo | sort -V &>/dev/null; then
+		# For sort support -V option
+		lower_version=$(echo "$target_version"$'\n'"$config_version" | sort -V | head -1)
+	else
+		lower_version=$(echo "$target_version"$'\n'"$config_version" | sort -t. -n -k1,1 -k2,2 -k3,3 -k4,4 | head -1)
+	fi
+	[[ "$lower_version" ]] || {
+		echo "WARNING: $FUNCNAME: compare version failed"
+		return 1
+	}
+
+	[[ "$lower_version" = "$target_version" ]]
+}
+
 if [ ! -e "$CONFIG" ]; then
 	wrap_warning "warning: $CONFIG does not exist, searching other paths for kernel config ..."
 	for tryConfig in "${possibleConfigs[@]}"; do
@@ -180,7 +206,6 @@ fi
 
 flags=(
 	NAMESPACES {NET,PID,IPC,UTS}_NS
-	DEVPTS_MULTIPLE_INSTANCES
 	CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG
 	KEYS
 	VETH BRIDGE BRIDGE_NETFILTER
@@ -192,6 +217,7 @@ flags=(
 	POSIX_MQUEUE
 )
 check_flags "${flags[@]}"
+kernel_version_ge 4.7 || check_flags DEVPTS_MULTIPLE_INSTANCES
 echo
 
 echo 'Optional Features:'


### PR DESCRIPTION
DEVPTS_MULTIPLE_INSTANCES is removed from kernel 4.7, by:
commit eedf265aa003b4781de24cfed40a655a664457e6
devpts: Make each mount of devpts an independent filesystem.

We should skip checking this flag for kernel upper than 4.7.

Signed-off-by: Zhao Lei zhaolei@cn.fujitsu.com
