### PR TITLE
Use pluginv2 in authz plugins.

### DIFF
--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -73,20 +73,3 @@ func (a *authorizationPlugin) AuthZResponse(authReq *Request) (*Response, error)
 
 	return authRes, nil
 }
-
-// initPlugin initializes the authorization plugin if needed
-func (a *authorizationPlugin) initPlugin() error {
-	// Lazy loading of plugins
-	var err error
-	a.once.Do(func() {
-		if a.plugin == nil {
-			plugin, e := plugins.Get(a.name, AuthZApiImplements)
-			if e != nil {
-				err = e
-				return
-			}
-			a.plugin = plugin.Client()
-		}
-	})
-	return err
-}

--- a/pkg/authorization/plugin_experimental.go
+++ b/pkg/authorization/plugin_experimental.go
@@ -1,0 +1,23 @@
+// +build experimental
+
+package authorization
+
+import (
+	pluginstore "github.com/docker/docker/plugin/store"
+)
+
+// initPlugin initializes the authorization plugin if needed.
+func (a *authorizationPlugin) initPlugin() error {
+	var err error
+	a.once.Do(func() {
+		if a.plugin == nil {
+			plugin, e := pluginstore.LookupWithCapability(a.name, AuthZApiImplements)
+			if e != nil {
+				err = e
+				return
+			}
+			a.plugin = plugin.Client()
+		}
+	})
+	return err
+}

--- a/pkg/authorization/plugin_regular.go
+++ b/pkg/authorization/plugin_regular.go
@@ -1,0 +1,23 @@
+// +build !experimental
+
+package authorization
+
+import (
+	"github.com/docker/docker/pkg/plugins"
+)
+
+// initPlugin initializes the authorization plugin if needed.
+func (a *authorizationPlugin) initPlugin() error {
+	var err error
+	a.once.Do(func() {
+		if a.plugin == nil {
+			plugin, e := plugins.Get(a.name, AuthZApiImplements)
+			if e != nil {
+				err = e
+				return
+			}
+			a.plugin = plugin.Client()
+		}
+	})
+	return err
+}


### PR DESCRIPTION
pluginstore provides the abstraction for legacy (pluginv1) and new
plugin model (pluginv2). In pluginv2, plugins are installed from the
registry and loaded right away (no lazy loading). Make authz capable of
using pluginv2.

Signed-off-by: Anusha Ragunathan anusha@docker.com
