### PR TITLE
Fix issue for `--fixed-cidr` when bridge has multiple addresses

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -70,7 +70,7 @@ clone git github.com/RackSec/srslog 365bf33cd9acc21ae1c355209865f17228ca534e
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 9fbb4ecbb45af655c4ac3c2f3a849b2294cb447a
+clone git github.com/docker/libnetwork f4338b6f1085ccfe5972e655cca8a1d15d73439d
 clone git github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/interface.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/interface.go
@@ -52,23 +52,22 @@ func (i *bridgeInterface) exists() bool {
 	return i.Link != nil
 }
 
-// addresses returns a single IPv4 address and all IPv6 addresses for the
-// bridge interface.
-func (i *bridgeInterface) addresses() (netlink.Addr, []netlink.Addr, error) {
+// addresses returns all IPv4 addresses and all IPv6 addresses for the bridge interface.
+func (i *bridgeInterface) addresses() ([]netlink.Addr, []netlink.Addr, error) {
 	v4addr, err := i.nlh.AddrList(i.Link, netlink.FAMILY_V4)
 	if err != nil {
-		return netlink.Addr{}, nil, fmt.Errorf("Failed to retrieve V4 addresses: %v", err)
+		return nil, nil, fmt.Errorf("Failed to retrieve V4 addresses: %v", err)
 	}
 
 	v6addr, err := i.nlh.AddrList(i.Link, netlink.FAMILY_V6)
 	if err != nil {
-		return netlink.Addr{}, nil, fmt.Errorf("Failed to retrieve V6 addresses: %v", err)
+		return nil, nil, fmt.Errorf("Failed to retrieve V6 addresses: %v", err)
 	}
 
 	if len(v4addr) == 0 {
-		return netlink.Addr{}, v6addr, nil
+		return nil, v6addr, nil
 	}
-	return v4addr[0], v6addr, nil
+	return v4addr, v6addr, nil
 }
 
 func (i *bridgeInterface) programIPv6Address() error {

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_verify.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_verify.go
@@ -11,11 +11,13 @@ import (
 )
 
 func setupVerifyAndReconcile(config *networkConfiguration, i *bridgeInterface) error {
-	// Fetch a single IPv4 and a slice of IPv6 addresses from the bridge.
-	addrv4, addrsv6, err := i.addresses()
+	// Fetch a slice of IPv4 addresses and a slice of IPv6 addresses from the bridge.
+	addrsv4, addrsv6, err := i.addresses()
 	if err != nil {
 		return fmt.Errorf("Failed to verify ip addresses: %v", err)
 	}
+
+	addrv4, _ := selectIPv4Address(addrsv4, config.AddressIPv4)
 
 	// Verify that the bridge does have an IPv4 address.
 	if addrv4.IPNet == nil {

--- a/vendor/src/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/netlabel"
+	"github.com/docker/libnetwork/ns"
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/osl"
 	"github.com/docker/libnetwork/types"
@@ -149,6 +150,15 @@ func (d *driver) DeleteNetwork(nid string) error {
 						n.config.Parent, err)
 				}
 			}
+		}
+	}
+	for _, ep := range n.endpoints {
+		if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
+			ns.NlHandle().LinkDel(link)
+		}
+
+		if err := d.storeDelete(ep); err != nil {
+			logrus.Warnf("Failed to remove macvlan endpoint %s from store: %v", ep.id[0:7], err)
 		}
 	}
 	// delete the *network

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_network.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_network.go
@@ -182,6 +182,18 @@ func (d *driver) DeleteNetwork(nid string) error {
 		return fmt.Errorf("could not find network with id %s", nid)
 	}
 
+	for _, ep := range n.endpoints {
+		if ep.ifName != "" {
+			if link, err := ns.NlHandle().LinkByName(ep.ifName); err != nil {
+				ns.NlHandle().LinkDel(link)
+			}
+		}
+
+		if err := d.deleteEndpointFromStore(ep); err != nil {
+			logrus.Warnf("Failed to delete overlay endpoint %s from local store: %v", ep.id[0:7], err)
+		}
+
+	}
 	d.deleteNetwork(nid)
 
 	vnis, err := n.releaseVxlanID()

--- a/vendor/src/github.com/docker/libnetwork/netutils/utils_freebsd.go
+++ b/vendor/src/github.com/docker/libnetwork/netutils/utils_freebsd.go
@@ -7,10 +7,12 @@ import (
 )
 
 // ElectInterfaceAddresses looks for an interface on the OS with the specified name
-// and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
-// it chooses from a predifined list the first IPv4 address which does not conflict
-// with other interfaces on the system.
-func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
+// and returns returns all its IPv4 and IPv6 addresses in CIDR notation.
+// If a failure in retrieving the addresses or no IPv4 address is found, an error is returned.
+// If the interface does not exist, it chooses from a predefined
+// list the first IPv4 address which does not conflict with other
+// interfaces on the system.
+func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 	return nil, nil, types.NotImplementedErrorf("not supported on freebsd")
 }
 

