### PR TITLE
Windows OCI: Remove endpoint list

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -69,34 +69,6 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	s.Root.Path = c.BaseFS
 	s.Root.Readonly = c.HostConfig.ReadonlyRootfs
 
-	// In s.Windows.Networking
-	// Connect all the libnetwork allocated networks to the container
-	var epList []string
-	if c.NetworkSettings != nil {
-		for n := range c.NetworkSettings.Networks {
-			sn, err := daemon.FindNetwork(n)
-			if err != nil {
-				continue
-			}
-
-			ep, err := c.GetEndpointInNetwork(sn)
-			if err != nil {
-				continue
-			}
-
-			data, err := ep.DriverInfo()
-			if err != nil {
-				continue
-			}
-			if data["hnsid"] != nil {
-				epList = append(epList, data["hnsid"].(string))
-			}
-		}
-	}
-	s.Windows.Networking = &windowsoci.WindowsNetworking{
-		EndpointList: epList,
-	}
-
 	// In s.Windows.Resources
 	// @darrenstahlmsft implement these resources
 	cpuShares := uint64(c.HostConfig.CPUShares)

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -106,10 +106,6 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		HvPartition:             false,
 	}
 
-	if spec.Windows.Networking != nil {
-		configuration.EndpointList = spec.Windows.Networking.EndpointList
-	}
-
 	if spec.Windows.Resources != nil {
 		if spec.Windows.Resources.CPU != nil {
 			if spec.Windows.Resources.CPU.Shares != nil {
@@ -151,6 +147,9 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		}
 		if l, ok := option.(*LayerOption); ok {
 			layerOpt = l
+		}
+		if n, ok := option.(*NetworkEndpointsOption); ok {
+			configuration.EndpointList = n.Endpoints
 			continue
 		}
 	}

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -32,13 +32,13 @@ type Stats hcsshim.Statistics
 // Resources defines updatable container resource values.
 type Resources struct{}
 
-// ServicingOption is an empty CreateOption with a no-op application that signifies
+// ServicingOption is a CreateOption with a no-op application that signifies
 // the container needs to be used for a Windows servicing operation.
 type ServicingOption struct {
 	IsServicing bool
 }
 
-// FlushOption is an empty CreateOption that signifies if the container should be
+// FlushOption is a CreateOption that signifies if the container should be
 // started with flushes ignored until boot has completed. This is an optimisation
 // for first boot of a container.
 type FlushOption struct {
@@ -59,6 +59,12 @@ type LayerOption struct {
 	LayerFolderPath string `json:",omitempty"`
 	// Layer paths of the parent layers
 	LayerPaths []string
+}
+
+// NetworkEndpointsOption is a CreateOption that provides the runtime list
+// of network endpoints to which a container should be attached during its creation.
+type NetworkEndpointsOption struct {
+	Endpoints []string
 }
 
 // Checkpoint holds the details of a checkpoint (not supported in windows)

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -34,3 +34,8 @@ func (h *HyperVIsolationOption) Apply(interface{}) error {
 func (h *LayerOption) Apply(interface{}) error {
 	return nil
 }
+
+// Apply for the network endpoints option is a no-op.
+func (s *NetworkEndpointsOption) Apply(interface{}) error {
+	return nil
+}

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -37,8 +37,6 @@ type Spec struct {
 type Windows struct {
 	// Resources contains information for handling resource constraints for the container
 	Resources *WindowsResources `json:"resources,omitempty"`
-	// Networking contains the platform specific network settings for the container.
-	Networking *WindowsNetworking `json:"networking,omitempty"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -114,12 +112,6 @@ type Mount struct {
 	Source string `json:"source"`
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
-}
-
-// WindowsNetworking contains the platform specific network settings for the container
-type WindowsNetworking struct {
-	// List of endpoints to be attached to the container
-	EndpointList []string `json:"endpoints,omitempty"`
 }
 
 // WindowsStorage contains storage resource management settings


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@mlaventure @tonistiigi @stevvooe 

Similar to https://github.com/docker/docker/pull/26650, this moves the list of endpoints from the hacked OCI spec used on Windows into the runtime itself via a new `CreateOption`. This gets docker extremely close to the proposed OCI runtime spec PR at https://github.com/opencontainers/runtime-spec/pull/573 following comments on the proof-of-concept PR https://github.com/opencontainers/runtime-spec/pull/504.

cc @wking FYI. 
