### PR TITLE
Modify usage of docker swarm join-token command

### DIFF
--- a/api/client/swarm/join_token.go
+++ b/api/client/swarm/join_token.go
@@ -16,7 +16,7 @@ func newJoinTokenCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var rotate, quiet bool
 
 	cmd := &cobra.Command{
-		Use:   "join-token [-q] [--rotate] (worker|manager)",
+		Use:   "join-token [OPTIONS] (worker|manager)",
 		Short: "Manage join tokens",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/swarm_join_token.md
+++ b/docs/reference/commandline/swarm_join_token.md
@@ -11,7 +11,7 @@ parent = "smn_cli"
 # swarm join-token
 
 ```markdown
-Usage:	docker swarm join-token [--rotate] (worker|manager)
+Usage:	docker swarm join-token [OPTIONS] (worker|manager)
 
 Manage join tokens
 


### PR DESCRIPTION
To current command usage"docker swarm join-token [--rotate](worker|manager)", there are other options such as "--help", "-q, --quiet" except "--rotate", so "--rotate" should be replaced by "OPTIONS".
