### PR TITLE
Add -a option to service/node ps

### DIFF
--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -22,7 +22,7 @@ Usage:  docker node ps [OPTIONS] [NODE...]
 List tasks running on one or more nodes, defaults to current node.
 
 Options:
-  -a, --all            Display all instances
+  -a, --all            Show all tasks (default shows tasks that are or will be running)
   -f, --filter value   Filter output based on conditions provided
       --help           Print usage
       --no-resolve     Do not map IDs to Names

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -22,6 +22,7 @@ Usage:  docker service ps [OPTIONS] SERVICE
 List the tasks of a service
 
 Options:
+  -a, --all             Show all tasks (default shows tasks that are or will be running)
   -f, --filter filter   Filter output based on conditions provided
       --help            Print usage
       --no-resolve      Do not map IDs to Names

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -203,6 +203,88 @@ func (s *DockerSwarmSuite) TestSwarmNodeTaskListFilter(c *check.C) {
 	c.Assert(out, checker.Not(checker.Contains), name+".1")
 	c.Assert(out, checker.Not(checker.Contains), name+".2")
 	c.Assert(out, checker.Not(checker.Contains), name+".3")
+
+	out, err = d.Cmd("node", "ps", "--filter", "desired-state=running", "self")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, name+".1")
+	c.Assert(out, checker.Contains, name+".2")
+	c.Assert(out, checker.Contains, name+".3")
+
+	out, err = d.Cmd("node", "ps", "--filter", "desired-state=shutdown", "self")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), name+".1")
+	c.Assert(out, checker.Not(checker.Contains), name+".2")
+	c.Assert(out, checker.Not(checker.Contains), name+".3")
+}
+
+func (s *DockerSwarmSuite) TestSwarmServiceTaskListAll(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	name := "service-task-list-1"
+	out, err := d.Cmd("service", "create", "--name", name, "--replicas=3", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+
+	// make sure task has been deployed.
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 3)
+
+	out, err = d.Cmd("service", "ps", name)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, name+".1")
+	c.Assert(out, checker.Contains, name+".2")
+	c.Assert(out, checker.Contains, name+".3")
+
+	// Get the last container id so we can restart it to cause a task error in the history
+	containerID, err := d.Cmd("ps", "-q", "-l")
+	c.Assert(err, checker.IsNil)
+
+	_, err = d.Cmd("stop", strings.TrimSpace(containerID))
+	c.Assert(err, checker.IsNil)
+
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 3)
+
+	out, err = d.Cmd("service", "ps", name)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Count, name, 3)
+
+	out, err = d.Cmd("service", "ps", name, "-a")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Count, name, 4)
+}
+
+func (s *DockerSwarmSuite) TestSwarmNodeTaskListAll(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	name := "node-task-list"
+	out, err := d.Cmd("service", "create", "--name", name, "--replicas=3", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+
+	// make sure task has been deployed.
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 3)
+
+	out, err = d.Cmd("service", "ps", name)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, name+".1")
+	c.Assert(out, checker.Contains, name+".2")
+	c.Assert(out, checker.Contains, name+".3")
+
+	// Get the last container id so we can restart it to cause a task error in the history
+	containerID, err := d.Cmd("ps", "-q", "-l")
+	c.Assert(err, checker.IsNil)
+
+	_, err = d.Cmd("stop", strings.TrimSpace(containerID))
+	c.Assert(err, checker.IsNil)
+
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 3)
+
+	out, err = d.Cmd("node", "ps", "self")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Count, name, 3)
+
+	out, err = d.Cmd("node", "ps", "self", "-a")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Count, name, 4)
 }
 
 // Test case for #25375


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Reopened https://github.com/docker/docker/pull/25251 because of weird github issue. 

closes #25180
closes #25196

**\- What I did**

I added an `-a` and `--all` flag to both commands to show all tasks.

**\- How I did it**

Added a default filter to the CLI command when -a is false.

**\- How to verify it**

Look at tests. 

Run `docker service ps` & `docker node ps` on various nodes to ensure that only tasks are shown that are running or will be running w/o the `-a` flag. Also, make sure that `--filter desired-state=<state>` works with `-a` true/false. 

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add -a option to service/node ps

Signed-off-by: Josh Horwitz horwitzja@gmail.com
