### PR TITLE
Don't attempt to evaluate drive root on Windows

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3022,14 +3022,17 @@ func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
 
 // gh #2446
 func (s *DockerSuite) TestBuildAddToSymlinkDest(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	makeLink := `ln -s /foo /bar`
+	if daemonPlatform == "windows" {
+		makeLink = `mklink /D C:\bar C:\foo`
+	}
 	name := "testbuildaddtosymlinkdest"
 	ctx, err := fakeContext(`FROM busybox
-        RUN mkdir /foo
-        RUN ln -s /foo /bar
+        RUN sh -c "mkdir /foo"
+        RUN `+makeLink+`
         ADD foo /bar/
-        RUN [ -f /bar/foo ]
-        RUN [ -f /foo/foo ]`,
+        RUN sh -c "[ -f /bar/foo ]"
+        RUN sh -c "[ -f /foo/foo ]"`,
 		map[string]string{
 			"foo": "hello",
 		})

--- a/pkg/symlink/fs.go
+++ b/pkg/symlink/fs.go
@@ -95,8 +95,8 @@ func evalSymlinksInScope(path, root string) (string, error) {
 		// root gets prepended and we Clean again (to remove any trailing slash
 		// if the first Clean gave us just "/")
 		cleanP := filepath.Clean(string(filepath.Separator) + b.String() + p)
-		if cleanP == string(filepath.Separator) {
-			// never Lstat "/" itself
+		if isDriveOrRoot(cleanP) {
+			// never Lstat "/" itself, or drive letters on Windows
 			b.Reset()
 			continue
 		}
@@ -113,7 +113,8 @@ func evalSymlinksInScope(path, root string) (string, error) {
 			return "", err
 		}
 		if fi.Mode()&os.ModeSymlink == 0 {
-			b.WriteString(p + string(filepath.Separator))
+			b.WriteString(p)
+			b.WriteRune(filepath.Separator)
 			continue
 		}
 

--- a/pkg/symlink/fs_unix.go
+++ b/pkg/symlink/fs_unix.go
@@ -9,3 +9,7 @@ import (
 func evalSymlinks(path string) (string, error) {
 	return filepath.EvalSymlinks(path)
 }
+
+func isDriveOrRoot(p string) bool {
+	return p == string(filepath.Separator)
+}

--- a/pkg/symlink/fs_windows.go
+++ b/pkg/symlink/fs_windows.go
@@ -153,3 +153,17 @@ func walkSymlinks(path string) (string, error) {
 	}
 	return filepath.Clean(b.String()), nil
 }
+
+func isDriveOrRoot(p string) bool {
+	if p == string(filepath.Separator) {
+		return true
+	}
+
+	length := len(p)
+	if length >= 2 {
+		if p[length-1] == ':' && (('a' <= p[length-2] && p[length-2] <= 'z') || ('A' <= p[length-2] && p[length-2] <= 'Z')) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Enabled the `TestBuildAddToSymlinkDest` test, and fixed the following symlink logic to make it pass on Windows daemons.

**\- How I did it**

Stop attempting to LStat on Windows drive of the container's mounted filesystem, as it is not a valid filename to LStat.

**\- How to verify it**

Enabled test `TestBuildAddToSymlinkDest` used to fail when enabled on Windows, it now passes.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**\- A picture of a cute animal (not mandatory but encouraged)**
![cute-frog](https://cloud.githubusercontent.com/assets/14114019/18366554/07bee7d2-75cc-11e6-92be-6c78a8c6e66e.jpg)

Signed-off-by: Darren Stahl darst@microsoft.com
