### PR TITLE
Dockerfile*: bump Go to 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ RUN set -x \
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
-ENV GO_VERSION 1.7
+ENV GO_VERSION 1.7.1
 RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -100,7 +100,7 @@ RUN set -x \
 # so we use gccgo as bootstrap to build Go from source code.
 # We don't use the official ARMv6 released binaries as a GOROOT_BOOTSTRAP, because
 # not all ARM64 platforms support 32-bit mode. 32-bit mode is optional for ARMv8.
-ENV GO_VERSION 1.7
+ENV GO_VERSION 1.7.1
 RUN mkdir /usr/src/go && curl -fsSL https://storage.googleapis.com/golang/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/src/go -xz --strip-components=1 \
 	&& cd /usr/src/go/src \
 	&& GOOS=linux GOARCH=arm64 GOROOT_BOOTSTRAP="$(go env GOROOT)" ./make.bash

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -65,7 +65,7 @@ RUN cd /usr/local/lvm2 \
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install Go
-ENV GO_VERSION 1.7
+ENV GO_VERSION 1.7.1
 RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -92,7 +92,7 @@ RUN set -x \
 # ppc64le doesn't have official go binaries, so use the version of go installed from the image
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
-ENV GO_VERSION 1.7
+ENV GO_VERSION 1.7.1
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 
 RUN set -x \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -97,7 +97,7 @@ RUN cd /usr/local/lvm2 \
 
 ## BUILD GOLANG 1.7 with existing gccgo
 
-ENV GO_VERSION 1.7
+ENV GO_VERSION 1.7.1
 ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
 ENV GOROOT_BOOTSTRAP /usr/local
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -49,7 +49,7 @@ RUN set -x \
 # IMPORTANT: If the version of Go is updated, the Windows to Linux CI machines
 #            will need updating, to avoid errors. Ping #docker-maintainers on IRC
 #            with a heads-up.
-ENV GO_VERSION 1.7
+ENV GO_VERSION 1.7.1
 RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" \
 	| tar -xzC /usr/local
 ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -34,7 +34,7 @@ FROM windowsservercore
 # Environment variable notes:
 #  - GO_VERSION must consistent with 'Dockerfile' used by Linux'.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.7 \
+ENV GO_VERSION=1.7.1 \
     GIT_LOCATION=https://github.com/git-for-windows/git/releases/download/v2.7.2.windows.1/Git-2.7.2-64-bit.exe \
     GOPATH=C:/go;C:/go/src/github.com/docker/docker/vendor \
     FROM_DOCKERFILE=1


### PR DESCRIPTION
**\- What I did**
I've bumped Go to the just released Go 1.7.1.

**\- How I did it**
I've changed the version in every Dockerfile.

**\- Description for the changelog**
Dockerfile*: bump Go to 1.7.1
