### PR TITLE
Modify rename function use tips

### DIFF
--- a/api/client/container/rename.go
+++ b/api/client/container/rename.go
@@ -21,7 +21,7 @@ func NewRenameCommand(dockerCli *client.DockerCli) *cobra.Command {
 	var opts renameOptions
 
 	cmd := &cobra.Command{
-		Use:   "rename OLD_NAME NEW_NAME",
+		Use:   "rename CONTAINER NEW_NAME",
 		Short: "Rename a container",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/rename.md
+++ b/docs/reference/commandline/rename.md
@@ -11,7 +11,7 @@ parent = "smn_cli"
 # rename
 
 ```markdown
-Usage:  docker rename OLD_NAME NEW_NAME
+Usage:  docker rename CONTAINER NEW_NAME
 
 Rename a container
 

--- a/man/docker-rename.1.md
+++ b/man/docker-rename.1.md
@@ -6,7 +6,7 @@ docker-rename - Rename a container
 
 # SYNOPSIS
 **docker rename**
-OLD_NAME NEW_NAME
+CONTAINER NEW_NAME
 
 # OPTIONS
 There are no available options.


### PR DESCRIPTION
When using the rename function, not only can use the old name, you can also use the container ID, so I think the original use of the prompt is not accurate

Signed-off-by: zhouhao zhouhao@cn.fujitsu.com
