### PR TITLE
[WIP, RFC] new make target: test-integration-cli-parallel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 bundles
+bundles-parallel
 .gopath
 vendor/pkg
 .go-pkg-cache

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .go-pkg-cache/
 autogen/
 bundles/
+bundles-parallel/
 cmd/dockerd/dockerd
 cmd/docker/docker
 dockerversion/version_autogen.go

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ deb: build  ## build the deb packages
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary build-deb
 
 
+echo-docker-run: ## echo DOCKER_RUN_DOCKER
+	@echo $(DOCKER_RUN_DOCKER)
+
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
@@ -128,6 +131,10 @@ test-docker-py: build ## run the docker-py tests
 
 test-integration-cli: build ## run the integration tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh build-integration-test-binary dynbinary test-integration-cli
+
+test-integration-cli-parallel: build ## run the integration tests in parallel (EXPERIMENTAL)
+	$(DOCKER_RUN_DOCKER) hack/make.sh build-integration-test-binary dynbinary
+	contrib/test-integration-cli-parallel.sh
 
 test-unit: build ## run the unit tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit

--- a/contrib/.test-integration-cli-parallel
+++ b/contrib/.test-integration-cli-parallel
@@ -1,0 +1,23 @@
+#!/bin/bash
+# stdin: regexp for test case (e.g. TestFooBar)
+set -e
+if [ -z $PARALLEL_SEQ ]; then
+    echo "Please run this script from parallel(1)"
+    false
+fi
+
+mkdir -p bundles-parallel/$PARALLEL_SEQ
+# TODO: dedup binaries
+cp -r bundles bundles-parallel/$PARALLEL_SEQ
+
+run=$(BINDDIR="bundles-parallel/$PARALLEL_SEQ/bundles" make --silent echo-docker-run)
+script=$(cat <<EOF
+ln -s bundles-parallel/$PARALLEL_SEQ/bundles bundles
+while read r; do
+    echo "Job $PARALLEL_SEQ: running \$r"
+    KEEPBUNDLE=1 DOCKER_INTEGRATION_TESTS_VERIFIED=1 TESTFLAGS="-check.f \$r" hack/make.sh test-integration-cli
+done
+EOF
+      )
+
+$run sh -c "$script"

--- a/contrib/test-integration-cli-parallel.sh
+++ b/contrib/test-integration-cli-parallel.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+### Usage:
+###     $ sudo apt install parallel
+###     $ ./contrib/test-integration-cli-parallel.sh
+set -e
+
+: ${NJOBS=$(nproc)}
+D=$(pwd)/bundles-parallel
+RUNNER=$(pwd)/contrib/.test-integration-cli-parallel
+PARALLEL=parallel
+
+echo "Running tests in parallel, using $NJOBS job containers"
+echo "See $D/results for the results"
+rm -rf $D/results
+mkdir -p $D
+grep -oPh '^func .*\KTest[^(]+' integration-cli/*_test.go | sort > $D/input
+
+$PARALLEL \
+    --no-notice \
+    --jobs $NJOBS \
+    --max-args $(( $(wc -l < $D/input) / $NJOBS + 1)) \
+    --pipe \
+    --results $D/results \
+    --joblog  $D/joblog \
+    $RUNNER < $D/input

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -20,7 +20,7 @@ bundle_test_integration_cli() {
 go_test_dir() {
 	dir=$1
 	precompiled=$2
-	testbinary="$DEST/test.main"
+	testbinary="$ABS_DEST/test.main"
 	testcover=()
 	testcoverprofile=()
 	(

--- a/hack/make/build-integration-test-binary
+++ b/hack/make/build-integration-test-binary
@@ -2,7 +2,7 @@
 set -e
 
 rm -rf "$DEST"
-DEST="$DEST/../test-integration-cli"
+DEST="$ABS_DEST/../test-integration-cli"
 
 if [ -z $DOCKER_INTEGRATION_TESTS_VERIFIED ]; then
 	source ${MAKEDIR}/.integration-test-helpers


### PR DESCRIPTION
### What I did

Introduced `make test-integration-cli-parallel`, which executes multiple integration tests in parallel.

### Experimental result: 2.83 times faster

on GCE n1-standard-32 (32 vCPUs, 120GB RAM, standard HDD) `DOCKER_INCREMENTAL_BINARY=1`. `DOCKER_EXPERIMENTAL=1`
- ` make test-integration-cli`: 68m46.127s
- `make test-integration-cli-parallel`:  24m16.555s

In the previous revision of this PR, it was about 3.8 times faster (September 2016): https://github.com/AkihiroSuda/docker/commit/1cd85f5f54564444e5cc3376005053db6e5a82ab#commitcomment-20027365
The previous revision used coarse-grained buckets:  `{"TestA*", "TestB*", "TestC*", .., "TestZ*"}` instead of `{"TestAPIClientVersionOldNotSupported", "TestAPICreateDeletePredefinedNetworks", .., "TestWaitNonBlockedExitZero"}`.

### Next steps
Probably, the next step is to use `check.list` for reducing overhead of spinning up of daemon for each of the test, running in the 32 containers: https://github.com/go-check/check/blob/v1/run.go#L43
I'm looking into whether that is the right direction.

The further next step is to execute the tests in parallel across a Docker Swarm cluster, but I think it can/should be done in an external tool.
Actually I've been already working on such a tool for k8s, and the tool will soon support Docker Swarm as well: https://github.com/osrg/namazu-swarm

Also, the support for "privilged" services would be needed for running integration tests across a Docker Swarm cluster: https://github.com/docker/docker/issues/24862 https://github.com/docker/swarmkit/pull/1722
(Or we can just bind the API socket as a workaround)

## How I did it

Executes equivalents of the following commands in parallel across multiple `docker-dev` containers, using `parallel(1)`:
- `TESTFLAGS='-check.f TestAPICreateDeletePredefinedNetworks' make test-integration-cli`
- `TESTFLAGS='-check.f  TestAPICreateEmptyEnv' make test-integration-cli`
- ..

The list of the test functions are generated in `contrib/test-integration-cli-parallel.sh`
```
grep -oPh '^func .*\KTest[^(]+' integration-cli/*_test.go
```

### How to verify it

``` console
$ sudo apt-get install parallel
$ make test-integration-cli-parallel
...
```

BUG: exit status not propagated yet

(TODO: rename `bundles-parallel` to `bundles/test-integration-cli-parallel` ?)


### Description for the changelog

new make target: test-integration-cli-parallel
### A picture of a cute animal (not mandatory but encouraged)**

![queue](http://4.bp.blogspot.com/-gx6McG_zAjo/UG0P5wiQhEI/AAAAAAAAHjA/Upn6AR_gYMQ/s1600/penguin+footer.jpg)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
