### PR TITLE
Fix issue in `--ip6` validation for `docker create`

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -256,8 +256,13 @@ func (daemon *Daemon) verifyNetworkingConfig(nwConfig *networktypes.NetworkingCo
 				if v.IPAMConfig.IPv4Address != "" && net.ParseIP(v.IPAMConfig.IPv4Address).To4() == nil {
 					return errors.NewBadRequestError(fmt.Errorf("invalid IPv4 address: %s", v.IPAMConfig.IPv4Address))
 				}
-				if v.IPAMConfig.IPv6Address != "" && net.ParseIP(v.IPAMConfig.IPv6Address).To16() == nil {
-					return errors.NewBadRequestError(fmt.Errorf("invalid IPv6 address: %s", v.IPAMConfig.IPv6Address))
+				if v.IPAMConfig.IPv6Address != "" {
+					n := net.ParseIP(v.IPAMConfig.IPv6Address)
+					// if the address is an invalid network address (ParseIP == nil) or if it is
+					// an IPv4 address (To4() != nil), then it is an invalid IPv6 address
+					if n == nil || n.To4() != nil {
+						return errors.NewBadRequestError(fmt.Errorf("invalid IPv6 address: %s", v.IPAMConfig.IPv6Address))
+					}
 				}
 			}
 		}

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1749,4 +1749,10 @@ func (s *DockerNetworkSuite) TestDockerNetworkValidateIP(c *check.C) {
 	c.Assert(err.Error(), checker.Contains, "invalid IPv4 address")
 	_, _, err = dockerCmdWithError("run", "--net=mynet", "--ip", "172.28.99.99", "--ip6", "mynet_ip6", "busybox", "top")
 	c.Assert(err.Error(), checker.Contains, "invalid IPv6 address")
+	// This is a case of IPv4 address to `--ip6`
+	_, _, err = dockerCmdWithError("run", "--net=mynet", "--ip6", "172.28.99.99", "busybox", "top")
+	c.Assert(err.Error(), checker.Contains, "invalid IPv6 address")
+	// This is a special case of an IPv4-mapped IPv6 address
+	_, _, err = dockerCmdWithError("run", "--net=mynet", "--ip6", "::ffff:172.28.99.99", "busybox", "top")
+	c.Assert(err.Error(), checker.Contains, "invalid IPv6 address")
 }


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in comment:
https://github.com/docker/docker/pull/25943#discussion_r76843081
Previously, the validation for `ip6` is done by checking ParseIP().To16(). However, in case an IPv4 address or an IPv4-mapped Ipv6 address has been provided, the validation will pass (should fail).

**\- How I did it**

This fix first check if `--ip6` is passed with a valid IP address and returns error for invalid IP addresses. It then check if an IPv4 or IPv4-mapped IPv6 address is passed, and return error accordingly.

**\- How to verify it**

This fix adds two more cases in the tests. One for IPv4 address passed to `--ip6` and another for IPv4-mapped IPv6 address passed to `--ip6`. In both cases, without this fix the validation will pass through.

cc @aboch please take a look.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
