### PR TITLE
Incorrect response field name for command "docker images"

### DIFF
--- a/docs/getstarted/step_four.md
+++ b/docs/getstarted/step_four.md
@@ -185,7 +185,7 @@ In this step, you verify the new images is on your computer and then you run you
     This command, you might remember, lists the images you have locally.
 
         $ docker images
-        REPOSITORY           TAG          IMAGE ID          CREATED             VIRTUAL SIZE
+        REPOSITORY           TAG          IMAGE ID          CREATED             SIZE
         docker-whale         latest       7d9495d03763      4 minutes ago       273.7 MB
         docker/whalesay      latest       fb434121fc77      4 hours ago         247 MB
         hello-world          latest       91c95931e552      5 weeks ago         910 B

--- a/docs/getstarted/step_six.md
+++ b/docs/getstarted/step_six.md
@@ -31,7 +31,7 @@ If you don't already have a terminal open, open one now:
 2. At the prompt, type `docker images` to list the images you currently have:
 
         $ docker images
-        REPOSITORY           TAG          IMAGE ID            CREATED             VIRTUAL SIZE
+        REPOSITORY           TAG          IMAGE ID            CREATED             SIZE
         docker-whale         latest       7d9495d03763        38 minutes ago      273.7 MB
         <none>               <none>       5dac217f722c        45 minutes ago      273.7 MB
         docker/whalesay      latest       fb434121fc77        4 hours ago         247 MB
@@ -61,7 +61,7 @@ If you don't already have a terminal open, open one now:
 7. Type the `docker images` command again to see your newly tagged image.
 
         $ docker images
-        REPOSITORY                  TAG       IMAGE ID        CREATED          VIRTUAL SIZE
+        REPOSITORY                  TAG       IMAGE ID        CREATED          SIZE
         maryatdocker/docker-whale   latest    7d9495d03763    5 minutes ago    273.7 MB
         docker-whale                latest    7d9495d03763    2 hours ago      273.7 MB
         <none>                      <none>    5dac217f722c    5 hours ago      273.7 MB
@@ -116,7 +116,7 @@ from the hub &mdash; why would it? The two images are identical.
 2. At the prompt, type `docker images` to list the images you currently have on your local machine.
 
 		$ docker images
-		REPOSITORY                  TAG       IMAGE ID        CREATED          VIRTUAL SIZE
+		REPOSITORY                  TAG       IMAGE ID        CREATED          SIZE
 		maryatdocker/docker-whale   latest    7d9495d03763    5 minutes ago    273.7 MB
 		docker-whale                latest    7d9495d03763    2 hours ago      273.7 MB
 		<none>                      <none>    5dac217f722c    5 hours ago      273.7 MB

--- a/docs/getstarted/step_three.md
+++ b/docs/getstarted/step_three.md
@@ -99,7 +99,7 @@ Make sure Docker is running. On Docker for Mac and Docker for Windows, this is i
     `docker/whalesay` in the list.
 
         $ docker images
-        REPOSITORY           TAG         IMAGE ID            CREATED            VIRTUAL SIZE
+        REPOSITORY           TAG         IMAGE ID            CREATED            SIZE
         docker/whalesay      latest      fb434121fc77        3 hours ago        247 MB
         hello-world          latest      91c95931e552        5 weeks ago        910 B
 


### PR DESCRIPTION
"VIRTUAL SIZE" should be"SIZE", it is "SIZE" in all other places such as commit.md:

```
$ docker images
REPOSITORY                        TAG                 ID                  CREATED             SIZE
svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
```
