### PR TITLE
validate build-arg

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -62,7 +62,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	ulimits := make(map[string]*units.Ulimit)
 	options := buildOptions{
 		tags:      opts.NewListOpts(validateTag),
-		buildArgs: opts.NewListOpts(runconfigopts.ValidateEnv),
+		buildArgs: opts.NewListOpts(runconfigopts.ValidateArg),
 		ulimits:   runconfigopts.NewUlimitOpt(&ulimits),
 	}
 

--- a/runconfig/opts/opts.go
+++ b/runconfig/opts/opts.go
@@ -46,6 +46,21 @@ func doesEnvExist(name string) bool {
 	return false
 }
 
+// ValidateArg validates a build-arg variable and returns it.
+// Build-arg is in the form of <varname>=<value> where <varname> is required.
+func ValidateArg(val string) (string, error) {
+	arr := strings.Split(val, "=")
+	if len(arr) > 1 && isNotEmpty(arr[0]) {
+		return val, nil
+	}
+
+	return "", fmt.Errorf("bad format for build-arg: %s", val)
+}
+
+func isNotEmpty(val string) bool {
+	return len(val) > 0
+}
+
 // ValidateExtraHost validates that the specified string is a valid extrahost and returns it.
 // ExtraHost is in the form of name:ip where the ip has to be a valid ip (IPv4 or IPv6).
 func ValidateExtraHost(val string) (string, error) {

--- a/runconfig/opts/opts_test.go
+++ b/runconfig/opts/opts_test.go
@@ -61,6 +61,42 @@ func TestValidateEnv(t *testing.T) {
 	}
 }
 
+func TestValidateArg(t *testing.T) {
+	valids := map[string]string{
+		"_=a":                "_=a",
+		"var1=value1":        "var1=value1",
+		"_var1=value1":       "_var1=value1",
+		"var2=value2=value3": "var2=value2=value3",
+		"var3=abc!qwe":       "var3=abc!qwe",
+		"var_4=value 4":      "var_4=value 4",
+		"var_5=":             "var_5=",
+	}
+	for value, expected := range valids {
+		actual, err := ValidateArg(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual != expected {
+			t.Fatalf("Expected [%v], got [%v]", expected, actual)
+		}
+	}
+
+	invalid := map[string]string{
+		"foo":  "bad format",
+		"=foo": "bad format",
+		"cc c": "bad format",
+	}
+	for value, expectedError := range invalid {
+		if _, err := ValidateArg(value); err == nil {
+			t.Fatalf("ValidateArg(`%s`) should have failed validation", value)
+		} else {
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Fatalf("ValidateArg(`%s`) error should contain %q", value, expectedError)
+			}
+		}
+	}
+}
+
 func TestValidateExtraHosts(t *testing.T) {
 	valid := []string{
 		`myhost:192.168.0.1`,


### PR DESCRIPTION
fixes #24101

**\- What I did**
fixes #24101
Build-arg is in the form of <varname>=<value>
1. <varname> is required, but <value> not
2. Shouldn't use env arg as a build-arg.
**\- How I did it**
Add validateArg
**\- How to verify it**
Some tests in runconfig/opts/opts_test.go
**\- Description for the changelog**

Signed-off-by: sakeven jc5930@sina.cn
