### PR TITLE
Added comments to PortConfig for greater clarity

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -25,10 +25,12 @@ const (
 
 // PortConfig represents the config of a port.
 type PortConfig struct {
-	Name          string             `json:",omitempty"`
-	Protocol      PortConfigProtocol `json:",omitempty"`
-	TargetPort    uint32             `json:",omitempty"`
-	PublishedPort uint32             `json:",omitempty"`
+	Name     string             `json:",omitempty"`
+	Protocol PortConfigProtocol `json:",omitempty"`
+	// TargetPort is the port inside the container
+	TargetPort uint32 `json:",omitempty"`
+	// PublishedPort is the port on the swarm hosts
+	PublishedPort uint32 `json:",omitempty"`
 }
 
 // PortConfigProtocol represents the protocol of a port.


### PR DESCRIPTION
I always forget which one is which. Now, I can't forget. This is
probably in the docs somewhere but now it's handy at a glance.

Signed-off-by: Drew Erny drew.erny@docker.com
