### PR TITLE
Add a script to install a bundle into Docker for Mac

### DIFF
--- a/contrib/mac-install-bundle.sh
+++ b/contrib/mac-install-bundle.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+
+errexit() {
+	echo "$1"
+	exit 1
+}
+
+[ "$(uname -s)" == "Darwin" ] || errexit "This script can only be used on a Mac"
+
+[ $# -eq 1 ] || errexit "Usage: $0 install|undo"
+
+BUNDLE="bundles/$(cat VERSION)"
+BUNDLE_PATH="$PWD/$BUNDLE"
+CLIENT_PATH="$BUNDLE_PATH/cross/darwin/amd64/docker"
+DATABASE="$HOME/Library/Containers/com.docker.docker/Data/database"
+DATABASE_KEY="$DATABASE/com.docker.driver.amd64-linux/bundle"
+
+[ -d "$DATABASE" ] || errexit "Docker for Mac must be installed for this script"
+
+case "$1" in
+"install")
+	[ -d "$BUNDLE" ] || errexit "cannot find bundle $BUNDLE"
+	[ -e "$CLIENT_PATH" ] || errexit "you need to run make cross first"
+	[ -e "$BUNDLE/binary-daemon/dockerd" ] || errexit "you need to build binaries first"
+	[ -f "$BUNDLE/binary-client/docker" ] || errexit "you need to build binaries first"
+	git -C "$DATABASE" reset --hard >/dev/null
+	echo "$BUNDLE_PATH" > "$DATABASE_KEY"
+	git -C "$DATABASE" add "$DATABASE_KEY"
+	git -C "$DATABASE" commit -m "update bundle to $BUNDLE_PATH"
+	rm -f /usr/local/bin/docker
+	cp "$CLIENT_PATH" /usr/local/bin
+	echo "Bundle installed. Restart Docker to use. To uninstall, reset Docker to factory defaults."
+	;;
+"undo")
+	git -C "$DATABASE" reset --hard >/dev/null
+	[ -f "$DATABASE_KEY" ] || errexit "bundle not set"
+	git -C "$DATABASE" rm "$DATABASE_KEY"
+	git -C "$DATABASE" commit -m "remove bundle"
+	rm -f /usr/local/bin/docker
+	ln -s "$HOME/Library/Group Containers/group.com.docker/bin/docker" /usr/local/bin
+	echo "Bundle removed. Using dev versions may cause issues, a reset to factory defaults is recommended."
+	;;
+esac


### PR DESCRIPTION
**Note this does not yet work on a released Docker for Mac, only the master channel. Support should land next week in the beta**

After building docker from the git repo, you can run

```
./contrib/mac-install-bundle.sh install
```

and this will tell Docker for Mac to look for a bundle at the current
path to run instead of the built in version of Docker. This will persist
until you do a factory reset or run

```
./contrib/mac-install-bundle.sh undo
```

A factory reset is advised to reset as a development Docker may break your
install.

The path must be a path that is shared with Docker for Mac so that the VM
can find it - nothing is installed into the image.

This is in `contrib/` as it is a best effort attempt to make it easier for
Docker for Mac users to test master or pull requests. If it breaks anything
a factory reset is your friend.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![meerkat](https://cloud.githubusercontent.com/assets/482364/18512483/4845f502-7a81-11e6-818a-d577ce430715.jpg)
