### PR TITLE
Update man page for `docker create` to add `--rm` flag

### DIFF
--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -64,6 +64,7 @@ docker-create - Create a new container
 [**--privileged**]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
+[**--rm**]
 [**--security-opt**[=*[]*]]
 [**--storage-opt**[=*[]*]]
 [**--stop-signal**[=*SIGNAL*]]
@@ -316,6 +317,9 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
 
 **--restart**="*no*"
    Restart policy to apply when a container exits (no, on-failure[:max-retry], always, unless-stopped).
+
+**--rm**=*true*|*false*
+   Automatically remove the container when it exits. The default is *false*.
 
 **--shm-size**=""
    Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.


### PR DESCRIPTION
The `--rm` flag has been part of the `docker create` (#20848) and related docs in `docs/reference/commandline/create.md` already includes the `--rm` flag. However, man page `man/docker-create.1.md` has not adds the `--rm` flag yet.

This fix adds the description of `--rm` flag to `man/docker-create.1.md`

Signed-off-by: Yong Tang yong.tang.github@outlook.com
