### PR TITLE
Fix issue of `WARNING: --size ignored for volume` for `docker inspect`

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -102,7 +102,7 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 		ObjectInspector func(string) (interface{}, []byte, error)
 	}{
 		{"container", true, inspectContainers(ctx, dockerCli, getSize)},
-		{"image", true, inspectImages(ctx, dockerCli)},
+		{"image", false, inspectImages(ctx, dockerCli)},
 		{"network", false, inspectNetwork(ctx, dockerCli)},
 		{"volume", false, inspectVolume(ctx, dockerCli)},
 		{"service", false, inspectService(ctx, dockerCli)},
@@ -126,7 +126,7 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 				}
 				return v, raw, err
 			}
-			if !inspectData.IsSizeSupported {
+			if getSize && !inspectData.IsSizeSupported {
 				fmt.Fprintf(dockerCli.Err(), "WARNING: --size ignored for %s\n", inspectData.ObjectType)
 			}
 			return v, raw, err


### PR DESCRIPTION
When `docker inspect` is invoked, it is possible to pass a flag of `-s` for container types to display size information. If `-s` is used for non-container types then a warning `WARNING: --size ignored for volume` will show up.

However, currently `WARNING: --size ignored for volume` will show up even when `-s` is not passed to `docker inspect` for non-container types.

This fix fixes this issue by checking if `-s` has been passed or not (`getSize`).
Also, since image inspect does not support `-s`, `IsSizeSupported` has been changed
to false for images.

This fix is tested manually.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
