### PR TITLE
[WIP,POC,RFC] experimental `docker tunnel` (TCP port foward over Websocket)

### DIFF
--- a/api/client/command/commands.go
+++ b/api/client/command/commands.go
@@ -67,5 +67,6 @@ func AddCommands(cmd *cobra.Command, dockerCli *client.DockerCli) {
 		volume.NewVolumeCommand(dockerCli),
 		system.NewInfoCommand(dockerCli),
 	)
+	addExperimentalCommands(cmd, dockerCli)
 	plugin.NewPluginCommand(cmd, dockerCli)
 }

--- a/api/client/command/commands_experimental.go
+++ b/api/client/command/commands_experimental.go
@@ -1,0 +1,13 @@
+// +build experimental
+
+package command
+
+import (
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/api/client/system"
+	"github.com/spf13/cobra"
+)
+
+func addExperimentalCommands(cmd *cobra.Command, dockerCli *client.DockerCli) {
+	cmd.AddCommand(system.NewTunnelCommand(dockerCli))
+}

--- a/api/client/command/commands_regular.go
+++ b/api/client/command/commands_regular.go
@@ -1,0 +1,11 @@
+// +build !experimental
+
+package command
+
+import (
+	"github.com/docker/docker/api/client"
+	"github.com/spf13/cobra"
+)
+
+func addExperimentalCommands(cmd *cobra.Command, dockerCli *client.DockerCli) {
+}

--- a/api/client/system/tunnel_experimental.go
+++ b/api/client/system/tunnel_experimental.go
@@ -1,0 +1,79 @@
+// +build experimental
+
+package system
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/websocket"
+
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/spf13/cobra"
+)
+
+type tunnelOptions struct {
+	local  int
+	remote int
+}
+
+// NewTunnelCommand creates a new cobra.Command for `docker tunnel`
+func NewTunnelCommand(dockerCli *client.DockerCli) *cobra.Command {
+	var opts tunnelOptions
+
+	cmd := &cobra.Command{
+		Use:   "tunnel REMOTE_TCP_PORT",
+		Short: "Connect to the published port over a secure tunnel",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			opts.remote, err = strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			if opts.local == 0 {
+				opts.local = opts.remote
+			}
+			return runTunnel(dockerCli, &opts)
+		},
+	}
+	flags := cmd.Flags()
+	flags.IntVarP(&opts.local, "local", "l", 0, "Local TCP port (default: the port identical to the repote)")
+	return cmd
+}
+
+func runTunnel(dockerCli *client.DockerCli, opts *tunnelOptions) error {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", opts.local))
+	if err != nil {
+		return err
+	}
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			fmt.Fprintf(dockerCli.Err(),
+				"Error while accepting a connection: %v\n", err)
+			continue
+		}
+		wsConn, err := dockerCli.Client().Tunnel(context.Background(), opts.remote)
+		if err != nil {
+			fmt.Fprintf(dockerCli.Err(),
+				"Error while connecting to websocket: %v\n", err)
+			conn.Close()
+			continue
+		}
+		go handleTunnelConnection(dockerCli, conn, wsConn)
+	}
+}
+
+func handleTunnelConnection(dockerCli *client.DockerCli, tcpConn net.Conn, wsConn *websocket.Conn) {
+	ioutils.BidirectionalCopy(tcpConn, wsConn,
+		func(err error, direction ioutils.Direction) {
+			fmt.Fprintf(dockerCli.Err(),
+				"error while copying (%v): %v\n",
+				direction, err)
+		})
+}

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -20,14 +20,14 @@ func NewRouter(b Backend, c *cluster.Cluster) router.Router {
 		clusterProvider: c,
 	}
 
-	r.routes = []router.Route{
+	r.routes = append([]router.Route{
 		router.NewOptionsRoute("/{anyroute:.*}", optionsHandler),
 		router.NewGetRoute("/_ping", pingHandler),
 		router.Cancellable(router.NewGetRoute("/events", r.getEvents)),
 		router.NewGetRoute("/info", r.getInfo),
 		router.NewGetRoute("/version", r.getVersion),
 		router.NewPostRoute("/auth", r.postAuth),
-	}
+	}, newExperimentalRoutes(r)...)
 
 	return r
 }

--- a/api/server/router/system/system_experimental.go
+++ b/api/server/router/system/system_experimental.go
@@ -1,0 +1,13 @@
+// +build experimental
+
+package system
+
+import (
+	"github.com/docker/docker/api/server/router"
+)
+
+func newExperimentalRoutes(r *systemRouter) []router.Route {
+	return []router.Route{
+		router.NewGetRoute("/tunnel/ws", r.wsTunnel),
+	}
+}

--- a/api/server/router/system/system_regular.go
+++ b/api/server/router/system/system_regular.go
@@ -1,0 +1,11 @@
+// +build !experimental
+
+package system
+
+import (
+	"github.com/docker/docker/api/server/router"
+)
+
+func newExperimentalRoutes(r *systemRouter) []router.Route {
+	return nil
+}

