### PR TITLE
Windows: OCI remove first start

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -90,6 +90,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		// Container is already locked in this case
 		c.SetRunning(int(e.Pid), e.State == libcontainerd.StateStart)
 		c.HasBeenManuallyStopped = false
+		c.HasBeenStartedBefore = true
 		if err := c.ToDisk(); err != nil {
 			c.Reset(false)
 			return err

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -78,9 +78,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	s.Root.Path = c.BaseFS
 	s.Root.Readonly = c.HostConfig.ReadonlyRootfs
 
-	// In s.Windows
-	s.Windows.FirstStart = !c.HasBeenStartedBefore
-
 	// s.Windows.LayerFolder.
 	m, err := c.RWLayer.Metadata()
 	if err != nil {

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -6,5 +6,7 @@ import (
 )
 
 func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Container) (*[]libcontainerd.CreateOption, error) {
-	return &[]libcontainerd.CreateOption{}, nil
+	createOptions := []libcontainerd.CreateOption{}
+	createOptions = append(createOptions, &libcontainerd.FlushOption{IgnoreFlushesDuringBoot: !container.HasBeenStartedBefore})
+	return &createOptions, nil
 }

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -41,12 +41,11 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 	logrus.Debugln("libcontainerd: client.Create() with spec", spec)
 
 	configuration := &hcsshim.ContainerConfig{
-		SystemType: "Container",
-		Name:       containerID,
-		Owner:      defaultOwner,
-
+		SystemType:              "Container",
+		Name:                    containerID,
+		Owner:                   defaultOwner,
 		VolumePath:              spec.Root.Path,
-		IgnoreFlushesDuringBoot: spec.Windows.FirstStart,
+		IgnoreFlushesDuringBoot: false,
 		LayerFolderPath:         spec.Windows.LayerFolder,
 		HostName:                spec.Hostname,
 	}
@@ -104,6 +103,10 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 	for _, option := range options {
 		if s, ok := option.(*ServicingOption); ok {
 			configuration.Servicing = s.IsServicing
+			break
+		}
+		if s, ok := option.(*FlushOption); ok {
+			configuration.IgnoreFlushesDuringBoot = s.IgnoreFlushesDuringBoot
 			break
 		}
 	}

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -38,6 +38,13 @@ type ServicingOption struct {
 	IsServicing bool
 }
 
+// FlushOption is an empty CreateOption that signifies if the container should be
+// started with flushes ignored until boot has completed. This is an optimisation
+// for first boot of a container.
+type FlushOption struct {
+	IgnoreFlushesDuringBoot bool
+}
+
 // Checkpoint holds the details of a checkpoint (not supported in windows)
 type Checkpoint struct {
 	Name string

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -23,6 +23,11 @@ func (s *ServicingOption) Apply(interface{}) error {
 	return nil
 }
 
+// Apply for the flush option is a no-op.
+func (s *FlushOption) Apply(interface{}) error {
+	return nil
+}
+
 // buildFromVersion takes an image version string and returns the Windows build
 // number. It returns 0 if the build number is not present.
 func buildFromVersion(osver string) int {

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -39,8 +39,6 @@ type Windows struct {
 	Resources *Resources `json:"resources,omitempty"`
 	// Networking contains the platform specific network settings for the container.
 	Networking *Networking `json:"networking,omitempty"`
-	// FirstStart is used for an optimization on first boot of Windows
-	FirstStart bool `json:"first_start,omitempty"`
 	// LayerFolder is the path to the current layer folder
 	LayerFolder string `json:"layer_folder,omitempty"`
 	// Layer paths of the parent layers


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR moves Windows a little closer to OCI compliance for the runtime spec. There are no functional changes in the PR. In the proof of concept PR https://github.com/opencontainers/runtime-spec/pull/504, there was a comment from @wking https://github.com/opencontainers/runtime-spec/pull/504#r67991039 that (rightly) the first start flag didn't belong in the spec and should be moved to the runtime.

This PR does exactly that, and handles the first start optimisation on Windows through a `CreateOption` to libcontainerd.

@mlaventure @tonistiigi PTAL.

/cc @jstarks FYI
