### PR TITLE
Modify incorrect repository URL

### DIFF
--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -201,7 +201,7 @@ created from a Dockerfile as follows:
 the plugin._
 
 ```bash
-$ git clone github.com/vieux/docker-volume-sshfs
+$ git clone https://github.com/vieux/docker-volume-sshfs
 $ cd docker-volume-sshfs
 $ docker build -t rootfs .
 $ id=$(docker create rootfs true) # id was cd851ce43a403 when the image was created


### PR DESCRIPTION
The repository cannot be downloaded by  incorrect repository URL. It should add "https://" to repository URL.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
