### PR TITLE
Replace docker command from 'docker daemon' to 'dockerd'

### DIFF
--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -25,7 +25,7 @@ or `systemd` to manage the `docker` daemon's start and stop.
 
 ### Running the docker daemon directly
 
-The `docker` daemon can be run directly using the `dockerd` command. By default it listens on
+The Docker daemon can be run directly using the `dockerd` command. By default it listens on
 the Unix socket `unix:///var/run/docker.sock`
 
     $ dockerd
@@ -38,9 +38,9 @@ the Unix socket `unix:///var/run/docker.sock`
 
 ### Configuring the docker daemon directly
 
-If you're running the `docker` daemon directly by running `docker daemon` instead
+If you're running the Docker daemon directly by running `dockerd` instead
 of using a process manager, you can append the configuration options to the `docker` run
-command directly. Other options can be passed to the `docker` daemon to configure it.
+command directly. Other options can be passed to the Docker daemon to configure it.
 
 Some of the daemon's options are:
 
@@ -51,7 +51,7 @@ Some of the daemon's options are:
 | `--tls=false`         | Enable or disable TLS. By default, this is false.         |
 
 
-Here is an example of running the `docker` daemon with configuration options:
+Here is an example of running the Docker daemon with configuration options:
 
     $ dockerd -D --tls=true --tlscert=/var/docker/server.pem --tlskey=/var/docker/serverkey.pem -H tcp://192.168.59.3:2376
 

