### PR TITLE
Rename the variable 'name' to 'destination'

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -85,8 +85,8 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 	}()
 
 	// 1. Read already configured mount points.
-	for name, point := range container.MountPoints {
-		mountPoints[name] = point
+	for destination, point := range container.MountPoints {
+		mountPoints[destination] = point
 	}
 
 	// 2. Read volumes from other containers.


### PR DESCRIPTION
Rename the variable `name` to `destination`.

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
