### PR TITLE
Add the content for Google Cloud Loging driver in index

### DIFF
--- a/docs/admin/logging/index.md
+++ b/docs/admin/logging/index.md
@@ -21,3 +21,4 @@ weight=9
 * [Amazon CloudWatch Logs logging driver](awslogs.md)
 * [Splunk logging driver](splunk.md)
 * [ETW logging driver](etwlogs.md)
+* [Google Cloud Logging driver](gcplogs.md)


### PR DESCRIPTION
It may be missed index for Google Cloud Loging driver in index.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
