### PR TITLE
update option for docker exec

### DIFF
--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -15,11 +15,12 @@ Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
 
 Run a command in a running container
 
+Options:
   -d, --detach         Detached mode: run command in the background
-  --detach-keys        Override the key sequence for detaching a container
-  --help               Print usage
+      --detach-keys    Override the key sequence for detaching a container
+      --help           Print usage
   -i, --interactive    Keep STDIN open even if not attached
-  --privileged         Give extended privileges to the command
+      --privileged     Give extended privileges to the command
   -t, --tty            Allocate a pseudo-TTY
   -u, --user           Username or UID (format: <name|uid>[:<group|gid>])
 ```

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -16,11 +16,12 @@ Usage:  docker inspect [OPTIONS] NAME|ID [NAME|ID...]
 Return low-level information on one or multiple containers, images, volumes,
 networks, nodes, services, or tasks identified by name or ID.
 
+Options:
   -f, --format       Format the output using the given go template
-  --help             Print usage
+      --help         Print usage
   -s, --size         Display total file sizes if the type is container
                      values are "image" or "container" or "task
-  --type             Return JSON for specified type
+      --type         Return JSON for specified type
 ```
 
 By default, this will render all results in a JSON array. If the container and


### PR DESCRIPTION
1.  Add option missed for docker exec
2.  Keep the same format among docker commands.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
