### PR TITLE
validate heartbeat in discovery cluster opts

### DIFF
--- a/daemon/discovery.go
+++ b/daemon/discovery.go
@@ -56,6 +56,12 @@ func discoveryOpts(clusterOpts map[string]string) (time.Duration, time.Duration,
 		if err != nil {
 			return time.Duration(0), time.Duration(0), err
 		}
+
+		if h <= 0 {
+			return time.Duration(0), time.Duration(0),
+				fmt.Errorf("discovery.heartbeat must be positive")
+		}
+
 		heartbeat = time.Duration(h) * time.Second
 		ttl = defaultDiscoveryTTLFactor * heartbeat
 	}
@@ -65,6 +71,12 @@ func discoveryOpts(clusterOpts map[string]string) (time.Duration, time.Duration,
 		if err != nil {
 			return time.Duration(0), time.Duration(0), err
 		}
+
+		if t <= 0 {
+			return time.Duration(0), time.Duration(0),
+				fmt.Errorf("discovery.ttl must be positive")
+		}
+
 		ttl = time.Duration(t) * time.Second
 
 		if _, ok := clusterOpts["discovery.heartbeat"]; !ok {

--- a/daemon/discovery_test.go
+++ b/daemon/discovery_test.go
@@ -18,6 +18,18 @@ func TestDiscoveryOpts(t *testing.T) {
 		t.Fatalf("discovery.ttl == discovery.heartbeat must fail")
 	}
 
+	clusterOpts = map[string]string{"discovery.heartbeat": "-10", "discovery.ttl": "10"}
+	heartbeat, ttl, err = discoveryOpts(clusterOpts)
+	if err == nil {
+		t.Fatalf("negative discovery.heartbeat must fail")
+	}
+
+	clusterOpts = map[string]string{"discovery.heartbeat": "10", "discovery.ttl": "-10"}
+	heartbeat, ttl, err = discoveryOpts(clusterOpts)
+	if err == nil {
+		t.Fatalf("negative discovery.ttl must fail")
+	}
+
 	clusterOpts = map[string]string{"discovery.heartbeat": "invalid"}
 	heartbeat, ttl, err = discoveryOpts(clusterOpts)
 	if err == nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This PR did:
1. validate heartbeat and ttl in discovery cluster opts, and make sure that both two are positive;
2. add related test case in discovery_test.go

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
