### PR TITLE
Remove option "--manager" description for swarm_join.md

### DIFF
--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -85,10 +85,6 @@ name, the default port 2377 will be used.
 
 This flag is generally not necessary when joining an existing swarm.
 
-### `--manager`
-
-Joins the node as a manager
-
 ### `--token string`
 
 Secret value required for nodes to join the swarm


### PR DESCRIPTION
Option "--manager" has been removed in the usage of the same md doc, so the description can be removed:

```
Usage:  docker swarm join [OPTIONS] HOST:PORT

Join a swarm as a node and/or manager

Options:
  --advertise-addr value   Advertised address (format: <ip|interface>[:port])
  --help                   Print usage
  --listen-addr value      Listen address (format: <ip|interface>[:port)
  --token string           Token for entry into the swarm
```
