### PR TITLE
Use microsoft/windowsservercore base image

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -29,7 +29,7 @@
 #
 # The steps are minimised dramatically to improve performance
 
-FROM windowsservercore
+FROM microsoft/windowsservercore
 
 # Environment variable notes:
 #  - GO_VERSION must consistent with 'Dockerfile' used by Linux'.


### PR DESCRIPTION
**\- What I did**

I tried to compile a Windows docker engine with the given `Dockerfile.windows`, but found out that the base image `windowsservercore` could not be found. The official base image is `microsoft/windowsservercore`, so I think this should be used.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update the Dockerfile.windows to use the official microsoft/windowsservercore base image.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Stefan Scherer scherer_stefan@icloud.com
