### PR TITLE
Add retry checks to TestSwarmPublishAdd

### DIFF
--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -354,3 +354,17 @@ func (d *SwarmDaemon) checkLeader(c *check.C) (interface{}, check.CommentInterfa
 	}
 	return fmt.Errorf("no leader"), check.Commentf("could not find leader")
 }
+
+func (d *SwarmDaemon) cmdRetryOutOfSequence(args ...string) (string, error) {
+	for i := 0; ; i++ {
+		out, err := d.Cmd(args...)
+		if err != nil {
+			if strings.Contains(err.Error(), "update out of sequence") {
+				if i < 10 {
+					continue
+				}
+			}
+		}
+		return out, err
+	}
+}

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -207,13 +207,13 @@ func (s *DockerSwarmSuite) TestSwarmPublishAdd(c *check.C) {
 	out, err = d.Cmd("service", "update", "--publish-add", "80:80", name)
 	c.Assert(err, checker.IsNil)
 
-	out, err = d.Cmd("service", "update", "--publish-add", "80:80", name)
+	out, err = d.cmdRetryOutOfSequence("service", "update", "--publish-add", "80:80", name)
 	c.Assert(err, checker.IsNil)
 
-	out, err = d.Cmd("service", "update", "--publish-add", "80:80", "--publish-add", "80:20", name)
+	out, err = d.cmdRetryOutOfSequence("service", "update", "--publish-add", "80:80", "--publish-add", "80:20", name)
 	c.Assert(err, checker.NotNil)
 
-	out, err = d.Cmd("service", "update", "--publish-add", "80:20", name)
+	out, err = d.cmdRetryOutOfSequence("service", "update", "--publish-add", "80:20", name)
 	c.Assert(err, checker.IsNil)
 
 	out, err = d.Cmd("service", "inspect", "--format", "{{ .Spec.EndpointSpec.Ports }}", name)


### PR DESCRIPTION
Add retry checks to `TestSwarmPublishAdd` test. Current version of swarmkit has an issue that may cause the service version to increment internally during a rolling update. This is not a real fix but makes the test non-flaky.

issue in swarmkit: https://github.com/docker/swarmkit/issues/1379

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
