### PR TITLE
Support systemd-journal-gatewayd

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -18,8 +18,9 @@ import (
 const name = "journald"
 
 type journald struct {
-	vars    map[string]string // additional variables and values to send to the journal along with the log message
-	readers readerList
+	vars           map[string]string // additional variables and values to send to the journal along with the log message
+	gatewayAddress string
+	readers        readerList
 }
 
 type readerList struct {
@@ -85,7 +86,11 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	for k, v := range extraAttrs {
 		vars[k] = v
 	}
-	return &journald{vars: vars, readers: readerList{readers: make(map[*logger.LogWatcher]*logger.LogWatcher)}}, nil
+	return &journald{
+		vars:           vars,
+		gatewayAddress: ctx.Config["journal-gateway-address"],
+		readers:        readerList{readers: make(map[*logger.LogWatcher]*logger.LogWatcher)},
+	}, nil
 }
 
 // We don't actually accept any options, but we have to supply a callback for
@@ -96,6 +101,7 @@ func validateLogOpt(cfg map[string]string) error {
 		case "labels":
 		case "env":
 		case "tag":
+		case "journal-gateway-address":
 		default:
 			return fmt.Errorf("unknown log opt '%s' for journald log driver", key)
 		}

--- a/docs/admin/logging/journald.md
+++ b/docs/admin/logging/journald.md
@@ -42,6 +42,9 @@ You can set the logging driver for a specific container by using the
 Users can use the `--log-opt NAME=VALUE` flag to specify additional
 journald logging driver options.
 
+Users can use the `--log-opt journal-gateway-address=host:port` option to
+specify the `systemd-journal-gatewayd` address where the driver connects to.
+
 ### tag
 
 Specify template to set `CONTAINER_TAG` value in journald logs. Refer to


### PR DESCRIPTION
**\- What I did**

Support systemd-journal-gatewayd[1](https://www.freedesktop.org/software/systemd/man/systemd-journal-gatewayd.service.html). This allows `docker logs` to fetch logs from the gateway
daemon instead of local journals. It is useful if a docker cluster is configured to collect their journals
in a single journal system.

**\- How I did it**

Add `journal-gateway-address` option for journald logging driver.

**\- How to verify it**
1. Start systemd-journal-gatewayd service in docker host.
2. Run a container with `journal-gateway-address` option: `docker run -d --name=web --log-driver=journald --log-opt=journal-gateway-address=dockerhost:19531 nginx`
3. See the logs: `docker logs`

**\- Description for the changelog**

Support systemd-journal-gatewayd.
