### PR TITLE
Converted API unit tests from stdlib to gocheck

### DIFF
--- a/api/client/container/exec_test.go
+++ b/api/client/container/exec_test.go
@@ -4,7 +4,15 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/go-check/check"
 )
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type DockerSuite struct{}
+
+var _ = check.Suite(&DockerSuite{})
 
 type arguments struct {
 	options   execOptions
@@ -12,7 +20,7 @@ type arguments struct {
 	execCmd   []string
 }
 
-func TestParseExec(t *testing.T) {
+func (s *DockerSuite) TestParseExec(c *check.C) {
 	valids := map[*arguments]*types.ExecConfig{
 		&arguments{
 			execCmd: []string{"command"},
@@ -74,11 +82,9 @@ func TestParseExec(t *testing.T) {
 
 	for valid, expectedExecConfig := range valids {
 		execConfig, err := parseExec(&valid.options, valid.container, valid.execCmd)
-		if err != nil {
-			t.Fatal(err)
-		}
+		c.Assert(err, check.IsNil)
 		if !compareExecConfig(expectedExecConfig, execConfig) {
-			t.Fatalf("Expected [%v] for %v, got [%v]", expectedExecConfig, valid, execConfig)
+			c.Fatalf("Expected [%v] for %v, got [%v]", expectedExecConfig, valid, execConfig)
 		}
 	}
 }

--- a/api/client/container/ps_test.go
+++ b/api/client/container/ps_test.go
@@ -1,8 +1,8 @@
 package container
 
-import "testing"
+import "github.com/go-check/check"
 
-func TestBuildContainerListOptions(t *testing.T) {
+func (s *DockerSuite) TestBuildContainerListOptions(c *check.C) {
 
 	contexts := []struct {
 		psOpts          *psOptions
@@ -40,34 +40,21 @@ func TestBuildContainerListOptions(t *testing.T) {
 		},
 	}
 
-	for _, c := range contexts {
-		options, err := buildContainerListOptions(c.psOpts)
-		if err != nil {
-			t.Fatal(err)
-		}
+	for _, ctxs := range contexts {
+		options, err := buildContainerListOptions(ctxs.psOpts)
+		c.Assert(err, check.IsNil)
 
-		if c.expectedAll != options.All {
-			t.Fatalf("Expected All to be %t but got %t", c.expectedAll, options.All)
-		}
-
-		if c.expectedSize != options.Size {
-			t.Fatalf("Expected Size to be %t but got %t", c.expectedSize, options.Size)
-		}
-
-		if c.expectedLimit != options.Limit {
-			t.Fatalf("Expected Limit to be %d but got %d", c.expectedLimit, options.Limit)
-		}
+		c.Assert(options.All, check.Equals, ctxs.expectedAll)
+		c.Assert(options.Size, check.Equals, ctxs.expectedSize)
+		c.Assert(options.Limit, check.Equals, ctxs.expectedLimit)
 
 		f := options.Filter
+		c.Assert(f.Len(), check.Equals, len(ctxs.expectedFilters))
 
-		if f.Len() != len(c.expectedFilters) {
-			t.Fatalf("Expected %d filters but got %d", len(c.expectedFilters), f.Len())
-		}
-
-		for k, v := range c.expectedFilters {
+		for k, v := range ctxs.expectedFilters {
 			f := options.Filter
 			if !f.ExactMatch(k, v) {
-				t.Fatalf("Expected filter with key %s to be %s but got %s", k, v, f.Get(k))
+				c.Fatalf("Expected filter with key %s to be %s but got %s", k, v, f.Get(k))
 			}
 		}
 	}

--- a/api/client/container/stats_unit_test.go
+++ b/api/client/container/stats_unit_test.go
@@ -2,13 +2,13 @@ package container
 
 import (
 	"bytes"
-	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/go-check/check"
 )
 
-func TestDisplay(t *testing.T) {
-	c := &containerStats{
+func (s *DockerSuite) TestDisplay(c *check.C) {
+	cts := &containerStats{
 		Name:             "app",
 		CPUPercentage:    30.0,
 		Memory:           100 * 1024 * 1024.0,
@@ -21,25 +21,18 @@ func TestDisplay(t *testing.T) {
 		PidsCurrent:      1,
 	}
 	var b bytes.Buffer
-	if err := c.Display(&b); err != nil {
-		t.Fatalf("c.Display() gave error: %s", err)
-	}
+	c.Assert(cts.Display(&b), check.IsNil)
+
 	got := b.String()
 	want := "app\t30.00%\t100 MiB / 2 GiB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\t1\n"
-	if got != want {
-		t.Fatalf("c.Display() = %q, want %q", got, want)
-	}
+	c.Assert(got, check.Equals, want)
 }
 
-func TestCalculBlockIO(t *testing.T) {
+func (s *DockerSuite) TestCalculBlockIO(c *check.C) {
 	blkio := types.BlkioStats{
 		IoServiceBytesRecursive: []types.BlkioStatEntry{{8, 0, "read", 1234}, {8, 1, "read", 4567}, {8, 0, "write", 123}, {8, 1, "write", 456}},
 	}
 	blkRead, blkWrite := calculateBlockIO(blkio)
-	if blkRead != 5801 {
-		t.Fatalf("blkRead = %d, want 5801", blkRead)
-	}
-	if blkWrite != 579 {
-		t.Fatalf("blkWrite = %d, want 579", blkWrite)
-	}
+	c.Assert(blkRead, check.Equals, uint64(5801))
+	c.Assert(blkWrite, check.Equals, uint64(579))
 }

--- a/api/client/formatter/custom_test.go
+++ b/api/client/formatter/custom_test.go
@@ -1,12 +1,12 @@
 package formatter
 
 import (
-	"reflect"
 	"strings"
-	"testing"
+
+	"github.com/go-check/check"
 )
 
-func compareMultipleValues(t *testing.T, value, expected string) {
+func compareMultipleValues(c *check.C, value, expected string) {
 	// comma-separated values means probably a map input, which won't
 	// be guaranteed to have the same order as our expected value
 	// We'll create maps and use reflect.DeepEquals to check instead:
@@ -22,7 +22,5 @@ func compareMultipleValues(t *testing.T, value, expected string) {
 		keyval := strings.Split(expected, "=")
 		expMap[keyval[0]] = keyval[1]
 	}
-	if !reflect.DeepEqual(expMap, entriesMap) {
-		t.Fatalf("Expected entries: %v, got: %v", expected, value)
-	}
+	c.Assert(expMap, check.DeepEquals, entriesMap)
 }

--- a/api/client/formatter/image_test.go
+++ b/api/client/formatter/image_test.go
@@ -4,14 +4,14 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/go-check/check"
 )
 
-func TestImageContext(t *testing.T) {
+func (s *DockerSuite) TestImageContext(c *check.C) {
 	imageID := stringid.GenerateRandomID()
 	unix := time.Now().Unix()
 
@@ -57,23 +57,20 @@ func TestImageContext(t *testing.T) {
 		}, "sha256:d149ab53f8718e987c3a3024bb8aa0e2caadf6c0328f1d9d850b2a2a67f2819a", digestHeader, ctx.Digest},
 	}
 
-	for _, c := range cases {
-		ctx = c.imageCtx
-		v := c.call()
+	for _, ca := range cases {
+		ctx = ca.imageCtx
+		v := ca.call()
 		if strings.Contains(v, ",") {
-			compareMultipleValues(t, v, c.expValue)
-		} else if v != c.expValue {
-			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+			compareMultipleValues(c, v, ca.expValue)
+		} else if v != ca.expValue {
+			c.Fatalf("Expected %s, was %s\n", ca.expValue, v)
 		}
 
-		h := ctx.fullHeader()
-		if h != c.expHeader {
-			t.Fatalf("Expected %s, was %s\n", c.expHeader, h)
-		}
+		c.Assert(ctx.fullHeader(), check.Equals, ca.expHeader)
 	}
 }
 
-func TestImageContextWrite(t *testing.T) {
+func (s *DockerSuite) TestImageContextWrite(c *check.C) {
 	unixTime := time.Now().AddDate(0, 0, -1).Unix()
 	expectedTime := time.Unix(unixTime, 0).String()
 
@@ -275,16 +272,13 @@ image_id: imageID3
 		context.context.Output = out
 		context.context.Images = images
 		context.context.Write()
-		actual := out.String()
-		if actual != context.expected {
-			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
-		}
+		c.Assert(out.String(), check.Equals, context.expected)
 		// Clean buffer
 		out.Reset()
 	}
 }
 
-func TestImageContextWriteWithNoImage(t *testing.T) {
+func (s *DockerSuite) TestImageContextWriteWithNoImage(c *check.C) {
 	out := bytes.NewBufferString("")
 	images := []types.Image{}
 
@@ -335,10 +329,7 @@ func TestImageContextWriteWithNoImage(t *testing.T) {
 	for _, context := range contexts {
 		context.context.Images = images
 		context.context.Write()
-		actual := out.String()
-		if actual != context.expected {
-			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
-		}
+		c.Assert(out.String(), check.Equals, context.expected)
 		// Clean buffer
 		out.Reset()
 	}

--- a/api/client/formatter/network_test.go
+++ b/api/client/formatter/network_test.go
@@ -3,13 +3,14 @@ package formatter
 import (
 	"bytes"
 	"strings"
-	"testing"
+
+	"github.com/go-check/check"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
 )
 
-func TestNetworkContext(t *testing.T) {
+func (s *DockerSuite) TestNetworkContext(c *check.C) {
 	networkID := stringid.GenerateRandomID()
 
 	var ctx networkContext
@@ -53,23 +54,20 @@ func TestNetworkContext(t *testing.T) {
 		}, "label1=value1,label2=value2", labelsHeader, ctx.Labels},
 	}
 
-	for _, c := range cases {
-		ctx = c.networkCtx
-		v := c.call()
+	for _, ca := range cases {
+		ctx = ca.networkCtx
+		v := ca.call()
 		if strings.Contains(v, ",") {
-			compareMultipleValues(t, v, c.expValue)
-		} else if v != c.expValue {
-			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+			compareMultipleValues(c, v, ca.expValue)
+		} else if v != ca.expValue {
+			c.Fatalf("Expected %s, was %s\n", ca.expValue, v)
 		}
 
-		h := ctx.fullHeader()
-		if h != c.expHeader {
-			t.Fatalf("Expected %s, was %s\n", c.expHeader, h)
-		}
+		c.Assert(ctx.fullHeader(), check.Equals, ca.expHeader)
 	}
 }
 
-func TestNetworkContextWrite(t *testing.T) {
+func (s *DockerSuite) TestNetworkContextWrite(c *check.C) {
 	contexts := []struct {
 		context  NetworkContext
 		expected string
@@ -191,10 +189,7 @@ foobar_bar
 		context.context.Output = out
 		context.context.Networks = networks
 		context.context.Write()
-		actual := out.String()
-		if actual != context.expected {
-			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
-		}
+		c.Assert(out.String(), check.Equals, context.expected)
 		// Clean buffer
 		out.Reset()
 	}

--- a/api/client/formatter/volume_test.go
+++ b/api/client/formatter/volume_test.go
@@ -3,13 +3,13 @@ package formatter
 import (
 	"bytes"
 	"strings"
-	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/go-check/check"
 )
 
-func TestVolumeContext(t *testing.T) {
+func (s *DockerSuite) TestVolumeContext(c *check.C) {
 	volumeName := stringid.GenerateRandomID()
 
 	var ctx volumeContext
@@ -39,23 +39,20 @@ func TestVolumeContext(t *testing.T) {
 		}, "label1=value1,label2=value2", labelsHeader, ctx.Labels},
 	}
 
-	for _, c := range cases {
-		ctx = c.volumeCtx
-		v := c.call()
+	for _, ca := range cases {
+		ctx = ca.volumeCtx
+		v := ca.call()
 		if strings.Contains(v, ",") {
-			compareMultipleValues(t, v, c.expValue)
-		} else if v != c.expValue {
-			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
+			compareMultipleValues(c, v, ca.expValue)
+		} else if v != ca.expValue {
+			c.Fatalf("Expected %s, was %s\n", ca.expValue, v)
 		}
 
-		h := ctx.fullHeader()
-		if h != c.expHeader {
-			t.Fatalf("Expected %s, was %s\n", c.expHeader, h)
-		}
+		c.Assert(ctx.fullHeader(), check.Equals, ca.expHeader)
 	}
 }
 
-func TestVolumeContextWrite(t *testing.T) {
+func (s *DockerSuite) TestVolumeContextWrite(c *check.C) {
 	contexts := []struct {
 		context  VolumeContext
 		expected string
@@ -173,10 +170,7 @@ foobar_bar
 		context.context.Output = out
 		context.context.Volumes = volumes
 		context.context.Write()
-		actual := out.String()
-		if actual != context.expected {
-			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
-		}
+		c.Assert(out.String(), check.Equals, context.expected)
 		// Clean buffer
 		out.Reset()
 	}

--- a/api/client/service/inspect_test.go
+++ b/api/client/service/inspect_test.go
@@ -2,14 +2,21 @@ package service
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/go-check/check"
 )
 
-func TestPrettyPrintWithNoUpdateConfig(t *testing.T) {
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type DockerSuite struct{}
+
+var _ = check.Suite(&DockerSuite{})
+
+func (s *DockerSuite) TestPrettyPrintWithNoUpdateConfig(c *check.C) {
 	b := new(bytes.Buffer)
 
 	endpointSpec := &swarm.EndpointSpec{
@@ -24,7 +31,7 @@ func TestPrettyPrintWithNoUpdateConfig(t *testing.T) {
 
 	two := uint64(2)
 
-	s := swarm.Service{
+	ss := swarm.Service{
 		ID: "de179gar9d0o7ltdybungplod",
 		Meta: swarm.Meta{
 			Version:   swarm.Version{Index: 315},
@@ -77,8 +84,6 @@ func TestPrettyPrintWithNoUpdateConfig(t *testing.T) {
 		},
 	}
 
-	printService(b, s)
-	if strings.Contains(b.String(), "UpdateStatus") {
-		t.Fatal("Pretty print failed before parsing UpdateStatus")
-	}
+	printService(b, ss)
+	c.Assert(b.String(), check.Not(check.Matches), "(?s).*UpdateStatus.*") // Pretty print failed before parsing UpdateStatus
 }

--- a/api/client/service/opts_test.go
+++ b/api/client/service/opts_test.go
@@ -1,63 +1,62 @@
 package service
 
 import (
-	"testing"
 	"time"
 
 	mounttypes "github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/go-check/check"
 )
 
-func TestMemBytesString(t *testing.T) {
+func (s *DockerSuite) TestMemBytesString(c *check.C) {
 	var mem memBytes = 1048576
-	assert.Equal(t, mem.String(), "1 MiB")
+	c.Assert(mem.String(), check.Equals, "1 MiB")
 }
 
-func TestMemBytesSetAndValue(t *testing.T) {
+func (s *DockerSuite) TestMemBytesSetAndValue(c *check.C) {
 	var mem memBytes
-	assert.NilError(t, mem.Set("5kb"))
-	assert.Equal(t, mem.Value(), int64(5120))
+	c.Assert(mem.Set("5kb"), check.IsNil)
+	c.Assert(mem.Value(), check.Equals, int64(5120))
 }
 
-func TestNanoCPUsString(t *testing.T) {
+func (s *DockerSuite) TestNanoCPUsString(c *check.C) {
 	var cpus nanoCPUs = 6100000000
-	assert.Equal(t, cpus.String(), "6.100")
+	c.Assert(cpus.String(), check.Equals, "6.100")
 }
 
-func TestNanoCPUsSetAndValue(t *testing.T) {
+func (s *DockerSuite) TestNanoCPUsSetAndValue(c *check.C) {
 	var cpus nanoCPUs
-	assert.NilError(t, cpus.Set("0.35"))
-	assert.Equal(t, cpus.Value(), int64(350000000))
+	c.Assert(cpus.Set("0.35"), check.IsNil)
+	c.Assert(cpus.Value(), check.Equals, int64(350000000))
 }
 
-func TestDurationOptString(t *testing.T) {
+func (s *DockerSuite) TestDurationOptString(c *check.C) {
 	dur := time.Duration(300 * 10e8)
 	duration := DurationOpt{value: &dur}
-	assert.Equal(t, duration.String(), "5m0s")
+	c.Assert(duration.String(), check.Equals, "5m0s")
 }
 
-func TestDurationOptSetAndValue(t *testing.T) {
+func (s *DockerSuite) TestDurationOptSetAndValue(c *check.C) {
 	var duration DurationOpt
-	assert.NilError(t, duration.Set("300s"))
-	assert.Equal(t, *duration.Value(), time.Duration(300*10e8))
+	c.Assert(duration.Set("300s"), check.IsNil)
+	c.Assert(*duration.Value(), check.Equals, time.Duration(300*10e8))
 }
 
-func TestUint64OptString(t *testing.T) {
+func (s *DockerSuite) TestUint64OptString(c *check.C) {
 	value := uint64(2345678)
 	opt := Uint64Opt{value: &value}
-	assert.Equal(t, opt.String(), "2345678")
+	c.Assert(opt.String(), check.Equals, "2345678")
 
 	opt = Uint64Opt{}
-	assert.Equal(t, opt.String(), "none")
+	c.Assert(opt.String(), check.Equals, "none")
 }
 
-func TestUint64OptSetAndValue(t *testing.T) {
+func (s *DockerSuite) TestUint64OptSetAndValue(c *check.C) {
 	var opt Uint64Opt
-	assert.NilError(t, opt.Set("14445"))
-	assert.Equal(t, *opt.Value(), uint64(14445))
+	c.Assert(opt.Set("14445"), check.IsNil)
+	c.Assert(*opt.Value(), check.Equals, uint64(14445))
 }
 
-func TestMountOptString(t *testing.T) {
+func (s *DockerSuite) TestMountOptString(c *check.C) {
 	mount := MountOpt{
 		values: []mounttypes.Mount{
 			{
@@ -73,10 +72,10 @@ func TestMountOptString(t *testing.T) {
 		},
 	}
 	expected := "bind /home/path /target, volume foo /target/foo"
-	assert.Equal(t, mount.String(), expected)
+	c.Assert(mount.String(), check.Equals, expected)
 }
 
-func TestMountOptSetNoError(t *testing.T) {
+func (s *DockerSuite) TestMountOptSetNoError(c *check.C) {
 	for _, testcase := range []string{
 		// tests several aliases that should have same result.
 		"type=bind,target=/target,source=/source",
@@ -86,11 +85,11 @@ func TestMountOptSetNoError(t *testing.T) {
 	} {
 		var mount MountOpt
 
-		assert.NilError(t, mount.Set(testcase))
+		c.Assert(mount.Set(testcase), check.IsNil)
 
 		mounts := mount.Value()
-		assert.Equal(t, len(mounts), 1)
-		assert.Equal(t, mounts[0], mounttypes.Mount{
+		c.Assert(len(mounts), check.Equals, 1)
+		c.Assert(mounts[0], check.Equals, mounttypes.Mount{
 			Type:   mounttypes.TypeBind,
 			Source: "/source",
 			Target: "/target",
@@ -100,77 +99,77 @@ func TestMountOptSetNoError(t *testing.T) {
 
 // TestMountOptDefaultType ensures that a mount without the type defaults to a
 // volume mount.
-func TestMountOptDefaultType(t *testing.T) {
+func (s *DockerSuite) TestMountOptDefaultType(c *check.C) {
 	var mount MountOpt
-	assert.NilError(t, mount.Set("target=/target,source=/foo"))
-	assert.Equal(t, mount.values[0].Type, mounttypes.TypeVolume)
+	c.Assert(mount.Set("target=/target,source=/foo"), check.IsNil)
+	c.Assert(mount.values[0].Type, check.Equals, mounttypes.TypeVolume)
 }
 
-func TestMountOptSetErrorNoTarget(t *testing.T) {
+func (s *DockerSuite) TestMountOptSetErrorNoTarget(c *check.C) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=volume,source=/foo"), "target is required")
+	c.Assert(mount.Set("type=volume,source=/foo"), check.ErrorMatches, ".*target is required.*")
 }
 
-func TestMountOptSetErrorInvalidKey(t *testing.T) {
+func (s *DockerSuite) TestMountOptSetErrorInvalidKey(c *check.C) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=volume,bogus=foo"), "unexpected key 'bogus'")
+	c.Assert(mount.Set("type=volume,bogus=foo"), check.ErrorMatches, ".*unexpected key 'bogus'.*")
 }
 
-func TestMountOptSetErrorInvalidField(t *testing.T) {
+func (s *DockerSuite) TestMountOptSetErrorInvalidField(c *check.C) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=volume,bogus"), "invalid field 'bogus'")
+	c.Assert(mount.Set("type=volume,bogus"), check.ErrorMatches, ".*invalid field 'bogus'.*")
 }
 
-func TestMountOptSetErrorInvalidReadOnly(t *testing.T) {
+func (s *DockerSuite) TestMountOptSetErrorInvalidReadOnly(c *check.C) {
 	var mount MountOpt
-	assert.Error(t, mount.Set("type=volume,readonly=no"), "invalid value for readonly: no")
-	assert.Error(t, mount.Set("type=volume,readonly=invalid"), "invalid value for readonly: invalid")
+	c.Assert(mount.Set("type=volume,readonly=no"), check.ErrorMatches, ".*invalid value for readonly: no.*")
+	c.Assert(mount.Set("type=volume,readonly=invalid"), check.ErrorMatches, ".*invalid value for readonly: invalid.*")
 }
 
-func TestMountOptDefaultEnableReadOnly(t *testing.T) {
+func (s *DockerSuite) TestMountOptDefaultEnableReadOnly(c *check.C) {
 	var m MountOpt
-	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo"))
-	assert.Equal(t, m.values[0].ReadOnly, false)
+	c.Assert(m.Set("type=bind,target=/foo,source=/foo"), check.IsNil)
+	c.Assert(m.values[0].ReadOnly, check.Equals, false)
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly"))
-	assert.Equal(t, m.values[0].ReadOnly, true)
+	c.Assert(m.Set("type=bind,target=/foo,source=/foo,readonly"), check.IsNil)
+	c.Assert(m.values[0].ReadOnly, check.Equals, true)
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=1"))
-	assert.Equal(t, m.values[0].ReadOnly, true)
+	c.Assert(m.Set("type=bind,target=/foo,source=/foo,readonly=1"), check.IsNil)
+	c.Assert(m.values[0].ReadOnly, check.Equals, true)
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=0"))
-	assert.Equal(t, m.values[0].ReadOnly, false)
+	c.Assert(m.Set("type=bind,target=/foo,source=/foo,readonly=0"), check.IsNil)
+	c.Assert(m.values[0].ReadOnly, check.Equals, false)
 }
 
-func TestMountOptVolumeNoCopy(t *testing.T) {
+func (s *DockerSuite) TestMountOptVolumeNoCopy(c *check.C) {
 	var m MountOpt
-	assert.Error(t, m.Set("type=volume,target=/foo,volume-nocopy"), "source is required")
+	c.Assert(m.Set("type=volume,target=/foo,volume-nocopy"), check.ErrorMatches, ".*source is required.*")
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo"))
-	assert.Equal(t, m.values[0].VolumeOptions == nil, true)
+	c.Assert(m.Set("type=volume,target=/foo,source=foo"), check.IsNil)
+	c.Assert(m.values[0].VolumeOptions == nil, check.Equals, true)
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo,volume-nocopy=true"))
-	assert.Equal(t, m.values[0].VolumeOptions != nil, true)
-	assert.Equal(t, m.values[0].VolumeOptions.NoCopy, true)
+	c.Assert(m.Set("type=volume,target=/foo,source=foo,volume-nocopy=true"), check.IsNil)
+	c.Assert(m.values[0].VolumeOptions != nil, check.Equals, true)
+	c.Assert(m.values[0].VolumeOptions.NoCopy, check.Equals, true)
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo,volume-nocopy"))
-	assert.Equal(t, m.values[0].VolumeOptions != nil, true)
-	assert.Equal(t, m.values[0].VolumeOptions.NoCopy, true)
+	c.Assert(m.Set("type=volume,target=/foo,source=foo,volume-nocopy"), check.IsNil)
+	c.Assert(m.values[0].VolumeOptions != nil, check.Equals, true)
+	c.Assert(m.values[0].VolumeOptions.NoCopy, check.Equals, true)
 
 	m = MountOpt{}
-	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo,volume-nocopy=1"))
-	assert.Equal(t, m.values[0].VolumeOptions != nil, true)
-	assert.Equal(t, m.values[0].VolumeOptions.NoCopy, true)
+	c.Assert(m.Set("type=volume,target=/foo,source=foo,volume-nocopy=1"), check.IsNil)
+	c.Assert(m.values[0].VolumeOptions != nil, check.Equals, true)
+	c.Assert(m.values[0].VolumeOptions.NoCopy, check.Equals, true)
 }
 
-func TestMountOptTypeConflict(t *testing.T) {
+func (s *DockerSuite) TestMountOptTypeConflict(c *check.C) {
 	var m MountOpt
-	assert.Error(t, m.Set("type=bind,target=/foo,source=/foo,volume-nocopy=true"), "cannot mix")
-	assert.Error(t, m.Set("type=volume,target=/foo,source=/foo,bind-propagation=rprivate"), "cannot mix")
+	c.Assert(m.Set("type=bind,target=/foo,source=/foo,volume-nocopy=true"), check.ErrorMatches, ".*cannot mix.*")
+	c.Assert(m.Set("type=volume,target=/foo,source=/foo,bind-propagation=rprivate"), check.ErrorMatches, ".*cannot mix.*")
 }

--- a/api/client/service/update_test.go
+++ b/api/client/service/update_test.go
@@ -2,14 +2,13 @@ package service
 
 import (
 	"sort"
-	"testing"
 
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/go-check/check"
 )
 
-func TestUpdateServiceArgs(t *testing.T) {
+func (s *DockerSuite) TestUpdateServiceArgs(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("args", "the \"new args\"")
 
@@ -18,10 +17,10 @@ func TestUpdateServiceArgs(t *testing.T) {
 	cspec.Args = []string{"old", "args"}
 
 	updateService(flags, spec)
-	assert.EqualStringSlice(t, cspec.Args, []string{"the", "new args"})
+	c.Assert(cspec.Args, check.DeepEquals, []string{"the", "new args"})
 }
 
-func TestUpdateLabels(t *testing.T) {
+func (s *DockerSuite) TestUpdateLabels(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("label-add", "toadd=newlabel")
 	flags.Set("label-rm", "toremove")
@@ -32,21 +31,21 @@ func TestUpdateLabels(t *testing.T) {
 	}
 
 	updateLabels(flags, &labels)
-	assert.Equal(t, len(labels), 2)
-	assert.Equal(t, labels["tokeep"], "value")
-	assert.Equal(t, labels["toadd"], "newlabel")
+	c.Assert(len(labels), check.Equals, 2)
+	c.Assert(labels["tokeep"], check.Equals, "value")
+	c.Assert(labels["toadd"], check.Equals, "newlabel")
 }
 
-func TestUpdateLabelsRemoveALabelThatDoesNotExist(t *testing.T) {
+func (s *DockerSuite) TestUpdateLabelsRemoveALabelThatDoesNotExist(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("label-rm", "dne")
 
 	labels := map[string]string{"foo": "theoldlabel"}
 	updateLabels(flags, &labels)
-	assert.Equal(t, len(labels), 1)
+	c.Assert(len(labels), check.Equals, 1)
 }
 
-func TestUpdatePlacement(t *testing.T) {
+func (s *DockerSuite) TestUpdatePlacement(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("constraint-add", "node=toadd")
 	flags.Set("constraint-rm", "node!=toremove")
@@ -56,12 +55,12 @@ func TestUpdatePlacement(t *testing.T) {
 	}
 
 	updatePlacement(flags, placement)
-	assert.Equal(t, len(placement.Constraints), 2)
-	assert.Equal(t, placement.Constraints[0], "container=tokeep")
-	assert.Equal(t, placement.Constraints[1], "node=toadd")
+	c.Assert(len(placement.Constraints), check.Equals, 2)
+	c.Assert(placement.Constraints[0], check.Equals, "container=tokeep")
+	c.Assert(placement.Constraints[1], check.Equals, "node=toadd")
 }
 
-func TestUpdateEnvironment(t *testing.T) {
+func (s *DockerSuite) TestUpdateEnvironment(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("env-add", "toadd=newenv")
 	flags.Set("env-rm", "toremove")
@@ -69,14 +68,14 @@ func TestUpdateEnvironment(t *testing.T) {
 	envs := []string{"toremove=theenvtoremove", "tokeep=value"}
 
 	updateEnvironment(flags, &envs)
-	assert.Equal(t, len(envs), 2)
+	c.Assert(len(envs), check.Equals, 2)
 	// Order has been removed in updateEnvironment (map)
 	sort.Strings(envs)
-	assert.Equal(t, envs[0], "toadd=newenv")
-	assert.Equal(t, envs[1], "tokeep=value")
+	c.Assert(envs[0], check.Equals, "toadd=newenv")
+	c.Assert(envs[1], check.Equals, "tokeep=value")
 }
 
-func TestUpdateEnvironmentWithDuplicateValues(t *testing.T) {
+func (s *DockerSuite) TestUpdateEnvironmentWithDuplicateValues(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("env-add", "foo=newenv")
 	flags.Set("env-add", "foo=dupe")
@@ -85,10 +84,10 @@ func TestUpdateEnvironmentWithDuplicateValues(t *testing.T) {
 	envs := []string{"foo=value"}
 
 	updateEnvironment(flags, &envs)
-	assert.Equal(t, len(envs), 0)
+	c.Assert(len(envs), check.Equals, 0)
 }
 
-func TestUpdateEnvironmentWithDuplicateKeys(t *testing.T) {
+func (s *DockerSuite) TestUpdateEnvironmentWithDuplicateKeys(c *check.C) {
 	// Test case for #25404
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("env-add", "A=b")
@@ -96,11 +95,11 @@ func TestUpdateEnvironmentWithDuplicateKeys(t *testing.T) {
 	envs := []string{"A=c"}
 
 	updateEnvironment(flags, &envs)
-	assert.Equal(t, len(envs), 1)
-	assert.Equal(t, envs[0], "A=b")
+	c.Assert(len(envs), check.Equals, 1)
+	c.Assert(envs[0], check.Equals, "A=b")
 }
 
-func TestUpdateGroups(t *testing.T) {
+func (s *DockerSuite) TestUpdateGroups(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("group-add", "wheel")
 	flags.Set("group-add", "docker")
@@ -111,13 +110,13 @@ func TestUpdateGroups(t *testing.T) {
 	groups := []string{"bar", "root"}
 
 	updateGroups(flags, &groups)
-	assert.Equal(t, len(groups), 3)
-	assert.Equal(t, groups[0], "bar")
-	assert.Equal(t, groups[1], "foo")
-	assert.Equal(t, groups[2], "wheel")
+	c.Assert(len(groups), check.Equals, 3)
+	c.Assert(groups[0], check.Equals, "bar")
+	c.Assert(groups[1], check.Equals, "foo")
+	c.Assert(groups[2], check.Equals, "wheel")
 }
 
-func TestUpdateMounts(t *testing.T) {
+func (s *DockerSuite) TestUpdateMounts(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("mount-add", "type=volume,target=/toadd")
 	flags.Set("mount-rm", "/toremove")
@@ -128,12 +127,12 @@ func TestUpdateMounts(t *testing.T) {
 	}
 
 	updateMounts(flags, &mounts)
-	assert.Equal(t, len(mounts), 2)
-	assert.Equal(t, mounts[0].Target, "/tokeep")
-	assert.Equal(t, mounts[1].Target, "/toadd")
+	c.Assert(len(mounts), check.Equals, 2)
+	c.Assert(mounts[0].Target, check.Equals, "/tokeep")
+	c.Assert(mounts[1].Target, check.Equals, "/toadd")
 }
 
-func TestUpdatePorts(t *testing.T) {
+func (s *DockerSuite) TestUpdatePorts(c *check.C) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("publish-add", "1000:1000")
 	flags.Set("publish-rm", "333/udp")
@@ -144,16 +143,16 @@ func TestUpdatePorts(t *testing.T) {
 	}
 
 	err := updatePorts(flags, &portConfigs)
-	assert.Equal(t, err, nil)
-	assert.Equal(t, len(portConfigs), 2)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(portConfigs), check.Equals, 2)
 	// Do a sort to have the order (might have changed by map)
 	targetPorts := []int{int(portConfigs[0].TargetPort), int(portConfigs[1].TargetPort)}
 	sort.Ints(targetPorts)
-	assert.Equal(t, targetPorts[0], 555)
-	assert.Equal(t, targetPorts[1], 1000)
+	c.Assert(targetPorts[0], check.Equals, 555)
+	c.Assert(targetPorts[1], check.Equals, 1000)
 }
 
-func TestUpdatePortsDuplicateEntries(t *testing.T) {
+func (s *DockerSuite) TestUpdatePortsDuplicateEntries(c *check.C) {
 	// Test case for #25375
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("publish-add", "80:80")
@@ -163,12 +162,12 @@ func TestUpdatePortsDuplicateEntries(t *testing.T) {
 	}
 
 	err := updatePorts(flags, &portConfigs)
-	assert.Equal(t, err, nil)
-	assert.Equal(t, len(portConfigs), 1)
-	assert.Equal(t, portConfigs[0].TargetPort, uint32(80))
+	c.Assert(err, check.IsNil)
+	c.Assert(len(portConfigs), check.Equals, 1)
+	c.Assert(portConfigs[0].TargetPort, check.Equals, uint32(80))
 }
 
-func TestUpdatePortsDuplicateKeys(t *testing.T) {
+func (s *DockerSuite) TestUpdatePortsDuplicateKeys(c *check.C) {
 	// Test case for #25375
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("publish-add", "80:20")
@@ -178,12 +177,12 @@ func TestUpdatePortsDuplicateKeys(t *testing.T) {
 	}
 
 	err := updatePorts(flags, &portConfigs)
-	assert.Equal(t, err, nil)
-	assert.Equal(t, len(portConfigs), 1)
-	assert.Equal(t, portConfigs[0].TargetPort, uint32(20))
+	c.Assert(err, check.IsNil)
+	c.Assert(len(portConfigs), check.Equals, 1)
+	c.Assert(portConfigs[0].TargetPort, check.Equals, uint32(20))
 }
 
-func TestUpdatePortsConflictingFlags(t *testing.T) {
+func (s *DockerSuite) TestUpdatePortsConflictingFlags(c *check.C) {
 	// Test case for #25375
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("publish-add", "80:80")
@@ -194,5 +193,5 @@ func TestUpdatePortsConflictingFlags(t *testing.T) {
 	}
 
 	err := updatePorts(flags, &portConfigs)
-	assert.Error(t, err, "conflicting port mapping")
+	c.Assert(err, check.ErrorMatches, ".*conflicting port mapping.*")
 }

--- a/api/client/swarm/opts_test.go
+++ b/api/client/swarm/opts_test.go
@@ -3,35 +3,42 @@ package swarm
 import (
 	"testing"
 
-	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/go-check/check"
 )
 
-func TestNodeAddrOptionSetHostAndPort(t *testing.T) {
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type DockerSuite struct{}
+
+var _ = check.Suite(&DockerSuite{})
+
+func (s *DockerSuite) TestNodeAddrOptionSetHostAndPort(c *check.C) {
 	opt := NewNodeAddrOption("old:123")
 	addr := "newhost:5555"
-	assert.NilError(t, opt.Set(addr))
-	assert.Equal(t, opt.Value(), addr)
+	c.Assert(opt.Set(addr), check.IsNil)
+	c.Assert(opt.Value(), check.Equals, addr)
 }
 
-func TestNodeAddrOptionSetHostOnly(t *testing.T) {
+func (s *DockerSuite) TestNodeAddrOptionSetHostOnly(c *check.C) {
 	opt := NewListenAddrOption()
-	assert.NilError(t, opt.Set("newhost"))
-	assert.Equal(t, opt.Value(), "newhost:2377")
+	c.Assert(opt.Set("newhost"), check.IsNil)
+	c.Assert(opt.Value(), check.Equals, "newhost:2377")
 }
 
-func TestNodeAddrOptionSetHostOnlyIPv6(t *testing.T) {
+func (s *DockerSuite) TestNodeAddrOptionSetHostOnlyIPv6(c *check.C) {
 	opt := NewListenAddrOption()
-	assert.NilError(t, opt.Set("::1"))
-	assert.Equal(t, opt.Value(), "[::1]:2377")
+	c.Assert(opt.Set("::1"), check.IsNil)
+	c.Assert(opt.Value(), check.Equals, "[::1]:2377")
 }
 
-func TestNodeAddrOptionSetPortOnly(t *testing.T) {
+func (s *DockerSuite) TestNodeAddrOptionSetPortOnly(c *check.C) {
 	opt := NewListenAddrOption()
-	assert.NilError(t, opt.Set(":4545"))
-	assert.Equal(t, opt.Value(), "0.0.0.0:4545")
+	c.Assert(opt.Set(":4545"), check.IsNil)
+	c.Assert(opt.Value(), check.Equals, "0.0.0.0:4545")
 }
 
-func TestNodeAddrOptionSetInvalidFormat(t *testing.T) {
+func (s *DockerSuite) TestNodeAddrOptionSetInvalidFormat(c *check.C) {
 	opt := NewListenAddrOption()
-	assert.Error(t, opt.Set("http://localhost:4545"), "Invalid")
+	c.Assert(opt.Set("http://localhost:4545"), check.ErrorMatches, ".*Invalid.*")
 }

--- a/api/client/trust_test.go
+++ b/api/client/trust_test.go
@@ -6,51 +6,50 @@ import (
 
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
+	"github.com/go-check/check"
 )
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type DockerSuite struct{}
+
+var _ = check.Suite(&DockerSuite{})
 
 func unsetENV() {
 	os.Unsetenv("DOCKER_CONTENT_TRUST")
 	os.Unsetenv("DOCKER_CONTENT_TRUST_SERVER")
 }
 
-func TestENVTrustServer(t *testing.T) {
+func (s *DockerSuite) TestENVTrustServer(c *check.C) {
 	defer unsetENV()
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
-	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "https://notary-test.com:5000"); err != nil {
-		t.Fatal("Failed to set ENV variable")
-	}
+	c.Assert(os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "https://notary-test.com:5000"), check.IsNil)
 	output, err := trustServer(indexInfo)
 	expectedStr := "https://notary-test.com:5000"
-	if err != nil || output != expectedStr {
-		t.Fatalf("Expected server to be %s, got %s", expectedStr, output)
-	}
+	c.Assert(err, check.IsNil)
+	c.Assert(output, check.Equals, expectedStr)
 }
 
-func TestHTTPENVTrustServer(t *testing.T) {
+func (s *DockerSuite) TestHTTPENVTrustServer(c *check.C) {
 	defer unsetENV()
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
-	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "http://notary-test.com:5000"); err != nil {
-		t.Fatal("Failed to set ENV variable")
-	}
+	c.Assert(os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "http://notary-test.com:5000"), check.IsNil)
 	_, err := trustServer(indexInfo)
-	if err == nil {
-		t.Fatal("Expected error with invalid scheme")
-	}
+	c.Assert(err, check.NotNil)
 }
 
-func TestOfficialTrustServer(t *testing.T) {
+func (s *DockerSuite) TestOfficialTrustServer(c *check.C) {
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver", Official: true}
 	output, err := trustServer(indexInfo)
-	if err != nil || output != registry.NotaryServer {
-		t.Fatalf("Expected server to be %s, got %s", registry.NotaryServer, output)
-	}
+	c.Assert(err, check.IsNil)
+	c.Assert(output, check.Equals, registry.NotaryServer)
 }
 
-func TestNonOfficialTrustServer(t *testing.T) {
+func (s *DockerSuite) TestNonOfficialTrustServer(c *check.C) {
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver", Official: false}
 	output, err := trustServer(indexInfo)
 	expectedStr := "https://" + indexInfo.Name
-	if err != nil || output != expectedStr {
-		t.Fatalf("Expected server to be %s, got %s", expectedStr, output)
-	}
+	c.Assert(err, check.IsNil)
+	c.Assert(output, check.Equals, expectedStr)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Converted stdlib unit tests to gocheck for the API package.
Replaced all `testutil/assert` with gocheck asserts.

**\- How I did it**
Reused already existing examples by the integration tests which are using the gocheck suite.

**\- How to verify it**

**\- Description for the changelog**
Converted stdlib unit tests to gocheck for the API package.

fixes partially #26175 

**\- A picture of a cute animal (not mandatory but encouraged)**
![hqdefault](https://cloud.githubusercontent.com/assets/2463119/18328860/3b18f42c-7551-11e6-8789-cbf8336dd58c.jpg)

Signed-off-by: Michel Vocks michelvocks@gmail.com
