### PR TITLE
Mask /sys/firmware using read-only tmpfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -231,11 +231,22 @@ RUN set -x \
 	&& go build -v -o /usr/local/bin/tomlv github.com/BurntSushi/toml/cmd/tomlv \
 	&& rm -rf "$GOPATH"
 
-# Install runc
-ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+# # Install runc
+# ENV RUNC_COMMIT cc29e3dded8e27ba8f65738f40d251c885030a28
+# RUN set -x \
+# 	&& export GOPATH="$(mktemp -d)" \
+# 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
+# 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
+# 	&& git checkout -q "$RUNC_COMMIT" \
+# 	&& make static BUILDTAGS="seccomp apparmor selinux" \
+# 	&& cp runc /usr/local/bin/docker-runc \
+# 	&& rm -rf "$GOPATH"
+
+# Install runc (DO NOT MERGE)
+ENV RUNC_COMMIT f77819655520276db900c6dc4707550e35b675f1
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
+	&& git clone https://github.com/AkihiroSuda/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
 	&& git checkout -q "$RUNC_COMMIT" \
 	&& make static BUILDTAGS="seccomp apparmor selinux" \

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4536,3 +4536,17 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "[nofile=42:42]")
 }
+
+func (s *DockerSuite) TestRunContainerWithSysFirmwareMountRO(c *check.C) {
+	testRequires(c, DaemonIsLinux, NotUserNamespace)
+
+	filename := "/sys/firmware/test123"
+	out, _, err := dockerCmdWithError("run", "busybox", "touch", filename)
+	if err == nil {
+		c.Fatal("expected /sys/firmware mount point to be read-only, touch file should fail")
+	}
+	expected := "Read-only file system"
+	if !strings.Contains(out, expected) {
+		c.Fatalf("expected output from failure to contain %s but contains %s", expected, out)
+	}
+}

--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -58,6 +58,13 @@ func DefaultSpec() specs.Spec {
 			Source:      "mqueue",
 			Options:     []string{"nosuid", "noexec", "nodev"},
 		},
+		// Masking /sys/firmware is not required (nor prohibited) by the OCI spec
+		{
+			Destination: "/sys/firmware",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+		},
 	}
 
 	s.Process.Capabilities = []string{


### PR DESCRIPTION
**\- What I did**
`TestBuildApiDockerFileRemote` has been consistently failing (`EPERM`) on the host with #26618, which prohibits /sys/firmware from being accessed using apparmor.
https://github.com/docker/docker/blob/8a46c18dd4e4f8091b9e02ef5b476e8b8aa77c47/integration-cli/docker_api_build_test.go#L19

``` console
RUN find / -name ba*
find: /sys/firmware/dmi: Permission denied
find: /sys/firmware/acpi: Permission denied
find: /sys/firmware/memmap: Permission denied
```

This PR masks `/sys/firmware` using a read-only tmpfs so that `TestBuildApiDockerFileRemote`  passes without a change.

**\- How I did it**
Masked `/sys/firmware` using a read-only tmpfs.

**\- How to verify it**
Make sure the latest apparmor profile is installed to the host:

``` console
$ cat /etc/apparmor.d/docker
...
profile docker-default flags=(attach_disconnected,mediate_deleted) {
...
  deny /sys/firmware/** rwklx,
...
}
```

Then execute tests

``` console
$ TESTFLAGS='-check.f TestBuildApiDockerFileRemote' make test-integration-cli
$ TESTFLAGS='-check.f TestRunContainerWithSysFirmwareMountRO' make test-integration-cli
```

Or just make sure that `docker run -it --rm busybox sh -c 'find / > /dev/null'` passes without any error.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Mask /sys/firmware using read-only tmpfs

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
