### PR TITLE
Fix govet for go1.7

### DIFF
--- a/api/client/trust.go
+++ b/api/client/trust.go
@@ -132,7 +132,7 @@ func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, aut
 		return nil, err
 	}
 
-	var cfg = tlsconfig.ClientDefault
+	var cfg = tlsconfig.ClientDefault()
 	cfg.InsecureSkipVerify = !repoInfo.Index.Secure
 
 	// Get certificate base directory
@@ -142,7 +142,7 @@ func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, aut
 	}
 	logrus.Debugf("reading certificate directory: %s", certDir)
 
-	if err := registry.ReadCertsDirectory(&cfg, certDir); err != nil {
+	if err := registry.ReadCertsDirectory(cfg, certDir); err != nil {
 		return nil, err
 	}
 
@@ -154,7 +154,7 @@ func (cli *DockerCli) getNotaryRepository(repoInfo *registry.RepositoryInfo, aut
 			DualStack: true,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     &cfg,
+		TLSClientConfig:     cfg,
 		DisableKeepAlives:   true,
 	}
 

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -214,7 +214,7 @@ func TestFrom(t *testing.T) {
 		}
 
 		if b.noBaseImage != true {
-			t.Fatalf("Image should not have any base image, got: %s", b.noBaseImage)
+			t.Fatalf("Image should not have any base image, got: %v", b.noBaseImage)
 		}
 	}
 }

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -64,7 +64,7 @@ clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units eb879ae3e2b84e2a142af415b679ddeda47ec71c
-clone git github.com/docker/go-connections fa2850ff103453a9ad190da0df0af134f0314b3d
+clone git github.com/docker/go-connections 988efe982fdecb46f01d53465878ff1f2ff411ce
 
 clone git github.com/docker/engine-api 8d8fffdf863b12d03c76abf6ca1377e6f8f4e549
 clone git github.com/RackSec/srslog 259aed10dfa74ea2961eddd1d9847619f6e98837

--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -17,9 +17,9 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/engine-api/types/events"
 	"github.com/docker/go-connections/sockets"
+	"github.com/docker/go-connections/tlsconfig"
 	"github.com/go-check/check"
 )
 

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/integration/checker"
-	"github.com/docker/docker/pkg/tlsconfig"
+	"github.com/docker/go-connections/tlsconfig"
 	"github.com/go-check/check"
 )
 
@@ -136,7 +136,7 @@ func newTestNotary(c *check.C) (*testNotary, error) {
 }
 
 func (t *testNotary) Ping() error {
-	tlsConfig := tlsconfig.ClientDefault
+	tlsConfig := tlsconfig.ClientDefault()
 	tlsConfig.InsecureSkipVerify = true
 	client := http.Client{
 		Transport: &http.Transport{
@@ -146,7 +146,7 @@ func (t *testNotary) Ping() error {
 				KeepAlive: 30 * time.Second,
 			}).Dial,
 			TLSHandshakeTimeout: 10 * time.Second,
-			TLSClientConfig:     &tlsConfig,
+			TLSClientConfig:     tlsConfig,
 		},
 	}
 	resp, err := client.Get(fmt.Sprintf("%s/v2/", notaryURL))