--- a/vendor/src/github.com/docker/libnetwork/netutils/utils_solaris.go
+++ b/vendor/src/github.com/docker/libnetwork/netutils/utils_solaris.go
@@ -22,10 +22,12 @@ func CheckRouteOverlaps(toCheck *net.IPNet) error {
 }
 
 // ElectInterfaceAddresses looks for an interface on the OS with the specified name
-// and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
-// it chooses from a predifined list the first IPv4 address which does not conflict
-// with other interfaces on the system.
-func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
+// and returns returns all its IPv4 and IPv6 addresses in CIDR notation.
+// If a failure in retrieving the addresses or no IPv4 address is found, an error is returned.
+// If the interface does not exist, it chooses from a predefined
+// list the first IPv4 address which does not conflict with other
+// interfaces on the system.
+func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 	var (
 		v4Net *net.IPNet
 	)
@@ -63,7 +65,7 @@ func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
 			return nil, nil, err
 		}
 	}
-	return v4Net, nil, nil
+	return []*net.IPNet{v4Net}, nil, nil
 }
 
 // FindAvailableNetwork returns a network from the passed list which does not

--- a/vendor/src/github.com/docker/libnetwork/netutils/utils_windows.go
+++ b/vendor/src/github.com/docker/libnetwork/netutils/utils_windows.go
@@ -7,10 +7,12 @@ import (
 )
 
 // ElectInterfaceAddresses looks for an interface on the OS with the specified name
-// and returns its IPv4 and IPv6 addresses in CIDR form. If the interface does not exist,
-// it chooses from a predifined list the first IPv4 address which does not conflict
-// with other interfaces on the system.
-func ElectInterfaceAddresses(name string) (*net.IPNet, []*net.IPNet, error) {
+// and returns returns all its IPv4 and IPv6 addresses in CIDR notation.
+// If a failure in retrieving the addresses or no IPv4 address is found, an error is returned.
+// If the interface does not exist, it chooses from a predefined
+// list the first IPv4 address which does not conflict with other
+// interfaces on the system.
+func ElectInterfaceAddresses(name string) ([]*net.IPNet, []*net.IPNet, error) {
 	return nil, nil, types.NotImplementedErrorf("not supported on windows")
 }
 

--- a/vendor/src/github.com/docker/libnetwork/networkdb/event_delegate.go
+++ b/vendor/src/github.com/docker/libnetwork/networkdb/event_delegate.go
@@ -29,6 +29,8 @@ func (e *eventDelegate) NotifyLeave(mn *memberlist.Node) {
 	e.nDB.Lock()
 	if n, ok := e.nDB.nodes[mn.Name]; ok {
 		delete(e.nDB.nodes, mn.Name)
+
+		n.reapTime = reapInterval
 		e.nDB.failedNodes[mn.Name] = n
 	}
 	e.nDB.Unlock()

--- a/vendor/src/github.com/docker/libnetwork/networkdb/networkdb.go
+++ b/vendor/src/github.com/docker/libnetwork/networkdb/networkdb.go
@@ -94,6 +94,8 @@ type NetworkDB struct {
 type node struct {
 	memberlist.Node
 	ltime serf.LamportTime
+	// Number of hours left before the reaper removes the node
+	reapTime time.Duration
 }
 
 // network describes the node/network attachment.


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #26341 where multiple addresses in a bridge may cause `--fixed-cidr` to not have the correct addresses.

The issue is that `netutils.ElectInterfaceAddresses(bridgeName)` only returns the first IPv4 address.

**\- How I did it**

This fix (together with the PR created in libnetwork https://github.com/docker/libnetwork/pull/1452) changes `ElectInterfaceAddresses()` and `addresses()` so that all IPv4 addresses are returned. This will allow the possibility of selectively choose the address needed.

In `daemon_unix.go`, bridge address is chosen by comparing with the `--fixed-cidr` first, thus resolve the issue in #26341.

**\- How to verify it**
This fix is tested manually, as is described in #26341:

```
brctl addbr cbr0
ip addr add 10.111.111.111/20 dev cbr0 label cbr0:main
ip addr add 10.222.222.222/12 dev cbr0 label cbr0:docker
ip link set cbr0 up
docker daemon --bridge=cbr0 --iptables=false --ip-masq=false --fixed-cidr=10.222.222.222/24
docker run --rm busybox ip route get 8.8.8.8 | grep -Po 'src.*'
src 10.222.222.0
```

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #26341.

This fix is related to libnetwork PR https://github.com/docker/libnetwork/pull/1452

**libnetwork vendoring:**
Fixes #22204 
Fixes #24637 
Fixes #27157 
Also, https://github.com/docker/libnetwork/pull/1333, https://github.com/docker/libnetwork/pull/1480

Signed-off-by: Yong Tang yong.tang.github@outlook.com
