### PR TITLE
display service name in log when service creating fails

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -132,7 +132,7 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 
 	id, err := sr.backend.CreateService(service, encodedAuth)
 	if err != nil {
-		logrus.Errorf("Error creating service %s: %v", id, err)
+		logrus.Errorf("Error creating service %s: %v", service.Name, err)
 		return err
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

display no id in log when service creating fails

**\- What I did**
Since service creating failure will not return a service id, it is an empty string instead.
I think there is no need to print this empty string in log.

Signed-off-by: allencloud allen.sun@daocloud.io
