### PR TITLE
Windows: OCI HVRuntime and LayerPaths to options

### DIFF
--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -1,12 +1,60 @@
 package daemon
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/layer"
 	"github.com/docker/docker/libcontainerd"
 )
 
 func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Container) (*[]libcontainerd.CreateOption, error) {
 	createOptions := []libcontainerd.CreateOption{}
+
+	// Are we going to run as a Hyper-V container?
+	hvOpts := &libcontainerd.HyperVIsolationOption{}
+	if container.HostConfig.Isolation.IsDefault() {
+		// Container is set to use the default, so take the default from the daemon configuration
+		hvOpts.IsHyperV = daemon.defaultIsolation.IsHyperV()
+	} else {
+		// Container is requesting an isolation mode. Honour it.
+		hvOpts.IsHyperV = container.HostConfig.Isolation.IsHyperV()
+	}
+
+	// Generate the layer folder of the layer options
+	layerOpts := &libcontainerd.LayerOption{}
+	m, err := container.RWLayer.Metadata()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get layer metadata - %s", err)
+	}
+	if hvOpts.IsHyperV {
+		hvOpts.SandboxPath = filepath.Dir(m["dir"])
+	} else {
+		layerOpts.LayerFolderPath = m["dir"]
+	}
+
+	// Generate the layer paths of the layer options
+	img, err := daemon.imageStore.Get(container.ImageID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to graph.Get on ImageID %s - %s", container.ImageID, err)
+	}
+	// Get the layer path for each layer.
+	max := len(img.RootFS.DiffIDs)
+	for i := 1; i <= max; i++ {
+		img.RootFS.DiffIDs = img.RootFS.DiffIDs[:i]
+		layerPath, err := layer.GetLayerPath(daemon.layerStore, img.RootFS.ChainID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get layer path from graphdriver %s for ImageID %s - %s", daemon.layerStore, img.RootFS.ChainID(), err)
+		}
+		// Reverse order, expecting parent most first
+		layerOpts.LayerPaths = append([]string{layerPath}, layerOpts.LayerPaths...)
+	}
+
+	// Now build the full set of options
 	createOptions = append(createOptions, &libcontainerd.FlushOption{IgnoreFlushesDuringBoot: !container.HasBeenStartedBefore})
+	createOptions = append(createOptions, hvOpts)
+	createOptions = append(createOptions, layerOpts)
+
 	return &createOptions, nil
 }

--- a/libcontainerd/types_windows.go
+++ b/libcontainerd/types_windows.go
@@ -45,6 +45,22 @@ type FlushOption struct {
 	IgnoreFlushesDuringBoot bool
 }
 
+// HyperVIsolationOption is a CreateOption that indicates whether the runtime
+// should start the container as a Hyper-V container, and if so, the sandbox path.
+type HyperVIsolationOption struct {
+	IsHyperV    bool
+	SandboxPath string `json:",omitempty"`
+}
+
+// LayerOption is a CreateOption that indicates to the runtime the layer folder
+// and layer paths for a container.
+type LayerOption struct {
+	// LayerFolder is the path to the current layer folder. Empty for Hyper-V containers.
+	LayerFolderPath string `json:",omitempty"`
+	// Layer paths of the parent layers
+	LayerPaths []string
+}
+
 // Checkpoint holds the details of a checkpoint (not supported in windows)
 type Checkpoint struct {
 	Name string

--- a/libcontainerd/utils_windows.go
+++ b/libcontainerd/utils_windows.go
@@ -21,6 +21,16 @@ func (s *ServicingOption) Apply(interface{}) error {
 }
 
 // Apply for the flush option is a no-op.
-func (s *FlushOption) Apply(interface{}) error {
+func (f *FlushOption) Apply(interface{}) error {
+	return nil
+}
+
+// Apply for the hypervisolation option is a no-op.
+func (h *HyperVIsolationOption) Apply(interface{}) error {
+	return nil
+}
+
+// Apply for the layer option is a no-op.
+func (h *LayerOption) Apply(interface{}) error {
 	return nil
 }

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -39,12 +39,6 @@ type Windows struct {
 	Resources *WindowsResources `json:"resources,omitempty"`
 	// Networking contains the platform specific network settings for the container.
 	Networking *WindowsNetworking `json:"networking,omitempty"`
-	// LayerFolder is the path to the current layer folder
-	LayerFolder string `json:"layer_folder,omitempty"`
-	// Layer paths of the parent layers
-	LayerPaths []string `json:"layer_paths,omitempty"`
-	// HvRuntime contains settings specific to Hyper-V containers, omitted if not using Hyper-V isolation
-	HvRuntime *WindowsHvRuntime `json:"hv_runtime,omitempty"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -120,12 +114,6 @@ type Mount struct {
 	Source string `json:"source"`
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
-}
-
-// WindowsHvRuntime contains settings specific to Hyper-V containers
-type WindowsHvRuntime struct {
-	// ImagePath is the path to the Utility VM image for this container
-	ImagePath string `json:"image_path,omitempty"`
 }
 
 // WindowsNetworking contains the platform specific network settings for the container


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This is the last of the refactoring necessary to bring Windows to a spec which is OCI compliant. Similar to https://github.com/docker/docker/pull/26650, https://github.com/docker/docker/pull/26640 and https://github.com/docker/docker/pull/26577 this moves structures from the hacked OCI spec to `CreateOptions` for libcontainerd, thus being controlled directly through the runtime, as they should be.

When combining this with the other PRs above (some merged), this gets Windows to a point where the OCI spec can subsequently be moved across to the OCI spec supporting Windows, currently under review in the following PRs: https://github.com/opencontainers/runtime-spec/pull/573https://github.com/opencontainers/runtime-spec/pull/567 https://github.com/opencontainers/runtime-spec/pull/564 and https://github.com/opencontainers/runtime-spec/pull/563.

@wking, @swernli fyi. 

@mlaventure @tonistiigi PTAL.