--- a/api/server/router/system/system_routes_experimental.go
+++ b/api/server/router/system/system_routes_experimental.go
@@ -1,0 +1,52 @@
+// +build experimental
+
+package system
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/pkg/ioutils"
+	"golang.org/x/net/context"
+	"golang.org/x/net/websocket"
+)
+
+func (s *systemRouter) getWSTunnelTCPPort(r *http.Request) (int, error) {
+	port := httputils.Int64ValueOrZero(r, "port")
+	// TODO: assert that the port is published by the daemon
+	if port == 0 || port > 65535 {
+		return 0, fmt.Errorf("invalid tcp port %d", port)
+	}
+	return int(port), nil
+}
+
+func tunnelHandler(tcpConn net.Conn) func(wsConn *websocket.Conn) {
+	return func(wsConn *websocket.Conn) {
+		ioutils.BidirectionalCopy(tcpConn, wsConn,
+			func(err error, direction ioutils.Direction) {
+				logrus.Warnf(
+					"error while copying (%v): %v",
+					direction, err)
+			})
+	}
+}
+
+func (s *systemRouter) wsTunnel(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	tcpPort, err := s.getWSTunnelTCPPort(r)
+	if err != nil {
+		return err
+	}
+	tcpConn, err := net.Dial("tcp", fmt.Sprintf(":%d", tcpPort))
+	if err != nil {
+		return err
+	}
+	srv := websocket.Server{Handler: tunnelHandler(tcpConn)}
+	srv.ServeHTTP(w, r)
+	return nil
+}

--- a/pkg/ioutils/bicopy.go
+++ b/pkg/ioutils/bicopy.go
@@ -1,0 +1,60 @@
+package ioutils
+
+import (
+	"io"
+	"sync"
+)
+
+// Direction denotes the error direction for BidirectionalCopy.
+type Direction int
+
+const (
+	// RemoteToLocal is remote to local
+	RemoteToLocal Direction = iota
+	// LocalToRemote is local to remote
+	LocalToRemote
+)
+
+// BidirectionalCopy is similar to io.Copy but bidirectional.
+// TODO: improve error handling interface.
+// Maybe we should just return err instead of having errHandler.
+func BidirectionalCopy(local io.ReadWriteCloser, remote io.ReadWriteCloser,
+	errHandler func(error, Direction)) {
+	var remoteClosed, localClosed bool
+	var m sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			m.Lock()
+			remoteClosed = true
+			if !localClosed {
+				local.Close()
+				localClosed = true
+			}
+			m.Unlock()
+		}()
+		_, err := io.Copy(local, remote)
+		if err != nil && !localClosed {
+			errHandler(err, RemoteToLocal)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		defer func() {
+			m.Lock()
+			if !remoteClosed {
+				remote.Close()
+				remoteClosed = true
+			}
+			localClosed = true
+			m.Unlock()
+		}()
+		_, err := io.Copy(remote, local)
+		if err != nil && !remoteClosed {
+			errHandler(err, LocalToRemote)
+		}
+	}()
+	wg.Wait()
+}

--- a/vendor/src/github.com/docker/engine-api/client/interface_experimental.go
+++ b/vendor/src/github.com/docker/engine-api/client/interface_experimental.go
@@ -5,6 +5,7 @@ package client
 import (
 	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
+	"golang.org/x/net/websocket"
 )
 
 // APIClient is an interface that clients that talk with a docker server must implement.
@@ -12,6 +13,7 @@ type APIClient interface {
 	CommonAPIClient
 	CheckpointAPIClient
 	PluginAPIClient
+	TunnelAPIClient
 }
 
 // CheckpointAPIClient defines API client methods for the checkpoints
@@ -31,6 +33,11 @@ type PluginAPIClient interface {
 	PluginPush(ctx context.Context, name string, registryAuth string) error
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)
+}
+
+// TunnelAPIClient defines API client methods for the tunnel
+type TunnelAPIClient interface {
+	Tunnel(ctx context.Context, port int) (*websocket.Conn, error)
 }
 
 // Ensure that Client always implements APIClient.

--- a/vendor/src/github.com/docker/engine-api/client/tunnel.go
+++ b/vendor/src/github.com/docker/engine-api/client/tunnel.go
@@ -1,0 +1,30 @@
+// +build experimental
+
+package client
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/websocket"
+)
+
+// Tunnel returns the WebSocket
+func (cli *Client) Tunnel(ctx context.Context, port int) (*websocket.Conn, error) {
+	config, err := websocket.NewConfig(
+		fmt.Sprintf("/tunnel/ws?port=%d", port),
+		"http://localhost",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to instantiate websocket config: %v", err)
+	}
+	conn, err := dial(cli.proto, cli.addr, cli.transport.TLSConfig())
+	if err != nil {
+		return nil, fmt.Errorf("unable to dial: %v", err)
+	}
+	ws, err := websocket.NewClient(config, conn)
+	if err != nil {
+		return nil, fmt.Errorf("unable to instantiate websocket client: %v", err)
+	}
+	return ws, nil
+}


### PR DESCRIPTION
**\- What I did**
Add `docker tunnel`, which enables TCP port forwarding over Websocket (over TLS, typically)

The motivation for this feature is illustrated in the attached image.
I think this feature should not be used in production, basically. (but maybe still useful for some production apps in some cases, e.g. Hue, Jupyter..?)

The feature is experimental and careful discussion about security, API, and CLI is needed.

![image](https://cloud.githubusercontent.com/assets/9248427/18303584/cf5b3872-7518-11e6-9922-62d6a4b7716c.png)

**\- How I did it**
`api/server/router/system/system_experimental.go` adds a new router `/tunnel/ws?port=%d`, and opens TCP socket for the specified port.

Maybe we should not allow connecting to a port that is not exposed by the daemon.

**\- How to verify it**

```
$ DOCKER_EXPERIMENTAL=1 make binary
$ docker service create --name nginx -p 80:80 --replicas 3 nginx
$ docker tunnel -l 10080 80
```

Then open `http://localhost:10080` via a web browser.

**\- Description for the changelog**
experimental `docker tunnel` (TCP port foward over Websocket)

**\- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/9248427/18303680/4874e726-7519-11e6-8d84-0aaeffcaef2a.png)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
