### PR TITLE
update go-md2man to v1.0.6

### DIFF
--- a/man/glide.lock
+++ b/man/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/BurntSushi/toml
   version: f0aeabca5a127c4078abb8c8d64298b147264b55
 - name: github.com/cpuguy83/go-md2man
-  version: 2724a9c9051aa62e9cca11304e7dd518e9e41599
+  version: a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
   subpackages:
   - md2man
 - name: github.com/fsnotify/fsnotify


### PR DESCRIPTION
**\- What I did**
Updated md2man to v1.0.6 (https://github.com/cpuguy83/go-md2man/commit/a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa) , which improves the rendering of hyperlinks.
cpuguy83/go-md2man#21

Replaces https://github.com/docker/docker/pull/26416
@dnephin @cpuguy83 

**\- How I did it**

**\- How to verify it**
`make manpages` (needs https://github.com/docker/docker/pull/26406)

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
