### PR TITLE
swarm: always check err before http status in tests

### DIFF
--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -106,7 +106,7 @@ func (d *SwarmDaemon) createService(c *check.C, f ...serviceConstructor) string 
 	}
 	status, out, err := d.SockRequest("POST", "/services/create", service.Spec)
 
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusCreated, check.Commentf("output: %q", string(out)))
 
 	var scr types.ServiceCreateResponse
@@ -117,8 +117,8 @@ func (d *SwarmDaemon) createService(c *check.C, f ...serviceConstructor) string 
 func (d *SwarmDaemon) getService(c *check.C, id string) *swarm.Service {
 	var service swarm.Service
 	status, out, err := d.SockRequest("GET", "/services/"+id, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
-	c.Assert(err, checker.IsNil)
 	c.Assert(json.Unmarshal(out, &service), checker.IsNil)
 	return &service
 }
@@ -133,8 +133,8 @@ func (d *SwarmDaemon) getServiceTasks(c *check.C, service string) []swarm.Task {
 	c.Assert(err, checker.IsNil)
 
 	status, out, err := d.SockRequest("GET", "/tasks?filters="+filters, nil)
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &tasks), checker.IsNil)
 	return tasks
 }
@@ -168,8 +168,8 @@ func (d *SwarmDaemon) checkRunningTaskImages(c *check.C) (interface{}, check.Com
 	c.Assert(err, checker.IsNil)
 
 	status, out, err := d.SockRequest("GET", "/tasks?filters="+filters, nil)
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &tasks), checker.IsNil)
 
 	result := make(map[string]int)
@@ -196,8 +196,8 @@ func (d *SwarmDaemon) getTask(c *check.C, id string) swarm.Task {
 	var task swarm.Task
 
 	status, out, err := d.SockRequest("GET", "/tasks/"+id, nil)
-	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &task), checker.IsNil)
 	return task
 }
@@ -208,21 +208,21 @@ func (d *SwarmDaemon) updateService(c *check.C, service *swarm.Service, f ...ser
 	}
 	url := fmt.Sprintf("/services/%s/update?version=%d", service.ID, service.Version.Index)
 	status, out, err := d.SockRequest("POST", url, service.Spec)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
 func (d *SwarmDaemon) removeService(c *check.C, id string) {
 	status, out, err := d.SockRequest("DELETE", "/services/"+id, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
-	c.Assert(err, checker.IsNil)
 }
 
 func (d *SwarmDaemon) getNode(c *check.C, id string) *swarm.Node {
 	var node swarm.Node
 	status, out, err := d.SockRequest("GET", "/nodes/"+id, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
-	c.Assert(err, checker.IsNil)
 	c.Assert(json.Unmarshal(out, &node), checker.IsNil)
 	c.Assert(node.ID, checker.Equals, id)
 	return &node
@@ -235,8 +235,8 @@ func (d *SwarmDaemon) removeNode(c *check.C, id string, force bool) {
 	}
 
 	status, out, err := d.SockRequest("DELETE", url, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
-	c.Assert(err, checker.IsNil)
 }
 
 func (d *SwarmDaemon) updateNode(c *check.C, id string, f ...nodeConstructor) {
@@ -251,7 +251,7 @@ func (d *SwarmDaemon) updateNode(c *check.C, id string, f ...nodeConstructor) {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		c.Assert(err, checker.IsNil)
+		c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 		c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 		return
 	}
@@ -259,7 +259,7 @@ func (d *SwarmDaemon) updateNode(c *check.C, id string, f ...nodeConstructor) {
 
 func (d *SwarmDaemon) listNodes(c *check.C) []swarm.Node {
 	status, out, err := d.SockRequest("GET", "/nodes", nil)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 
 	nodes := []swarm.Node{}
@@ -269,7 +269,7 @@ func (d *SwarmDaemon) listNodes(c *check.C) []swarm.Node {
 
 func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 	status, out, err := d.SockRequest("GET", "/services", nil)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 
 	services := []swarm.Service{}
@@ -280,7 +280,7 @@ func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &sw), checker.IsNil)
 	return sw
@@ -293,27 +293,27 @@ func (d *SwarmDaemon) updateSwarm(c *check.C, f ...specConstructor) {
 	}
 	url := fmt.Sprintf("/swarm/update?version=%d", sw.Version.Index)
 	status, out, err := d.SockRequest("POST", url, sw.Spec)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
 func (d *SwarmDaemon) rotateTokens(c *check.C) {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &sw), checker.IsNil)
 
 	url := fmt.Sprintf("/swarm/update?version=%d&rotateWorkerToken=true&rotateManagerToken=true", sw.Version.Index)
 	status, out, err = d.SockRequest("POST", url, sw.Spec)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
 func (d *SwarmDaemon) joinTokens(c *check.C) swarm.JoinTokens {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)
-	c.Assert(err, checker.IsNil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	c.Assert(json.Unmarshal(out, &sw), checker.IsNil)
 	return sw.JoinTokens


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Improved error logging for the Swarm Suite tests

**\- How I did it**
Moved the err check to before the http status check always. It was already before it in a couple of places.

**\- How to verify it**
docker run -it --privileged -e TESTFLAGS="-check.f=DockerSwarmSuite" docker-dev ./hack/make.sh binary test-integration-cli

If a sockRequest returns an err you'll get more info this way. 

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
![Butterfly Swarm](https://s-media-cache-ak0.pinimg.com/736x/cc/fb/86/ccfb8621a7b9d557f6f35827416bcd11.jpg)

A test failed expecting 200, but received -1, which is an err rc,
not an HTTP status code, so move these checks up.

Also log the output an not just check for a nil err.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
