### PR TITLE
[WIP] Support OCI image layout in docker save/load

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -34,9 +34,9 @@ type imageBackend interface {
 }
 
 type importExportBackend interface {
-	LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error
+	LoadImage(inTar io.ReadCloser, outStream io.Writer, name string, refs map[string]string, quiet bool) error
 	ImportImage(src string, repository, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error
-	ExportImage(names []string, outStream io.Writer) error
+	ExportImage(names []string, format string, refs map[string]string, outStream io.Writer) error
 }
 
 type registryBackend interface {

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -137,6 +137,21 @@ func (h *HijackedResponse) CloseWrite() error {
 	return nil
 }
 
+// ImageSaveOptions holds the information
+// necessary to save a set of images.
+type ImageSaveOptions struct {
+	Format string
+	Refs   map[string]string
+}
+
+// ImageLoadOptions holds the information
+// necessary to load a set of images.
+type ImageLoadOptions struct {
+	Quiet bool
+	Name  string
+	Refs  map[string]string
+}
+
 // ImageBuildOptions holds the information
 // necessary to build images.
 type ImageBuildOptions struct {

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"io"
 	"net/url"
 
@@ -12,12 +13,18 @@ import (
 // ImageLoad loads an image in the docker host from the client host.
 // It's up to the caller to close the io.ReadCloser in the
 // ImageLoadResponse returned by this function.
-func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
+func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, opts types.ImageLoadOptions) (types.ImageLoadResponse, error) {
 	v := url.Values{}
 	v.Set("quiet", "0")
-	if quiet {
+	if opts.Quiet {
 		v.Set("quiet", "1")
 	}
+	refsJSON, err := json.Marshal(opts.Refs)
+	if err != nil {
+		return types.ImageLoadResponse{}, err
+	}
+	v.Set("refs", string(refsJSON))
+	v.Set("name", opts.Name)
 	headers := map[string][]string{"Content-Type": {"application/x-tar"}}
 	resp, err := cli.postRaw(ctx, "/images/load", v, input, headers)
 	if err != nil {

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+
 	"golang.org/x/net/context"
 )
 
@@ -16,7 +18,7 @@ func TestImageLoadError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ImageLoad(context.Background(), nil, true)
+	_, err := client.ImageLoad(context.Background(), nil, types.ImageLoadOptions{Quiet: true})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -77,7 +79,7 @@ func TestImageLoad(t *testing.T) {
 		}
 
 		input := bytes.NewReader([]byte(expectedInput))
-		imageLoadResponse, err := client.ImageLoad(context.Background(), input, loadCase.quiet)
+		imageLoadResponse, err := client.ImageLoad(context.Background(), input, types.ImageLoadOptions{Quiet: loadCase.quiet})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -1,18 +1,27 @@
 package client
 
 import (
+	"encoding/json"
 	"io"
 	"net/url"
+
+	"github.com/docker/docker/api/types"
 
 	"golang.org/x/net/context"
 )
 
 // ImageSave retrieves one or more images from the docker host as an io.ReadCloser.
 // It's up to the caller to store the images and close the stream.
-func (cli *Client) ImageSave(ctx context.Context, imageIDs []string) (io.ReadCloser, error) {
+func (cli *Client) ImageSave(ctx context.Context, images []string, opts types.ImageSaveOptions) (io.ReadCloser, error) {
 	query := url.Values{
-		"names": imageIDs,
+		"names": images,
 	}
+	query.Set("format", opts.Format)
+	refsJSON, err := json.Marshal(opts.Refs)
+	if err != nil {
+		return nil, err
+	}
+	query.Set("refs", string(refsJSON))
 
 	resp, err := cli.get(ctx, "/images/get", query, nil)
 	if err != nil {

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+
 	"golang.org/x/net/context"
 
 	"strings"
@@ -17,7 +19,7 @@ func TestImageSaveError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageSave(context.Background(), []string{"nothing"})
+	_, err := client.ImageSave(context.Background(), []string{"nothing"}, types.ImageSaveOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
 	}
@@ -43,7 +45,7 @@ func TestImageSave(t *testing.T) {
 			}, nil
 		}),
 	}
-	saveResponse, err := client.ImageSave(context.Background(), []string{"image_id1", "image_id2"})
+	saveResponse, err := client.ImageSave(context.Background(), []string{"image_id1", "image_id2"}, types.ImageSaveOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -76,12 +76,12 @@ type ImageAPIClient interface {
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error)
 	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
 	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error)
-	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
+	ImageLoad(ctx context.Context, input io.Reader, options types.ImageLoadOptions) (types.ImageLoadResponse, error)
 	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options types.ImagePushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
-	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
+	ImageSave(ctx context.Context, images []string, options types.ImageSaveOptions) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (types.ImagesPruneReport, error)
 }

--- a/daemon/image_exporter.go
+++ b/daemon/image_exporter.go
@@ -9,17 +9,30 @@ import (
 // ExportImage exports a list of images to the given output stream. The
 // exported images are archived into a tar when written to the output
 // stream. All images with the given tag and all versions containing
-// the same tag are exported. names is the set of tags to export, and
-// outStream is the writer which the images are written to.
-func (daemon *Daemon) ExportImage(names []string, outStream io.Writer) error {
-	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon)
+// the same tag are exported. names is the set of tags to export.
+// outStream is the writer which the images are written to. refs is a map used
+// when exporting to the OCI format.
+// format is the format of the resulting tar ball.
+func (daemon *Daemon) ExportImage(names []string, format string, refs map[string]string, outStream io.Writer) error {
+	opts := &tarexport.Options{
+		Format:       format,
+		Refs:         refs,
+		Experimental: daemon.HasExperimental(),
+	}
+	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon, opts)
 	return imageExporter.Save(names, outStream)
 }
 
-// LoadImage uploads a set of images into the repository. This is the
+// LoadImage loads a set of images into the repository. This is the
 // complement of ImageExport.  The input stream is an uncompressed tar
 // ball containing images and metadata.
-func (daemon *Daemon) LoadImage(inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
-	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon)
+func (daemon *Daemon) LoadImage(inTar io.ReadCloser, outStream io.Writer, name string, refs map[string]string, quiet bool) error {
+	opts := &tarexport.Options{
+		Name:         name,
+		Refs:         refs,
+		Experimental: daemon.HasExperimental(),
+	}
+	imageExporter := tarexport.NewTarExporter(daemon.imageStore, daemon.layerStore, daemon.referenceStore, daemon, opts)
+	// the first arg will be "name" passed down from LoadImage() itself
 	return imageExporter.Load(inTar, outStream, quiet)
 }

--- a/image/tarexport/loader.go
+++ b/image/tarexport/loader.go
@@ -1,0 +1,132 @@
+package tarexport
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/reference"
+	digest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type loader interface {
+	Load() error
+}
+
+type dockerLoader struct {
+	manifests      []manifestItem
+	tr             *tarexporter
+	tmpDir         string
+	outStream      io.Writer
+	progressOutput progress.Output
+}
+
+func (dl *dockerLoader) Load() error {
+	return dl.tr.loadHelper(dl.manifests, dl.outStream, dl.progressOutput, dl.tmpDir)
+}
+
+type dockerLegacyLoader struct {
+	tr             *tarexporter
+	tmpDir         string
+	outStream      io.Writer
+	progressOutput progress.Output
+}
+
+func (dll *dockerLegacyLoader) Load() error {
+	return dll.tr.legacyLoad(dll.tmpDir, dll.outStream, dll.progressOutput)
+}
+
+type ociLoader struct {
+	tr             *tarexporter
+	tmpDir         string
+	outStream      io.Writer
+	progressOutput progress.Output
+}
+
+func (ol *ociLoader) Load() error {
+	if ol.tr.name != "" && len(ol.tr.refs) != 0 {
+		return errors.New("cannot load with either name and refs")
+	}
+	if ol.tr.name == "" && len(ol.tr.refs) == 0 {
+		return errors.New("no OCI name mapping provided")
+	}
+
+	// FIXME(runcom): validate and check version of "oci-layout" file
+
+	manifests := []manifestItem{}
+	refsPath := filepath.Join(ol.tmpDir, "refs")
+	if err := filepath.Walk(refsPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		descriptor := ociv1.Descriptor{}
+		if err := json.NewDecoder(f).Decode(&descriptor); err != nil {
+			return err
+		}
+		// TODO(runcom): validate mediatype and size
+		d := digest.Digest(descriptor.Digest)
+		manifestPath := filepath.Join(ol.tmpDir, "blobs", d.Algorithm().String(), d.Hex())
+		f, err = os.Open(manifestPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		man := ociv1.Manifest{}
+		if err := json.NewDecoder(f).Decode(&man); err != nil {
+			return err
+		}
+		layers := make([]string, len(man.Layers))
+		for i, l := range man.Layers {
+			layerDigest := digest.Digest(l.Digest)
+			layers[i] = filepath.Join("blobs", layerDigest.Algorithm().String(), layerDigest.Hex())
+		}
+		tag := ""
+		if ol.tr.name != "" {
+			named, err := reference.ParseNamed(ol.tr.name)
+			if err != nil {
+				return err
+			}
+			withTag, err := reference.WithTag(named, info.Name())
+			if err != nil {
+				return err
+			}
+			tag = withTag.String()
+		} else {
+			_, rs, err := ol.tr.getRefs()
+			if err != nil {
+				return err
+			}
+			r, ok := rs[info.Name()]
+			if !ok {
+				return fmt.Errorf("no naming provided for %q", info.Name())
+			}
+			tag = r.String()
+		}
+		configDigest := digest.Digest(man.Config.Digest)
+		manifests = append(manifests, manifestItem{
+			Config:   filepath.Join("blobs", configDigest.Algorithm().String(), configDigest.Hex()),
+			RepoTags: []string{tag},
+			Layers:   layers,
+			// TODO(runcom): foreign srcs?
+			// See https://github.com/docker/docker/pull/22866/files#r96125181
+		})
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return ol.tr.loadHelper(manifests, ol.outStream, ol.progressOutput, ol.tmpDir)
+}

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -42,7 +42,7 @@ func (l *tarexporter) Save(names []string, outStream io.Writer) error {
 		}
 
 		return (&saveSession{tarexporter: l, images: images}).save(outStream)
-	case "oci":
+	case "oci.v1":
 		if !l.experimental {
 			return fmt.Errorf("saving to OCI format is experimental, please run daemon with --experimental")
 		}

--- a/image/tarexport/save_oci.go
+++ b/image/tarexport/save_oci.go
@@ -1,0 +1,416 @@
+package tarexport
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/system"
+	"github.com/docker/docker/reference"
+	"github.com/opencontainers/go-digest"
+	imgspec "github.com/opencontainers/image-spec/specs-go"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type layerInfo struct {
+	digest digest.Digest
+	size   int64
+}
+
+type ociSaveSession struct {
+	*tarexporter
+	images       map[image.ID]*imageDescriptor
+	name         string
+	savedImages  map[image.ID][]byte // cache image.ID -> manifest bytes
+	diffIDsCache map[layer.DiffID]*layerInfo
+	outDir       string
+}
+
+func (l *tarexporter) getRefs() (map[string]string, map[string]reference.NamedTagged, error) {
+	refs := make(map[string]string)
+	reversed := make(map[string]reference.NamedTagged)
+	for image, ref := range l.refs {
+		r, err := reference.ParseNamed(image)
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, ok := r.(reference.Canonical); ok {
+			continue // a digest reference it's unique, no need for a --ref
+		}
+		var (
+			tagged reference.NamedTagged
+			ok     bool
+		)
+		if tagged, ok = r.(reference.NamedTagged); !ok {
+			var err error
+			if tagged, err = reference.WithTag(r, reference.DefaultTag); err != nil {
+				return nil, nil, err
+			}
+		}
+		if !ociRefRegexp.MatchString(ref) {
+			return nil, nil, fmt.Errorf(`invalid reference "%s=%s", reference must not include characters outside of the set of "A" to "Z", "a" to "z", "0" to "9", the hyphen "-", the dot ".", and the underscore "_"`, image, ref)
+		}
+		refs[tagged.String()] = ref
+		reversed[ref] = tagged
+	}
+	return refs, reversed, nil
+}
+
+var ociRefRegexp = regexp.MustCompile(`^([A-Za-z0-9._-]+)+$`)
+
+func (l *tarexporter) parseOCINames(names []string) (map[image.ID]*imageDescriptor, error) {
+	refs, _, err := l.getRefs()
+	if err != nil {
+		return nil, err
+	}
+	imgDescr := make(map[image.ID]*imageDescriptor)
+	tags := make(map[string]bool)
+
+	addAssoc := func(id image.ID, ref reference.Named) error {
+		if _, ok := imgDescr[id]; !ok {
+			imgDescr[id] = &imageDescriptor{}
+		}
+
+		if ref != nil {
+			var tagged reference.NamedTagged
+			if _, ok := ref.(reference.Canonical); ok {
+				return nil
+			}
+			var ok bool
+			if tagged, ok = ref.(reference.NamedTagged); !ok {
+				var err error
+				if tagged, err = reference.WithTag(ref, reference.DefaultTag); err != nil {
+					return nil
+				}
+			}
+
+			r, ok := refs[tagged.String()]
+			if ok {
+				var err error
+				if tagged, err = reference.WithTag(tagged, r); err != nil {
+					return err
+				}
+			}
+
+			for _, t := range imgDescr[id].refs {
+				if tagged.String() == t.String() {
+					return nil
+				}
+			}
+
+			if tags[tagged.Tag()] {
+				return fmt.Errorf("unable to include unique references %q in OCI image", tagged.Tag())
+			}
+
+			tags[tagged.Tag()] = true
+
+			imgDescr[id].refs = append(imgDescr[id].refs, tagged)
+		}
+
+		return nil
+	}
+
+	// TODO(runcom): same as docker-save except the error return in addAssoc
+	// and the tags map above.
+	for _, name := range names {
+		id, ref, err := reference.ParseIDOrReference(name)
+		if err != nil {
+			return nil, err
+		}
+		if id != "" {
+			_, err := l.is.Get(image.ID(id))
+			if err != nil {
+				return nil, err
+			}
+			if err := addAssoc(image.ID(id), nil); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if ref.Name() == string(digest.Canonical) {
+			imgID, err := l.is.Search(name)
+			if err != nil {
+				return nil, err
+			}
+			if err := addAssoc(imgID, nil); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if reference.IsNameOnly(ref) {
+			assocs := l.rs.ReferencesByName(ref)
+			for _, assoc := range assocs {
+				if err := addAssoc(image.IDFromDigest(assoc.ID), assoc.Ref); err != nil {
+					return nil, err
+				}
+			}
+			if len(assocs) == 0 {
+				imgID, err := l.is.Search(name)
+				if err != nil {
+					return nil, err
+				}
+				if err := addAssoc(imgID, nil); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
+		id, err = l.rs.Get(ref)
+		if err != nil {
+			return nil, err
+		}
+		if err := addAssoc(image.IDFromDigest(id), ref); err != nil {
+			return nil, err
+		}
+	}
+	return imgDescr, nil
+}
+
+func (s *ociSaveSession) save(outStream io.Writer) error {
+	s.diffIDsCache = make(map[layer.DiffID]*layerInfo)
+	s.savedImages = make(map[image.ID][]byte)
+	tempDir, err := ioutil.TempDir("", "oci-export-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	s.outDir = tempDir
+
+	if err := ioutil.WriteFile(filepath.Join(tempDir, "oci-layout"), []byte(`{"imageLayoutVersion": "1.0.0"}`), 0644); err != nil {
+		return err
+	}
+
+	for id, info := range s.images {
+		for _, i := range info.refs {
+			// TODO(runcom): handle foreign srcs like save.go
+			if err := s.saveImage(id, i.Tag()); err != nil {
+				return err
+			}
+		}
+		if len(info.refs) == 0 {
+			// TODO(runcom): handle foreign srcs like save.go
+			if err := s.saveImage(id, id.Digest().Hex()); err != nil {
+				return err
+			}
+		}
+	}
+
+	fs, err := archive.Tar(tempDir, archive.Uncompressed)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	_, err = io.Copy(outStream, fs)
+	return err
+}
+
+func (s *ociSaveSession) saveImage(id image.ID, ref string) error {
+	if m, ok := s.savedImages[id]; ok {
+		if err := s.saveManifest(ref, m); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	img, err := s.is.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if len(img.RootFS.DiffIDs) == 0 {
+		return fmt.Errorf("empty export - not implemented")
+	}
+
+	configFile, err := blobPath(s.outDir, id.Digest())
+	if err != nil {
+		return err
+	}
+	if err := ensureParentDirectoryExists(configFile); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(configFile, img.RawJSON(), 0644); err != nil {
+		return err
+	}
+	if err := system.Chtimes(configFile, img.Created, img.Created); err != nil {
+		return err
+	}
+
+	// TODO(runcom): there should likely be a manifest builder (like docker/distribution)
+	m := ociv1.Manifest{
+		Versioned: imgspec.Versioned{
+			SchemaVersion: 2,
+			MediaType:     ociv1.MediaTypeImageManifest,
+		},
+		Config: ociv1.Descriptor{
+			MediaType: ociv1.MediaTypeImageConfig,
+			Digest:    img.ImageID(),
+			Size:      int64(len(img.RawJSON())),
+		},
+	}
+
+	for i := range img.RootFS.DiffIDs {
+		rootFS := *img.RootFS
+		rootFS.DiffIDs = rootFS.DiffIDs[:i+1]
+
+		l, err := s.ls.Get(rootFS.ChainID())
+		if err != nil {
+			return err
+		}
+		defer layer.ReleaseAndLog(s.ls, l)
+
+		var (
+			digest digest.Digest
+			size   int64
+		)
+		if i, ok := s.diffIDsCache[l.DiffID()]; ok {
+			digest = i.digest
+			size = i.size
+		} else {
+			lInfo, err := s.saveLayer(l)
+			if err != nil {
+				return err
+			}
+			digest = lInfo.digest
+			size = lInfo.size
+		}
+
+		descriptor := ociv1.Descriptor{
+			MediaType: ociv1.MediaTypeImageLayer,
+			Digest:    digest.String(),
+			Size:      size,
+		}
+		m.Layers = append(m.Layers, descriptor)
+	}
+
+	mJSON, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	if err := s.saveManifest(ref, mJSON); err != nil {
+		return err
+	}
+
+	s.savedImages[id] = mJSON
+
+	return nil
+}
+
+func (s *ociSaveSession) saveManifest(ref string, ociMan []byte) error {
+	d := digest.FromBytes(ociMan)
+	desc := ociv1.Descriptor{}
+	desc.Digest = d.String()
+	desc.MediaType = ociv1.MediaTypeImageManifest
+	desc.Size = int64(len(ociMan))
+	data, err := json.Marshal(desc)
+	if err != nil {
+		return err
+	}
+
+	blobPath, err := blobPath(s.outDir, d)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(blobPath, ociMan, 0644); err != nil {
+		return err
+	}
+	descriptorPath := descriptorPath(s.outDir, ref)
+	if err := ensureParentDirectoryExists(descriptorPath); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(descriptorPath, data, 0644)
+}
+
+func (s *ociSaveSession) saveLayer(l layer.Layer) (*layerInfo, error) {
+	arch, err := l.TarStream()
+	if err != nil {
+		return nil, err
+	}
+	defer arch.Close()
+
+	// FIXME: anywhere I can get a gzipped layer (and digest) as found in remote registries?
+	pr, pw := io.Pipe()
+	defer pr.Close()
+	go func() {
+		err := errors.New("internal error: unexpected panic in compressing layer")
+		defer func() {
+			pw.CloseWithError(err)
+		}()
+		zipper, err := archive.CompressStream(pw, archive.Gzip)
+		if err != nil {
+			return
+		}
+		defer zipper.Close()
+
+		_, err = io.Copy(zipper, arch)
+	}()
+
+	blobFile, err := ioutil.TempFile(s.outDir, "oci-blob")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(blobFile.Name())
+
+	digester := digest.Canonical.Digester()
+	tee := io.TeeReader(pr, digester.Hash())
+
+	size, err := io.Copy(blobFile, tee)
+	if err != nil {
+		return nil, err
+	}
+	computedDigest := digester.Digest()
+	if err := blobFile.Sync(); err != nil {
+		return nil, err
+	}
+	if err := blobFile.Chmod(0644); err != nil {
+		return nil, err
+	}
+	blobPath, err := blobPath(s.outDir, computedDigest)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureParentDirectoryExists(blobPath); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(blobFile.Name(), blobPath); err != nil {
+		return nil, err
+	}
+	li := &layerInfo{digest: computedDigest, size: size}
+	s.diffIDsCache[l.DiffID()] = li
+	return li, nil
+}
+
+func ensureDirectoryExists(path string) error {
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureParentDirectoryExists ensures the parent of the supplied path exists.
+func ensureParentDirectoryExists(path string) error {
+	return ensureDirectoryExists(filepath.Dir(path))
+}
+
+func blobPath(tmp string, digest digest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil {
+		return "", fmt.Errorf("unexpected digest reference %s: %v", digest.String(), err)
+	}
+	return filepath.Join(tmp, "blobs", digest.Algorithm().String(), digest.Hex()), nil
+}
+
+func descriptorPath(tmp, ref string) string {
+	return filepath.Join(tmp, "refs", ref)
+}

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -28,6 +28,10 @@ type tarexporter struct {
 	ls             layer.Store
 	rs             refstore.Store
 	loggerImgEvent LogImageEvent
+	format         string
+	refs           map[string]string
+	name           string
+	experimental   bool
 }
 
 // LogImageEvent defines interface for event generation related to image tar(load and save) operations
@@ -36,12 +40,24 @@ type LogImageEvent interface {
 	LogImageEvent(imageID, refName, action string)
 }
 
+// Options holds options to be used by the exporter.
+type Options struct {
+	Name         string
+	Format       string
+	Refs         map[string]string
+	Experimental bool
+}
+
 // NewTarExporter returns new Exporter for tar packages
-func NewTarExporter(is image.Store, ls layer.Store, rs refstore.Store, loggerImgEvent LogImageEvent) image.Exporter {
+func NewTarExporter(is image.Store, ls layer.Store, rs refstore.Store, loggerImgEvent LogImageEvent, opts *Options) image.Exporter {
 	return &tarexporter{
 		is:             is,
 		ls:             ls,
 		rs:             rs,
 		loggerImgEvent: loggerImgEvent,
+		format:         opts.Format,
+		refs:           opts.Refs,
+		name:           opts.Name,
+		experimental:   opts.Experimental,
 	}
 }

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -382,3 +382,152 @@ func (s *DockerSuite) TestSaveLoadNoTag(c *check.C) {
 	c.Assert(out, checker.Contains, "Loaded image: "+name+":latest")
 	c.Assert(out, checker.Not(checker.Contains), "Loaded image ID:")
 }
+
+func (s *DockerSuite) TestSaveOCIReferencesConflicts(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
+
+	name0 := "frombusybox0"
+	_, err := buildImage(name0, "FROM busybox\nENV oci=true", true)
+	c.Assert(err, checker.IsNil)
+
+	name1 := "frombusybox1"
+	_, err = buildImage(name1, "FROM busybox\nENV oci=true\nENV oci=false", true)
+	c.Assert(err, checker.IsNil)
+
+	// test that the same tag conflicts
+	out, _, err := dockerCmdWithError("save", "--format", "oci", "-o", "test.tar", "busybox", name0)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `unable to include unique references "latest" in OCI image`)
+
+	// test that --ref on just a subset of the images raise a conflict (because name1 and busybox are still "latest")
+	out, _, err = dockerCmdWithError("save", "--format", "oci", "--ref", name0+"="+name0+"-latest", "-o", "test.tar", "busybox", name0, name1)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `unable to include unique references "latest" in OCI image`)
+
+	// silly test
+	out, _, err = dockerCmdWithError("save", "--format", "oci", "-o", "test.tar", "notexists")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "No such image: notexists")
+
+	// test that the same tag is invalid even if it's not "latest"
+	dockerCmd(c, "tag", name0, name0+":12.04")
+	dockerCmd(c, "tag", "busybox:latest", "busybox:12.04")
+	out, _, err = dockerCmdWithError("save", "--format", "oci", "-o", "test.tar", "busybox", name0+":12.04", "busybox:12.04")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `unable to include unique references "12.04" in OCI image`)
+
+	// silly test in case you have --ref pointing to an actual tag
+	out, _, err = dockerCmdWithError("save", "--format", "oci", "--ref", "busybox:latest=12.04", "-o", "test.tar", "busybox:latest", name0+":12.04")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `unable to include unique references "12.04" in OCI image`)
+
+	dockerCmd(c, "tag", "busybox:latest", "busybox0")
+	out, _, err = dockerCmdWithError("save", "--format", "oci", "-o", "test.tar", "busybox:latest", "busybox0")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `unable to include unique references "latest" in OCI image`)
+
+	// test that invalid --ref aren't accepted
+	out, _, err = dockerCmdWithError("save", "--format", "oci", "-o", "test.tar", "--ref", "busybox=invalid:reference", "busybox")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `invalid reference "busybox=invalid:reference", reference must not include characters outside of the set of "A" to "Z", "a" to "z", "0" to "9", the hyphen "-", the dot ".", and the underscore "_"`)
+}
+
+func (s *DockerSuite) TestSaveOCIReferences(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
+
+	name0 := "frombusybox0"
+	_, err := buildImage(name0, "FROM busybox\nENV oci=true", true)
+	c.Assert(err, checker.IsNil)
+
+	// test that the same tag can be saved with --ref
+	out, _, err := testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "--ref", name0+"="+name0+"-latest", "busybox:latest", name0),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/latest")
+	c.Assert(out, checker.Contains, "refs/"+name0+"-latest")
+
+	// save with just an image
+	out, _, err = testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "busybox:latest"),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/latest")
+	// additional test...
+	c.Assert(out, checker.Contains, "oci-layout")
+
+	// test save with 2 tags (same underlying image)
+	dockerCmd(c, "tag", "busybox:latest", "busybox:notlatest")
+	out, _, err = testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "busybox:notlatest", "busybox"),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/notlatest")
+	c.Assert(out, checker.Contains, "refs/latest")
+
+	// test can save with image id
+	imageID := inspectField(c, "busybox:latest", "Id")
+	imageID = strings.Replace(imageID, "sha256:", "", -1)
+
+	out, _, err = testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", imageID),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/"+imageID)
+
+	// test that saving "name:tag" just includes "refs/tag" and not all the tags
+	out, _, err = testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "busybox:latest"),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/")
+	c.Assert(out, checker.Contains, "refs/latest")
+	c.Assert(strings.Count(out, "refs/"), checker.Equals, 2)
+
+	// as in saving just "name"
+	dockerCmd(c, "tag", "busybox:latest", "img0")
+	dockerCmd(c, "tag", "img0:latest", "img0:notlatest")
+	dockerCmd(c, "tag", "img0:latest", "img0:another")
+	out, _, err = testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "img0"),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/")
+	c.Assert(out, checker.Contains, "refs/latest")
+	c.Assert(out, checker.Contains, "refs/notlatest")
+	c.Assert(out, checker.Contains, "refs/another")
+	c.Assert(strings.Count(out, "refs/"), checker.Equals, 4)
+
+	// test --ref name:tag=reference
+	dockerCmd(c, "tag", "busybox:latest", "img0")
+	dockerCmd(c, "tag", "img0:latest", "img0:notlatest")
+	dockerCmd(c, "tag", "busybox:latest", "busybox:notlatest")
+	dockerCmd(c, "tag", "img0:latest", "img0:another")
+	out, _, err = testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "--ref", "img0:notlatest=img0-notlatest-ref", "busybox:latest", "busybox:notlatest", "img0:notlatest"),
+		exec.Command("tar", "t"))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, "refs/")
+	c.Assert(out, checker.Contains, "refs/img0-notlatest-ref")
+	c.Assert(out, checker.Contains, "refs/notlatest")
+	c.Assert(out, checker.Contains, "refs/latest")
+	c.Assert(strings.Count(out, "refs/"), checker.Equals, 4)
+}
+
+func (s *DockerSuite) TestSaveLoadOCI(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
+
+	out, _, err := testutil.RunCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", "--format", "oci", "busybox:latest"),
+		exec.Command(dockerBinary, "load", "--name", "busybox"))
+	c.Assert(err, checker.IsNil, check.Commentf("failed to save OCI and load repo: %s", out))
+	c.Assert(out, checker.Contains, "Loaded image: busybox:latest")
+}
+
+func (s *DockerSuite) TestSaveUnknownFormat(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
+
+	out, _, err := dockerCmdWithError("save", "--format", "test", "-o", "test.tar", "busybox")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, `format "test" unsupported`)
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -142,3 +142,6 @@ github.com/xeipuuv/gojsonpointer e0fe6f68307607d540ed8eac07a342c33fa1b54a
 github.com/xeipuuv/gojsonreference e02fc20de94c78484cd5ffb007f8af96be030a45
 github.com/xeipuuv/gojsonschema 93e72a773fade158921402d6a24c819b48aba29d
 gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
