### PR TITLE
cluster: Do not autodetect advertise address on join

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -467,11 +467,13 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 	}
 
 	var advertiseAddr string
-	advertiseHost, advertisePort, err := c.resolveAdvertiseAddr(req.AdvertiseAddr, listenPort)
-	// For joining, we don't need to provide an advertise address,
-	// since the remote side can detect it.
-	if err == nil {
-		advertiseAddr = net.JoinHostPort(advertiseHost, advertisePort)
+	if req.AdvertiseAddr != "" {
+		advertiseHost, advertisePort, err := c.resolveAdvertiseAddr(req.AdvertiseAddr, listenPort)
+		// For joining, we don't need to provide an advertise address,
+		// since the remote side can detect it.
+		if err == nil {
+			advertiseAddr = net.JoinHostPort(advertiseHost, advertisePort)
+		}
 	}
 
 	// todo: check current state existing


### PR DESCRIPTION
On join, remote addresses are supposed to be detected by the manager
that receives the join request. However, the daemon is interfering with
this by automatically detecting an advertise address and specifying that
to the remote manager. Fix this so that an advertise address is only
specified while joining a cluster if one was given by the user.

Fixes part of #26167.

This is 1.12.2 material in case we release one.

cc @LK4D4 @tonistiigi @mavenugo @mrjana
