### PR TITLE
Miss the options in some commands

### DIFF
--- a/api/client/plugin/list.go
+++ b/api/client/plugin/list.go
@@ -22,7 +22,7 @@ func newListCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts listOptions
 
 	cmd := &cobra.Command{
-		Use:     "ls",
+		Use:     "ls [OPTIONS]",
 		Short:   "List plugins",
 		Aliases: []string{"list"},
 		Args:    cli.NoArgs,

--- a/api/client/system/info.go
+++ b/api/client/system/info.go
@@ -27,7 +27,7 @@ func NewInfoCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts infoOptions
 
 	cmd := &cobra.Command{
-		Use:   "info",
+		Use:   "info [OPTIONS]",
 		Short: "Display system-wide information",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -11,7 +11,7 @@ parent = "smn_cli"
 # info
 
 ```markdown
-Usage:  docker info
+Usage:  docker info [OPTIONS]
 
 Display system-wide information
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -12,7 +12,7 @@ parent = "smn_cli"
 # plugin ls (experimental)
 
 ```markdown
-Usage:  docker plugin ls
+Usage:  docker plugin ls [OPTIONS]
 
 List plugins
 


### PR DESCRIPTION
Miss the options in some commands such as plugin inspect, plugin info, ls.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
