### PR TITLE
image -f function add 'tag' search options

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -17,6 +18,8 @@ var acceptedImageFilterTags = map[string]bool{
 	"label":    true,
 	"before":   true,
 	"since":    true,
+	"name":     true,
+	"tag":      true,
 }
 
 // byCreated is a temporary type used to sort a list of images by creation
@@ -115,6 +118,19 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
 			// We are now sure image.Config is not nil
 			if !imageFilters.MatchKVList("label", img.Config.Labels) {
 				continue
+			}
+		}
+
+		if imageFilters.Include("name") {
+			tab := strings.SplitN(img.Config.Image, ":", 2)
+			if tab[0] != "*" {
+				if !imageFilters.Match("name", img.Config.Image) {
+					continue
+				}
+			} else {
+				if !imageFilters.Match("tag", strings.TrimSpace(tab[1])) {
+					continue
+				}
 			}
 		}
 

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -116,6 +116,24 @@ func (s *DockerSuite) TestImagesFilterLabelWithCommit(c *check.C) {
 	c.Assert(out, check.Equals, imageID)
 }
 
+func (s *DockerSuite) TestImagesFilterName(c *check.C) {
+	imageID1, err := buildImage("image1:test_a", `FROM busybox LABEL number=1`, true)
+	c.Assert(err, check.IsNil)
+	imageID2, err := buildImage("image2:test_a", `FROM busybox LABEL number=2`, true)
+	c.Assert(err, check.IsNil)
+	imageID3, err := buildImage("image3:test_b", `FROM busybox LABEL number=2`, true)
+	c.Assert(err, check.IsNil)
+
+	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "name=*:test_a")
+	out = strings.TrimSpace(out)
+	c.Assert(out, check.Equals, imageID1)
+	c.Assert(out, check.Equals, imageID2)
+
+	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "name=image1:test_a")
+	out = strings.TrimSpace(out)
+	c.Assert(out, check.Equals, imageID1)
+}
+
 func (s *DockerSuite) TestImagesFilterSinceAndBefore(c *check.C) {
 	imageID1, err := buildImage("image:1", `FROM `+minimalBaseImage()+`
 LABEL number=1`, true)


### PR DESCRIPTION
My idea is to be able to execute images -f tag=XXX,This is my general idea,There's a little bit of a problem with the pr, if there is any wrong place, please advise

Signed-off-by: zhouhao zhouhao@cn.fujitsu.com
