### PR TITLE
Fix: docker info not list all the volume drivers on daemon fresh start.

### DIFF
--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -141,11 +141,10 @@ func GetDriver(name string) (volume.Driver, error) {
 // If no driver is registered, empty string list will be returned.
 func GetDriverList() []string {
 	var driverList []string
-	drivers.Lock()
-	for driverName := range drivers.extensions {
-		driverList = append(driverList, driverName)
+	allDriver, _ := GetAllDrivers()
+	for _, driver := range allDriver {
+		driverList = append(driverList, driver.Name())
 	}
-	drivers.Unlock()
 	return driverList
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

make sure every time we get list of volume drivers we get the correct result

Fix: #26272

**\- How I did it**

change the GetDriverList() to use the GetAllDrivers(), which will add plugin to storage which are not in drivers.extensions

**\- How to verify it**

I compile it, run it, and the result is exactly as I expected

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix: docker info not list all the volume drivers on fresh start.

**\- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/3241438/18201768/9294253a-713e-11e6-8c8d-9ec6eaec33d2.png)
