### PR TITLE
api/client/node: correct ordering in context argument

### DIFF
--- a/api/client/node/cmd.go
+++ b/api/client/node/cmd.go
@@ -3,13 +3,11 @@ package node
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
-	"github.com/spf13/cobra"
-
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/cli"
 	apiclient "github.com/docker/engine-api/client"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 // NewNodeCommand returns a cobra command for `node` subcommands
@@ -37,7 +35,7 @@ func NewNodeCommand(dockerCli *client.DockerCli) *cobra.Command {
 // Reference returns the reference of a node. The special value "self" for a node
 // reference is mapped to the current node, hence the node ID is retrieved using
 // the `/info` endpoint.
-func Reference(client apiclient.APIClient, ctx context.Context, ref string) (string, error) {
+func Reference(ctx context.Context, client apiclient.APIClient, ref string) (string, error) {
 	if ref == "self" {
 		info, err := client.Info(ctx)
 		if err != nil {

--- a/api/client/node/inspect.go
+++ b/api/client/node/inspect.go
@@ -45,7 +45,7 @@ func runInspect(dockerCli *client.DockerCli, opts inspectOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 	getRef := func(ref string) (interface{}, []byte, error) {
-		nodeRef, err := Reference(client, ctx, ref)
+		nodeRef, err := Reference(ctx, client, ref)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/api/client/node/ps.go
+++ b/api/client/node/ps.go
@@ -1,8 +1,6 @@
 package node
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/api/client/idresolver"
 	"github.com/docker/docker/api/client/task"
@@ -10,6 +8,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/engine-api/types"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type psOptions struct {
@@ -48,7 +47,7 @@ func runPs(dockerCli *client.DockerCli, opts psOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 
-	nodeRef, err := Reference(client, ctx, opts.nodeID)
+	nodeRef, err := Reference(ctx, client, opts.nodeID)
 	if err != nil {
 		return nil
 	}

--- a/api/client/service/ps.go
+++ b/api/client/service/ps.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/api/client/idresolver"
 	"github.com/docker/docker/api/client/node"
@@ -11,6 +9,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/engine-api/types"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type psOptions struct {
@@ -54,7 +53,7 @@ func runPS(dockerCli *client.DockerCli, opts psOptions) error {
 	if filter.Include("node") {
 		nodeFilters := filter.Get("node")
 		for _, nodeFilter := range nodeFilters {
-			nodeReference, err := node.Reference(client, ctx, nodeFilter)
+			nodeReference, err := node.Reference(ctx, client, nodeFilter)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
I stumbled upon this when reviewing https://github.com/docker/docker/pull/26299. Looking at https://github.com/docker/docker/blob/master/api/client/node/cmd.go#L40, we have a function where the first argument is not context but takes a context. This is bad style and problematic. Imagine an object that implements context interface but is not _the_ context.

Signed-off-by: Stephen J Day stephen.day@docker.com
