### PR TITLE
Provide correct superlink for installing docker compose

### DIFF
--- a/docs/security/trust/deploying_notary.md
+++ b/docs/security/trust/deploying_notary.md
@@ -10,7 +10,7 @@ parent= "smn_content_trust"
 
 # Deploying Notary Server with Compose
 
-The easiest way to deploy Notary Server is by using Docker Compose. To follow the procedure on this page, you must have already [installed Docker Compose](/compose/install.md).
+The easiest way to deploy Notary Server is by using Docker Compose. To follow the procedure on this page, you must have already [installed Docker Compose](https://docs.docker.com/compose/install/).
 
 1. Clone the Notary repository
 


### PR DESCRIPTION
Previous superlink "/compose/installed.md" cann't be found, should be modified to another one.