+
+# OCI save/load
+github.com/opencontainers/image-spec v1.0.0-rc3

--- a/vendor.conf
+++ b/vendor.conf
@@ -144,4 +144,4 @@ github.com/xeipuuv/gojsonschema 93e72a773fade158921402d6a24c819b48aba29d
 gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 
 # OCI save/load
-github.com/opencontainers/image-spec v1.0.0-rc3
+github.com/opencontainers/image-spec v1.0.0-rc5

--- a/vendor/github.com/opencontainers/image-spec/LICENSE
+++ b/vendor/github.com/opencontainers/image-spec/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2016 The Linux Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -14,19 +14,12 @@
 
 package v1
 
+import "time"
+
 // ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
 type ImageConfig struct {
 	// User defines the username or UID which the process in the container should run as.
 	User string `json:"User,omitempty"`
-
-	// Memory defines the memory limit.
-	Memory int64 `json:"Memory,omitempty"`
-
-	// MemorySwap defines the total memory usage limit (memory + swap).
-	MemorySwap int64 `json:"MemorySwap,omitempty"`
-
-	// CPUShares is the CPU shares (relative weight vs. other containers).
-	CPUShares int64 `json:"CpuShares,omitempty"`
 
 	// ExposedPorts a set of ports to expose from a container running this image.
 	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
@@ -45,6 +38,9 @@ type ImageConfig struct {
 
 	// WorkingDir sets the current working directory of the entrypoint process in the container.
 	WorkingDir string `json:"WorkingDir,omitempty"`
+
+	// Labels contains arbitrary metadata for the container.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // RootFS describes a layer content addresses
@@ -58,8 +54,8 @@ type RootFS struct {
 
 // History describes the history of a layer.
 type History struct {
-	// Created is the creation time.
-	Created string `json:"created,omitempty"`
+	// Created is the combined date and time at which the layer was created, formatted as defined by RFC 3339, section 5.6.
+	Created time.Time `json:"created,omitempty"`
 
 	// CreatedBy is the command which created the layer.
 	CreatedBy string `json:"created_by,omitempty"`
@@ -75,9 +71,10 @@ type History struct {
 }
 
 // Image is the JSON structure which describes some basic information about the image.
+// This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
 type Image struct {
-	// Created defines an ISO-8601 formatted combined date and time at which the image was created.
-	Created string `json:"created,omitempty"`
+	// Created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
+	Created time.Time `json:"created,omitempty"`
 
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
 	Author string `json:"author,omitempty"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -1,0 +1,99 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
+type ImageConfig struct {
+	// User defines the username or UID which the process in the container should run as.
+	User string `json:"User,omitempty"`
+
+	// Memory defines the memory limit.
+	Memory int64 `json:"Memory,omitempty"`
+
+	// MemorySwap defines the total memory usage limit (memory + swap).
+	MemorySwap int64 `json:"MemorySwap,omitempty"`
+
+	// CPUShares is the CPU shares (relative weight vs. other containers).
+	CPUShares int64 `json:"CpuShares,omitempty"`
+
+	// ExposedPorts a set of ports to expose from a container running this image.
+	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
+
+	// Env is a list of environment variables to be used in a container.
+	Env []string `json:"Env,omitempty"`
+
+	// Entrypoint defines a list of arguments to use as the command to execute when the container starts.
+	Entrypoint []string `json:"Entrypoint,omitempty"`
+
+	// Cmd defines the default arguments to the entrypoint of the container.
+	Cmd []string `json:"Cmd,omitempty"`
+
+	// Volumes is a set of directories which should be created as data volumes in a container running this image.
+	Volumes map[string]struct{} `json:"Volumes,omitempty"`
+
+	// WorkingDir sets the current working directory of the entrypoint process in the container.
+	WorkingDir string `json:"WorkingDir,omitempty"`
+}
+
+// RootFS describes a layer content addresses
+type RootFS struct {
+	// Type is the type of the rootfs.
+	Type string `json:"type"`
+
+	// DiffIDs is an array of layer content hashes (DiffIDs), in order from bottom-most to top-most.
+	DiffIDs []string `json:"diff_ids"`
+}
+
+// History describes the history of a layer.
+type History struct {
+	// Created is the creation time.
+	Created string `json:"created,omitempty"`
+
+	// CreatedBy is the command which created the layer.
+	CreatedBy string `json:"created_by,omitempty"`
+
+	// Author is the author of the build point.
+	Author string `json:"author,omitempty"`
+
+	// Comment is a custom message set when creating the layer.
+	Comment string `json:"comment,omitempty"`
+
+	// EmptyLayer is used to mark if the history item created a filesystem diff.
+	EmptyLayer bool `json:"empty_layer,omitempty"`
+}
+
+// Image is the JSON structure which describes some basic information about the image.
+type Image struct {
+	// Created defines an ISO-8601 formatted combined date and time at which the image was created.
+	Created string `json:"created,omitempty"`
+
+	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
+	Author string `json:"author,omitempty"`
+
+	// Architecture is the CPU architecture which the binaries in this image are built to run on.
+	Architecture string `json:"architecture"`
+
+	// OS is the name of the operating system which the image is built to run on.
+	OS string `json:"os"`
+
+	// Config defines the execution parameters which should be used as a base when running a container using the image.
+	Config ImageConfig `json:"config,omitempty"`
+
+	// RootFS references the layer content addresses used by the image.
+	RootFS RootFS `json:"rootfs"`
+
+	// History describes the history of each layer.
+	History []History `json:"history,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -1,0 +1,30 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// Descriptor describes the disposition of targeted content.
+type Descriptor struct {
+	// MediaType contains the MIME type of the referenced object.
+	MediaType string `json:"mediaType"`
+
+	// Digest is the digest of the targeted content.
+	Digest string `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -14,17 +14,23 @@
 
 package v1
 
+import digest "github.com/opencontainers/go-digest"
+
 // Descriptor describes the disposition of targeted content.
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype when marshalled to JSON
 type Descriptor struct {
-	// MediaType contains the MIME type of the referenced object.
-	MediaType string `json:"mediaType"`
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
 
 	// Digest is the digest of the targeted content.
-	Digest string `json:"digest"`
+	Digest digest.Digest `json:"digest"`
 
 	// Size specifies the size in bytes of the blob.
 	Size int64 `json:"size"`
 
 	// URLs specifies a list of URLs from which this object MAY be downloaded
 	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/image_index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/image_index.go
@@ -50,13 +50,14 @@ type ManifestDescriptor struct {
 	Platform Platform `json:"platform"`
 }
 
-// ManifestList  references manifests for various platforms.
-type ManifestList struct {
+// ImageIndex references manifests for various platforms.
+// This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
+type ImageIndex struct {
 	specs.Versioned
 
 	// Manifests references platform specific manifests.
 	Manifests []ManifestDescriptor `json:"manifests"`
 
-	// Annotations contains arbitrary metadata for the manifest list.
+	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
@@ -1,0 +1,28 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "regexp"
+
+// ImageLayout is the structure in the "oci-layout" file, found in the root
+// of an OCI Image-layout directory.
+type ImageLayout struct {
+	Version string `json:"imageLayoutVersion"`
+}
+
+var (
+	// RefsRegexp matches requirement of image-layout 'refs' charset.
+	RefsRegexp = regexp.MustCompile(`^[a-zA-Z0-9-._]+$`)
+)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
@@ -14,15 +14,15 @@
 
 package v1
 
-import "regexp"
+const (
+	// ImageLayoutFile is the file name of oci image layout file
+	ImageLayoutFile = "oci-layout"
+	// ImageLayoutVersion is the version of ImageLayout
+	ImageLayoutVersion = "1.0.0"
+)
 
 // ImageLayout is the structure in the "oci-layout" file, found in the root
 // of an OCI Image-layout directory.
 type ImageLayout struct {
 	Version string `json:"imageLayoutVersion"`
 }
-
-var (
-	// RefsRegexp matches requirement of image-layout 'refs' charset.
-	RefsRegexp = regexp.MustCompile(`^[a-zA-Z0-9-._]+$`)
-)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "github.com/opencontainers/image-spec/specs-go"
+
+// Manifest defines a schema2 manifest
+type Manifest struct {
+	specs.Versioned
+
+	// Config references a configuration object for a container, by digest.
+	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
+	Config Descriptor `json:"config"`
+
+	// Layers is an indexed list of layers referenced by the manifest.
+	Layers []Descriptor `json:"layers"`
+
+	// Annotations contains arbitrary metadata for the manifest list.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -16,7 +16,7 @@ package v1
 
 import "github.com/opencontainers/image-spec/specs-go"
 
-// Manifest defines a schema2 manifest
+// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
 type Manifest struct {
 	specs.Versioned
 
@@ -27,6 +27,6 @@ type Manifest struct {
 	// Layers is an indexed list of layers referenced by the manifest.
 	Layers []Descriptor `json:"layers"`
 
-	// Annotations contains arbitrary metadata for the manifest list.
+	// Annotations contains arbitrary metadata for the manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest_list.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest_list.go
@@ -1,0 +1,62 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "github.com/opencontainers/image-spec/specs-go"
+
+// Platform describes the platform which the image in the manifest runs on.
+type Platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings, each
+	// listing a required CPU feature (for example `sse4` or `aes`).
+	Features []string `json:"features,omitempty"`
+}
+
+// ManifestDescriptor describes a platform specific manifest.
+type ManifestDescriptor struct {
+	Descriptor
+
+	// Platform describes the platform which the image in the manifest runs on.
+	Platform Platform `json:"platform"`
+}
+
+// ManifestList  references manifests for various platforms.
+type ManifestList struct {
+	specs.Versioned
+
+	// Manifests references platform specific manifests.
+	Manifests []ManifestDescriptor `json:"manifests"`
+
+	// Annotations contains arbitrary metadata for the manifest list.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -21,15 +21,24 @@ const (
 	// MediaTypeImageManifest specifies the media type for an image manifest.
 	MediaTypeImageManifest = "application/vnd.oci.image.manifest.v1+json"
 
-	// MediaTypeImageManifestList specifies the media type for an image manifest list.
-	MediaTypeImageManifestList = "application/vnd.oci.image.manifest.list.v1+json"
+	// MediaTypeImageIndex specifies the media type for an image index.
+	MediaTypeImageIndex = "application/vnd.oci.image.index.v1+json"
 
 	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
-	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar+gzip"
+	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar"
+
+	// MediaTypeImageLayerGzip is the media type used for gzipped layers
+	// referenced by the manifest.
+	MediaTypeImageLayerGzip = "application/vnd.oci.image.layer.v1.tar+gzip"
 
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
-	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar"
+
+	// MediaTypeImageLayerNonDistributableGzip is the media type for
+	// gzipped layers referenced by the manifest but with distribution
+	// restrictions.
+	MediaTypeImageLayerNonDistributableGzip = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+const (
+	// MediaTypeDescriptor specifies the media type for a content descriptor.
+	MediaTypeDescriptor = "application/vnd.oci.descriptor.v1+json"
+
+	// MediaTypeImageManifest specifies the media type for an image manifest.
+	MediaTypeImageManifest = "application/vnd.oci.image.manifest.v1+json"
+
+	// MediaTypeImageManifestList specifies the media type for an image manifest list.
+	MediaTypeImageManifestList = "application/vnd.oci.image.manifest.list.v1+json"
+
+	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
+	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
+	// the manifest but with distribution restrictions.
+	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+
+	// MediaTypeImageConfig specifies the media type for the image configuration.
+	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"
+)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specs
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 1
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 0
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+
+	// VersionDev indicates development branch. Releases will be empty string.
+	VersionDev = "-rc3"
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc3"
+	VersionDev = "-rc5"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
@@ -1,0 +1,26 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specs
+
+// Versioned provides a struct with the manifest schemaVersion and mediaType.
+// Incoming content with unknown schema version can be decoded against this
+// struct to check the version.
+type Versioned struct {
+	// SchemaVersion is the image manifest schema that this image follows
+	SchemaVersion int `json:"schemaVersion"`
+
+	// MediaType is the media type of this schema.
+	MediaType string `json:"mediaType"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
@@ -20,7 +20,4 @@ package specs
 type Versioned struct {
 	// SchemaVersion is the image manifest schema that this image follows
 	SchemaVersion int `json:"schemaVersion"`
-
-	// MediaType is the media type of this schema.
-	MediaType string `json:"mediaType"`
 }


### PR DESCRIPTION
Closes https://github.com/docker/docker/issues/25779

This PR tries to tackle #25779 by supporting the OCI image layout when saving and loading Docker images.

Right now, this PR contains just the code for `docker save --format oci` because I found various aspects that still need to be discussed (I left many comments around in the code, please review them).

I'm also opening this in RFC because I didn't want to go that far and finding out that what I've been doing was completely wrong, so I'm here to gather feedback and comments to go forward (with `docker load --format oci`)

**Changes**:
- Implement everything from the linked issue wrt `docker save` (plus I guessed on something like `docker save --format oci name@digest`
- ~~This PR vendors [containers/image](https://github.com/containers/image) and~~ [the image spec](https://github.com/opencontainers/image-spec) to be able to deal with the OCI image layout and w/o the need to re-implement everything in the Docker code base.
- added a bunch of integration tests to make sure we're on the same page wrt how this should work (at least with `docker save` now...)

**TODO:**
- discuss around saving image IDs and images by digest (name@digest)
- discuss API
- finish `docker load --format oci`
- integration tests for `docker load` and combined `docker save --format oci | docker load -`
- documentation

Alright, here's the net result as a simple example of `docker save`, please do review the integration tests to have a picture of how this looks like in other scenarios:

``` shell
$ docker save --format oci busybox:latest | tar t
blobs/
blobs/sha256/
blobs/sha256/2a2b6168c040d25148a4972cb20108b737adc51685d4dc68a8e01d55416d27a1
blobs/sha256/2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749
blobs/sha256/8ddc19f16526912237dd8af81971d5e4dd0587907234be2b83e249518d5b673f
oci-layout
refs/
refs/latest

$ mkdir busybox-oci
$ docker save --format oci busybox:latest |  tar -C busybox-oci -xf -

$ go get github.com/opencontainers/image-spec/cmd/oci-image-tool
$ oci-image-tool validate --ref latest busybox-oci
reference "latest": OK
busybox-oci: OK
```

/cc @stevvooe @aaronlehmann @vdemeester @vbatts @rhatdan @cpuguy83 @duglin @icecrime @estesp @tonistiigi 
