### PR TITLE
Fixed support for docker compose by allowing connect/disconnect on stopped containers

### DIFF
--- a/daemon/container_operations_solaris.go
+++ b/daemon/container_operations_solaris.go
@@ -2,30 +2,15 @@
 
 package daemon
 
-import (
-	"fmt"
-
-	networktypes "github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/container"
-)
+import "github.com/docker/docker/container"
 
 func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]string, error) {
 	return nil, nil
 }
 
-// ConnectToNetwork connects a container to a network
-func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings) error {
-	return fmt.Errorf("Solaris does not support connecting a running container to a network")
-}
-
 // getSize returns real size & virtual size
 func (daemon *Daemon) getSize(container *container.Container) (int64, int64) {
 	return 0, 0
-}
-
-// DisconnectFromNetwork disconnects a container from the network
-func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, networkName string, force bool) error {
-	return fmt.Errorf("Solaris does not support disconnecting a running container from a network")
 }
 
 func (daemon *Daemon) setupIpcDirs(container *container.Container) error {
@@ -45,5 +30,9 @@ func detachMounted(path string) error {
 }
 
 func isLinkable(child *container.Container) bool {
+	return false
+}
+
+func (daemon *Daemon) isNetworkHotPluggable() bool {
 	return false
 }

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -2,25 +2,10 @@
 
 package daemon
 
-import (
-	"fmt"
-
-	networktypes "github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/container"
-)
+import "github.com/docker/docker/container"
 
 func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]string, error) {
 	return nil, nil
-}
-
-// ConnectToNetwork connects a container to a network
-func (daemon *Daemon) ConnectToNetwork(container *container.Container, idOrName string, endpointConfig *networktypes.EndpointSettings) error {
-	return fmt.Errorf("Windows does not support connecting a running container to a network")
-}
-
-// DisconnectFromNetwork disconnects container from a network.
-func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, networkName string, force bool) error {
-	return fmt.Errorf("Windows does not support disconnecting a running container from a network")
 }
 
 // getSize returns real size & virtual size
@@ -57,4 +42,8 @@ func isLinkable(child *container.Container) bool {
 
 func enableIPOnPredefinedNetwork() bool {
 	return true
+}
+
+func (daemon *Daemon) isNetworkHotPluggable() bool {
+	return false
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Docker-compose v2 doesn't work with windows and shows the following error:

>  Windows does not support disconnecting a running container from a network
> This is because docker-compose expects networking to be allocated at create and if networking is not allocated it will try to connect the container to the network which is not supported in windows.

**\- How I did it**
Windows doesn't support hot add of endpoints to running containers. But adding endpoints to stopped containers is not an issue. This PR adds support of adding endpoints to containers as long as they are not running.
We also need my service discovery change for compose to work on windows.  https://github.com/docker/docker/pull/25097
**\- How to verify it**
Validated compose with privates of this PR and all my service discovery related changes.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed support for connecting and disconnecting containers to networks on windows as long as they are not running

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: msabansal sabansal@microsoft.com
