### PR TITLE
Remove -h option for docker cli

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -26,7 +26,7 @@ Options:
   --config=~/.docker              Location of client config files
   -D, --debug                     Enable debug mode
   -H, --host=[]                   Daemon socket(s) to connect to
-  -h, --help                      Print usage
+  --help                          Print usage
   -l, --log-level=info            Set the logging level
   --tls                           Use TLS; implied by --tlsverify
   --tlscacert=~/.docker/ca.pem    Trust certs signed only by this CA


### PR DESCRIPTION
@dnephin PTAL
I find that docker cli still support '-h' option.
According to your comment (my older PR #25969), remove -h option for docker cli and update document.
Thanks!

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
