### PR TITLE
Check for non-nil container after match

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -147,7 +147,9 @@ func (daemon *Daemon) filterByNameIDMatches(ctx *listContext) []*container.Conta
 
 	cntrs := make([]*container.Container, 0, len(matches))
 	for id := range matches {
-		cntrs = append(cntrs, daemon.containers.Get(id))
+		if c := daemon.containers.Get(id); c != nil {
+			cntrs = append(cntrs, c)
+		}
 	}
 
 	// Restore sort-order after filtering


### PR DESCRIPTION
There can be a race between getting the container ids for matches and
getting the actual container.  This makes sure that we check that the
container returned by `Get` is non-nil before adding it to the list of
matches.

Fixes #25991

Signed-off-by: Michael Crosby crosbymichael@gmail.com
