### PR TITLE
Validate `--ip` and `--ip6` for `docker create`

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -121,6 +121,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /containers/json` now accepts `removing` as a valid value for the `status` filter.
 * `DELETE /volumes/(name)` now accepts a `force` query parameter to force removal of volumes that were already removed out of band by the volume driver plugin.
 * `POST /containers/create/` and `POST /containers/(name)/update` now validates restart policies.
+* `POST /containers/create` now validates IPAMConfig in NetworkingConfig, and returns error for invalid IPv4 and IPv6 addresses (`--ip` and `--ip6` in `docker create/run`).
 
 ### v1.24 API changes
 


### PR DESCRIPTION
**\- What I did**

This fix tries to fix the issue raised in #25863 where `--ip` value is not validated for `docker create`. As a result, the IP address passed by `--ip` is not used for `docker create` (ignored silently).

**\- How I did it**

This fix adds validation in the daemon so that `--ip` and  `--ip6` are properly validated for `docker create`.

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25863.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
