### PR TITLE
Fix 25798 : Allow "partial/prefix" filter for health_status, exec_create and exec_start events

### DIFF
--- a/daemon/events/filter.go
+++ b/daemon/events/filter.go
@@ -18,7 +18,7 @@ func NewFilter(filter filters.Args) *Filter {
 
 // Include returns true when the event ev is included by the filters
 func (ef *Filter) Include(ev events.Message) bool {
-	return ef.filter.ExactMatch("event", ev.Action) &&
+	return ef.matchEvent(ev) &&
 		ef.filter.ExactMatch("type", ev.Type) &&
 		ef.matchDaemon(ev) &&
 		ef.matchContainer(ev) &&
@@ -27,6 +27,24 @@ func (ef *Filter) Include(ev events.Message) bool {
 		ef.matchNetwork(ev) &&
 		ef.matchImage(ev) &&
 		ef.matchLabels(ev.Actor.Attributes)
+}
+
+func (ef *Filter) matchEvent(ev events.Message) bool {
+	// #25798 if an event filter contains either health_status, exec_create or exec_start without a colon
+	// Let's to a FuzzyMatch instead of an ExactMatch.
+	if ef.filterContains("event", map[string]struct{}{"health_status": {}, "exec_create": {}, "exec_start": {}}) {
+		return ef.filter.FuzzyMatch("event", ev.Action)
+	}
+	return ef.filter.ExactMatch("event", ev.Action)
+}
+
+func (ef *Filter) filterContains(field string, values map[string]struct{}) bool {
+	for _, v := range ef.filter.Get(field) {
+		if _, ok := values[v]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (ef *Filter) matchLabels(attributes map[string]string) bool {


### PR DESCRIPTION
Fixes #25798, by using partial filtering for `health_status`, `exec_create` and `exec_start` events if there is no `:` in the filter 🐅.

<del>When we filter event, we do an exact match. Thus if the Action content is dynamic, we are filtering out some events. The Attributes field is there to pass additional data with events.</del>


<del>Fixing exec_create, exec_start and health_status event in that matter. A possible follow-up of this would be to force a type for Action in these methods to make sure we pass predefined actions.</del>


**\- How to verify it**

In one terminal:

``` bash
docker events --filter event=health_status
```

In another terminal;

``` bash
docker run --name=test -d --health-cmd='stat /etc/passwd || exit 1' --health-interval=2s   busybox sleep 1d
```

**\- Expected**

``` bash
$ docker events --filter event=health_status

2016-08-17T12:10:34.337301145Z container health_status: healthy da1bab7bc91a424cd8e0571808c1b4638a903a8508eb6612e9cdfc49f9dde555 (image=busybox, name=test)


$ docker events --filter event=exec_create

2016-08-17T12:10:34.198347963Z container exec_create: /bin/sh -c stat /etc/passwd || exit 1 da1bab7bc91a424cd8e0571808c1b4638a903a8508eb6612e9cdfc49f9dde555 (image=busybox, name=test)
2016-08-17T12:10:36.338156681Z container exec_create: /bin/sh -c stat /etc/passwd || exit 1 da1bab7bc91a424cd8e0571808c1b4638a903a8508eb6612e9cdfc49f9dde555 (image=busybox, name=test)


$ docker events --filter event=exec_start

2016-08-17T12:10:34.198549073Z container exec_start: /bin/sh -c stat /etc/passwd || exit 1 da1bab7bc91a424cd8e0571808c1b4638a903a8508eb6612e9cdfc49f9dde555 (image=busybox, name=test)
2016-08-17T12:10:36.338214034Z container exec_start: /bin/sh -c stat /etc/passwd || exit 1 da1bab7bc91a424cd8e0571808c1b4638a903a8508eb6612e9cdfc49f9dde555 (image=busybox, name=test)
```

**\- Todo**
- [x] Add an integrations test for that.
- [x] Decide if the map key are the right one for these cases.

/cc @thaJeztah @icecrime @tiborvass @stevvooe @calavera @cpuguy83 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
