### PR TITLE
Use the correct version of glide

### DIFF
--- a/man/Dockerfile
+++ b/man/Dockerfile
@@ -9,6 +9,7 @@ RUN     export GLIDE=v0.11.1; \
         mkdir -p ${TARGET} && \
         git clone https://github.com/Masterminds/glide.git ${TARGET}/glide && \
         cd ${TARGET}/glide && \
+        git checkout $GLIDE && \
         make build && \
         cp ./glide /usr/bin/glide && \
         cd / && rm -rf /go/src/* /go/bin/* /go/pkg/*

--- a/man/Dockerfile.armhf
+++ b/man/Dockerfile.armhf
@@ -9,6 +9,7 @@ RUN     export GLIDE=v0.11.1; \
         mkdir -p ${TARGET} && \
         git clone https://github.com/Masterminds/glide.git ${TARGET}/glide && \
         cd ${TARGET}/glide && \
+        git checkout $GLIDE && \
         make build && \
         cp ./glide /usr/bin/glide && \
         cd / && rm -rf /go/src/* /go/bin/* /go/pkg/*


### PR DESCRIPTION
In `man/Dockerfile` we are specifying a tagged version of glide to
checkout, but never actually checking it out.
This checks out the requested version before building.

Signed-off-by: Brian Goff cpuguy83@gmail.com
