### PR TITLE
Easily use $(docker swarm join-token worker|manager) without copy paste.

### DIFF
--- a/cli/command/swarm/join_token.go
+++ b/cli/command/swarm/join_token.go
@@ -94,10 +94,10 @@ func printJoinCommand(ctx context.Context, dockerCli *command.DockerCli, nodeID 
 
 	if node.ManagerStatus != nil {
 		if worker {
-			fmt.Fprintf(dockerCli.Out(), "To add a worker to this swarm, run the following command:\n\n    docker swarm join \\\n    --token %s \\\n    %s\n\n", swarm.JoinTokens.Worker, node.ManagerStatus.Addr)
+			fmt.Fprintf(dockerCli.Out(), "#To add a worker to this swarm, run the following command:\n\n    docker swarm join \\\n    --token %s \\\n    %s\n\n", swarm.JoinTokens.Worker, node.ManagerStatus.Addr)
 		}
 		if manager {
-			fmt.Fprintf(dockerCli.Out(), "To add a manager to this swarm, run the following command:\n\n    docker swarm join \\\n    --token %s \\\n    %s\n\n", swarm.JoinTokens.Manager, node.ManagerStatus.Addr)
+			fmt.Fprintf(dockerCli.Out(), "#To add a manager to this swarm, run the following command:\n\n    docker swarm join \\\n    --token %s \\\n    %s\n\n", swarm.JoinTokens.Manager, node.ManagerStatus.Addr)
 		}
 	}
 


### PR DESCRIPTION
Consider we already created node-1, node-2 with docker-machine,
And node-1 already use
`docker swarm init --advertise-addr $(docker-machine ip node-1)`

`export MANAGER_HOST=tcp://$(docker-machine ip node-1):2376`
# switch to node-2

`eval $(docker-machine env node-2)`
# join to worker

`eval $(docker -H $MANAGER_HOST swarm join-token worker)`
# or join to manager

`eval $(docker -H $MANAGER_HOST swarm join-token manager)`
