### PR TITLE
add `--interface-priority` and `--net-classid` flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,7 +232,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+ENV RUNC_COMMIT 189a2ab2f7acc59043e457cea25b58f631443f08
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -175,7 +175,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+ENV RUNC_COMMIT 189a2ab2f7acc59043e457cea25b58f631443f08
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -173,7 +173,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+ENV RUNC_COMMIT 189a2ab2f7acc59043e457cea25b58f631443f08
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -193,7 +193,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+ENV RUNC_COMMIT 189a2ab2f7acc59043e457cea25b58f631443f08
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -185,7 +185,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+ENV RUNC_COMMIT 189a2ab2f7acc59043e457cea25b58f631443f08
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -57,7 +57,7 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 ENV CGO_LDFLAGS -L/lib
 
 # Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+ENV RUNC_COMMIT 189a2ab2f7acc59043e457cea25b58f631443f08
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types/blkiodev"
@@ -229,6 +230,16 @@ type LogConfig struct {
 	Config map[string]string
 }
 
+// IfPriority represents the priority of network traffic for the specific network interface
+type IfPriority struct {
+	Name     string
+	Priority uint32
+}
+
+func (p *IfPriority) String() string {
+	return fmt.Sprintf("%s:%d", p.Name, p.Priority)
+}
+
 // Resources contains container's resources (cgroups config, ulimits...)
 type Resources struct {
 	// Applicable to all platforms
@@ -256,6 +267,8 @@ type Resources struct {
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
+	IfPriorities         []*IfPriority   // priority of network traffic for container
+	NetClassID           *uint32         // class identifier for container's network packets
 
 	// Applicable to Windows
 	CPUCount           int64  `json:"CpuCount"`   // CPU count

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2351,6 +2351,7 @@ _docker_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--interface-priority
 		--ip
 		--ip6
 		--ipc
@@ -2368,6 +2369,7 @@ _docker_run() {
 		--memory-swappiness
 		--memory-reservation
 		--name
+		--net-classid
 		--network
 		--network-alias
 		--oom-score-adj

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -194,6 +194,22 @@ func getBlkioThrottleDevices(devs []*blkiodev.ThrottleDevice) ([]specs.ThrottleD
 	return throttleDevices, nil
 }
 
+func getPriorities(config containertypes.Resources) []specs.InterfacePriority {
+	var priorities []specs.InterfacePriority
+
+	for _, p := range config.IfPriorities {
+		name := p.Name
+		prio := p.Priority
+		priority := specs.InterfacePriority{
+			Name:     name,
+			Priority: prio,
+		}
+		priorities = append(priorities, priority)
+	}
+
+	return priorities
+}
+
 func checkKernel() error {
 	// Check for unsupported kernel versions
 	// FIXME: it would be cleaner to not test for specific versions, but rather

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -48,9 +48,21 @@ func setResources(s *specs.Spec, r containertypes.Resources) error {
 		return err
 	}
 
+	priorities := getPriorities(r)
+
 	memoryRes := getMemoryResources(r)
 	cpuRes := getCPUResources(r)
 	blkioWeight := r.BlkioWeight
+	classID := r.NetClassID
+
+	fmt.Println("###notice")
+	if len(priorities) == 0 {
+		fmt.Println("###priorities is nil")
+	}
+
+	if classID == nil {
+		fmt.Println("###classID is nil")
+	}
 
 	specResources := &specs.Resources{
 		Memory: memoryRes,
@@ -66,6 +78,10 @@ func setResources(s *specs.Spec, r containertypes.Resources) error {
 		DisableOOMKiller: r.OomKillDisable,
 		Pids: &specs.Pids{
 			Limit: &r.PidsLimit,
+		},
+		Network: &specs.Network{
+			ClassID:    classID,
+			Priorities: priorities,
 		},
 	}
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -116,6 +116,8 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
+* `POST /containers/create` now takes `IfPriorities` in HostConfig, to set the priority of network traffic.
+* `POST /containers/create` now takes `NetClassID` in HostConfig, to tag network packets with a class identifier.
 * `POST /containers/create` now takes `AutoRemove` in HostConfig, to enable auto-removal of the container on daemon side when the container's process exits.
 * `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.
 * `GET /containers/json` now accepts `removing` as a valid value for the `status` filter.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -312,6 +312,8 @@ Create a container
              "OomScoreAdj": 500,
              "PidMode": "",
              "PidsLimit": -1,
+             "IfPriorities": [{ "Name": "eth0", "Priority": 5 }],
+             "NetClassID": 3,
              "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
              "PublishAllPorts": false,
              "Privileged": false,
@@ -430,6 +432,9 @@ Create a container
           `"container:<name|id>"`: joins another container's PID namespace
           `"host"`: use the host's PID namespace inside the container
     -   **PidsLimit** - Tune a container's pids limit. Set -1 for unlimited.
+    -   **IfPriorities** - Set the priority of network traffic in the form: `[{"Name": "<interface_name>", "Priority": <priority>}]`, for example:
+        `"IfPriorities": [{"Name": "eth0", "Priority": 5}]`
+    -   **NetClassID** - Tag network packets with a class identifier. Accepts a natural number.
     -   **PortBindings** - A map of exposed container ports and the host port they
           should map to. A JSON object in the form
           `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -53,6 +53,7 @@ Options:
       --help                        Print usage
   -h, --hostname string             Container host name
   -i, --interactive                 Keep STDIN open even if not attached
+      --interface-priority value    Set the priority of network traffic (default [])
       --io-maxbandwidth string      Maximum IO bandwidth limit for the system drive (Windows only)
       --io-maxiops uint             Maximum IOps limit for the system drive (Windows only)
       --ip string                   Container IPv4 address (e.g. 172.30.100.104)
@@ -83,6 +84,7 @@ Options:
       --oom-kill-disable            Disable OOM Killer
       --oom-score-adj int           Tune host's OOM preferences (-1000 to 1000)
       --pid string                  PID namespace to use
+      --net-classid value           Tag network packets with a class identifier (classid)
       --pids-limit int              Tune container pids limit (set -1 for unlimited), kernel >= 4.3
       --privileged                  Give extended privileges to this container
   -p, --publish value               Publish a container's port(s) to the host (default [])

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -53,6 +53,7 @@ Options:
       --help                        Print usage
   -h, --hostname string             Container host name
   -i, --interactive                 Keep STDIN open even if not attached
+      --interface-priority value    Set the priority of network traffic (default [])
       --io-maxbandwidth string      Maximum IO bandwidth limit for the system drive (Windows only)
                                     (Windows only). The format is `<number><unit>`.
                                     Unit is optional and can be `b` (bytes per second),
@@ -78,6 +79,7 @@ Options:
       --memory-swap string          Swap limit equal to memory plus swap: '-1' to enable unlimited swap
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1).
       --name string                 Assign a name to the container
+      --net-classid value           Tag network packets with a class identifier (classid)
       --network-alias value         Add network-scoped alias for the container (default [])
       --network string              Connect a container to a network
                                     'bridge': create a network stack on the default Docker bridge

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -688,6 +688,8 @@ container:
 | `--device-write-bps=""`    | Limit write rate to a device (format: `<device-path>:<number>[<unit>]`). Number is a positive integer. Unit can be one of `kb`, `mb`, or `gb`.  |
 | `--device-read-iops="" `   | Limit read rate (IO per second) from a device (format: `<device-path>:<number>`). Number is a positive integer.                                 |
 | `--device-write-iops="" `  | Limit write rate (IO per second) to a device (format: `<device-path>:<number>`). Number is a positive integer.                                  |
+| `--interface-priority="" ` | Set the priority of network traffic (format: `<interface-name>:<number>`). Number is a positive integer.                                  |
+| `--net-classid="" `        | Tag network packets with a class identifier. Number is a positive integer.                                  |
 | `--oom-kill-disable=false` | Whether to disable OOM Killer for the container or not.                                                                                         |
 | `--oom-score-adj=0`        | Tune container's OOM preferences (-1000 to 1000)                                                                                                |
 | `--memory-swappiness=""`   | Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.                                                            |
@@ -1073,6 +1075,20 @@ For example, this command creates a container and limits the write rate to
 
 Both flags take limits in the `<device-path>:<limit>` format. Both read and
 write rates must be a positive integer.
+
+## Network traffic constraints
+You can change the default priority of network traffic per each network interface
+by specifying the `--interface-priority` flag. For example, this command creates
+a container and set the priority of network interface eth0 to 5 :
+
+    $ docker run -ti --interface-priority eth0:5 busybox
+
+## Network class identifier
+You can tag network packets with a class identifier by specifying the `--net-classid`
+flag. For example, this command creates a container and tag network packets with the
+class identifier 0x1000200 :
+
+    $ docker run -ti --net-classid 0x1000200 busybox
 
 ## Additional groups
     --group-add: Add additional groups to run as

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -107,7 +107,7 @@ clone git github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
 clone git github.com/docker/go v1.5.1-1-1-gbaf439e
 clone git github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 
-clone git github.com/opencontainers/runc cc29e3dded8e27ba8f65738f40d251c885030a28 # libcontainer
+clone git github.com/opencontainers/runc 189a2ab2f7acc59043e457cea25b58f631443f08 # libcontainer
 clone git github.com/opencontainers/runtime-spec v1.0.0-rc1 # specs
 clone git github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 # libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -112,6 +112,18 @@ var (
 		},
 		"Test cannot be run with 'sysctl kernel.unprivileged_userns_clone' = 0",
 	}
+	netclsEnable = testRequirement{
+		func() bool {
+			return SysInfo.CgroupNetclsEnabled
+		},
+		"Test requires an environment that supports net_cls.",
+	}
+	netprioEnable = testRequirement{
+		func() bool {
+			return SysInfo.CgroupNetprioEnabled
+		},
+		"Test requires an environment that supports net_prio.",
+	}
 )
 
 func init() {

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -24,6 +24,8 @@ docker-create - Create a new container
 [**--device-read-iops**[=*[]*]]
 [**--device-write-bps**[=*[]*]]
 [**--device-write-iops**[=*[]*]]
+[**--interface-priority**[=*[]*]]
+[**--net-classid**[=*[0]*]]
 [**--dns**[=*[]*]]
 [**--dns-search**[=*[]*]]
 [**--dns-opt**[=*[]*]]
@@ -149,6 +151,12 @@ two memory nodes.
 
 **--device-write-iops**=[]
     Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)
+
+**--interface-priority**=[]
+    Set the priority of network traffic (e.g. --interface-priority=eth0:5)
+
+**--net-classid**=*0*
+    Tag network packets with a class identifier (classid)
 
 **--dns**=[]
    Set custom DNS servers

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -26,6 +26,8 @@ docker-run - Run a command in a new container
 [**--device-read-iops**[=*[]*]]
 [**--device-write-bps**[=*[]*]]
 [**--device-write-iops**[=*[]*]]
+[**--interface-priority**[=*[]*]]
+[**--net-classid**[=*[0]*]]
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
 [**--dns-search**[=*[]*]]
@@ -221,6 +223,12 @@ See **config-json(5)** for documentation on using a configuration file.
 
 **--device-write-iops**=[]
    Limit write rate to a device (e.g. --device-write-iops=/dev/sda:1000)
+
+**--interface-priority**=[]
+   Set the priority of network traffic (e.g. --interface-priority=eth0:5)
+
+**--net-classid**=*0*
+   Tag network packets with a class identifier (classid)
 
 **--dns-search**=[]
    Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -27,6 +27,12 @@ type SysInfo struct {
 
 	// Whether the cgroup has the mountpoint of "devices" or not
 	CgroupDevicesEnabled bool
+
+	// Whether the cgroup has the mountpoint of "net_cls" or not
+	CgroupNetclsEnabled bool
+
+	// Whether the cgroup has the mountpoint of "net_prio" or not
+	CgroupNetprioEnabled bool
 }
 
 type cgroupMemInfo struct {

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -50,6 +50,12 @@ func New(quiet bool) *SysInfo {
 	_, ok := cgMounts["devices"]
 	sysInfo.CgroupDevicesEnabled = ok
 
+	_, ok = cgMounts["net_cls"]
+	sysInfo.CgroupNetclsEnabled = ok
+
+	_, ok = cgMounts["net_prio"]
+	sysInfo.CgroupNetprioEnabled = ok
+
 	sysInfo.IPv4ForwardingDisabled = !readProcBool("/proc/sys/net/ipv4/ip_forward")
 	sysInfo.BridgeNFCallIPTablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-iptables")
 	sysInfo.BridgeNFCallIP6TablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-ip6tables")

--- a/runconfig/opts/InterfacePriority.go
+++ b/runconfig/opts/InterfacePriority.go
@@ -1,0 +1,84 @@
+package opts
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	containertypes "github.com/docker/docker/api/types/container"
+)
+
+// ValidatorIfPriorityFctType defines a validator function that returns a validated struct and/or an error.
+type ValidatorIfPriorityFctType func(val string) (*containertypes.IfPriority, error)
+
+// ValidateIfPriority validates that the specified string has a valid device-rate format.
+func ValidateIfPriority(val string) (*containertypes.IfPriority, error) {
+	split := strings.SplitN(val, ":", 2)
+	if len(split) != 2 {
+		return nil, fmt.Errorf("bad format: %s", val)
+	}
+
+	prio, err := strconv.ParseUint(split[1], 10, 32)
+	if err != nil || prio < 0 {
+		return nil, fmt.Errorf("invalid priority for network interface: %s. The correct format is <network-interface>:<number>. Number must be a positive integer", val)
+	}
+
+	return &containertypes.IfPriority{
+		Name:     split[0],
+		Priority: uint32(prio),
+	}, nil
+}
+
+// IfPriorityOpt defines a map of IfPrioritys
+type IfPriorityOpt struct {
+	values    []*containertypes.IfPriority
+	validator ValidatorIfPriorityFctType
+}
+
+// NewIfPriorityOpt creates a new IfPriorityOpt
+func NewIfPriorityOpt(validator ValidatorIfPriorityFctType) IfPriorityOpt {
+	values := []*containertypes.IfPriority{}
+	return IfPriorityOpt{
+		values:    values,
+		validator: validator,
+	}
+}
+
+// Set validates a IfPriority and sets its name as a key in IfPriorityOpt
+func (opt *IfPriorityOpt) Set(val string) error {
+	var value *containertypes.IfPriority
+	if opt.validator != nil {
+		v, err := opt.validator(val)
+		if err != nil {
+			return err
+		}
+		value = v
+	}
+	opt.values = append(opt.values, value)
+	return nil
+}
+
+// String returns IfPriorityOpt values as a string.
+func (opt *IfPriorityOpt) String() string {
+	var out []string
+	for _, v := range opt.values {
+		out = append(out, v.String())
+	}
+
+	return fmt.Sprintf("%v", out)
+}
+
+// GetList returns a slice of pointers to IfPrioritys.
+func (opt *IfPriorityOpt) GetList() []*containertypes.IfPriority {
+	var ifPriorities []*containertypes.IfPriority
+	for _, v := range opt.values {
+		ifPriorities = append(ifPriorities, v)
+	}
+
+	return ifPriorities
+}
+
+// Type returns the option type
+func (opt *IfPriorityOpt) Type() string {
+	return "interface-priority"
+}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/cgroup_unix.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/cgroup_unix.go
@@ -36,7 +36,7 @@ type Cgroup struct {
 type Resources struct {
 	// If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
 	// Deprecated
-	AllowAllDevices bool `json:"allow_all_devices,omitempty"`
+	AllowAllDevices *bool `json:"allow_all_devices,omitempty"`
 	// Deprecated
 	AllowedDevices []*Device `json:"allowed_devices,omitempty"`
 	// Deprecated
@@ -69,10 +69,10 @@ type Resources struct {
 	CpuPeriod int64 `json:"cpu_period"`
 
 	// How many time CPU will use in realtime scheduling (in usecs).
-	CpuRtRuntime int64 `json:"cpu_quota"`
+	CpuRtRuntime int64 `json:"cpu_rt_quota"`
 
 	// CPU period to be used for realtime scheduling (in usecs).
-	CpuRtPeriod int64 `json:"cpu_period"`
+	CpuRtPeriod int64 `json:"cpu_rt_period"`
 
 	// CPU to use
 	CpusetCpus string `json:"cpuset_cpus"`
@@ -120,5 +120,5 @@ type Resources struct {
 	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`
 
 	// Set class identifier for container's network packets
-	NetClsClassid string `json:"net_cls_classid"`
+	NetClsClassid uint32 `json:"net_cls_classid"`
 }

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -148,10 +148,6 @@ type Config struct {
 	// More information about kernel oom score calculation here: https://lwn.net/Articles/317814/
 	OomScoreAdj int `json:"oom_score_adj"`
 
-	// AdditionalGroups specifies the gids that should be added to supplementary groups
-	// in addition to those that the user belongs to.
-	AdditionalGroups []string `json:"additional_groups"`
-
 	// UidMappings is an array of User ID mappings for User Namespaces
 	UidMappings []IDMap `json:"uid_mappings"`
 
@@ -304,29 +300,38 @@ func (c Command) Run(s HookState) error {
 	if err != nil {
 		return err
 	}
+	var stdout, stderr bytes.Buffer
 	cmd := exec.Cmd{
-		Path:  c.Path,
-		Args:  c.Args,
-		Env:   c.Env,
-		Stdin: bytes.NewReader(b),
+		Path:   c.Path,
+		Args:   c.Args,
+		Env:    c.Env,
+		Stdin:  bytes.NewReader(b),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	if err := cmd.Start(); err != nil {
+		return err
 	}
 	errC := make(chan error, 1)
 	go func() {
-		out, err := cmd.CombinedOutput()
+		err := cmd.Wait()
 		if err != nil {
-			err = fmt.Errorf("%s: %s", err, out)
+			err = fmt.Errorf("error running hook: %v, stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
 		}
 		errC <- err
 	}()
+	var timerCh <-chan time.Time
 	if c.Timeout != nil {
-		select {
-		case err := <-errC:
-			return err
-		case <-time.After(*c.Timeout):
-			cmd.Process.Kill()
-			cmd.Wait()
-			return fmt.Errorf("hook ran past specified timeout of %.1fs", c.Timeout.Seconds())
-		}
+		timer := time.NewTimer(*c.Timeout)
+		defer timer.Stop()
+		timerCh = timer.C
 	}
-	return <-errC
+	select {
+	case err := <-errC:
+		return err
+	case <-timerCh:
+		cmd.Process.Kill()
+		cmd.Wait()
+		return fmt.Errorf("hook ran past specified timeout of %.1fs", c.Timeout.Seconds())
+	}
 }

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/device_defaults.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/device_defaults.go
@@ -107,19 +107,5 @@ var (
 			Permissions: "rwm",
 		},
 	}, DefaultSimpleDevices...)
-	DefaultAutoCreatedDevices = append([]*Device{
-		{
-			// /dev/fuse is created but not allowed.
-			// This is to allow java to work.  Because java
-			// Insists on there being a /dev/fuse
-			// https://github.com/docker/docker/issues/514
-			// https://github.com/docker/docker/issues/2393
-			//
-			Path:        "/dev/fuse",
-			Type:        'c',
-			Major:       10,
-			Minor:       229,
-			Permissions: "rwm",
-		},
-	}, DefaultSimpleDevices...)
+	DefaultAutoCreatedDevices = append([]*Device{}, DefaultSimpleDevices...)
 )

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/system/syscall_linux_386.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/system/syscall_linux_386.go
@@ -8,7 +8,7 @@ import (
 
 // Setuid sets the uid of the calling thread to the specified uid.
 func Setuid(uid int) (err error) {
-	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID, uintptr(uid), 0, 0)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID32, uintptr(uid), 0, 0)
 	if e1 != 0 {
 		err = e1
 	}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/system/sysconfig.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/system/sysconfig.go
@@ -4,28 +4,9 @@ package system
 
 /*
 #include <unistd.h>
-#include <limits.h>
-
-int GetLongBit() {
-#ifdef _SC_LONG_BIT
-    int longbits;
-
-    longbits = sysconf(_SC_LONG_BIT);
-    if (longbits <  0) {
-        longbits = (CHAR_BIT * sizeof(long));
-    }
-    return longbits;
-#else
-    return (CHAR_BIT * sizeof(long));
-#endif
-}
 */
 import "C"
 
 func GetClockTicks() int {
 	return int(C.sysconf(C._SC_CLK_TCK))
-}
-
-func GetLongBit() int {
-	return int(C.GetLongBit())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Add option `--interface-priority` and `--net-classid` to `docker run` 
and `docker create`

`--interface-priority` is used to set the priority of network traffic, 
corresponding net_prio in cgroup.

`--net-classid` is used to tag network packets with a class identifier, 
corresponding net_cls in cgroup.

This PR depends on docker/engine-api/pull/384

**\- How I did it**
Get option values, and then pass them to containerd. 
Change the runc's verion, for commit bb42f80a86997d8265ee31e2aed33a6670859ac1 in 
https://github.com/opencontainers/runc . If i doesn't do it, runc cann't start up.

**\- How to verify it**
Run integration tests `TestRunWithInterfacePriority` and `TestRunWithClassid`

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

`--interface-priority` is used to set the priority of
network traffic, corresponding net_prio in cgroup.
`--net-classid` is used to tag network packets with a
class identifier, corresponding net_cls in cgroup.

Signed-off-by: Fengtu Wang wangfengtu@huawei.com
