### PR TITLE
POST /services/*/update does not accept name

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4733,7 +4733,7 @@ Return information on the service `id`.
 
 ### Update a service
 
-`POST /services/(id or name)/update`
+`POST /services/(id)/update`
 
 Update a service. When using this endpoint to create a service using a
 private repository from the registry, the `X-Registry-Auth` header can be used


### PR DESCRIPTION
I don't know whether this is intentional, but Docker does not accept a name for the Update command (It does, however, for GET and DELETE).
