### PR TITLE
Add default timeout to pkg/plugins/client

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	defaultTimeOut = 30
+	defaultTimeOut     = 30
+	defaultHTTPTimeOut = 32 * time.Second
 )
 
 // NewClient creates a new plugin client (http).
@@ -53,6 +54,7 @@ func NewClient(addr string, tlsConfig *tlsconfig.Options) (*Client, error) {
 func NewClientWithTransport(tr transport.Transport) *Client {
 	return &Client{
 		http: &http.Client{
+			Timeout:   defaultHTTPTimeOut,
 			Transport: tr,
 		},
 		requestFactory: tr,

--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,26 @@ func setupRemotePluginServer() string {
 func teardownRemotePluginServer() {
 	if server != nil {
 		server.Close()
+	}
+}
+
+func TestHttpTimeout(t *testing.T) {
+	addr := setupRemotePluginServer()
+	defer teardownRemotePluginServer()
+	stop := false // we need this variable to stop the http server
+	mux.HandleFunc("/hang", func(w http.ResponseWriter, r *http.Request) {
+		for {
+			if stop {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+	})
+	c, _ := NewClient(addr, &tlsconfig.Options{InsecureSkipVerify: true})
+	_, err := c.callWithRetry("hang", nil, false)
+	stop = true
+	if err == nil || !strings.Contains(err.Error(), "request canceled") {
+		t.Fatalf("The request should be canceled %v", err)
 	}
 }
 


### PR DESCRIPTION
Happened to find some `docker create` command hangs for a long time due to remote volume plugin. The goroutine stack is as follows. I believe timeout is necessary. 

![d1afb70c-533e-49c6-a0e6-a8dee4968dcc](https://cloud.githubusercontent.com/assets/985861/17730859/4f01b3c6-649d-11e6-8a7d-9955b9d182b9.png)
