### PR TITLE
Handle success and failure for v1.Migrate separately

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -575,8 +575,9 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 	migrationStart := time.Now()
 	if err := v1.Migrate(config.Root, graphDriver, d.layerStore, d.imageStore, referenceStore, distributionMetadataStore); err != nil {
 		logrus.Errorf("Graph migration failed: %q. Your old graph data was found to be too inconsistent for upgrading to content-addressable storage. Some of the old data was probably not upgraded. We recommend starting over with a clean storage directory if possible.", err)
+	} else {
+		logrus.Infof("Graph migration to content-addressability took %.2f seconds", time.Since(migrationStart).Seconds())
 	}
-	logrus.Infof("Graph migration to content-addressability took %.2f seconds", time.Since(migrationStart).Seconds())
 
 	// Discovery is only enabled when the daemon is launched with an address to advertise.  When
 	// initialized, the daemon is registered and we can store the discovery backend as its read-only


### PR DESCRIPTION
to "Graph migration to content-addressability took %.2f seconds", the time should be computed after successful handling.
