### PR TITLE
DO NOT MERGE Windows CI: Port TestAttachDisconnect

### DIFF
--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -124,8 +124,14 @@ func (s *DockerSuite) TestAttachTTYWithoutStdin(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
+	var out string
+	if daemonPlatform == "windows" {
+		// Windows busybox doesn't work interactively in a container as it relies on
+		// conhost support. Instead, use a poor mans `cat` implemented in PowerShell.
+		out, _ = dockerCmd(c, "run", "-di", WindowsBaseImage, "powershell", "while(1){write-host(read-host)}")
+	} else {
+		out, _ = dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
+	}
 	id := strings.TrimSpace(out)
 
 	cmd := exec.Command(dockerBinary, "attach", id)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ported by using a simple PowerShell implementation of cat to workaround the inability of the Windows busybox image to support interactive inside a container on Windows.
