### PR TITLE
Use `filepath.Clean` in `normaliseWorkdir` for windows

### DIFF
--- a/builder/dockerfile/dispatchers_windows_test.go
+++ b/builder/dockerfile/dispatchers_windows_test.go
@@ -7,9 +7,15 @@ import "testing"
 func TestNormaliseWorkdir(t *testing.T) {
 	tests := []struct{ current, requested, expected, etext string }{
 		{``, ``, ``, `cannot normalise nothing`},
+		{``, `C:`, ``, `C:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{``, `C:.`, ``, `C:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{`c:`, `\a`, ``, `c:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
+		{`c:.`, `\a`, ``, `c:. is not a directory. If you are specifying a drive letter, please add a trailing '\'`},
 		{``, `a`, `C:\a`, ``},
 		{``, `c:\foo`, `C:\foo`, ``},
+		{``, `c:\\foo`, `C:\foo`, ``},
 		{``, `\foo`, `C:\foo`, ``},
+		{``, `\\foo`, `C:\foo`, ``},
 		{``, `/foo`, `C:\foo`, ``},
 		{``, `C:/foo`, `C:\foo`, ``},
 		{`C:\foo`, `bar`, `C:\foo\bar`, ``},
@@ -20,15 +26,15 @@ func TestNormaliseWorkdir(t *testing.T) {
 		r, e := normaliseWorkdir(i.current, i.requested)
 
 		if i.etext != "" && e == nil {
-			t.Fatalf("TestNormaliseWorkingDir Expected error %s", i.etext)
+			t.Fatalf("TestNormaliseWorkingDir Expected error %s for '%s' '%s', got no error", i.etext, i.current, i.requested)
 		}
 
 		if i.etext != "" && e.Error() != i.etext {
-			t.Fatalf("TestNormaliseWorkingDir Expected error %s, got %s", i.etext, e.Error())
+			t.Fatalf("TestNormaliseWorkingDir Expected error %s for '%s' '%s', got %s", i.etext, i.current, i.requested, e.Error())
 		}
 
 		if r != i.expected {
-			t.Fatalf("TestNormaliseWorkingDir Expected %s for %s %s", i.expected, i.current, i.requested)
+			t.Fatalf("TestNormaliseWorkingDir Expected '%s' for '%s' '%s', got '%s'", i.expected, i.current, i.requested, r)
 		}
 	}
 }


### PR DESCRIPTION
**\- What I did**

As is seem in the comment of `normaliseWorkdir` for windows, the behavior of `normaliseWorkdir` is supposed to be:

```
...
    //  WORKDIR c:\\foo                 --> C:\foo
    //  WORKDIR \\foo                   --> C:\foo
...
```

However, this is not the case in the current implementation because `filepath.FromSlash` is used and `FromSlash` does not replace multiple separator with a single one (`file.Clean` does).
So `normaliseWorkdir` does not truly normalize workdir.

**\- How I did it**

This fix changes the implementation of `normaliseWorkdir` and use `filepath.Clean` instead of `filepath.FromSlash`.

**\- How to verify it**

Additional test cases have been added to the unit test.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Yong Tang yong.tang.github@outlook.com
