### PR TITLE
Fix broken JSON support in cli/command/formatter

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -79,6 +79,10 @@ type containerContext struct {
 	c     types.Container
 }
 
+func (c *containerContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(c)
+}
+
 func (c *containerContext) ID() string {
 	c.AddHeader(containerIDHeader)
 	if c.trunc {

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -321,5 +322,51 @@ func TestContainerContextWriteWithNoContainers(t *testing.T) {
 		assert.Equal(t, context.expected, out.String())
 		// Clean buffer
 		out.Reset()
+	}
+}
+
+func TestContainerContextWriteJSON(t *testing.T) {
+	unix := time.Now().Add(-65 * time.Second).Unix()
+	containers := []types.Container{
+		{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unix},
+		{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu", Created: unix},
+	}
+	expectedCreated := time.Unix(unix, 0).String()
+	expectedJSONs := []map[string]interface{}{
+		{"Command": "\"\"", "CreatedAt": expectedCreated, "ID": "containerID1", "Image": "ubuntu", "Labels": "", "LocalVolumes": "0", "Mounts": "", "Names": "foobar_baz", "Ports": "", "RunningFor": "About a minute", "Size": "0 B", "Status": ""},
+		{"Command": "\"\"", "CreatedAt": expectedCreated, "ID": "containerID2", "Image": "ubuntu", "Labels": "", "LocalVolumes": "0", "Mounts": "", "Names": "foobar_bar", "Ports": "", "RunningFor": "About a minute", "Size": "0 B", "Status": ""},
+	}
+	out := bytes.NewBufferString("")
+	err := ContainerWrite(Context{Format: "{{json .}}", Output: out}, containers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		t.Logf("Output: line %d: %s", i, line)
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatal(err)
+		}
+		assert.DeepEqual(t, m, expectedJSONs[i])
+	}
+}
+
+func TestContainerContextWriteJSONField(t *testing.T) {
+	containers := []types.Container{
+		{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu"},
+		{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu"},
+	}
+	out := bytes.NewBufferString("")
+	err := ContainerWrite(Context{Format: "{{json .ID}}", Output: out}, containers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		t.Logf("Output: line %d: %s", i, line)
+		var s string
+		if err := json.Unmarshal([]byte(line), &s); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, s, containers[i].ID)
 	}
 }

--- a/cli/command/formatter/network.go
+++ b/cli/command/formatter/network.go
@@ -53,6 +53,10 @@ type networkContext struct {
 	n     types.NetworkResource
 }
 
+func (c *networkContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(c)
+}
+
 func (c *networkContext) ID() string {
 	c.AddHeader(networkIDHeader)
 	if c.trunc {

--- a/cli/command/formatter/reflect.go
+++ b/cli/command/formatter/reflect.go
@@ -1,0 +1,65 @@
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"unicode"
+)
+
+func marshalJSON(x interface{}) ([]byte, error) {
+	m, err := marshalMap(x)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(m)
+}
+
+// marshalMap marshals x to map[string]interface{}
+func marshalMap(x interface{}) (map[string]interface{}, error) {
+	val := reflect.ValueOf(x)
+	if val.Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("expected a pointer to a struct, got %v", val.Kind())
+	}
+	if val.IsNil() {
+		return nil, fmt.Errorf("expxected a pointer to a struct, got nil pointer")
+	}
+	valElem := val.Elem()
+	if valElem.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected a pointer to a struct, got a pointer to %v", valElem.Kind())
+	}
+	typ := val.Type()
+	m := make(map[string]interface{})
+	for i := 0; i < val.NumMethod(); i++ {
+		k, v, err := marshalForMethod(typ.Method(i), val.Method(i))
+		if err != nil {
+			return nil, err
+		}
+		if k != "" {
+			m[k] = v
+		}
+	}
+	return m, nil
+}
+
+var unmarshallableNames = map[string]struct{}{"FullHeader": {}}
+
+// marshalForMethod returns the map key and the map value for marshalling the method.
+// It returns ("", nil, nil) for valid but non-marshallable parameter. (e.g. "unexportedFunc()")
+func marshalForMethod(typ reflect.Method, val reflect.Value) (string, interface{}, error) {
+	if val.Kind() != reflect.Func {
+		return "", nil, fmt.Errorf("expected func, got %v", val.Kind())
+	}
+	name, numIn, numOut := typ.Name, val.Type().NumIn(), val.Type().NumOut()
+	_, blackListed := unmarshallableNames[name]
+	// FIXME: In text/template, (numOut == 2) is marshallable,
+	//        if the type of the second param is error.
+	marshallable := unicode.IsUpper(rune(name[0])) && !blackListed &&
+		numIn == 0 && numOut == 1
+	if !marshallable {
+		return "", nil, nil
+	}
+	result := val.Call(make([]reflect.Value, numIn))
+	intf := result[0].Interface()
+	return name, intf, nil
+}

--- a/cli/command/formatter/reflect_test.go
+++ b/cli/command/formatter/reflect_test.go
@@ -1,0 +1,66 @@
+package formatter
+
+import (
+	"reflect"
+	"testing"
+)
+
+type dummy struct {
+}
+
+func (d *dummy) Func1() string {
+	return "Func1"
+}
+
+func (d *dummy) func2() string {
+	return "func2(should not be marshalled)"
+}
+
+func (d *dummy) Func3() (string, int) {
+	return "Func3(should not be marshalled)", -42
+}
+
+func (d *dummy) Func4() int {
+	return 4
+}
+
+type dummyType string
+
+func (d *dummy) Func5() dummyType {
+	return dummyType("Func5")
+}
+
+func (d *dummy) FullHeader() string {
+	return "FullHeader(should not be marshalled)"
+}
+
+var dummyExpected = map[string]interface{}{
+	"Func1": "Func1",
+	"Func4": 4,
+	"Func5": dummyType("Func5"),
+}
+
+func TestMarshalMap(t *testing.T) {
+	d := dummy{}
+	m, err := marshalMap(&d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dummyExpected, m) {
+		t.Fatalf("expected %+v, got %+v",
+			dummyExpected, m)
+	}
+}
+
+func TestMarshalMapBad(t *testing.T) {
+	if _, err := marshalMap(nil); err == nil {
+		t.Fatal("expected an error (argument is nil)")
+	}
+	if _, err := marshalMap(dummy{}); err == nil {
+		t.Fatal("expected an error (argument is non-pointer)")
+	}
+	x := 42
+	if _, err := marshalMap(&x); err == nil {
+		t.Fatal("expected an error (argument is a pointer to non-struct)")
+	}
+}

--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -139,6 +139,10 @@ type serviceInspectContext struct {
 	subContext
 }
 
+func (ctx *serviceInspectContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(ctx)
+}
+
 func (ctx *serviceInspectContext) ID() string {
 	return ctx.Service.ID
 }

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -52,6 +52,10 @@ type volumeContext struct {
 	v types.Volume
 }
 
+func (c *volumeContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(c)
+}
+
 func (c *volumeContext) Name() string {
 	c.AddHeader(nameHeader)
 	return c.v.Name

--- a/pkg/testutil/assert/assert.go
+++ b/pkg/testutil/assert/assert.go
@@ -4,6 +4,7 @@ package assert
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 )
@@ -41,6 +42,14 @@ func EqualStringSlice(t TestingT, actual, expected []string) {
 func NilError(t TestingT, err error) {
 	if err != nil {
 		fatal(t, "Expected no error, got: %s", err.Error())
+	}
+}
+
+// DeepEqual compare the actual value to the expected value and fails the test if
+// they are not "deeply equal".
+func DeepEqual(t TestingT, actual, expected interface{}) {
+	if !reflect.DeepEqual(actual, expected) {
+		fatal(t, "Expected '%v' (%T) got '%v' (%T)", expected, expected, actual, actual)
 	}
 }
 


### PR DESCRIPTION
**\- What I did**

Fix these commands (results were empty):

```
$ docker ps --format '{{json .}}'
$ docker network ls --format '{{json .}}'
$ docker volume ls --format '{{json .}}'
```

**\- How I did it**

Implemented the [`json.Marshaler`](https://golang.org/pkg/encoding/json/#Marshaler) interface

**\- How to verify it**

```
$ docker ps --format '{{json .}}'
$ docker network ls --format '{{json .}}'
$ docker volume ls --format '{{json .}}'
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
