### PR TITLE
Modify link for hub and registry 

### DIFF
--- a/docs/reference/api/hub_registry_spec.md
+++ b/docs/reference/api/hub_registry_spec.md
@@ -12,7 +12,7 @@ parent="smn_hub_ref"
 # The Docker Hub and the Registry v1
 
 This API is deprecated as of 1.7. To view the old version, see the [go
-here](hub_registry_spec.md) in
+here](https://docs.docker.com/v1.7/docker/reference/api/hub_registry_spec/) in
 the 1.7 documentation. If you want an overview of the current features in
 Docker Hub or other image management features see the [image management
 overview](../../userguide/eng-image/image_management.md) in the current documentation set.


### PR DESCRIPTION
The link should be  is "https://docs.docker.com/v1.7/docker/reference/api/hub_registry_spec/"  for hub and registry v1 in hub_registry_spec.md.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
