### PR TITLE
add creation timestamp to `docker network inspect`

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -159,6 +159,7 @@ func (n *networkRouter) buildNetworkResource(nw libnetwork.Network) *types.Netwo
 	info := nw.Info()
 	r.Name = nw.Name()
 	r.ID = nw.ID()
+	r.Created = info.Created()
 	r.Scope = info.Scope()
 	if n.clusterProvider.IsManager() {
 		if _, err := n.clusterProvider.GetNetwork(nw.Name()); err == nil {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -470,6 +470,7 @@ type VolumeCreateRequest struct {
 type NetworkResource struct {
 	Name       string                      // Name is the requested name of the network
 	ID         string                      `json:"Id"` // ID uniquely identifies a network on a single machine
+	Created    time.Time                   // Created is the time the network created
 	Scope      string                      // Scope describes the level at which the network exists (e.g. `global` for cluster-wide or `local` for machine level)
 	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
 	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -130,6 +130,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
   containers that are tasks (part of a service in swarm mode).
 * `POST /containers/create` now takes `StopTimeout` field.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept `Monitor` and `MaxFailureRatio` parameters, which control the response to failures during service updates.
+* `GET /networks/(name)` now returns `Created`.
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3528,6 +3528,7 @@ Content-Type: application/json
   {
     "Name": "bridge",
     "Id": "f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566",
+    "Created": "2016-10-19T06:21:00.416543526Z",
     "Scope": "local",
     "Driver": "bridge",
     "EnableIPv6": false,
@@ -3560,6 +3561,7 @@ Content-Type: application/json
   {
     "Name": "none",
     "Id": "e086a3893b05ab69242d3c44e49483a3bbbd3a26b46baa8f61ab797c1088d794",
+    "Created": "0001-01-01T00:00:00Z",
     "Scope": "local",
     "Driver": "null",
     "EnableIPv6": false,
@@ -3574,6 +3576,7 @@ Content-Type: application/json
   {
     "Name": "host",
     "Id": "13e871235c677f196c4e1ecebb9dc733b9b2d2ab589e30c539efeda84a24215e",
+    "Created": "0001-01-01T00:00:00Z",
     "Scope": "local",
     "Driver": "host",
     "EnableIPv6": false,
@@ -3619,6 +3622,7 @@ Content-Type: application/json
 {
   "Name": "net01",
   "Id": "7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99",
+  "Created": "2016-10-19T04:33:30.360899459Z",
   "Scope": "local",
   "Driver": "bridge",
   "EnableIPv6": false,

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -41,6 +41,7 @@ $ sudo docker network inspect bridge
     {
         "Name": "bridge",
         "Id": "b2b1a2cba717161d984383fd68218cf70bbbd17d328496885f7c921333228b0f",
+        "Created": "2016-10-19T04:33:30.360899459Z",
         "Scope": "local",
         "Driver": "bridge",
         "IPAM": {
@@ -92,6 +93,7 @@ $ docker network inspect simple-network
     {
         "Name": "simple-network",
         "Id": "69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a",
+        "Created": "2016-10-19T04:33:30.360899459Z",
         "Scope": "local",
         "Driver": "bridge",
         "IPAM": {


### PR DESCRIPTION
**\- What I did**
Add creation timestamp to `docker network inspect`

**\- How I did it**
- Add a new field `Created` to `engine-api/types.NetworkResource`
- Add a new method `Created()` to `libnetwork.NetworkInfo`

~~I'll create corresponding PRs to `engine-api` and `libnetwork` after getting lgtms.~~ opened https://github.com/docker/libnetwork/pull/1455

**\- How to verify it**

```
$ docker network create foo
```

Then apply this PR

```
$ docker network inspect foo | jq '.[0].Created'
"0001-01-01T00:00:00Z"
$ docker network create bar
$ docker network inspect bar | jq '.[0].Created'
"2016-08-30T04:56:13.391974977Z"
```

It should also work with built-in networks (e.g. "bridge", "host", ..)

**\- Description for the changelog**
add creation timestamp to `docker network inspect`

**\- A picture of a cute animal (not mandatory but encouraged)**
![](https://www.whoi.edu/cms/images/mediarelations/Adelie_750_342264.jpg)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
