### PR TITLE
`docker node inspect <node> --pretty`  needs an extra newline at the end

### DIFF
--- a/api/client/node/inspect.go
+++ b/api/client/node/inspect.go
@@ -71,6 +71,8 @@ func printHumanFriendly(out io.Writer, refs []string, getRef inspect.GetRefFunc)
 		// print extra space between objects, but not after the last one
 		if idx+1 != len(refs) {
 			fmt.Fprintf(out, "\n\n")
+		} else {
+			fmt.Fprintf(out, "\n")
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #26280 

**\- What I did**
There was code in place to add two newlines after all pieces of info except the last one. I changed it to add one newline after the last one.

**\- How I did it**

**\- How to verify it**
I used `make shell` and initialized a swarm in the created container, then I ran `docker node inspect <node> --pretty` and verified that it did not corrupt the prompt.

**\- Description for the changelog**
Improved output of `docker node inspect <node> --pretty`

Signed-off-by: Misty Stanley-Jones misty@docker.com
