### PR TITLE
Remove redundant filepath.Clean()

### DIFF
--- a/volume/volume_unix.go
+++ b/volume/volume_unix.go
@@ -56,7 +56,7 @@ func ParseMountSpec(spec, volumeDriver string) (*MountPoint, error) {
 	switch len(arr) {
 	case 1:
 		// Just a destination path in the container
-		mp.Destination = filepath.Clean(arr[0])
+		mp.Destination = arr[0]
 	case 2:
 		if isValid := ValidMountMode(arr[1]); isValid {
 			// Destination + Mode is not a valid volume - volumes


### PR DESCRIPTION
just a nit: If only a destination was specified, the path was cleaned twice. This removes the redundant `filepath.Clean()`

/cc @cpuguy83 @vdemeester 
