### PR TITLE
Add docs for "--containerd" in dockerd

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -594,6 +594,14 @@ The Docker daemon relies on a
 (invoked via the `containerd` daemon) as its interface to the Linux
 kernel `namespaces`, `cgroups`, and `SELinux`.
 
+By default, the Docker daemon automatically starts `containerd`. If you want to
+control `containerd` startup, manually start `containerd` and pass the path to
+the `containerd` socket using the `--containerd` flag. For example:
+
+```bash
+$ dockerd --containerd /var/run/dev/docker-containerd.sock
+```
+
 Runtimes can be registered with the daemon either via the
 configuration file or using the `--add-runtime` command line argument.
 


### PR DESCRIPTION
**Why I add docs for Docker daemon's `--containerd` option**

When I was trying to use `--containerd` option of `dockerd`, I cannot find any detail docs.

Here is some of my assumptions.
1. `--containerd` needs the path to containerd socket. I thought it accepted a string, with `unix://` prefix, just like `-H` did.
2. I thought `dockerd` will automatically run a `containerd` with my customized socket address, just like `-H` did.

BUT, I found that I was wrong.
1. `--containerd` doesn't need the `unix://` prefix.
2. If I use `--containerd` option, `dockerd` will not run a `containerd` for me. I didn't realized this root cause until I read the [source code](https://github.com/docker/docker/blob/v1.12.1/cmd/dockerd/daemon_unix.go#L66-L70). `remote.startDaemon` will be set to `false` if using `--containerd`.

IMHO, some docs should be added to make these things clear.

Signed-off-by: ohmystack jiangjun1990@gmail.com
