### PR TITLE
Add shell completions to tgz

### DIFF
--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -56,6 +56,12 @@ for d in "$CROSS/"*/*; do
 	# copy over all the containerd binaries
 	copy_containerd $TAR_PATH
 
+	# add completions
+	for s in bash fish powershell zsh; do
+		mkdir -p $TAR_PATH/completion/$s
+		cp -L contrib/completion/$s/*docker* $TAR_PATH/completion/$s/
+	done
+
 	if [ "$IS_TAR" == "true" ]; then
 		echo "Creating tgz from $BUILD_PATH and naming it $TGZ"
 		tar --numeric-owner --owner 0 -C "$BUILD_PATH" -czf "$TGZ" $TAR_BASE_DIRECTORY


### PR DESCRIPTION
Docker for Mac and Windows use the tgz file but we currently get
the completions seperately, which is much less convenient, especially
when testing unreleased versions.

Add all the completions to the tarball.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![binturong-babies](https://cloud.githubusercontent.com/assets/482364/17812781/7fd68470-6620-11e6-976a-01485b9c6ed9.jpg)
