### PR TITLE
project: move go binaries installation to separate script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -222,48 +222,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	hello-world:latest@sha256:8be990ef2aeb16dbcb9271ddfe2610fa6658d13f6dfb8bc72074cc1ca36966a7
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Download toml validator
-ENV TOMLV_COMMIT 9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml" \
-	&& (cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT") \
-	&& go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv \
-	&& rm -rf "$GOPATH"
-
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
-	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
-	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp apparmor selinux" \
-	&& cp runc /usr/local/bin/docker-runc \
-	&& rm -rf "$GOPATH"
-
-# Install containerd
-ENV CONTAINERD_COMMIT 2545227b0357eb55e369fa0072baef9ad91cdb69
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \
-	&& cd "$GOPATH/src/github.com/docker/containerd" \
-	&& git checkout -q "$CONTAINERD_COMMIT" \
-	&& make static \
-	&& cp bin/containerd /usr/local/bin/docker-containerd \
-	&& cp bin/containerd-shim /usr/local/bin/docker-containerd-shim \
-	&& cp bin/ctr /usr/local/bin/docker-containerd-ctr \
-	&& rm -rf "$GOPATH"
-
-ENV GRIMES_COMMIT f207601a8d19a534cc90d9e26e037e9931ccb9db
-RUN set -x \
-    && export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes" \
-	&& cd "$GOPATH/grimes" \
-	&& git checkout -q "$GRIMES_COMMIT" \
-	&& make \
-	&& cp init /usr/local/bin/docker-init \
-	&& rm -rf "$GOPATH"
+# Install tomlv, runc, containerd.and grimes
+# Please edit hack/dockerfile/install-binaries.sh to update them.
+COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
+RUN /tmp/install-binaries.sh tomlv runc containerd grimes
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -165,48 +165,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	aarch64/hello-world:latest@sha256:65a4a158587b307bb02db4de41b836addb0c35175bdc801367b1ac1ddeb9afda
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Download toml validator
-ENV TOMLV_COMMIT 9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml" \
-	&& (cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT") \
-	&& go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv \
-	&& rm -rf "$GOPATH"
-
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
-	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
-	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp apparmor selinux" \
-	&& cp runc /usr/local/bin/docker-runc \
-	&& rm -rf "$GOPATH"
-
-# Install containerd
-ENV CONTAINERD_COMMIT 2545227b0357eb55e369fa0072baef9ad91cdb69
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \
-	&& cd "$GOPATH/src/github.com/docker/containerd" \
-	&& git checkout -q "$CONTAINERD_COMMIT" \
-	&& make static \
-	&& cp bin/containerd /usr/local/bin/docker-containerd \
-	&& cp bin/containerd-shim /usr/local/bin/docker-containerd-shim \
-	&& cp bin/ctr /usr/local/bin/docker-containerd-ctr \
-	&& rm -rf "$GOPATH"
-
-ENV GRIMES_COMMIT f207601a8d19a534cc90d9e26e037e9931ccb9db
-RUN set -x \
-    && export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes" \
-	&& cd "$GOPATH/grimes" \
-	&& git checkout -q "$GRIMES_COMMIT" \
-	&& make \
-	&& cp init /usr/local/bin/docker-init \
-	&& rm -rf "$GOPATH"
+# Install tomlv, runc, containerd.and grimes
+# Please edit hack/dockerfile/install-binaries.sh to update them.
+COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
+RUN /tmp/install-binaries.sh tomlv runc containerd grimes
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -163,48 +163,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	armhf/hello-world:latest@sha256:161dcecea0225975b2ad5f768058212c1e0d39e8211098666ffa1ac74cfb7791
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Download toml validator
-ENV TOMLV_COMMIT 9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml" \
-	&& (cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT") \
-	&& go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv \
-	&& rm -rf "$GOPATH"
-
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
-	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
-	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp apparmor selinux" \
-	&& cp runc /usr/local/bin/docker-runc \
-	&& rm -rf "$GOPATH"
-
-# Install containerd
-ENV CONTAINERD_COMMIT 2545227b0357eb55e369fa0072baef9ad91cdb69
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \
-	&& cd "$GOPATH/src/github.com/docker/containerd" \
-	&& git checkout -q "$CONTAINERD_COMMIT" \
-	&& make static \
-	&& cp bin/containerd /usr/local/bin/docker-containerd \
-	&& cp bin/containerd-shim /usr/local/bin/docker-containerd-shim \
-	&& cp bin/ctr /usr/local/bin/docker-containerd-ctr \
-	&& rm -rf "$GOPATH"
-
-ENV GRIMES_COMMIT f207601a8d19a534cc90d9e26e037e9931ccb9db
-RUN set -x \
-    && export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes" \
-	&& cd "$GOPATH/grimes" \
-	&& git checkout -q "$GRIMES_COMMIT" \
-	&& make \
-	&& cp init /usr/local/bin/docker-init \
-	&& rm -rf "$GOPATH"
+# Install tomlv, runc, containerd.and grimes
+# Please edit hack/dockerfile/install-binaries.sh to update them.
+COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
+RUN /tmp/install-binaries.sh tomlv runc containerd grimes
 
 ENTRYPOINT ["hack/dind"]
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -183,48 +183,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	ppc64le/hello-world:latest@sha256:186a40a9a02ca26df0b6c8acdfb8ac2f3ae6678996a838f977e57fac9d963974
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Download toml validator
-ENV TOMLV_COMMIT 9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml" \
-	&& (cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT") \
-	&& go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv \
-	&& rm -rf "$GOPATH"
-
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
-	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
-	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="apparmor seccomp selinux" \
-	&& cp runc /usr/local/bin/docker-runc \
-	&& rm -rf "$GOPATH"
-
-# Install containerd
-ENV CONTAINERD_COMMIT 2545227b0357eb55e369fa0072baef9ad91cdb69
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \
-	&& cd "$GOPATH/src/github.com/docker/containerd" \
-	&& git checkout -q "$CONTAINERD_COMMIT" \
-	&& make static \
-	&& cp bin/containerd /usr/local/bin/docker-containerd \
-	&& cp bin/containerd-shim /usr/local/bin/docker-containerd-shim \
-	&& cp bin/ctr /usr/local/bin/docker-containerd-ctr \
-	&& rm -rf "$GOPATH"
-
-ENV GRIMES_COMMIT f207601a8d19a534cc90d9e26e037e9931ccb9db
-RUN set -x \
-    && export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes" \
-	&& cd "$GOPATH/grimes" \
-	&& git checkout -q "$GRIMES_COMMIT" \
-	&& make \
-	&& cp init /usr/local/bin/docker-init \
-	&& rm -rf "$GOPATH"
+# Install tomlv, runc, containerd.and grimes
+# Please edit hack/dockerfile/install-binaries.sh to update them.
+COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
+RUN /tmp/install-binaries.sh tomlv runc containerd grimes
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -175,48 +175,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	s390x/hello-world:latest@sha256:780d80b3a7677c3788c0d5cd9168281320c8d4a6d9183892d8ee5cdd610f5699
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Download toml validator
-ENV TOMLV_COMMIT 9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml" \
-	&& (cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT") \
-	&& go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv \
-	&& rm -rf "$GOPATH"
-
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
-	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
-	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp apparmor selinux" \
-	&& cp runc /usr/local/bin/docker-runc \
-	&& rm -rf "$GOPATH"
-
-# Install containerd
-ENV CONTAINERD_COMMIT 2545227b0357eb55e369fa0072baef9ad91cdb69
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \
-	&& cd "$GOPATH/src/github.com/docker/containerd" \
-	&& git checkout -q "$CONTAINERD_COMMIT" \
-	&& make static \
-	&& cp bin/containerd /usr/local/bin/docker-containerd \
-	&& cp bin/containerd-shim /usr/local/bin/docker-containerd-shim \
-	&& cp bin/ctr /usr/local/bin/docker-containerd-ctr \
-	&& rm -rf "$GOPATH"
-
-ENV GRIMES_COMMIT f207601a8d19a534cc90d9e26e037e9931ccb9db
-RUN set -x \
-    && export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes" \
-	&& cd "$GOPATH/grimes" \
-	&& git checkout -q "$GRIMES_COMMIT" \
-	&& make \
-	&& cp init /usr/local/bin/docker-init \
-	&& rm -rf "$GOPATH"
+# Install tomlv, runc, containerd.and grimes
+# Please edit hack/dockerfile/install-binaries.sh to update them.
+COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
+RUN /tmp/install-binaries.sh tomlv runc containerd grimes
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -56,39 +56,10 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 ENV CGO_LDFLAGS -L/lib
 
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
-	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
-	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp apparmor selinux" \
-	&& cp runc /usr/local/bin/docker-runc \
-	&& rm -rf "$GOPATH"
-
-# Install containerd
-ENV CONTAINERD_COMMIT 2545227b0357eb55e369fa0072baef9ad91cdb69
-RUN set -x \
-	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \
-	&& cd "$GOPATH/src/github.com/docker/containerd" \
-	&& git checkout -q "$CONTAINERD_COMMIT" \
-	&& make static \
-	&& cp bin/containerd /usr/local/bin/docker-containerd \
-	&& cp bin/containerd-shim /usr/local/bin/docker-containerd-shim \
-	&& cp bin/ctr /usr/local/bin/docker-containerd-ctr \
-	&& rm -rf "$GOPATH"
-
-ENV GRIMES_COMMIT f207601a8d19a534cc90d9e26e037e9931ccb9db
-RUN set -x \
-    && export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes" \
-	&& cd "$GOPATH/grimes" \
-	&& git checkout -q "$GRIMES_COMMIT" \
-	&& make \
-	&& cp init /usr/local/bin/docker-init \
-	&& rm -rf "$GOPATH"
+# Install runc, containerd.and grimes
+# Please edit hack/dockerfile/install-binaries.sh to update them.
+COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
+RUN /tmp/install-binaries.sh runc containerd grimes
 
 ENV AUTO_GOPATH 1
 WORKDIR /usr/src/docker

