### PR TITLE
Use latest version of notary server in trust sandbox docs

### DIFF
--- a/docs/security/trust/trust_sandbox.md
+++ b/docs/security/trust/trust_sandbox.md
@@ -83,7 +83,7 @@ the `trustsandbox` container, the Notary server, and the Registry server.
         version: "2"
         services:
           notaryserver:
-            image: dockersecurity/notary_autobuilds:server-v0.3.0
+            image: dockersecurity/notary_autobuilds:server
             volumes:
               - notarycerts:/go/src/github.com/docker/notary/fixtures
             networks:


### PR DESCRIPTION
~~cc @cyli @endophage : I'm fine with just pointing to the latest build off master but we might want to wait until we cut `v0.4.0` (scheduled for this week) and point to that tag instead.~~
Edit: good to merge, no need to wait for `v0.4.0`

Points the trust sandbox to use the latest version of notary server, which has refreshed certificates and new server functionality.  I went through the content trust sandbox docs with this change and everything worked as expected.

Fixes https://github.com/docker/notary/issues/949

**\- A picture of a cute animal (not mandatory but encouraged)**
<img src="https://s-media-cache-ak0.pinimg.com/736x/15/50/68/1550686078adf3d88b9007464503dbcb.jpg" width=300/></img>

Signed-off-by: Riyaz Faizullabhoy riyaz.faizullabhoy@docker.com
