### PR TITLE
Update ENTRYPOINT/CMD table to agree with docs

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1154,12 +1154,12 @@ or for executing an ad-hoc command in a container.
 
 The table below shows what command is executed for different `ENTRYPOINT` / `CMD` combinations:
 
-|                                | No ENTRYPOINT              | ENTRYPOINT exec_entry p1_entry                            | ENTRYPOINT ["exec_entry", "p1_entry"]          |
-|--------------------------------|----------------------------|-----------------------------------------------------------|------------------------------------------------|
-| **No CMD**                     | *error, not allowed*       | /bin/sh -c exec_entry p1_entry                            | exec_entry p1_entry                            |
-| **CMD ["exec_cmd", "p1_cmd"]** | exec_cmd p1_cmd            | /bin/sh -c exec_entry p1_entry exec_cmd p1_cmd            | exec_entry p1_entry exec_cmd p1_cmd            |
-| **CMD ["p1_cmd", "p2_cmd"]**   | p1_cmd p2_cmd              | /bin/sh -c exec_entry p1_entry p1_cmd p2_cmd              | exec_entry p1_entry p1_cmd p2_cmd              |
-| **CMD exec_cmd p1_cmd**        | /bin/sh -c exec_cmd p1_cmd | /bin/sh -c exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd | exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd |
+|                                | No ENTRYPOINT              | ENTRYPOINT exec_entry p1_entry | ENTRYPOINT ["exec_entry", "p1_entry"]          |
+|--------------------------------|----------------------------|--------------------------------|------------------------------------------------|
+| **No CMD**                     | *error, not allowed*       | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry                            |
+| **CMD ["exec_cmd", "p1_cmd"]** | exec_cmd p1_cmd            | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry exec_cmd p1_cmd            |
+| **CMD ["p1_cmd", "p2_cmd"]**   | p1_cmd p2_cmd              | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry p1_cmd p2_cmd              |
+| **CMD exec_cmd p1_cmd**        | /bin/sh -c exec_cmd p1_cmd | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd |
 
 ## VOLUME
 


### PR DESCRIPTION
**\- What I did**

In the Dockerfile reference documentation, the table describing the interaction of ENTRYPOINT and CMD was not in agreement with what other parts of the document said. For example, this sentence https://github.com/docker/docker/blame/master/docs/reference/builder.md#L1084-L1085 states that CMD is ignored when the shell form of the ENTRYPOINT command is used but the table indicated otherwise. I tested myself which was correct, finding the table was incorrect, so I updated the table.

**\- How I did it**

I edited the markdown in a text editor.

**\- How to verify it**

You can create a Dockerfile with the following contents:

```
FROM busybox:latest
ENTRYPOINT /bin/echo p1_entry
CMD shell_cmd p1_cmd
```

build a container, run it, and see that `p1_entry` is output but `shell_cmd p1_cmd` is not.  Similar for an exec form of CMD.

**\- Description for the changelog**

Dockerfile documentation more consistent and accurate

**\- A picture of a cute animal (not mandatory but encouraged)**

![Thumbs up](http://justcuteanimals.com/wp-content/uploads/2014/07/hamster-thumbs-up-cute-hamters-animal-picture-pics.jpg)

Several other places in the document it states that when using the shell
form of ENTRYPOINT, CMD and command line arguments are ignored.  That is
accurate, this table was not.  It is now.

Signed-off-by: David Dooling dooling@gmail.com
