### PR TITLE
check inconsistant command in docs/reference/commandline

### DIFF
--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -14,7 +14,7 @@ parent = "smn_cli"
 ```markdown
 Usage:  docker plugin rm [OPTIONS] PLUGIN [PLUGIN...]
 
-Remove a plugin
+Remove one or more plugins
 
 Aliases:
   rm, remove


### PR DESCRIPTION
find "docker plugin rm", in remove.go:

```
cmd := &cobra.Command{
    Use:     "rm [OPTIONS] PLUGIN [PLUGIN...]",
    Short:   "Remove one or more plugins",
```
