### PR TITLE
add `docker events --format`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1162,7 +1162,7 @@ _docker_events() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter -f --help --since --until" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter -f --help --since --until --format" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -164,6 +164,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from events' -s f -l filter 
 complete -c docker -A -f -n '__fish_seen_subcommand_from events' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from events' -l since -d 'Show all events created since timestamp'
 complete -c docker -A -f -n '__fish_seen_subcommand_from events' -l until -d 'Stream events until this timestamp'
+complete -c docker -A -f -n '__fish_seen_subcommand_from events' -l format -d 'Format the output using the given go template'
 
 # exec
 complete -c docker -f -n '__fish_docker_no_subcommand' -a exec -d 'Run a command in a running container'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1660,7 +1660,8 @@ __docker_subcommand() {
                 $opts_help \
                 "($help)*"{-f=,--filter=}"[Filter values]:filter:__docker_complete_events_filter" \
                 "($help)--since=[Events created since this timestamp]:timestamp: " \
-                "($help)--until=[Events created until this timestamp]:timestamp: " && ret=0
+                "($help)--until=[Events created until this timestamp]:timestamp: " \
+                "($help)--format=[Format the output using the given go template]:template: " && ret=0
             ;;
         (exec)
             local state

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -17,6 +17,7 @@ Get real time events from the server
 
 Options:
   -f, --filter value   Filter output based on conditions provided (default [])
+      --format string  Format the output using the given go template
       --help           Print usage
       --since string   Show all events created since timestamp
       --until string   Stream events until this timestamp
@@ -84,6 +85,16 @@ The currently supported filters are:
 * volume (`volume=<name or id>`)
 * network (`network=<name or id>`)
 * daemon (`daemon=<name or id>`)
+
+## Format
+
+If a format (`--format`) is specified, the given template will be executed
+instead of the default
+format. Go's [text/template](http://golang.org/pkg/text/template/) package
+describes all the details of the format.
+
+If a format is set to `{{json .}}`, the events are streamed as valid JSON
+Lines. For information about JSON Lines, please refer to http://jsonlines.org/ .
 
 ## Examples
 
@@ -180,3 +191,22 @@ relative to the current time on the client machine:
     $ docker events --filter 'type=plugin' (experimental)
     2016-07-25T17:30:14.825557616Z plugin pull ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/no-remove:latest)
     2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/no-remove:latest)
