### PR TITLE
Support container disconnect for non-existing network

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -15,6 +15,6 @@ type Backend interface {
 	GetNetworks() []libnetwork.Network
 	CreateNetwork(nc types.NetworkCreateRequest) (*types.NetworkCreateResponse, error)
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
-	DisconnectContainerFromNetwork(containerName string, network libnetwork.Network, force bool) error
+	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
 	DeleteNetwork(name string) error
 }

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -143,17 +143,14 @@ func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.Respon
 		return err
 	}
 
-	nw, err := n.backend.FindNetwork(vars["id"])
-	if err != nil {
-		return err
-	}
+	nw, _ := n.backend.FindNetwork(vars["id"])
 
-	if nw.Info().Dynamic() {
+	if nw != nil && nw.Info().Dynamic() {
 		err := fmt.Errorf("operation not supported for swarm scoped networks")
 		return errors.NewRequestForbiddenError(err)
 	}
 
-	return n.backend.DisconnectContainerFromNetwork(disconnect.Container, nw, disconnect.Force)
+	return n.backend.DisconnectContainerFromNetwork(disconnect.Container, vars["id"], disconnect.Force)
 }
 
 func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -618,8 +618,13 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 	return nil
 }
 
-// ForceEndpointDelete deletes an endpoing from a network forcefully
-func (daemon *Daemon) ForceEndpointDelete(name string, n libnetwork.Network) error {
+// ForceEndpointDelete deletes an endpoint from a network forcefully
+func (daemon *Daemon) ForceEndpointDelete(name string, networkName string) error {
+	n, err := daemon.FindNetwork(networkName)
+	if err != nil {
+		return err
+	}
+
 	ep, err := n.EndpointByName(name)
 	if err != nil {
 		return err

--- a/daemon/container_operations_solaris.go
+++ b/daemon/container_operations_solaris.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/container"
 	networktypes "github.com/docker/engine-api/types/network"
-	"github.com/docker/libnetwork"
 )
 
 func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]string, error) {
@@ -25,7 +24,7 @@ func (daemon *Daemon) getSize(container *container.Container) (int64, int64) {
 }
 
 // DisconnectFromNetwork disconnects a container from the network
-func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, n libnetwork.Network, force bool) error {
+func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, networkName string, force bool) error {
 	return fmt.Errorf("Solaris does not support disconnecting a running container from a network")
 }
 

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/docker/container"
 	networktypes "github.com/docker/engine-api/types/network"
-	"github.com/docker/libnetwork"
 )
 
 func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]string, error) {
@@ -20,7 +19,7 @@ func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName 
 }
 
 // DisconnectFromNetwork disconnects container from a network.
-func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, n libnetwork.Network, force bool) error {
+func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, networkName string, force bool) error {
 	return fmt.Errorf("Windows does not support disconnecting a running container from a network")
 }
 

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -316,15 +316,15 @@ func (daemon *Daemon) ConnectContainerToNetwork(containerName, networkName strin
 
 // DisconnectContainerFromNetwork disconnects the given container from
 // the given network. If either cannot be found, an err is returned.
-func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, network libnetwork.Network, force bool) error {
+func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error {
 	container, err := daemon.GetContainer(containerName)
 	if err != nil {
 		if force {
-			return daemon.ForceEndpointDelete(containerName, network)
+			return daemon.ForceEndpointDelete(containerName, networkName)
 		}
 		return err
 	}
-	return daemon.DisconnectFromNetwork(container, network, force)
+	return daemon.DisconnectFromNetwork(container, networkName, force)
 }
 
 // GetNetworkDriverList returns the list of plugins drivers


### PR DESCRIPTION
There are cases such as migrating from classic overlay network to the
swarm-mode networking (without kv-store), such a mechanism to allow
disconnecting a container even when a network isnt available will be
useful.

fixes #25624

Signed-off-by: Madhu Venugopal madhu@docker.com
