### PR TITLE
check-config.sh: Add check for CONFIG_BTRFS_FS_POSIX_ACL

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -268,6 +268,7 @@ echo '- Storage Drivers:'
 
 	echo '- "'$(wrap_color 'btrfs' blue)'":'
 	check_flags BTRFS_FS | sed 's/^/  /'
+	check_flags BTRFS_FS_POSIX_ACL | sed 's/^/  /'
 
 	echo '- "'$(wrap_color 'devicemapper' blue)'":'
 	check_flags BLK_DEV_DM DM_THIN_PROVISIONING | sed 's/^/  /'


### PR DESCRIPTION
docker is trying to set system.posix_acl_access but using BTRFS this fails if
CONFIG_BTRFS_FS_POSIX_ACL is not activated.

Signed-off-by: Andrei Gherzan andrei@resin.io
