### PR TITLE
Return error for incorrect argument of `service update --publish-rm`

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -108,6 +108,12 @@ func (opts *ListOpts) Type() string {
 	return "list"
 }
 
+// WithValidator returns the ListOpts with validator set.
+func (opts *ListOpts) WithValidator(validator ValidatorFctType) *ListOpts {
+	opts.validator = validator
+	return opts
+}
+
 // NamedOption is an interface that list and map options
 // with names implement.
 type NamedOption interface {


### PR DESCRIPTION
**\- What I did**

Currently `--publish-rm` only accepts `<TargetPort>` or `<TargetPort>[/Protocol]` though there are some confusions.

Since `--publish-add` accepts `<PublishedPort>:<TargetPort>[/Protocol]`, some user may provide `--publish-rm 80:80`. However, there is no error checking so the incorrectly provided argument is ignored silently.

This fix is an attempt to address this issue.

**\- How I did it**

This fix adds the check to make sure `--publish-rm` only accepts `<TargetPort>[/Protocol]` and returns error if the format is invalid.

This fix also fixes an issue in the `equalPort()` so that if `tcp` is not present in `PortConfig`, the equal check is still valid (i.e., `80/tcp` == `80`).

**\- How to verify it**

Additional unit tests have been added.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

The `--publish-rm` itself may needs to be revisited to have a better UI/UX experience,
see discussions on:
https://github.com/docker/swarmkit/issues/1396
https://github.com/docker/docker/issues/25200#issuecomment-236213242
https://github.com/docker/docker/issues/25338#issuecomment-240787002

This fix is short term measure so that end users are not misled by the silently ignored error
of `--publish-rm`.

This fix is related to (but is not a complete fix):
https://github.com/docker/swarmkit/issues/1396

Signed-off-by: Yong Tang yong.tang.github@outlook.com
