### PR TITLE
Dockerfile.s390x: Use binary go package

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -95,20 +95,11 @@ RUN cd /usr/local/lvm2 \
 	&& make install_device-mapper
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
-## BUILD GOLANG 1.7 with existing gccgo
-
 ENV GO_VERSION 1.7.1
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
-ENV GOROOT_BOOTSTRAP /usr/local
+RUN curl -fsSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-s390x.tar.gz" \
+	| tar -xzC /usr/local
 
-RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \
-    && tar -C /usr/src -xzf golang.tar.gz \
-    && rm golang.tar.gz \
-    && cd /usr/src/go/src && ./make.bash 2>&1
-
-ENV GOROOT_BOOTSTRAP /usr/src/
-
-ENV PATH /usr/src/go/bin/:/go/bin:$PATH
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 # Dependency for golint


### PR DESCRIPTION
We finally have a s390x binary tarball for go on "storage.googleapis.com".
So use this instead of bootstrapping with gccgo.

The following tests have been successful with the new Dockerfile.s390x:
- Build Docker:  `docker build --rm --force-rm -t docker:build -f Dockerfile.s390x .`
- Run CI: `DOCKER_GRAPHDRIVER=vfs DOCKER_EXECDRIVER=native TIMEOUT="120m"   hack/make.sh binary test-integration-cli`

Signed-off-by: Michael Holzheu holzheu@linux.vnet.ibm.com
