### PR TITLE
Specify woker node for docker swarm leave command

### DIFF
--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -31,7 +31,7 @@ dkp8vy1dq1kxleu9g4u78tlag    worker1   Ready   Active        Reachable
 dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
 ```
 
-On a worker node:
+On a worker node, worker2 in the following example:
 ```bash
 $ docker swarm leave
 Node left the default swarm.


### PR DESCRIPTION
From result of swarm leave command, it is the worker2 left not other woker, so it is better to specify woker2 node:

```
$ docker node ls
ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
7ln70fl22uw2dvjn2ft53m3q5    worker2   Down    Active
dkp8vy1dq1kxleu9g4u78tlag    worker1   Ready   Active        Reachable
dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
```
