### PR TITLE
Taking stop-signal into account when docker kill

### DIFF
--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -68,7 +68,17 @@ func (daemon *Daemon) killWithSignal(container *container.Container, sig int) er
 		return errNotRunning{container.ID}
 	}
 
-	container.ExitOnNext()
+	if container.Config.StopSignal != "" {
+		containerStopSignal, err := signal.ParseSignal(container.Config.StopSignal)
+		if err != nil {
+			return err
+		}
+		if containerStopSignal == syscall.Signal(sig) {
+			container.ExitOnNext()
+		}
+	} else {
+		container.ExitOnNext()
+	}
 
 	if !daemon.IsShuttingDown() {
 		container.HasBeenManuallyStopped = true


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue #11065, taking into account `stop-signal` if present so that non-fatal signal (i.e. `SIGKILL`) is sent using `docker kill` command, it will not disable the restart policy. 🐯

**\- How to verify it**

Added 2 integration tests to handle those cases.

**\- Still todo**
- [x] Validate `SIGKILL` behavior
- [ ] Update documentation

This fix fixes #11065.

/cc @tonistiigi @crosbymichael 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
