### PR TITLE
Update fluent-logger-golang to v1.2.0.

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -119,7 +119,7 @@ clone git github.com/golang/protobuf 3c84672111d91bb5ac31719e112f9f7126a0e26e
 # gelf logging driver deps
 clone git github.com/Graylog2/go-gelf aab2f594e4585d43468ac57287b0dece9d806883
 
-clone git github.com/fluent/fluent-logger-golang v1.1.0
+clone git github.com/fluent/fluent-logger-golang v1.2.0
 # fluent-logger-golang deps
 clone git github.com/philhofer/fwd 899e4efba8eaa1fea74175308f3fae18ff3319fa
 clone git github.com/tinylib/msgp 75ee40d2601edf122ef667e2a07d600d4c44490c

--- a/vendor/src/github.com/fluent/fluent-logger-golang/LICENSE
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/LICENSE
@@ -1,13 +1,202 @@
-Copyright (c) 2013 Tatsuo Kaniwa
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
@@ -1,6 +1,7 @@
 package fluent
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -25,24 +26,28 @@ const (
 )
 
 type Config struct {
-	FluentPort       int
-	FluentHost       string
-	FluentNetwork    string
-	FluentSocketPath string
-	Timeout          time.Duration
-	BufferLimit      int
-	RetryWait        int
-	MaxRetry         int
-	TagPrefix        string
-	AsyncConnect     bool
+	FluentPort       int           `json:"fluent_port"`
+	FluentHost       string        `json:"fluent_host"`
+	FluentNetwork    string        `json:"fluent_network"`
+	FluentSocketPath string        `json:"fluent_socket_path"`
+	Timeout          time.Duration `json:"timeout"`
+	BufferLimit      int           `json:"buffer_limit"`
+	RetryWait        int           `json:"retry_wait"`
+	MaxRetry         int           `json:"max_retry"`
+	TagPrefix        string        `json:"tag_prefix"`
+	AsyncConnect     bool          `json:"async_connect"`
+	MarshalAsJSON    bool          `json:"marshal_as_json"`
 }
 
 type Fluent struct {
 	Config
+
+	mubuff  sync.Mutex
+	pending []byte
+
+	muconn       sync.Mutex
 	conn         io.WriteCloser
-	pending      []byte
 	reconnecting bool
-	mu           sync.Mutex
 }
 
 // New creates a new Logger.
@@ -140,9 +145,9 @@ func (f *Fluent) PostWithTime(tag string, tm time.Time, message interface{}) err
 	}
 
 	if msgtype.Kind() != reflect.Map {
-		return errors.New("messge must be a map")
+		return errors.New("fluent#PostWithTime: message must be a map")
 	} else if msgtype.Key().Kind() != reflect.String {
-		return errors.New("map keys must be strings")
+		return errors.New("fluent#PostWithTime: map keys must be strings")
 	}
 
 	kv := make(map[string]interface{})
@@ -154,33 +159,54 @@ func (f *Fluent) PostWithTime(tag string, tm time.Time, message interface{}) err
 }
 
 func (f *Fluent) EncodeAndPostData(tag string, tm time.Time, message interface{}) error {
-	if data, dumperr := f.EncodeData(tag, tm, message); dumperr != nil {
-		return fmt.Errorf("fluent#EncodeAndPostData: can't convert '%s' to msgpack:%s", message, dumperr)
-		// fmt.Println("fluent#Post: can't convert to msgpack:", message, dumperr)
-	} else {
-		f.PostRawData(data)
-		return nil
+	var data []byte
+	var err error
+	if data, err = f.EncodeData(tag, tm, message); err != nil {
+		return fmt.Errorf("fluent#EncodeAndPostData: can't convert '%#v' to msgpack:%v", message, err)
 	}
+	return f.postRawData(data)
 }
 
+// Deprecated: Use EncodeAndPostData instead
 func (f *Fluent) PostRawData(data []byte) {
-	f.mu.Lock()
-	f.pending = append(f.pending, data...)
-	f.mu.Unlock()
+	f.postRawData(data)
+}
+
+func (f *Fluent) postRawData(data []byte) error {
+	if err := f.appendBuffer(data); err != nil {
+		return err
+	}
 	if err := f.send(); err != nil {
 		f.close()
-		if len(f.pending) > f.Config.BufferLimit {
-			f.flushBuffer()
-		}
-	} else {
-		f.flushBuffer()
+		return err
 	}
+	return nil
+}
+
+// For sending forward protocol adopted JSON
+type MessageChunk struct {
+	message Message
+}
+
+// Golang default marshaler does not support
+// ["value", "value2", {"key":"value"}] style marshaling.
+// So, it should write JSON marshaler by hand.
+func (chunk *MessageChunk) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(chunk.message.Record)
+	return []byte(fmt.Sprintf("[\"%s\",%d,%s,null]", chunk.message.Tag,
+		chunk.message.Time, data)), err
 }
 
 func (f *Fluent) EncodeData(tag string, tm time.Time, message interface{}) (data []byte, err error) {
 	timeUnix := tm.Unix()
-	msg := &Message{Tag: tag, Time: timeUnix, Record: message}
-	data, err = msg.MarshalMsg(nil)
+	if f.Config.MarshalAsJSON {
+		msg := Message{Tag: tag, Time: timeUnix, Record: message}
+		chunk := &MessageChunk{message: msg}
+		data, err = json.Marshal(chunk)
+	} else {
+		msg := &Message{Tag: tag, Time: timeUnix, Record: message}
+		data, err = msg.MarshalMsg(nil)
+	}
 	return
 }
 
