### PR TITLE
Remove the redundant words in reference for swarm

### DIFF
--- a/docs/swarm/admin_guide.md
+++ b/docs/swarm/admin_guide.md
@@ -32,7 +32,7 @@ This article covers the following swarm administration tasks:
 * [Forcefully removing a node](#force-remove-a-node)
 * [Recovering from disaster](#recover-from-disaster)
 
-Refer to [How swarm mode nodes work](how-swarm-mode-works/nodes.md)
+Refer to [How nodes work](how-swarm-mode-works/nodes.md)
 for a brief overview of Docker Swarm mode and the difference between manager and
 worker nodes.
 


### PR DESCRIPTION
Remove the redundant description in reference for swarm/admin_guide.md which is helpful to understand

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
