### PR TITLE
Use daemon exec root for swarm control socket

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -275,6 +275,7 @@ func (cli *DaemonCli) start() (err error) {
 		Backend:                d,
 		NetworkSubnetsProvider: d,
 		DefaultAdvertiseAddr:   cli.Config.SwarmDefaultAdvertiseAddr,
+		RuntimeRoot:            cli.getSwarmRunRoot(),
 	})
 	if err != nil {
 		logrus.Fatalf("Error creating cluster component: %v", err)

--- a/cmd/dockerd/daemon_solaris.go
+++ b/cmd/dockerd/daemon_solaris.go
@@ -61,6 +61,12 @@ func (cli *DaemonCli) getLibcontainerdRoot() string {
 	return filepath.Join(cli.Config.ExecRoot, "libcontainerd")
 }
 
+// getSwarmRunRoot gets the root directory for swarm to store runtime state
+// For example, the control socket
+func (cli *DaemonCli) getSwarmRunRoot() string {
+	return filepath.Join(cli.Config.ExecRoot, "swarm")
+}
+
 func allocateDaemonPort(addr string) error {
 	return nil
 }

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -85,6 +85,12 @@ func (cli *DaemonCli) getLibcontainerdRoot() string {
 	return filepath.Join(cli.Config.ExecRoot, "libcontainerd")
 }
 
+// getSwarmRunRoot gets the root directory for swarm to store runtime state
+// For example, the control socket
+func (cli *DaemonCli) getSwarmRunRoot() string {
+	return filepath.Join(cli.Config.ExecRoot, "swarm")
+}
+
 // allocateDaemonPort ensures that there are no containers
 // that try to use any port allocated for the docker server.
 func allocateDaemonPort(addr string) error {

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -73,6 +73,12 @@ func (cli *DaemonCli) getLibcontainerdRoot() string {
 	return ""
 }
 
+// getSwarmRunRoot gets the root directory for swarm to store runtime state
+// For example, the control socket
+func (cli *DaemonCli) getSwarmRunRoot() string {
+	return ""
+}
+
 func allocateDaemonPort(addr string) error {
 	return nil
 }

--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -41,6 +41,7 @@ type Daemon struct {
 	userlandProxy     bool
 	useDefaultHost    bool
 	useDefaultTLSHost bool
+	execRoot          string
 }
 
 type clientConfig struct {
@@ -81,6 +82,7 @@ func NewDaemon(c *check.C) *Daemon {
 		root:          daemonRoot,
 		storageDriver: os.Getenv("DOCKER_GRAPHDRIVER"),
 		userlandProxy: userlandProxy,
+		execRoot:      filepath.Join(os.TempDir(), "docker-execroot", id),
 	}
 }
 
@@ -145,7 +147,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	args := append(d.GlobalFlags,
 		"--containerd", "/var/run/docker/libcontainerd/docker-containerd.sock",
 		"--graph", d.root,
-		"--exec-root", filepath.Join(d.folder, "exec-root"),
+		"--exec-root", d.execRoot,
 		"--pidfile", fmt.Sprintf("%s/docker.pid", d.folder),
 		fmt.Sprintf("--userland-proxy=%t", d.userlandProxy),
 	)


### PR DESCRIPTION
Right now docker puts swarm's control socket into the docker root dir
(e.g. /var/lib/docker).
This can cause some nasty issues with path length being > 108
characters, especially in our CI environment.

Since we already have some other state going in the daemon's exec root
(libcontainerd and libnetwork), I think it makes sense to move the
control socket to this location, especially since there are other unix
sockets being created here by docker so it must always be at a path that
works.
