### PR TITLE
Windows: Turn off builds<14393

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -164,8 +164,8 @@ func checkSystem() error {
 	if osv.MajorVersion < 10 {
 		return fmt.Errorf("This version of Windows does not support the docker daemon")
 	}
-	if osv.Build < 14300 {
-		return fmt.Errorf("The docker daemon requires Windows Server 2016 Technical Preview 5 build 14300 or later")
+	if osv.Build < 14393 {
+		return fmt.Errorf("The docker daemon requires build 14393 or later of Windows Server 2016 or Windows 10")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This disables the docker daemon on pre-RTM builds of Windows Server 2016/Windows 10. So long TP3, TP4, TP5 and other pre-release versions :smile:
