### PR TITLE
Windows: Error if mapping single file volume

### DIFF
--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -77,6 +77,7 @@ func TestParseMountSpec(t *testing.T) {
 			`lpt7:d:`:                          `cannot be a reserved word for Windows filenames`,
 			`lpt8:d:`:                          `cannot be a reserved word for Windows filenames`,
 			`lpt9:d:`:                          `cannot be a reserved word for Windows filenames`,
+			`c:\windows\system32\ntdll.dll`:    `Only directories can be mapped on this platform`,
 		}
 
 	} else {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes #26329. Gives error message (rather than starting the container and hitting `Access is denied`) if attempt to map a single file into a container. This is not supported by the platform.

New error message with this change (using the same example as per 26329):

```
PS E:\go\src\github.com\docker\docker> docker run -it --rm -v c:\config\test-rainer.txt windowsservercore cmd /c "type c
:\config\test-rainer.txt"
e:\go\src\github.com\docker\docker\binary\docker.exe: Error response from daemon: Invalid volume spec "c:\\config\\test-rainer.txt": file 'c:\config\test-rainer.txt' cannot be mapped. Only directories can be mapped on this platform.
See 'e:\go\src\github.com\docker\docker\binary\docker.exe run --help'.
PS E:\go\src\github.com\docker\docker>
```

@justincormack 
