### PR TITLE
Fix Ulimits in `docker inspect` when daemon default exists

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -110,6 +110,9 @@ func (daemon *Daemon) getInspectData(container *container.Container, size bool) 
 		hostConfig.Links = append(hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
 	}
 
+	// We merge the Ulimits from hostConfig with daemon default
+	daemon.mergeUlimits(&hostConfig)
+
 	var containerHealth *types.Health
 	if container.State.Health != nil {
 		containerHealth = &types.Health{

--- a/daemon/oci_solaris.go
+++ b/daemon/oci_solaris.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/oci"
@@ -9,4 +10,10 @@ import (
 func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, error) {
 	s := oci.DefaultSpec()
 	return (*libcontainerd.Spec)(&s), nil
+}
+
+// mergeUlimits merge the Ulimits from HostConfig with daemon defaults, and update HostConfig
+// It will do nothing on non-Linux platform
+func (daemon *Daemon) mergeUlimits(c *containertypes.HostConfig) {
+	return
 }

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
@@ -191,4 +192,10 @@ func escapeArgs(args []string) []string {
 		escapedArgs[i] = syscall.EscapeArg(a)
 	}
 	return escapedArgs
+}
+
+// mergeUlimits merge the Ulimits from HostConfig with daemon defaults, and update HostConfig
+// It will do nothing on non-Linux platform
+func (daemon *Daemon) mergeUlimits(c *containertypes.HostConfig) {
+	return
 }


### PR DESCRIPTION
**\- What I did**

This fix tries to fix #26326 where `docker inspect` will not show Ulimits even when daemon default ulimits has been set.

**\- How I did it**

This fix merge the HostConfig's ulimit with daemon default in `docker inspect`, so that when daemon is started with `default-ulimits` and HostConfig's ulimits is not set, `docker inspect` will output the daemon default.

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #26326.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
