### PR TITLE
Add maximum bandwidth and IOPS settings to --mount on Windows containers

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -156,6 +156,16 @@ definitions:
       ReadOnly:
         description: "Whether the mount should be read-only."
         type: "boolean"
+      MaxBandwidth:
+        description: "Maximum Bandwidth (Windows only)"
+        type: "integer"
+        format: "int64"
+        minimum: 0
+      MaxIOps:
+        description: "Maximum IOPS (Windows only)"
+        type: "integer"
+        format: "int64"
+        minimum: 0
       BindOptions:
         description: "Optional configuration for the `bind` type."
         type: "object"

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -23,9 +23,11 @@ type Mount struct {
 	// Source specifies the name of the mount. Depending on mount type, this
 	// may be a volume name or a host path, or even ignored.
 	// Source is not supported for tmpfs (must be an empty value)
-	Source   string `json:",omitempty"`
-	Target   string `json:",omitempty"`
-	ReadOnly bool   `json:",omitempty"`
+	Source       string `json:",omitempty"`
+	Target       string `json:",omitempty"`
+	ReadOnly     bool   `json:",omitempty"`
+	MaxBandwidth uint64 `json:",omitempty"`
+	MaxIOps      uint64 `json:",omitempty"`
 
 	BindOptions   *BindOptions   `json:",omitempty"`
 	VolumeOptions *VolumeOptions `json:",omitempty"`

--- a/container/mounts_windows.go
+++ b/container/mounts_windows.go
@@ -2,7 +2,9 @@ package container
 
 // Mount contains information for a mount operation.
 type Mount struct {
-	Source      string `json:"source"`
-	Destination string `json:"destination"`
-	Writable    bool   `json:"writable"`
+	Source       string `json:"source"`
+	Destination  string `json:"destination"`
+	Writable     bool   `json:"writable"`
+	MaxBandwidth uint64 `json:"max_bandwidth"`
+	MaxIOps      uint64 `json:"max_iops"`
 }

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"syscall"
 
 	containertypes "github.com/docker/docker/api/types/container"
@@ -39,6 +40,12 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		}
 		if !mount.Writable {
 			m.Options = append(m.Options, "ro")
+		}
+		if mount.MaxBandwidth != 0 {
+			m.Options = append(m.Options, fmt.Sprintf("maximum_bandwidth=%d", mount.MaxBandwidth))
+		}
+		if mount.MaxIOps != 0 {
+			m.Options = append(m.Options, fmt.Sprintf("maximum_iops=%d", mount.MaxIOps))
 		}
 		s.Mounts = append(s.Mounts, m)
 	}

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -9,6 +9,13 @@ import (
 	"github.com/docker/docker/volume"
 )
 
+var (
+	// maximumBandwidth is the maximum bandwidth of a volume
+	maximumBandwidth = "volume.maximum_bandwidth"
+	// maximumIOPS is the maximum IO per second of a volume
+	maximumIOPS = "volume.maximum_iops"
+)
+
 // setupMounts configures the mount points for a container by appending each
 // of the configured mounts on the container to the OCI mount structure
 // which will ultimately be passed into the oci runtime during container creation.
@@ -30,9 +37,11 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		}
 
 		mnts = append(mnts, container.Mount{
-			Source:      s,
-			Destination: mount.Destination,
-			Writable:    mount.RW,
+			Source:       s,
+			Destination:  mount.Destination,
+			Writable:     mount.RW,
+			MaxBandwidth: mount.MaxBandwidth,
+			MaxIOps:      mount.MaxIOps,
 		})
 	}
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -218,6 +219,21 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		for _, o := range mount.Options {
 			if strings.ToLower(o) == "ro" {
 				mds[i].ReadOnly = true
+			}
+			optionParts := strings.SplitN(o, "=", 2)
+			switch optionParts[0] {
+			case "maximum_bandwidth":
+				bandwidth, err := strconv.Atoi(optionParts[1])
+				if err != nil {
+					return fmt.Errorf("failed to parse maximum_bandwidth: %v", err)
+				}
+				mds[i].BandwidthMaximum = uint64(bandwidth)
+			case "maximum_iops":
+				iops, err := strconv.Atoi(optionParts[1])
+				if err != nil {
+					return fmt.Errorf("failed to parse maximum_iops: %v", err)
+				}
+				mds[i].IOPSMaximum = uint64(iops)
 			}
 		}
 	}

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	mounttypes "github.com/docker/docker/api/types/mount"
+	units "github.com/docker/go-units"
 )
 
 // MountOpt is a Value type for parsing mounts
@@ -86,6 +87,19 @@ func (m *MountOpt) Set(value string) error {
 			if err != nil {
 				return fmt.Errorf("invalid value for %s: %s", key, value)
 			}
+		case "max-bandwidth":
+			var bandwidth int64
+			bandwidth, err = units.RAMInBytes(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for %s: %s", key, value)
+			}
+			mount.MaxBandwidth = uint64(bandwidth)
+		case "max-iops":
+			maxiops, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for %s: %s", key, value)
+			}
+			mount.MaxIOps = uint64(maxiops)
 		case "bind-propagation":
 			bindOptions().Propagation = mounttypes.Propagation(strings.ToLower(value))
 		case "volume-nocopy":

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -94,6 +94,9 @@ type MountPoint struct {
 	// Note Propagation is not used on Windows
 	Propagation mounttypes.Propagation `json:",omitempty"` // Mount propagation string
 
+	MaxBandwidth uint64
+	MaxIOps      uint64
+
 	// Specifies if data should be copied from the container before the first mount
 	// Use a pointer here so we can tell if the user set this value explicitly
 	// This allows us to error out when the user explicitly enabled copy but we can't copy due to the volume being populated
@@ -255,10 +258,12 @@ func ParseMountSpec(cfg mounttypes.Mount, options ...func(*validateOpts)) (*Moun
 		return nil, err
 	}
 	mp := &MountPoint{
-		RW:          !cfg.ReadOnly,
-		Destination: clean(convertSlash(cfg.Target)),
-		Type:        cfg.Type,
-		Spec:        cfg,
+		RW:           !cfg.ReadOnly,
+		Destination:  clean(convertSlash(cfg.Target)),
+		Type:         cfg.Type,
+		Spec:         cfg,
+		MaxBandwidth: cfg.MaxBandwidth,
+		MaxIOps:      cfg.MaxIOps,
 	}
 
 	switch cfg.Type {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Added settings to manage QoS settings on bind mount and volumes on Windows containers.

**\- How I did it**

Added keys to the `--mount` flag for QoS settings `io-maxbandwidth` and `io-maxiops`, passed them as options to libcontainerd, and populated the BandwidthMaximum and IopsMaximum fields at container creation.

**\- How to verify it**

Currently manual verification by inspecting the JSON sent to HCS.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added settings to manage QoS on bindmounts and volumes for Windows containers.

**\- A picture of a cute animal (not mandatory but encouraged)**
![puppy-eyes](https://cloud.githubusercontent.com/assets/14114019/18293350/2059cb76-7447-11e6-9bfb-e1d15517fafb.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
