### PR TITLE
Allow providing a custom storage directory for docker checkpoints

### DIFF
--- a/api/server/router/checkpoint/backend.go
+++ b/api/server/router/checkpoint/backend.go
@@ -5,6 +5,6 @@ import "github.com/docker/docker/api/types"
 // Backend for Checkpoint
 type Backend interface {
 	CheckpointCreate(container string, config types.CheckpointCreateOptions) error
-	CheckpointDelete(container string, checkpointID string) error
-	CheckpointList(container string) ([]types.Checkpoint, error)
+	CheckpointDelete(container string, config types.CheckpointDeleteOptions) error
+	CheckpointList(container string, config types.CheckpointListOptions) ([]types.Checkpoint, error)
 }

--- a/api/server/router/checkpoint/checkpoint_routes.go
+++ b/api/server/router/checkpoint/checkpoint_routes.go
@@ -35,7 +35,10 @@ func (s *checkpointRouter) getContainerCheckpoints(ctx context.Context, w http.R
 		return err
 	}
 
-	checkpoints, err := s.backend.CheckpointList(vars["name"])
+	checkpoints, err := s.backend.CheckpointList(vars["name"], types.CheckpointListOptions{
+		CheckpointDir: r.Form.Get("dir"),
+	})
+
 	if err != nil {
 		return err
 	}
@@ -48,7 +51,11 @@ func (s *checkpointRouter) deleteContainerCheckpoint(ctx context.Context, w http
 		return err
 	}
 
-	err := s.backend.CheckpointDelete(vars["name"], vars["checkpoint"])
+	err := s.backend.CheckpointDelete(vars["name"], types.CheckpointDeleteOptions{
+		CheckpointDir: r.Form.Get("dir"),
+		CheckpointID:  vars["checkpoint"],
+	})
+
 	if err != nil {
 		return err
 	}

--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -39,7 +39,7 @@ type stateBackend interface {
 	ContainerResize(name string, height, width int) error
 	ContainerRestart(name string, seconds *int) error
 	ContainerRm(name string, config *types.ContainerRmConfig) error
-	ContainerStart(name string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string) error
+	ContainerStart(name string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string, checkpointDir string) error
 	ContainerStop(name string, seconds *int) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig, validateHostname bool) (types.ContainerUpdateResponse, error)

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -155,8 +155,9 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 	}
 
 	checkpoint := r.Form.Get("checkpoint")
+	checkpointDir := r.Form.Get("checkpoint-dir")
 	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")
