### PR TITLE
Add TERM env var to exec

### DIFF
--- a/daemon/exec/exec.go
+++ b/daemon/exec/exec.go
@@ -27,6 +27,7 @@ type Config struct {
 	Tty         bool
 	Privileged  bool
 	User        string
+	Env         []string
 }
 
 // NewConfig initializes the a new exec configuration

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -68,3 +68,26 @@ func (s *DockerSuite) TestExecTTY(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(bytes.Contains(buf, []byte("hello")), checker.Equals, true, check.Commentf(string(buf[:read])))
 }
+
+// Test the the TERM env var is set when -t is provided on exec
+func (s *DockerSuite) TestExecWithTERM(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
+	out, _ := dockerCmd(c, "run", "-id", "busybox", "/bin/cat")
+	contID := strings.TrimSpace(out)
+	cmd := exec.Command(dockerBinary, "exec", "-t", contID, "sh", "-c", "if [ -z $TERM ]; then exit 1; else exit 0; fi")
+	if err := cmd.Run(); err != nil {
+		c.Assert(err, checker.IsNil)
+	}
+}
+
+// Test that the TERM env var is not set on exec when -t is not provided, even if it was set
+// on run
+func (s *DockerSuite) TestExecWithNoTERM(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
+	out, _ := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
+	contID := strings.TrimSpace(out)
+	cmd := exec.Command(dockerBinary, "exec", contID, "sh", "-c", "if [ -z $TERM ]; then exit 0; else exit 1; fi")
+	if err := cmd.Run(); err != nil {
+		c.Assert(err, checker.IsNil)
+	}
+}


### PR DESCRIPTION
When the `-t` flag is passed on exec make sure to add the TERM env var
to mirror the expected configuration from run.

Fixes #9299

Signed-off-by: Michael Crosby crosbymichael@gmail.com
