### PR TITLE
Shrink the DockerCLI type

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -31,27 +31,24 @@ type DockerCli struct {
 	// configFile has the client configuration file
 	configFile *configfile.ConfigFile
 	// in holds the input stream and closer (io.ReadCloser) for the client.
+	// TODO: remove
 	in io.ReadCloser
-	// out holds the output stream (io.Writer) for the client.
-	out io.Writer
 	// err holds the error stream (io.Writer) for the client.
 	err io.Writer
 	// keyFile holds the key file as a string.
 	keyFile string
 	// inFd holds the file descriptor of the client's STDIN (if valid).
+	// TODO: remove
 	inFd uintptr
-	// outFd holds file descriptor of the client's STDOUT (if valid).
-	outFd uintptr
 	// isTerminalIn indicates whether the client's STDIN is a TTY
+	// TODO: remove
 	isTerminalIn bool
-	// isTerminalOut indicates whether the client's STDOUT is a TTY
-	isTerminalOut bool
 	// client is the http client that performs all API operations
 	client client.APIClient
 	// inState holds the terminal input state
+	// TODO: remove
 	inState *term.State
-	// outState holds the terminal output state
-	outState *term.State
+	out     *OutStream
 }
 
 // Client returns the APIClient
@@ -60,7 +57,7 @@ func (cli *DockerCli) Client() client.APIClient {
 }
 
 // Out returns the writer used for stdout
-func (cli *DockerCli) Out() io.Writer {
+func (cli *DockerCli) Out() *OutStream {
 	return cli.out
 }
 
@@ -80,18 +77,9 @@ func (cli *DockerCli) ConfigFile() *configfile.ConfigFile {
 }
 
 // IsTerminalIn returns true if the clients stdin is a TTY
+// TODO: remove
 func (cli *DockerCli) IsTerminalIn() bool {
 	return cli.isTerminalIn
-}
-
-// IsTerminalOut returns true if the clients stdout is a TTY
-func (cli *DockerCli) IsTerminalOut() bool {
-	return cli.isTerminalOut
-}
-
-// OutFd returns the fd for the stdout stream
-func (cli *DockerCli) OutFd() uintptr {
-	return cli.outFd
 }
 
 // CheckTtyInput checks if we are trying to attach to a container tty
@@ -119,12 +107,8 @@ func (cli *DockerCli) setRawTerminal() error {
 			}
 			cli.inState = state
 		}
