### PR TITLE
Add exception handling for dockerd initService

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -212,6 +212,12 @@ func unregisterService() error {
 }
 
 func initService(daemonCli *DaemonCli) (bool, error) {
+	if !*flUnregisterService {
+		if !*flRegisterService {
+			return true, errors.New("--register-service and --unregister-service cannot be both empty")
+		}
+	}
+
 	if *flUnregisterService {
 		if *flRegisterService {
 			return true, errors.New("--register-service and --unregister-service cannot be used together")


### PR DESCRIPTION
for dockerd initService(), only three conditions handled:

```
if *flUnregisterService {
    if *flRegisterService {
        return true, errors.New("--register-service and --unregister-service cannot be used together")
    }
    return true, unregisterService()
}

if *flRegisterService {
    return true, registerService()
}
```
