### PR TITLE
Windows: Remove osversion from OCI

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -35,8 +35,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		return nil, fmt.Errorf("Failed to graph.Get on ImageID %s - %s", c.ImageID, err)
 	}
 
-	s.Platform.OSVersion = img.OSVersion
-
 	// In base spec
 	s.Hostname = c.FullHostname()
 

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -122,9 +122,6 @@ func (ctr *container) start() error {
 
 	iopipe.Stdin = createStdInCloser(stdin, hcsProcess)
 
-	// TEMP: Work around Windows BS/DEL behavior.
-	iopipe.Stdin = fixStdinBackspaceBehavior(iopipe.Stdin, ctr.ociSpec.Platform.OSVersion, ctr.ociSpec.Process.Terminal)
-
 	// Convert io.ReadClosers to io.Readers
 	if stdout != nil {
 		iopipe.Stdout = openReaderFromPipe(stdout)

--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -29,40 +29,6 @@ func openReaderFromPipe(p io.ReadCloser) io.Reader {
 	return r
 }
 
-// fixStdinBackspaceBehavior works around a bug in Windows before build 14350
-// where it interpreted DEL as VK_DELETE instead of as VK_BACK. This replaces
-// DEL with BS to work around this.
-func fixStdinBackspaceBehavior(w io.WriteCloser, osversion string, tty bool) io.WriteCloser {
-	if !tty {
-		return w
-	}
-	if build := buildFromVersion(osversion); build == 0 || build >= 14350 {
-		return w
-	}
-
-	return &delToBsWriter{w}
-}
-
-type delToBsWriter struct {
-	io.WriteCloser
-}
-
-func (w *delToBsWriter) Write(b []byte) (int, error) {
-	const (
-		backspace = 0x8
-		del       = 0x7f
-	)
-	bc := make([]byte, len(b))
-	for i, c := range b {
-		if c == del {
-			bc[i] = backspace
-		} else {
-			bc[i] = c
-		}
-	}
-	return w.WriteCloser.Write(bc)
-}
-
 type stdInCloser struct {
 	io.WriteCloser
 	hcsshim.Process

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -1,9 +1,6 @@
 package libcontainerd
 
-import (
-	"strconv"
-	"strings"
-)
+import "strings"
 
 // setupEnvironmentVariables converts a string array of environment variables
 // into a map as required by the HCS. Source array is in format [v1=k1] [v2=k2] etc.
@@ -26,17 +23,4 @@ func (s *ServicingOption) Apply(interface{}) error {
 // Apply for the flush option is a no-op.
 func (s *FlushOption) Apply(interface{}) error {
 	return nil
-}
-
-// buildFromVersion takes an image version string and returns the Windows build
-// number. It returns 0 if the build number is not present.
-func buildFromVersion(osver string) int {
-	v := strings.Split(osver, ".")
-	if len(v) < 3 {
-		return 0
-	}
-	if build, err := strconv.Atoi(v[2]); err == nil {
-		return build
-	}
-	return 0
 }

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -91,8 +91,6 @@ type Platform struct {
 	OS string `json:"os"`
 	// Arch is the architecture
 	Arch string `json:"arch"`
-	// OSVersion is the version of the operating system.
-	OSVersion string `json:"os.version,omitempty"`
 }
 
 // Mount specifies a mount for a container.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Now TP5 is no longer supported, we don't need the image version in the OCI spec. This also removes the temporary hack for BS/DEL in TP5.

@jstarks FYI. 
