### PR TITLE
Move Logger/LogCopier out of container

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -85,11 +85,8 @@ type CommonContainer struct {
 	MountPoints            map[string]*volume.MountPoint
 	HostConfig             *containertypes.HostConfig `json:"-"` // do not serialize the host config in the json, otherwise we'll make the container unportable
 	ExecCommands           *exec.Store                `json:"-"`
-	// logDriver for closing
-	LogDriver      logger.Logger  `json:"-"`
-	LogCopier      *logger.Copier `json:"-"`
-	restartManager restartmanager.RestartManager
-	attachContext  *attachContext
+	restartManager         restartmanager.RestartManager
+	attachContext          *attachContext
 }
 
 // NewBaseContainer creates a new container with its

--- a/container/monitor.go
+++ b/container/monitor.go
@@ -1,14 +1,6 @@
 package container
 
-import (
-	"time"
-
-	"github.com/Sirupsen/logrus"
-)
-
-const (
-	loggerCloseTimeout = 10 * time.Second
-)
+import "github.com/Sirupsen/logrus"
 
 // Reset puts a container into a state where it can be restarted again.
 func (container *Container) Reset(lock bool) {
@@ -24,23 +16,5 @@ func (container *Container) Reset(lock bool) {
 	// Re-create a brand new stdin pipe once the container exited
 	if container.Config.OpenStdin {
 		container.NewInputPipes()
-	}
-
-	if container.LogDriver != nil {
-		if container.LogCopier != nil {
-			exit := make(chan struct{})
-			go func() {
-				container.LogCopier.Wait()
-				close(exit)
-			}()
-			select {
-			case <-time.After(loggerCloseTimeout):
-				logrus.Warn("Logger didn't exit in time: logs may be truncated")
-			case <-exit:
-			}
-		}
-		container.LogDriver.Close()
-		container.LogCopier = nil
-		container.LogDriver = nil
 	}
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -100,6 +100,7 @@ type Daemon struct {
 	containerdRemote          libcontainerd.Remote
 	defaultIsolation          containertypes.Isolation // Default isolation mode on Windows
 	clusterProvider           cluster.Provider
+	loggers                   *loggerStore
 }
 
 func (daemon *Daemon) restore() error {
@@ -655,6 +656,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 	d.nameIndex = registrar.NewRegistrar()
 	d.linkIndex = newLinkIndex()
 	d.containerdRemote = containerdRemote
+	d.loggers = newLoggerStore()
 
 	go d.execCommandGC()
 


### PR DESCRIPTION
Let's these objects be managed based on container state notifications
rather than directly caching them on the container object.

Adds an object on daemon for pub/sub of various events that can happen
in the daemon, e.g. container is stopped (currelty the only event being
consumed).
This is different from the public facing events API.

This is the first step to remove some of the unnecessary runtime state
from the container object.
