### PR TITLE
Windows: Enable TestHelpExitCodesHelpOutput

### DIFF
--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -143,7 +143,6 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 }
 
 func (s *DockerSuite) TestHelpExitCodesHelpOutput(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	// Test to make sure the exit code and output (stdout vs stderr) of
 	// various good and bad cases are what we expect
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Removes the test requirement for a Linux daemon for `TestHelpExitCodesHelpOutput` in `docker_cli_help_test.go`
