### PR TITLE
Propagate BUILD_APT_MIRROR and consume in buil-deb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $$
 # to allow things like `make KEEPBUNDLE=1 binary` easily
 # `project/PACKAGERS.md` have some limited documentation of some of these
 DOCKER_ENVS := \
+	-e BUILD_APT_MIRROR \
 	-e BUILDFLAGS \
 	-e KEEPBUNDLE \
 	-e DOCKER_BUILD_ARGS \
@@ -60,6 +61,7 @@ DOCKER_PORT_FORWARD := $(if $(DOCKER_PORT),-p "$(DOCKER_PORT)",)
 
 DOCKER_FLAGS := docker run --rm -i --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT) $(DOCKER_PORT_FORWARD)
 BUILD_APT_MIRROR := $(if $(DOCKER_BUILD_APT_MIRROR),--build-arg APT_MIRROR=$(DOCKER_BUILD_APT_MIRROR))
+export BUILD_APT_MIRROR
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -52,7 +52,14 @@ set -e
 
 		image="dockercore/builder-deb:$version"
 		if ! docker inspect "$image" &> /dev/null; then
-			( set -x && docker build ${DOCKER_BUILD_ARGS} -t "$image" "$dir" )
+			(
+				# Add the APT_MIRROR args only if the consuming Dockerfile uses it
+				# Otherwise this will cause the build to fail
+				if [ "$(grep 'ARG APT_MIRROR=' $dir/Dockerfile)" ] && [ "$BUILD_APT_MIRROR" ]; then
+					DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS $BUILD_APT_MIRROR"
+				fi
+				set -x && docker build ${DOCKER_BUILD_ARGS} -t "$image" "$dir"
+			)
 		fi
 
 		mkdir -p "$DEST/$version"


### PR DESCRIPTION
Passses down BUILD_APT_MIRROR to the docker env.
Ensures BUILD_APT_MIRROR is used when building debs, but only when the
consuming `Dockerfile` actually uses it, else it will cause the
build to fail (e.g. on Ubuntu builds we aren't using APT_MIRROR).
