### PR TITLE
fix the wrong option info while specifying the command with the "--help"

### DIFF
--- a/docs/tutorials/usingdocker.md
+++ b/docs/tutorials/usingdocker.md
@@ -73,9 +73,11 @@ To see usage for a specific command, specify the command with the `--help` flag:
 
     Attach to a running container
 
-      --help              Print usage
-      --no-stdin          Do not attach stdin
-      --sig-proxy=true    Proxy all received signals to the process
+    Options:
+      --detach-keys string   Override the key sequence for detaching a container
+      --help                 Print usage
+      --no-stdin             Do not attach STDIN
+      --sig-proxy            Proxy all received signals to the process (default true)
 
 > **Note:**
 > For further details and examples of each command, see the


### PR DESCRIPTION
in attach.md, actual info like this:

```
Usage: docker attach [OPTIONS] CONTAINER

Attach to a running container

Options:
      --detach-keys string   Override the key sequence for detaching a container
      --help                 Print usage
      --no-stdin             Do not attach STDIN
      --sig-proxy            Proxy all received signals to the process (default true)
```
