### PR TITLE
Remove the option for the command service rm

### DIFF
--- a/api/client/service/remove.go
+++ b/api/client/service/remove.go
@@ -13,7 +13,7 @@ import (
 func newRemoveCommand(dockerCli *client.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:     "rm [OPTIONS] SERVICE [SERVICE...]",
+		Use:     "rm SERVICE [SERVICE...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more services",
 		Args:    cli.RequiresMinArgs(1),

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -11,7 +11,7 @@ parent = "smn_cli"
 # service rm
 
 ```Markdown
-Usage:	docker service rm [OPTIONS] SERVICE [SERVICE...]
+Usage:	docker service rm SERVICE [SERVICE...]
 
 Remove one or more services
 


### PR DESCRIPTION
Remove the option for the command service rm which only has a --help option.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
