### PR TITLE
Change TMPDIR to DOCKER_TMPDIR

### DIFF
--- a/contrib/init/sysvinit-debian/docker.default
+++ b/contrib/init/sysvinit-debian/docker.default
@@ -17,4 +17,4 @@
 #export http_proxy="http://127.0.0.1:3128/"
 
 # This is also a handy place to tweak where Docker's temporary files go.
-#export TMPDIR="/mnt/bigdrive/docker-tmp"
+#export DOCKER_TMPDIR="/mnt/bigdrive/docker-tmp"


### PR DESCRIPTION
TMPDIR was changed to DOCKER_TMPDIR in pull request 7113 but the file still asks user to set TMPDIR.
I am new to docker and wasted sometime this morning because of this.
I am using docker version 1.12.1 on ubuntu server 14.04
