### PR TITLE
Cleanup / sync RHEL, CentOS, Fedora installation docs

### DIFF
--- a/docs/installation/linux/centos.md
+++ b/docs/installation/linux/centos.md
@@ -16,114 +16,151 @@ Docker runs on CentOS 7.X. An installation on other binary compatible EL7
 distributions such as Scientific Linux might succeed, but Docker does not test
 or support Docker on these distributions.
 
-This page instructs you to install using Docker-managed release packages and
-installation mechanisms. Using these packages ensures you get the latest release
-of Docker. If you wish to install using CentOS-managed packages, consult your
-CentOS documentation.
+These instructions install Docker using release packages and installation
+mechanisms managed by Docker, to be sure that you get the latest version
+of Docker. If you wish to install using CentOS-managed packages, consult
+your CentOS release documentation.
 
 ## Prerequisites
 
-Docker requires a 64-bit installation regardless of your CentOS version. Also,
-your kernel must be 3.10 at minimum, which CentOS 7 runs.
+Docker requires a 64-bit OS and version 3.10 or higher of the Linux kernel.
 
 To check your current kernel version, open a terminal and use `uname -r` to
 display your kernel version:
 
-    $ uname -r
-    3.10.0-229.el7.x86_64
+```bash
+$ uname -r
+3.10.0-229.el7.x86_64
+```
 
-Finally, it is recommended that you fully update your system. Please keep in
-mind that your system should be fully patched to fix any potential kernel bugs.
+Finally, it is recommended that you fully update your system. Keep in mind
+that your system should be fully patched to fix any potential kernel bugs.
 Any reported kernel bugs may have already been fixed on the latest kernel
 packages.
 
-## Install
+## Install Docker Engine
 
