### PR TITLE
clean up the run.md in reference

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -9,15 +9,6 @@ weight=-80
 +++
 <![end-metadata]-->
 
-<!-- TODO (@thaJeztah) define more flexible table/td classes -->
-<style>
-table .no-wrap {
-    white-space: nowrap;
-}
-table code {
-    white-space: nowrap;
-}
-</style>
 # Docker run reference
 
 Docker runs processes in isolated containers. A container is a process


### PR DESCRIPTION
It is the same problem as #25751 for run.md in reference.
Rendering on GitHub is slightly different than in the generated docs as follows:
https://docs.docker.com/engine/reference/run/
I removed the following lsetting in run.md. Is it right?
Run 'make docs' and everything is going well.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
