### PR TITLE
Windows: Enable 5 Build API tests

### DIFF
--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -13,7 +13,6 @@ import (
 
 func (s *DockerSuite) TestBuildApiDockerFileRemote(c *check.C) {
 	testRequires(c, NotUserNamespace)
-	testRequires(c, DaemonIsLinux)
 	server, err := fakeStorage(map[string]string{
 		"testD": `FROM busybox
 COPY * /tmp/
@@ -38,7 +37,6 @@ RUN find /tmp/`,
 }
 
 func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
 	defer tw.Close()
@@ -72,7 +70,6 @@ func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildApiRemoteTarballContextWithCustomDockerfile(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
 	defer tw.Close()
@@ -128,7 +125,6 @@ RUN echo 'right'
 }
 
 func (s *DockerSuite) TestBuildApiLowerDockerfile(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	git, err := newFakeGit("repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
@@ -148,7 +144,6 @@ RUN echo from dockerfile`,
 }
 
 func (s *DockerSuite) TestBuildApiBuildGitWithF(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	git, err := newFakeGit("repo", map[string]string{
 		"baz": `FROM busybox
 RUN echo from baz`,


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Enables 5 tests from docker_api_build_test.go for the integration tests on Windows. Simple removal of the `DaemonIsLinux` requirement.
