### PR TITLE
removes sfsmithcha from maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -61,7 +61,6 @@
 			"jamtur01",
 			"misty",
 			"moxiegirl",
-			"sfsmithcha",
 			"sven",
 			"thajeztah"
 		]
@@ -114,7 +113,7 @@
 			# expressions (coz, YOLO!) on July 10, 2014
 			# https://github.com/docker/docker/pull/6950/commits/f3a68ffa390fb851115c77783fa4031f1d3b2995.
 			# Jess was Release Captain for Docker 1.4, 1.6 and 1.7, and contributed
-			# many features and improvement, among which "seccomp profiles" (making 
+			# many features and improvement, among which "seccomp profiles" (making
 			# containers a lot more secure). Besides being a maintainer, she
 			# set up the CI infrastructure for the project, giving everyone
 			# something to shout at if a PR failed ("noooo Janky!").
@@ -126,7 +125,7 @@
 			"jfrazelle",
 
 			# Vincent "vbatts!" Batts made his first contribution to the project
-			# in November 2013, to become a maintainer a few months later, on 
+			# in November 2013, to become a maintainer a few months later, on
 			# May 10, 2014 (https://github.com/docker/docker/commit/d6e666a87a01a5634c250358a94c814bf26cb778).
 			# As a maintainer, Vincent made important contributions to core elements
 			# of Docker, such as "distribution" (tarsum) and graphdrivers (btrfs, devicemapper).
@@ -283,11 +282,6 @@
 	Name = "Antonio Murdaca"
 	Email = "runcom@redhat.com"
 	GitHub = "runcom"
-
-	[people.sfsmithcha]
-	Name = "Charles Smith"
-	Email = "charles.smith@docker.com"
-	GitHub = "sfsmithcha"
 
 	[people.shykes]
 	Name = "Solomon Hykes"


### PR DESCRIPTION
Removes Charles (sfsmithcha) from docs maintainers.

👋  🐳 

Signed-off-by: Charles Smith charles.smith@docker.com
