### PR TITLE
Fix typo in api/types/container/host_config.go

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -323,7 +323,7 @@ type HostConfig struct {
 	Mounts []mount.Mount `json:",omitempty"`
 
 	// Run a custom init inside the container, if null, use the daemon's configured settings
-	Init *bool `json:",om        itempty"`
+	Init *bool `json:",omitempty"`
 }
 
 // Box specifies height and width dimensions. Used for sizing of a console.


### PR DESCRIPTION
**\- What I did**

Fixed a typo I noticed when reading #26061.

**\- How I did it**

Deleted from strange spaces in the middle of an identifier.

**\- How to verify it**

Look at the json serialization of daemon settings and check if the `Init` field is present.

**\- Description for the changelog**

N/A

**\- A picture of a cute animal (not mandatory but encouraged)**

![Image of cute animal](http://67.media.tumblr.com/e0ebffb52c81d4d0157821382c271ce8/tumblr_mpbogjFu5X1r2soa9o1_500.jpg)
