### PR TITLE
Revert "Fix issue in API `POST /services/(id or name)/update`" (#26093) and update docs

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -903,7 +903,7 @@ func (c *Cluster) GetService(input string) (types.Service, error) {
 }
 
 // UpdateService updates existing service to match new properties.
-func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec types.ServiceSpec, encodedAuth string) error {
+func (c *Cluster) UpdateService(serviceID string, version uint64, spec types.ServiceSpec, encodedAuth string) error {
 	c.RLock()
 	defer c.RUnlock()
 
@@ -924,11 +924,6 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 		return err
 	}
 
-	currentService, err := getService(ctx, c.client, serviceIDOrName)
-	if err != nil {
-		return err
-	}
-
 	if encodedAuth != "" {
 		ctnr := serviceSpec.Task.GetContainer()
 		if ctnr == nil {
@@ -938,6 +933,10 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 	} else {
 		// this is needed because if the encodedAuth isn't being updated then we
 		// shouldn't lose it, and continue to use the one that was already present
+		currentService, err := getService(ctx, c.client, serviceID)
+		if err != nil {
+			return err
+		}
 		ctnr := currentService.Spec.Task.GetContainer()
 		if ctnr == nil {
 			return fmt.Errorf("service does not use container tasks")
@@ -948,7 +947,7 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 	_, err = c.client.UpdateService(
 		ctx,
 		&swarmapi.UpdateServiceRequest{
-			ServiceID: currentService.ID,
+			ServiceID: serviceID,
 			Spec:      &serviceSpec,
 			ServiceVersion: &swarmapi.Version{
 				Index: version,

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4729,7 +4729,7 @@ Return information on the service `id`.
 
 ### Update a service
 
-`POST /services/(id or name)/update`
+`POST /services/<id>/update`
 
 Update a service. When using this endpoint to create a service using a
 private repository from the registry, the `X-Registry-Auth` header can be used

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4759,7 +4759,7 @@ Return information on the service `id`.
 
 ### Update a service
 
-`POST /services/(id or name)/update`
+`POST /services/<id>/update`
 
 Update a service. When using this endpoint to create a service using a
 private repository from the registry, the `X-Registry-Auth` header can be used

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -1168,21 +1168,3 @@ func (s *DockerSwarmSuite) TestApiSwarmRestartCluster(c *check.C) {
 
 	checkClusterHealth(c, nodes, mCount, wCount)
 }
-
-func (s *DockerSwarmSuite) TestApiSwarmServicesUpdateWithName(c *check.C) {
-	d := s.AddDaemon(c, true, true)
-
-	instances := 2
-	id := d.createService(c, simpleTestService, setInstances(instances))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
-
-	service := d.getService(c, id)
-	instances = 5
-
-	setInstances(instances)(service)
-	url := fmt.Sprintf("/services/%s/update?version=%d", service.Spec.Name, service.Version.Index)
-	status, out, err := d.SockRequest("POST", url, service.Spec)
-	c.Assert(err, checker.IsNil)
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
-	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
-}


### PR DESCRIPTION
This fix reverts "Fix issue in API `POST /services/(id or name)/update`" (#26093) and update the docs so that the documentation matches the intended behavior.

In #26093 the implementation was changed to match the docs of the API `POST /services/(id or name)/update`". Based on discussion on #26093, only allowing `<id>` to be specified is the intended behavior and docs should be updated instead.

This fix reverts "Fix issue in API `POST /services/(id or name)/update`" (#26093).

This fix updates documentation so that (for both `v1.24` and `v1.25`) the REMOTE API specification for `POST /services/<id>/update` matches the intended behavior.

Note `<id>` (instead of `(id)`) is used in the docs here. This is to match the documentation in `POST /nodes/<id>/update`.

This fix is related to #26093 (reverted).

Signed-off-by: Yong Tang yong.tang.github@outlook.com
