### PR TITLE
Fix documentation for `Step 0` to `Step 1` in `docker build`

### DIFF
--- a/docs/getstarted/step_four.md
+++ b/docs/getstarted/step_four.md
@@ -123,13 +123,13 @@ Then, Docker loads with the `whalesay` image.	It already has this image
 locally as you might recall from the last page. So, Docker doesn't need to
 download it.
 
-    Step 0 : FROM docker/whalesay:latest
+    Step 1 : FROM docker/whalesay:latest
      ---> fb434121fc77
 
 Docker moves onto the next step which is to update the `apt-get` package
 manager. This takes a lot of lines, no need to list them all again here.
 
-    Step 1 : RUN apt-get -y update && apt-get install -y fortunes
+    Step 2 : RUN apt-get -y update && apt-get install -y fortunes
      ---> Running in 27d224dfa5b2
     Ign http://archive.ubuntu.com trusty InRelease
     Ign http://archive.ubuntu.com trusty-updates InRelease
@@ -144,7 +144,7 @@ manager. This takes a lot of lines, no need to list them all again here.
 Then, Docker installs the new `fortunes` software.
 
     Removing intermediate container e2a84b5f390f
-    Step 2 : RUN apt-get install -y fortunes
+    Step 3 : RUN apt-get install -y fortunes
      ---> Running in 23aa52c1897c
     Reading package lists...
     Building dependency tree...
@@ -167,7 +167,7 @@ Then, Docker installs the new `fortunes` software.
 
 Finally, Docker finishes the build and reports its outcome.		
 
-    Step 3 : CMD /usr/games/fortune -a | cowsay
+    Step 4 : CMD /usr/games/fortune -a | cowsay
      ---> Running in a8e6faa88df3
      ---> 7d9495d03763
     Removing intermediate container a8e6faa88df3

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -86,15 +86,15 @@ the `Using cache` message in the console output.
 
     $ docker build -t svendowideit/ambassador .
     Sending build context to Docker daemon 15.36 kB
-    Step 0 : FROM alpine:3.2
+    Step 1 : FROM alpine:3.2
      ---> 31f630c65071
-    Step 1 : MAINTAINER SvenDowideit@home.org.au
+    Step 2 : MAINTAINER SvenDowideit@home.org.au
      ---> Using cache
      ---> 2a1c91448f5f
-    Step 2 : RUN apk update &&      apk add socat &&        rm -r /var/cache/
+    Step 3 : RUN apk update &&      apk add socat &&        rm -r /var/cache/
      ---> Using cache
      ---> 21ed6e7fbb73
-    Step 3 : CMD env | grep _TCP= | (sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/' && echo wait) | sh
+    Step 4 : CMD env | grep _TCP= | (sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/' && echo wait) | sh
      ---> Using cache
      ---> 7ea8aef582cc
     Successfully built 7ea8aef582cc

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -231,12 +231,12 @@ specify an arbitrary Git repository by using the `git://` or `git@` scheme.
 $ docker build -f ctx/Dockerfile http://server/ctx.tar.gz
 
 Downloading context: http://server/ctx.tar.gz [===================>]    240 B/240 B
-Step 0 : FROM busybox
+Step 1 : FROM busybox
  ---> 8c2e06607696
-Step 1 : ADD ctx/container.cfg /
+Step 2 : ADD ctx/container.cfg /
  ---> e7829950cee3
 Removing intermediate container b35224abf821
-Step 2 : CMD /bin/ls
+Step 3 : CMD /bin/ls
  ---> Running in fbc63d321d73
  ---> 3286931702ad
 Removing intermediate container fbc63d321d73


### PR DESCRIPTION
The indexing of steps in the output of `docker build` starts with `Step 1`. However, there are several places in the docs that start with `Step 0`.

This fix addresses the issue and changes `Step 0` to `Step 1` (and subsequent steps).

Signed-off-by: Yong Tang yong.tang.github@outlook.com
