### PR TITLE
support docker node ps multiNodes

### DIFF
--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -1,7 +1,11 @@
 package node
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/idresolver"
@@ -12,7 +16,7 @@ import (
 )
 
 type psOptions struct {
-	nodeID    string
+	nodeIDs   []string
 	noResolve bool
 	noTrunc   bool
 	filter    opts.FilterOpt
@@ -22,14 +26,14 @@ func newPsCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
-		Use:   "ps [OPTIONS] [NODE]",
-		Short: "List tasks running on a node, defaults to current node",
-		Args:  cli.RequiresRangeArgs(0, 1),
+		Use:   "ps [OPTIONS] [NODE...]",
+		Short: "List tasks running on one or more nodes, defaults to current node",
+		Args:  cli.RequiresMinArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.nodeID = "self"
+			opts.nodeIDs = []string{"self"}
 
 			if len(args) != 0 {
-				opts.nodeID = args[0]
+				opts.nodeIDs = args
 			}
 
 			return runPs(dockerCli, opts)
@@ -47,23 +51,43 @@ func runPs(dockerCli *command.DockerCli, opts psOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 
-	nodeRef, err := Reference(ctx, client, opts.nodeID)
-	if err != nil {
-		return nil
-	}
-	node, _, err := client.NodeInspectWithRaw(ctx, nodeRef)
-	if err != nil {
-		return err
+	var (
+		errs  []string
+		tasks []swarm.Task
+	)
+
+	for _, nodeID := range opts.nodeIDs {
+		nodeRef, err := Reference(ctx, client, nodeID)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		node, _, err := client.NodeInspectWithRaw(ctx, nodeRef)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		filter := opts.filter.Value()
+		filter.Add("node", node.ID)
+
+		nodeTasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+
+		tasks = append(tasks, nodeTasks...)
 	}
 
-	filter := opts.filter.Value()
-	filter.Add("node", node.ID)
-	tasks, err := client.TaskList(
-		ctx,
-		types.TaskListOptions{Filter: filter})
-	if err != nil {
-		return err
+	if err := task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), opts.noTrunc); err != nil {
+		errs = append(errs, err.Error())
 	}
 
-	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), opts.noTrunc)
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
 }

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -792,7 +792,7 @@ __docker_node_commands() {
         "ls:List nodes in the swarm"
         "promote:Promote a node as manager in the swarm"
         "rm:Remove one or more nodes from the swarm"
-        "ps:List tasks running on a node, defaults to current node"
+        "ps:List tasks running on one or more nodes, defaults to current node"
         "update:Update a node"
     )
     _describe -t docker-node-commands "docker node command" _docker_node_subcommands

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -115,7 +115,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [node demote](node_demote.md) | Demotes an existing manager so that it is no longer a manager |
 | [node inspect](node_inspect.md) | Inspect a node in the swarm                |
 | [node update](node_update.md) | Update attributes for a node                 |
-| [node ps](node_ps.md) | List tasks running on a node                         |
+| [node ps](node_ps.md) | List tasks running on one or more nodes                         |
 | [node ls](node_ls.md) | List nodes in the swarm                              |
 | [node rm](node_rm.md) | Remove one or more nodes from the swarm                         |
 

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -12,9 +12,9 @@ parent = "smn_cli"
 # node ps
 
 ```markdown
-Usage:  docker node ps [OPTIONS] [NODE]
+Usage:  docker node ps [OPTIONS] [NODE...]
 
-List tasks running on a node, defaults to current node.
+List tasks running on one or more nodes, defaults to current node.
 
 Options:
   -a, --all            Display all instances


### PR DESCRIPTION
Support `docker node ps node1 node2 node3...` Multi Nodes.

related to PR #25214 

@stevvooe 

Signed-off-by: allencloud allen.sun@daocloud.io
