### PR TITLE
Fix a race in libcontainerd/pausemonitor_linux.go

### DIFF
--- a/libcontainerd/pausemonitor_linux.go
+++ b/libcontainerd/pausemonitor_linux.go
@@ -1,11 +1,18 @@
 package libcontainerd
 
+import (
+	"sync"
+)
+
 // pauseMonitor is helper to get notifications from pause state changes.
 type pauseMonitor struct {
+	sync.Mutex
 	waiters map[string][]chan struct{}
 }
 
 func (m *pauseMonitor) handle(t string) {
+	m.Lock()
+	defer m.Unlock()
 	if m.waiters == nil {
 		return
 	}
@@ -20,6 +27,8 @@ func (m *pauseMonitor) handle(t string) {
 }
 
 func (m *pauseMonitor) append(t string, waiter chan struct{}) {
+	m.Lock()
+	defer m.Unlock()
 	if m.waiters == nil {
 		m.waiters = make(map[string][]chan struct{})
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Fixed a race found in #26685 

``` console
WARNING: DATA RACE
Read at 0x00c4215cbad0 by goroutine 78:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:297 +0x0
  github.com/docker/docker/libcontainerd.(*client).setState()
      /go/src/github.com/docker/docker/libcontainerd/client_linux.go:252 +0x456
  github.com/docker/docker/libcontainerd.(*client).Resume()
      /go/src/github.com/docker/docker/libcontainerd/client_linux.go:259 +0x65
  github.com/docker/docker/daemon.(*Daemon).containerUnpause()
      /go/src/github.com/docker/docker/daemon/unpause.go:33 +0x17d
  github.com/docker/docker/daemon.(*Daemon).ContainerUnpause()
      /go/src/github.com/docker/docker/daemon/unpause.go:16 +0xa7
  github.com/docker/docker/api/server/router/container.(*containerRouter).postContainersUnpause()
      /go/src/github.com/docker/docker/api/server/router/container/container_routes.go:257 +0x11d
  github.com/docker/docker/api/server/router/container.(*containerRouter).(github.com/docker/docker/api/server/router/container.postContainersUnpause)-fm()
      /go/src/github.com/docker/docker/api/server/router/container/container.go:58 +0x8a
  github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1()
      /go/src/github.com/docker/docker/api/server/middleware/version.go:56 +0x952
  github.com/docker/docker/api/server/middleware.UserAgentMiddleware.WrapHandler.func1()
      /go/src/github.com/docker/docker/api/server/middleware/user_agent.go:45 +0x307
  github.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1()
      /go/src/github.com/docker/docker/pkg/authorization/middleware.go:34 +0xe5
  github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1()
      /go/src/github.com/docker/docker/api/server/middleware/debug.go:25 +0x346
  github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1()
      /go/src/github.com/docker/docker/api/server/server.go:139 +0x11e
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1726 +0x51
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:103 +0x358
  github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP()
      /go/src/github.com/docker/docker/api/server/router_swapper.go:29 +0x93
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2202 +0xbb
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1579 +0x5f6

Previous write at 0x00c4215cbad0 by goroutine 116:
  runtime.mapassign1()
      /usr/local/go/src/runtime/hashmap.go:442 +0x0
  github.com/docker/docker/libcontainerd.(*container).handleEvent.func1()
      /go/src/github.com/docker/docker/libcontainerd/container_linux.go:216 +0x4de
  github.com/docker/docker/libcontainerd.(*queue).append.func1()
      /go/src/github.com/docker/docker/libcontainerd/queue_linux.go:26 +0x3d

Goroutine 78 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:2293 +0x540
  github.com/docker/docker/api/server.(*HTTPServer).Serve()
      /go/src/github.com/docker/docker/api/server/server.go:114 +0x74
  github.com/docker/docker/api/server.(*Server).serveAPI.func1()
      /go/src/github.com/docker/docker/api/server/server.go:87 +0x106

Goroutine 116 (finished) created at:
  github.com/docker/docker/libcontainerd.(*queue).append()
      /go/src/github.com/docker/docker/libcontainerd/queue_linux.go:28 +0x1ea
  github.com/docker/docker/libcontainerd.(*container).handleEvent()
      /go/src/github.com/docker/docker/libcontainerd/container_linux.go:223 +0x5dd
  github.com/docker/docker/libcontainerd.(*remote).handleEventStream()
      /go/src/github.com/docker/docker/libcontainerd/remote_linux.go:321 +0x30f
```

**\- How I did it**

**\- How to verify it**

```
$ BUILDFLAGS=-race TESTFLAGS='-check.f Pause' make test-integration-cli
$ grep RACE bundles/latest/test-integration-cli/docker.log
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
