### PR TITLE
[proposal] [graphdriver] move overlay's priority one level up

### DIFF
--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -56,8 +56,8 @@ var (
 		"aufs",
 		"btrfs",
 		"zfs",
-		"devicemapper",
 		"overlay",
+		"devicemapper",
 		"vfs",
 	}
 


### PR DESCRIPTION
This is a follow-up from #26199. Lately there has been some changes in `hack/install.sh` so that systemd would configure overlay as the default driver on raspbian. It can cause some integration issues with docker machine for example, it would also still defaults to devicemapper in case users don't install docker through the helper script.

Instead of relying on systemd for it, I'd like to propose moving overlay one level up in the priority list. This would make sure it is the default on raspbian, I'm not sure if there are negative impacts for other distributions? From the searches I've made it seems like overlay has good feedbacks from docker users. What do you think?
