### PR TITLE
Host mounted directories are correctly chowned to the remapped root, if the directory does not already exist

### DIFF
--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -28,7 +28,8 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		if err := daemon.lazyInitializeVolume(c.ID, m); err != nil {
 			return nil, err
 		}
-		path, err := m.Setup(c.MountLabel)
+		rootUID, rootGID := daemon.GetRemappedUIDGID()
+		path, err := m.Setup(c.MountLabel, rootUID, rootGID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**\- What I did**

Host mounts created by Docker now make sure:
1. Already existing directories are left untouched
2. Newly created directories are chowned to the correct root UID/GID in case of user namespaces
3. All parent directories still get created with host root UID/GID

Fix #21738

**\- How I did it**

Changed `MountPoint.Setup()` to accept the remapped UID/GID, which is then passed to `idtools. MkdirAllNewAs()`, [as it is already done with local driver volumes](https://github.com/docker/docker/blob/923053d1edac552a8d48cbb293c4ec935a93348b/volume/local/local.go#L167)

**\- How to verify it**
1. [With `dockerd`] Run `docker run --rm -v /tmp/without-user-ns:/tmp hello-world` and verify it's owned by root
2. [With `dockerd --userns-remap default`] Run `docker run --rm -v /tmp/with-user-ns:/tmp hello-world` and verify it's owned by the remapped root
3. [With `dockerd --userns-remap default`] Run `docker run --rm -v /tmp/without-user-ns:/tmp hello-world` and verify it's owned by root, since it already existed

**\- Description for the changelog**

Host mounted directories are correctly chowned to the remapped root, if the directory does not already exist

![help-dog-picture](https://cloud.githubusercontent.com/assets/788386/17885616/a2478ac8-6926-11e6-9b95-710964182ffa.jpg)

Signed-off-by: Antonis Kalipetis akalipetis@gmail.com
