### PR TITLE
daemon: add a flag to override the default seccomp profile

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -42,10 +42,20 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 	if versions.LessThan(httputils.VersionFromContext(ctx), "1.25") {
 		// TODO: handle this conversion in engine-api
 		type oldInfo struct {
-			*types.Info
+			*types.InfoBase
 			ExecutionDriver string
+			SecurityOptions []string
 		}
-		return httputils.WriteJSON(w, http.StatusOK, &oldInfo{Info: info, ExecutionDriver: "<not supported>"})
+		old := &oldInfo{
+			InfoBase:        info.InfoBase,
+			ExecutionDriver: "<not supported>",
+		}
+		for _, s := range info.SecurityOptions {
+			if s.Key == "Name" {
+				old.SecurityOptions = append(old.SecurityOptions, s.Value)
+			}
+		}
+		return httputils.WriteJSON(w, http.StatusOK, old)
 	}
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -142,9 +142,9 @@ type Version struct {
 	BuildTime     string `json:",omitempty"`
 }
 
-// Info contains response of Remote API:
+// InfoBase contains the base response of Remote API:
 // GET "/info"
-type Info struct {
+type InfoBase struct {
 	ID                 string
 	Containers         int
 	ContainersRunning  int
@@ -191,7 +191,6 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
-	SecurityOptions    []string
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info
@@ -200,6 +199,18 @@ type Info struct {
 	// running containers are detected
 	LiveRestoreEnabled bool
 	Isolation          container.Isolation
+}
+
+// SecurityOpt holds key/value pair about a security option
+type SecurityOpt struct {
+	Key, Value string
+}
+
+// Info contains response of Remote API:
+// GET "/info"
+type Info struct {
+	*InfoBase
+	SecurityOptions []SecurityOpt
 }
 
 // PluginsInfo is a temp struct holding Plugins name

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -140,9 +140,20 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 	}
 
 	if info.OSType == "linux" {
-		fmt.Fprintf(dockerCli.Out(), "Security Options:")
-		ioutils.FprintfIfNotEmpty(dockerCli.Out(), " %s", strings.Join(info.SecurityOptions, " "))
-		fmt.Fprintf(dockerCli.Out(), "\n")
+		if len(info.SecurityOptions) != 0 {
+			fmt.Fprintf(dockerCli.Out(), "Security Options:\n")
+			for _, o := range info.SecurityOptions {
+				switch o.Key {
+				case "Name":
+					fmt.Fprintf(dockerCli.Out(), " %s\n", o.Value)
+				case "Profile":
+					if o.Key != "default" {
+						fmt.Fprintf(dockerCli.Err(), "  WARNING: You're not using the Docker's default seccomp profile\n")
+					}
+					fmt.Fprintf(dockerCli.Out(), "  %s: %s\n", o.Key, o.Value)
+				}
+			}
+		}
 	}
 
 	// Isolation only has meaning on a Windows daemon.

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -46,8 +46,10 @@ func TestInfo(t *testing.T) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
 			info := &types.Info{
-				ID:         "daemonID",
-				Containers: 3,
+				InfoBase: &types.InfoBase{
+					ID:         "daemonID",
+					Containers: 3,
+				},
 			}
 			b, err := json.Marshal(info)
 			if err != nil {

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -39,6 +39,7 @@ type Config struct {
 	OOMScoreAdjust       int                      `json:"oom-score-adjust,omitempty"`
 	Init                 bool                     `json:"init,omitempty"`
 	InitPath             string                   `json:"init-path,omitempty"`
+	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -101,6 +102,7 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&config.InitPath, "init-path", "", "Path to the docker-init binary")
 	flags.Int64Var(&config.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds")
 	flags.Int64Var(&config.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds")
+	flags.StringVar(&config.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
 
 	config.attachExperimentalFlags(flags)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -104,6 +104,9 @@ type Daemon struct {
 	defaultIsolation          containertypes.Isolation // Default isolation mode on Windows
 	clusterProvider           cluster.Provider
 	cluster                   Cluster
+
+	seccompProfile     []byte
+	seccompProfilePath string
 }
 
 // HasExperimental returns whether the experimental features of the daemon are enabled or not
@@ -529,6 +532,10 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 			}
 		}
 	}()
+
+	if err := d.setupSeccompProfile(); err != nil {
+		return nil, err
+	}
 
 	// Set the default isolation mode (only applicable on Windows)
 	if err := d.setDefaultIsolation(); err != nil {

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -177,3 +177,7 @@ func setupDaemonProcess(config *Config) error {
 func (daemon *Daemon) verifyVolumesInfo(container *container.Container) error {
 	return nil
 }
+
+func (daemon *Daemon) setupSeccompProfile() error {
+	return nil
+}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -1242,6 +1243,23 @@ func (daemon *Daemon) initCgroupsPath(path string) error {
 			return err
 		}
 	}
+	return nil
+}
 
+func (daemon *Daemon) setupSeccompProfile() error {
+	if daemon.configStore.SeccompProfile != "" {
+		daemon.seccompProfilePath = daemon.configStore.SeccompProfile
+		b, err := ioutil.ReadFile(daemon.configStore.SeccompProfile)
+		if err != nil {
+			return fmt.Errorf("opening seccomp profile (%s) failed: %v", daemon.configStore.SeccompProfile, err)
+		}
+		daemon.seccompProfile = b
+		p := struct {
+			DefaultAction string `json:"defaultAction"`
+		}{}
+		if err := json.Unmarshal(daemon.seccompProfile, &p); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -532,3 +532,7 @@ func setupDaemonProcess(config *Config) error {
 func (daemon *Daemon) verifyVolumesInfo(container *container.Container) error {
 	return nil
 }
+
+func (daemon *Daemon) setupSeccompProfile() error {
+	return nil
+}

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -37,9 +37,16 @@ func setSeccomp(daemon *Daemon, rs *specs.Spec, c *container.Container) error {
 			return err
 		}
 	} else {
-		profile, err = seccomp.GetDefaultProfile(rs)
-		if err != nil {
-			return err
+		if daemon.seccompProfile != nil {
+			profile, err = seccomp.LoadProfile(string(daemon.seccompProfile), rs)
+			if err != nil {
+				return err
+			}
+		} else {
+			profile, err = seccomp.GetDefaultProfile(rs)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -74,6 +74,7 @@ Options:
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring
       --registry-mirror value                 Preferred Docker registry mirror (default [])
+      --seccomp-profile value                 Path to seccomp profile
       --selinux-enabled                       Enable selinux support
       --shutdown-timeout=15                   Set the shutdown timeout value in seconds
   -s, --storage-driver string                 Storage driver to use
@@ -1195,6 +1196,7 @@ This is a full example of the allowed configuration options on Linux:
 	"icc": false,
 	"raw-logs": false,
 	"registry-mirrors": [],
+	"seccomp-profile": "",
 	"insecure-registries": [],
 	"disable-legacy-registry": false,
 	"default-runtime": "runc",

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -11,5 +11,5 @@ func (s *DockerSuite) TestInfoSecurityOptions(c *check.C) {
 	testRequires(c, SameHostDaemon, seccompEnabled, Apparmor, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "info")
-	c.Assert(out, checker.Contains, "Security Options: apparmor seccomp")
+	c.Assert(out, checker.Contains, "Security Options:\n apparmor\n seccomp\n  Profile: default\n")
 }

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -56,6 +56,7 @@ dockerd - Enable daemon mode
 [**--raw-logs**]
 [**--registry-mirror**[=*[]*]]
 [**-s**|**--storage-driver**[=*STORAGE-DRIVER*]]
+[**--seccomp-profile**[=*SECCOMP-PROFILE-PATH*]]
 [**--selinux-enabled**]
 [**--shutdown-timeout**[=*15*]]
 [**--storage-opt**[=*[]*]]
@@ -247,6 +248,9 @@ output otherwise.
 
 **-s**, **--storage-driver**=""
   Force the Docker runtime to use a specific storage driver.
+
+**--seccomp-profile**=""
+  Path to seccomp profile.
 
 **--selinux-enabled**=*true*|*false*
   Enable selinux support. Default is false.


### PR DESCRIPTION
Supersedes https://github.com/docker/docker/pull/24221

Introduce `/etc/docker/seccomp.json` as per discussion in #24221

/cc @justincormack @cpuguy83 @LK4D4 @jfrazelle @cyphar @rhatdan 

Signed-off-by: Antonio Murdaca runcom@redhat.com
