### PR TITLE
Print stacktrace on failing to leave cluster

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/errors"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/runconfig"
 	apitypes "github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
@@ -560,6 +561,8 @@ func (c *Cluster) Leave(force bool) error {
 		return fmt.Errorf(msg)
 	}
 	if err := c.stopNode(); err != nil {
+		logrus.Errorf("failed to shut down cluster node: %v", err)
+		signal.DumpStacks("")
 		c.Unlock()
 		return err
 	}


### PR DESCRIPTION
Occasionally we have errors in the CI where cluster node fails to shut down cleanly on time. For example https://jenkins.dockerproject.org/job/Docker%20Master%20(arm)/2973/console . This will print out the stacktrace when this happens so we can figure out what is going on internally. It may also help debugging cases like https://github.com/docker/docker/issues/26038#issuecomment-243537936

cc @aaronlehmann 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
