### PR TITLE
apparmor: prohibit /sys/firmware/** from being accessed

### DIFF
--- a/docs/security/apparmor.md
+++ b/docs/security/apparmor.md
@@ -59,7 +59,7 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
-  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
 }
 ```
@@ -175,7 +175,7 @@ profile docker-nginx flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
-  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
 }
 ```

--- a/profiles/apparmor/template.go
+++ b/profiles/apparmor/template.go
@@ -35,7 +35,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
-  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
 {{if ge .Version 208095}}


### PR DESCRIPTION
Some firmware information including SMBIOS and ACPI tables were unexpectedly exposed.
Basically they shouldn't contain sensitive information, but some exceptions:
-   `/sys/firmware/acpi/tables/{SLIC,MSDM}`: Windows license information: http://feishare.com/attachments/article/265/microsoft-software-licensing-tables.pdf (original copy at microsoft.com seems [404](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/dn653305%28v=vs.85%29.aspx))
- `/sys/firmware/ibft/target0/chap-secret`: iSCSI CHAP secret: ftp://ftp.software.ibm.com/systems/support/bladecenter/iscsi_boot_firmware_table_v1.03.pdf
- Other vendor-specific information (Anyone know? DMI can be a vulnerability in some specific case?)

I think this issue should be fixed but not critical.

**\- What I did**
Prohibit /sys/firmware/*\* from being accessed.

**\- How I did it**
Modified the template for the default apparmor profile

**\- How to verify it**

``` console
$ docker run --rm alpine sh -c 'for f in $(find /sys/firmware/acpi/tables -type f); do echo $f; hexdump -C $f; done'
find: /sys/firmware/acpi/tables: Permission denied
```

``` console
$ docker run --rm alpine sh -c 'apk update && apk add dmidecode && dmidecode'
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
v3.4.3-62-gaaf1b40 [http://dl-cdn.alpinelinux.org/alpine/v3.4/main]
v3.4.3-62-gaaf1b40 [http://dl-cdn.alpinelinux.org/alpine/v3.4/community]
OK: 5973 distinct packages available
(1/1) Installing dmidecode (3.0-r0)
Executing busybox-1.24.2-r9.trigger
OK: 5 MiB in 12 packages
dmidecode 3.0
Scanning /dev/mem for entry point.
/sys/firmware/dmi/tables/smbios_entry_point: Permission denied
/dev/mem: No such file or directory
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

apparmor: prohibit /sys/firmware/*\* from being accessed

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
