### PR TITLE
Fixes #25412 Clarify default PID value

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1455,7 +1455,7 @@ __docker_subcommand() {
         "($help)*--network-alias=[Add network-scoped alias for the container]:alias: "
         "($help)--oom-kill-disable[Disable OOM Killer]"
         "($help)--oom-score-adj[Tune the host's OOM preferences for containers (accepts -1000 to 1000)]"
-        "($help)--pids-limit[Tune container pids limit (set -1 for unlimited)]"
+        "($help)--pids-limit[Tune container pids limit (set < 0 for unlimited)]"
         "($help -P --publish-all)"{-P,--publish-all}"[Publish all exposed ports]"
         "($help)*"{-p=,--publish=}"[Expose a container's port to the host]:port:_ports"
         "($help)--pid=[PID namespace to use]:PID namespace:__docker_complete_pid"

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -83,7 +83,7 @@ Options:
       --oom-kill-disable            Disable OOM Killer
       --oom-score-adj int           Tune host's OOM preferences (-1000 to 1000)
       --pid string                  PID namespace to use
-      --pids-limit int              Tune container pids limit (set -1 for unlimited), kernel >= 4.3
+      --pids-limit int              Tune container pids limit (set < 0 for unlimited), kernel >= 4.3
       --privileged                  Give extended privileges to this container
   -p, --publish value               Publish a container's port(s) to the host (default [])
   -P, --publish-all                 Publish all exposed ports to random ports

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -89,7 +89,7 @@ Options:
       --oom-kill-disable            Disable OOM Killer
       --oom-score-adj int           Tune host's OOM preferences (-1000 to 1000)
       --pid string                  PID namespace to use
-      --pids-limit int              Tune container pids limit (set -1 for unlimited)
+      --pids-limit int              Tune container pids limit (set < 0 for unlimited)
       --privileged                  Give extended privileges to this container
   -p, --publish value               Publish a container's port(s) to the host (default [])
   -P, --publish-all                 Publish all exposed ports to random ports

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -233,7 +233,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.Int64Var(&copts.swappiness, "memory-swappiness", -1, "Tune container memory swappiness (0 to 100)")
 	flags.BoolVar(&copts.oomKillDisable, "oom-kill-disable", false, "Disable OOM Killer")
 	flags.IntVar(&copts.oomScoreAdj, "oom-score-adj", 0, "Tune host's OOM preferences (-1000 to 1000)")
-	flags.Int64Var(&copts.pidsLimit, "pids-limit", 0, "Tune container pids limit (set -1 for unlimited)")
+	flags.Int64Var(&copts.pidsLimit, "pids-limit", 0, "Tune container pids limit (set < 0 for unlimited)")
 
 	// Low-level execution (cgroups, namespaces, ...)
 	flags.StringVar(&copts.cgroupParent, "cgroup-parent", "", "Optional parent cgroup for the container")


### PR DESCRIPTION
**\- What I did**

The current docs say to set it to -1 for unlimited, but in reality anything other
than a positive integer will result in unlimited. First attempt to try to clarify that.

**\- How I did it**
Updated all files which used or reused the help text.

**\- How to verify it**
Rebuild the client and docs and check the usage strings

**\- Description for the changelog**
Clarify that the default PID value of 0 means unlimited processes, not 0 processes.

**\- A picture of a cute animal (not mandatory but encouraged)**
