### PR TITLE
Revert Box from HostConfig

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -313,7 +313,7 @@ type HostConfig struct {
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
-	ConsoleSize Box       // Initial console size
+	ConsoleSize [2]uint   // Initial console size (height,width)
 	Isolation   Isolation // Isolation technology of the container (eg default, hyperv)
 
 	// Contains container's resources (cgroups, ulimits)
@@ -324,10 +324,4 @@ type HostConfig struct {
 
 	// Run a custom init inside the container, if null, use the daemon's configured settings
 	Init *bool `json:",omitempty"`
-}
-
-// Box specifies height and width dimensions. Used for sizing of a console.
-type Box struct {
-	Height uint
-	Width  uint
 }

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -135,7 +135,7 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 	// a far better user experience rather than relying on subsequent resizes
 	// to cause things to catch up.
 	if runtime.GOOS == "windows" {
-		hostConfig.ConsoleSize.Height, hostConfig.ConsoleSize.Width = dockerCli.Out().GetTtySize()
+		hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = dockerCli.Out().GetTtySize()
 	}
 
 	ctx, cancelFun := context.WithCancel(context.Background())

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -71,8 +71,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 		s.Process.Cwd = `C:\`
 	}
 	s.Process.Env = c.CreateDaemonEnvironment(linkedEnv)
-	s.Process.ConsoleSize.Height = c.HostConfig.ConsoleSize.Height
-	s.Process.ConsoleSize.Width = c.HostConfig.ConsoleSize.Width
+	s.Process.ConsoleSize.Height = c.HostConfig.ConsoleSize[0]
+	s.Process.ConsoleSize.Width = c.HostConfig.ConsoleSize[1]
 	s.Process.Terminal = c.Config.Tty
 	s.Process.User.Username = c.Config.User
 


### PR DESCRIPTION
Fixes #26758 

Signed-off-by: John Howard jhoward@microsoft.com

Fixes the regression I introduced in https://github.com/docker/docker/pull/26579#issuecomment-248366336 - For downlevel Linux clients, we need to keep compatibility, even though at this point it's not necessary on Windows. So kept as an array in `HostConfig`. I'm pretty sure though the int to uint change should not cause any compatbility issues.

@runcom @mlaventure @thaJeztah @tonistiigi 
