### PR TITLE
Windows: Write fatal error to event log if running as service

### DIFF
--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -41,6 +41,9 @@ func notifySystem() {
 // notifyShutdown is called after the daemon shuts down but before the process exits.
 func notifyShutdown(err error) {
 	if service != nil {
+		if err != nil {
+			logrus.Fatal(err)
+		}
 		service.stopped(err)
 	}
 }


### PR DESCRIPTION
**\- What I did**

I've updated a TP5 machine to use the latest docker-1.13.0-dev.zip binaries. But I couldn't start the Windows Service docker. I found no useful information in the Event log viewer.

Only after starting the `dockerd.exe` manually I found a message on stdout that TP5 seems to be too old:

```
Error starting daemon: The docker daemon requires build 14393 or later of Windows Server 2016 or Windows 10
```

The message is swallowed if `dockerd.exe` is started as a service as [discussed here](https://github.com/StefanScherer/packer-windows/pull/14#r79337616). So I looked for a good place to log that error with logrus to the Event log.

**\- How I did it**

**\- How to verify it**

Install the binaries on TP5 and try to start the service and have a look at the Event log.

**\- Description for the changelog**
Write fatal error to the Windows event log when the service could not be started.

**\- A picture of a cute animal (not mandatory but encouraged)**

Not an animal, but the result of this PR:

<img width="1077" alt="bildschirmfoto 2016-09-19 um 23 01 02" src="https://cloud.githubusercontent.com/assets/207759/18649011/7beb2f22-7ebd-11e6-950c-410d19a511e5.png">

Signed-off-by: Stefan Scherer scherer_stefan@icloud.com