--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e
+set -x
+
+TOMLV_COMMIT=9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
+RUNC_COMMIT=cc29e3dded8e27ba8f65738f40d251c885030a28
+CONTAINERD_COMMIT=2545227b0357eb55e369fa0072baef9ad91cdb69
+GRIMES_COMMIT=f207601a8d19a534cc90d9e26e037e9931ccb9db
+
+export GOPATH="$(mktemp -d)"
+
+for prog in "$@"
+do
+	case $prog in
+		tomlv)
+			echo "Install tomlv version $TOMLV_COMMIT"
+			git clone https://github.com/BurntSushi/toml.git "$GOPATH/src/github.com/BurntSushi/toml"
+			cd "$GOPATH/src/github.com/BurntSushi/toml" && git checkout -q "$TOMLV_COMMIT"
+			go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv
+			;;
+
+		runc)
+			echo "Install runc version $RUNC_COMMIT"
+			git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
+			cd "$GOPATH/src/github.com/opencontainers/runc"
+			git checkout -q "$RUNC_COMMIT"
+			make static BUILDTAGS="seccomp apparmor selinux"
+			cp runc /usr/local/bin/docker-runc
+			;;
+
+		containerd)
+			echo "Install containerd version $CONTAINERD_COMMIT"
+			git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd"
+			cd "$GOPATH/src/github.com/docker/containerd"
+			git checkout -q "$CONTAINERD_COMMIT"
+			make static
+			cp bin/containerd /usr/local/bin/docker-containerd
+			cp bin/containerd-shim /usr/local/bin/docker-containerd-shim
+			cp bin/ctr /usr/local/bin/docker-containerd-ctr
+			;;
+
+		grimes)
+			echo "Install grimes version $GRIMES_COMMIT"
+			git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes"
+			cd "$GOPATH/grimes"
+			git checkout -q "$GRIMES_COMMIT"
+			make
+			cp init /usr/local/bin/docker-init
+			;;
+
+		*)
+			echo echo "Usage: $0 [tomlv|runc|containerd|grimes]"
+			exit 1
+
+	esac
+done
+
+rm -rf "$GOPATH"

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -72,9 +72,8 @@ set -e
 				&& ln -snf /usr/src/docker /go/src/github.com/docker/docker
 		EOF
 
