### PR TITLE
daemon: Allow Proxy Configuration in daemon.json

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -179,6 +179,7 @@ type Info struct {
 	// running containers are detected
 	LiveRestoreEnabled bool
 	Isolation          container.Isolation
+	ProxyEnv           []string
 	InitBinary         string
 	ContainerdCommit   Commit
 	RuncCommit         Commit

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -319,6 +319,13 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 
 	fmt.Fprintf(dockerCli.Out(), "Live Restore Enabled: %v\n", info.LiveRestoreEnabled)
 
+	if len(info.ProxyEnv) > 0 {
+		fmt.Fprintln(dockerCli.Out(), "Proxy Environment Variables:")
+		for _, v := range info.ProxyEnv {
+			fmt.Fprintf(dockerCli.Out(), " %s\n", v)
+		}
+	}
+
 	return nil
 }
 

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -50,10 +50,10 @@ type ExitStatus struct {
 }
 
 // CreateDaemonEnvironment returns the list of all environment variables given the list of
-// environment variables related to links.
+// environment variables related to links and those that are to be globally propagated
 // Sets PATH, HOSTNAME and if container.Config.Tty is set: TERM.
 // The defaults set here do not override the values in container.Config.Env
-func (container *Container) CreateDaemonEnvironment(tty bool, linkedEnv []string) []string {
+func (container *Container) CreateDaemonEnvironment(tty bool, linkedEnv []string, proxyEnv []string) []string {
 	// Setup environment
 	env := []string{
 		"PATH=" + system.DefaultPathEnv,
@@ -63,6 +63,7 @@ func (container *Container) CreateDaemonEnvironment(tty bool, linkedEnv []string
 		env = append(env, "TERM=xterm")
 	}
 	env = append(env, linkedEnv...)
+	env = append(env, proxyEnv...)
 	// because the env on the container can override certain default values
 	// we need to replace the 'env' keys where they match and append anything
 	// else.

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -25,11 +25,12 @@ type ExitStatus struct {
 }
 
 // CreateDaemonEnvironment creates a new environment variable slice for this container.
-func (container *Container) CreateDaemonEnvironment(_ bool, linkedEnv []string) []string {
+func (container *Container) CreateDaemonEnvironment(_ bool, linkedEnv []string, proxyEnv []string) []string {
 	// because the env on the container can override certain default values
 	// we need to replace the 'env' keys where they match and append anything
 	// else.
-	return ReplaceOrAppendEnvValues(linkedEnv, container.Config.Env)
+	env := append(linkedEnv, proxyEnv...)
+	return ReplaceOrAppendEnvValues(env, container.Config.Env)
 }
 
 // UnmountIpcMounts unmounts Ipc related mounts.

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -102,6 +102,10 @@ type CommonConfig struct {
 	CorsHeaders          string              `json:"api-cors-header,omitempty"`
 	EnableCors           bool                `json:"api-enable-cors,omitempty"`
 
+	// ProxyEnv is a list of environment variables that configure proxy behaviour
+	// in all containers
+	ProxyEnv []string `json:"proxy-env,omitempty"`
+
 	// LiveRestoreEnabled determines whether we should keep containers
 	// alive upon daemon shutdown/start
 	LiveRestoreEnabled bool `json:"live-restore,omitempty"`
@@ -194,6 +198,7 @@ func (config *Config) InstallCommonFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&config.Experimental, "experimental", false, "Enable experimental features")
 
 	flags.StringVar(&config.MetricsAddress, "metrics-addr", "", "Set default address and port to serve the metrics api on")
+	flags.Var(opts.NewListOptsRef(&config.ProxyEnv, opts.ValidateProxyEnv), "proxy-env", "Proxy environment variables")
 
 	config.MaxConcurrentDownloads = &maxConcurrentDownloads
 	config.MaxConcurrentUploads = &maxConcurrentUploads

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -107,6 +107,7 @@ type Daemon struct {
 	defaultIsolation          containertypes.Isolation // Default isolation mode on Windows
 	clusterProvider           cluster.Provider
 	cluster                   Cluster
+	proxyEnv                  []string
 
 	machineMemory uint64
 
@@ -685,6 +686,8 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 	d.gidMaps = gidMaps
 	d.seccompEnabled = sysInfo.Seccomp
 	d.apparmorEnabled = sysInfo.AppArmor
+
+	d.proxyEnv = config.ProxyEnv
 
 	d.nameIndex = registrar.NewRegistrar()
 	d.linkIndex = newLinkIndex()

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -127,7 +127,7 @@ func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (str
 	if err != nil {
 		return "", err
 	}
-	execConfig.Env = container.ReplaceOrAppendEnvValues(cntr.CreateDaemonEnvironment(config.Tty, linkedEnv), config.Env)
+	execConfig.Env = container.ReplaceOrAppendEnvValues(cntr.CreateDaemonEnvironment(config.Tty, linkedEnv, d.proxyEnv), config.Env)
 	if len(execConfig.User) == 0 {
 		execConfig.User = cntr.Config.User
 	}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -129,6 +129,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		LiveRestoreEnabled: daemon.configStore.LiveRestoreEnabled,
 		SecurityOptions:    securityOptions,
 		Isolation:          daemon.defaultIsolation,
+		ProxyEnv:           daemon.proxyEnv,
 	}
 
 	// Retrieve platform specific info

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -644,7 +644,7 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 		}
 	}
 	s.Process.Cwd = cwd
-	s.Process.Env = c.CreateDaemonEnvironment(c.Config.Tty, linkedEnv)
+	s.Process.Env = c.CreateDaemonEnvironment(c.Config.Tty, linkedEnv, daemon.proxyEnv)
 	s.Process.Terminal = c.Config.Tty
 	s.Hostname = c.FullHostname()
 

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -57,7 +57,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		// as c:\. Hence, setting it to default of c:\ makes for consistency.
 		s.Process.Cwd = `C:\`
 	}
-	s.Process.Env = c.CreateDaemonEnvironment(c.Config.Tty, linkedEnv)
+	s.Process.Env = c.CreateDaemonEnvironment(c.Config.Tty, linkedEnv, daemon.proxyEnv)
 	s.Process.ConsoleSize.Height = c.HostConfig.ConsoleSize[0]
 	s.Process.ConsoleSize.Width = c.HostConfig.ConsoleSize[1]
 	s.Process.Terminal = c.Config.Tty

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4439,3 +4439,19 @@ func (s *DockerSuite) TestWindowsRunAsSystem(c *check.C) {
 	out, _ := dockerCmd(c, "run", "--net=none", `--user=nt authority\system`, "--hostname=XYZZY", minimalBaseImage(), "cmd", "/c", `@echo %USERNAME%`)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "XYZZY$")
 }
+
+func (s *DockerDaemonSuite) TestRunWithProxyEnv(c *check.C) {
+	expectedOutput := "HTTP_PROXY=127.0.0.1:3001"
+	s.d.StartWithBusybox(c, "--debug", "--proxy-env", expectedOutput)
+	out, err := s.d.Cmd("run", "busybox", "env")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+}
+
+func (s *DockerDaemonSuite) TestRunWithProxyEnvOverride(c *check.C) {
+	s.d.StartWithBusybox(c, "--debug", "--proxy-env", "HTTP_PROXY=127.0.0.1:3001")
+	expectedOutput := "HTTP_PROXY=127.0.0.1:3003"
+	out, err := s.d.Cmd("run", "-e", expectedOutput, "busybox", "env")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+}

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -303,6 +303,27 @@ func ValidateSysctl(val string) (string, error) {
 	return "", fmt.Errorf("sysctl '%s' is not whitelisted", val)
 }
 
+// ValidateProxyEnv checks proxy environment variables for validity
+func ValidateProxyEnv(val string) (string, error) {
+	permitted := []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "FTP_PROXY"}
+	matched := false
+	varName := strings.TrimSpace(strings.Split(val, "=")[0])
+	for _, p := range permitted {
+		if varName == p {
+			matched = true
+			break
+		}
+		if varName == strings.ToLower(p) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return "", fmt.Errorf("Variable %s is not a permitted proxy variable", val)
+	}
+	return val, nil
+}
+
 // FilterOpt is a flag type for validating filters
 type FilterOpt struct {
 	filter filters.Args

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -305,3 +305,33 @@ func TestParseLink(t *testing.T) {
 		t.Fatalf("Expected error 'bad format for links: link:alias:wrong' but got: %v", err)
 	}
 }
+
+func TestValidateProxyEnv(t *testing.T) {
+	valid := []string{
+		`HTTP_PROXY=foo`,
+		`http_proxy=foo`,
+		`HTTPS_PROXY=foo`,
+		`https_proxy=foo`,
+		`FTP_PROXY=foo`,
+		`ftp_proxy=foo`,
+		`NO_PROXY=foo`,
+		`no_proxy=foo`,
+		`HTTP_PROXY = foo`,
+	}
+	invalid := []string{
+		`HTZP_PROXY=foo`,
+		`foo=bar`,
+	}
+
+	for _, proxyVar := range valid {
+		if ret, err := ValidateProxyEnv(proxyVar); err != nil || ret == "" {
+			t.Fatalf("ValidateProxyEnv(`"+proxyVar+"`) got %s %s", ret, err)
+		}
+	}
+
+	for _, proxyVar := range invalid {
+		if ret, err := ValidateProxyEnv(proxyVar); err == nil || ret != "" {
+			t.Fatalf("ValidateProxyEnv(`"+proxyVar+"`) got %s %s", ret, err)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
_Updated 30/01/2016 to reflect the current state of this PR_

**\- What I did**

Added a new configuration option to allow proxy settings to be configured at the daemon level and inherited by every container that's run.

**\- How I did it**

Added a new `proxyEnv` field to the `Daemon` struct and piggybacked on the existing implementation of environment injection used by `links`.

**\- How to verify it**

There are tests! But you can manually verify by:
1) Setting `proxy-env` in your `daemon.json`
2) `docker run --rm -it alpine env`

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Allowed a set of environment variables to be configured that allow the setting of HTTP/HTTPS/FTP proxy settings of every container run on this host.

**\- A picture of a cute animal (not mandatory but encouraged)**
![](http://i1.mirror.co.uk/incoming/article7262982.ece/ALTERNATES/s615b/Pay-penguins_0710.jpg)