### PR TITLE
Add direct link to event chart image

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -94,7 +94,7 @@ wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem \
 
 The following diagram depicts the container states accessible through the API.
 
-![States](images/event_state.png)
+[![States](images/event_state.png)](../images/event_state.png)
 
 Some container-related events are not affected by container state, so they are not included in this diagram. These events are:
 


### PR DESCRIPTION
This adds a direct link to the event chart image
so that the full-resolution image can be "zoomed"
in to.

fixes https://github.com/docker/docker/issues/15234
