### PR TITLE
Fix incorrect help output in `docker network ls`

### DIFF
--- a/api/client/network/list.go
+++ b/api/client/network/list.go
@@ -40,7 +40,7 @@ func newListCommand(dockerCli *client.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display volume names")
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display network IDs")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate the output")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print networks using a Go template")
 	flags.StringSliceVarP(&opts.filter, "filter", "f", []string{}, "Provide filter values (i.e. 'dangling=true')")

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -23,7 +23,7 @@ Options:
       --format string  Pretty-print networks using a Go template
       --help           Print usage
       --no-trunc       Do not truncate the output
-  -q, --quiet          Only display volume names
+  -q, --quiet          Only display network IDs
 ```
 
 Lists all the networks the Engine `daemon` knows about. This includes the

--- a/man/docker-network-ls.1.md
+++ b/man/docker-network-ls.1.md
@@ -179,7 +179,7 @@ attached.
   Do not truncate the output
 
 **-q**, **--quiet**=*true*|*false*
-  Only display numeric IDs
+  Only display network IDs
 
 **--help**
   Print usage statement


### PR DESCRIPTION
As is raised in #26312, in `docker network ls`, the help output was mistaken to `volume names`:

```
-q, --quiet Only display volume names
```

This fix changes the help output to:

```
-q, --quiet Only display network IDs
```

This fix also updates the documentation in:
`docs/reference/commandline/network_ls.md`

This fix fixes #26312.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
