### PR TITLE
Avoid fork on mount for overlay2 in common case

### DIFF
--- a/daemon/graphdriver/overlay2/mount.go
+++ b/daemon/graphdriver/overlay2/mount.go
@@ -31,12 +31,12 @@ type mountOptions struct {
 	Flag   uint32
 }
 
-func mountFrom(dir, device, target, mType, label string) error {
+func mountFrom(dir, device, target, mType string, flags uintptr, label string) error {
 	options := &mountOptions{
 		Device: device,
 		Target: target,
 		Type:   mType,
-		Flag:   0,
+		Flag:   uint32(flags),
 		Label:  label,
 	}
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -409,13 +409,36 @@ func (d *Driver) Get(id string, mountLabel string) (s string, err error) {
 	}()
 
 	workDir := path.Join(dir, "work")
-	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", string(lowers), path.Join(id, "diff"), path.Join(id, "work"))
-	mountLabel = label.FormatMountLabel(opts, mountLabel)
-	if len(mountLabel) > syscall.Getpagesize() {
-		return "", fmt.Errorf("cannot mount layer, mount label too large %d", len(mountLabel))
+	splitLowers := strings.Split(string(lowers), ":")
+	absLowers := make([]string, len(splitLowers))
+	for i, s := range splitLowers {
+		absLowers[i] = path.Join(d.home, s)
+	}
+	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), path.Join(dir, "diff"), path.Join(dir, "work"))
+	mountData := label.FormatMountLabel(opts, mountLabel)
+	mount := syscall.Mount
+	mountTarget := mergedDir
+
+	pageSize := syscall.Getpagesize()
+
+	// Use relative paths and mountFrom when the mount data has exceeded
+	// the page size. The mount syscall fails if the mount data cannot
+	// fit within a page and relative links make the mount data much
+	// smaller at the expense of requiring a fork exec to chroot.
+	if len(mountData) > pageSize {
+		opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", string(lowers), path.Join(id, "diff"), path.Join(id, "work"))
+		mountData = label.FormatMountLabel(opts, mountLabel)
+		if len(mountData) > pageSize {
+			return "", fmt.Errorf("cannot mount layer, mount label too large %d", len(mountData))
+		}
+
+		mount = func(source string, target string, mType string, flags uintptr, label string) error {
+			return mountFrom(d.home, source, target, mType, flags, label)
+		}
+		mountTarget = path.Join(id, "merged")
 	}
 
-	if err := mountFrom(d.home, "overlay", path.Join(id, "merged"), "overlay", mountLabel); err != nil {
+	if err := mount("overlay", mountTarget, "overlay", 0, mountData); err != nil {
 		return "", fmt.Errorf("error creating overlay mount to %s: %v", mergedDir, err)
 	}
 


### PR DESCRIPTION
In the common case where the user is using /var/lib/docker and
an image with less than 60 layers, forking is not needed. Calculate
whether absolute paths can be used and avoid forking to mount in
those cases.

I do not have any statistics of what percentage of images
are less than 60 layers deep, but my guess is a vast majority and
even larger majority when accounting for images which are run most often.
## Mount Benchmarks
### Overlay2 (pre-change) vs Overlay2 (updated)

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkGetSingleBaseMount-8     7744409       231444        -97.01%
BenchmarkGet20BaseMount-8         8324308       307961        -96.30%
BenchmarkGet50BaseMount-8         8482378       420499        -95.04%
BenchmarkGet100BaseMount-8        8252170       7976995       -3.33%
```
### Overlay vs Overlay2 (updated)

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkGetSingleBaseMount-8     339539        231444        -31.84%
BenchmarkGet20BaseMount-8         249545        307961        +23.41%
BenchmarkGet50BaseMount-8         200676        420499        +109.54%
BenchmarkGet100BaseMount-8        252296        7976995       +3061.76%
```
### AUFS vs Overlay2 (updated)

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkGetSingleBaseMount-8     305157        231444        -24.16%
BenchmarkGet20BaseMount-8         1830297       307961        -83.17%
BenchmarkGet50BaseMount-8         10263958      420499        -95.90%
BenchmarkGet100BaseMount-8        36276899      7976995       -78.01%
```
### AUFS vs Overlay2 (pre-change)

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkGetSingleBaseMount-8     305157        7744409       +2437.84%
BenchmarkGet20BaseMount-8         1830297       8324308       +354.81%
BenchmarkGet50BaseMount-8         10263958      8482378       -17.36%
BenchmarkGet100BaseMount-8        36276899      8252170       -77.25%
```

Note `overlay` will always mount faster than `overlay2` for a larger number of lower directories since it can only have one lower directory (which it achieves at the expense of duplicating files). These are the first benchmarks I have done with aufs vs overlay2 so I included the benchmark comparison with the pre-changed overlay2.

Benchmarks done with https://github.com/dmcgowan/dsdbench
