### PR TITLE
Update docker remote api to mention restart policy validation

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -120,6 +120,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.
 * `GET /containers/json` now accepts `removing` as a valid value for the `status` filter.
 * `DELETE /volumes/(name)` now accepts a `force` query parameter to force removal of volumes that were already removed out of band by the volume driver plugin.
+* `POST /containers/create/` and `POST /containers/(name)/update` now validates restart policies.
 
 ### v1.24 API changes
 


### PR DESCRIPTION
Follow-up for #24073, adds a note on `v1.25 API changes` on restart policies validation.

/cc @thaJeztah @SvenDowideit 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
