### PR TITLE
return err when both two service modes in request

### DIFF
--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -185,7 +185,11 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 		}
 	}
 
-	//Mode
+	// Mode
+	if s.Mode.Global != nil && s.Mode.Replicated != nil {
+		return swarmapi.ServiceSpec{}, fmt.Errorf("cannot specify both replicated mode and global mode")
+	}
+
 	if s.Mode.Global != nil {
 		spec.Mode = &swarmapi.ServiceSpec_Global{
 			Global: &swarmapi.GlobalService{},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes #26642 

**\- What I did**
When validating service mode in dockerd, if both service modes `replicated` and `global` are set, return an error to tell user instead of creating a global mode service.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
