### PR TITLE
correct handling of volumes while service update.

### DIFF
--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -122,18 +122,36 @@ func TestUpdateGroups(t *testing.T) {
 
 func TestUpdateMounts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("mount-add", "type=volume,target=/toadd")
+	flags.Set("mount-add", "type=volume,source=vol2,target=/toadd")
 	flags.Set("mount-rm", "/toremove")
 
 	mounts := []mounttypes.Mount{
-		{Target: "/toremove", Type: mounttypes.TypeBind},
-		{Target: "/tokeep", Type: mounttypes.TypeBind},
+		{Target: "/toremove", Source: "vol1", Type: mounttypes.TypeBind},
+		{Target: "/tokeep", Source: "vol3", Type: mounttypes.TypeBind},
 	}
 
 	updateMounts(flags, &mounts)
 	assert.Equal(t, len(mounts), 2)
-	assert.Equal(t, mounts[0].Target, "/tokeep")
-	assert.Equal(t, mounts[1].Target, "/toadd")
+	assert.Equal(t, mounts[0].Target, "/toadd")
+	assert.Equal(t, mounts[1].Target, "/tokeep")
+
+}
+
+func TestUpdateMountsWithDuplicateMounts(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("mount-add", "type=volume,source=vol4,target=/toadd")
+
+	mounts := []mounttypes.Mount{
+		{Target: "/tokeep1", Source: "vol1", Type: mounttypes.TypeBind},
+		{Target: "/toadd", Source: "vol2", Type: mounttypes.TypeBind},
+		{Target: "/tokeep2", Source: "vol3", Type: mounttypes.TypeBind},
+	}
+
+	updateMounts(flags, &mounts)
+	assert.Equal(t, len(mounts), 3)
+	assert.Equal(t, mounts[0].Target, "/tokeep1")
+	assert.Equal(t, mounts[1].Target, "/tokeep2")
+	assert.Equal(t, mounts[2].Target, "/toadd")
 }
 
 func TestUpdatePorts(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #25772 "

Please provide the following information:
-->

**\- What I did**
Fixed #25772, with proper handling of volume mount data in `docker service update` command.

i.e. while building `docker service update` container Specs, check if volume(mount target) already exists, delete the existing mount data and append new volume mount data to avoid duplicates entry.

**\- How I did it**
In `api/client/service/update.go`, instead of blindly appending the mount list, check for entry in `mounts` list, and replace it with new entry.
If it doesn't exist append the list.
Function added : `findAndReplaceMountDatamounts *[]mounttypes.Mount, values []mounttypes.Mount) bool`

**\- How to verify it**
Test added as `TestUpdateMountsWithDuplicateMounts`
and also steps from #25772 can be followed.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- `--mount-add` option for `docker service update` handle mount points as expected.

**\- A picture of a cute animal (not mandatory but encouraged)**

Updating a service to replace a volume is handled properly now.
Fixes #25772 

Signed-off-by: Kunal Kushwaha kushwaha_kunal_v7@lab.ntt.co.jp
