### PR TITLE
Windows: Enable some cp integration tests

### DIFF
--- a/integration-cli/docker_cli_cp_from_container_test.go
+++ b/integration-cli/docker_cli_cp_from_container_test.go
@@ -24,7 +24,6 @@ import (
 
 // Test for error when SRC does not exist.
 func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{})
 
 	tmpDir := getTestDir(c, "test-cp-from-err-src-not-exists")

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -36,7 +36,6 @@ func (s *DockerSuite) TestCpLocalOnly(c *check.C) {
 // Test for #5656
 // Check that garbage paths don't escape the container's rootfs
 func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 
 	containerID := strings.TrimSpace(out)
@@ -79,7 +78,6 @@ func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
 
 // Check that relative paths are relative to the container's rootfs
 func (s *DockerSuite) TestCpRelativePath(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 
 	containerID := strings.TrimSpace(out)
@@ -128,7 +126,6 @@ func (s *DockerSuite) TestCpRelativePath(c *check.C) {
 
 // Check that absolute paths are relative to the container's rootfs
 func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 
 	containerID := strings.TrimSpace(out)
@@ -519,7 +516,6 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpToDot(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
 
 	containerID := strings.TrimSpace(out)
@@ -541,7 +537,6 @@ func (s *DockerSuite) TestCpToDot(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpToStdout(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
 
 	containerID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -23,7 +23,6 @@ import (
 
 // Test for error when SRC does not exist.
 func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{})
 
 	tmpDir := getTestDir(c, "test-cp-to-err-src-not-exists")
@@ -41,7 +40,6 @@ func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
 // Test for error when SRC ends in a trailing
 // path separator but it exists as a file.
 func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{})
 
 	tmpDir := getTestDir(c, "test-cp-to-err-src-not-dir")
@@ -227,7 +225,6 @@ func (s *DockerSuite) TestCpToSymlinkDestination(c *check.C) {
 //    exist. This should create a file with the name DST and copy the
 //    contents of the source file into it.
 func (s *DockerSuite) TestCpToCaseA(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{
 		workDir: "/root", command: makeCatFileCommand("itWorks.txt"),
 	})
@@ -249,7 +246,6 @@ func (s *DockerSuite) TestCpToCaseA(c *check.C) {
 //    exist. This should cause an error because the copy operation cannot
 //    create a directory when copying a single file.
 func (s *DockerSuite) TestCpToCaseB(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("testDir/file1"),
 	})
@@ -344,7 +340,6 @@ func (s *DockerSuite) TestCpToCaseD(c *check.C) {
 //    directory. Ensure this works whether DST has a trailing path separator or
 //    not.
 func (s *DockerSuite) TestCpToCaseE(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
@@ -449,7 +444,6 @@ func (s *DockerSuite) TestCpToCaseG(c *check.C) {
 //    directory (but not the directory itself) into the DST directory. Ensure
 //    this works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpToCaseH(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	containerID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Enables some of the easier, no modification other than remove the Linux test requirement, docker cp tests on Windows CI. More can be made to work in the future.
