### PR TITLE
Fix exec form of HEALTHCHECK CMD

### DIFF
--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -357,5 +357,5 @@ func parseHealthConfig(rest string, d *Directive) (*Node, map[string]bool, error
 		return nil, nil, err
 	}
 
-	return &Node{Value: typ, Next: cmd, Attributes: attrs}, nil, err
+	return &Node{Value: typ, Next: cmd}, attrs, err
 }

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -149,4 +149,19 @@ func (s *DockerSuite) TestHealth(c *check.C) {
 	c.Check(last.ExitCode, checker.Equals, -1)
 	c.Check(last.Output, checker.Equals, "Health check exceeded timeout (1ms)")
 	dockerCmd(c, "rm", "-f", "test")
+
+	// Check JSON-format
+	_, err = buildImage(imageName,
+		`FROM busybox
+		RUN echo OK > /status
+		CMD ["/bin/sleep", "120"]
+		STOPSIGNAL SIGKILL
+		HEALTHCHECK --interval=1s --timeout=30s \
+		  CMD ["cat", "/my status"]`,
+		true)
+	c.Check(err, check.IsNil)
+	out, _ = dockerCmd(c, "inspect",
+		"--format={{.Config.Healthcheck.Test}}", imageName)
+	c.Check(out, checker.Equals, "[CMD cat /my status]\n")
+
 }


### PR DESCRIPTION
**\- What I did**

My code for parsing the HEALTHCHECK command didn't work correctly for JSON-format commands because I was attaching the JSON flag to the wrong AST node, causing Docker to treat the exec form ["binary", "arg"] as if the shell form "binary arg" had been used. This failed if "sh" was not present. I added a test to detect the problem and fixed it.

Fixes #26174

**\- How to verify it**

Try the example in the linked bug report.

**\- Description for the changelog**

Fix exec form of HEALTHCHECK CMD

Signed-off-by: Thomas Leonard thomas.leonard@docker.com
