### PR TITLE
[1.12] Skip always pulling images on integration tests

### DIFF
--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -172,7 +172,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 
 	args = append(args, providedArgs...)
 	d.cmd = exec.Command(dockerdBinary, args...)
-
+	d.cmd.Env = append(os.Environ(), "DOCKER_SERVICE_PREFER_OFFLINE_IMAGE=1")
 	d.cmd.Stdout = out
 	d.cmd.Stderr = out
 	d.logFile = out


### PR DESCRIPTION
Cherry-picking https://github.com/docker/docker/pull/23790 to test if it fixes failing tests on ARM CI.
