### PR TITLE
Lock concurrent access to remove map during Daemon restore

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -201,7 +201,9 @@ func (daemon *Daemon) restore() error {
 					restartContainers[c] = make(chan struct{})
 					mapLock.Unlock()
 				} else if c.HostConfig != nil && c.HostConfig.AutoRemove {
+					mapLock.Lock()
 					removeContainers[c.ID] = c
+					mapLock.Unlock()
 				}
 			}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Prevent concurrent access to the remove map during daemon restore.

**\- How I did it**

Added the same locking that protects the other map access when restoring containers during a daemon restore to the remove map.

**\- How to verify it**

I hit the concurrent map access once during a restore, but was never able to replicate it. So this will have to be verification by code inspection.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

Signed-off-by: Darren Stahl darst@microsoft.com