@@ -193,23 +219,32 @@ func (f *Fluent) Close() (err error) {
 	return
 }
 
-// close closes the connection.
-func (f *Fluent) close() (err error) {
-	if f.conn != nil {
-		f.mu.Lock()
-		defer f.mu.Unlock()
-	} else {
-		return
+// appendBuffer appends data to buffer with lock.
+func (f *Fluent) appendBuffer(data []byte) error {
+	f.mubuff.Lock()
+	defer f.mubuff.Unlock()
+	if len(f.pending)+len(data) > f.Config.BufferLimit {
+		return errors.New(fmt.Sprintf("fluent#appendBuffer: Buffer full, limit %v", f.Config.BufferLimit))
 	}
+	f.pending = append(f.pending, data...)
+	return nil
+}
+
+// close closes the connection.
+func (f *Fluent) close() {
+	f.muconn.Lock()
 	if f.conn != nil {
 		f.conn.Close()
 		f.conn = nil
 	}
-	return
+	f.muconn.Unlock()
 }
 
 // connect establishes a new connection using the specified transport.
 func (f *Fluent) connect() (err error) {
+	f.muconn.Lock()
+	defer f.muconn.Unlock()
+
 	switch f.Config.FluentNetwork {
 	case "tcp":
 		f.conn, err = net.DialTimeout(f.Config.FluentNetwork, f.Config.FluentHost+":"+strconv.Itoa(f.Config.FluentPort), f.Config.Timeout)
@@ -217,6 +252,10 @@ func (f *Fluent) connect() (err error) {
 		f.conn, err = net.DialTimeout(f.Config.FluentNetwork, f.Config.FluentSocketPath, f.Config.Timeout)
 	default:
 		err = net.UnknownNetworkError(f.Config.FluentNetwork)
+	}
+
+	if err != nil {
+		f.reconnecting = false
 	}
 	return
 }
@@ -226,44 +265,45 @@ func e(x, y float64) int {
 }
 
 func (f *Fluent) reconnect() {
-	go func() {
-		for i := 0; ; i++ {
-			err := f.connect()
-			if err == nil {
-				f.mu.Lock()
-				f.reconnecting = false
-				f.mu.Unlock()
-				break
-			} else {
-				if i == f.Config.MaxRetry {
-					panic("fluent#reconnect: failed to reconnect!")
-				}
-				waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
-				time.Sleep(time.Duration(waitTime) * time.Millisecond)
-			}
+	for i := 0; ; i++ {
+		err := f.connect()
+		if err == nil {
+			f.send()
+			return
 		}
-	}()
+		if i == f.Config.MaxRetry {
+			// TODO: What we can do when connection failed MaxRetry times?
+			panic("fluent#reconnect: failed to reconnect!")
+		}
+		waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
+		time.Sleep(time.Duration(waitTime) * time.Millisecond)
+	}
 }
 
-func (f *Fluent) flushBuffer() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.pending = f.pending[0:0]
-}
+func (f *Fluent) send() error {
+	f.muconn.Lock()
+	defer f.muconn.Unlock()
 
-func (f *Fluent) send() (err error) {
 	if f.conn == nil {
 		if f.reconnecting == false {
-			f.mu.Lock()
 			f.reconnecting = true
-			f.mu.Unlock()
-			f.reconnect()
+			go f.reconnect()
 		}
-		err = errors.New("fluent#send: can't send logs, client is reconnecting")
-	} else {
-		f.mu.Lock()
-		_, err = f.conn.Write(f.pending)
-		f.mu.Unlock()
+		return errors.New("fluent#send: can't send logs, client is reconnecting")
 	}
-	return
+
+	f.mubuff.Lock()
+	defer f.mubuff.Unlock()
+
+	var err error
+	if len(f.pending) > 0 {
+		_, err = f.conn.Write(f.pending)
+		if err != nil {
+			f.conn.Close()
+			f.conn = nil
+		} else {
+			f.pending = f.pending[:0]
+		}
+	}
+	return err
 }


### PR DESCRIPTION
**\- What I did**
This change fixes the problem of "panic: runtime error: invalid memory address or nil pointer dereference", described in #20960.

**\- How I did it**
fluent-logger-golang has been fixed to solve race condition of internal buffers, and this change will use the fixed version `v1.2.0` to send logs to Fluentd nodes.
https://github.com/fluent/fluent-logger-golang/pull/30

**\- How to verify it**
We made a short golang code to generate the same error with one from Docker, and confirmed that fixed fluent-logger-golang doesn't crash with just same program.
https://github.com/fluent/fluent-logger-golang/issues/29

**\- Description for the changelog**
Update fluent-logger-golang dependency to v1.2.0.

**\- A picture of a cute animal (not mandatory but encouraged)**
![latest fluentd logo](https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_icon.png)

Fix race condition issue to solve an issue about "panic: runtime error: invalid memory address or nil pointer dereference".
This fix stabilize Docker daemon under the situation of communication problem with Fluentd processes.

Signed-off-by: Satoshi Tagomori tagomoris@gmail.com
