### PR TITLE
Add a Dockerfile for generating manpages on aarch64

### DIFF
--- a/man/Dockerfile.aarch64
+++ b/man/Dockerfile.aarch64
@@ -1,0 +1,25 @@
+FROM    aarch64/ubuntu:xenial
+
+RUN     apt-get update && apt-get install -y git golang-go
+
+RUN     mkdir -p /go/src /go/bin /go/pkg
+ENV     GOPATH=/go
+RUN     export GLIDE=v0.11.1; \
+        export TARGET=/go/src/github.com/Masterminds; \
+        mkdir -p ${TARGET} && \
+        git clone https://github.com/Masterminds/glide.git ${TARGET}/glide && \
+        cd ${TARGET}/glide && \
+        git checkout $GLIDE && \
+        make build && \
+        cp ./glide /usr/bin/glide && \
+        cd / && rm -rf /go/src/* /go/bin/* /go/pkg/*
+
+COPY    glide.yaml /manvendor/
+COPY    glide.lock /manvendor/
+WORKDIR /manvendor/
+RUN     glide install && mv vendor src
+ENV     GOPATH=$GOPATH:/go/src/github.com/docker/docker/vendor:/manvendor
+RUN     go build -o /usr/bin/go-md2man github.com/cpuguy83/go-md2man
+
+WORKDIR /go/src/github.com/docker/docker/
+ENTRYPOINT ["man/generate.sh"]


### PR DESCRIPTION
Allow generation of man pages on aarch64. Tested myself as we have no aarch64 CI at present.

Signed-off-by: Justin Cormack justin.cormack@docker.com

We currently have a PR for ppc64le as part of https://github.com/docker/docker/pull/23438

![redpanda](https://cloud.githubusercontent.com/assets/482364/17813816/d1c11a26-6624-11e6-9912-0d945c58a09c.jpg)