-		if cli.isTerminalOut {
-			state, err := term.SetRawTerminalOutput(cli.outFd)
-			if err != nil {
-				return err
-			}
-			cli.outState = state
+		if err := cli.out.setRawTerminal(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -134,9 +118,7 @@ func (cli *DockerCli) restoreTerminal(in io.Closer) error {
 	if cli.inState != nil {
 		term.RestoreTerminal(cli.inFd, cli.inState)
 	}
-	if cli.outState != nil {
-		term.RestoreTerminal(cli.outFd, cli.outState)
-	}
+	cli.out.restoreTerminal()
 	// WARNING: DO NOT REMOVE THE OS CHECK !!!
 	// For some reason this Close call blocks on darwin..
 	// As the client exists right after, simply discard the close
@@ -149,21 +131,16 @@ func (cli *DockerCli) restoreTerminal(in io.Closer) error {
 
 // Initialize the dockerCli runs initialization that must happen after command
 // line flags are parsed.
-func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
+func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) (err error) {
 	cli.configFile = LoadDefaultConfigFile(cli.err)
 
-	client, err := NewAPIClientFromFlags(opts.Common, cli.configFile)
+	cli.client, err = NewAPIClientFromFlags(opts.Common, cli.configFile)
 	if err != nil {
 		return err
 	}
 
-	cli.client = client
-
 	if cli.in != nil {
 		cli.inFd, cli.isTerminalIn = term.GetFdInfo(cli.in)
-	}
-	if cli.out != nil {
-		cli.outFd, cli.isTerminalOut = term.GetFdInfo(cli.out)
 	}
 
 	if opts.Common.TrustKey == "" {
@@ -177,11 +154,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 
 // NewDockerCli returns a DockerCli instance with IO output and error streams set by in, out and err.
 func NewDockerCli(in io.ReadCloser, out, err io.Writer) *DockerCli {
-	return &DockerCli{
-		in:  in,
-		out: out,
-		err: err,
-	}
+	return &DockerCli{in: in, out: NewOutStream(out), err: err}
 }
 
 // LoadDefaultConfigFile attempts to load the default config file and returns

--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -57,31 +57,12 @@ func (cli *DockerCli) ConfigFile() *configfile.ConfigFile {
 	return cli.configFile
 }
 
-func (cli *DockerCli) setRawTerminal() error {
-	if err := cli.in.setRawTerminal(); err != nil {
-		return err
-	}
-	return cli.out.setRawTerminal()
-}
-
-func (cli *DockerCli) restoreTerminal(in io.Closer) error {
-	cli.in.restoreTerminal()
-	cli.out.restoreTerminal()
-	// WARNING: DO NOT REMOVE THE OS CHECK !!!
-	// For some reason this Close call blocks on darwin..
-	// As the client exists right after, simply discard the close
-	// until we find a better solution.
-	if in != nil && runtime.GOOS != "darwin" {
-		return in.Close()
-	}
-	return nil
-}
-
 // Initialize the dockerCli runs initialization that must happen after command
 // line flags are parsed.
-func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) (err error) {
+func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 	cli.configFile = LoadDefaultConfigFile(cli.err)
 
+	var err error
 	cli.client, err = NewAPIClientFromFlags(opts.Common, cli.configFile)
 	if err != nil {
 		return err

--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -110,7 +110,7 @@ func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 			logrus.Debugf("Error monitoring TTY size: %s", err)
 		}
 	}
-	if err := dockerCli.HoldHijackedConnection(ctx, c.Config.Tty, in, dockerCli.Out(), dockerCli.Err(), resp); err != nil {
+	if err := holdHijackedConnection(ctx, dockerCli, c.Config.Tty, in, dockerCli.Out(), dockerCli.Err(), resp); err != nil {
 		return err
 	}
 

--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -60,7 +60,7 @@ func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 		return fmt.Errorf("You cannot attach to a paused container, unpause it first")
 	}
 
-	if err := dockerCli.CheckTtyInput(!opts.noStdin, c.Config.Tty); err != nil {
+	if err := dockerCli.In().CheckTty(!opts.noStdin, c.Config.Tty); err != nil {
 		return err
 	}
 

--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -46,8 +46,9 @@ func NewAttachCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 	ctx := context.Background()
+	client := dockerCli.Client()
 
-	c, err := dockerCli.Client().ContainerInspect(ctx, opts.container)
+	c, err := client.ContainerInspect(ctx, opts.container)
 	if err != nil {
 		return err
 	}
@@ -82,11 +83,11 @@ func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 	}
 
 	if opts.proxy && !c.Config.Tty {
-		sigc := dockerCli.ForwardAllSignals(ctx, opts.container)
+		sigc := ForwardAllSignals(ctx, dockerCli, opts.container)
 		defer signal.StopCatch(sigc)
 	}
 
-	resp, errAttach := dockerCli.Client().ContainerAttach(ctx, opts.container, options)
+	resp, errAttach := client.ContainerAttach(ctx, opts.container, options)
 	if errAttach != nil && errAttach != httputil.ErrPersistEOF {
 		// ContainerAttach returns an ErrPersistEOF (connection closed)
 		// means server met an error and put it in Hijacked connection
@@ -101,11 +102,11 @@ func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 		// terminal, the only way to get the shell prompt to display for attaches 2+ is to artificially
 		// resize it, then go back to normal. Without this, every attach after the first will
 		// require the user to manually resize or hit enter.
-		dockerCli.ResizeTtyTo(ctx, opts.container, height+1, width+1, false)
+		resizeTtyTo(ctx, client, opts.container, height+1, width+1, false)
 
 		// After the above resizing occurs, the call to MonitorTtySize below will handle resetting back
 		// to the actual size.
-		if err := dockerCli.MonitorTtySize(ctx, opts.container, false); err != nil {
+		if err := MonitorTtySize(ctx, dockerCli, opts.container, false); err != nil {
 			logrus.Debugf("Error monitoring TTY size: %s", err)
 		}
 	}

--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -95,8 +95,8 @@ func runAttach(dockerCli *client.DockerCli, opts *attachOptions) error {
 	}
 	defer resp.Close()
 
-	if c.Config.Tty && dockerCli.IsTerminalOut() {
-		height, width := dockerCli.GetTtySize()
+	if c.Config.Tty && dockerCli.Out().IsTerminal() {
+		height, width := dockerCli.Out().GetTtySize()
 		// To handle the case where a user repeatedly attaches/detaches without resizing their
 		// terminal, the only way to get the shell prompt to display for attaches 2+ is to artificially
 		// resize it, then go back to normal. Without this, every attach after the first will

--- a/api/client/container/create.go
+++ b/api/client/container/create.go
@@ -103,8 +103,8 @@ func pullImage(ctx context.Context, dockerCli *client.DockerCli, image string, o
 	return jsonmessage.DisplayJSONMessagesStream(
 		responseBody,
 		out,
-		dockerCli.OutFd(),
-		dockerCli.IsTerminalOut(),
+		dockerCli.Out().FD(),
+		dockerCli.Out().IsTerminal(),
 		nil)
 }
 

--- a/api/client/container/exec.go
+++ b/api/client/container/exec.go
@@ -11,6 +11,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/promise"
+	apiclient "github.com/docker/docker/client"
+	"github.com/docker/engine-api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -66,8 +68,9 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 	execConfig.DetachKeys = dockerCli.ConfigFile().DetachKeys
 
 	ctx := context.Background()
+	client := dockerCli.Client()
 
-	response, err := dockerCli.Client().ContainerExecCreate(ctx, container, *execConfig)
+	response, err := client.ContainerExecCreate(ctx, container, *execConfig)
 	if err != nil {
 		return err
 	}
@@ -89,7 +92,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 			Tty:    execConfig.Tty,
 		}
 
-		if err := dockerCli.Client().ContainerExecStart(ctx, execID, execStartCheck); err != nil {
+		if err := client.ContainerExecStart(ctx, execID, execStartCheck); err != nil {
 			return err
 		}
 		// For now don't print this - wait for when we support exec wait()
@@ -118,7 +121,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 		}
 	}
 
-	resp, err := dockerCli.Client().ContainerExecAttach(ctx, execID, *execConfig)
+	resp, err := client.ContainerExecAttach(ctx, execID, *execConfig)
 	if err != nil {
 		return err
 	}
@@ -128,7 +131,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 	})
 
 	if execConfig.Tty && dockerCli.In().IsTerminal() {
-		if err := dockerCli.MonitorTtySize(ctx, execID, true); err != nil {
+		if err := MonitorTtySize(ctx, dockerCli, execID, true); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "Error monitoring TTY size: %s\n", err)
 		}
 	}
@@ -139,7 +142,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 	}
 
 	var status int
-	if _, status, err = dockerCli.GetExecExitCode(ctx, execID); err != nil {
+	if _, status, err = getExecExitCode(ctx, client, execID); err != nil {
 		return err
 	}
 
@@ -148,6 +151,21 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 	}
 
 	return nil
+}
+
+// getExecExitCode perform an inspect on the exec command. It returns
+// the running state and the exit code.
+func getExecExitCode(ctx context.Context, client apiclient.ContainerAPIClient, execID string) (bool, int, error) {
+	resp, err := client.ContainerExecInspect(ctx, execID)
+	if err != nil {
+		// If we can't connect, then the daemon probably died.
+		if err != apiclient.ErrConnectionFailed {
+			return false, -1, err
+		}
+		return false, -1, nil
+	}
+
+	return resp.Running, resp.ExitCode, nil
 }
 
 // parseExec parses the specified args for the specified command and generates

