### PR TITLE
Windows OCI convergence step 1

### DIFF
--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Spec is the base configuration for the container.
-type Spec windowsoci.WindowsSpec
+type Spec windowsoci.Spec
 
 // Process contains information to start a specific application inside the container.
 type Process windowsoci.Process

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -6,31 +6,31 @@ package windowsoci
 
 import "fmt"
 
-// WindowsSpec is the full specification for Windows containers.
-type WindowsSpec struct {
-	Spec
-
-	// Windows is platform specific configuration for Windows based containers.
-	Windows Windows `json:"windows"`
-}
-
-// Spec is the base configuration for the container.  It specifies platform
-// independent configuration. This information must be included when the
-// bundle is packaged for distribution.
+// Spec is the base configuration for the container.
 type Spec struct {
-
-	// Version is the version of the specification that is supported.
+	// Version of the Open Container Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
-	// Platform is the host information for OS and Arch.
+	// Platform specifies the configuration's target platform.
 	Platform Platform `json:"platform"`
-	// Process is the container's main process.
+	// Process configures the container process.
 	Process Process `json:"process"`
-	// Root is the root information for the container's filesystem.
+	// Root configures the container's root filesystem.
 	Root Root `json:"root"`
-	// Hostname is the container's host name.
+	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
-	// Mounts profiles configuration for adding mounts to the container's filesystem.
-	Mounts []Mount `json:"mounts"`
+	// Mounts configures additional mounts (on top of Root).
+	Mounts []Mount `json:"mounts,omitempty"`
+	// Hooks configures callbacks for container lifecycle events.
+	Hooks Hooks `json:"hooks"`
+	// Annotations contains arbitrary metadata for the container.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Linux is platform specific configuration for Linux based containers.
+	Linux *Linux `json:"linux,omitempty" platform:"linux"`
+	// Solaris is platform specific configuration for Solaris containers.
+	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
+	// Windows is platform specific configuration for Windows based containers, including Hyper-V containers.
+	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 }
 
 // Windows contains platform specific configuration for Windows based containers.
@@ -177,3 +177,19 @@ const (
 
 // Version is the specification version that the package types support.
 var Version = fmt.Sprintf("%d.%d.%d%s (Windows)", VersionMajor, VersionMinor, VersionPatch, VersionDev)
+
+//
+// Temporary structures. Ultimately this whole file will be removed.
+//
+
+// Linux contains platform specific configuration for Linux based containers.
+type Linux struct {
+}
+
+// Solaris contains platform specific configuration for Solaris application containers.
+type Solaris struct {
+}
+
+// Hooks for container setup and teardown
+type Hooks struct {
+}

--- a/oci/defaults_windows.go
+++ b/oci/defaults_windows.go
@@ -7,17 +7,13 @@ import (
 )
 
 // DefaultSpec returns default spec used by docker.
-func DefaultSpec() windowsoci.WindowsSpec {
-	s := windowsoci.Spec{
+func DefaultSpec() windowsoci.Spec {
+	return windowsoci.Spec{
 		Version: windowsoci.Version,
 		Platform: windowsoci.Platform{
 			OS:   runtime.GOOS,
 			Arch: runtime.GOARCH,
 		},
-	}
-
-	return windowsoci.WindowsSpec{
-		Spec:    s,
-		Windows: windowsoci.Windows{},
+		Windows: &windowsoci.Windows{},
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This make the Windows hacked `OCI` implementation converging towards the current master of `opencontainers\specs\specs-go`.

It removes the `WindowsSpec` structure, and instead uses the same pattern of having the platform struct as a pointer in the main `Spec` structure.

The `Spec` structure itself is copied directly from opencontainers. Rather than modify the structure to comment out Linux/Solaris, stub implementations for them have been added to `types_windows.go`. In this way, it will be much easier to create a PR back to OCI as this file gets closer and closer to OCI master.

The rest of the changes are compilation fix-ups.

Would appreciate getting this merged into docker master sooner so that I can crack on with further updates :smile:

@crosbymichael 
