### PR TITLE
fixed line spacing in Swarm tutorial bullets

### DIFF
--- a/docs/swarm/swarm-tutorial/index.md
+++ b/docs/swarm/swarm-tutorial/index.md
@@ -83,7 +83,8 @@ mode, including initializing a swarm with a single node, creating services,
 and scaling services. Docker "Moby" on Hyperkit (Mac) or Hyper-V (Windows)
 will serve as the single swarm node.
 
-<br /><br />
+<p />
+
 * Currently, you cannot use Docker for Mac or Windows alone to test a
 _multi-node_ swarm. However, you can use the included version of [Docker
 Machine](/machine/overview.md) to create the swarm nodes, then follow the


### PR DESCRIPTION
**\- What I did**

Fixed line spacing on bullets under "Use Docker for Mac or Docker for Windows" in Swarm topic "Set up for the tutorial"

**\- How I did it**

Added `<p />` between the bullet items

**\- How to verify it**

Run `make docs` to look at HTML display in web browser

**\- Description for the changelog**

Fixed line spacing in Swarm docs tutorial d4mac, d4win topic.

**\- A picture of a cute animal (not mandatory but encouraged)**

![nemo](https://cloud.githubusercontent.com/assets/11660803/18063508/125abda4-6de0-11e6-80bd-f19125de64f0.jpeg)

Signed-off-by: Victoria Bialas victoria.bialas@docker.com