-There are two ways to install Docker Engine.  You can install using the `yum`
-package manager. Or you can use `curl` with the  `get.docker.com` site. This
-second method runs an installation script which also installs via the `yum`
-package manager.
+There are two ways to install Docker Engine.  You can [install using the `yum`
+package manager](#install-with-yum). Or you can use `curl` with the [`get.docker.com`
+site](#install-with-the-script). This second method runs an installation script
+which also installs via the `yum` package manager.
 
 ### Install with yum
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing yum packages are up-to-date.
+2. Make sure your existing packages are up-to-date.
 
-        $ sudo yum update
+    ```bash
+    $ sudo yum update
+    ```
 
-3. Add the yum repo.
+3. Add the `yum` repo.
 
-        $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
-        [dockerrepo]
-        name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/centos/7/
-        enabled=1
-        gpgcheck=1
-        gpgkey=https://yum.dockerproject.org/gpg
-        EOF
+    ```bash
+    $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+    [dockerrepo]
+    name=Docker Repository
+    baseurl=https://yum.dockerproject.org/repo/main/centos/7/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.dockerproject.org/gpg
+    EOF
+    ```
 
 4. Install the Docker package.
 
-        $ sudo yum install docker-engine
+    ```bash
+    $ sudo yum install docker-engine
+    ```
 
-5. Start the Docker daemon.
+5. Enable the service.
 
-        $ sudo service docker start
+    ```bash
+    $ sudo systemctl enable docker.service
+    ```
 
-6. Verify `docker` is installed correctly by running a test image in a container.
+6. Start the Docker daemon.
 
-        $ sudo docker run hello-world
+    ```bash
+    $ sudo systemctl start docker
+    ```
+
+7. Verify `docker` is installed correctly by running a test image in a container.
+
+        $ sudo docker run --rm hello-world
+
         Unable to find image 'hello-world:latest' locally
-    		latest: Pulling from hello-world
-    		a8219747be10: Pull complete
-    		91c95931e552: Already exists
-    		hello-world:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
-    		Digest: sha256:aa03e5d0d5553b4c3473e89c8619cf79df368babd1.7.1cf5daeb82aab55838d
-    		Status: Downloaded newer image for hello-world:latest
-    		Hello from Docker.
-    		This message shows that your installation appears to be working correctly.
+        latest: Pulling from library/hello-world
+        c04b14da8d14: Pull complete
+        Digest: sha256:0256e8a36e2070f7bf2d0b0763dbabdd67798512411de4cdcf9431a1feb60fd9
+        Status: Downloaded newer image for hello-world:latest
 
-    		To generate this message, Docker took the following steps:
-    		 1. The Docker client contacted the Docker daemon.
-    		 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    				(Assuming it was not already locally available.)
-    		 3. The Docker daemon created a new container from that image which runs the
-    				executable that produces the output you are currently reading.
-    		 4. The Docker daemon streamed that output to the Docker client, which sent it
-    				to your terminal.
+        Hello from Docker!
+        This message shows that your installation appears to be working correctly.
 
-    		To try something more ambitious, you can run an Ubuntu container with:
-    		 $ docker run -it ubuntu bash
+        To generate this message, Docker took the following steps:
+         1. The Docker client contacted the Docker daemon.
+         2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+         3. The Docker daemon created a new container from that image which runs the
+            executable that produces the output you are currently reading.
+         4. The Docker daemon streamed that output to the Docker client, which sent it
+            to your terminal.
 
-    		For more examples and ideas, visit:
-    		 http://docs.docker.com/userguide/
+        To try something more ambitious, you can run an Ubuntu container with:
+         $ docker run -it ubuntu bash
+
+        Share images, automate workflows, and more with a free Docker Hub account:
+         https://hub.docker.com
+
+        For more examples and ideas, visit:
+         https://docs.docker.com/engine/userguide/
+
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
 
 ### Install with the script
 
-
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing yum packages are up-to-date.
+2. Make sure your existing packages are up-to-date.
 
-		$ sudo yum update
+    ```bash
+    $ sudo yum update
+    ```
 
 3. Run the Docker installation script.
 
-		$ curl -fsSL https://get.docker.com/ | sh
+    ```bash
+    $ curl -fsSL https://get.docker.com/ | sh
+    ```
 
-	This script adds the `docker.repo` repository and installs Docker.
+    This script adds the `docker.repo` repository and installs Docker.
 
-4. Start the Docker daemon.
+4. Enable the service.
 
-		$ sudo service docker start
+    ```bash
+    $ sudo systemctl enable docker.service
+    ```
 
-5. Verify `docker` is installed correctly by running a test image in a container.
+5. Start the Docker daemon.
 
-		$ sudo docker run hello-world
+    ```bash
+    $ sudo systemctl start docker
+    ```
 
+6. Verify `docker` is installed correctly by running a test image in a container.
 
-## Create a docker group		
+    ```bash
+    $ sudo docker run hello-world
+    ```
+
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
+
+## Create a docker group
 
 The `docker` daemon binds to a Unix socket instead of a TCP port. By default
 that Unix socket is owned by the user `root` and other users can access it with
@@ -139,54 +176,63 @@ makes the ownership of the Unix socket read/writable by the `docker` group.
 
 To create the `docker` group and add your user:
 
-1. Log into Centos as a user with `sudo` privileges.
+1. Log into your machine as a user with `sudo` or `root` privileges.
 
 2. Create the `docker` group.
 
-    `sudo groupadd docker`
+    ```bash
+    $ sudo groupadd docker
+    ```
 
 3. Add your user to `docker` group.
 
-    `sudo usermod -aG docker your_username`
+    ```bash
+    $ sudo usermod -aG docker your_username`
+    ```
 
 4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-5. Verify your work by running `docker` without `sudo`.
+5. Verify that your user is in the docker group by running `docker` without `sudo`.
 
-		$ docker run hello-world
+    ```bash
+    $ docker run hello-world
+    ```
 
 ## Start the docker daemon at boot
 
-To ensure Docker starts when you boot your system, do the following:
+Configure the Docker daemon to start automatically when the host starts:
 
-      $ sudo chkconfig docker on
-
-If you need to add an HTTP Proxy, set a different directory or partition for the
-Docker runtime files, or make other customizations, read our Systemd article to
-learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
-
+```bash
+$ sudo systemctl enable docker
+```
 
 ## Uninstall
 
-You can uninstall the Docker software with `yum`.  
+You can uninstall the Docker software with `yum`.
 
-1. List the package you have installed.
+1. List the installed Docker packages.
 
-		$ yum list installed | grep docker
-		yum list installed | grep docker
-		docker-engine.x86_64   1.7.1-1.el7 @/docker-engine-1.7.1-1.el7.x86_64.rpm
+    ```bash
+    $ yum list installed | grep docker
+
+    docker-engine.x86_64     1.7.1-0.1.el7@/docker-engine-1.7.1-0.1.el7.x86_64
+    ```
 
 2. Remove the package.
 
-		$ sudo yum -y remove docker-engine.x86_64
+    ```bash
+    $ sudo yum -y remove docker-engine.x86_64
+    ```
 
 	This command does not remove images, containers, volumes, or user-created
 	configuration files on your host.
 
 3. To delete all images, containers, and volumes, run the following command:
 
-		$ rm -rf /var/lib/docker
+    ```bash
+    $ rm -rf /var/lib/docker
+    ```
 
 4. Locate and delete any user-created configuration files.

--- a/docs/installation/linux/fedora.md
+++ b/docs/installation/linux/fedora.md
@@ -12,80 +12,94 @@ weight=-3
 
 # Fedora
 
-Docker is supported on Fedora version 22, 23, and 24. This page instructs you to install
-using Docker-managed release packages and installation mechanisms. Using these
-packages ensures you get the latest release of Docker. If you wish to install
-using Fedora-managed packages, consult your Fedora release documentation for
-information on Fedora's Docker support.
+Docker is supported on Fedora version 22, 23, and 24. These instructions install
+Docker using release packages and installation mechanisms managed by Docker, to
+be sure that you get the latest version of Docker. If you wish to install using
+Fedora-managed packages, consult your Fedora release documentation.
 
 ## Prerequisites
 
-Docker requires a 64-bit installation regardless of your Fedora version. Also, your kernel must be 3.10 at minimum. To check your current kernel
-version, open a terminal and use `uname -r` to display your kernel version:
+Docker requires a 64-bit OS and version 3.10 or higher of the Linux kernel.
 
-    $ uname -r
-    3.19.5-100.fc21.x86_64
+To check your current kernel version, open a terminal and use `uname -r` to
+display your kernel version:
+
+```bash
+$ uname -r
+3.19.5-100.fc21.x86_64
+```
 
 If your kernel is at an older version, you must update it.
 
-Finally, is it recommended that you fully update your system. Please keep in
-mind that your system should be fully patched to fix any potential kernel bugs. Any
-reported kernel bugs may have already been fixed on the latest kernel packages
+Finally, it is recommended that you fully update your system. Keep in mind
+that your system should be fully patched to fix any potential kernel bugs.
+Any reported kernel bugs may have already been fixed on the latest kernel
+packages.
 
+## Install Docker Engine
 
-## Install
-
-There are two ways to install Docker Engine.  You can install with the `dnf` package manager. Or you can use `curl` with the  `get.docker.com` site. This second method runs an installation script which also installs via the `dnf` package manager.
+There are two ways to install Docker Engine.  You can [install using the `dnf`
+package manager](#install-with-dnf). Or you can use `curl` [with the  `get.docker.com`
+site](#install-with-the-script). This second method runs an installation script
+which also installs via the `dnf` package manager.
 
 ### Install with DNF
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing dnf packages are up-to-date.
+2. Make sure your existing packages are up-to-date.
 
-		$ sudo dnf update
+    ```bash
+    $ sudo dnf update
+    ```
 
-3. Add the yum repo yourself.
+3. Add the `yum` repo.
 
-        $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
-        [dockerrepo]
-        name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/fedora/$releasever/
-        enabled=1
-        gpgcheck=1
-        gpgkey=https://yum.dockerproject.org/gpg
-        EOF
+    ```bash
+    $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+    [dockerrepo]
+    name=Docker Repository
+    baseurl=https://yum.dockerproject.org/repo/main/fedora/$releasever/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.dockerproject.org/gpg
+    EOF
+    ```
 
 4. Install the Docker package.
 
-        $ sudo dnf install docker-engine
+    ```bash
+    $ sudo dnf install docker-engine
+    ```
 
 5. Enable the service.
 
-		$ sudo systemctl enable docker.service
+    ```bash
+    $ sudo systemctl enable docker.service
+    ```
 
 6. Start the Docker daemon.
 
-		$ sudo systemctl start docker
+    ```bash
+    $ sudo systemctl start docker
+    ```
 
 7. Verify `docker` is installed correctly by running a test image in a container.
 
+        $ sudo docker run --rm hello-world
 
-        $ sudo docker run hello-world
         Unable to find image 'hello-world:latest' locally
-        latest: Pulling from hello-world
-        a8219747be10: Pull complete
-        91c95931e552: Already exists
-        hello-world:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
-        Digest: sha256:aa03e5d0d5553b4c3473e89c8619cf79df368babd1.7.1cf5daeb82aab55838d
+        latest: Pulling from library/hello-world
+        c04b14da8d14: Pull complete
+        Digest: sha256:0256e8a36e2070f7bf2d0b0763dbabdd67798512411de4cdcf9431a1feb60fd9
         Status: Downloaded newer image for hello-world:latest
-        Hello from Docker.
+
+        Hello from Docker!
         This message shows that your installation appears to be working correctly.
 
         To generate this message, Docker took the following steps:
          1. The Docker client contacted the Docker daemon.
          2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-            (Assuming it was not already locally available.)
          3. The Docker daemon created a new container from that image which runs the
             executable that produces the output you are currently reading.
          4. The Docker daemon streamed that output to the Docker client, which sent it
@@ -94,36 +108,57 @@ There are two ways to install Docker Engine.  You can install with the `dnf` pac
         To try something more ambitious, you can run an Ubuntu container with:
          $ docker run -it ubuntu bash
 
-        For more examples and ideas, visit:
-         http://docs.docker.com/userguide/
+        Share images, automate workflows, and more with a free Docker Hub account:
+         https://hub.docker.com
 
+        For more examples and ideas, visit:
+         https://docs.docker.com/engine/userguide/
+
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
 
 ### Install with the script
 
+You use the same installation procedure for all versions of Fedora.
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing dnf packages are up-to-date.
+2. Make sure your existing packages are up-to-date.
 
-		$ sudo dnf update
+    ```bash
+    $ sudo dnf update
+    ```
 
 3. Run the Docker installation script.
 
-		$ curl -fsSL https://get.docker.com/ | sh
+    ```bash
+    $ curl -fsSL https://get.docker.com/ | sh
+    ```
 
-	This script adds the `docker.repo` repository and installs Docker.
+    This script adds the `docker.repo` repository and installs Docker.
 
 4. Enable the service.
 
-		$ sudo systemctl enable docker.service
+    ```bash
+    $ sudo systemctl enable docker.service
+    ```
 
 5. Start the Docker daemon.
 
-        $ sudo systemctl start docker
+    ```bash
+    $ sudo systemctl start docker
+    ```
 
 6. Verify `docker` is installed correctly by running a test image in a container.
 
-		$ sudo docker run hello-world
+    ```bash
+    $ sudo docker run hello-world
+    ```
+
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
 
 ## Create a docker group
 
@@ -141,27 +176,37 @@ makes the ownership of the Unix socket read/writable by the `docker` group.
 
 To create the `docker` group and add your user:
 
-1. Log into your system as a user with `sudo` privileges.
+1. Log into your machine as a user with `sudo` or `root` privileges.
 
 2. Create the `docker` group.
 
-    `sudo groupadd docker`
+    ```bash
+    $ sudo groupadd docker
+    ```
 
 3. Add your user to `docker` group.
 
-    `sudo usermod -aG docker your_username`
+    ```bash
+    $ sudo usermod -aG docker your_username`
+    ```
 
 4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-5. Verify your work by running `docker` without `sudo`.
+5. Verify that your user is in the docker group by running `docker` without `sudo`.
 
-        $ docker run hello-world
+    ```bash
+    $ docker run hello-world
+    ```
 
-If you need to add an HTTP Proxy, set a different directory or partition for the
-Docker runtime files, or make other customizations, read our Systemd article to
-learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
+## Start the docker daemon at boot
+
+Configure the Docker daemon to start automatically when the host starts:
+
+```bash
+$ sudo systemctl enable docker
+```
 
 ## Running Docker with a manually-defined network
 
@@ -186,20 +231,27 @@ This configuration allows IP forwarding from the container as expected.
 
 You can uninstall the Docker software with `dnf`.
 
-1. List the package you have installed.
+1. List the installed Docker packages.
 
-		$ dnf list installed | grep docker
-		docker-engine.x86_64     1.7.1-0.1.fc21 @/docker-engine-1.7.1-0.1.fc21.el7.x86_64
+    ```bash
+    $ dnf list installed | grep docker
+
+    docker-engine.x86_64     1.7.1-0.1.fc21 @/docker-engine-1.7.1-0.1.fc21.el7.x86_64
+    ```
 
 2. Remove the package.
 
-		$ sudo dnf -y remove docker-engine.x86_64
+    ```bash
+    $ sudo dnf -y remove docker-engine.x86_64
+    ```
 
 	This command does not remove images, containers, volumes, or user-created
 	configuration files on your host.
 
 3. To delete all images, containers, and volumes, run the following command:
 
-		$ rm -rf /var/lib/docker
+    ```bash
+    $ rm -rf /var/lib/docker
+    ```
 
 4. Locate and delete any user-created configuration files.

--- a/docs/installation/linux/rhel.md
+++ b/docs/installation/linux/rhel.md
@@ -12,110 +12,151 @@ weight = -5
 
 # Red Hat Enterprise Linux
 
-Docker is supported on Red Hat Enterprise Linux 7. This page instructs you to
-install using Docker-managed release packages and installation mechanisms. Using
-these packages ensures you get the latest release of Docker. If you wish to
-install using Red Hat-managed packages, consult your Red Hat release
-documentation for information on Red Hat's Docker support.
+Docker is supported on Red Hat Enterprise Linux 7. These instructions install
+Docker using release packages and installation mechanisms managed by Docker,
+to be sure that you get the latest version of Docker. If you wish to install
+using Red Hat-managed packages, consult your Red Hat release documentation.
 
 ## Prerequisites
 
-Docker requires a 64-bit installation regardless of your Red Hat version. Docker
-requires that your kernel must be 3.10 at minimum, which Red Hat 7 runs.
+Docker requires a 64-bit OS and version 3.10 or higher of the Linux kernel.
 
 To check your current kernel version, open a terminal and use `uname -r` to
 display your kernel version:
 
-    $ uname -r
-    3.10.0-229.el7.x86_64
+```bash
+$ uname -r
+3.10.0-229.el7.x86_64
+```
 
-Finally, is it recommended that you fully update your system. Please keep in
-mind that your system should be fully patched to fix any potential kernel bugs.
+Finally, it is recommended that you fully update your system. Keep in mind
+that your system should be fully patched to fix any potential kernel bugs.
 Any reported kernel bugs may have already been fixed on the latest kernel
 packages.
 
 ## Install Docker Engine
 
-There are two ways to install Docker Engine.  You can install with the `yum` package manager directly yourself. Or you can use `curl` with the  `get.docker.com` site. This second method runs an installation script which installs via the `yum` package manager.
+There are two ways to install Docker Engine.  You can [install using the `yum`
+package manager](#install-with-yum). Or you can use `curl` with the [`get.docker.com`
+site](#install-with-the-script). This second method runs an installation script
+which also installs via the `yum` package manager.
 
 ### Install with yum
 
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing yum packages are up-to-date.
+2. Make sure your existing packages are up-to-date.
 
-  		$ sudo yum update
+    ```bash
+    $ sudo yum update
+    ```
 
-3. Add the yum repo yourself.
+3. Add the `yum` repo.
 
-        $ sudo tee /etc/yum.repos.d/docker.repo <<-EOF
-        [dockerrepo]
-        name=Docker Repository
-        baseurl=https://yum.dockerproject.org/repo/main/centos/7
-        enabled=1
-        gpgcheck=1
-        gpgkey=https://yum.dockerproject.org/gpg
-        EOF
+    ```bash
+    $ sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+    [dockerrepo]
+    name=Docker Repository
+    baseurl=https://yum.dockerproject.org/repo/main/centos/7/
+    enabled=1
+    gpgcheck=1
+    gpgkey=https://yum.dockerproject.org/gpg
+    EOF
+    ```
 
 4. Install the Docker package.
 
-        $ sudo yum install docker-engine
+    ```bash
+    $ sudo yum install docker-engine
+    ```
 
-5. Start the Docker daemon.
+5. Enable the service.
 
-		$ sudo service docker start
+    ```bash
+    $ sudo systemctl enable docker.service
+    ```
 
-6. Verify `docker` is installed correctly by running a test image in a container.
+6. Start the Docker daemon.
 
-		$ sudo docker run hello-world
+    ```bash
+    $ sudo systemctl start docker
+    ```
+
+7. Verify `docker` is installed correctly by running a test image in a container.
+
+        $ sudo docker run --rm hello-world
+
         Unable to find image 'hello-world:latest' locally
-    		latest: Pulling from hello-world
-    		a8219747be10: Pull complete
-    		91c95931e552: Already exists
-    		hello-world:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
-    		Digest: sha256:aa03e5d0d5553b4c3473e89c8619cf79df368babd1.7.1cf5daeb82aab55838d
-    		Status: Downloaded newer image for hello-world:latest
-    		Hello from Docker.
-    		This message shows that your installation appears to be working correctly.
+        latest: Pulling from library/hello-world
+        c04b14da8d14: Pull complete
+        Digest: sha256:0256e8a36e2070f7bf2d0b0763dbabdd67798512411de4cdcf9431a1feb60fd9
+        Status: Downloaded newer image for hello-world:latest
 
-    		To generate this message, Docker took the following steps:
-    		 1. The Docker client contacted the Docker daemon.
-    		 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    				(Assuming it was not already locally available.)
-    		 3. The Docker daemon created a new container from that image which runs the
-    				executable that produces the output you are currently reading.
-    		 4. The Docker daemon streamed that output to the Docker client, which sent it
-    				to your terminal.
+        Hello from Docker!
+        This message shows that your installation appears to be working correctly.
 
-    		To try something more ambitious, you can run an Ubuntu container with:
-    		 $ docker run -it ubuntu bash
+        To generate this message, Docker took the following steps:
+         1. The Docker client contacted the Docker daemon.
+         2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+         3. The Docker daemon created a new container from that image which runs the
+            executable that produces the output you are currently reading.
+         4. The Docker daemon streamed that output to the Docker client, which sent it
+            to your terminal.
 
-    		For more examples and ideas, visit:
-    		 http://docs.docker.com/userguide/
+        To try something more ambitious, you can run an Ubuntu container with:
+         $ docker run -it ubuntu bash
+
+        Share images, automate workflows, and more with a free Docker Hub account:
+         https://hub.docker.com
+
+        For more examples and ideas, visit:
+         https://docs.docker.com/engine/userguide/
+
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
 
 ### Install with the script
 
-You use the same installation procedure for all versions of CentOS.
-
 1. Log into your machine as a user with `sudo` or `root` privileges.
 
-2. Make sure your existing yum packages are up-to-date.
+2. Make sure your existing packages are up-to-date.
 
-		$ sudo yum update
+    ```bash
+    $ sudo yum update
+    ```
 
 3. Run the Docker installation script.
 
-		$ curl -fsSL https://get.docker.com/ | sh
+    ```bash
+    $ curl -fsSL https://get.docker.com/ | sh
+    ```
 
-4. Start the Docker daemon.
+    This script adds the `docker.repo` repository and installs Docker.
 
-		$ sudo service docker start
+4. Enable the service.
 
-5. Verify `docker` is installed correctly by running a test image in a container.
+    ```bash
+    $ sudo systemctl enable docker.service
+    ```
 
-		$ sudo docker run hello-world
+5. Start the Docker daemon.
 
-## Create a docker group		
+    ```bash
+    $ sudo systemctl start docker
+    ```
+
+6. Verify `docker` is installed correctly by running a test image in a container.
+
+    ```bash
+    $ sudo docker run hello-world
+    ```
+
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
+
+## Create a docker group
 
 The `docker` daemon binds to a Unix socket instead of a TCP port. By default
 that Unix socket is owned by the user `root` and other users can access it with
@@ -135,50 +176,59 @@ To create the `docker` group and add your user:
 
 2. Create the `docker` group.
 
-    `sudo groupadd docker`
+    ```bash
+    $ sudo groupadd docker
+    ```
 
 3. Add your user to `docker` group.
 
-    `sudo usermod -aG docker your_username`
+    ```bash
+    $ sudo usermod -aG docker your_username`
+    ```
 
 4. Log out and log back in.
 
     This ensures your user is running with the correct permissions.
 
-5. Verify your work by running `docker` without `sudo`.
+5. Verify that your user is in the docker group by running `docker` without `sudo`.
 
-			$ docker run hello-world
+    ```bash
+    $ docker run hello-world
+    ```
 
 ## Start the docker daemon at boot
 
-To ensure Docker starts when you boot your system, do the following:
+Configure the Docker daemon to start automatically when the host starts:
 
-    $ sudo chkconfig docker on
-
-If you need to add an HTTP Proxy, set a different directory or partition for the
-Docker runtime files, or make other customizations, read our Systemd article to
-learn how to [customize your Systemd Docker daemon options](../../admin/systemd.md).
-
+```bash
+$ sudo systemctl enable docker
+```
 
 ## Uninstall
 
-You can uninstall the Docker software with `yum`.  
+You can uninstall the Docker software with `yum`.
 
-1. List the package you have installed.
+1. List the installed Docker packages.
 
-		$ yum list installed | grep docker
-		yum list installed | grep docker
-		docker-engine.x86_64                1.7.1-0.1.el7@/docker-engine-1.7.1-0.1.el7.x86_64
+    ```bash
+    $ yum list installed | grep docker
+
+    docker-engine.x86_64     1.7.1-0.1.el7@/docker-engine-1.7.1-0.1.el7.x86_64
+    ```
 
 2. Remove the package.
 
-		$ sudo yum -y remove docker-engine.x86_64
+    ```bash
+    $ sudo yum -y remove docker-engine.x86_64
+    ```
 
-	This command does not remove images, containers, volumes, or user created
+	This command does not remove images, containers, volumes, or user-created
 	configuration files on your host.
 
-3. To delete all images, containers, and volumes run the following command:
+3. To delete all images, containers, and volumes, run the following command:
 
-		$ rm -rf /var/lib/docker
+    ```bash
+    $ rm -rf /var/lib/docker
+    ```
 
 4. Locate and delete any user-created configuration files.


### PR DESCRIPTION
These installation procedures are very similar, so synchronized these docs and removed some differences.

Also;
- updated markdown, added language-hints where possible
- replaced "service docker start" with "systemctl start"
- replaced "chkconfig docker on" with "systemctl enable"
- added "systemctl enable" to the list of steps for
  installation, because most people want to have docker
  started automatically (and overlooked this step).

fixes https://github.com/docker/docker/issues/15456

ping @LK4D4 @vdemeester PTAL
