### PR TITLE
Windows: Fix regression pulling linux images

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -272,3 +272,10 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPullNoCredentialsNotFound(c *check
 	c.Assert(err, check.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "Error: image busybox:latest not found")
 }
+
+// Regression test for https://github.com/docker/docker/issues/26429
+func (s *DockerSuite) TestPullLinuxImageFailsOnWindows(c *check.C) {
+	testRequires(c, DaemonIsWindows, Network)
+	_, _, err := dockerCmdWithError("pull", "ubuntu")
+	c.Assert(err.Error(), checker.Contains, "cannot be used on this platform")
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes #26429.  https://github.com/docker/docker/commit/f342b27145d8f5af27cd5de1501551af275e899b from https://github.com/docker/docker/pull/25090 had regressed the check on Windows when attempting to pull Linux images. The original fix was in https://github.com/docker/docker/pull/24819. 

Re-fixed, and added a test case to make sure this doesn't regress in the future.

@aaronlehmann @stevvooe PTAL. Thanks!

@swernli @darrenstahlmsft FYI.
