### PR TITLE
delete a function which isn't used in the project

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -77,14 +77,6 @@ func ParseForm(r *http.Request) error {
 	return nil
 }
 
-// ParseMultipartForm ensures the request form is parsed, even with invalid content types.
-func ParseMultipartForm(r *http.Request) error {
-	if err := r.ParseMultipartForm(4096); err != nil && !strings.HasPrefix(err.Error(), "mime:") {
-		return err
-	}
-	return nil
-}
-
 // WriteJSON writes the value v to the http response stream as json with standard json encoding.
 func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Delete the function `ParseMultipartForm` in the `api/server/httputils/httputils.go`, because it is not used anywhere in the project.

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
