### PR TITLE
[test] Fix TestBuildApiDockerFileRemote

### DIFF
--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -13,12 +13,20 @@ import (
 
 func (s *DockerSuite) TestBuildApiDockerFileRemote(c *check.C) {
 	testRequires(c, NotUserNamespace)
-	server, err := fakeStorage(map[string]string{
-		"testD": `FROM busybox
+	var testD string
+	if daemonPlatform == "windows" {
+		testD = `FROM busybox
 COPY * /tmp/
 RUN find / -name ba*
-RUN find /tmp/`,
-	})
+RUN find /tmp/`
+	} else {
+		// -xdev is required because sysfs can cause EPERM
+		testD = `FROM busybox
+COPY * /tmp/
+RUN find / -xdev -name ba*
+RUN find /tmp/`
+	}
+	server, err := fakeStorage(map[string]string{"testD": testD})
 	c.Assert(err, checker.IsNil)
 	defer server.Close()
 


### PR DESCRIPTION
**\- What I did**
`TestBuildApiDockerFileRemote` has been consistently failing (`EPERM`) on the host with #26618, which prohibits /sys/firmware from being accessed using apparmor.
https://github.com/docker/docker/blob/8a46c18dd4e4f8091b9e02ef5b476e8b8aa77c47/integration-cli/docker_api_build_test.go#L19

``` console
RUN find / -name ba*
find: /sys/firmware/dmi: Permission denied
find: /sys/firmware/acpi: Permission denied
find: /sys/firmware/memmap: Permission denied
```

Replaces https://github.com/docker/docker/pull/26689

**\- How I did it**
Add `-xdev` to `find`.

**\- How to verify it**
Make sure the latest apparmor profile is installed to the host:

``` console
$ cat /etc/apparmor.d/docker
...
profile docker-default flags=(attach_disconnected,mediate_deleted) {
...
  deny /sys/firmware/** rwklx,
...
}
```

Then execute the test

``` console
$ TESTFLAGS='-check.f TestBuildApiDockerFileRemote' make test-integration-cli
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
