### PR TITLE
bugfix: report "destroy" after all volumes of container destroy

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -90,7 +90,7 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.cleanupContainer(container, true); err != nil {
+			if err := daemon.cleanupContainer(container, true, true); err != nil {
 				logrus.Errorf("failed to cleanup container on create error: %v", err)
 			}
 		}
@@ -118,13 +118,6 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig, managed bool) (
 	if err := daemon.setHostConfig(container, params.HostConfig); err != nil {
 		return nil, err
 	}
-	defer func() {
-		if retErr != nil {
-			if err := daemon.removeMountPoints(container, true); err != nil {
-				logrus.Error(err)
-			}
-		}
-	}()
 
 	if err := daemon.createContainerPlatformSpecificSettings(container, params.Config, params.HostConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #25766

If a container's AutoRemove is enabled, client will wait until it's
removed after container exits, this is implemented based on "destroy"
event.

Currently an "AutoRemove" container will report "destroy" event to
notify a hanging client to exit before all volumes are removed, this is
wrong, we should wait container until everything is cleaned up.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
