### PR TITLE
Fixing Regression in exit codes in 1.12

### DIFF
--- a/api/client/container/attach.go
+++ b/api/client/container/attach.go
@@ -36,7 +36,6 @@ func NewAttachCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runAttach(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.noStdin, "no-stdin", false, "Do not attach STDIN")

--- a/api/client/container/commit.go
+++ b/api/client/container/commit.go
@@ -41,7 +41,6 @@ func NewCommitCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runCommit(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)

--- a/api/client/container/create.go
+++ b/api/client/container/create.go
@@ -43,7 +43,6 @@ func NewCreateCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runCreate(dockerCli, cmd.Flags(), &opts, copts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)

--- a/api/client/container/diff.go
+++ b/api/client/container/diff.go
@@ -28,7 +28,6 @@ func NewDiffCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runDiff(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	return cmd
 }

--- a/api/client/container/logs.go
+++ b/api/client/container/logs.go
@@ -41,7 +41,6 @@ func NewLogsCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runLogs(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")

--- a/api/client/container/pause.go
+++ b/api/client/container/pause.go
@@ -28,7 +28,6 @@ func NewPauseCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runPause(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	return cmd
 }

--- a/api/client/container/port.go
+++ b/api/client/container/port.go
@@ -34,7 +34,6 @@ func NewPortCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runPort(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	return cmd
 }

--- a/api/client/container/rename.go
+++ b/api/client/container/rename.go
@@ -30,7 +30,6 @@ func NewRenameCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runRename(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	return cmd
 }

--- a/api/client/container/run.go
+++ b/api/client/container/run.go
@@ -54,7 +54,6 @@ func NewRunCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runRun(dockerCli, cmd.Flags(), &opts, copts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)
@@ -73,13 +72,6 @@ func NewRunCommand(dockerCli *client.DockerCli) *cobra.Command {
 	client.AddTrustedFlags(flags, true)
 	copts = runconfigopts.AddFlags(flags)
 	return cmd
-}
-
-func flagErrorFunc(cmd *cobra.Command, err error) error {
-	return cli.StatusError{
-		Status:     cli.FlagErrorFunc(cmd, err).Error(),
-		StatusCode: 125,
-	}
 }
 
 func runRun(dockerCli *client.DockerCli, flags *pflag.FlagSet, opts *runOptions, copts *runconfigopts.ContainerOptions) error {

--- a/api/client/container/start.go
+++ b/api/client/container/start.go
@@ -37,7 +37,6 @@ func NewStartCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runStart(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.attach, "attach", "a", false, "Attach STDOUT/STDERR and forward signals")

--- a/api/client/container/stop.go
+++ b/api/client/container/stop.go
@@ -31,7 +31,6 @@ func NewStopCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runStop(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.IntVarP(&opts.time, "time", "t", 10, "Seconds to wait for stop before killing it")

--- a/api/client/container/top.go
+++ b/api/client/container/top.go
@@ -32,7 +32,6 @@ func NewTopCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runTop(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)

--- a/api/client/container/unpause.go
+++ b/api/client/container/unpause.go
@@ -28,7 +28,6 @@ func NewUnpauseCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runUnpause(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	return cmd
 }

--- a/api/client/container/wait.go
+++ b/api/client/container/wait.go
@@ -28,7 +28,6 @@ func NewWaitCommand(dockerCli *client.DockerCli) *cobra.Command {
 			return runWait(dockerCli, &opts)
 		},
 	}
-	cmd.SetFlagErrorFunc(flagErrorFunc)
 
 	return cmd
 }

--- a/cli/flagerrors.go
+++ b/cli/flagerrors.go
@@ -17,5 +17,8 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 	if cmd.HasSubCommands() {
 		usage = "\n\n" + cmd.UsageString()
 	}
-	return fmt.Errorf("%s\nSee '%s --help'.%s", err, cmd.CommandPath(), usage)
+	return StatusError{
+		Status:     fmt.Sprintf("%s\nSee '%s --help'.%s", err, cmd.CommandPath(), usage),
+		StatusCode: 125,
+	}
 }


### PR DESCRIPTION
Fixes #26775. Opened the PR against `1.12.x` branch.

```
   # docker load --input;echo $?
   flag needs an argument: --input
   See 'docker load --help'.
   125    <-- 125 with docker-1.10 ; 1 with docker-1.12

   # docker ps --filters;echo $?         <-- same with -n or --format
   unknown flag: --filters
   See 'docker ps --help'.
   125    <-- 125 with docker-1.10 ; 1 with docker-1.12
```

/cc @dnephin @runcom @thaJeztah @icecrime 

Signed-off-by: Vincent Demeester vincent@sbr.pm
