### PR TITLE
remove systemd drop-in unit on raspbian

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -396,11 +396,7 @@ do_install() {
 				fi
 			}
 
-			if [ "$lsb_dist" = "raspbian" ]; then
-				# Create Raspbian specific systemd drop-in file, use overlay by default
-				( set -x; $sh_c "mkdir -p /etc/systemd/system/docker.service.d" )
-				( set -x; $sh_c "echo '[Service]\nExecStart=\nExecStart=/usr/bin/dockerd --storage-driver overlay -H fd://' > /etc/systemd/system/docker.service.d/overlay.conf" )
-			else
+			if [ "$lsb_dist" != "raspbian" ]; then
 				# aufs is preferred over devicemapper; try to ensure the driver is available.
 				if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
 					if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -qE '^ii|^hi' 2>/dev/null; then


### PR DESCRIPTION
This PR is related to the raspbian integration on docker machine (https://github.com/docker/machine/pull/3605).

Docker machine relies on a `/etc/systemd/system/docker.service` file with all required flags in ExecStart (tcp socket, tls config, ...) but at the moment it gets overwritten because of the drop-in file, breaking the systemd integration.

Looking at https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/, it seems like overlayfs is modern and promising, I was surprised to see it so low in the priority list. Would it make sense to move it one level-up?

(If this PR is not accepted, an alternative is to revert #25684.)
