### PR TITLE
Windows: Unify OCI user struct

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -72,7 +72,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	s.Process.Env = c.CreateDaemonEnvironment(linkedEnv)
 	s.Process.InitialConsoleSize = c.HostConfig.ConsoleSize
 	s.Process.Terminal = c.Config.Tty
-	s.Process.User.User = c.Config.User
+	s.Process.User.Username = c.Config.User
 
 	// In spec.Root
 	s.Root.Path = c.BaseFS

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -66,9 +66,16 @@ type Process struct {
 	Cwd string `json:"cwd"`
 }
 
-// User contains the user information for Windows
+// User specifies specific user (and group) information for the container process.
 type User struct {
-	User string `json:"user,omitempty"`
+	// UID is the user id.
+	UID uint32 `json:"uid" platform:"linux,solaris"`
+	// GID is the group id.
+	GID uint32 `json:"gid" platform:"linux,solaris"`
+	// AdditionalGids are additional group ids set for the container's process.
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
+	// Username is the user name.
+	Username string `json:"username,omitempty" platform:"windows"`
 }
 
 // Root contains information about the container's root filesystem on the host.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Convergence closer to OCI compliance - this modified the `User` struct definition in the hacked OCI spec used on Windows to match the existing `user` structure from https://github.com/opencontainers/runtime-spec/blob/master/specs-go/config.go#L84-L95, but also adding the user field which is required on Windows where UID/GID is meaningless.

There are no functional changes in the PR.
