### PR TITLE
Using waitExitOrRemoved for `docker start`

### DIFF
--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -185,3 +185,15 @@ func (s *DockerSuite) TestStartAttachWithRename(c *check.C) {
 	_, stderr, _, _ := runCommandWithStdoutStderr(exec.Command(dockerBinary, "start", "-a", "before"))
 	c.Assert(stderr, checker.Not(checker.Contains), "No such container")
 }
+
+func (s *DockerSuite) TestStartReturnCorrectExitCode(c *check.C) {
+	dockerCmd(c, "create", "--restart=on-failure:2", "--name", "withRestart", "busybox", "sh", "-c", "exit 11")
+	dockerCmd(c, "create", "--rm", "--name", "withRm", "busybox", "sh", "-c", "exit 12")
+
+	_, exitCode, err := dockerCmdWithError("start", "-a", "withRestart")
+	c.Assert(err, checker.NotNil)
+	c.Assert(exitCode, checker.Equals, 11)
+	_, exitCode, err = dockerCmdWithError("start", "-a", "withRm")
+	c.Assert(err, checker.NotNil)
+	c.Assert(exitCode, checker.Equals, 12)
+}


### PR DESCRIPTION
Currently `start` command will invoke `getExitCode` - which is based on
`Inspect` API - to get returned exit code after container exits, there's
two race conditions here:
1. if container is started with Restart Policy, there's chance that the
   container is restarted quickly before it calls `getExitCode`, under such
   circumstance, the exit code is wrong.
2. if container is started with `--rm`, it's possible that container is
   removed before `getExitCode`, in this situation, you can't get correct
   exit code either.

Replace `getExitCode` with `waitExitOrRemoved` can solve this problem.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
