### PR TITLE
Integration-cli: change daemon id generation from time to rand

### DIFF
--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/engine-api/types/events"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
@@ -61,7 +62,7 @@ func NewDaemon(c *check.C) *Daemon {
 	err := os.MkdirAll(daemonSockRoot, 0700)
 	c.Assert(err, checker.IsNil, check.Commentf("could not create daemon socket root"))
 
-	id := fmt.Sprintf("d%d", time.Now().UnixNano()%100000000)
+	id := fmt.Sprintf("d%s", stringid.TruncateID(stringid.GenerateRandomID()))
 	dir := filepath.Join(dest, id)
 	daemonFolder, err := filepath.Abs(dir)
 	c.Assert(err, check.IsNil, check.Commentf("Could not make %q an absolute path", dir))


### PR DESCRIPTION
Fixes #24805

Changes test daemon id generation from using time.Now().UnixNano() to using
crypto rand.Read(). This is because of a go bug (fixed upstream for 1.8)
on ppc64le and s390x where time.Now().UnixNano() would not actually
return nanosecond precision, so initializing consecutive daemons sometimes
would result in them having the same id.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

ping @tonistiigi 

![time dog](http://images.buycostumes.com/mgen/merchandiser/31693.jpg)
