### PR TITLE
Fix issue in `docker stats` with `NetworkDisabled=true`

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -138,8 +138,10 @@ func (daemon *Daemon) GetContainerStats(container *container.Container) (*types.
 		return nil, err
 	}
 
-	if stats.Networks, err = daemon.getNetworkStats(container); err != nil {
-		return nil, err
+	if !container.Config.NetworkDisabled {
+		if stats.Networks, err = daemon.getNetworkStats(container); err != nil {
+			return nil, err
+		}
 	}
 
 	return stats, nil


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue in #25000 where `docker stats` will not show network stats with `NetworkDisabled=true`.

The `NetworkDisabled=true` could be either invoked through remote API, or through `docker daemon -b none`.

The issue was that when `NetworkDisabled=true` either by API or by daemon config, there is no SandboxKey for container so an error will be returned.

**\- How I did it**

This fix fixes this issue by skipping obtaining SandboxKey if `NetworkDisabled=true`.

**\- How to verify it**

Additional test has bee added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25000.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
