### PR TITLE
Fix typo for docs reference

### DIFF
--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -38,7 +38,7 @@ meta data regarding those images are stored. When run for the first time Docker
 allocates a certain amount of data space and meta data space from the space
 available on the volume where `/var/lib/docker` is mounted.
 
-# EXAMPLES
+# Examples
 
 ## Display Docker system information
 

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -31,7 +31,7 @@ running in a terminal, terminates the push operation.
 
 Registry credentials are managed by [docker login](login.md).
 
-## EXAMPLES
+## Examples
 
 ### Pushing a new image to a registry
 

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -41,7 +41,7 @@ options on a running or a stopped container. On kernel version older than
 4.6, you can only update `--kernel-memory` on a stopped container or on
 a running container with kernel memory initialized.
 
-## EXAMPLES
+## Examples
 
 The following sections illustrate ways to use this command.
 


### PR DESCRIPTION
Fix typo for docs reference from EXAMPLES to Examples and keep the same format among docker commands.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
