### PR TITLE
Remove erroneous ENTRYPOINT note

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1075,8 +1075,6 @@ sys	0m 0.03s
 > `ENTRYPOINT [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo $HOME" ]`.
-> Variables that are defined in the `Dockerfile`using `ENV`, will be substituted by
-> the `Dockerfile` parser.
 
 ### Shell form ENTRYPOINT example
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -541,6 +541,9 @@ RUN /bin/bash -c 'source $HOME/.bashrc ; echo $HOME'
 > `RUN [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `RUN [ "sh", "-c", "echo $HOME" ]`.
+> When using the exec form and executing a shell directly, as in the case for
+> the shell form, it is the shell that is doing the environment variable
+> expansion, not docker.
 >
 > **Note**:
 > In the *JSON* form, it is necessary to escape backslashes. This is
@@ -607,6 +610,9 @@ instruction as well.
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `CMD [ "sh", "-c", "echo $HOME" ]`.
+> When using the exec form and executing a shell directly, as in the case for
+> the shell form, it is the shell that is doing the environment variable
+> expansion, not docker.
 
 When used in the shell or exec formats, the `CMD` instruction sets the command
 to be executed when running the image.
@@ -1075,6 +1081,9 @@ sys	0m 0.03s
 > `ENTRYPOINT [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
 > If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo $HOME" ]`.
+> When using the exec form and executing a shell directly, as in the case for
+> the shell form, it is the shell that is doing the environment variable
+> expansion, not docker.
 
 ### Shell form ENTRYPOINT example
 


### PR DESCRIPTION
**\- What I did**

I removed a confusing and inaccurate note about the behavior of ENV variable substitution in the ENTRYPOINT command documentation.

**\- How I did it**

I edited the markdown with a text editor.

**\- How to verify it**

Use an ENV variable in an ENTRYPOINT command and inspect the resulting image. See that in the image the literal `$ENV_VAR` is in the image, not its value. Therefore, it is clear that the Dockerfile parser does not do any substitution.

**\- Description for the changelog**

Correct ENTRYPOINT documentation

**\- A picture of a cute animal (not mandatory but encouraged)**

![Two Words](http://3.bp.blogspot.com/_aNTsUIQhmf0/SZLZ7187pQI/AAAAAAAACMk/oWGHtvA4joM/s320/Overwhelming+Colorfast+-+Two+Words+-+1994.jpg)

The Dockerfile parser does not subsitute ENV variables in any form of
the ENTRYPOINT command.  Any substitution, if done, is done by the shell
when the command is executed.

Signed-off-by: David Dooling dooling@gmail.com
