### PR TITLE
Fix a race found in TestBuildCancellationKillsSleep

### DIFF
--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -523,10 +522,7 @@ func (b *Builder) run(cID string) (err error) {
 	}()
 
 	finished := make(chan struct{})
-	var once sync.Once
-	finish := func() { close(finished) }
 	cancelErrCh := make(chan error, 1)
-	defer once.Do(finish)
 	go func() {
 		select {
 		case <-b.clientCtx.Done():
@@ -540,22 +536,37 @@ func (b *Builder) run(cID string) (err error) {
 	}()
 
 	if err := b.docker.ContainerStart(cID, nil, true, ""); err != nil {
+		close(finished)
+		if cancelErr := <-cancelErrCh; cancelErr != nil {
+			logrus.Debugf("Build cancelled (%v) and got an error from ContainerStart: %v",
+				cancelErr, err)
+		}
 		return err
 	}
 
 	// Block on reading output from container, stop on err or chan closed
 	if err := <-errCh; err != nil {
+		close(finished)
+		if cancelErr := <-cancelErrCh; cancelErr != nil {
+			logrus.Debugf("Build cancelled (%v) and got an error from errCh: %v",
+				cancelErr, err)
+		}
 		return err
 	}
 
 	if ret, _ := b.docker.ContainerWait(cID, -1); ret != 0 {
+		close(finished)
+		if cancelErr := <-cancelErrCh; cancelErr != nil {
+			logrus.Debugf("Build cancelled (%v) and got a non-zero code from ContainerWait: %d",
+				cancelErr, ret)
+		}
 		// TODO: change error type, because jsonmessage.JSONError assumes HTTP
 		return &jsonmessage.JSONError{
 			Message: fmt.Sprintf("The command '%s' returned a non-zero code: %d", strings.Join(b.runConfig.Cmd, " "), ret),
 			Code:    ret,
 		}
 	}
-	once.Do(finish)
+	close(finished)
 	return <-cancelErrCh
 }
 


### PR DESCRIPTION
**\- What I did**
Fix a race found in `TestBuildCancellationKillsSleep`: container(`container.Config`) vs builder (`builder.runConfig`)

https://github.com/docker/docker/issues/26685

``` console
WARNING: DATA RACE
Read at 0x00c421418548 by goroutine 10:
  reflect.Value.IsNil()
      /usr/local/go/src/reflect/value.go:975 +0xd8
  encoding/json.(*sliceEncoder).encode()
      /usr/local/go/src/encoding/json/encode.go:693 +0x50
  encoding/json.(*sliceEncoder).(encoding/json.encode)-fm()
      /usr/local/go/src/encoding/json/encode.go:709 +0x7b
  encoding/json.(*structEncoder).encode()
      /usr/local/go/src/encoding/json/encode.go:601 +0x2d9
  encoding/json.(*structEncoder).(encoding/json.encode)-fm()
      /usr/local/go/src/encoding/json/encode.go:615 +0x7b
  encoding/json.(*ptrEncoder).encode()
      /usr/local/go/src/encoding/json/encode.go:742 +0x12a
  encoding/json.(*ptrEncoder).(encoding/json.encode)-fm()
      /usr/local/go/src/encoding/json/encode.go:747 +0x7b
  encoding/json.(*structEncoder).encode()
      /usr/local/go/src/encoding/json/encode.go:601 +0x2d9
  encoding/json.(*structEncoder).(encoding/json.encode)-fm()
      /usr/local/go/src/encoding/json/encode.go:615 +0x7b
  encoding/json.(*ptrEncoder).encode()
      /usr/local/go/src/encoding/json/encode.go:742 +0x12a
  encoding/json.(*ptrEncoder).(encoding/json.encode)-fm()
      /usr/local/go/src/encoding/json/encode.go:747 +0x7b
  encoding/json.(*encodeState).reflectValue()
      /usr/local/go/src/encoding/json/encode.go:307 +0x93
  encoding/json.(*encodeState).marshal()
      /usr/local/go/src/encoding/json/encode.go:280 +0xc5
  encoding/json.(*Encoder).Encode()
      /usr/local/go/src/encoding/json/stream.go:193 +0x136
  github.com/docker/docker/container.(*Container).ToDisk()
      /go/src/github.com/docker/docker/container/container.go:153 +0x1f9
  github.com/docker/docker/container.(*Container).ToDiskLocking()
      /go/src/github.com/docker/docker/container/container.go:163 +0x6a
  github.com/docker/docker/daemon.(*Daemon).cleanupContainer()
      /go/src/github.com/docker/docker/daemon/delete.go:98 +0x1cf
  github.com/docker/docker/daemon.(*Daemon).ContainerRm()
      /go/src/github.com/docker/docker/daemon/delete.go:42 +0x24b
  github.com/docker/docker/builder/dockerfile.(*Builder).removeContainer()
      /go/src/github.com/docker/docker/builder/dockerfile/internals.go:571 +0x103
  github.com/docker/docker/builder/dockerfile.(*Builder).run.func3()
      /go/src/github.com/docker/docker/builder/dockerfile/internals.go:539 +0x2b6

Previous write at 0x00c421418548 by goroutine 94:
  github.com/docker/docker/builder/dockerfile.run.func2()
      /go/src/github.com/docker/docker/builder/dockerfile/dispatchers.go:323 +0x56
  github.com/docker/docker/builder/dockerfile.run()
      /go/src/github.com/docker/docker/builder/dockerfile/dispatchers.go:392 +0xf2d
  github.com/docker/docker/builder/dockerfile.(*Builder).dispatch()
      /go/src/github.com/docker/docker/builder/dockerfile/evaluator.go:199 +0x168f
  github.com/docker/docker/builder/dockerfile.(*Builder).build()
      /go/src/github.com/docker/docker/builder/dockerfile/builder.go:246 +0x3af
  github.com/docker/docker/builder/dockerfile.(*BuildManager).BuildFromContext()
      /go/src/github.com/docker/docker/builder/dockerfile/builder.go:108 +0x2e8
  github.com/docker/docker/api/server/router/build.(*buildRouter).postBuild()
      /go/src/github.com/docker/docker/api/server/router/build/build_routes.go:181 +0xc50
  github.com/docker/docker/api/server/router/build.(*buildRouter).(github.com/docker/docker/api/server/router/build.postBuild)-fm()
      /go/src/github.com/docker/docker/api/server/router/build/build.go:27 +0x8a
  github.com/docker/docker/api/server/router.cancellableHandler.func1()
      /go/src/github.com/docker/docker/api/server/router/local.go:84 +0x124
  github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1()
      /go/src/github.com/docker/docker/api/server/middleware/version.go:56 +0x952
  github.com/docker/docker/api/server/middleware.UserAgentMiddleware.WrapHandler.func1()
      /go/src/github.com/docker/docker/api/server/middleware/user_agent.go:45 +0x307
  github.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1()
      /go/src/github.com/docker/docker/pkg/authorization/middleware.go:34 +0xe5
  github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1()
      /go/src/github.com/docker/docker/api/server/middleware/debug.go:25 +0x346
  github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1()
      /go/src/github.com/docker/docker/api/server/server.go:139 +0x11e
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1726 +0x51
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:103 +0x358
  github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP()
      /go/src/github.com/docker/docker/api/server/router_swapper.go:29 +0x93
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2202 +0xbb
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1579 +0x5f6

Goroutine 10 (running) created at:
  github.com/docker/docker/builder/dockerfile.(*Builder).run()
      /go/src/github.com/docker/docker/builder/dockerfile/internals.go:544 +0x23e
  github.com/docker/docker/builder/dockerfile.run()
      /go/src/github.com/docker/docker/builder/dockerfile/dispatchers.go:391 +0xf0d
  github.com/docker/docker/builder/dockerfile.(*Builder).dispatch()
      /go/src/github.com/docker/docker/builder/dockerfile/evaluator.go:199 +0x168f
  github.com/docker/docker/builder/dockerfile.(*Builder).build()
      /go/src/github.com/docker/docker/builder/dockerfile/builder.go:246 +0x3af
  github.com/docker/docker/builder/dockerfile.(*BuildManager).BuildFromContext()
      /go/src/github.com/docker/docker/builder/dockerfile/builder.go:108 +0x2e8
  github.com/docker/docker/api/server/router/build.(*buildRouter).postBuild()
      /go/src/github.com/docker/docker/api/server/router/build/build_routes.go:181 +0xc50
  github.com/docker/docker/api/server/router/build.(*buildRouter).(github.com/docker/docker/api/server/router/build.postBuild)-fm()
      /go/src/github.com/docker/docker/api/server/router/build/build.go:27 +0x8a
  github.com/docker/docker/api/server/router.cancellableHandler.func1()
      /go/src/github.com/docker/docker/api/server/router/local.go:84 +0x124
  github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1()
      /go/src/github.com/docker/docker/api/server/middleware/version.go:56 +0x952
  github.com/docker/docker/api/server/middleware.UserAgentMiddleware.WrapHandler.func1()
      /go/src/github.com/docker/docker/api/server/middleware/user_agent.go:45 +0x307
  github.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1()
      /go/src/github.com/docker/docker/pkg/authorization/middleware.go:34 +0xe5
  github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1()
      /go/src/github.com/docker/docker/api/server/middleware/debug.go:25 +0x346
  github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1()
      /go/src/github.com/docker/docker/api/server/server.go:139 +0x11e
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1726 +0x51
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:103 +0x358
  github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP()
      /go/src/github.com/docker/docker/api/server/router_swapper.go:29 +0x93
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2202 +0xbb
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1579 +0x5f6

Goroutine 94 (finished) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:2293 +0x540
  github.com/docker/docker/api/server.(*HTTPServer).Serve()
      /go/src/github.com/docker/docker/api/server/server.go:114 +0x74
  github.com/docker/docker/api/server.(*Server).serveAPI.func1()
      /go/src/github.com/docker/docker/api/server/server.go:87 +0x106
```

**\- How I did it**
Wait for `cancelErrCh`

**\- How to verify it**

``` console
$ BUILDFLAGS=-race TESTFLAGS='-check.f TestBuildCancellationKillsSleep -test.count 100' make test-integration-cli`
$ grep RACE bundles/latest/test-integration-cli/docker.log
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
