### PR TITLE
Update docs for `docker create` to include `--rm` flag

### DIFF
--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -90,6 +90,7 @@ Options:
       --read-only                   Mount the container's root filesystem as read only
       --restart string              Restart policy to apply when a container exits (default "no")
                                     Possible values are: no, on-failure[:max-retry], always, unless-stopped
+      --rm                          Automatically remove the container when it exits
       --runtime string              Runtime to use for this container
       --security-opt value          Security Options (default [])
       --shm-size string             Size of /dev/shm, default value is 64MB.


### PR DESCRIPTION
Since #20848 has been merged and both `docker create` and `docker run` share the same `runconfig` parser, now both `docker run` and `docker create` allow to specify the `--rm` flag. However, docs for `docker create` has not been udpated yet.

This fix updates docs for `docker create` so that `--rm` flag has been included.

This fix is related to #20848 and #25577.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
