### PR TITLE
Add prometheus metrics output to docker

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -248,6 +248,15 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		return fmt.Errorf("Error starting daemon: %v", err)
 	}
 
+	if cli.Config.MetricsAddress != "" {
+		if !d.HasExperimental() {
+			return fmt.Errorf("metrics-addr is only supported when experimental is enabled")
+		}
+		if err := startMetricsServer(cli.Config.MetricsAddress); err != nil {
+			return err
+		}
+	}
+
 	name, _ := os.Hostname()
 
 	c, err := cluster.New(cluster.Config{

--- a/cmd/dockerd/metrics.go
+++ b/cmd/dockerd/metrics.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	metrics "github.com/docker/go-metrics"
+)
+
+func startMetricsServer(addr string) error {
+	if err := allocateDaemonPort(addr); err != nil {
+		return err
+	}
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", metrics.Handler())
+	go func() {
+		if err := http.Serve(l, mux); err != nil {
+			logrus.Errorf("serve metrics api: %s", err)
+		}
+	}()
+	return nil
+}

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -1,9 +1,14 @@
 package daemon
 
-import "github.com/docker/docker/pkg/archive"
+import (
+	"time"
+
+	"github.com/docker/docker/pkg/archive"
+)
 
 // ContainerChanges returns a list of container fs changes
 func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
+	start := time.Now()
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
@@ -11,5 +16,10 @@ func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
 
 	container.Lock()
 	defer container.Unlock()
-	return container.RWLayer.Changes()
+	c, err := container.RWLayer.Changes()
+	if err != nil {
+		return nil, err
+	}
+	containerActions.WithValues("changes").UpdateSince(start)
+	return c, nil
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -120,6 +120,7 @@ func merge(userConf, imageConf *containertypes.Config) error {
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository.
 func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (string, error) {
+	start := time.Now()
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return "", err
@@ -244,6 +245,7 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 		"comment": c.Comment,
 	}
 	daemon.LogContainerEventWithAttributes(container, "commit", attributes)
+	containerActions.WithValues("commit").UpdateSince(start)
 	return id.String(), nil
 }
 

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -146,6 +146,7 @@ type CommonConfig struct {
 	// given to the /swarm/init endpoint and no advertise address is
 	// specified.
 	SwarmDefaultAdvertiseAddr string `json:"swarm-default-advertise-addr"`
+	MetricsAddress            string `json:"metrics-addr"`
 
 	LogConfig
 	bridgeConfig // bridgeConfig holds bridge network specific configuration.
@@ -190,6 +191,8 @@ func (config *Config) InstallCommonFlags(flags *pflag.FlagSet) {
 
 	flags.StringVar(&config.SwarmDefaultAdvertiseAddr, "swarm-default-advertise-addr", "", "Set default address or interface for swarm advertised address")
 	flags.BoolVar(&config.Experimental, "experimental", false, "Enable experimental features")
+
+	flags.StringVar(&config.MetricsAddress, "metrics-addr", "", "Set default address and port to serve the metrics api on")
 
 	config.MaxConcurrentDownloads = &maxConcurrentDownloads
 	config.MaxConcurrentUploads = &maxConcurrentUploads

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
@@ -31,6 +32,7 @@ func (daemon *Daemon) ContainerCreate(params types.ContainerCreateConfig, valida
 }
 
 func (daemon *Daemon) containerCreate(params types.ContainerCreateConfig, managed bool, validateHostname bool) (types.ContainerCreateResponse, error) {
+	start := time.Now()
 	if params.Config == nil {
 		return types.ContainerCreateResponse{}, fmt.Errorf("Config cannot be empty in order to create a container")
 	}
@@ -57,7 +59,7 @@ func (daemon *Daemon) containerCreate(params types.ContainerCreateConfig, manage
 	if err != nil {
 		return types.ContainerCreateResponse{Warnings: warnings}, daemon.imageNotExistToErrcode(err)
 	}
-
+	containerActions.WithValues("create").UpdateSince(start)
 	return types.ContainerCreateResponse{ID: container.ID, Warnings: warnings}, nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/exec"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/libnetwork/cluster"
 	// register graph drivers
 	_ "github.com/docker/docker/daemon/graphdriver/register"
@@ -684,12 +685,25 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 		return nil, err
 	}
 
+	// FIXME: this method never returns an error
+	info, _ := d.SystemInfo()
+
+	engineVersion.WithValues(
+		dockerversion.Version,
+		dockerversion.GitCommit,
+		info.Architecture,
+		info.Driver,
+		info.KernelVersion,
+		info.OperatingSystem,
+	).Set(1)
+	engineCpus.Set(float64(info.NCPU))
+	engineMemory.Set(float64(info.MemTotal))
+
 	return d, nil
 }
 
 func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 	stopTimeout := c.StopTimeout()
-
 	// TODO(windows): Handle docker restart with paused containers
 	if c.IsPaused() {
 		// To terminate a process in freezer cgroup, we should send

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/errors"
@@ -19,6 +20,7 @@ import (
 // fails. If the remove succeeds, the container name is released, and
 // network links are removed.
 func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) error {
+	start := time.Now()
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -40,7 +42,10 @@ func (daemon *Daemon) ContainerRm(name string, config *types.ContainerRmConfig) 
 		return daemon.rmLink(container, name)
 	}
 
-	return daemon.cleanupContainer(container, config.ForceRemove, config.RemoveVolume)
+	err = daemon.cleanupContainer(container, config.ForceRemove, config.RemoveVolume)
+	containerActions.WithValues("delete").UpdateSince(start)
+
+	return err
 }
 
 func (daemon *Daemon) rmLink(container *container.Container, name string) error {

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -33,6 +33,7 @@ func New() *Events {
 // of interface{}, so you need type assertion), and a function to call
 // to stop the stream of events.
 func (e *Events) Subscribe() ([]eventtypes.Message, chan interface{}, func()) {
+	eventSubscribers.Inc()
 	e.mu.Lock()
 	current := make([]eventtypes.Message, len(e.events))
 	copy(current, e.events)
@@ -49,6 +50,7 @@ func (e *Events) Subscribe() ([]eventtypes.Message, chan interface{}, func()) {
 // last events, a channel in which you can expect new events (in form
 // of interface{}, so you need type assertion).
 func (e *Events) SubscribeTopic(since, until time.Time, ef *Filter) ([]eventtypes.Message, chan interface{}) {
+	eventSubscribers.Inc()
 	e.mu.Lock()
 
 	var topic func(m interface{}) bool
@@ -72,12 +74,14 @@ func (e *Events) SubscribeTopic(since, until time.Time, ef *Filter) ([]eventtype
 
 // Evict evicts listener from pubsub
 func (e *Events) Evict(l chan interface{}) {
+	eventSubscribers.Dec()
 	e.pub.Evict(l)
 }
 
 // Log broadcasts event to listeners. Each listener has 100 millisecond for
 // receiving event or it will be skipped.
 func (e *Events) Log(action, eventType string, actor eventtypes.Actor) {
+	eventsCounter.Inc()
 	now := time.Now().UTC()
 	jm := eventtypes.Message{
 		Action:   action,

--- a/daemon/events/metrics.go
+++ b/daemon/events/metrics.go
@@ -1,0 +1,15 @@
+package events
+
+import "github.com/docker/go-metrics"
+
+var (
+	eventsCounter    metrics.Counter
+	eventSubscribers metrics.Gauge
+)
+
+func init() {
+	ns := metrics.NewNamespace("engine", "daemon", nil)
+	eventsCounter = ns.NewCounter("events", "The number of events logged")
+	eventSubscribers = ns.NewGauge("events_subscribers", "The number of current subscribers to events", metrics.Total)
+	metrics.Register(ns)
+}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -60,6 +60,7 @@ type cmdProbe struct {
 // exec the healthcheck command in the container.
 // Returns the exit code and probe output (if any)
 func (p *cmdProbe) run(ctx context.Context, d *Daemon, container *container.Container) (*types.HealthcheckResult, error) {
+
 	cmdSlice := strslice.StrSlice(container.Config.Healthcheck.Test)[1:]
 	if p.shell {
 		if runtime.GOOS != "windows" {
@@ -157,8 +158,10 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 			ctx, cancelProbe := context.WithTimeout(context.Background(), probeTimeout)
 			results := make(chan *types.HealthcheckResult)
 			go func() {
+				healthChecksCounter.Inc()
 				result, err := probe.run(ctx, d, c)
 				if err != nil {
+					healthChecksFailedCounter.Inc()
 					logrus.Warnf("Health check for container %s error: %v", c.ID, err)
 					results <- &types.HealthcheckResult{
 						ExitCode: -1,

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types"
@@ -61,6 +62,7 @@ const (
 // package. This would require that we no longer need the daemon to determine
 // whether images are being used by a stopped or running container.
 func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.ImageDelete, error) {
+	start := time.Now()
 	records := []types.ImageDelete{}
 
 	imgID, err := daemon.GetImageID(imageRef)
@@ -168,7 +170,13 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		}
 	}
 
-	return records, daemon.imageDeleteHelper(imgID, &records, force, prune, removedRepositoryRef)
+	if err := daemon.imageDeleteHelper(imgID, &records, force, prune, removedRepositoryRef); err != nil {
+		return nil, err
+	}
+
+	imageActions.WithValues("delete").UpdateSince(start)
+
+	return records, nil
 }
 
 // isSingleReference returns true when all references are from one repository

--- a/daemon/image_history.go
+++ b/daemon/image_history.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/layer"
@@ -11,6 +12,7 @@ import (
 // ImageHistory returns a slice of ImageHistory structures for the specified image
 // name by walking the image lineage.
 func (daemon *Daemon) ImageHistory(name string) ([]*types.ImageHistory, error) {
+	start := time.Now()
 	img, err := daemon.GetImage(name)
 	if err != nil {
 		return nil, err
@@ -77,6 +79,6 @@ func (daemon *Daemon) ImageHistory(name string) ([]*types.ImageHistory, error) {
 			break
 		}
 	}
-
+	imageActions.WithValues("history").UpdateSince(start)
 	return history, nil
 }

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -165,7 +165,9 @@ func (daemon *Daemon) filterByNameIDMatches(ctx *listContext) []*container.Conta
 
 // reduceContainers parses the user's filtering options and generates the list of containers to return based on a reducer.
 func (daemon *Daemon) reduceContainers(config *types.ContainerListOptions, reducer containerReducer) ([]*types.Container, error) {
-	containers := []*types.Container{}
+	var (
+		containers = []*types.Container{}
+	)
 
 	ctx, err := daemon.foldFilter(config)
 	if err != nil {
@@ -190,6 +192,7 @@ func (daemon *Daemon) reduceContainers(config *types.ContainerListOptions, reduc
 			ctx.idx++
 		}
 	}
+
 	return containers, nil
 }
 

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -1,0 +1,42 @@
+package daemon
+
+import "github.com/docker/go-metrics"
+
+var (
+	containerActions          metrics.LabeledTimer
+	imageActions              metrics.LabeledTimer
+	networkActions            metrics.LabeledTimer
+	engineVersion             metrics.LabeledGauge
+	engineCpus                metrics.Gauge
+	engineMemory              metrics.Gauge
+	healthChecksCounter       metrics.Counter
+	healthChecksFailedCounter metrics.Counter
+)
+
+func init() {
+	ns := metrics.NewNamespace("engine", "daemon", nil)
+	containerActions = ns.NewLabeledTimer("container_actions", "The number of seconds it takes to process each container action", "action")
+	for _, a := range []string{
+		"start",
+		"changes",
+		"commit",
+		"create",
+		"delete",
+	} {
+		containerActions.WithValues(a).Update(0)
+	}
+	networkActions = ns.NewLabeledTimer("network_actions", "The number of seconds it takes to process each network action", "action")
+	engineVersion = ns.NewLabeledGauge("engine", "The version and commit information for the engine process", metrics.Unit("info"),
+		"version",
+		"commit",
+		"architecture",
+		"graph_driver", "kernel",
+		"os",
+	)
+	engineCpus = ns.NewGauge("engine_cpus", "The number of cpus that the host system of the engine has", metrics.Unit("cpus"))
+	engineMemory = ns.NewGauge("engine_memory", "The number of bytes of memory that the host system of the engine has", metrics.Bytes)
+	healthChecksCounter = ns.NewCounter("health_checks", "The total number of health checks")
+	healthChecksFailedCounter = ns.NewCounter("health_checks_failed", "The total number of failed health checks")
+	imageActions = ns.NewLabeledTimer("image_actions", "The number of seconds it takes to process each image action", "action")
+	metrics.Register(ns)
+}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -292,6 +292,7 @@ func (daemon *Daemon) createNetwork(create types.NetworkCreateRequest, id string
 	}
 
 	daemon.LogNetworkEvent(n, "create")
+
 	return &types.NetworkCreateResponse{
 		ID:      n.ID(),
 		Warning: warning,

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"google.golang.org/grpc"
 
@@ -90,6 +91,7 @@ func (daemon *Daemon) Start(container *container.Container) error {
 // between containers. The container is left waiting for a signal to
 // begin running.
 func (daemon *Daemon) containerStart(container *container.Container, checkpoint string, resetRestartManager bool) (err error) {
+	start := time.Now()
 	container.Lock()
 	defer container.Unlock()
 
@@ -176,6 +178,8 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 
 		return fmt.Errorf("%s", errDesc)
 	}
+
+	containerActions.WithValues("start").UpdateSince(start)
 
 	return nil
 }

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -175,4 +175,7 @@ clone git github.com/spf13/pflag dabebe21bf790f782ea4c7bbd2efc430de182afd
 clone git github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 clone git github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
 
+# metrics
+clone git github.com/docker/go-metrics 86138d05f285fd9737a99bee2d9be30866b59d72
+
 clean

--- a/integration-cli/docker_cli_external_graphdriver_unix_test.go
+++ b/integration-cli/docker_cli_external_graphdriver_unix_test.go
@@ -379,7 +379,7 @@ func (s *DockerExternalGraphdriverSuite) testExternalGraphDriver(name string, ex
 	c.Assert(s.ec[ext].removals >= 1, check.Equals, true)
 	c.Assert(s.ec[ext].gets >= 1, check.Equals, true)
 	c.Assert(s.ec[ext].puts >= 1, check.Equals, true)
-	c.Assert(s.ec[ext].stats, check.Equals, 3)
+	c.Assert(s.ec[ext].stats, check.Equals, 5)
 	c.Assert(s.ec[ext].cleanups, check.Equals, 2)
 	c.Assert(s.ec[ext].applydiff >= 1, check.Equals, true)
 	c.Assert(s.ec[ext].changes, check.Equals, 1)

--- a/vendor/src/github.com/docker/go-metrics/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/go-metrics/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+## Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/vendor/src/github.com/docker/go-metrics/LICENSE.code
+++ b/vendor/src/github.com/docker/go-metrics/LICENSE.code
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2013-2016 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/src/github.com/docker/go-metrics/LICENSE.docs
+++ b/vendor/src/github.com/docker/go-metrics/LICENSE.docs
@@ -1,0 +1,425 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public:
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+
+     including for purposes of Section 3(b); and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the "Licensor." Except for the limited purpose of indicating
+that material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/vendor/src/github.com/docker/go-metrics/NOTICE
+++ b/vendor/src/github.com/docker/go-metrics/NOTICE
@@ -1,0 +1,16 @@
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/vendor/src/github.com/docker/go-metrics/README.md
+++ b/vendor/src/github.com/docker/go-metrics/README.md
@@ -1,0 +1,22 @@
+# go-metrics [![GoDoc](https://godoc.org/github.com/docker/go-metrics?status.svg)](https://godoc.org/github.com/docker/go-metrics) ![Badge Badge](http://doyouevenbadge.com/github.com/docker/go-metrics)
+
+This package is small wrapper around the prometheus go client to help enforce convention and best practices for metrics collection in Docker projects.
+
+## Status
+
+This project is a work in progress.
+It is under heavy development and not intended to be used.
+
+## Docs
+
+Package documentation can be found [here](https://godoc.org/github.com/docker/go-metrics).
+
+## Additional Metrics
+
+Additional metrics are also defined here that are not avaliable in the prometheus client.
+If you need a custom metrics and it is generic enough to be used by multiple projects, define it here.
+
+
+## Copyright and license
+
+Copyright © 2016 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. The README.md file, and files in the "docs" folder are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.

--- a/vendor/src/github.com/docker/go-metrics/counter.go
+++ b/vendor/src/github.com/docker/go-metrics/counter.go
@@ -1,0 +1,52 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Counter is a metrics that can only increment its current count
+type Counter interface {
+	// Inc adds Sum(vs) to the counter. Sum(vs) must be positive.
+	//
+	// If len(vs) == 0, increments the counter by 1.
+	Inc(vs ...float64)
+}
+
+// LabeledCounter is counter that must have labels populated before use.
+type LabeledCounter interface {
+	WithValues(vs ...string) Counter
+}
+
+type labeledCounter struct {
+	pc *prometheus.CounterVec
+}
+
+func (lc *labeledCounter) WithValues(vs ...string) Counter {
+	return &counter{pc: lc.pc.WithLabelValues(vs...)}
+}
+
+func (lc *labeledCounter) Describe(ch chan<- *prometheus.Desc) {
+	lc.pc.Describe(ch)
+}
+
+func (lc *labeledCounter) Collect(ch chan<- prometheus.Metric) {
+	lc.pc.Collect(ch)
+}
+
+type counter struct {
+	pc prometheus.Counter
+}
+
+func (c *counter) Inc(vs ...float64) {
+	if len(vs) == 0 {
+		c.pc.Inc()
+	}
+
+	c.pc.Add(sumFloat64(vs...))
+}
+
+func (c *counter) Describe(ch chan<- *prometheus.Desc) {
+	c.pc.Describe(ch)
+}
+
+func (c *counter) Collect(ch chan<- prometheus.Metric) {
+	c.pc.Collect(ch)
+}

--- a/vendor/src/github.com/docker/go-metrics/docs.go
+++ b/vendor/src/github.com/docker/go-metrics/docs.go
@@ -1,0 +1,3 @@
+// This package is small wrapper around the prometheus go client to help enforce convention and best practices for metrics collection in Docker projects.
+
+package metrics

--- a/vendor/src/github.com/docker/go-metrics/gauge.go
+++ b/vendor/src/github.com/docker/go-metrics/gauge.go
@@ -1,0 +1,72 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Gauge is a metric that allows incrementing and decrementing a value
+type Gauge interface {
+	Inc(...float64)
+	Dec(...float64)
+
+	// Add adds the provided value to the gauge's current value
+	Add(float64)
+
+	// Set replaces the gauge's current value with the provided value
+	Set(float64)
+}
+
+// LabeledGauge describes a gauge the must have values populated before use.
+type LabeledGauge interface {
+	WithValues(labels ...string) Gauge
+}
+
+type labeledGauge struct {
+	pg *prometheus.GaugeVec
+}
+
+func (lg *labeledGauge) WithValues(labels ...string) Gauge {
+	return &gauge{pg: lg.pg.WithLabelValues(labels...)}
+}
+
+func (lg *labeledGauge) Describe(c chan<- *prometheus.Desc) {
+	lg.pg.Describe(c)
+}
+
+func (lg *labeledGauge) Collect(c chan<- prometheus.Metric) {
+	lg.pg.Collect(c)
+}
+
+type gauge struct {
+	pg prometheus.Gauge
+}
+
+func (g *gauge) Inc(vs ...float64) {
+	if len(vs) == 0 {
+		g.pg.Inc()
+	}
+
+	g.Add(sumFloat64(vs...))
+}
+
+func (g *gauge) Dec(vs ...float64) {
+	if len(vs) == 0 {
+		g.pg.Dec()
+	}
+
+	g.Add(-sumFloat64(vs...))
+}
+
+func (g *gauge) Add(v float64) {
+	g.pg.Add(v)
+}
+
+func (g *gauge) Set(v float64) {
+	g.pg.Set(v)
+}
+
+func (g *gauge) Describe(c chan<- *prometheus.Desc) {
+	g.pg.Describe(c)
+}
+
+func (g *gauge) Collect(c chan<- prometheus.Metric) {
+	g.pg.Collect(c)
+}

--- a/vendor/src/github.com/docker/go-metrics/handler.go
+++ b/vendor/src/github.com/docker/go-metrics/handler.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Handler returns the global http.Handler that provides the prometheus
+// metrics format on GET requests
+func Handler() http.Handler {
+	return prometheus.Handler()
+}

--- a/vendor/src/github.com/docker/go-metrics/helpers.go
+++ b/vendor/src/github.com/docker/go-metrics/helpers.go
@@ -1,0 +1,10 @@
+package metrics
+
+func sumFloat64(vs ...float64) float64 {
+	var sum float64
+	for _, v := range vs {
+		sum += v
+	}
+
+	return sum
+}

--- a/vendor/src/github.com/docker/go-metrics/namespace.go
+++ b/vendor/src/github.com/docker/go-metrics/namespace.go
@@ -1,0 +1,159 @@
+package metrics
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Labels map[string]string
+
+// NewNamespace returns a namespaces that is responsible for managing a collection of
+// metrics for a particual namespace and subsystem
+//
+// labels allows const labels to be added to all metrics created in this namespace
+// and are commonly used for data like application version and git commit
+func NewNamespace(name, subsystem string, labels Labels) *Namespace {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	return &Namespace{
+		name:      name,
+		subsystem: subsystem,
+		labels:    labels,
+	}
+}
+
+// Namespace describes a set of metrics that share a namespace and subsystem.
+type Namespace struct {
+	name      string
+	subsystem string
+	labels    Labels
+	mu        sync.Mutex
+	metrics   []prometheus.Collector
+}
+
+// WithConstLabels returns a namespace with the provided set of labels merged
+// with the existing constant labels on the namespace.
+//
+//  Only metrics created with the returned namespace will get the new constant
+//  labels.  The returned namespace must be registered separately.
+func (n *Namespace) WithConstLabels(labels Labels) *Namespace {
+	ns := *n
+	ns.metrics = nil // blank this out
+	ns.labels = mergeLabels(ns.labels, labels)
+	return &ns
+}
+
+func (n *Namespace) NewCounter(name, help string) Counter {
+	c := &counter{pc: prometheus.NewCounter(n.newCounterOpts(name, help))}
+	n.addMetric(c)
+	return c
+}
+
+func (n *Namespace) NewLabeledCounter(name, help string, labels ...string) LabeledCounter {
+	c := &labeledCounter{pc: prometheus.NewCounterVec(n.newCounterOpts(name, help), labels)}
+	n.addMetric(c)
+	return c
+}
+
+func (n *Namespace) newCounterOpts(name, help string) prometheus.CounterOpts {
+	return prometheus.CounterOpts{
+		Namespace:   n.name,
+		Subsystem:   n.subsystem,
+		Name:        fmt.Sprintf("%s_%s", name, Total),
+		Help:        help,
+		ConstLabels: prometheus.Labels(n.labels),
+	}
+}
+
+func (n *Namespace) NewTimer(name, help string) Timer {
+	t := &timer{
+		m: prometheus.NewHistogram(n.newTimerOpts(name, help)),
+	}
+	n.addMetric(t)
+	return t
+}
+
+func (n *Namespace) NewLabeledTimer(name, help string, labels ...string) LabeledTimer {
+	t := &labeledTimer{
+		m: prometheus.NewHistogramVec(n.newTimerOpts(name, help), labels),
+	}
+	n.addMetric(t)
+	return t
+}
+
+func (n *Namespace) newTimerOpts(name, help string) prometheus.HistogramOpts {
+	return prometheus.HistogramOpts{
+		Namespace:   n.name,
+		Subsystem:   n.subsystem,
+		Name:        fmt.Sprintf("%s_%s", name, Seconds),
+		Help:        help,
+		ConstLabels: prometheus.Labels(n.labels),
+	}
+}
+
+func (n *Namespace) NewGauge(name, help string, unit Unit) Gauge {
+	g := &gauge{
+		pg: prometheus.NewGauge(n.newGaugeOpts(name, help, unit)),
+	}
+	n.addMetric(g)
+	return g
+}
+
+func (n *Namespace) NewLabeledGauge(name, help string, unit Unit, labels ...string) LabeledGauge {
+	g := &labeledGauge{
+		pg: prometheus.NewGaugeVec(n.newGaugeOpts(name, help, unit), labels),
+	}
+	n.addMetric(g)
+	return g
+}
+
+func (n *Namespace) newGaugeOpts(name, help string, unit Unit) prometheus.GaugeOpts {
+	return prometheus.GaugeOpts{
+		Namespace:   n.name,
+		Subsystem:   n.subsystem,
+		Name:        fmt.Sprintf("%s_%s", name, unit),
+		Help:        help,
+		ConstLabels: prometheus.Labels(n.labels),
+	}
+}
+
+func (n *Namespace) Describe(ch chan<- *prometheus.Desc) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	for _, metric := range n.metrics {
+		metric.Describe(ch)
+	}
+}
+
+func (n *Namespace) Collect(ch chan<- prometheus.Metric) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	for _, metric := range n.metrics {
+		metric.Collect(ch)
+	}
+}
+
+func (n *Namespace) addMetric(collector prometheus.Collector) {
+	n.mu.Lock()
+	n.metrics = append(n.metrics, collector)
+	n.mu.Unlock()
+}
+
+// mergeLabels merges two or more labels objects into a single map, favoring
+// the later labels.
+func mergeLabels(lbs ...Labels) Labels {
+	merged := make(Labels)
+
+	for _, target := range lbs {
+		for k, v := range target {
+			merged[k] = v
+		}
+	}
+
+	return merged
+}

--- a/vendor/src/github.com/docker/go-metrics/register.go
+++ b/vendor/src/github.com/docker/go-metrics/register.go
@@ -1,0 +1,15 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Register adds all the metrics in the provided namespace to the global
+// metrics registry
+func Register(n *Namespace) {
+	prometheus.MustRegister(n)
+}
+
+// Deregister removes all the metrics in the provided namespace from the
+// global metrics registry
+func Deregister(n *Namespace) {
+	prometheus.Unregister(n)
+}

--- a/vendor/src/github.com/docker/go-metrics/timer.go
+++ b/vendor/src/github.com/docker/go-metrics/timer.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// StartTimer begins a timer observation at the callsite. When the target
+// operation is completed, the caller should call the return done func().
+func StartTimer(timer Timer) (done func()) {
+	start := time.Now()
+	return func() {
+		timer.Update(time.Since(start))
+	}
+}
+
+// Timer is a metric that allows collecting the duration of an action in seconds
+type Timer interface {
+	// Update records an observation, duration, and converts to the target
+	// units.
+	Update(duration time.Duration)
+
+	// UpdateSince will add the duration from the provided starting time to the
+	// timer's summary with the precisions that was used in creation of the timer
+	UpdateSince(time.Time)
+}
+
+// LabeledTimer is a timer that must have label values populated before use.
+type LabeledTimer interface {
+	WithValues(labels ...string) Timer
+}
+
+type labeledTimer struct {
+	m *prometheus.HistogramVec
+}
+
+func (lt *labeledTimer) WithValues(labels ...string) Timer {
+	return &timer{m: lt.m.WithLabelValues(labels...)}
+}
+
+func (lt *labeledTimer) Describe(c chan<- *prometheus.Desc) {
+	lt.m.Describe(c)
+}
+
+func (lt *labeledTimer) Collect(c chan<- prometheus.Metric) {
+	lt.m.Collect(c)
+}
+
+type timer struct {
+	m prometheus.Histogram
+}
+
+func (t *timer) Update(duration time.Duration) {
+	t.m.Observe(duration.Seconds())
+}
+
+func (t *timer) UpdateSince(since time.Time) {
+	t.m.Observe(time.Since(since).Seconds())
+}
+
+func (t *timer) Describe(c chan<- *prometheus.Desc) {
+	t.m.Describe(c)
+}
+
+func (t *timer) Collect(c chan<- prometheus.Metric) {
+	t.m.Collect(c)
+}

--- a/vendor/src/github.com/docker/go-metrics/unit.go
+++ b/vendor/src/github.com/docker/go-metrics/unit.go
@@ -1,0 +1,12 @@
+package metrics
+
+// Unit represents the type or precision of a metric that is appended to
+// the metrics fully qualified name
+type Unit string
+
+const (
+	Nanoseconds Unit = "nanoseconds"
+	Seconds     Unit = "seconds"
+	Bytes       Unit = "bytes"
+	Total       Unit = "total"
+)


### PR DESCRIPTION
This adds metrics support to docker via the prometheus output.  There is a new `/metrics` endpoint where the prometheus handler is installed.

This adds metrics to the daemon package for basic container, image, and daemon operations.

The client package being used is located here:

https://github.com/docker/go-metrics

This pr is the beginning, any more packages need to be instrumented but help/suggestions from the individual subsystem maintainers is needed to collection relevant and useful information. 
