### PR TITLE
Sanitize uses of Swarm as a proper and improper noun (Fixes #24905)

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4009,7 +4009,7 @@ Return low-level information on the node `id`
 
 `DELETE /nodes/<id>`
 
-Remove a node [`id`] from the Swarm.
+Remove a node [`id`] from the swarm.
 
 **Example request**:
 
@@ -4249,7 +4249,7 @@ JSON Parameters:
   address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when
   possible.
 - **RemoteAddr** – Address of any manager node already participating in the swarm.
-- **JoinToken** – Secret token for joining this Swarm.
+- **JoinToken** – Secret token for joining this swarm.
 
 ### Leave a swarm
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4039,7 +4039,7 @@ Return low-level information on the node `id`
 
 `DELETE /nodes/<id>`
 
-Remove a node [`id`] from the Swarm.
+Remove a node [`id`] from the swarm.
 
 **Example request**:
 
@@ -4279,7 +4279,7 @@ JSON Parameters:
   address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when
   possible.
 - **RemoteAddr** – Address of any manager node already participating in the swarm.
-- **JoinToken** – Secret token for joining this Swarm.
+- **JoinToken** – Secret token for joining this swarm.
 
 ### Leave a swarm
 

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -72,7 +72,7 @@ This flag forces an existing node that was part of a quorum that was lost to res
 
 ### `--listen-addr value`
 
-The node listens for inbound Swarm manager traffic on this address. The default is to listen on
+The node listens for inbound swarm manager traffic on this address. The default is to listen on
 0.0.0.0:2377. It is also possible to specify a network interface to listen on that interface's
 address; for example `--listen-addr eth0:2377`.
 

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -59,7 +59,7 @@ dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
 
 ### `--listen-addr value`
 
-If the node is a manager, it will listen for inbound Swarm manager traffic on this
+If the node is a manager, it will listen for inbound swarm manager traffic on this
 address. The default is to listen on 0.0.0.0:2377. It is also possible to specify a
 network interface to listen on that interface's address; for example `--listen-addr eth0:2377`.
 

--- a/docs/swarm/swarm-tutorial/drain-node.md
+++ b/docs/swarm/swarm-tutorial/drain-node.md
@@ -97,7 +97,7 @@ task assignments for the `redis` service:
     9bg7cezvedmkgg6c8yzvbhwsd  redis.3       redis:3.0.6  worker2   Running        Running 4 minutes
     ```
 
-    The Swarm manager maintains the desired state by ending the task on a node
+    The swarm manager maintains the desired state by ending the task on a node
     with `Drain` availability and creating a new task on a node with `Active`
     availability.
 

--- a/docs/userguide/networking/get-started-overlay.md
+++ b/docs/userguide/networking/get-started-overlay.md
@@ -71,7 +71,7 @@ store uses the hostnames to identify cluster members.
 Though Docker Machine and Docker Swarm are not mandatory to experience Docker
 multi-host networking with a key-value store, this example uses them to
 illustrate how they are integrated. You'll use Machine to create both the
-key-value store server and the host cluster. This example creates a Swarm
+key-value store server and the host cluster. This example creates a swarm
 cluster.
 
 >**Note:** Docker Engine running in swarm mode is not compatible with networking
@@ -135,11 +135,11 @@ Keep your terminal open and move onto the next step.
 
 In this step, you use `docker-machine` to provision the hosts for your network.
 At this point, you won't actually create the network. You'll create several
-machines in VirtualBox. One of the machines will act as the Swarm master;
+machines in VirtualBox. One of the machines will act as the swarm master;
 you'll create that first. As you create each host, you'll pass the Engine on
 that machine options that are needed by the `overlay` network driver.
 
-1. Create a Swarm master.
+1. Create a swarm master.
 
 		$ docker-machine create \
 		-d virtualbox \
@@ -151,7 +151,7 @@ that machine options that are needed by the `overlay` network driver.
 
 	At creation time, you supply the Engine `daemon` with the ` --cluster-store` option. This option tells the Engine the location of the key-value store for the `overlay` network. The bash expansion `$(docker-machine ip mh-keystore)` resolves to the IP address of the Consul server you created in "STEP 1". The `--cluster-advertise` option advertises the machine on the network.
 
-2. Create another host and add it to the Swarm cluster.
+2. Create another host and add it to the swarm cluster.
 
 		$ docker-machine create -d virtualbox \
 			--swarm \
@@ -178,13 +178,13 @@ Leave your terminal open and go onto the next step.
 
 To create an overlay network
 
-1. Set your docker environment to the Swarm master.
+1. Set your docker environment to the swarm master.
 
 		$ eval $(docker-machine env --swarm mhs-demo0)
 
-	Using the `--swarm` flag with `docker-machine` restricts the `docker` commands to Swarm information alone.
+	Using the `--swarm` flag with `docker-machine` restricts the `docker` commands to swarm information alone.
 
-2. Use the `docker info` command to view the Swarm.
+2. Use the `docker info` command to view the swarm.
 
 		$ docker info
 
@@ -214,7 +214,7 @@ To create an overlay network
 
 		$ docker network create --driver overlay --subnet=10.0.9.0/24 my-net
 
-	You only need to create the network on a single host in the cluster. In this case, you used the Swarm master but you could easily have run it on any host in the cluster.
+	You only need to create the network on a single host in the cluster. In this case, you used the swarm master but you could easily have run it on any host in the cluster.
 
 > **Note** : It is highly recommended to use the `--subnet` option when creating
 > a network. If the `--subnet` is not specified, the docker daemon automatically
@@ -235,11 +235,11 @@ To create an overlay network
 		d0bb78cbe7bd        mhs-demo1/bridge    bridge
 		1c0eb8f69ebb        mhs-demo1/none      null
 
-	As you are in the Swarm master environment, you see all the networks on all
-	the Swarm agents: the default networks on each engine and the single overlay
+	As you are in the swarm master environment, you see all the networks on all
+	the swarm agents: the default networks on each engine and the single overlay
 	network. Notice that each `NETWORK ID` is unique.
 
-5. Switch to each Swarm agent in turn and list the networks.
+5. Switch to each swarm agent in turn and list the networks.
 
 		$ eval $(docker-machine env mhs-demo0)
 
@@ -268,7 +268,7 @@ To create an overlay network
 
 Once your network is created, you can start a container on any of the hosts and it automatically is part of the network.
 
-1. Point your environment to the Swarm master.
+1. Point your environment to the swarm master.
 
 		$ eval $(docker-machine env --swarm mhs-demo0)
 
@@ -322,7 +322,7 @@ Additionally, containers connected to the multi-host network are automatically
 connected to the `docker_gwbridge` network. This network allows the containers
 to have external connectivity outside of their cluster.
 
-1. Change your environment to the Swarm agent.
+1. Change your environment to the swarm agent.
 
 		$ eval $(docker-machine env mhs-demo1)
 
@@ -337,7 +337,7 @@ to have external connectivity outside of their cluster.
 		1aeead6dd890        host                host
 		e1dbd5dff8be        docker_gwbridge     bridge
 
-3. Repeat steps 1 and 2 on the Swarm master.
+3. Repeat steps 1 and 2 on the swarm master.
 
 		$ eval $(docker-machine env mhs-demo0)
 
@@ -381,7 +381,7 @@ to have external connectivity outside of their cluster.
 
 Please refer to the Networking feature introduced in [Compose V2 format]
 (https://docs.docker.com/compose/networking/) and execute the
-multi-host networking scenario in the Swarm cluster used above.
+multi-host networking scenario in the swarm cluster used above.
 
 ## Related information
 

--- a/docs/userguide/networking/index.md
+++ b/docs/userguide/networking/index.md
@@ -497,7 +497,7 @@ Docker Engine for use with `overlay` network. There are three options to set:
     </tbody>
 </table>
 
-Create an `overlay` network on one of the machines in the Swarm.
+Create an `overlay` network on one of the machines in the swarm.
 
     $ docker network create --driver overlay my-multi-host-network
 


### PR DESCRIPTION
**\- What I did**
Looked for uses of Swarm where they were referring to a swarm and not the Docker Swarm project itself, and changed the ones that shouldn't otherwise be capitalized

**\- How I did it**
Lots of grep!

**\- How to verify it**

**\- Description for the changelog**
Standardize usage of 'Swarm' and 'swarm'

Fixes #24905

Signed-off-by: Misty Stanley-Jones misty@docker.com
