### PR TITLE
client: transport: fix tlsconfig Clone() on different Golang versions

### DIFF
--- a/client/transport/tlsconfig_clone.go
+++ b/client/transport/tlsconfig_clone.go
@@ -1,4 +1,4 @@
-// +build !go1.7,!windows
+// +build go1.8
 
 package transport
 

--- a/client/transport/tlsconfig_clone_go16.go
+++ b/client/transport/tlsconfig_clone_go16.go
@@ -1,0 +1,31 @@
+// +build go1.6,!go1.7
+
+package transport
+
+import "crypto/tls"
+
+// TLSConfigClone returns a clone of tls.Config. This function is provided for
+// compatibility for go1.6 that doesn't include this method in stdlib.
+func TLSConfigClone(c *tls.Config) *tls.Config {
+	return &tls.Config{
+		Rand:                     c.Rand,
+		Time:                     c.Time,
+		Certificates:             c.Certificates,
+		NameToCertificate:        c.NameToCertificate,
+		GetCertificate:           c.GetCertificate,
+		RootCAs:                  c.RootCAs,
+		NextProtos:               c.NextProtos,
+		ServerName:               c.ServerName,
+		ClientAuth:               c.ClientAuth,
+		ClientCAs:                c.ClientCAs,
+		InsecureSkipVerify:       c.InsecureSkipVerify,
+		CipherSuites:             c.CipherSuites,
+		PreferServerCipherSuites: c.PreferServerCipherSuites,
+		SessionTicketsDisabled:   c.SessionTicketsDisabled,
+		SessionTicketKey:         c.SessionTicketKey,
+		ClientSessionCache:       c.ClientSessionCache,
+		MinVersion:               c.MinVersion,
+		MaxVersion:               c.MaxVersion,
+		CurvePreferences:         c.CurvePreferences,
+	}
+}

--- a/client/transport/tlsconfig_clone_go17.go
+++ b/client/transport/tlsconfig_clone_go17.go
@@ -1,4 +1,4 @@
-// +build go1.7
+// +build go1.7,!go1.8
 
 package transport
 


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/26410

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
