### PR TITLE
Windows: OCI `process` struct and console size to uint

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -229,8 +229,8 @@ type ImageSearchOptions struct {
 // It can be used to resize container ttys and
 // exec process ttys too.
 type ResizeOptions struct {
-	Height int
-	Width  int
+	Height uint
+	Width  uint
 }
 
 // VersionResponse holds version information for the client and the server

--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -313,7 +313,7 @@ type HostConfig struct {
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
-	ConsoleSize [2]int    // Initial console size
+	ConsoleSize Box       // Initial console size
 	Isolation   Isolation // Isolation technology of the container (eg default, hyperv)
 
 	// Contains container's resources (cgroups, ulimits)
@@ -321,4 +321,10 @@ type HostConfig struct {
 
 	// Mounts specs used by the container
 	Mounts []mount.Mount `json:",omitempty"`
+}
+
+// Box specifies height and width dimensions. Used for sizing of a console.
+type Box struct {
+	Height uint
+	Width  uint
 }

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -135,7 +135,7 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 	// a far better user experience rather than relying on subsequent resizes
 	// to cause things to catch up.
 	if runtime.GOOS == "windows" {
-		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = dockerCli.Out().GetTtySize()
+		hostConfig.ConsoleSize.Height, hostConfig.ConsoleSize.Width = dockerCli.Out().GetTtySize()
 	}
 
 	ctx, cancelFun := context.WithCancel(context.Background())

--- a/cli/command/container/tty.go
+++ b/cli/command/container/tty.go
@@ -16,7 +16,7 @@ import (
 )
 
 // resizeTtyTo resizes tty to specific height and width
-func resizeTtyTo(ctx context.Context, client client.ContainerAPIClient, id string, height, width int, isExec bool) {
+func resizeTtyTo(ctx context.Context, client client.ContainerAPIClient, id string, height, width uint, isExec bool) {
 	if height == 0 && width == 0 {
 		return
 	}

--- a/cli/command/out.go
+++ b/cli/command/out.go
@@ -48,7 +48,7 @@ func (o *OutStream) RestoreTerminal() {
 }
 
 // GetTtySize returns the height and width in characters of the tty
-func (o *OutStream) GetTtySize() (int, int) {
+func (o *OutStream) GetTtySize() (uint, uint) {
 	if !o.isTerminal {
 		return 0, 0
 	}
@@ -59,7 +59,7 @@ func (o *OutStream) GetTtySize() (int, int) {
 			return 0, 0
 		}
 	}
-	return int(ws.Height), int(ws.Width)
+	return uint(ws.Height), uint(ws.Width)
 }
 
 // NewOutStream returns a new OutStream object from a Writer

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -18,10 +18,10 @@ func (cli *Client) ContainerExecResize(ctx context.Context, execID string, optio
 	return cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
 }
 
-func (cli *Client) resize(ctx context.Context, basePath string, height, width int) error {
+func (cli *Client) resize(ctx context.Context, basePath string, height, width uint) error {
 	query := url.Values{}
-	query.Set("h", strconv.Itoa(height))
-	query.Set("w", strconv.Itoa(width))
+	query.Set("h", strconv.Itoa(int(height)))
+	query.Set("w", strconv.Itoa(int(width)))
 
 	resp, err := cli.post(ctx, basePath+"/resize", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -73,7 +73,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		s.Process.Cwd = `C:\`
 	}
 	s.Process.Env = c.CreateDaemonEnvironment(linkedEnv)
-	s.Process.InitialConsoleSize = c.HostConfig.ConsoleSize
+	s.Process.ConsoleSize.Height = c.HostConfig.ConsoleSize.Height
+	s.Process.ConsoleSize.Width = c.HostConfig.ConsoleSize.Width
 	s.Process.Terminal = c.Config.Tty
 	s.Process.User.Username = c.Config.User
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -198,11 +198,12 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 	// is only created if it we're not -t.
 	createProcessParms := hcsshim.ProcessConfig{
 		EmulateConsole:   procToAdd.Terminal,
-		ConsoleSize:      procToAdd.InitialConsoleSize,
 		CreateStdInPipe:  true,
 		CreateStdOutPipe: true,
 		CreateStdErrPipe: !procToAdd.Terminal,
 	}
+	createProcessParms.ConsoleSize[0] = int(procToAdd.ConsoleSize.Height)
+	createProcessParms.ConsoleSize[1] = int(procToAdd.ConsoleSize.Width)
 
 	// Take working directory from the process to add if it is defined,
 	// otherwise take from the first process.

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -66,11 +66,12 @@ func (ctr *container) start() error {
 	createProcessParms := &hcsshim.ProcessConfig{
 		EmulateConsole:   ctr.ociSpec.Process.Terminal,
 		WorkingDirectory: ctr.ociSpec.Process.Cwd,
-		ConsoleSize:      ctr.ociSpec.Process.InitialConsoleSize,
 		CreateStdInPipe:  !isServicing,
 		CreateStdOutPipe: !isServicing,
 		CreateStdErrPipe: !ctr.ociSpec.Process.Terminal && !isServicing,
 	}
+	createProcessParms.ConsoleSize[0] = int(ctr.ociSpec.Process.ConsoleSize.Height)
+	createProcessParms.ConsoleSize[1] = int(ctr.ociSpec.Process.ConsoleSize.Width)
 
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(ctr.ociSpec.Process.Env)

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -49,10 +49,8 @@ type Windows struct {
 
 // Process contains information to start a specific application inside the container.
 type Process struct {
-	// Terminal indicates if stderr should NOT be attached for the container.
-	Terminal bool `json:"terminal"`
-	// ConsoleSize contains the initial h,w of the console size
-	InitialConsoleSize [2]int `json:"-"`
+	// Terminal creates an interactive terminal for the container.
+	Terminal bool `json:"terminal,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
@@ -62,6 +60,24 @@ type Process struct {
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
 	Cwd string `json:"cwd"`
+	// Capabilities are Linux capabilities that are kept for the container.
+	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
+	// Rlimits specifies rlimit options to apply to the process.
+	Rlimits []Rlimit `json:"rlimits,omitempty" platform:"linux"`
+	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
+	// ApparmorProfile specifies the apparmor profile for the container.
+	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
+	// SelinuxLabel specifies the selinux context that the container process is run as.
+	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
+	// ConsoleSize contains the initial size of the console.
+	ConsoleSize Box `json:"consoleSize" platform:"windows"`
+}
+
+// Box specifies height and width dimensions. Used for sizing of a console.
+type Box struct {
+	Height uint
+	Width  uint
 }
 
 // User specifies specific user (and group) information for the container process.
@@ -197,4 +213,9 @@ type Solaris struct {
 
 // Hooks for container setup and teardown
 type Hooks struct {
+}
+
+// Rlimit type and restrictions. Placeholder only to support the Process structure.
+// Not used on Windows, only present for compilation purposes.
+type Rlimit struct {
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Convergence closer to OCI compliance - this modifies the Process struct definition in the hacked OCI spec used on Windows to match the existing structure from https://github.com/opencontainers/runtime-spec/blob/master/specs-go/config.go#L30-L54, but also adding the initialConsoleSize field which is required on Windows submitted to OCI as https://github.com/opencontainers/runtime-spec/pull/563.

As a result of https://github.com/opencontainers/runtime-spec/pull/563#r78852905, have changed the docker codebase to use uint instead of int for the console size throughout.

There is one further update which will be required (and simplify the code by no longer needing to cast from uint to int in the Windows libcontainerd files) after https://github.com/Microsoft/hcsshim/pull/67 is merged, and a revendor of https://github.com/Microsoft/hcsshim is done in docker.

There are no functional changes in the PR.
