### PR TITLE
fix docs about `sudo docker login`

### DIFF
--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -38,9 +38,6 @@ You can log into any public or private repository for which you have
 credentials.  When you log in, the command stores encoded credentials in
 `$HOME/.docker/config.json` on Linux or `%USERPROFILE%/.docker/config.json` on Windows.
 
-> **Note**:  When running `sudo docker login` credentials are saved in `/root/.docker/config.json`.
->
-
 ## Credentials store
 
 The Docker Engine can keep user credentials in an external credentials store,

--- a/man/docker-login.1.md
+++ b/man/docker-login.1.md
@@ -26,9 +26,6 @@ You can log into any public or private repository for which you have
 credentials.  When you log in, the command stores encoded credentials in
 `$HOME/.docker/config.json` on Linux or `%USERPROFILE%/.docker/config.json` on Windows.
 
-> **Note**: When running `sudo docker login` credentials are saved in `/root/.docker/config.json`.
->
-
 # OPTIONS
 **--help**
   Print usage statement


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/26291

Actually  `sudo docker login`  creates credentials in the normal user's HOME unless `-H` or `-E` is specified.
So I suggest removing the sentence.

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
