### PR TITLE
api: client: container: update: fix help text

### DIFF
--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -67,13 +67,6 @@ func NewRunCommand(dockerCli *client.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func flagErrorFunc(cmd *cobra.Command, err error) error {
-	return cli.StatusError{
-		Status:     cli.FlagErrorFunc(cmd, err).Error(),
-		StatusCode: 125,
-	}
-}
-
 func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions, copts *runconfigopts.ContainerOptions) error {
 	stdout, stderr, stdin := dockerCli.Out(), dockerCli.Err(), dockerCli.In()
 	client := dockerCli.Client()

--- a/api/client/container/update.go
+++ b/api/client/container/update.go
@@ -46,7 +46,6 @@ func NewUpdateCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runUpdate(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.Uint16Var(&opts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000")


### PR DESCRIPTION
Before:

```
$ docker update --cpu-period
Status: flag needs an argument: --cpu-period
See 'docker update --help'., Code: 125
```

After:

```
$ docker update --cpu-period
flag needs an argument: --cpu-period
See 'docker update --help'.
```

Also remove `flagErrorFunc` function which isn't needed anymore.

Signed-off-by: Antonio Murdaca runcom@redhat.com
