### PR TITLE
Restrict size to 2 fractional digits for `docker images`

### DIFF
--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -194,8 +194,8 @@ func (s *containerStats) Display(w io.Writer) error {
 		s.CPUPercentage,
 		units.BytesSize(s.Memory), units.BytesSize(s.MemoryLimit),
 		s.MemoryPercentage,
-		units.HumanSize(s.NetworkRx), units.HumanSize(s.NetworkTx),
-		units.HumanSize(s.BlockRead), units.HumanSize(s.BlockWrite),
+		units.HumanSizeWithPrecision(s.NetworkRx, 3), units.HumanSizeWithPrecision(s.NetworkTx, 3),
+		units.HumanSizeWithPrecision(s.BlockRead, 3), units.HumanSizeWithPrecision(s.BlockWrite, 3),
 		s.PidsCurrent)
 	return nil
 }

--- a/cli/command/container/stats_unit_test.go
+++ b/cli/command/container/stats_unit_test.go
@@ -25,7 +25,7 @@ func TestDisplay(t *testing.T) {
 		t.Fatalf("c.Display() gave error: %s", err)
 	}
 	got := b.String()
-	want := "app\t30.00%\t100 MiB / 2 GiB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\n"
+	want := "app\t30.00%\t100 MiB / 2 GiB\t4.88%\t105 MB / 839 MB\t105 MB / 839 MB\t1\n"
 	if got != want {
 		t.Fatalf("c.Display() = %q, want %q", got, want)
 	}

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -152,8 +152,8 @@ func (c *containerContext) Status() string {
 
 func (c *containerContext) Size() string {
 	c.addHeader(sizeHeader)
-	srw := units.HumanSize(float64(c.c.SizeRw))
-	sv := units.HumanSize(float64(c.c.SizeRootFs))
+	srw := units.HumanSizeWithPrecision(float64(c.c.SizeRw), 3)
+	sv := units.HumanSizeWithPrecision(float64(c.c.SizeRootFs), 3)
 
 	sf := srw
 	if c.c.SizeRootFs > 0 {

--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -225,5 +225,5 @@ func (c *imageContext) CreatedAt() string {
 
 func (c *imageContext) Size() string {
 	c.addHeader(sizeHeader)
-	return units.HumanSize(float64(c.i.Size))
+	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
 }

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -86,7 +86,7 @@ func runHistory(dockerCli *command.DockerCli, opts historyOptions) error {
 
 		if opts.human {
 			created = units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))) + " ago"
-			size = units.HumanSize(float64(entry.Size))
+			size = units.HumanSizeWithPrecision(float64(entry.Size), 3)
 		} else {
 			created = time.Unix(entry.Created, 0).Format(time.RFC3339)
 			size = strconv.FormatInt(entry.Size, 10)

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -63,7 +63,7 @@ clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
-clone git github.com/docker/go-units eb879ae3e2b84e2a142af415b679ddeda47ec71c
+clone git github.com/docker/go-units f2145db703495b2e525c59662db69a7344b00bb8
 clone git github.com/docker/go-connections 988efe982fdecb46f01d53465878ff1f2ff411ce
 
 clone git github.com/docker/engine-api f9cef590446e4e6073b49b652f47a337b897c1a3

--- a/vendor/src/github.com/docker/go-units/size.go
+++ b/vendor/src/github.com/docker/go-units/size.go
@@ -37,22 +37,34 @@ var (
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 
-// CustomSize returns a human-readable approximation of a size
-// using custom format.
-func CustomSize(format string, size float64, base float64, _map []string) string {
+func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
 	i := 0
 	unitsLimit := len(_map) - 1
 	for size >= base && i < unitsLimit {
 		size = size / base
 		i++
 	}
-	return fmt.Sprintf(format, size, _map[i])
+	return size, _map[i]
+}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	size, unit := getSizeAndUnit(size, base, _map)
+	return fmt.Sprintf(format, size, unit)
+}
+
+// HumanSizeWithPrecision allows the size to be in any precision,
+// instead of 4 digit precision used in units.HumanSize.
+func HumanSizeWithPrecision(size float64, precision int) string {
+	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
+	return fmt.Sprintf("%.*g %s", precision, size, unit)
 }
 
 // HumanSize returns a human-readable approximation of a size
 // capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
 func HumanSize(size float64) string {
-	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
+	return HumanSizeWithPrecision(size, 4)
 }
 
 // BytesSize returns a human-readable size in bytes, kibibytes,


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #26300. Previously `docker images` will use `HumanSize()` to display the size which has a fixed precision of 4 (thus 3 fractional digits). This
could be problematic in certain languages (e.g. , German, see #26300) as `.` may be interpreted as thousands-separator in number.

**\- How I did it**

This fix use `CustomSize()` instead and limit the precision to 3 (thus 2 fractional digits).

**\- How to verify it**

This fix has been tested manually.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #26300.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
