### PR TITLE
Fixes #25918 - Changed --permissive to --privileged.

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -645,7 +645,7 @@ allows you to share the same content between containers.
 > **Note**: Automatic translation of MLS labels is not currently supported.
 
 To disable the security labeling for this container versus running with the
-`--permissive` flag, use the following command:
+`--privileged` flag, use the following command:
 
     $ docker run --security-opt label=disable -it fedora bash
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Changed `--permissive` to `--privileged` in `docker run` docs explaining how to disable a specific SELinux label instead of disabling SELinux label by running a privileged container.

**\- How I did it**
Simply replaced one word for the other.

**\- How to verify it**
run `make docs` and view link: https://docs.docker.com/engine/reference/run/#/security-configuration

**\- Description for the changelog**
Replaced --permissive to --privileged in docker run reference describing disabling SELinux container labeling.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Signed-off-by: Rich Moyse rich@moyse.us
