### PR TITLE
Revert "Add default timeout to pkg/plugins/client"

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	defaultTimeOut     = 30
-	defaultHTTPTimeOut = 32 * time.Second
+	defaultTimeOut = 30
 )
 
 // NewClient creates a new plugin client (http).
@@ -54,7 +53,6 @@ func NewClient(addr string, tlsConfig *tlsconfig.Options) (*Client, error) {
 func NewClientWithTransport(tr transport.Transport) *Client {
 	return &Client{
 		http: &http.Client{
-			Timeout:   defaultHTTPTimeOut,
 			Transport: tr,
 		},
 		requestFactory: tr,


### PR DESCRIPTION
This PR reverts https://github.com/docker/docker/pull/25794 - that PR totally broke existing plugins (authorization and volumes ones especially) which were doing something longer that 32 seconds and were relying on not having a timeout (or have it longer than just 32 seconds if you prefer..).

I'm not saying https://github.com/docker/docker/pull/25794 is wrong - I'm saying that PR puts a timeout and break plugins already deployed (when 1.13 will land lots of plugins will start failing because of that timeout) - instead I think the timeout should be removed and we have to think about a way to configure timeouts for various need. Till that day, it won't break existing plugins.

/cc @tiborvass @anusha-ragunathan @chenchun
