### PR TITLE
remove running judgement when unpause container

### DIFF
--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -25,11 +25,6 @@ func (daemon *Daemon) containerUnpause(container *container.Container) error {
 	container.Lock()
 	defer container.Unlock()
 
-	// We cannot unpause the container which is not running
-	if !container.Running {
-		return errNotRunning{container.ID}
-	}
-
 	// We cannot unpause the container which is not paused
 	if !container.Paused {
 		return fmt.Errorf("Container %s is not paused", container.ID)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
fixes #26078 

remove code infers that unpause a container should judge if it is running.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
