### PR TITLE
Prevent stdout / stderr race condition in limitedBuffer

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/net/context"
@@ -271,11 +272,15 @@ func (d *Daemon) stopHealthchecks(c *container.Container) {
 // Buffer up to maxOutputLen bytes. Further data is discarded.
 type limitedBuffer struct {
 	buf       bytes.Buffer
+	mu        sync.Mutex
 	truncated bool // indicates that data has been lost
 }
 
 // Append to limitedBuffer while there is room.
 func (b *limitedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	bufLen := b.buf.Len()
 	dataLen := len(data)
 	keep := min(maxOutputLen-bufLen, dataLen)
@@ -290,6 +295,9 @@ func (b *limitedBuffer) Write(data []byte) (int, error) {
 
 // The contents of the buffer, with "..." appended if it overflowed.
 func (b *limitedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	out := b.buf.String()
 	if b.truncated {
 		out = out + "..."


### PR DESCRIPTION
There is a possibility of a race condition in the stdout / stderr stream capture processing for container health checks. Output from the stdout and stderr streams are collected into the same bytes.Buffer via limitedBuffer, however bytes.Buffer is not thread-safe.

This change, which Fixes #26384, introduces a mutex in limitedBuffer to synchronize writes.
### Steps to reproduce

When run as a HEALTHCHECK, the following example program will spontaneously cause a panic.

stdio.go:

```
package main

import (
    "fmt"
    "io"
    "os"
    "strings"
    "sync"
)

func main() {
    var doneWait sync.WaitGroup
    var readyWait sync.WaitGroup
    var barrierWait sync.WaitGroup

    barrierWait.Add(1)

    out := func(target io.Writer, str string) {
        readyWait.Done()

        // Collect all goroutines here so stdio/err is written to as close to the same time as possible
        barrierWait.Wait()

        fmt.Fprintf(target, "%s\n", str)
        doneWait.Done()
    }

    for i := 0; i < 16; i++ {
        readyWait.Add(2)
        doneWait.Add(2)

        go out(os.Stdout, strings.Repeat(".", 40))
        go out(os.Stderr, strings.Repeat("!", 40))
    }

    readyWait.Wait()
    barrierWait.Done()
    doneWait.Wait()
}

```

An example of the panic, This is similar to those mentioned in #26384.

```
panic: runtime error: slice bounds out of range

goroutine 584795 [running]:
panic(0x1b1e1c0, 0xc82000e070)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
bytes.(*Buffer).grow(0xc823e45d00, 0x11f, 0xc821ae4db0)
        /usr/local/go/src/bytes/buffer.go:112 +0x141
bytes.(*Buffer).Write(0xc823e45d00, 0xc823816000, 0x11f, 0x8000, 0x5f, 0x0, 0x0)
        /usr/local/go/src/bytes/buffer.go:134 +0x4b
github.com/docker/docker/daemon.(*limitedBuffer).Write(0xc823e45d00, 0xc823816000, 0x11f, 0x8000, 0x11f, 0x0, 0x0)
        /go/src/github.com/docker/docker/daemon/health.go:288 +0xae
io.copyBuffer(0x7f6598480a48, 0xc823e45d00, 0x7f659852f710, 0xc821925840, 0xc823816000, 0x8000, 0x8000, 0x0, 0x0, 0x0)
        /usr/local/go/src/io/io.go:382 +0x2c9
io.Copy(0x7f6598480a48, 0xc823e45d00, 0x7f659852f710, 0xc821925840, 0xc821925840, 0x0, 0x0)
        /usr/local/go/src/io/io.go:350 +0x64
github.com/docker/docker/container.AttachStreams.func2(0x1e03aa0, 0x6, 0x7f6598480a48, 0xc823e45d00, 0x7f659852f6e0, 0xc821925840)
        /go/src/github.com/docker/docker/container/container.go:433 +0x1cc
created by github.com/docker/docker/container.AttachStreams
        /go/src/github.com/docker/docker/container/container.go:450 +0x37e
```

As this is intermittent, it may take a while before the panic occurs, running more containers (e.g. scaling the service to 100) improves the chances of the issue occurring.

Dockerfile used for testing, uses stdio.go from above.

```
FROM busybox:latest

COPY stdio /stdio
HEALTHCHECK --interval=1s CMD /stdio

ENTRYPOINT ["busybox"]
CMD ["sleep", "99999999"]

```

Signed-off-by: Stephen Drake stephen@xenolith.net
