### PR TITLE
 Improve error message for removing pre-defined (e.g., `ingress`) network

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -143,7 +143,7 @@ clone git github.com/docker/docker-credential-helpers v0.3.0
 clone git github.com/docker/containerd 2545227b0357eb55e369fa0072baef9ad91cdb69
 
 # cluster
-clone git github.com/docker/swarmkit 191acc1bbdb13d8ea3b8059dda14a12f8c3903f2
+clone git github.com/docker/swarmkit 7b202f058db2f3a7d41351a56e5ef720c9b5a45d
 clone git github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 clone git github.com/gogo/protobuf v0.3
 clone git github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -264,3 +264,13 @@ func (s *DockerSwarmSuite) TestSwarmContainerAutoStart(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 }
+
+func (s *DockerSwarmSuite) TestSwarmRemoveInternalNetwork(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	name := "ingress"
+	out, err := d.Cmd("network", "rm", name)
+	c.Assert(err, checker.NotNil)
+	c.Assert(strings.TrimSpace(out), checker.Contains, name)
+	c.Assert(strings.TrimSpace(out), checker.Contains, "is a pre-defined network and cannot be removed")
+}

--- a/vendor/src/github.com/docker/swarmkit/manager/controlapi/network.go
+++ b/vendor/src/github.com/docker/swarmkit/manager/controlapi/network.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/docker/libnetwork/ipamapi"
@@ -186,7 +187,11 @@ func (s *Server) RemoveNetwork(ctx context.Context, request *api.RemoveNetworkRe
 	err = s.store.Update(func(tx store.Tx) error {
 		nw := store.GetNetwork(tx, request.NetworkID)
 		if _, ok := nw.Spec.Annotations.Labels["com.docker.swarm.internal"]; ok {
-			return grpc.Errorf(codes.PermissionDenied, "%s is a pre-defined network and cannot be removed", request.NetworkID)
+			networkDescription := nw.ID
+			if nw.Spec.Annotations.Name != "" {
+				networkDescription = fmt.Sprintf("%s (%s)", nw.Spec.Annotations.Name, nw.ID)
+			}
+			return grpc.Errorf(codes.PermissionDenied, "%s is a pre-defined network and cannot be removed", networkDescription)
 		}
 		return store.DeleteNetwork(tx, request.NetworkID)
 	})


### PR DESCRIPTION
**\- What I did**
This fix tries to address the issue raised in #24538

where the error message is unclear when removing pre-defined networks:

```
docker network rm ingress
Error response from daemon: rpc error: code = 7 desc = 4vlxuzpk8bxdsxpyvkxluol5g is a pre-defined network and cannot be removed
```

**\- How I did it**

This fix improve the error message so that if network's name is specified
in the `RemoveNetwork`, then error message will contain the name and the ID
(instead of just an ID):

```
docker network rm ingress
Error response from daemon: rpc error: code = 7 desc = ingress (4vlxuzpk8bxdsxpyvkxluol5g) is a pre-defined network and cannot be removed
```

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #24538.

**A swarmkit PR has been opened**: https://github.com/docker/swarmkit/pull/1540

Signed-off-by: Yong Tang yong.tang.github@outlook.com
