### PR TITLE
Fixing race in Windows container servicing

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -95,7 +95,7 @@ func (ctr *container) start() error {
 	ctr.process.hcsProcess = hcsProcess
 
 	// If this is a servicing container, wait on the process synchronously here and
-	// immediately call shutdown/terminate when it returns.
+	// if it succeeds, wait for it cleanly shutdown and merge into the parent container.
 	if isServicing {
 		exitCode := ctr.waitProcessExitCode(&ctr.process)
 
@@ -104,7 +104,7 @@ func (ctr *container) start() error {
 			return ctr.terminate()
 		}
 
-		return ctr.shutdown()
+		return ctr.hcsContainer.WaitTimeout(time.Minute * 5)
 	}
 
 	var stdout, stderr io.ReadCloser


### PR DESCRIPTION
@jhowardmsft @brian-young
There exists a race in container servicing on Windows where, during normal operation, the container will begin to shut itself down while docker calls shutdown explicitly.  If the former succeeds just as the latter is attempting to communicate with the container to request the shutdown, an error comes back that can cause the servicing to incorrectly register as a failure.  Instead, we just wait for the servicing container to shutdown on it's own, using a reasonable timeout to allow for merging in the updates.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
