### PR TITLE
Sort the order of network driver list for `docker info`

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"runtime"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -180,6 +181,8 @@ func (daemon *Daemon) showPluginsInfo() types.PluginsInfo {
 	for nd := range networkDriverList {
 		pluginsInfo.Network = append(pluginsInfo.Network, nd)
 	}
+	// Sort so that the order is not random
+	sort.Strings(pluginsInfo.Network)
 
 	pluginsInfo.Authorization = daemon.configStore.AuthorizationPlugins
 


### PR DESCRIPTION
**\- What I did**
While playing with `docker info` I noticed that the output of the network may change randomly with different runs. For example, below are the two consecutive runs of `docker info`:

```
ubuntu@ubuntu:~/docker$ sudo docker info
...
Plugins:
 Volume: local
 Network: host bridge overlay null
...
```

```
ubuntu@ubuntu:~/docker$ sudo docker info
...
Plugins:
 Volume: local
 Network: null host bridge overlay
...
```

I think it might make sense to sort the list so that the output of the `docker info` is predictable.
**\- How I did it**

This fix sorts the order of network driver for `docker info`.

**\- How to verify it**

Tested manually, below is the output (predictable):

```
ubuntu@ubuntu:~/docker$ sudo docker info
...
Plugins: 
 Volume: local
 Network: bridge host null overlay
...
```

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Yong Tang yong.tang.github@outlook.com
