### PR TITLE
Disable coverage on test-integration-cli

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -73,7 +73,6 @@ DEFAULT_BUNDLES=(
 	test-integration-cli
 	test-docker-py
 
-	cover
 	cross
 	tgz
 )

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -23,22 +23,15 @@ go_test_dir() {
 	testcover=()
 	testcoverprofile=()
 	testbinary="$DEST/test.main"
-	if [ "$HAVE_GO_TEST_COVER" ]; then
-		# if our current go install has -cover, we want to use it :)
-		mkdir -p "$DEST/coverprofiles"
-		coverprofile="docker${dir#.}"
-		coverprofile="$ABS_DEST/coverprofiles/${coverprofile//\//-}"
-		testcover=( -test.cover )
-		testcoverprofile=( -test.coverprofile "$coverprofile" $coverpkg )
-	fi
 	(
+		mkdir -p "$DEST/coverprofiles"
 		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
 		cd "$dir"
 		export DEST="$ABS_DEST" # in a subshell this is safe -- our integration-cli tests need DEST, and "cd" screws it up
-		go test -c -o "$testbinary" ${testcover[@]} -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}"
+		go test -c -o "$testbinary" -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}"
 		i=0
 		while ((++i)); do
-			test_env "$testbinary" ${testcoverprofile[@]} $TESTFLAGS
+			test_env "$testbinary" $TESTFLAGS
 			if [ $i -gt "$TEST_REPEAT" ]; then
 				break
 			fi


### PR DESCRIPTION
Closes #25313, disables `-cover` on `test-integration-cli` 🐯.

/cc @aaronlehmann @tianon @thaJeztah @tiborvass 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
