### PR TITLE
Move ListContainersForNode into cluster package

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -546,7 +546,11 @@ func (c *Cluster) Leave(force bool) error {
 	}
 	c.Unlock()
 	if nodeID := node.NodeID(); nodeID != "" {
-		for _, id := range c.config.Backend.ListContainersForNode(nodeID) {
+		nodeContainers, err := c.listContainerForNode(nodeID)
+		if err != nil {
+			return err
+		}
+		for _, id := range nodeContainers {
 			if err := c.config.Backend.ContainerRm(id, &apitypes.ContainerRmConfig{ForceRemove: true}); err != nil {
 				logrus.Errorf("error removing %v: %v", id, err)
 			}
@@ -558,6 +562,22 @@ func (c *Cluster) Leave(force bool) error {
 		return err
 	}
 	return nil
+}
+
+func (c *Cluster) listContainerForNode(nodeID string) ([]string, error) {
+	var ids []string
+	filters := filters.NewArgs()
+	filters.Add("label", fmt.Sprintf("com.docker.swarm.node.id=%s", nodeID))
+	containers, err := c.config.Backend.Containers(&apitypes.ContainerListOptions{
+		Filter: filters,
+	})
+	if err != nil {
+		return []string{}, err
+	}
+	for _, c := range containers {
+		ids = append(ids, c.ID)
+	}
+	return ids, nil
 }
 
 func (c *Cluster) clearState() error {

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -34,7 +34,7 @@ type Backend interface {
 	ContainerKill(name string, sig uint64) error
 	SystemInfo() (*types.Info, error)
 	VolumeCreate(name, driverName string, opts, labels map[string]string) (*types.Volume, error)
-	ListContainersForNode(nodeID string) []string
+	Containers(config *types.ContainerListOptions) ([]*types.Container, error)
 	SetNetworkBootstrapKeys([]*networktypes.EncryptionKey) error
 	SetClusterProvider(provider cluster.Provider)
 	IsSwarmCompatible() error

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -102,17 +102,6 @@ func (daemon *Daemon) Containers(config *types.ContainerListOptions) ([]*types.C
 	return daemon.reduceContainers(config, daemon.transformContainer)
 }
 
-// ListContainersForNode returns all containerID that match the specified nodeID
-func (daemon *Daemon) ListContainersForNode(nodeID string) []string {
-	var ids []string
-	for _, c := range daemon.List() {
-		if c.Config.Labels["com.docker.swarm.node.id"] == nodeID {
-			ids = append(ids, c.ID)
-		}
-	}
-	return ids
-}
-
 func (daemon *Daemon) filterByNameIDMatches(ctx *listContext) []*container.Container {
 	idSearch := false
 	names := ctx.filters.Get("name")


### PR DESCRIPTION
This is purely a design refactoring so feel free to close or discuss why you think it shouldn't be done that way 👼.

It makes little sense to me to have swarm related code into the daemon package. This refactor the `daemon` and `cluster` package to remove `ListContainersForNode` from the daemon.

/cc @vieux @stevvooe @aaronlehmann 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
