### PR TITLE
Output docker-py test results in xunit format

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -14,7 +14,7 @@ source hack/make/.integration-test-helpers
 	}
 
 	# exporting PYTHONPATH to import "docker" from our local docker-py
-	test_env PYTHONPATH="$dockerPy" py.test "$dockerPy/tests/integration"
+	test_env PYTHONPATH="$dockerPy" py.test --junitxml="$DEST/results.xml" "$dockerPy/tests/integration"
 
 	bundle .integration-daemon-stop
 ) 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
This adds a `results.xml` to the test-docker-py output folder.

Related: https://github.com/docker/docker-py/issues/1176

Signed-off-by: Michael Crosby crosbymichael@gmail.com
