### PR TITLE
It is orchestrator not scheduler to create swarm task

### DIFF
--- a/docs/swarm/how-swarm-mode-works/services.md
+++ b/docs/swarm/how-swarm-mode-works/services.md
@@ -61,7 +61,7 @@ that spawns a new container.
 
 A task is a one-directional mechanism. It progresses monotonically through a
 series of states: assigned, prepared, running, etc.  If the task fails the
-scheduler removes the task and its container and then creates a new task to
+orchestrator removes the task and its container and then creates a new task to
 replace it according to the desired state specified by the service.
 
 The underlying logic of Docker swarm mode is a general purpose scheduler and


### PR DESCRIPTION
because orchestrator  has been descripted as creating task in same doc line 59:

```
If a HTTP listener task subsequently
fails its health check or crashes, the orchestrator creates a new replica task
that spawns a new container.
```
