### PR TITLE
Windows: Move to fstab options as per OCI

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -46,11 +46,14 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		return nil, err
 	}
 	for _, mount := range mounts {
-		s.Mounts = append(s.Mounts, windowsoci.Mount{
+		m := windowsoci.Mount{
 			Source:      mount.Source,
 			Destination: mount.Destination,
-			Readonly:    !mount.Writable,
-		})
+		}
+		if !mount.Writable {
+			m.Options = append(m.Options, "ro")
+		}
+		s.Mounts = append(s.Mounts, m)
 	}
 
 	// In s.Process

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -126,7 +126,13 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		mds[i] = hcsshim.MappedDir{
 			HostPath:      mount.Source,
 			ContainerPath: mount.Destination,
-			ReadOnly:      mount.Readonly}
+			ReadOnly:      false,
+		}
+		for _, o := range mount.Options {
+			if strings.ToLower(o) == "ro" {
+				mds[i].ReadOnly = true
+			}
+		}
 	}
 	configuration.MappedDirectories = mds
 

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -96,11 +96,11 @@ type Mount struct {
 	Destination string `json:"destination"`
 	// Type specifies the mount kind.
 	Type string `json:"type"`
-	// Source specifies the source path of the mount.  In the case of bind mounts
-	// this would be the file on the host.
+	// Source specifies the source path of the mount.  In the case of bind mounts on
+	// Linux based systems this would be the file on the host.
 	Source string `json:"source"`
-	// Readonly specifies if the mount should be read-only
-	Readonly bool `json:"readonly"`
+	// Options are fstab style mount options.
+	Options []string `json:"options,omitempty"`
 }
 
 // HvRuntime contains settings specific to Hyper-V containers


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

No functional changes. Minor update to the currently hacked non-OCI compliant `spec` used in Windows to get closer to OCI compliance. Instead of an explicit readonly field, uses the `fstab` style options as per the current OCI spec (even though fstab is strictly meaningless on Windows). 

The mount structure is now identical to https://github.com/opencontainers/runtime-spec/blob/master/specs-go/config.go#L84-L95
