### PR TITLE
Make `docker volume list` lookup plugins installed using new model.

### DIFF
--- a/integration-cli/docker_cli_daemon_experimental_test.go
+++ b/integration-cli/docker_cli_daemon_experimental_test.go
@@ -206,6 +206,13 @@ func (s *DockerDaemonSuite) TestVolumePlugin(c *check.C) {
 		}
 	}()
 
+	out, err = s.d.Cmd("volume", "ls")
+	if err != nil {
+		c.Fatalf("Could not list volume: %v %s", err, out)
+	}
+	c.Assert(out, checker.Contains, volName)
+	c.Assert(out, checker.Contains, pluginName)
+
 	mountPoint, err := s.d.Cmd("volume", "inspect", volName, "--format", "{{.Mountpoint}}")
 	if err != nil {
 		c.Fatalf("Could not inspect volume: %v %s", err, mountPoint)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -181,14 +181,13 @@ func FindWithCapability(capability string) ([]Plugin, error) {
 		handleLegacy = manager.handleLegacy
 		manager.RLock()
 		defer manager.RUnlock()
-	pluginLoop:
 		for _, p := range manager.plugins {
 			for _, typ := range p.PluginObj.Manifest.Interface.Types {
-				if typ.Capability != capability || typ.Prefix != "docker" {
-					continue pluginLoop
+				if strings.EqualFold(typ.Capability, capability) && typ.Prefix == "docker" {
+					result = append(result, p)
+					break
 				}
 			}
-			result = append(result, p)
 		}
 	}
 	if handleLegacy {
@@ -244,9 +243,8 @@ func LookupWithCapability(name, capability string) (Plugin, error) {
 		return nil, err
 	}
 
-	capability = strings.ToLower(capability)
 	for _, typ := range p.PluginObj.Manifest.Interface.Types {
-		if typ.Capability == capability && typ.Prefix == "docker" {
+		if strings.EqualFold(typ.Capability, capability) && typ.Prefix == "docker" {
 			return p, nil
 		}
 	}

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -107,7 +107,7 @@ func lookup(name string) (volume.Driver, error) {
 		return nil, fmt.Errorf("Error looking up volume plugin %s: %v", name, err)
 	}
 
-	d := NewVolumeDriver(name, p.Client())
+	d := NewVolumeDriver(p.Name(), p.Client())
 	if err := validateDriver(d); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**\- What I did**
Make plugins installed using new plugins model show up in `docker volume list`
Also, updated a test in this regard.

**\- How I did it**
Lookup should happen with the full plugin reference (not just the name) and capabilities comparison should be case-insensitive. Fixed those.

**\- How to verify it**
Updated TestVolumePlugin with this case and test passed.
Ran "TestExternalVolumeDriver*" tests that deal with legacy volume plugins and tests passed.

Signed-off-by: Anusha Ragunathan anusha@docker.com
