### PR TITLE
Fix improper use of `--rm` in test case

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1764,7 +1764,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromBridge(c *check.C) {
 	network := strings.TrimSpace(out)
 
 	name := "test"
-	dockerCmd(c, "create", "--rm", "--name", name, "busybox", "top")
+	dockerCmd(c, "create", "--name", name, "busybox", "top")
 
 	_, _, err := dockerCmdWithError("network", "disconnect", network, name)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
Test is testing that a user can disconnect from the default network
before it is started (#26220).
This test does not need to use `--rm`, which is never taken into account
since the container is never started.

Signed-off-by: Brian Goff cpuguy83@gmail.com
