### PR TITLE
fix rm plugin arg number to be min 1

### DIFF
--- a/api/client/plugin/remove.go
+++ b/api/client/plugin/remove.go
@@ -26,7 +26,7 @@ func newRemoveCommand(dockerCli *client.DockerCli) *cobra.Command {
 		Use:     "rm [OPTIONS] PLUGIN [PLUGIN...]",
 		Short:   "Remove one or more plugins",
 		Aliases: []string{"remove"},
-		Args:    cli.ExactArgs(1),
+		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.plugins = args
 			return runRemove(dockerCli, &opts)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
fix rm plugin arg number to be min 1
As this commands allows to input several arg nums.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
