### PR TITLE
Ignore failure to set oom_score_adj, as happens in an unprivileged container.

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -37,6 +37,7 @@ import (
 	lntypes "github.com/docker/libnetwork/types"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/opencontainers/runc/libcontainer/label"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -1147,10 +1148,16 @@ func setupOOMScoreAdj(score int) error {
 	if err != nil {
 		return err
 	}
-	_, err = f.WriteString(strconv.Itoa(score))
+
+	stringScore := strconv.Itoa(score)
+	_, err = f.WriteString(stringScore)
 	if os.IsPermission(err) {
 		// Setting oom_score_adj does not work in an
-		// unprivileged container. Ignore the error.
+		// unprivileged container. Ignore the error, but log
+		// it if we appear not to be in that situation.
+		if !rsystem.RunningInUserNS() {
+			logrus.Debugf("Permission denied writing %q to /proc/self/oom_score_adj", stringScore)
+		}
 		return nil
 	}
 	f.Close()

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1148,6 +1148,11 @@ func setupOOMScoreAdj(score int) error {
 		return err
 	}
 	_, err = f.WriteString(strconv.Itoa(score))
+	if os.IsPermission(err) {
+		// Setting oom_score_adj does not work in an
+		// unprivileged container. Ignore the error.
+		return nil
+	}
 	f.Close()
 	return err
 }

--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -435,6 +435,11 @@ func setOOMScore(pid, score int) error {
 	}
 	_, err = f.WriteString(strconv.Itoa(score))
 	f.Close()
+	if os.IsPermission(err) {
+		// Setting oom_score_adj does not work in an
+		// unprivileged container. Ignore the error.
+		return nil
+	}
 	return err
 }
 

--- a/libcontainerd/remote_linux.go
+++ b/libcontainerd/remote_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/utils"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
@@ -429,15 +430,21 @@ func (r *remote) runContainerdDaemon() error {
 }
 
 func setOOMScore(pid, score int) error {
-	f, err := os.OpenFile(fmt.Sprintf("/proc/%d/oom_score_adj", pid), os.O_WRONLY, 0)
+	oomScoreAdjPath := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	f, err := os.OpenFile(oomScoreAdjPath, os.O_WRONLY, 0)
 	if err != nil {
 		return err
 	}
-	_, err = f.WriteString(strconv.Itoa(score))
+	stringScore := strconv.Itoa(score)
+	_, err = f.WriteString(stringScore)
 	f.Close()
 	if os.IsPermission(err) {
 		// Setting oom_score_adj does not work in an
-		// unprivileged container. Ignore the error.
+		// unprivileged container. Ignore the error, but log
+		// it if we appear not to be in that situation.
+		if !rsystem.RunningInUserNS() {
+			logrus.Debugf("Permission denied writing %q to %s", stringScore, oomScoreAdjPath)
+		}
 		return nil
 	}
 	return err


### PR DESCRIPTION
**\- What I did**

Running docker 1.12 in an unprivileged container (e.g. from lxd) fails.

**\- How I did it**

Found the places that adjust oom_score_adj and patch them to ignore permission denied (as e.g. systemd does: https://github.com/systemd/systemd/blob/dd8352659c9428b196706d04399eec106a8917ed/src/core/execute.c#L2014-L2028)

**\- How to verify it**

https://github.com/mwhudson/debian-docker/blob/ubuntu/debian/tests/docker-in-lxd is a script designed to run in Ubuntu's autopkgtest that tests this functionality.

**\- Description for the changelog**

Ignore failure to set oom_score_adj, as happens in an unprivileged container.

**\- A picture of a cute animal (not mandatory but encouraged)**

![](http://folksong.org.nz/wottenwood_weta/giantweta.jpg)

Signed-off-by: Michael Hudson-Doyle michael.hudson@canonical.com