+
+**Format:**
+
+    $ docker events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
+    Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=attach  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=start  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=resize  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=die  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+
+**Format (as JSON Lines):**
+
+    $ docker events --format '{{json .}}'
+    {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+    {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+    {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
+    {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
+    {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	eventtypes "github.com/docker/docker/api/types/events"
 	eventstestutils "github.com/docker/docker/daemon/events/testutils"
 	"github.com/docker/docker/pkg/integration/checker"
 	icmd "github.com/docker/docker/pkg/integration/cmd"
@@ -744,4 +747,47 @@ func (s *DockerSuite) TestEventsUntilInThePast(c *check.C) {
 
 	c.Assert(out, checker.Not(checker.Contains), "test-container2")
 	c.Assert(out, checker.Contains, "test-container")
+}
+
+func (s *DockerSuite) TestEventsFormat(c *check.C) {
+	since := daemonUnixTime(c)
+	dockerCmd(c, "run", "--rm", "busybox", "true")
+	dockerCmd(c, "run", "--rm", "busybox", "true")
+	out, _ := dockerCmd(c, "events", "--since", since, "--until", daemonUnixTime(c), "--format", "{{json .}}")
+	dec := json.NewDecoder(strings.NewReader(out))
+	// make sure we got 2 start events
+	startCount := 0
+	for {
+		var err error
+		var ev eventtypes.Message
+		if err = dec.Decode(&ev); err == io.EOF {
+			break
+		}
+		c.Assert(err, checker.IsNil)
+		if ev.Status == "start" {
+			startCount++
+		}
+	}
+
+	c.Assert(startCount, checker.Equals, 2, check.Commentf("should have had 2 start events but had %d, out: %s", startCount, out))
+}
+
+func (s *DockerSuite) TestEventsFormatBadFunc(c *check.C) {
+	// make sure it fails immediately, without receiving any event
+	result := dockerCmdWithResult("events", "--format", "{{badFuncString .}}")
+	c.Assert(result, icmd.Matches, icmd.Expected{
+		Error:    "exit status 64",
+		ExitCode: 64,
+		Err:      "Error parsing format: template: :1: function \"badFuncString\" not defined",
+	})
+}
+
+func (s *DockerSuite) TestEventsFormatBadField(c *check.C) {
+	// make sure it fails immediately, without receiving any event
+	result := dockerCmdWithResult("events", "--format", "{{.badFieldString}}")
+	c.Assert(result, icmd.Matches, icmd.Expected{
+		Error:    "exit status 64",
+		ExitCode: 64,
+		Err:      "Error parsing format: template: :1:2: executing \"\" at <.badFieldString>: can't evaluate field badFieldString in type *events.Message",
+	})
 }

--- a/man/docker-events.1.md
+++ b/man/docker-events.1.md
@@ -10,6 +10,7 @@ docker-events - Get real time events from the server
 [**-f**|**--filter**[=*[]*]]
 [**--since**[=*SINCE*]]
 [**--until**[=*UNTIL*]]
+[**--format**[=*FORMAT*]]
 
 
 # DESCRIPTION
@@ -44,6 +45,9 @@ Docker networks report the following events:
 
 **--until**=""
    Stream events until this timestamp
+
+**--format**=""
+   Format the output using the given go template
 
 The `--since` and `--until` parameters can be Unix timestamps, date formatted
 timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
@@ -95,6 +99,31 @@ relative to the current time on the client machine:
 
 If you do not provide the --since option, the command returns only new and/or
 live events.
+
+## Format
+
+If a format (`--format`) is specified, the given template will be executed
+instead of the default format. Go's **text/template** package describes all the
+details of the format.
+
+    # docker events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
+    Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=attach  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=start  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=resize  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=die  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+    Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
+
+If a format is set to `{{json .}}`, the events are streamed as valid JSON
+Lines. For information about JSON Lines, please refer to http://jsonlines.org/ .
+
+    # docker events --format '{{json .}}'
+    {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+    {"status":"attach","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+    {"Type":"network","Action":"connect","Actor":{"ID":"1b50a5bf755f6021dfa78e..
+    {"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
+    {"status":"resize","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..
+
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)


### PR DESCRIPTION
**\- What I did**
Add `docker events --format`.

Note that `-f` is the short form of the existing `--filter`.
(similar to `docker ps`)

**\- How I did it**
Please refer to the code

**\- How to verify it**
Example: [JSON Lines](http://jsonlines.org/) (aka NDJSON, LDJSON, JSON stream, ...) 

```
$ docker events --format="{{json .}}"
{"status":"create","id":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","from":"alpine","Type":"container","Action":"create","Actor":{"ID":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","Attributes":{"image":"alpine","name":"goofy_yonath"}},"time":1472807143,"timeNano":1472807143011844368}
{"status":"attach","id":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","from":"alpine","Type":"container","Action":"attach","Actor":{"ID":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","Attributes":{"image":"alpine","name":"goofy_yonath"}},"time":1472807143,"timeNano":1472807143012990299}
{"Type":"network","Action":"connect","Actor":{"ID":"c8b01845e3aa17dc3f9026125c44cf0075de8672a086c04ecfa02c6d8b359afa","Attributes":{"container":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","name":"bridge","type":"bridge"}},"time":1472807143,"timeNano":1472807143033449708}
{"status":"start","id":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","from":"alpine","Type":"container","Action":"start","Actor":{"ID":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","Attributes":{"image":"alpine","name":"goofy_yonath"}},"time":1472807143,"timeNano":1472807143208051400}
{"status":"resize","id":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","from":"alpine","Type":"container","Action":"resize","Actor":{"ID":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","Attributes":{"height":"46","image":"alpine","name":"goofy_yonath","width":"174"}},"time":1472807143,"timeNano":1472807143209296139}
{"status":"die","id":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","from":"alpine","Type":"container","Action":"die","Actor":{"ID":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","Attributes":{"exitCode":"0","image":"alpine","name":"goofy_yonath"}},"time":1472807143,"timeNano":1472807143241584111}
{"Type":"network","Action":"disconnect","Actor":{"ID":"c8b01845e3aa17dc3f9026125c44cf0075de8672a086c04ecfa02c6d8b359afa","Attributes":{"container":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","name":"bridge","type":"bridge"}},"time":1472807143,"timeNano":1472807143384316935}
{"status":"destroy","id":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","from":"alpine","Type":"container","Action":"destroy","Actor":{"ID":"7129b55274d19b62cbae90561b455403a3784364d4187c42cf1d533dd665b112","Attributes":{"image":"alpine","name":"goofy_yonath"}},"time":1472807143,"timeNano":1472807143421794702}
```

automated test:

```
$ DOCKER_INCREMENTAL_BINARY=1 TESTFLAGS='-check.f DockerSuite.TestEvents' make test-integration-cli 
```

**\- Description for the changelog**
add `docker events --format`

**\- A picture of a cute animal (not mandatory but encouraged)**
https://commons.wikimedia.org/wiki/Pygoscelis_adeliae

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
