### PR TITLE
Fix golint errors in api

### DIFF
--- a/api/client/image/build.go
+++ b/api/client/image/build.go
@@ -421,7 +421,7 @@ func replaceDockerfileTarWrapper(ctx context.Context, inputTarStream io.ReadClos
 				return
 			}
 
-			var content io.Reader = tarReader
+			content := io.Reader(tarReader)
 			if hdr.Name == dockerfileName {
 				// This entry is the Dockerfile. Since the tar archive was
 				// generated from a directory on the local filesystem, the

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -163,7 +163,7 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 		return progress.NewProgressReader(in, progressOutput, r.ContentLength, "Downloading context", remoteURL)
 	}
 
-	var out io.Writer = output
+	out := io.Writer(output)
 	if buildOptions.SuppressOutput {
 		out = notVerboseBuffer
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Found while working on another PR which touched these two files, and the golint checks failed in Jenkins. 

```
13:14:56 Errors from golint:
13:14:56 api/client/image/build.go:427:16: should omit type io.Reader from declaration of var content; it will be inferred from the right-hand side
13:14:56 api/server/router/build/build_routes.go:172:10: should omit type io.Writer from declaration of var out; it will be inferred from the right-hand side
13:14:56 
13:14:56 Please fix the above errors. You can test via "golint" and commit the result.
```

This PR fixes those. Looks like the changes were introduced in https://github.com/docker/docker/pull/21399 (@LK4D4), but I don't understand why it wasn't caught by that PR, or the handful of changes which have been made since in this area (unless someone recently changed the golint checks, or it's part of the go 1.7 update?)
