### PR TITLE
Fix retry logic for out of sequence errors

### DIFF
--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -359,7 +359,7 @@ func (d *SwarmDaemon) cmdRetryOutOfSequence(args ...string) (string, error) {
 	for i := 0; ; i++ {
 		out, err := d.Cmd(args...)
 		if err != nil {
-			if strings.Contains(err.Error(), "update out of sequence") {
+			if strings.Contains(out, "update out of sequence") {
 				if i < 10 {
 					continue
 				}


### PR DESCRIPTION
Fix bug in #25765. Error is always `exit status <code>` for this helper. Command output needs to be checked for the actual error message.

cc @tiborvass 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
