### PR TITLE
Delete a redundent version judgment

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -156,8 +156,7 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 	}
 
 	checkpoint := r.Form.Get("checkpoint")
-	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")
-	if err := s.backend.ContainerStart(vars["name"], hostConfig, validateHostname, checkpoint); err != nil {
+	if err := s.backend.ContainerStart(vars["name"], hostConfig, false, checkpoint); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
As can be seen from the function `verifyContainerSettings` in `daemon/container.go`, the parameter `validateHostname` is useful only when `config` is not `nil`. 

`verifyContainerSettings` is called in `ContainerStart` with `config==nil`, so we should delete the redundent version judgment in `api/server/router/container/container_routes.go#L160`

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