-	if err := s.backend.ContainerStart(vars["name"], hostConfig, validateHostname, checkpoint); err != nil {
+	if err := s.backend.ContainerStart(vars["name"], hostConfig, validateHostname, checkpoint, checkpointDir); err != nil {
 		return err
 	}
 

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -12,8 +12,20 @@ import (
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
 type CheckpointCreateOptions struct {
-	CheckpointID string
-	Exit         bool
+	CheckpointID  string
+	CheckpointDir string
+	Exit          bool
+}
+
+// CheckpointListOptions holds parameters to list checkpoints for a container
+type CheckpointListOptions struct {
+	CheckpointDir string
+}
+
+// CheckpointDeleteOptions holds parameters to delete a checkpoint from a container
+type CheckpointDeleteOptions struct {
+	CheckpointID  string
+	CheckpointDir string
 }
 
 // ContainerAttachOptions holds parameters to attach to a container.
@@ -77,7 +89,8 @@ type ContainerRemoveOptions struct {
 
 // ContainerStartOptions holds parameters to start containers.
 type ContainerStartOptions struct {
-	CheckpointID string
+	CheckpointID  string
+	CheckpointDir string
 }
 
 // CopyToContainerOptions holds information

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -124,7 +124,7 @@ type Backend interface {
 	// ContainerKill stops the container execution abruptly.
 	ContainerKill(containerID string, sig uint64) error
 	// ContainerStart starts a new container
-	ContainerStart(containerID string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string) error
+	ContainerStart(containerID string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
 	ContainerWait(containerID string, timeout time.Duration) (int, error)
 	// ContainerUpdateCmdOnBuild updates container.Path and container.Args

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -537,7 +537,7 @@ func (b *Builder) run(cID string) (err error) {
 		}
 	}()
 
-	if err := b.docker.ContainerStart(cID, nil, true, ""); err != nil {
+	if err := b.docker.ContainerStart(cID, nil, true, "", ""); err != nil {
 		close(finished)
 		if cancelErr := <-cancelErrCh; cancelErr != nil {
 			logrus.Debugf("Build cancelled (%v) and got an error from ContainerStart: %v",

--- a/cli/command/checkpoint/create.go
+++ b/cli/command/checkpoint/create.go
@@ -10,9 +10,10 @@ import (
 )
 
 type createOptions struct {
-	container    string
-	checkpoint   string
-	leaveRunning bool
+	container     string
+	checkpoint    string
+	checkpointDir string
+	leaveRunning  bool
 }
 
 func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
@@ -31,6 +32,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.leaveRunning, "leave-running", false, "leave the container running after checkpoint")
+	flags.StringVarP(&opts.checkpointDir, "checkpoint-dir", "", "", "use a custom checkpoint storage directory")
 
 	return cmd
 }
@@ -39,8 +41,9 @@ func runCreate(dockerCli *command.DockerCli, opts createOptions) error {
 	client := dockerCli.Client()
 
 	checkpointOpts := types.CheckpointCreateOptions{
-		CheckpointID: opts.checkpoint,
-		Exit:         !opts.leaveRunning,
+		CheckpointID:  opts.checkpoint,
+		CheckpointDir: opts.checkpointDir,
+		Exit:          !opts.leaveRunning,
 	}
 
 	err := client.CheckpointCreate(context.Background(), opts.container, checkpointOpts)

--- a/cli/command/checkpoint/remove.go
+++ b/cli/command/checkpoint/remove.go
@@ -3,24 +3,42 @@ package checkpoint
 import (
 	"golang.org/x/net/context"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
 )
 
+type removeOptions struct {
+	checkpointDir string
+}
+
 func newRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
-	return &cobra.Command{
+	var opts removeOptions
+
+	cmd := &cobra.Command{
 		Use:     "rm CONTAINER CHECKPOINT",
 		Aliases: []string{"remove"},
 		Short:   "Remove a checkpoint",
 		Args:    cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(dockerCli, args[0], args[1])
+			return runRemove(dockerCli, args[0], args[1], opts)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.checkpointDir, "checkpoint-dir", "", "", "use a custom checkpoint storage directory")
+
+	return cmd
 }
 
-func runRemove(dockerCli *command.DockerCli, container string, checkpoint string) error {
+func runRemove(dockerCli *command.DockerCli, container string, checkpoint string, opts removeOptions) error {
 	client := dockerCli.Client()
-	return client.CheckpointDelete(context.Background(), container, checkpoint)
+
+	removeOpts := types.CheckpointDeleteOptions{
+		CheckpointID:  checkpoint,
+		CheckpointDir: opts.checkpointDir,
+	}
+
+	return client.CheckpointDelete(context.Background(), container, removeOpts)
 }

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -17,10 +17,11 @@ import (
 )
 
 type startOptions struct {
-	attach     bool
-	openStdin  bool
-	detachKeys string
-	checkpoint string
+	attach        bool
+	openStdin     bool
+	detachKeys    string
+	checkpoint    string
+	checkpointDir string
 
 	containers []string
 }
@@ -46,6 +47,7 @@ func NewStartCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	if dockerCli.HasExperimental() {
 		flags.StringVar(&opts.checkpoint, "checkpoint", "", "Restore from this checkpoint")
+		flags.StringVar(&opts.checkpointDir, "checkpoint-dir", "", "Use a custom checkpoint storage directory")
 	}
 
 	return cmd
@@ -112,7 +114,8 @@ func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 		// no matter it's detached, removed on daemon side(--rm) or exit normally.
 		statusChan := waitExitOrRemoved(dockerCli, ctx, c.ID, c.HostConfig.AutoRemove)
 		startOptions := types.ContainerStartOptions{
-			CheckpointID: opts.checkpoint,
+			CheckpointID:  opts.checkpoint,
+			CheckpointDir: opts.checkpointDir,
 		}
 
 		// 4. Start the container.
@@ -145,7 +148,8 @@ func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 		}
 		container := opts.containers[0]
 		startOptions := types.ContainerStartOptions{
-			CheckpointID: opts.checkpoint,
+			CheckpointID:  opts.checkpoint,
+			CheckpointDir: opts.checkpointDir,
 		}
 		return dockerCli.Client().ContainerStart(ctx, container, startOptions)
 

--- a/client/checkpoint_delete.go
+++ b/client/checkpoint_delete.go
@@ -1,12 +1,20 @@
 package client
 
 import (
+	"net/url"
+
+	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
 
 // CheckpointDelete deletes the checkpoint with the given name from the given container
-func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, checkpointID string) error {
-	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+checkpointID, nil, nil)
+func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, options types.CheckpointDeleteOptions) error {
+	query := url.Values{}
+	if options.CheckpointDir != "" {
+		query.Set("dir", options.CheckpointDir)
+	}
+
+	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+options.CheckpointID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
 
@@ -16,7 +17,10 @@ func TestCheckpointDeleteError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.CheckpointDelete(context.Background(), "container_id", "checkpoint_id")
+	err := client.CheckpointDelete(context.Background(), "container_id", types.CheckpointDeleteOptions{
+		CheckpointID: "checkpoint_id",
+	})
+
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -40,7 +44,10 @@ func TestCheckpointDelete(t *testing.T) {
 		}),
 	}
 
-	err := client.CheckpointDelete(context.Background(), "container_id", "checkpoint_id")
+	err := client.CheckpointDelete(context.Background(), "container_id", types.CheckpointDeleteOptions{
+		CheckpointID: "checkpoint_id",
+	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -2,16 +2,22 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
 
 // CheckpointList returns the volumes configured in the docker host.
-func (cli *Client) CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error) {
+func (cli *Client) CheckpointList(ctx context.Context, container string, options types.CheckpointListOptions) ([]types.Checkpoint, error) {
 	var checkpoints []types.Checkpoint
 
-	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", nil, nil)
+	query := url.Values{}
+	if options.CheckpointDir != "" {
+		query.Set("dir", options.CheckpointDir)
+	}
+
+	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
 	if err != nil {
 		return checkpoints, err
 	}

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -18,7 +18,7 @@ func TestCheckpointListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.CheckpointList(context.Background(), "container_id")
+	_, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -47,7 +47,7 @@ func TestCheckpointList(t *testing.T) {
 		}),
 	}
 
-	checkpoints, err := client.CheckpointList(context.Background(), "container_id")
+	checkpoints, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -14,6 +14,9 @@ func (cli *Client) ContainerStart(ctx context.Context, containerID string, optio
 	if len(options.CheckpointID) != 0 {
 		query.Set("checkpoint", options.CheckpointID)
 	}
+	if len(options.CheckpointDir) != 0 {
+		query.Set("checkpoint-dir", options.CheckpointDir)
+	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/client/interface_experimental.go
+++ b/client/interface_experimental.go
@@ -13,8 +13,8 @@ type apiClientExperimental interface {
 // CheckpointAPIClient defines API client methods for the checkpoints
 type CheckpointAPIClient interface {
 	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
-	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
-	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
+	CheckpointDelete(ctx context.Context, container string, options types.CheckpointDeleteOptions) error
+	CheckpointList(ctx context.Context, container string, options types.CheckpointListOptions) ([]types.Checkpoint, error)
 }
 
 // PluginAPIClient defines API client methods for the plugins

--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -21,7 +21,14 @@ func (daemon *Daemon) CheckpointCreate(name string, config types.CheckpointCreat
 		return fmt.Errorf("Container %s not running", name)
 	}
 
-	err = daemon.containerd.CreateCheckpoint(container.ID, config.CheckpointID, container.CheckpointDir(), config.Exit)
+	var checkpointDir string
+	if config.CheckpointDir != "" {
+		checkpointDir = config.CheckpointDir
+	} else {
+		checkpointDir = container.CheckpointDir()
+	}
+
+	err = daemon.containerd.CreateCheckpoint(container.ID, config.CheckpointID, checkpointDir, config.Exit)
 	if err != nil {
 		return fmt.Errorf("Cannot checkpoint container %s: %s", name, err)
 	}
@@ -32,18 +39,24 @@ func (daemon *Daemon) CheckpointCreate(name string, config types.CheckpointCreat
 }
 
 // CheckpointDelete deletes the specified checkpoint
-func (daemon *Daemon) CheckpointDelete(name string, checkpoint string) error {
+func (daemon *Daemon) CheckpointDelete(name string, config types.CheckpointDeleteOptions) error {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
 	}
 
-	checkpointDir := container.CheckpointDir()
-	return os.RemoveAll(filepath.Join(checkpointDir, checkpoint))
+	var checkpointDir string
+	if config.CheckpointDir != "" {
+		checkpointDir = config.CheckpointDir
+	} else {
+		checkpointDir = container.CheckpointDir()
+	}
+
+	return os.RemoveAll(filepath.Join(checkpointDir, config.CheckpointID))
 }
 
 // CheckpointList lists all checkpoints of the specified container
-func (daemon *Daemon) CheckpointList(name string) ([]types.Checkpoint, error) {
+func (daemon *Daemon) CheckpointList(name string, config types.CheckpointListOptions) ([]types.Checkpoint, error) {
 	var out []types.Checkpoint
 
 	container, err := daemon.GetContainer(name)
@@ -51,7 +64,13 @@ func (daemon *Daemon) CheckpointList(name string) ([]types.Checkpoint, error) {
 		return nil, err
 	}
 
-	checkpointDir := container.CheckpointDir()
+	var checkpointDir string
+	if config.CheckpointDir != "" {
+		checkpointDir = config.CheckpointDir
+	} else {
+		checkpointDir = container.CheckpointDir()
+	}
+
 	if err := os.MkdirAll(checkpointDir, 0755); err != nil {
 		return nil, err
 	}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -24,7 +24,7 @@ type Backend interface {
 	SetupIngress(req clustertypes.NetworkCreateRequest, nodeIP string) error
 	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
 	CreateManagedContainer(config types.ContainerCreateConfig, validateHostname bool) (types.ContainerCreateResponse, error)
-	ContainerStart(name string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string) error
+	ContainerStart(name string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string, checkpointDir string) error
 	ContainerStop(name string, seconds *int) error
 	ConnectContainerToNetwork(containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -224,7 +224,7 @@ func (c *containerAdapter) create(ctx context.Context) error {
 func (c *containerAdapter) start(ctx context.Context) error {
 	version := httputils.VersionFromContext(ctx)
 	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")
-	return c.backend.ContainerStart(c.container.name(), nil, validateHostname, "")
+	return c.backend.ContainerStart(c.container.name(), nil, validateHostname, "", "")
 }
 
 func (c *containerAdapter) inspect(ctx context.Context) (types.ContainerJSON, error) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -305,7 +305,7 @@ func (daemon *Daemon) restore() error {
 
 			// Make sure networks are available before starting
 			daemon.waitForNetworks(c)
-			if err := daemon.containerStart(c, "", true); err != nil {
+			if err := daemon.containerStart(c, "", "", true); err != nil {
 				logrus.Errorf("Failed to start container %s: %s", c.ID, err)
 			}
 			close(chNotify)
@@ -372,7 +372,7 @@ func (daemon *Daemon) RestartSwarmContainers() {
 				group.Add(1)
 				go func(c *container.Container) {
 					defer group.Done()
-					if err := daemon.containerStart(c, "", true); err != nil {
+					if err := daemon.containerStart(c, "", "", true); err != nil {
 						logrus.Error(err)
 					}
 				}(c)

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -62,7 +62,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 			go func() {
 				err := <-wait
 				if err == nil {
-					if err = daemon.containerStart(c, "", false); err != nil {
+					if err = daemon.containerStart(c, "", "", false); err != nil {
 						logrus.Debugf("failed to restart contianer: %+v", err)
 					}
 				}

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -61,7 +61,7 @@ func (daemon *Daemon) containerRestart(container *container.Container, seconds i
 		}
 	}
 
-	if err := daemon.containerStart(container, "", true); err != nil {
+	if err := daemon.containerStart(container, "", "", true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**\- What I did**

Add a "checkpoint-dir" option to each checkpoint related command, for providing a custom storage location for checkpoints.

This is extremely valuable for many C/R use cases, and is necessary to support restoring a checkpoint created in one container into another container.

**\- How to verify it**

Pass --checkpoint-dir to checkpoint create/ls/rm or start

**\- Description for the changelog**

Allow providing a custom storage directory for docker checkpoints

(Note, this is largely a port of: https://github.com/docker/engine-api/pull/295)