--- a/api/client/container/exec.go
+++ b/api/client/container/exec.go
@@ -10,9 +10,8 @@ import (
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
-	"github.com/docker/docker/pkg/promise"
 	apiclient "github.com/docker/docker/client"
-	"github.com/docker/engine-api/types"
+	"github.com/docker/docker/pkg/promise"
 	"github.com/spf13/cobra"
 )
 
@@ -127,7 +126,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 	}
 	defer resp.Close()
 	errCh = promise.Go(func() error {
-		return dockerCli.HoldHijackedConnection(ctx, execConfig.Tty, in, out, stderr, resp)
+		return holdHijackedConnection(ctx, dockerCli, execConfig.Tty, in, out, stderr, resp)
 	})
 
 	if execConfig.Tty && dockerCli.In().IsTerminal() {

--- a/api/client/container/exec.go
+++ b/api/client/container/exec.go
@@ -80,7 +80,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 
 	//Temp struct for execStart so that we don't need to transfer all the execConfig
 	if !execConfig.Detach {
-		if err := dockerCli.CheckTtyInput(execConfig.AttachStdin, execConfig.Tty); err != nil {
+		if err := dockerCli.In().CheckTty(execConfig.AttachStdin, execConfig.Tty); err != nil {
 			return err
 		}
 	} else {
@@ -127,7 +127,7 @@ func runExec(dockerCli *client.DockerCli, opts *execOptions, container string, e
 		return dockerCli.HoldHijackedConnection(ctx, execConfig.Tty, in, out, stderr, resp)
 	})
 
-	if execConfig.Tty && dockerCli.IsTerminalIn() {
+	if execConfig.Tty && dockerCli.In().IsTerminal() {
 		if err := dockerCli.MonitorTtySize(ctx, execID, true); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "Error monitoring TTY size: %s\n", err)
 		}

--- a/api/client/container/export.go
+++ b/api/client/container/export.go
@@ -38,7 +38,7 @@ func NewExportCommand(dockerCli *client.DockerCli) *cobra.Command {
 }
 
 func runExport(dockerCli *client.DockerCli, opts exportOptions) error {
-	if opts.output == "" && dockerCli.IsTerminalOut() {
+	if opts.output == "" && dockerCli.Out().IsTerminal() {
 		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
 	}
 

--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -135,7 +135,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 	// a far better user experience rather than relying on subsequent resizes
 	// to cause things to catch up.
 	if runtime.GOOS == "windows" {
-		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = dockerCli.GetTtySize()
+		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = dockerCli.Out().GetTtySize()
 	}
 
 	ctx, cancelFun := context.WithCancel(context.Background())
@@ -234,7 +234,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		return runStartContainerErr(err)
 	}
 
-	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && dockerCli.IsTerminalOut() {
+	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && dockerCli.Out().IsTerminal() {
 		if err := dockerCli.MonitorTtySize(ctx, createResponse.ID, false); err != nil {
 			fmt.Fprintf(stderr, "Error monitoring TTY size: %s\n", err)
 		}

--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -109,7 +109,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 	config.ArgsEscaped = false
 
 	if !opts.detach {
-		if err := dockerCli.CheckTtyInput(config.AttachStdin, config.Tty); err != nil {
+		if err := dockerCli.In().CheckTty(config.AttachStdin, config.Tty); err != nil {
 			return err
 		}
 	} else {

--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -203,7 +203,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		defer resp.Close()
 
 		errCh = promise.Go(func() error {
-			errHijack := dockerCli.HoldHijackedConnection(ctx, config.Tty, in, out, cerr, resp)
+			errHijack := holdHijackedConnection(ctx, dockerCli, config.Tty, in, out, cerr, resp)
 			if errHijack == nil {
 				return errAttach
 			}

--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -146,7 +146,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 		return runStartContainerErr(err)
 	}
 	if opts.sigProxy {
-		sigc := dockerCli.ForwardAllSignals(ctx, createResponse.ID)
+		sigc := ForwardAllSignals(ctx, dockerCli, createResponse.ID)
 		defer signal.StopCatch(sigc)
 	}
 	var (
@@ -235,7 +235,7 @@ func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions,
 	}
 
 	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && dockerCli.Out().IsTerminal() {
-		if err := dockerCli.MonitorTtySize(ctx, createResponse.ID, false); err != nil {
+		if err := MonitorTtySize(ctx, dockerCli, createResponse.ID, false); err != nil {
 			fmt.Fprintf(stderr, "Error monitoring TTY size: %s\n", err)
 		}
 	}

--- a/api/client/container/start.go
+++ b/api/client/container/start.go
@@ -118,7 +118,7 @@ func runStart(dockerCli *client.DockerCli, opts *startOptions) error {
 		}
 
 		// 5. Wait for attachment to break.
-		if c.Config.Tty && dockerCli.IsTerminalOut() {
+		if c.Config.Tty && dockerCli.Out().IsTerminal() {
 			if err := dockerCli.MonitorTtySize(ctx, c.ID, false); err != nil {
 				fmt.Fprintf(dockerCli.Err(), "Error monitoring TTY size: %s\n", err)
 			}

--- a/api/client/container/start.go
+++ b/api/client/container/start.go
@@ -95,7 +95,7 @@ func runStart(dockerCli *client.DockerCli, opts *startOptions) error {
 		}
 		defer resp.Close()
 		cErr := promise.Go(func() error {
-			errHijack := dockerCli.HoldHijackedConnection(ctx, c.Config.Tty, in, dockerCli.Out(), dockerCli.Err(), resp)
+			errHijack := holdHijackedConnection(ctx, dockerCli, c.Config.Tty, in, dockerCli.Out(), dockerCli.Err(), resp)
 			if errHijack == nil {
 				return errAttach
 			}

--- a/api/client/container/start.go
+++ b/api/client/container/start.go
@@ -64,7 +64,7 @@ func runStart(dockerCli *client.DockerCli, opts *startOptions) error {
 
 		// We always use c.ID instead of container to maintain consistency during `docker start`
 		if !c.Config.Tty {
-			sigc := dockerCli.ForwardAllSignals(ctx, c.ID)
+			sigc := ForwardAllSignals(ctx, dockerCli, c.ID)
 			defer signal.StopCatch(sigc)
 		}
 
@@ -119,7 +119,7 @@ func runStart(dockerCli *client.DockerCli, opts *startOptions) error {
 
 		// 5. Wait for attachment to break.
 		if c.Config.Tty && dockerCli.Out().IsTerminal() {
-			if err := dockerCli.MonitorTtySize(ctx, c.ID, false); err != nil {
+			if err := MonitorTtySize(ctx, dockerCli, c.ID, false); err != nil {
 				fmt.Fprintf(dockerCli.Err(), "Error monitoring TTY size: %s\n", err)
 			}
 		}

--- a/api/client/container/tty.go
+++ b/api/client/container/tty.go
@@ -1,0 +1,103 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	gosignal "os/signal"
+	"runtime"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/pkg/signal"
+	apiclient "github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// ResizeTtyTo resizes tty to specific height and width
+func resizeTtyTo(ctx context.Context, client apiclient.ContainerAPIClient, id string, height, width int, isExec bool) {
+	if height == 0 && width == 0 {
+		return
+	}
+
+	options := types.ResizeOptions{
+		Height: height,
+		Width:  width,
+	}
+
+	var err error
+	if isExec {
+		err = client.ContainerExecResize(ctx, id, options)
+	} else {
+		err = client.ContainerResize(ctx, id, options)
+	}
+
+	if err != nil {
+		logrus.Debugf("Error resize: %s", err)
+	}
+}
+
+// MonitorTtySize updates the container tty size when the terminal tty changes size
+func MonitorTtySize(ctx context.Context, cli *client.DockerCli, id string, isExec bool) error {
+	resizeTty := func() {
+		height, width := cli.Out().GetTtySize()
+		resizeTtyTo(ctx, cli.Client(), id, height, width, isExec)
+	}
+
+	resizeTty()
+
+	if runtime.GOOS == "windows" {
+		go func() {
+			prevH, prevW := cli.Out().GetTtySize()
+			for {
+				time.Sleep(time.Millisecond * 250)
+				h, w := cli.Out().GetTtySize()
+
+				if prevW != w || prevH != h {
+					resizeTty()
+				}
+				prevH = h
+				prevW = w
+			}
+		}()
+	} else {
+		sigchan := make(chan os.Signal, 1)
+		gosignal.Notify(sigchan, signal.SIGWINCH)
+		go func() {
+			for range sigchan {
+				resizeTty()
+			}
+		}()
+	}
+	return nil
+}
+
+// ForwardAllSignals forwards signals to the container
+func ForwardAllSignals(ctx context.Context, cli *client.DockerCli, cid string) chan os.Signal {
+	sigc := make(chan os.Signal, 128)
+	signal.CatchAll(sigc)
+	go func() {
+		for s := range sigc {
+			if s == signal.SIGCHLD || s == signal.SIGPIPE {
+				continue
+			}
+			var sig string
+			for sigStr, sigN := range signal.SignalMap {
+				if sigN == s {
+					sig = sigStr
+					break
+				}
+			}
+			if sig == "" {
+				fmt.Fprintf(cli.Err(), "Unsupported signal: %v. Discarding.\n", s)
+				continue
+			}
+
+			if err := cli.Client().ContainerKill(ctx, cid, sig); err != nil {
+				logrus.Debugf("Error sending signal: %s", err)
+			}
+		}
+	}()
+	return sigc
+}

--- a/api/client/container/tty.go
+++ b/api/client/container/tty.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/api/types"
+	apiclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/signal"
-	apiclient "github.com/docker/engine-api/client"
-	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
-// ResizeTtyTo resizes tty to specific height and width
+// resizeTtyTo resizes tty to specific height and width
 func resizeTtyTo(ctx context.Context, client apiclient.ContainerAPIClient, id string, height, width int, isExec bool) {
 	if height == 0 && width == 0 {
 		return

--- a/api/client/image/build.go
+++ b/api/client/image/build.go
@@ -227,7 +227,7 @@ func runBuild(dockerCli *client.DockerCli, options buildOptions) error {
 
 	// Setup an upload progress bar
 	progressOutput := streamformatter.NewStreamFormatter().NewProgressOutput(progBuff, true)
-	if !dockerCli.IsTerminalOut() {
+	if !dockerCli.Out().IsTerminal() {
 		progressOutput = &lastProgressOutput{output: progressOutput}
 	}
 
@@ -293,7 +293,7 @@ func runBuild(dockerCli *client.DockerCli, options buildOptions) error {
 	}
 	defer response.Body.Close()
 
-	err = jsonmessage.DisplayJSONMessagesStream(response.Body, buildBuff, dockerCli.OutFd(), dockerCli.IsTerminalOut(), nil)
+	err = jsonmessage.DisplayJSONMessagesStream(response.Body, buildBuff, dockerCli.Out().FD(), dockerCli.Out().IsTerminal(), nil)
 	if err != nil {
 		if jerr, ok := err.(*jsonmessage.JSONError); ok {
 			// If no error code is set, default to 1

--- a/api/client/image/import.go
+++ b/api/client/image/import.go
@@ -84,5 +84,5 @@ func runImport(dockerCli *client.DockerCli, opts importOptions) error {
 	}
 	defer responseBody.Close()
 
-	return jsonmessage.DisplayJSONMessagesStream(responseBody, dockerCli.Out(), dockerCli.OutFd(), dockerCli.IsTerminalOut(), nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
 }

--- a/api/client/image/load.go
+++ b/api/client/image/load.go
@@ -49,7 +49,7 @@ func runLoad(dockerCli *client.DockerCli, opts loadOptions) error {
 		defer file.Close()
 		input = file
 	}
-	if !dockerCli.IsTerminalOut() {
+	if !dockerCli.Out().IsTerminal() {
 		opts.quiet = true
 	}
 	response, err := dockerCli.Client().ImageLoad(context.Background(), input, opts.quiet)
@@ -59,7 +59,7 @@ func runLoad(dockerCli *client.DockerCli, opts loadOptions) error {
 	defer response.Body.Close()
 
 	if response.Body != nil && response.JSON {
-		return jsonmessage.DisplayJSONMessagesStream(response.Body, dockerCli.Out(), dockerCli.OutFd(), dockerCli.IsTerminalOut(), nil)
+		return jsonmessage.DisplayJSONMessagesToStream(response.Body, dockerCli.Out(), nil)
 	}
 
 	_, err = io.Copy(dockerCli.Out(), response.Body)

--- a/api/client/image/push.go
+++ b/api/client/image/push.go
@@ -57,6 +57,5 @@ func runPush(dockerCli *client.DockerCli, remote string) error {
 	}
 
 	defer responseBody.Close()
-
-	return jsonmessage.DisplayJSONMessagesStream(responseBody, dockerCli.Out(), dockerCli.OutFd(), dockerCli.IsTerminalOut(), nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
 }

--- a/api/client/image/save.go
+++ b/api/client/image/save.go
@@ -38,7 +38,7 @@ func NewSaveCommand(dockerCli *client.DockerCli) *cobra.Command {
 }
 
 func runSave(dockerCli *client.DockerCli, opts saveOptions) error {
-	if opts.output == "" && dockerCli.IsTerminalOut() {
+	if opts.output == "" && dockerCli.Out().IsTerminal() {
 		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
 	}
 

--- a/api/client/in.go
+++ b/api/client/in.go
@@ -36,7 +36,8 @@ func (i *InStream) IsTerminal() bool {
 	return i.isTerminal
 }
 
-func (i *InStream) setRawTerminal() (err error) {
+// SetRawTerminal sets raw mode on the input terminal
+func (i *InStream) SetRawTerminal() (err error) {
 	if os.Getenv("NORAW") != "" || !i.isTerminal {
 		return nil
 	}
@@ -44,7 +45,8 @@ func (i *InStream) setRawTerminal() (err error) {
 	return err
 }
 
-func (i *InStream) restoreTerminal() {
+// RestoreTerminal restores normal mode to the terminal
+func (i *InStream) RestoreTerminal() {
 	if i.state != nil {
 		term.RestoreTerminal(i.fd, i.state)
 	}

--- a/api/client/in.go
+++ b/api/client/in.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"errors"
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/docker/docker/pkg/term"
+)
+
+// InStream is an input stream used by the DockerCli to read user input
+type InStream struct {
+	in         io.ReadCloser
+	fd         uintptr
+	isTerminal bool
+	state      *term.State
+}
+
+func (i *InStream) Read(p []byte) (int, error) {
+	return i.in.Read(p)
+}
+
+// Close implements the Closer interface
+func (i *InStream) Close() error {
+	return i.in.Close()
+}
+
+// FD returns the file descriptor number for this stream
+func (i *InStream) FD() uintptr {
+	return i.fd
+}
+
+// IsTerminal returns true if this stream is connected to a terminal
+func (i *InStream) IsTerminal() bool {
+	return i.isTerminal
+}
+
+func (i *InStream) setRawTerminal() (err error) {
+	if os.Getenv("NORAW") != "" || !i.isTerminal {
+		return nil
+	}
+	i.state, err = term.SetRawTerminal(i.fd)
+	return err
+}
+
+func (i *InStream) restoreTerminal() {
+	if i.state != nil {
+		term.RestoreTerminal(i.fd, i.state)
+	}
+}
+
+// CheckTty checks if we are trying to attach to a container tty
+// from a non-tty client input stream, and if so, returns an error.
+func (i *InStream) CheckTty(attachStdin, ttyMode bool) error {
+	// In order to attach to a container tty, input stream for the client must
+	// be a tty itself: redirecting or piping the client standard input is
+	// incompatible with `docker run -t`, `docker exec -t` or `docker attach`.
+	if ttyMode && attachStdin && !i.isTerminal {
+		eText := "the input device is not a TTY"
+		if runtime.GOOS == "windows" {
+			return errors.New(eText + ".  If you are using mintty, try prefixing the command with 'winpty'")
+		}
+		return errors.New(eText)
+	}
+	return nil
+}
+
+// NewInStream returns a new OutStream object from a Writer
+func NewInStream(in io.ReadCloser) *InStream {
+	fd, isTerminal := term.GetFdInfo(in)
+	return &InStream{in: in, fd: fd, isTerminal: isTerminal}
+}

--- a/api/client/out.go
+++ b/api/client/out.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"io"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/term"
+)
+
+// OutStream is an output stream used by the DockerCli to write normal program
+// output.
+type OutStream struct {
+	out        io.Writer
+	fd         uintptr
+	isTerminal bool
+	state      *term.State
+}
+
+func (o *OutStream) Write(p []byte) (int, error) {
+	return o.out.Write(p)
+}
+
+// FD returns the file descriptor number for this stream
+func (o *OutStream) FD() uintptr {
+	return o.fd
+}
+
+// IsTerminal returns true if this stream is connected to a terminal
+func (o *OutStream) IsTerminal() bool {
+	return o.isTerminal
+}
+
+func (o *OutStream) setRawTerminal() (err error) {
+	if os.Getenv("NORAW") != "" || !o.isTerminal {
+		return nil
+	}
+	o.state, err = term.SetRawTerminalOutput(o.fd)
+	return err
+}
+
+func (o *OutStream) restoreTerminal() {
+	if o.state != nil {
+		term.RestoreTerminal(o.fd, o.state)
+	}
+}
+
+// GetTtySize returns the height and width in characters of the tty
+func (o *OutStream) GetTtySize() (int, int) {
+	if !o.isTerminal {
+		return 0, 0
+	}
+	ws, err := term.GetWinsize(o.fd)
+	if err != nil {
+		logrus.Debugf("Error getting size: %s", err)
+		if ws == nil {
+			return 0, 0
+		}
+	}
+	return int(ws.Height), int(ws.Width)
+}
+
+// NewOutStream returns a new OutStream object from a Writer
+func NewOutStream(out io.Writer) *OutStream {
+	fd, isTerminal := term.GetFdInfo(out)
+	return &OutStream{out: out, fd: fd, isTerminal: isTerminal}
+}

--- a/api/client/out.go
+++ b/api/client/out.go
@@ -31,7 +31,8 @@ func (o *OutStream) IsTerminal() bool {
 	return o.isTerminal
 }
 
-func (o *OutStream) setRawTerminal() (err error) {
+// SetRawTerminal sets raw mode on the output terminal
+func (o *OutStream) SetRawTerminal() (err error) {
 	if os.Getenv("NORAW") != "" || !o.isTerminal {
 		return nil
 	}
@@ -39,7 +40,8 @@ func (o *OutStream) setRawTerminal() (err error) {
 	return err
 }
 
-func (o *OutStream) restoreTerminal() {
+// RestoreTerminal restores normal mode to the terminal
+func (o *OutStream) RestoreTerminal() {
 	if o.state != nil {
 		term.RestoreTerminal(o.fd, o.state)
 	}

--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -440,14 +440,14 @@ func (cli *DockerCli) TrustedPush(ctx context.Context, repoInfo *registry.Reposi
 	// We want trust signatures to always take an explicit tag,
 	// otherwise it will act as an untrusted push.
 	if tag == "" {
-		if err = jsonmessage.DisplayJSONMessagesStream(responseBody, cli.out, cli.outFd, cli.isTerminalOut, nil); err != nil {
+		if err = jsonmessage.DisplayJSONMessagesToStream(responseBody, cli.Out(), nil); err != nil {
 			return err
 		}
 		fmt.Fprintln(cli.out, "No tag specified, skipping trust metadata push")
 		return nil
 	}
 
-	if err = jsonmessage.DisplayJSONMessagesStream(responseBody, cli.out, cli.outFd, cli.isTerminalOut, handleTarget); err != nil {
+	if err = jsonmessage.DisplayJSONMessagesToStream(responseBody, cli.Out(), handleTarget); err != nil {
 		return err
 	}
 
@@ -580,7 +580,7 @@ func (cli *DockerCli) ImagePullPrivileged(ctx context.Context, authConfig types.
 	}
 	defer responseBody.Close()
 
-	return jsonmessage.DisplayJSONMessagesStream(responseBody, cli.out, cli.outFd, cli.isTerminalOut, nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, cli.Out(), nil)
 }
 
 // ImagePushPrivileged push the image

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -5,94 +5,9 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	gosignal "os/signal"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"time"
-
-	"golang.org/x/net/context"
-
-	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/signal"
-	"github.com/docker/engine-api/types"
 )
-
-func (cli *DockerCli) resizeTty(ctx context.Context, id string, isExec bool) {
-	height, width := cli.Out().GetTtySize()
-	cli.ResizeTtyTo(ctx, id, height, width, isExec)
-}
-
-// ResizeTtyTo resizes tty to specific height and width
-// TODO: this can be unexported again once all container related commands move to package container
-func (cli *DockerCli) ResizeTtyTo(ctx context.Context, id string, height, width int, isExec bool) {
-	if height == 0 && width == 0 {
-		return
-	}
-
-	options := types.ResizeOptions{
-		Height: height,
-		Width:  width,
-	}
-
-	var err error
-	if isExec {
-		err = cli.client.ContainerExecResize(ctx, id, options)
-	} else {
-		err = cli.client.ContainerResize(ctx, id, options)
-	}
-
-	if err != nil {
-		logrus.Debugf("Error resize: %s", err)
-	}
-}
-
-// GetExecExitCode perform an inspect on the exec command. It returns
-// the running state and the exit code.
-func (cli *DockerCli) GetExecExitCode(ctx context.Context, execID string) (bool, int, error) {
-	resp, err := cli.client.ContainerExecInspect(ctx, execID)
-	if err != nil {
-		// If we can't connect, then the daemon probably died.
-		if err != client.ErrConnectionFailed {
-			return false, -1, err
-		}
-		return false, -1, nil
-	}
-
-	return resp.Running, resp.ExitCode, nil
-}
-
-// MonitorTtySize updates the container tty size when the terminal tty changes size
-func (cli *DockerCli) MonitorTtySize(ctx context.Context, id string, isExec bool) error {
-	cli.resizeTty(ctx, id, isExec)
-
-	if runtime.GOOS == "windows" {
-		go func() {
-			prevH, prevW := cli.Out().GetTtySize()
-			for {
-				time.Sleep(time.Millisecond * 250)
-				h, w := cli.Out().GetTtySize()
-
-				if prevW != w || prevH != h {
-					cli.resizeTty(ctx, id, isExec)
-				}
-				prevH = h
-				prevW = w
-			}
-		}()
-	} else {
-		sigchan := make(chan os.Signal, 1)
-		gosignal.Notify(sigchan, signal.SIGWINCH)
-		go func() {
-			for range sigchan {
-				cli.resizeTty(ctx, id, isExec)
-			}
-		}()
-	}
-	return nil
-}
 
 // CopyToFile writes the content of the reader to the specified file
 func CopyToFile(outfile string, r io.Reader) error {
@@ -117,37 +32,6 @@ func CopyToFile(outfile string, r io.Reader) error {
 	}
 
 	return nil
-}
-
-// ForwardAllSignals forwards signals to the container
-// TODO: this can be unexported again once all container commands are under
-// api/client/container
-func (cli *DockerCli) ForwardAllSignals(ctx context.Context, cid string) chan os.Signal {
-	sigc := make(chan os.Signal, 128)
-	signal.CatchAll(sigc)
-	go func() {
-		for s := range sigc {
-			if s == signal.SIGCHLD || s == signal.SIGPIPE {
-				continue
-			}
-			var sig string
-			for sigStr, sigN := range signal.SignalMap {
-				if sigN == s {
-					sig = sigStr
-					break
-				}
-			}
-			if sig == "" {
-				fmt.Fprintf(cli.err, "Unsupported signal: %v. Discarding.\n", s)
-				continue
-			}
-
-			if err := cli.client.ContainerKill(ctx, cid, sig); err != nil {
-				logrus.Debugf("Error sending signal: %s", err)
-			}
-		}
-	}()
-	return sigc
 }
 
 // capitalizeFirst capitalizes the first character of string

--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -219,3 +219,14 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 	}
 	return nil
 }
+
+type stream interface {
+	io.Writer
+	FD() uintptr
+	IsTerminal() bool
+}
+
+// DisplayJSONMessagesToStream prints json messages to the output stream
+func DisplayJSONMessagesToStream(in io.Reader, stream stream, auxCallback func(*json.RawMessage)) error {
+	return DisplayJSONMessagesStream(in, stream, stream.FD(), stream.IsTerminal(), auxCallback)
+}


### PR DESCRIPTION
The migration from `cli/` to `sfp13/cobra` allowed us to greatly reduce the size of the `DockerCLI` type by moving methods into different packages.  However we were forced to expose a few more methods so they could be used in those new packages.

This PR moves some of those methods off of `DockerCLI` by:
- moving "output" related state and methods into a new type `OutStream`
- moving "input" related state and methods into a new type `InStream`
- moving container utility methods into the container package

Moving the output and input methods into their own types allows us to improve the interface of other functions as well. `DisplayJSONMessagesToStream()` is one example of this.

These changes will allow further cleanup to `api/client/trust.go`, moving more methods into the image package.
