### PR TITLE
Optimize the restart function code

### DIFF
--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -36,25 +36,27 @@ func (daemon *Daemon) containerRestart(container *container.Container, seconds i
 		defer daemon.Unmount(container)
 	}
 
-	// set AutoRemove flag to false before stop so the container won't be
-	// removed during restart process
-	autoRemove := container.HostConfig.AutoRemove
+	if container.IsRunning() {
+		// set AutoRemove flag to false before stop so the container won't be
+		// removed during restart process
+		autoRemove := container.HostConfig.AutoRemove
 
-	container.HostConfig.AutoRemove = false
-	err := daemon.containerStop(container, seconds)
-	// restore AutoRemove irrespective of whether the stop worked or not
-	container.HostConfig.AutoRemove = autoRemove
-	// containerStop will write HostConfig to disk, we shall restore AutoRemove
-	// in disk too
-	if toDiskErr := container.ToDiskLocking(); toDiskErr != nil {
-		logrus.Errorf("Write container to disk error: %v", toDiskErr)
+		container.HostConfig.AutoRemove = false
+		err := daemon.containerStop(container, seconds)
+		// restore AutoRemove irrespective of whether the stop worked or not
+		container.HostConfig.AutoRemove = autoRemove
+		// containerStop will write HostConfig to disk, we shall restore AutoRemove
+		// in disk too
+		if toDiskErr := container.ToDiskLocking(); toDiskErr != nil {
+			logrus.Errorf("Write container to disk error: %v", toDiskErr)
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 
-	if err != nil {
-		return err
-	}
-
-	if err = daemon.containerStart(container); err != nil {
+	if err := daemon.containerStart(container); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I think the restart time should determine the state of the container first , if  the container is stop state,there is no need to call the stop function 

Signed-off-by: zhouhao zhouhao@cn.fujitsu.com
