### PR TITLE
Revert commit of #26236 to 1.12.x branch

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -26,7 +26,7 @@ Options:
   --config=~/.docker              Location of client config files
   -D, --debug                     Enable debug mode
   -H, --host=[]                   Daemon socket(s) to connect to
-  --help                          Print usage
+  -h, --help                      Print usage
   -l, --log-level=info            Set the logging level
   --tls                           Use TLS; implied by --tlsverify
   --tlscacert=~/.docker/ca.pem    Trust certs signed only by this CA


### PR DESCRIPTION
Pull request #26236 was cherry-picked to 1.12.x by mistake. This commit reverts it. @thaJeztah PTAL. cc @vdemeester @sfsmithcha @tiborvass 
