### PR TITLE
Add --mount syntax documentation to CLI reference

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -240,6 +240,8 @@ binary (refer to [get the linux binary](
 you give the container the full access to create and manipulate the host's
 Docker daemon.
 
+For in-depth information about volumes, refer to [manage data in containers](../../tutorials/dockervolumes.md)
+
 ### Publish or expose port (-p, --expose)
 
     $ docker run -p 127.0.0.1:80:8080 ubuntu bash

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -197,8 +197,8 @@ The `-w` lets the command being executed inside directory given, here
 
     $ docker run -it --storage-opt size=120G fedora /bin/bash
 
-This (size) will allow to set the container rootfs size to 120G at creation time. 
-User cannot pass a size less than the Default BaseFS Size. This option is only 
+This (size) will allow to set the container rootfs size to 120G at creation time.
+User cannot pass a size less than the Default BaseFS Size. This option is only
 available for the `devicemapper`, `btrfs`, `windowsfilter`, and `zfs` graph drivers.
 
 ### Mount tmpfs (--tmpfs)
@@ -636,14 +636,14 @@ On Microsoft Windows, can take any of these values:
 | `hyperv`   | Hyper-V hypervisor partition-based isolation.                                                                                                                  |
 
 On Windows, the default isolation for client is `hyperv`, and for server is
-`process`. Therefore when running on Windows server without a `daemon` option 
+`process`. Therefore when running on Windows server without a `daemon` option
 set, these two commands are equivalent:
 ```
 $ docker run -d --isolation default busybox top
 $ docker run -d --isolation process busybox top
 ```
 
-If you have set the `--exec-opt isolation=hyperv` option on the Docker `daemon`, 
+If you have set the `--exec-opt isolation=hyperv` option on the Docker `daemon`,
 if running on Windows server, any of these commands also result in `hyperv` isolation:
 
 ```

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -69,19 +69,36 @@ $ docker service update --limit-cpu 2 redis
 
 ### Adding and removing mounts
 
-You can add, or remove bind-mounts or volumes to a service using the
-`--mount-add` and `--mount-rm` options.
+Use the `--mount-add` or `--mount-rm` options add or remove a service's bind-mounts
+or volumes.
 
-The following example creates a service using the `test-data` volume, then
-updates the service to mount another volume, and finally unmounts the first
-volume:
+The following example creates a service which mounts the `test-data` volume to
+`/somewhere`. The next step updates the service to also mount the `other-volume`
+volume to `/somewhere-else`volume, The last step unmounts the `/somewhere` mount
+point, effectively removing the `test-data` volume. Each command returns the
+service name.
+
+- The `--mount-add` flag takes the same parameters as the `--mount` flag on
+  `service create`. Refer to the [volumes and
+  bind-mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
+  `service create` reference for details.
+
+- The `--mount-rm` flag takes the `target` path of the mount.
 
 ```bash
-$ docker service create --name=myservice --mount type=volume,source=test-data,target=/somewhere nginx:alpine
+$ docker service create \
+    --name=myservice \
+    --mount \
+      type=volume,source=test-data,target=/somewhere \
+    nginx:alpine \
+    myservice
 
 myservice
 
-$ docker service update --mount-add type=volume,source=other-volume,target=/somewhere-else myservice
+$ docker service update \
+    --mount-add \
+      type=volume,source=other-volume,target=/somewhere-else \
+    myservice
 
 myservice
 
@@ -89,12 +106,6 @@ $ docker service update --mount-rm /somewhere myservice
 
 myservice
 ```
-
-The `--mount-rm` flag takes the `target` path of the mount. The `--mount-add`
-flag takes the same parameters as the `--mount` flag on `service create`. Refer
-to the [volumes and bind-mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
-`service create` reference for details.
-
 
 ## Related information
 

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -67,6 +67,35 @@ for further information.
 $ docker service update --limit-cpu 2 redis
 ```
 
+### Adding and removing mounts
+
+You can add, or remove bind-mounts or volumes to a service using the
+`--mount-add` and `--mount-rm` options.
+
+The following example creates a service using the `test-data` volume, then
+updates the service to mount another volume, and finally unmounts the first
+volume:
+
+```bash
+$ docker service create --name=myservice --mount type=volume,source=test-data,target=/somewhere nginx:alpine
+
+myservice
+
+$ docker service update --mount-add type=volume,source=other-volume,target=/somewhere-else myservice
+
+myservice
+
+$ docker service update --mount-rm /somewhere myservice
+
+myservice
+```
+
+The `--mount-rm` flag takes the `target` path of the mount. The `--mount-add`
+flag takes the same parameters as the `--mount` flag on `service create`. Refer
+to the [volumes and bind-mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
+`service create` reference for details.
+
+
 ## Related information
 
 * [service create](service_create.md)


### PR DESCRIPTION
This is a first stab at adding some information about the `--mount` syntax and options. Should fix https://github.com/docker/docker/issues/24277 once merged

ping @sfsmithcha @cpuguy83 PTAL; I'm sure there's lots of improvements to be made (but I found a couple of issues / bugs, so it was useful :smile:) 