-		# get the RUNC and CONTAINERD commit from the root Dockerfile, this keeps the commits in sync
-		awk '$1 == "ENV" && $2 == "RUNC_COMMIT" { print; exit }' Dockerfile >> "$DEST/$version/Dockerfile.build"
-		awk '$1 == "ENV" && $2 == "CONTAINERD_COMMIT" { print; exit }' Dockerfile >> "$DEST/$version/Dockerfile.build"
+		echo "ENV RUNC_COMMIT $(grep "^RUNC_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
+		echo "ENV CONTAINERD_COMMIT $(grep "^CONTAINERD_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
 
 		# add runc and containerd compile and install
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -92,9 +92,8 @@ set -e
 			RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 		EOF
 
-		# get the RUNC and CONTAINERD commit from the root Dockerfile, this keeps the commits in sync
-		awk '$1 == "ENV" && $2 == "RUNC_COMMIT" { print; exit }' Dockerfile >> "$DEST/$version/Dockerfile.build"
-		awk '$1 == "ENV" && $2 == "CONTAINERD_COMMIT" { print; exit }' Dockerfile >> "$DEST/$version/Dockerfile.build"
+		echo "ENV RUNC_COMMIT $(grep "^RUNC_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
+		echo "ENV CONTAINERD_COMMIT $(grep "^CONTAINERD_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
 
 		# add runc and containerd compile and install
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF


### PR DESCRIPTION
It makes containerd and runc updates little more pleasant at the expense of cloning and compiling them on each change of vendor.sh.
