### PR TITLE
Revert the fix to invalid handles due to a platform bug

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -224,11 +224,6 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 	}
 
 	pid := newProcess.Pid()
-	openedProcess, err := container.hcsContainer.OpenProcess(pid)
-	if err != nil {
-		logrus.Errorf("AddProcess %s OpenProcess() failed %s", containerID, err)
-		return err
-	}
 
 	stdin, stdout, stderr, err = newProcess.Stdio()
 	if err != nil {
@@ -255,7 +250,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 			systemPid:    uint32(pid),
 		},
 		commandLine: createProcessParms.CommandLine,
-		hcsProcess:  openedProcess,
+		hcsProcess:  newProcess,
 	}
 
 	// Add the process to the container's list of processes

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -93,20 +93,10 @@ func (ctr *container) start() error {
 	ctr.startedAt = time.Now()
 
 	pid := newProcess.Pid()
-	openedProcess, err := ctr.hcsContainer.OpenProcess(pid)
-	if err != nil {
-		logrus.Errorf("OpenProcess() failed %s", err)
-		if err := ctr.terminate(); err != nil {
-			logrus.Errorf("Failed to cleanup after a failed OpenProcess. %s", err)
-		} else {
-			logrus.Debugln("Cleaned up after failed OpenProcess by calling Terminate")
-		}
-		return err
-	}
 
 	// Save the hcs Process and PID
 	ctr.process.friendlyName = InitFriendlyName
-	ctr.process.hcsProcess = openedProcess
+	ctr.process.hcsProcess = newProcess
 
 	// If this is a servicing container, wait on the process synchronously here and
 	// if it succeeds, wait for it cleanly shutdown and merge into the parent container.

--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -47,6 +47,6 @@ func createStdInCloser(pipe io.WriteCloser, process hcsshim.Process) io.WriteClo
 			}
 		}
 
-		return process.Close()
+		return err
 	})
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Revert part of https://github.com/docker/docker/pull/25849 that exposes a race condition on certain CI machines due to a platform bug with opened process handles and short lived processes. This reopens #24004 while I work on a different fix 😢.

**\- How I did it**

Stop opening a new handle to the HCS process.

**\- How to verify it**

We'll see in CI.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

Signed-off-by: Darren Stahl darst@microsoft.com
