### PR TITLE
docker daemon requires windows version info while low build

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -165,7 +165,7 @@ func checkSystem() error {
 		return fmt.Errorf("This version of Windows does not support the docker daemon")
 	}
 	if osv.Build < 14300 {
-		return fmt.Errorf("The Windows daemon requires Windows Server 2016 Technical Preview 5 build 14300 or later")
+		return fmt.Errorf("The docker daemon requires Windows Server 2016 Technical Preview 5 build 14300 or later")
 	}
 	return nil
 }


### PR DESCRIPTION
Specify the required version while the version not support daemon.
In addition, "windows daemon" should be "docker daemon"
