### PR TITLE
Windows: Enable docker_cli_history_test.go tests

### DIFF
--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -13,10 +13,6 @@ import (
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
 // sort is not predictable it doesn't always fail.
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
-	testRequires(c, DaemonIsLinux) // TODO Windows: This test passes on Windows,
-	// but currently adds a disproportionate amount of time for the value it has.
-	// Removing it from Windows CI for now, but this will be revisited in the
-	// TP5 timeframe when perf is better.
 	name := "testbuildhistory"
 	_, err := buildImage(name, `FROM `+minimalBaseImage()+`
 LABEL label.A="A"


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Enables TestBuildHistory in `docker_cli_history_test.go` in Windows CI now perf is acceptable on RS1 builds.