--- a/docs/admin/logging/awslogs.md
+++ b/docs/admin/logging/awslogs.md
@@ -22,7 +22,7 @@ and Command Line Tools](http://docs.aws.amazon.com/cli/latest/reference/logs/ind
 You can configure the default logging driver by passing the `--log-driver`
 option to the Docker daemon:
 
-    docker daemon --log-driver=awslogs
+    dockerd --log-driver=awslogs
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:

--- a/docs/admin/logging/fluentd.md
+++ b/docs/admin/logging/fluentd.md
@@ -39,7 +39,7 @@ Some options are supported by specifying `--log-opt` as many times as needed:
 Configure the default logging driver by passing the
 `--log-driver` option to the Docker daemon:
 
-    docker daemon --log-driver=fluentd
+    dockerd --log-driver=fluentd
 
 To set the logging driver for a specific container, pass the
 `--log-driver` option to `docker run`:

--- a/docs/admin/logging/gcplogs.md
+++ b/docs/admin/logging/gcplogs.md
@@ -18,7 +18,7 @@ Logging</a>.
 You can configure the default logging driver by passing the `--log-driver`
 option to the Docker daemon:
 
-    docker daemon --log-driver=gcplogs
+    dockerd --log-driver=gcplogs
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:

--- a/docs/admin/logging/journald.md
+++ b/docs/admin/logging/journald.md
@@ -30,7 +30,7 @@ driver stores the following metadata in the journal with each message:
 You can configure the default logging driver by passing the
 `--log-driver` option to the Docker daemon:
 
-    docker daemon --log-driver=journald
+    dockerd --log-driver=journald
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:

--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -45,7 +45,7 @@ to manually start the daemon with the `json-file` driver, and include additional
 attributes in the output, run the following command:
 
 ```bash
-$ docker daemon \
+$ dockerd \
     --log-driver=json-file \
     --log-opt labels=foo \
     --log-opt env=foo,fizz

--- a/docs/admin/logging/splunk.md
+++ b/docs/admin/logging/splunk.md
@@ -20,7 +20,7 @@ in Splunk Enterprise and Splunk Cloud.
 You can configure the default logging driver by passing the `--log-driver`
 option to the Docker daemon:
 
-    docker daemon --log-driver=splunk
+    dockerd --log-driver=splunk
 
 You can set the logging driver for a specific container by using the
 `--log-driver` option to `docker run`:

--- a/docs/admin/systemd.md
+++ b/docs/admin/systemd.md
@@ -53,7 +53,7 @@ following:
     EnvironmentFile=-/etc/sysconfig/docker-storage
     EnvironmentFile=-/etc/sysconfig/docker-network
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// $OPTIONS \
+    ExecStart=/usr/bin/dockerd -H fd:// $OPTIONS \
               $DOCKER_STORAGE_OPTIONS \
               $DOCKER_NETWORK_OPTIONS \
               $BLOCK_REGISTRY \
@@ -90,7 +90,7 @@ In this example, we'll assume that your `docker.service` file looks something li
 
     [Service]
     Type=notify
-    ExecStart=/usr/bin/docker daemon -H fd://
+    ExecStart=/usr/bin/dockerd -H fd://
     LimitNOFILE=1048576
     LimitNPROC=1048576
     TasksMax=1048576
@@ -104,7 +104,7 @@ directory:
 
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --graph="/mnt/docker-data" --storage-driver=overlay
+    ExecStart=/usr/bin/dockerd -H fd:// --graph="/mnt/docker-data" --storage-driver=overlay
 
 You can also set other environment variables in this file, for example, the
 `HTTP_PROXY` environment variables described below.
@@ -114,7 +114,7 @@ by a new configuration as follows:
 
     [Service]
     ExecStart=
-    ExecStart=/usr/bin/docker daemon -H fd:// --bip=172.17.42.1/16
+    ExecStart=/usr/bin/dockerd -H fd:// --bip=172.17.42.1/16
 
 If you fail to specify an empty configuration, Docker reports an error such as:
 

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -112,7 +112,7 @@ Authorization plugins can be loaded without restarting the daemon. Refer
 to the [`dockerd` documentation](../reference/commandline/dockerd.md#configuration-reloading) for more information.
 
 ```bash
-$ docker daemon --authorization-plugin=plugin1 --authorization-plugin=plugin2,...
+$ dockerd --authorization-plugin=plugin1 --authorization-plugin=plugin2,...
 ```
 
 Docker's authorization subsystem supports multiple `--authorization-plugin` parameters.

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -2357,4 +2357,4 @@ To set cross origin requests to the remote api please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,
 default or blank means CORS disabled
 
-    $ docker daemon -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"
+    $ dockerd -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -2923,4 +2923,4 @@ To set cross origin requests to the remote api please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,
 default or blank means CORS disabled
 
-    $ docker daemon -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"
+    $ dockerd -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -3258,4 +3258,4 @@ To set cross origin requests to the remote api please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,
 default or blank means CORS disabled
 
-    $ docker daemon -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"
+    $ dockerd -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -3374,4 +3374,4 @@ To set cross origin requests to the remote api please give values to
 `--api-cors-header` when running Docker in daemon mode. Set * (asterisk) allows all,
 default or blank means CORS disabled
 
-    $ docker daemon -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"
+    $ dockerd -H="192.168.1.9:2375" --api-cors-header="http://foo.bar"

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -574,7 +574,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     **size** cannot be smaller than **btrfs.min_space**.
 
     Example use:
-        $ docker daemon -s btrfs --storage-opt btrfs.min_space=10G
+        $ dockerd -s btrfs --storage-opt btrfs.min_space=10G
 
 #### Overlay2 options
 
@@ -1213,7 +1213,7 @@ The `--tls*` options enable use of specific certificates for individual daemons.
 Example script for a separate “bootstrap” instance of the Docker daemon without network:
 
 ```bash
-$ docker daemon \
+$ dockerd \
         -H unix:///var/run/docker-bootstrap.sock \
         -p /var/run/docker-bootstrap.pid \
         --iptables=false \

--- a/docs/security/https.md
+++ b/docs/security/https.md
@@ -136,7 +136,7 @@ prevent accidental damage:
 Now you can make the Docker daemon only accept connections from clients
 providing a certificate trusted by our CA:
 
-    $ docker daemon --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem \
+    $ dockerd --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem \
       -H=0.0.0.0:2376
 
 To be able to connect to Docker and validate its certificate, you now

--- a/docs/security/https/Makefile
+++ b/docs/security/https/Makefile
@@ -13,7 +13,7 @@ cert: build
 certs: cert
 
 run:
-	sudo docker daemon -D --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem -H=0.0.0.0:6666 --pidfile=$(pwd)/docker.pid --graph=$(pwd)/graph
+	sudo dockerd -D --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem -H=0.0.0.0:6666 --pidfile=$(pwd)/docker.pid --graph=$(pwd)/graph
 
 client:
 	sudo docker --tls --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem   -H=$(HOST):6666 version

--- a/docs/userguide/labels-custom-metadata.md
+++ b/docs/userguide/labels-custom-metadata.md
@@ -182,7 +182,7 @@ on how to query labels set on a container.
 
 ## Daemon labels
 
-    docker daemon \
+    dockerd \
       --dns 8.8.8.8 \
       --dns 8.8.4.4 \
       -H unix:///var/run/docker.sock \


### PR DESCRIPTION
It uses the command 'dockerd' instead of 'docker daemon' in docker v1.12

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
