### PR TITLE
Windows: Enable TestImage and TestImport tests

### DIFF
--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -16,14 +16,11 @@ import (
 )
 
 func (s *DockerSuite) TestImagesEnsureImageIsListed(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	imagesOut, _ := dockerCmd(c, "images")
 	c.Assert(imagesOut, checker.Contains, "busybox")
 }
 
 func (s *DockerSuite) TestImagesEnsureImageWithTagIsListed(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-
 	name := "imagewithtag"
 	dockerCmd(c, "tag", "busybox", name+":v1")
 	dockerCmd(c, "tag", "busybox", name+":v1v1")
@@ -48,19 +45,18 @@ func (s *DockerSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	id1, err := buildImage("order:test_a",
-		`FROM scratch
+		`FROM busybox
                 MAINTAINER dockerio1`, true)
 	c.Assert(err, checker.IsNil)
 	time.Sleep(1 * time.Second)
 	id2, err := buildImage("order:test_c",
-		`FROM scratch
+		`FROM busybox
                 MAINTAINER dockerio2`, true)
 	c.Assert(err, checker.IsNil)
 	time.Sleep(1 * time.Second)
 	id3, err := buildImage("order:test_b",
-		`FROM scratch
+		`FROM busybox
                 MAINTAINER dockerio3`, true)
 	c.Assert(err, checker.IsNil)
 
@@ -78,22 +74,21 @@ func (s *DockerSuite) TestImagesErrorWithInvalidFilterNameTest(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesFilterLabelMatch(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	imageName1 := "images_filter_test1"
 	imageName2 := "images_filter_test2"
 	imageName3 := "images_filter_test3"
 	image1ID, err := buildImage(imageName1,
-		`FROM scratch
+		`FROM busybox
                  LABEL match me`, true)
 	c.Assert(err, check.IsNil)
 
 	image2ID, err := buildImage(imageName2,
-		`FROM scratch
+		`FROM busybox
                  LABEL match="me too"`, true)
 	c.Assert(err, check.IsNil)
 
 	image3ID, err := buildImage(imageName3,
-		`FROM scratch
+		`FROM busybox
                  LABEL nomatch me`, true)
 	c.Assert(err, check.IsNil)
 
@@ -191,10 +186,9 @@ func assertImageList(out string, expected []string) bool {
 }
 
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	imageName := "images_filter_test"
 	buildImage(imageName,
-		`FROM scratch
+		`FROM busybox
                  RUN touch /test/foo
                  RUN touch /test/bar
                  RUN touch /test/baz`, true)
@@ -263,10 +257,8 @@ func (s *DockerSuite) TestImagesWithIncorrectFilter(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesEnsureOnlyHeadsImagesShown(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-
 	dockerfile := `
-        FROM scratch
+        FROM busybox
         MAINTAINER docker
         ENV foo bar`
 
@@ -287,7 +279,7 @@ func (s *DockerSuite) TestImagesEnsureOnlyHeadsImagesShown(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesEnsureImagesFromScratchShown(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux) // Windows does not support FROM scratch
 
 	dockerfile := `
         FROM scratch
@@ -298,6 +290,21 @@ func (s *DockerSuite) TestImagesEnsureImagesFromScratchShown(c *check.C) {
 
 	out, _ := dockerCmd(c, "images")
 	// images should contain images built from scratch
+	c.Assert(out, checker.Contains, stringid.TruncateID(id))
+}
+
+// For W2W - equivalent to TestImagesEnsureImagesFromScratchShown but Windows
+// doesn't support from scratch
+func (s *DockerSuite) TestImagesEnsureImagesFromBusyboxShown(c *check.C) {
+	dockerfile := `
+        FROM busybox
+        MAINTAINER docker`
+
+	id, _, err := buildImageWithOut("busybox-image", dockerfile, false)
+	c.Assert(err, check.IsNil)
+
+	out, _ := dockerCmd(c, "images")
+	// images should contain images built from busybox
 	c.Assert(out, checker.Contains, stringid.TruncateID(id))
 }
 

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -32,7 +32,6 @@ func (s *DockerSuite) TestImportDisplay(c *check.C) {
 }
 
 func (s *DockerSuite) TestImportBadURL(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("import", "http://nourl/bad")
 	c.Assert(err, checker.NotNil, check.Commentf("import was supposed to fail but didn't"))
 	// Depending on your system you can get either of these errors


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Enables/ports a bunch of integration tests `TestImage*` or `TestImport*` for Windows CI.
