### PR TITLE
Modify use of docker exec command in exec.go

### DIFF
--- a/api/client/container/exec.go
+++ b/api/client/container/exec.go
@@ -28,7 +28,7 @@ func NewExecCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts execOptions
 
 	cmd := &cobra.Command{
-		Use:   "exec CONTAINER COMMAND [ARG...]",
+		Use:   "exec [OPTIONS] CONTAINER COMMAND [ARG...]",
 		Short: "Run a command in a running container",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
the usage of docker exec in exec.md is as the following, and the actual command is just like this:

``````
```markdown
Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]

Run a command in a running container
``````
