### PR TITLE
Fix issue in `docker import -c` with quoted flags

### DIFF
--- a/api/client/image/import.go
+++ b/api/client/image/import.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/cli"
+	dockeropts "github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/engine-api/types"
@@ -17,7 +18,7 @@ import (
 type importOptions struct {
 	source    string
 	reference string
-	changes   []string
+	changes   dockeropts.ListOpts
 	message   string
 }
 
@@ -40,7 +41,8 @@ func NewImportCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	flags.StringSliceVarP(&opts.changes, "change", "c", []string{}, "Apply Dockerfile instruction to the created image")
+	opts.changes = dockeropts.NewListOpts(nil)
+	flags.VarP(&opts.changes, "change", "c", "Apply Dockerfile instruction to the created image")
 	flags.StringVarP(&opts.message, "message", "m", "", "Set commit message for imported image")
 
 	return cmd
@@ -71,7 +73,7 @@ func runImport(dockerCli *client.DockerCli, opts importOptions) error {
 
 	options := types.ImageImportOptions{
 		Message: opts.message,
-		Changes: opts.changes,
+		Changes: opts.changes.GetAll(),
 	}
 
 	clnt := dockerCli.Client()


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue in #26173 where `docker import -c` with quoted flags returns an error.

The issue was that in `api/client/image/import.go` the flag `--change/-c` was handled by `StringSliceVarP` which does not handle the quote well.

The similiar issue was enountered for #23309 (`docker commit`):
https://github.com/docker/docker/pull/23309#discussion_r66090808

**\- How I did it**

This fix takes the same approach as 23309 where `StringSliceVarP` was replaced with `VarP` and `opts.ListOpts`.

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #26173.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