--- a/pkg/plugins/discovery_test.go
+++ b/pkg/plugins/discovery_test.go
@@ -59,7 +59,7 @@ func TestFileSpecPlugin(t *testing.T) {
 		}
 
 		if p.name != c.name {
-			t.Fatalf("Expected plugin `%s`, got %s\n", c.name, p.Name)
+			t.Fatalf("Expected plugin `%s`, got %s\n", c.name, p.name)
 		}
 
 		if p.Addr != c.addr {
@@ -97,8 +97,8 @@ func TestFileJSONSpecPlugin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if plugin.name != "example" {
-		t.Fatalf("Expected plugin `plugin-example`, got %s\n", plugin.Name)
+	if expected, actual := "example", plugin.name; expected != actual {
+		t.Fatalf("Expected plugin %q, got %s\n", expected, actual)
 	}
 
 	if plugin.Addr != "https://example.com/docker/plugin" {
@@ -138,8 +138,8 @@ func TestFileJSONSpecPluginWithoutTLSConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if plugin.name != "example" {
-		t.Fatalf("Expected plugin `plugin-example`, got %s\n", plugin.Name)
+	if expected, actual := "example", plugin.name; expected != actual {
+		t.Fatalf("Expected plugin %q, got %s\n", expected, actual)
 	}
 
 	if plugin.Addr != "https://example.com/docker/plugin" {

--- a/pkg/plugins/discovery_unix_test.go
+++ b/pkg/plugins/discovery_unix_test.go
@@ -46,7 +46,7 @@ func TestLocalSocket(t *testing.T) {
 		}
 
 		if p.name != "echo" {
-			t.Fatalf("Expected plugin `echo`, got %s\n", p.Name)
+			t.Fatalf("Expected plugin `echo`, got %s\n", p.name)
 		}
 
 		addr := fmt.Sprintf("unix://%s", c)

--- a/pkg/tlsconfig/config.go
+++ b/pkg/tlsconfig/config.go
@@ -52,19 +52,23 @@ var clientCipherSuites = []uint16{
 // known weak algorithms removed.
 var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers...)
 
-// ServerDefault is a secure-enough TLS configuration for the server TLS configuration.
-var ServerDefault = tls.Config{
-	// Avoid fallback to SSL protocols < TLS1.0
-	MinVersion:               tls.VersionTLS10,
-	PreferServerCipherSuites: true,
-	CipherSuites:             DefaultServerAcceptedCiphers,
+// ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
+func ServerDefault() *tls.Config {
+	return &tls.Config{
+		// Avoid fallback to SSL protocols < TLS1.0
+		MinVersion:               tls.VersionTLS10,
+		PreferServerCipherSuites: true,
+		CipherSuites:             DefaultServerAcceptedCiphers,
+	}
 }
 
-// ClientDefault is a secure-enough TLS configuration for the client TLS configuration.
-var ClientDefault = tls.Config{
-	// Prefer TLS1.2 as the client minimum
-	MinVersion:   tls.VersionTLS12,
-	CipherSuites: clientCipherSuites,
+// ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
+func ClientDefault() *tls.Config {
+	return &tls.Config{
+		// Prefer TLS1.2 as the client minimum
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: clientCipherSuites,
+	}
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
@@ -78,20 +82,15 @@ func certPool(caFile string) (*x509.CertPool, error) {
 	if !certPool.AppendCertsFromPEM(pem) {
 		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)
 	}
-	s := certPool.Subjects()
-	subjects := make([]string, len(s))
-	for i, subject := range s {
-		subjects[i] = string(subject)
-	}
-	logrus.Debugf("Trusting certs with subjects: %v", subjects)
+	logrus.Debugf("Trusting %d certs", len(certPool.Subjects()))
 	return certPool, nil
 }
 
 // Client returns a TLS configuration meant to be used by a client.
 func Client(options Options) (*tls.Config, error) {
-	tlsConfig := ClientDefault
+	tlsConfig := ClientDefault()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
-	if !options.InsecureSkipVerify {
+	if !options.InsecureSkipVerify && options.CAFile != "" {
 		CAs, err := certPool(options.CAFile)
 		if err != nil {
 			return nil, err
@@ -99,7 +98,7 @@ func Client(options Options) (*tls.Config, error) {
 		tlsConfig.RootCAs = CAs
 	}
 
-	if options.CertFile != "" && options.KeyFile != "" {
+	if options.CertFile != "" || options.KeyFile != "" {
 		tlsCert, err := tls.LoadX509KeyPair(options.CertFile, options.KeyFile)
 		if err != nil {
 			return nil, fmt.Errorf("Could not load X509 key pair: %v. Make sure the key is not encrypted", err)
@@ -107,12 +106,12 @@ func Client(options Options) (*tls.Config, error) {
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	}
 
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }
 
 // Server returns a TLS configuration meant to be used by a server.
 func Server(options Options) (*tls.Config, error) {
-	tlsConfig := ServerDefault
+	tlsConfig := ServerDefault()
 	tlsConfig.ClientAuth = options.ClientAuth
 	tlsCert, err := tls.LoadX509KeyPair(options.CertFile, options.KeyFile)
 	if err != nil {
@@ -129,5 +128,5 @@ func Server(options Options) (*tls.Config, error) {
 		}
 		tlsConfig.ClientCAs = CAs
 	}
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -28,19 +28,19 @@ var (
 
 func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect
-	tlsConfig := tlsconfig.ServerDefault
+	tlsConfig := tlsconfig.ServerDefault()
 
 	tlsConfig.InsecureSkipVerify = !isSecure
 
 	if isSecure && CertsDir != "" {
 		hostDir := filepath.Join(CertsDir, cleanPath(hostname))
 		logrus.Debugf("hostDir: %s", hostDir)
-		if err := ReadCertsDirectory(&tlsConfig, hostDir); err != nil {
+		if err := ReadCertsDirectory(tlsConfig, hostDir); err != nil {
 			return nil, err
 		}
 	}
 
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }
 
 func hasFile(files []os.FileInfo, name string) bool {
@@ -163,8 +163,7 @@ func addRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Reque
 // default TLS configuration.
 func NewTransport(tlsConfig *tls.Config) *http.Transport {
 	if tlsConfig == nil {
-		var cfg = tlsconfig.ServerDefault
-		tlsConfig = &cfg
+		tlsConfig = tlsconfig.ServerDefault()
 	}
 
 	direct := &net.Dialer{

--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -7,8 +7,7 @@ import (
 )
 
 func (s *DefaultService) lookupV1Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
-	var cfg = tlsconfig.ServerDefault
-	tlsConfig := &cfg
+	tlsConfig := tlsconfig.ServerDefault()
 	if hostname == DefaultNamespace {
 		endpoints = append(endpoints, APIEndpoint{
 			URL:          DefaultV1Registry,

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -8,8 +8,7 @@ import (
 )
 
 func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
-	var cfg = tlsconfig.ServerDefault
-	tlsConfig := &cfg
+	tlsConfig := tlsconfig.ServerDefault()
 	if hostname == DefaultNamespace || hostname == DefaultV1Registry.Host {
 		// v2 mirrors
 		for _, mirror := range s.config.Mirrors {

--- a/vendor/src/github.com/docker/go-connections/nat/nat.go
+++ b/vendor/src/github.com/docker/go-connections/nat/nat.go
@@ -85,14 +85,10 @@ func (p Port) Port() string {
 // Int returns the port number of a Port as an int
 func (p Port) Int() int {
 	portStr := p.Port()
-	if len(portStr) == 0 {
-		return 0
-	}
-
 	// We don't need to check for an error because we're going to
 	// assume that any error would have been found, and reported, in NewPort()
-	port, _ := strconv.ParseUint(portStr, 10, 16)
-	return int(port)
+	port, _ := ParsePort(portStr)
+	return port
 }
 
 // Range returns the start/end port numbers of a Port range as ints

--- a/vendor/src/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/src/github.com/docker/go-connections/tlsconfig/config.go
@@ -46,19 +46,23 @@ var acceptedCBCCiphers = []uint16{
 // known weak algorithms removed.
 var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers...)
 
-// ServerDefault is a secure-enough TLS configuration for the server TLS configuration.
-var ServerDefault = tls.Config{
-	// Avoid fallback to SSL protocols < TLS1.0
-	MinVersion:               tls.VersionTLS10,
-	PreferServerCipherSuites: true,
-	CipherSuites:             DefaultServerAcceptedCiphers,
+// ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
+func ServerDefault() *tls.Config {
+	return &tls.Config{
+		// Avoid fallback to SSL protocols < TLS1.0
+		MinVersion:               tls.VersionTLS10,
+		PreferServerCipherSuites: true,
+		CipherSuites:             DefaultServerAcceptedCiphers,
+	}
 }
 
-// ClientDefault is a secure-enough TLS configuration for the client TLS configuration.
-var ClientDefault = tls.Config{
-	// Prefer TLS1.2 as the client minimum
-	MinVersion:   tls.VersionTLS12,
-	CipherSuites: clientCipherSuites,
+// ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
+func ClientDefault() *tls.Config {
+	return &tls.Config{
+		// Prefer TLS1.2 as the client minimum
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: clientCipherSuites,
+	}
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
@@ -78,7 +82,7 @@ func certPool(caFile string) (*x509.CertPool, error) {
 
 // Client returns a TLS configuration meant to be used by a client.
 func Client(options Options) (*tls.Config, error) {
-	tlsConfig := ClientDefault
+	tlsConfig := ClientDefault()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
 	if !options.InsecureSkipVerify && options.CAFile != "" {
 		CAs, err := certPool(options.CAFile)
@@ -96,12 +100,12 @@ func Client(options Options) (*tls.Config, error) {
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	}
 
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }
 
 // Server returns a TLS configuration meant to be used by a server.
 func Server(options Options) (*tls.Config, error) {
-	tlsConfig := ServerDefault
+	tlsConfig := ServerDefault()
 	tlsConfig.ClientAuth = options.ClientAuth
 	tlsCert, err := tls.LoadX509KeyPair(options.CertFile, options.KeyFile)
 	if err != nil {
@@ -118,5 +122,5 @@ func Server(options Options) (*tls.Config, error) {
 		}
 		tlsConfig.ClientCAs = CAs
 	}
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }


### PR DESCRIPTION
Because we only run govet on changed files we missed some updates when upgrading to go1.7. Most significant fix is to remove copying `tls.Config` because it contains a mutex.

Also updated `pkg/tlsconfig` directly from `docker/go-connections`. We can remove that package after https://github.com/docker/libnetwork/pull/1429 is merged.

cc @tiborvass 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
