### PR TITLE
integration-cli: fix TestImportBadURL w/o network

### DIFF
--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -37,6 +37,7 @@ func (s *DockerSuite) TestImportBadURL(c *check.C) {
 	c.Assert(err, checker.NotNil, check.Commentf("import was supposed to fail but didn't"))
 	// Depending on your system you can get either of these errors
 	if !strings.Contains(out, "dial tcp") &&
+		!strings.Contains(out, "ApplyLayer exit status 1 stdout:  stderr: archive/tar: invalid tar header") &&
 		!strings.Contains(out, "Error processing tar file") {
 		c.Fatalf("expected an error msg but didn't get one.\nErr: %v\nOut: %v", err, out)
 	}


### PR DESCRIPTION
As explained in the test comment itself, the error message may vary on
different platform (https://github.com/docker/docker/compare/master...runcom:fix-TestImportBadURL?expand=1#diff-cf2b675ae05fcdf56b7e02753365b572R38).
This patch adds another condition found while testing w/o network
access on RHEL based distros (Fedora, RHEL, CentOS).

Signed-off-by: Antonio Murdaca runcom@redhat.com
