### PR TITLE
Update sshd example to use ubuntu 16.04

### DIFF
--- a/docs/examples/running_ssh_service.Dockerfile
+++ b/docs/examples/running_ssh_service.Dockerfile
@@ -1,14 +1,10 @@
-# sshd
-#
-# VERSION               0.0.2
-
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Sven Dowideit <SvenDowideit@docker.com>
 
 RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:screencast' | chpasswd
-RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd

--- a/docs/examples/running_ssh_service.md
+++ b/docs/examples/running_ssh_service.md
@@ -16,48 +16,52 @@ The following `Dockerfile` sets up an SSHd service in a container that you
 can use to connect to and inspect other container's volumes, or to get
 quick access to a test container.
 
-    # sshd
-    #
-    # VERSION               0.0.2
+```Dockerfile
+FROM ubuntu:16.04
+MAINTAINER Sven Dowideit <SvenDowideit@docker.com>
 
-    FROM ubuntu:14.04
-    MAINTAINER Sven Dowideit <SvenDowideit@docker.com>
+RUN apt-get update && apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'root:screencast' | chpasswd
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
-    RUN apt-get update && apt-get install -y openssh-server
-    RUN mkdir /var/run/sshd
-    RUN echo 'root:screencast' | chpasswd
-    RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
-    # SSH login fix. Otherwise user is kicked off after login
-    RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
 
-    ENV NOTVISIBLE "in users profile"
-    RUN echo "export VISIBLE=now" >> /etc/profile
-
-    EXPOSE 22
-    CMD ["/usr/sbin/sshd", "-D"]
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+```
 
 Build the image using:
 
-    $ docker build -t eg_sshd .
-
+```bash
+$ docker build -t eg_sshd .
+```
 ## Run a `test_sshd` container
 
 Then run it. You can then use `docker port` to find out what host port
 the container's port 22 is mapped to:
 
-    $ docker run -d -P --name test_sshd eg_sshd
-    $ docker port test_sshd 22
-    0.0.0.0:49154
+```bash
+$ docker run -d -P --name test_sshd eg_sshd
+$ docker port test_sshd 22
+
+0.0.0.0:49154
+```
 
 And now you can ssh as `root` on the container's IP address (you can find it
 with `docker inspect`) or on port `49154` of the Docker daemon's host IP address
 (`ip address` or `ifconfig` can tell you that) or `localhost` if on the
 Docker daemon host:
 
-    $ ssh root@192.168.1.2 -p 49154
-    # The password is ``screencast``.
-    root@f38c87f2a42d:/#
+```bash
+$ ssh root@192.168.1.2 -p 49154
+# The password is ``screencast``.
+root@f38c87f2a42d:/#
+```
 
 ## Environment variables
 
@@ -78,7 +82,8 @@ short script to do the same before you start `sshd -D` and then replace the
 Finally, clean up after your test by stopping and removing the
 container, and then removing the image.
 
-    $ docker stop test_sshd
-    $ docker rm test_sshd
-    $ docker rmi eg_sshd
-
+```bash
+$ docker stop test_sshd
+$ docker rm test_sshd
+$ docker rmi eg_sshd
+```


### PR DESCRIPTION
Although the example is just for illustrational purposes, many users are now switching to Ubuntu 16.04 as the "default" version for Ubuntu, so updating the example for those that use this example as a starting point.

fixes https://github.com/docker/docker/issues/23621
