### PR TITLE
debian sysvinitscript one missed DOCKER->DOCKERD change

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -142,7 +142,7 @@ case "$1" in
 
 	status)
 		check_init
-		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" "$DOCKER_DESC"
+		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKERD" "$DOCKER_DESC"
 		;;
 
 	*)


### PR DESCRIPTION
missed in 1ac1b78b3a771c562d9cfa91c14f8a494c3723c1 for /etc/init.d/docker status

would previously fail with "could not access PID file for Docker"
