### PR TITLE
Add support for compressing build context during image build

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -56,6 +56,7 @@ type buildOptions struct {
 	forceRm        bool
 	pull           bool
 	cacheFrom      []string
+	compress       bool
 }
 
 // NewBuildCommand creates a new `docker build` command
@@ -100,6 +101,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Suppress the build output and print image ID on success")
 	flags.BoolVar(&options.pull, "pull", false, "Always attempt to pull a newer version of the image")
 	flags.StringSliceVar(&options.cacheFrom, "cache-from", []string{}, "Images to consider as cache sources")
+	flags.BoolVar(&options.compress, "compress", false, "Compress the build context using gzip")
 
 	command.AddTrustedFlags(flags, true)
 
@@ -208,8 +210,12 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 			includes = append(includes, ".dockerignore", relDockerfile)
 		}
 
+		compression := archive.Uncompressed
+		if options.compress {
+			compression = archive.Gzip
+		}
 		buildCtx, err = archive.TarWithOptions(contextDir, &archive.TarOptions{
-			Compression:     archive.Uncompressed,
+			Compression:     compression,
 			ExcludePatterns: excludes,
 			IncludeFiles:    includes,
 		})

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -758,6 +758,7 @@ _docker_build() {
 	"
 
 	local boolean_options="
+		--compress
 		--disable-content-trust=false
 		--force-rm
 		--help
@@ -1300,7 +1301,7 @@ _docker_info() {
 			return
 			;;
 	esac
-    
+
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1509,6 +1509,7 @@ __docker_subcommand() {
                 $opts_build_create_run \
                 $opts_build_create_run_update \
                 "($help)*--build-arg[Build-time variables]:<varname>=<value>: " \
+                "($help)--compress[Compress the build context using gzip]" \
                 "($help -f --file)"{-f=,--file=}"[Name of the Dockerfile]:Dockerfile:_files" \
                 "($help)--force-rm[Always remove intermediate containers]" \
                 "($help)*--label=[Set metadata for an image]:label=value: " \

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -19,6 +19,7 @@ Options:
       --build-arg value         Set build-time variables (default [])
       --cache-from value        Images to consider as cache sources (default [])
       --cgroup-parent string    Optional parent cgroup for the container
+      --compress                Compress the build context using gzip
       --cpu-period int          Limit the CPU CFS (Completely Fair Scheduler) period
       --cpu-quota int           Limit the CPU CFS (Completely Fair Scheduler) quota
   -c, --cpu-shares int          CPU shares (relative weight)

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -16,6 +16,7 @@ docker-build - Build a new image from the source code at PATH
 [**--label**[=*[]*]]
 [**--no-cache**]
 [**--pull**]
+[**--compress**]
 [**-q**|**--quiet**]
 [**--rm**[=*true*]]
 [**-t**|**--tag**[=*[]*]]
@@ -83,6 +84,9 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
 
 **--pull**=*true*|*false*
    Always attempt to pull a newer version of the image. The default is *false*.
+
+**--compress**=*true*|*false*
+    Compress the build context using gzip. The default is *false*.
 
 **-q**, **--quiet**=*true*|*false*
    Suppress the build output and print image ID on success. The default is *false*.


### PR DESCRIPTION
**\- What I did**

Added support for optionally compressing build contexts when invoking `docker build`. This provides significant performance improvements when sending contexts to remote servers with low bandwidth. It is, however, a performance regression when sending to local sockets or over very high bandwidth connections so it should default to off.

**\- How I did it**

Added a new `--compress` boolean flag. If set then a gzip compression argument is passed to the existing `archive.TarWithOptions` which already supports this behavior. For example `docker build --compress .` `xz` and `bz2` support were not added because Go doesn't support compressing these formats (it can decompress bz2, but xz isn't available at all).

**\- How to verify it**

If you build it and use `--compress` you can see the size difference when sending a build context. However, I was unable to find any unit tests for this file. I may be blind so please let me know if I'm mistaken (or if there are tests I should add in other places to verify this functionality). I would be happy to add testing if someone can point me in the right direction.

**\- Description for the changelog**
- Added support for optionally compressing build contexts (using `--compress`) when invoking `docker build`
