### PR TITLE
Remove extra paren in `run --link` docs

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1362,7 +1362,7 @@ If the operator uses `--link` when starting a new client container in the
 default bridge network, then the client container can access the exposed
 port via a private networking interface.
 If `--link` is used when starting a container in a user-defined network as
-described in [*Docker network overview*](../userguide/networking/index.md)),
+described in [*Docker network overview*](../userguide/networking/index.md),
 it will provide a named alias for the container being linked to.
 
 ### ENV (environment variables)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Fixed a typo in the docs

**\- How I did it**

Using the vigilance of a hawk and with a key named "delete"

**\- How to verify it**

N/A

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fixed typo in docs for `docker run --link`

**\- A picture of a cute animal (not mandatory but encouraged)**

See avatar
