### PR TITLE
Allow windows environment variables to contain `=`

### DIFF
--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -10,7 +10,7 @@ import (
 func setupEnvironmentVariables(a []string) map[string]string {
 	r := make(map[string]string)
 	for _, s := range a {
-		arr := strings.Split(s, "=")
+		arr := strings.SplitN(s, "=", 2)
 		if len(arr) == 2 {
 			r[arr[0]] = arr[1]
 		}

--- a/libcontainerd/utils_windows_test.go
+++ b/libcontainerd/utils_windows_test.go
@@ -1,0 +1,13 @@
+package libcontainerd
+
+import (
+	"testing"
+)
+
+func TestEnvironmentParsing(t *testing.T) {
+	env := []string{"foo=bar", "car=hat", "a=b=c"}
+	result := setupEnvironmentVariables(env)
+	if len(result) != 3 || result["foo"] != "bar" || result["car"] != "hat" || result["a"] != "b=c" {
+		t.Fatalf("Expected map[foo:bar car:hat a:b=c], got %v", result)
+	}
+}


### PR DESCRIPTION
**\- What I did**
Fixed bug #26178 to allow embedded equals signs in windows environment variables.

**\- How I did it**
Instead of using `strings.Split(s, "=")`, it now uses `strings.SplitN(s, "=", 2)` to limit how many parts the results are returned.

**Note**: All the unit tests have been run, but I was unable to get the integration tests to work (the windows development workflow needs a bit of TLC). Also, this is my first foray into golang, so let me know if there's any way I can improve the code.

**\- How to verify it**

Prior to the fix:
`docker run -e="deep=purple=fred" --rm microsoft/windowsservercore cmd /c set`
-> there will be no variable displayed called `deep`.
After the fix is applied:
`docker run -e="deep=purple=fred" --rm microsoft/windowsservercore cmd /c set`
-> there will be a variable `deep` with value `purple=fred`

**\- Description for the changelog**
Fixed bug preventing environment variables with embedded equals signs.

**\- A picture of a cute animal (not mandatory but encouraged)**

![](https://s-media-cache-ak0.pinimg.com/236x/bd/eb/79/bdeb79e5bb2df7b81647f2cc1fc9521a.jpg)
