### PR TITLE
Labels info ommitted while inspecting self-defined network

### DIFF
--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -80,7 +80,8 @@ $ sudo docker network inspect bridge
             "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
             "com.docker.network.bridge.name": "docker0",
             "com.docker.network.driver.mtu": "1500"
-        }
+        },
+        "Labels": {}
     }
 ]
 ```
@@ -107,7 +108,8 @@ $ docker network inspect simple-network
             ]
         },
         "Containers": {},
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 ```

--- a/docs/tutorials/networkingcontainers.md
+++ b/docs/tutorials/networkingcontainers.md
@@ -141,7 +141,8 @@ $ docker network inspect bridge
             "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
             "com.docker.network.bridge.name": "docker0",
             "com.docker.network.driver.mtu": "9001"
-        }
+        },
+        "Labels": {}
     }
 ]
 ```
@@ -188,7 +189,8 @@ If you inspect the network, you'll find that it has nothing in it.
                 ]
             },
             "Containers": {},
-            "Options": {}
+            "Options": {},
+            "Labels": {}
         }
     ]
 

--- a/docs/userguide/networking/index.md
+++ b/docs/userguide/networking/index.md
@@ -125,7 +125,8 @@ $ docker network inspect bridge
            "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
            "com.docker.network.bridge.name": "docker0",
            "com.docker.network.driver.mtu": "9001"
-       }
+       },
+       "Labels": {}
    }
 ]
 ```
@@ -183,7 +184,8 @@ $ docker network inspect bridge
             "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
             "com.docker.network.bridge.name": "docker0",
             "com.docker.network.driver.mtu": "9001"
-        }
+        },
+        "Labels": {}
     }
 ]
 ```
@@ -336,7 +338,8 @@ $ docker network inspect isolated_nw
             ]
         },
         "Containers": {},
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 
@@ -378,7 +381,8 @@ $ docker network inspect isolated_nw
                 "IPv6Address": ""
             }
         },
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 ```

--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -62,7 +62,8 @@ $ docker network inspect simple-network
             ]
         },
         "Containers": {},
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 ```
@@ -160,7 +161,8 @@ $ docker network inspect my-network
         "Containers": {},
         "Options": {
             "com.docker.network.bridge.host_binding_ipv4": "172.23.0.1"
-        }
+        },
+        "Labels": {}
     }
 ]
 
@@ -236,7 +238,8 @@ $ docker network inspect isolated_nw
                 "IPv6Address": ""
             }
         },
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 ```
@@ -797,7 +800,8 @@ $ docker network inspect isolated_nw
                 "IPv6Address": ""
             }
         },
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 ```
@@ -900,7 +904,8 @@ docker network inspect isolated_nw
             ]
         },
         "Containers": {},
-        "Options": {}
+        "Options": {},
+        "Labels": {}
     }
 ]
 


### PR DESCRIPTION
Labels info included while executing the docker network inspect, and there are Labels info in other md docs such as networking.md:

$ docker network inspect my-network
[
    {
        "Name": "my-network",
        "Id": "7m2rjx0a97n88wzr4nu8772r3",
        "Scope": "swarm",
        "Driver": "overlay",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": null,
            "Config": [
                {
                    "Subnet": "10.0.9.0/24",
                    "Gateway": "10.0.9.1"
                }
            ]
        },
        "Internal": false,
        "Containers": {
            "404d1dec939a021678132a35259c3604b9657649437e59060621a17edae7a819": {
                "Name": "my-web.1.63s86gf6a0ms34mvboniev7bs",
                "EndpointID": "3c9588d04db9bc2bf8749cb079689a3072c44c68e544944cbea8e4bc20eb7de7",
                "MacAddress": "02:42:0a:00:09:03",
                "IPv4Address": "10.0.9.3/24",
                "IPv6Address": ""
            }
        },
        "Options": {
            "com.docker.network.driver.overlay.vxlanid_list": "257"
        },
        "Labels": {}
    }
]
