### PR TITLE
Move HostConfig.Mounts to correct API version

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -334,8 +334,7 @@ Create a container
              "StorageOpt": {},
              "CgroupParent": "",
              "VolumeDriver": "",
-             "ShmSize": 67108864,
-             "Mounts": []
+             "ShmSize": 67108864
           },
           "NetworkingConfig": {
               "EndpointsConfig": {
@@ -611,8 +610,7 @@ Return low-level information on the container `id`
 			"VolumesFrom": null,
 			"Ulimits": [{}],
 			"VolumeDriver": "",
-			"ShmSize": 67108864,
-			"Mounts": []
+			"ShmSize": 67108864
 		},
 		"HostnamePath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname",
 		"HostsPath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts",

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -334,7 +334,8 @@ Create a container
              "StorageOpt": {},
              "CgroupParent": "",
              "VolumeDriver": "",
-             "ShmSize": 67108864
+             "ShmSize": 67108864,
+             "Mounts": []
           },
           "NetworkingConfig": {
               "EndpointsConfig": {
@@ -633,7 +634,8 @@ Return low-level information on the container `id`
 			"VolumesFrom": null,
 			"Ulimits": [{}],
 			"VolumeDriver": "",
-			"ShmSize": 67108864
+			"ShmSize": 67108864,
+			"Mounts": []
 		},
 		"HostnamePath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname",
 		"HostsPath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts",


### PR DESCRIPTION
This was added in fc7b904dced4d18d49c8a6c47ae3f415d16d0c43 (https://github.com/docker/docker/pull/22373), but some parts of the documentation ended up in the wrong API version, and was overlooked during review :)
