### PR TITLE
Add Logs to ContainerAttachOptions

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -23,6 +23,7 @@ type ContainerAttachOptions struct {
 	Stdout     bool
 	Stderr     bool
 	DetachKeys string
+	Logs       bool
 }
 
 // ContainerCommitOptions holds parameters to commit changes into a container.

--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -28,6 +28,9 @@ func (cli *Client) ContainerAttach(ctx context.Context, container string, option
 	if options.DetachKeys != "" {
 		query.Set("detachKeys", options.DetachKeys)
 	}
+	if options.Logs {
+		query.Set("logs", "1")
+	}
 
 	headers := map[string][]string{"Content-Type": {"text/plain"}}
 	return cli.postHijacked(ctx, "/containers/"+container+"/attach", query, nil, headers)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Added `Logs` to `ContainerAttachOptions` so go clients can request to retrieve container logs as part of the attach process.

**\- How I did it**
N/A

**\- How to verify it**
Create a go client and attempt to attach to a container with `Logs` set to `true`. You should get container logs whereas before you wouldn't. I'd be happy to write a test for this if you can point me at the appropriate file to do this in.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add Logs to ContainerAttachOptions

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Andy Goldstein agoldste@redhat.com

cc @runcom 
