### PR TITLE
Fix flaky unit test

### DIFF
--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -47,14 +47,14 @@ func testHTTPTimeout(t *testing.T, timeout, epsilon time.Duration) {
 		t.Fatalf("The request should be canceled %v", err)
 	}
 	elapsed := time.Now().Sub(begin)
-	if elapsed < timeout || elapsed > timeout+epsilon {
+	if elapsed < timeout-epsilon || elapsed > timeout+epsilon {
 		t.Fatalf("elapsed time: got %v, expected %v (epsilon=%v)",
 			elapsed, timeout, epsilon)
 	}
 }
 
 func TestHTTPTimeout(t *testing.T) {
-	testHTTPTimeout(t, 5*time.Second, 1*time.Second)
+	testHTTPTimeout(t, 5*time.Second, 500*time.Millisecond)
 }
 
 func TestFailedConnection(t *testing.T) {


### PR DESCRIPTION
Fix flaky test `TestHTTPTimeout` caused by precision problem.

Observed in https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/3234/console

```
11:14:40 --- FAIL: TestHTTPTimeout (5.00s)
11:14:40    client_test.go:52: elapsed time: got 4.9997688s, expected 5s (epsilon=1s)
11:14:40 FAIL
11:14:40 coverage: 30.8% of statements
11:14:40 FAIL   github.com/docker/docker/pkg/plugins    6.050s
```

Signed-off-by: Zhang Wei zhangwei555@huawei.com
