### PR TITLE
Only output security options if there are any

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -135,9 +135,11 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 		fmt.Fprintf(dockerCli.Out(), "Default Runtime: %s\n", info.DefaultRuntime)
 	}
 
-	fmt.Fprintf(dockerCli.Out(), "Security Options:")
-	ioutils.FprintfIfNotEmpty(dockerCli.Out(), " %s", strings.Join(info.SecurityOptions, " "))
-	fmt.Fprintf(dockerCli.Out(), "\n")
+	if info.OSType == "linux" {
+		fmt.Fprintf(dockerCli.Out(), "Security Options:")
+		ioutils.FprintfIfNotEmpty(dockerCli.Out(), " %s", strings.Join(info.SecurityOptions, " "))
+		fmt.Fprintf(dockerCli.Out(), "\n")
+	}
 
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "Operating System: %s\n", info.OperatingSystem)

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -33,8 +33,11 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Storage Driver:",
 		"Volume:",
 		"Network:",
-		"Security Options:",
 		"Live Restore Enabled:",
+	}
+
+	if daemonPlatform == "linux" {
+		stringsToCheck = append(stringsToCheck, "Security Options:")
 	}
 
 	if DaemonIsLinux.Condition() {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

As there are no security options on Windows, you always get an unnecessary empty line.

Before

```
PS E:\Docker\ci\W2W\runCI> docker info
<snip>
Plugins:
 Volume: local
 Network: nat null overlay
Swarm: inactive
Security Options:
Kernel Version: 10.0 14393 (14393.0.amd64fre.rs1_release(pbozza).160831-1404)
Operating System: Windows Server 2016 Datacenter
<snip>
```

After

```
<snip>
Plugins:
 Volume: local
 Network: nat null overlay
Swarm: inactive
Kernel Version: 10.0 14393 (14393.0.amd64fre.rs1_release(pbozza).160831-1404)
Operating System: Windows Server 2016 Datacenter
OSType: windows
Architecture: x86_64
CPUs: 8
Total Memory: 1.999 GiB
<snip>
```
