### PR TITLE
Update info for labels custom metedata

### DIFF
--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -73,7 +73,7 @@ storage driver and a node that is part of a 2-node swarm:
     Architecture: x86_64
     CPUs: 24
     Total Memory: 62.86 GiB
-    Name: docker
+    Name: ubuntu
     ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
     Docker Root Dir: /var/lib/docker
     Debug mode (client): true

--- a/docs/userguide/labels-custom-metadata.md
+++ b/docs/userguide/labels-custom-metadata.md
@@ -210,7 +210,7 @@ These labels appear as part of the `docker info` output for the daemon:
     Operating System: Ubuntu 15.04
     CPUs: 24
     Total Memory: 62.86 GiB
-    Name: docker
+    Name: ubuntu
     ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
     Debug mode (server): true
      File Descriptors: 59
@@ -228,3 +228,5 @@ These labels appear as part of the `docker info` output for the daemon:
     Labels:
      com.example.environment=production
      com.example.storage=ssd
+
+The global `-D` option tells all `docker` commands to output debug information.


### PR DESCRIPTION
Modify the value of name from docker to ubuntu and add description for "-D".

The info is shown by docker -D info as follows:

$ docker -D info 
Containers: 1
 Running: 1
 Paused: 0
 Stopped: 0
Images: 1
Server Version: 1.12.1
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Backing Filesystem: extfs
 Dirs: 6
 Dirperm1 Supported: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: overlay bridge null host
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Security Options: apparmor
Kernel Version: 4.2.0-42-generic
Operating System: Ubuntu 14.04.4 LTS
OSType: linux
Architecture: x86_64
CPUs: 4
Total Memory: 7.797 GiB
Name: ubuntu
ID: IM2I:YVN5:XM64:O3US:QKAG:V2KY:P75A:RDCV:XQHR:G52M:ILCT:7WYX
Docker Root Dir: /var/lib/docker
Debug Mode (client): true
Debug Mode (server): false
Registry: https://index.docker.io/v1/
WARNING: No swap limit support
Insecure Registries:
 127.0.0.0/8

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
