### PR TITLE
IPAM driver name should not be required in network create

### DIFF
--- a/api/client/network/create.go
+++ b/api/client/network/create.go
@@ -79,7 +79,7 @@ func runCreate(dockerCli *client.DockerCli, opts createOptions) error {
 	nc := types.NetworkCreate{
 		Driver:  opts.driver,
 		Options: opts.driverOpts.GetAll(),
-		IPAM: network.IPAM{
+		IPAM: &network.IPAM{
 			Driver:  opts.ipamDriver,
 			Config:  ipamCfg,
 			Options: opts.ipamOpt.GetAll(),

--- a/api/client/stack/deploy.go
+++ b/api/client/stack/deploy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/api/client/bundlefile"
 	"github.com/docker/docker/cli"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/swarm"
 )
 
@@ -105,8 +104,6 @@ func updateNetworks(
 	createOpts := types.NetworkCreate{
 		Labels: getStackLabels(namespace, nil),
 		Driver: defaultNetworkDriver,
-		// TODO: remove when engine-api uses omitempty for IPAM
-		IPAM: network.IPAM{Driver: "default"},
 	}
 
 	for _, internalName := range networks {

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -179,21 +179,23 @@ func BasicNetworkCreateToGRPC(create basictypes.NetworkCreateRequest) swarmapi.N
 		},
 		Ipv6Enabled: create.EnableIPv6,
 		Internal:    create.Internal,
-		IPAM: &swarmapi.IPAMOptions{
+	}
+	if create.IPAM != nil {
+		ns.IPAM = &swarmapi.IPAMOptions{
 			Driver: &swarmapi.Driver{
 				Name:    create.IPAM.Driver,
 				Options: create.IPAM.Options,
 			},
-		},
+		}
+		ipamSpec := make([]*swarmapi.IPAMConfig, 0, len(create.IPAM.Config))
+		for _, ipamConfig := range create.IPAM.Config {
+			ipamSpec = append(ipamSpec, &swarmapi.IPAMConfig{
+				Subnet:  ipamConfig.Subnet,
+				Range:   ipamConfig.IPRange,
+				Gateway: ipamConfig.Gateway,
+			})
+		}
+		ns.IPAM.Configs = ipamSpec
 	}
-	ipamSpec := make([]*swarmapi.IPAMConfig, 0, len(create.IPAM.Config))
-	for _, ipamConfig := range create.IPAM.Config {
-		ipamSpec = append(ipamSpec, &swarmapi.IPAMConfig{
-			Subnet:  ipamConfig.Subnet,
-			Range:   ipamConfig.IPRange,
-			Gateway: ipamConfig.Gateway,
-		})
-	}
-	ns.IPAM.Configs = ipamSpec
 	return ns
 }

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -478,7 +478,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 	options := types.NetworkCreate{
 		// ID:     na.Network.ID,
 		Driver: na.Network.DriverState.Name,
-		IPAM: network.IPAM{
+		IPAM: &network.IPAM{
 			Driver: na.Network.IPAM.Driver.Name,
 		},
 		Options:        na.Network.DriverState.Options,

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -94,7 +94,7 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 
 	options := types.NetworkCreate{
 		Driver: na.Network.DriverState.Name,
-		IPAM: network.IPAM{
+		IPAM: &network.IPAM{
 			Driver: na.Network.IPAM.Driver.Name,
 		},
 		Options:        na.Network.DriverState.Options,

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -233,18 +233,22 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 		driver = c.Config().Daemon.DefaultDriver
 	}
 
-	ipam := create.IPAM
-	v4Conf, v6Conf, err := getIpamConfig(ipam.Config)
-	if err != nil {
-		return nil, err
-	}
-
 	nwOptions := []libnetwork.NetworkOption{
-		libnetwork.NetworkOptionIpam(ipam.Driver, "", v4Conf, v6Conf, ipam.Options),
 		libnetwork.NetworkOptionEnableIPv6(create.EnableIPv6),
 		libnetwork.NetworkOptionDriverOpts(create.Options),
 		libnetwork.NetworkOptionLabels(create.Labels),
 	}
+
+	if create.IPAM != nil {
+		ipam := create.IPAM
+		v4Conf, v6Conf, err := getIpamConfig(ipam.Config)
+		if err != nil {
+			return nil, err
+		}
+
+		nwOptions = append(nwOptions, libnetwork.NetworkOptionIpam(ipam.Driver, "", v4Conf, v6Conf, ipam.Options))
+	}
+
 	if create.Internal {
 		nwOptions = append(nwOptions, libnetwork.NetworkOptionInternalNetwork())
 	}

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -109,7 +109,7 @@ func (s *DockerSuite) TestApiNetworkInspect(c *check.C) {
 		Name: "br0",
 		NetworkCreate: types.NetworkCreate{
 			Driver:  "bridge",
-			IPAM:    ipam,
+			IPAM:    &ipam,
 			Options: map[string]string{"foo": "bar", "opts": "dopts"},
 		},
 	}
@@ -181,7 +181,7 @@ func (s *DockerSuite) TestApiNetworkIpamMultipleBridgeNetworks(c *check.C) {
 		Name: "test0",
 		NetworkCreate: types.NetworkCreate{
 			Driver: "bridge",
-			IPAM:   ipam0,
+			IPAM:   &ipam0,
 		},
 	}
 	id0 := createNetwork(c, config0, true)
@@ -196,7 +196,7 @@ func (s *DockerSuite) TestApiNetworkIpamMultipleBridgeNetworks(c *check.C) {
 		Name: "test1",
 		NetworkCreate: types.NetworkCreate{
 			Driver: "bridge",
-			IPAM:   ipam1,
+			IPAM:   &ipam1,
 		},
 	}
 	createNetwork(c, config1, false)
@@ -211,7 +211,7 @@ func (s *DockerSuite) TestApiNetworkIpamMultipleBridgeNetworks(c *check.C) {
 		Name: "test2",
 		NetworkCreate: types.NetworkCreate{
 			Driver: "bridge",
-			IPAM:   ipam2,
+			IPAM:   &ipam2,
 		},
 	}
 	createNetwork(c, config2, true)

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -475,7 +475,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool
 	Driver         string
 	EnableIPv6     bool
-	IPAM           network.IPAM
+	IPAM           *network.IPAM
 	Internal       bool
 	Options        map[string]string
 	Labels         map[string]string


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raise in #25735 and https://github.com/docker/engine-api/issues/368
where currently IPAM driver name is required in NetworkCreate ('/networks/create').

**\- How I did it**

This fix (together with engine-api update) changes the type of IPAM in NetworkCreate
to be a pointer so that by default IPAM driver name is not needed.

**\- How to verify it**

This fix has been tested manually, as is specified in https://github.com/docker/engine-api/issues/368.

**\- Description for the changelog**

This fix fixes #25735.

This fix is related to #25735 and https://github.com/docker/engine-api/issues/368.

A pull request in engine-api has been created separately:
https://github.com/docker/engine-api/pull/372

Signed-off-by: Yong Tang yong.tang.github@outlook.com
