### PR TITLE
Email deprecation for step 6 of tutorial

### DIFF
--- a/docs/getstarted/step_six.md
+++ b/docs/getstarted/step_six.md
@@ -72,13 +72,12 @@ If you don't already have a terminal open, open one now:
 
     The format for the login command is:
 
-        docker login --username=yourhubusername --email=youremail@company.com
+        docker login --username=yourhubusername --password=fake123
 
     When prompted, enter your password and press enter. So, for example:
 
-        $ docker login --username=maryatdocker --email=mary@docker.com
-        Password:
-        WARNING: login credentials saved in C:\Users\sven\.docker\config.json
+        $ docker login --username=maryatdocker --password=fake123
+        Password:        
         Login Succeeded
 
 9. Type the `docker push` command to push your image to your new repository.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Updated Trivial Aspect of Tutorial for Login Changes. Email is Deprecated in Step 6 of tutorial.

**\- How I did it**
Removed `--email` comments.

**\- How to verify it**
Please try login commands without --email and with following tutorial procedure.

**\- Description for the changelog**

<!--
Remove --email from step 6 tutorial.
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

http://i.imgur.com/911OR75.gifv
