### PR TITLE
project: add area/daemon and area/docs labels

### DIFF
--- a/project/ISSUE-TRIAGE.md
+++ b/project/ISSUE-TRIAGE.md
@@ -37,7 +37,6 @@ An issue can have multiple of the following labels.
 | Kind             | Description                                                                                                                     |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | kind/bug         | Bugs are bugs. The cause may or may not be known at triage time so debugging should be taken account into the time estimate.    |
-| kind/docs        | Writing documentation, man pages, articles, blogs, or other significant word-driven task.                                       |
 | kind/enhancement | Enhancement are not bugs or new features but can drastically improve usability or performance of a project component.           |
 | kind/feature     | Functionality or other elements that the project does not currently support.  Features are new and shiny.                       |
 | kind/question    | Contains a user or contributor question requiring a response.                                                                   |
@@ -49,7 +48,9 @@ An issue can have multiple of the following labels.
 | area/api                  |
 | area/builder              |
 | area/cli                  |
+| area/daemon               |
 | area/distribution         |
+| area/docs                 |
 | area/kernel               |
 | area/logging              |
 | area/networking           |


### PR DESCRIPTION
I've removed `kind/docs` because I don't think that it's right kind for
issues.
