### PR TITLE
client: don't hide context errors

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client/transport/cancellable"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -131,7 +132,8 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 				}
 			}
 		}
-		return serverResp, fmt.Errorf("An error occurred trying to connect: %v", err)
+
+		return serverResp, errors.Wrap(err, "error during connect")
 	}
 
 	if resp != nil {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1703,7 +1703,7 @@ func (s *DockerDaemonSuite) TestDaemonNoTlsCliTlsVerifyWithEnv(c *check.C) {
 	cmd.Env = []string{"DOCKER_TLS_VERIFY=1", "DOCKER_CERT_PATH=fixtures/https"}
 	out, _, err := runCommandWithOutput(cmd)
 	c.Assert(err, check.Not(check.IsNil), check.Commentf("%s", out))
-	c.Assert(strings.Contains(out, "error occurred trying to connect"), check.Equals, true)
+	c.Assert(strings.Contains(out, "error during connect"), check.Equals, true)
 
 }
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2662,7 +2662,7 @@ func (s *DockerSuite) TestRunTLSverify(c *check.C) {
 	// Regardless of whether we specify true or false we need to
 	// test to make sure tls is turned on if --tlsverify is specified at all
 	result := dockerCmdWithResult("--tlsverify=false", "ps")
-	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "trying to connect"})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "error during connect"})
 
 	result = dockerCmdWithResult("--tlsverify=true", "ps")
 	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "cert"})


### PR DESCRIPTION
Instead of reformatting error from the request action, we wrap it,
allowing the cause to be recovered. This is important for consumers that
need to be able to detect context errors, such as `Cancelled` and
`DeadlineExceeded`.

Signed-off-by: Stephen J Day stephen.day@docker.com
