### PR TITLE
Add isolation to info - enables Hyper-V containers CI bring-up

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -260,6 +260,7 @@ type Info struct {
 	// running when the daemon is shutdown or upon daemon start if
 	// running containers are detected
 	LiveRestoreEnabled bool
+	Isolation          container.Isolation
 }
 
 // PluginsInfo is a temp struct holding Plugins name

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -141,6 +141,11 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 		fmt.Fprintf(dockerCli.Out(), "\n")
 	}
 
+	// Isolation only has meaning on a Windows daemon.
+	if info.OSType == "windows" {
+		fmt.Fprintf(dockerCli.Out(), "Default Isolation: %v\n", info.Isolation)
+	}
+
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "Operating System: %s\n", info.OperatingSystem)
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "OSType: %s\n", info.OSType)

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -118,6 +118,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		NoProxy:            sockets.GetProxyEnv("no_proxy"),
 		SecurityOptions:    securityOptions,
 		LiveRestoreEnabled: daemon.configStore.LiveRestoreEnabled,
+		Isolation:          daemon.defaultIsolation,
 	}
 
 	// TODO Windows. Refactor this more once sysinfo is refactored into

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -116,6 +116,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
+* `GET /info` now returns `Isolation`.
 * `POST /containers/create` now takes `AutoRemove` in HostConfig, to enable auto-removal of the container on daemon side when the container's process exits.
 * `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.
 * `GET /containers/json` now accepts `removing` as a valid value for the `status` filter.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -2221,7 +2221,7 @@ Display system-wide information
 
     GET /info HTTP/1.1
 
-**Example response**:
+**Example response (Linux)**:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
@@ -2297,6 +2297,109 @@ Display system-wide information
         "SwapLimit": false,
         "SystemStatus": [["State", "Healthy"]],
         "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
+    }
+
+
+**Example response (Windows)**:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+        "ID": "NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62",
+        "Containers": 1,
+        "ContainersRunning": 0,
+        "ContainersPaused": 0,
+        "ContainersStopped": 1,
+        "Images": 17,
+        "Driver": "windowsfilter",
+        "DriverStatus": [
+            ["Windows", ""]
+        ],
+        "SystemStatus": null,
+            "Plugins": {
+                "Volume": ["local"],
+                "Network": ["nat", "null", "overlay"],
+                "Authorization": null
+            },
+        "MemoryLimit": false,
+        "SwapLimit": false,
+        "KernelMemory": false,
+        "CpuCfsPeriod": false,
+        "CpuCfsQuota": false,
+        "CPUShares": false,
+        "CPUSet": false,
+        "IPv4Forwarding": true,
+        "BridgeNfIptables": true,
+        "BridgeNfIp6tables": true,
+        "Debug": false,
+        "NFd": -1,
+        "OomKillDisable": false,
+        "NGoroutines": 11,
+        "SystemTime": "2016-09-23T11:59:58.9843533-07:00",
+        "LoggingDriver": "json-file",
+        "CgroupDriver": "",
+        "NEventsListener": 0,
+        "KernelVersion": "10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)",
+        "OperatingSystem": "Windows Server 2016 Datacenter",
+        "OSType": "windows",
+        "Architecture": "x86_64",
+        "IndexServerAddress": "https://index.docker.io/v1/",
+        "RegistryConfig": {
+                "InsecureRegistryCIDRs": ["127.0.0.0/8"],
+                "IndexConfigs": {
+                    "docker.io": {
+                        "Name": "docker.io",
+                        "Mirrors": null,
+                        "Secure": true,
+                        "Official": true
+                    }
+                },
+                "Mirrors": null
+        },
+        "NCPU": 8,
+        "MemTotal": 4293828608,
+        "DockerRootDir": "C:\\control",
+        "HttpProxy": "",
+        "HttpsProxy": "",
+        "NoProxy": "",
+        "Name": "WIN-V0V70C0LU5P",
+        "Labels": null,
+        "ExperimentalBuild": false,
+        "ServerVersion": "1.13.0-dev",
+        "ClusterStore": "",
+        "ClusterAdvertise": "",
+        "SecurityOptions": null,
+        "Runtimes": null,
+        "DefaultRuntime": "",
+        "Swarm": {
+            "NodeID": "",
+            "NodeAddr": "",
+            "LocalNodeState": "inactive",
+            "ControlAvailable": false,
+            "Error": "",
+            "RemoteManagers": null,
+            "Nodes": 0,
+            "Managers": 0,
+            "Cluster": {
+                "ID": "",
+                "Version": {},
+                "CreatedAt": "0001-01-01T00:00:00Z",
+                "UpdatedAt": "0001-01-01T00:00:00Z",
+                "Spec": {
+                    "Orchestration": {},
+                    "Raft": {
+                        "ElectionTick": 0,
+                        "HeartbeatTick": 0
+                    },
+                    "Dispatcher": {},
+                    "CAConfig": {},
+                    "TaskDefaults": {}
+                }
+            }
+        },
+        "LiveRestoreEnabled": false,
+        "Isolation": "process"
     }
 
 **Status codes**:

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -154,3 +154,36 @@ You can also specify the output format:
 
     $ docker info --format '{{json .}}'
 	{"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}
+
+Here is a sample output for a daemon running on Windows Server 2016:
+
+    E:\docker>docker info
+    Containers: 1
+     Running: 0
+     Paused: 0
+     Stopped: 1
+    Images: 17
+    Server Version: 1.13.0-dev
+    Storage Driver: windowsfilter
+     Windows:
+    Logging Driver: json-file
+    Plugins:
+     Volume: local
+     Network: nat null overlay
+    Swarm: inactive
+    Default Isolation: process
+    Kernel Version: 10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)
+    Operating System: Windows Server 2016 Datacenter
+    OSType: windows
+    Architecture: x86_64
+    CPUs: 8
+    Total Memory: 3.999 GiB
+    Name: WIN-V0V70C0LU5P
+    ID: NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62
+    Docker Root Dir: C:\control
+    Debug Mode (client): false
+    Debug Mode (server): false
+    Registry: https://index.docker.io/v1/
+    Insecure Registries:
+     127.0.0.0/8
+    Live Restore Enabled: false

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/reexec"
 )
 
@@ -68,6 +69,9 @@ var (
 	// WindowsBaseImage is the name of the base image for Windows testing
 	// Environment variable WINDOWS_BASE_IMAGE can override this
 	WindowsBaseImage = "windowsservercore"
+
+	// isolation is the isolation mode of the daemon under test
+	isolation container.Isolation
 
 	// daemonPid is the pid of the main test daemon
 	daemonPid int

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -84,6 +84,7 @@ func init() {
 		volumesConfigPath = strings.Replace(volumesConfigPath, `\`, `/`, -1)
 		containerStoragePath = strings.Replace(containerStoragePath, `\`, `/`, -1)
 	}
+	isolation = info.Isolation
 }
 
 func convertBasesize(basesizeBytes int64) (int64, error) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This enables integration tests to know the isolation mode of the daemon under test so that they can take different actions between (on Windows) Window Server containers and Hyper-V containers. This change is essential to start getting coverage of Hyper-V containers - currently there is no coverage.
