### PR TITLE
Fix inspect Dead container

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -167,7 +167,10 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 	contJSONBase.GraphDriver.Name = container.Driver
 
 	graphDriverData, err := container.RWLayer.Metadata()
-	if err != nil {
+	// If container is marked as Dead, the container's graphdriver metadata
+	// could have been removed, it will cause error if we try to get the metadata,
+	// we can ignore the error if the container is dead.
+	if err != nil && !container.Dead {
 		return nil, err
 	}
 	contJSONBase.GraphDriver.Data = graphDriverData


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Daemon using devicemapper  ungratefully shutdown leave a container with `Dead` status.

```
[lei@fedora docker]$ docker ps -l
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
f78535913421        busybox             "sh"                About an hour ago   Dead                                    zen_swanson
```

when I `docker inspect` this container, it faile with:

```
[lei@fedora docker]$ docker inspect f78535913421
[]
Error response from daemon: devmapper: Unknown device 9628eeec48a39fa1397ef65765b8dd1613ed7126774360d3fa418b3e9ae01419
```

Seems the daemon shutdown happened between removing graphdriver driver metadata and removing container metadata.

**\- How I did it**
Don't try to get the graph driver metadata if the container is `Dead`

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Lei Jitang leijitang@huawei.com
