### PR TITLE
Add spec file support for Windows plugin discovery.

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -16,7 +16,6 @@ var (
 	// ErrNotFound plugin not found
 	ErrNotFound = errors.New("plugin not found")
 	socketsPath = "/run/docker/plugins"
-	specsPaths  = []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}
 )
 
 // localRegistry defines a registry that is local (using unix socket).

--- a/pkg/plugins/discovery_unix.go
+++ b/pkg/plugins/discovery_unix.go
@@ -1,0 +1,3 @@
+package plugins
+
+var specsPaths = []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}

--- a/pkg/plugins/discovery_windows.go
+++ b/pkg/plugins/discovery_windows.go
@@ -1,0 +1,8 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var specPaths = []string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")}


### PR DESCRIPTION
**\- What I did**
Plugin discovery on Windows is currently not possible using named pipes. 
However, it is possible using spec file (tcp based). This adds Windows specific
paths for discovery.

Fixes #23605

**\- How I did it**
Add Windows specific paths to plugin discovery.

**\- How to verify it**
make cross. 

Signed-off-by: Anusha Ragunathan anusha@docker.com
