### PR TITLE
improve error message for volume names that are too short

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -256,6 +256,9 @@ func (r *Root) Scope() string {
 }
 
 func (r *Root) validateName(name string) error {
+	if len(name) == 1 {
+		return validationError{fmt.Errorf("volume name is too short, names should be at least two alphanumeric characters")}
+	}
 	if !volumeNameRegex.MatchString(name) {
 		return validationError{fmt.Errorf("%q includes invalid characters for a local volume name, only %q are allowed", name, utils.RestrictedNameChars)}
 	}

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -138,6 +138,7 @@ func TestCreate(t *testing.T) {
 func TestValidateName(t *testing.T) {
 	r := &Root{}
 	names := map[string]bool{
+		"x":           false,
 		"/testvol":    false,
 		"thing.d":     true,
 		"hello-world": true,


### PR DESCRIPTION
this improves the error message if a user tries to create a volume with a single-character name:

Before this change:

```
docker volume create --name a
Error response from daemon: create a: "a" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
```

After this change:

```
docker volume create --name a
Error response from daemon: create a: volume name is too short, names should be at least two alphanumeric characters
```
