### PR TITLE
layer_store: Use CreateReadWrite() for -init layer instead of Create()

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -201,7 +201,9 @@ func (daemon *Daemon) setRWLayer(container *container.Container) error {
 		}
 		layerID = img.RootFS.ChainID()
 	}
-	rwLayer, err := daemon.layerStore.CreateRWLayer(container.ID, layerID, container.MountLabel, daemon.setupInitLayer, container.HostConfig.StorageOpt)
+
+	rwLayer, err := daemon.layerStore.CreateRWLayer(container.ID, layerID, container.MountLabel, daemon.getLayerInit(), container.HostConfig.StorageOpt)
+
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -779,6 +779,10 @@ func initBridgeDriver(controller libnetwork.NetworkController, config *Config) e
 	return nil
 }
 
+func (daemon *Daemon) getLayerInit() func(string) error {
+	return daemon.setupInitLayer
+}
+
 // setupInitLayer populates a directory with mountpoints suitable
 // for bind-mounting things into the container.
 //

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -61,6 +61,10 @@ func setupInitLayer(initLayer string, rootUID, rootGID int) error {
 	return nil
 }
 
+func (daemon *Daemon) getLayerInit() func(string) error {
+	return nil
+}
+
 func checkKernel() error {
 	return nil
 }

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -586,7 +586,7 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 	// then the initID should be randomly generated.
 	initID := fmt.Sprintf("%s-init", graphID)
 
-	if err := ls.driver.Create(initID, parent, mountLabel, storageOpt); err != nil {
+	if err := ls.driver.CreateReadWrite(initID, parent, mountLabel, storageOpt); err != nil {
 		return "", err
 	}
 	p, err := ls.driver.Get(initID, "")


### PR DESCRIPTION
init layer is read/write layer and not read only layer. Following commit
introduced new graph driver method CreateReadWrite.

ef5bfad Adding readOnly parameter to graphdriver Create method

So far only windows seem to be differentiating between above two methods.
Making this change to make sure -init layer calls right method so that
we don't have surprises in future.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
