### PR TITLE
Fix regex for the json-file logger opts in overview.md

### DIFF
--- a/docs/admin/logging/overview.md
+++ b/docs/admin/logging/overview.md
@@ -71,8 +71,8 @@ This adds additional fields to the log depending on the driver, e.g. for
 The following logging options are supported for the `json-file` logging driver:
 
 ```bash
---log-opt max-size=[0-9+][k|m|g]
---log-opt max-file=[0-9+]
+--log-opt max-size=[0-9]+[kmg]
+--log-opt max-file=[0-9]+
 --log-opt labels=label1,label2
 --log-opt env=env1,env2
 ```


### PR DESCRIPTION
The regex used to describe the max-file and max-size logging options for
the json-file logger were incorrect. The regexes would only match a
single character (a digit or a literal +). Instead the regexes should
match 1 or more digits.

The character class for the units of the max-size also included a pipe
which meant that the regex would match 1| instead of only matching 1m,
1k, and 1g.

Signed-off-by: Steven Erenst stevenerenst@gmail.com
