### PR TITLE
some fixes to clean up new plugin system docs

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -3,8 +3,8 @@
 aliases = [
 "/engine/extend/"
 ]
-title = "New Plugin System"
-description = "How to operate and create a plugin with the new system"
+title = "Managed plugin system"
+description = "How develop and use a plugin with the managed plugin system"
 keywords = ["API, Usage, plugins, documentation, developer"]
 advisory = "experimental"
 [menu.main]
@@ -13,7 +13,7 @@ weight=1
 +++
 <![end-metadata]-->
 
-# Docker Engine plugin system
+# Docker Engine managed plugin system
 
 This document describes the plugin system available today in the **experimental
 build** of Docker 1.12:

--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -1,6 +1,7 @@
 <!--[metadata]>
 +++
-title = "Extending Engine with plugins"
+aliases = "/engine/extend/plugins/"
+title = "Use Docker Engine plugins"
 description = "How to add additional functionality to Docker with plugins extensions"
 keywords = ["Examples, Usage, plugins, docker, documentation, user guide"]
 [menu.main]
@@ -9,11 +10,11 @@ weight=3
 +++
 <![end-metadata]-->
 
-# Understand legacy Docker Engine plugins
+# Use Docker Engine plugins
 
 This document describes the Docker Engine plugins generally available in Docker
-Engine 1.12 and earlier. To view information on plugins managed by Docker
-Engine, refer to [Docker Engine plugin system](plugins.md).
+Engine. To view information on plugins managed by Docker Engine currently in
+experimental status, refer to [Docker Engine plugin system](index.md).
 
 You can extend the capabilities of the Docker Engine by loading third-party
 plugins. This page explains the types of plugins and provides links to several
@@ -21,7 +22,7 @@ volume and network plugins for Docker.
 
 ## Types of plugins
 
-Plugins extend Docker's functionality.  They come in specific types.  For
+Plugins extend Docker's functionality. They come in specific types.  For
 example, a [volume plugin](plugins_volume.md) might enable Docker
 volumes to persist across multiple Docker hosts and a
 [network plugin](plugins_network.md) might provide network plumbing.

--- a/docs/extend/menu.md
+++ b/docs/extend/menu.md
@@ -1,7 +1,7 @@
 <!--[metadata]>
 +++
-title = "Extend Docker"
-description = "How to extend Docker Engine with plugins"
+title = "Implement plugins"
+description = "Develop plugins and use existing plugins for Docker Engine"
 keywords = ["extend, plugins, docker, documentation, developer"]
 type="menu"
 [menu.main]
@@ -12,9 +12,4 @@ weight = 0
 <![end-metadata]-->
 
 
-## New Docker Plugin System
-
-Currently, you can extend Docker Engine by adding a plugin. This section contains the following topics:
-
-* [Understand Docker plugins](plugins.md)
-* [Write a volume plugin](plugins_volume.md)
+<!--menu page not rendered-->

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -14,9 +14,9 @@ weight=7
 Docker plugins are out-of-process extensions which add capabilities to the
 Docker Engine.
 
-This document describes the Docker Engine plugin API generally available in
-Docker Engine 1.12 and earlier. To view information on plugins managed by Docker
-Engine, refer to [Docker Engine plugin system](plugins.md).
+This document describes the Docker Engine plugin API. To view information on
+plugins managed by Docker Engine currently in experimental status, refer to
+[Docker Engine plugin system](index.md).
 
 This page is intended for people who want to develop their own Docker plugin.
 If you just want to learn about or use Docker plugins, look

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -13,9 +13,9 @@ weight = 4
 
 # Create an authorization plugin
 
-This document describes Docker Engine authorization plugins generally
-available in Docker Engine 1.12 and earlier. To view information on plugins
-managed by Docker Engine, refer to [Docker Engine plugin system](plugins.md).
+This document describes the Docker Engine plugins generally available in Docker
+Engine. To view information on plugins managed by Docker Engine currently in
+experimental status, refer to [Docker Engine plugin system](index.md).
 
 Docker's out-of-the-box authorization model is all or nothing. Any user with
 permission to access the Docker daemon can run any Docker client command. The

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -12,8 +12,8 @@ weight=5
 # Engine network driver plugins
 
 This document describes Docker Engine network driver plugins generally
-available in Docker Engine 1.12 and earlier. To view information on plugins
-managed by Docker Engine, refer to [Docker Engine plugin system](plugins.md).
+available in Docker Engine. To view information on plugins
+managed by Docker Engine, refer to [Docker Engine plugin system](index.md).
 
 Docker Engine network plugins enable Engine deployments to be extended to
 support a wide range of networking technologies, such as VXLAN, IPVLAN, MACVLAN
@@ -46,7 +46,7 @@ commands. For example,
 
     $ docker network create --driver weave mynet
 
-Some network driver plugins are listed in [plugins](plugins.md)
+Some network driver plugins are listed in [plugins](legacy_plugins.md)
 
 The `mynet` network is now owned by `weave`, so subsequent commands
 referring to that network will be sent to the plugin,

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -13,8 +13,8 @@ weight=6
 
 Docker Engine volume plugins enable Engine deployments to be integrated with
 external storage systems, such as Amazon EBS, and enable data volumes to persist
-beyond the lifetime of a single Engine host. See the [plugin
-documentation](plugins.md) for more information.
+beyond the lifetime of a single Engine host. See the
+[plugin documentation](legacy_plugins.md) for more information.
 
 ## Changelog
 

--- a/docs/tutorials/dockervolumes.md
+++ b/docs/tutorials/dockervolumes.md
@@ -211,7 +211,7 @@ $ docker run -d -P \
 ```
 
 A list of available plugins, including volume plugins, is available
-[here](../extend/plugins.md).
+[here](../extend/legacy_plugins.md).
 
 ### Volume labels
 

--- a/docs/userguide/networking/index.md
+++ b/docs/userguide/networking/index.md
@@ -537,7 +537,7 @@ built-in network drivers. For example:
 You can inspect it, add containers to and from it, and so forth. Of course,
 different plugins may make use of different technologies or frameworks. Custom
 networks can include features not present in Docker's default networks. For more
-information on writing plugins, see [Extending Docker](../../extend/plugins.md) and
+information on writing plugins, see [Extending Docker](../../extend/legacy_plugins.md) and
 [Writing a network driver plugin](../../extend/plugins_network.md).
 
 ### Docker embedded DNS server


### PR DESCRIPTION
**\- What I did**
This fixes up some of the issues raised by @thaJeztah and @vdemeester  in https://github.com/docker/docker/pull/25726
- Changes title for "New Plugin System" to "Managed plugin system"
- Links `/engine/extend/plugins/` to legacy_plugins.md
- Links `/engine/extend/` to index.md (Managed plugin system)
- Fixes broken links to `plugins.md`
- Changes menu item from "Extend Docker" to "Implement plugins," which should cover creation and deployment
- Edited the disambiguation between the experimental plugins and the GA plugins
- Fix some typos

Signed-off-by: Charles Smith charles.smith@docker.com
