### PR TITLE
Updated Windows mounting example

### DIFF
--- a/docs/tutorials/dockervolumes.md
+++ b/docs/tutorials/dockervolumes.md
@@ -134,7 +134,7 @@ docker run -v /Users/<path>:/<container path> ...
 On Windows, mount directories using:
 
 ```bash
-docker run -v /c/Users/<path>:/<container path> ...`
+docker run -v c:\<path>:/c:\<container path>
 ```
 
 All other paths come from your virtual machine's filesystem, so if you want


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Corrected an example of mounting persistent storage on windows according to http://superuser.com/questions/1051520/docker-windows-container-how-to-mount-a-host-folder-as-data-volume-on-windows
The original syntax was not working...

**\- How I did it**
Fixed according to this: https://msdn.microsoft.com/en-us/virtualization/windowscontainers/management/manage_data

**\- How to verify it**
Run the example command. I tested it on WS2016 TP5. Works fine.

**\- Description for the changelog**
Updated example of mounting persistent storage on Windows

Replaces this PR: https://github.com/docker/docker/pull/23569
