### PR TITLE
provide actual command format for docker network create

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -11,7 +11,7 @@ parent = "smn_cli"
 # network create
 
 ```markdown
-Usage:	docker network create [OPTIONS]
+Usage:	docker network create [OPTIONS] NETWORK
 
 Create a network
 


### PR DESCRIPTION
in create.go, command "docker network create" like this:

```
cmd := &cobra.Command{
    Use:   "create [OPTIONS] NETWORK",
    Short: "Create a network",
```
