### PR TITLE
ensure transport.Client be closed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -108,6 +108,19 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 	}, nil
 }
 
+// Close ensures that transport.Client is closed
+// especially needed while using NewClient with *http.Client = nil
+// for example
+// client.NewClient("unix:///var/run/docker.sock", nil, "v1.18", map[string]string{"User-Agent": "engine-api-cli-1.0"})
+func (cli *Client) Close() error {
+
+	if t, ok := cli.client.Transport.(*http.Transport); ok {
+		t.CloseIdleConnections()
+	}
+
+	return nil
+}
+
 // getAPIPath returns the versioned request path to call the api.
 // It appends the query parameters to the path if they are not empty.
 func (cli *Client) getAPIPath(p string, query url.Values) string {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -133,6 +133,11 @@ func TestGetAPIPath(t *testing.T) {
 		if g != cs.e {
 			t.Fatalf("Expected %s, got %s", cs.e, g)
 		}
+
+		err = c.Close()
+		if nil != err {
+			t.Fatalf("close client failed, error message: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
make sure transport.Client be closed

especially needed while using cli.NewClient with *http.Client = nil, otherwise  fd leaking will happen.

for example

``` golang
client.NewClient("unix:///var/run/docker.sock", nil, "v1.18", map[string]string{"User-Agent": "engine-api-cli-1.0"})
```

Signed-off-by: qudongfang qudongfang@gmail.com
