### PR TITLE
daemon: ensure systemd cgroup is passed down to runtimes

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -566,11 +566,7 @@ func verifyDaemonSettings(config *Config) error {
 	if config.Runtimes == nil {
 		config.Runtimes = make(map[string]types.Runtime)
 	}
-	stockRuntimeOpts := []string{}
-	if UsingSystemd(config) {
-		stockRuntimeOpts = append(stockRuntimeOpts, "--systemd-cgroup=true")
-	}
-	config.Runtimes[stockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary, Args: stockRuntimeOpts}
+	config.Runtimes[stockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
 
 	return nil
 }

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -20,6 +20,9 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 	if rt == nil {
 		return nil, fmt.Errorf("no such runtime '%s'", container.HostConfig.Runtime)
 	}
+	if UsingSystemd(daemon.configStore) {
+		rt.Args = append(rt.Args, "--systemd-cgroup=true")
+	}
 	createOptions = append(createOptions, libcontainerd.WithRuntime(rt.Path, rt.Args))
 
 	return &createOptions, nil


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/26043

I wish there was a way to pass runtimes' specific arguments (maybe there's already and I missed it).
This patch is basically applying `--systemd-cgroup=true` to custom runtimes instead of applying it only to the stock runtime. Hopefully, the CLI in OCI will get standardized and all will be ok (given, right now, ppl have to adhere to runc CLI in order to get their custom runtime to work properly).

/cc @mrunalp @crosbymichael @LK4D4 @cyphar

Signed-off-by: Antonio Murdaca runcom@redhat.com
