### PR TITLE
Optimization images function

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -66,6 +66,7 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
 	}
 
 	var beforeFilter, sinceFilter *image.Image
+
 	err = imageFilters.WalkValues("before", func(value string) error {
 		beforeFilter, err = daemon.GetImage(value)
 		return err
@@ -86,6 +87,9 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
 
 	var filterTagged bool
 	if filter != "" {
+		if _, err := daemon.GetImage(filter); err != nil {
+			return nil, err
+		}
 		filterRef, err := reference.ParseNamed(filter)
 		if err == nil { // parse error means wildcard repo
 			if _, ok := filterRef.(reference.NamedTagged); ok {


### PR DESCRIPTION
When I perform “docker images XX”(XX is a no image name), there will be the following: 
root@zz:/# docker images XX
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
root@zz:/# 

the system will not be reported to the wrong, I think this time the system should be reported to the wrong

Signed-off-by: zhouhao zhouhao@cn.fujitsu.com
