### PR TITLE
Correct typo in run reference docs that use the create command

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -194,7 +194,7 @@ The `-w` lets the command being executed inside directory given, here
 
 ### Set storage driver options per container
 
-    $ docker create -it --storage-opt size=120G fedora /bin/bash
+    $ docker run -it --storage-opt size=120G fedora /bin/bash
 
 This (size) will allow to set the container rootfs size to 120G at creation time. 
 User cannot pass a size less than the Default BaseFS Size. This option is only 


### PR DESCRIPTION
**\- What I did**
Modified the `run` reference documentation that used `create` instead of `run` in the description of `storage-opt` usage.

Signed-off-by: Yosef Fertel yfertel@gmail.com
