### PR TITLE
fix for PR #25903 - spec file support for Windows plugin discovery 

### DIFF
--- a/pkg/plugins/discovery_unix.go
+++ b/pkg/plugins/discovery_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package plugins
 
 var specsPaths = []string{"/etc/docker/plugins", "/usr/lib/docker/plugins"}

--- a/pkg/plugins/discovery_windows.go
+++ b/pkg/plugins/discovery_windows.go
@@ -5,4 +5,4 @@ import (
 	"path/filepath"
 )
 
-var specPaths = []string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")}
+var specsPaths = []string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")}


### PR DESCRIPTION
**\- What I did**
Fixed typo in pkg/plugins/discovery_windows.go (from #25903)
And added build tag for pkg/plugins/discovery_unix.go (unix is not a GOOS so file suffix is not enough)

**\- How I did it**
It's just a small fix. Without it docker on windows is still using "/etc/docker/plugins", "/usr/lib/docker/plugins"

**\- How to verify it**
Run a plugin. I used https://github.com/Azure/azurefile-dockervolumedriver (with small changes to run it on windows). Check if address from .spec file is used by docker.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Michal Wieczorek wieczorek-michal@wp.pl
