### PR TITLE
Fix AuthZ plugins headers change issue

### DIFF
--- a/pkg/authorization/response.go
+++ b/pkg/authorization/response.go
@@ -175,16 +175,18 @@ func (rm *responseModifier) Flush() {
 
 // FlushAll flushes all data to the HTTP response
 func (rm *responseModifier) FlushAll() error {
-	// Copy the status code
-	if rm.statusCode > 0 {
-		rm.rw.WriteHeader(rm.statusCode)
-	}
-
 	// Copy the header
 	for k, vv := range rm.header {
 		for _, v := range vv {
 			rm.rw.Header().Add(k, v)
 		}
+	}
+
+	// Copy the status code
+	// Also WriteHeader needs to be done after all the headers
+	// have been copied (above).
+	if rm.statusCode > 0 {
+		rm.rw.WriteHeader(rm.statusCode)
 	}
 
 	var err error


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #25927 where the HTTP headers have been chaged when AUthZ plugin is in place.

This issue is that in `FlushAll` (`pkg/authorization/response.go`), the headers have been written (with `WriteHeader`) before all the headers have bee copied.

**\- How I did it**

This fix fixes the issue by placing `WriteHeader` after.

**\- How to verify it**

A test has been added to cover the changes.`

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25927

Signed-off-by: Yong Tang yong.tang.github@outlook.com
