### PR TITLE
Add errexit to mkimage-yum.sh

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -6,6 +6,8 @@
 # a CentOS image on CentOS).  See contrib/mkimage-rinse.sh for a way
 # to build CentOS images on other systems.
 
+set -e
+
 usage() {
     cat <<EOOPTS
 $(basename $0) [OPTIONS] <name>


### PR DESCRIPTION
![chi](https://67.media.tumblr.com/tumblr_me08v7ZyWz1rlklz4o1_500.gif)

Add errexit to mkimage-yum bash script to abort early. This to prevent
disaster when mktemp fails and leave $target variable empty.
