### PR TITLE
Adding pluginv2 support for libnetwork.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -623,11 +623,12 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 		return nil, err
 	}
 
-	if err := d.restore(); err != nil {
+	// Plugin system initialization should happen before restore. Dont change order.
+	if err := pluginInit(d, config, containerdRemote); err != nil {
 		return nil, err
 	}
 
-	if err := pluginInit(d, config, containerdRemote); err != nil {
+	if err := d.restore(); err != nil {
 		return nil, err
 	}
 

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -43,11 +43,7 @@ func (pm *Manager) enable(p *v2.Plugin, force bool) error {
 	}
 
 	pm.pluginStore.SetState(p, true)
-	for _, typ := range p.GetTypes() {
-		if handler := pm.handlers[typ.String()]; handler != nil {
-			handler(p.Name(), p.Client())
-		}
-	}
+	pm.pluginStore.CallHandler(p)
 
 	return nil
 }


### PR DESCRIPTION
Legacy plugins (aka pluginv1) calls in libnetwork are replaced with
calls using the new plugin model (aka pluginv2). pkg/plugins is still
used for managing the http client connections to the plugin.

This commit makes the necessary changes in docker/docker. Part 2 will
will take care of the libnetwork changes.

Signed-off-by: Anusha Ragunathan anusha@docker.com
