### PR TITLE
Add man pages to tgz

### DIFF
--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -10,6 +10,11 @@ if [ ! -d "$CROSS/linux/${arch}" ]; then
 	false
 fi
 
+bundle .integration-daemon-start
+bundle .detect-daemon-osarch
+
+make manpages
+
 (
 for d in "$CROSS/"*/*; do
 	export GOARCH="$(basename "$d")"
@@ -43,6 +48,18 @@ for d in "$CROSS/"*/*; do
 
 	# $DEST/build/docker
 	TAR_PATH="$BUILD_PATH/$TAR_BASE_DIRECTORY"
+
+	# Include man pages
+	manRoot="$TAR_PATH/man"
+	mkdir -p "$manRoot"
+	for manDir in man/man?; do
+		manBase="$(basename "$manDir")" # "man1"
+		for manFile in "$manDir"/*; do
+			manName="$(basename "$manFile")" # "docker-build.1"
+			mkdir -p "$manRoot/$manBase"
+			gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+		done
+	done
 
 	# Copy the correct docker binary
 	mkdir -p $TAR_PATH
@@ -81,3 +98,5 @@ for d in "$CROSS/"*/*; do
 	echo "Created tgz: $TGZ"
 done
 )
+
+bundle .integration-daemon-stop


### PR DESCRIPTION
We use the tarball for installing on Docker for Mac, but we currently are not installing the man pages because they are not available anywhere to download, so add to tgz so we can get them from there.

~~This requires #25881 #25883 merged as it would be annoying not to be able to generate a tgz on those architectures as you can't build the man pages...~~ DONE

![bunny](https://cloud.githubusercontent.com/assets/482364/17816607/e48bca9a-6631-11e6-9a91-10dee9ac963d.jpg)
