### PR TITLE
Fix issue in disconnecting a container from network

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -129,6 +129,11 @@ func (daemon *Daemon) DisconnectFromNetwork(container *container.Container, netw
 		if container.RemovalInProgress || container.Dead {
 			return errRemovalContainer(container.ID)
 		}
+		// In case networkName is resolved we will use n.Name()
+		// this will cover the case where network id is passed.
+		if n != nil {
+			networkName = n.Name()
+		}
 		if _, ok := container.NetworkSettings.Networks[networkName]; !ok {
 			return fmt.Errorf("container %s is not connected to the network %s", container.ID, networkName)
 		}

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1756,3 +1756,16 @@ func (s *DockerNetworkSuite) TestDockerNetworkValidateIP(c *check.C) {
 	_, _, err = dockerCmdWithError("run", "--net=mynet", "--ip6", "::ffff:172.28.99.99", "busybox", "top")
 	c.Assert(err.Error(), checker.Contains, "invalid IPv6 address")
 }
+
+// Test case for 26220
+func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromBridge(c *check.C) {
+	out, _ := dockerCmd(c, "network", "inspect", "--format", "{{.Id}}", "bridge")
+
+	network := strings.TrimSpace(out)
+
+	name := "test"
+	dockerCmd(c, "create", "--rm", "--name", name, "busybox", "top")
+
+	_, _, err := dockerCmdWithError("network", "disconnect", network, name)
+	c.Assert(err, check.IsNil)
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #26220 where disconnecting a container from network does not work if the network id (instead of network name) has been specified.

The issue was that internally when trying to disconnecting a contaienr fromt the network, the originally passed network name or id has been used.

**\- How I did it**

This fix uses the resolved network name (e.g., `bridge`).

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #26220.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
