### PR TITLE
Fix a missed option parameter

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -13,7 +13,7 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 	rootCmd.SetHelpTemplate(helpTemplate)
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
 
-	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
+	rootCmd.PersistentFlags().BoolP("help", false, "Print usage")
 	rootCmd.PersistentFlags().MarkShorthandDeprecated("help", "please use --help")
 }
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -26,7 +26,7 @@ Options:
   --config=~/.docker              Location of client config files
   -D, --debug                     Enable debug mode
   -H, --host=[]                   Daemon socket(s) to connect to
-  -h, --help                      Print usage
+  --help                      Print usage
   -l, --log-level=info            Set the logging level
   --tls                           Use TLS; implied by --tlsverify
   --tlscacert=~/.docker/ca.pem    Trust certs signed only by this CA


### PR DESCRIPTION
It missed the option parameter "-h" for the command dockerd.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
