### PR TITLE
Add registry mirrors information in the output of `docker info`

### DIFF
--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -237,6 +237,13 @@ func prettyPrintInfo(dockerCli *client.DockerCli, info types.Info) error {
 		}
 	}
 
+	if info.RegistryConfig != nil && len(info.RegistryConfig.Mirrors) > 0 {
+		fmt.Fprintln(dockerCli.Out(), "Registry Mirrors:")
+		for _, mirror := range info.RegistryConfig.Mirrors {
+			fmt.Fprintf(dockerCli.Out(), " %s\n", mirror)
+		}
+	}
+
 	fmt.Fprintf(dockerCli.Out(), "Live Restore Enabled: %v\n", info.LiveRestoreEnabled)
 
 	return nil

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -200,3 +200,19 @@ func (s *DockerSuite) TestInsecureRegistries(c *check.C) {
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s\n", registryHost))
 	c.Assert(out, checker.Contains, fmt.Sprintf(" %s\n", registryCIDR))
 }
+
+func (s *DockerDaemonSuite) TestRegistryMirrors(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	registryMirror1 := "https://192.168.1.2"
+	registryMirror2 := "http://registry.mirror.com:5000"
+
+	err := s.d.Start("--registry-mirror="+registryMirror1, "--registry-mirror="+registryMirror2)
+	c.Assert(err, checker.IsNil)
+
+	out, err := s.d.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "Registry Mirrors:\n")
+	c.Assert(out, checker.Contains, fmt.Sprintf(" %s", registryMirror1))
+	c.Assert(out, checker.Contains, fmt.Sprintf(" %s", registryMirror2))
+}


### PR DESCRIPTION
**\- What I did**
This fix tries to add the registry mirrors information in the output of `docker info`.

In our active docker deployment, we use registry mirrors to help speeding up the `docker pull`. In the current output of `docker info`, registry mirrors is not present though it is available in `/info` API.

I think it makes sense to add the registry mirrors to `docker info`, similiar to insecure registries.

**\- How I did it**

This fix adds the registry mirrors to the output of `docker info`, e.g.,:

```
Registry Mirrors:
 https://192.168.1.2/
 http://registry.mirror.com:5000/
```

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Yong Tang yong.tang.github@outlook.com
