### PR TITLE
Try connecting to ~/.docker/docker.sock if main socket missing

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/docker/docker/pkg/homedir"
 )
 
 var (
@@ -18,6 +20,8 @@ var (
 	// DefaultUnixSocket Path for the unix socket.
 	// Docker daemon by default always listens on the default unix socket
 	DefaultUnixSocket = "/var/run/docker.sock"
+	// AltUnixSocket Alternate unprivileged Unix socket
+	AltUnixSocket = fmt.Sprintf("%s/.docker/docker.sock", homedir.Get())
 	// DefaultTCPHost constant defines the default host string used by docker on Windows
 	DefaultTCPHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultHTTPPort)
 	// DefaultTLSHost constant defines the default host string used by docker for TLS sockets
@@ -48,7 +52,7 @@ func ParseHost(defaultToTLS bool, val string) (string, error) {
 		if defaultToTLS {
 			host = DefaultTLSHost
 		} else {
-			host = DefaultHost
+			host = DefaultOrAltHost()
 		}
 	} else {
 		var err error

--- a/opts/hosts_unix.go
+++ b/opts/hosts_unix.go
@@ -2,7 +2,24 @@
 
 package opts
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 // DefaultHost constant defines the default host string used by docker on other hosts than Windows
 var DefaultHost = fmt.Sprintf("unix://%s", DefaultUnixSocket)
+
+// DefaultOrAltHost function returns the name of either the default host if found or the alternate Unix socket
+func DefaultOrAltHost() string {
+	fi, err := os.Stat(DefaultUnixSocket)
+	if err == nil && fi.Mode()&os.ModeSocket != 0 {
+		return DefaultHost
+	}
+	fi, err = os.Stat(AltUnixSocket)
+	if err == nil && fi.Mode()&os.ModeSocket != 0 {
+		return fmt.Sprintf("unix://%s", AltUnixSocket)
+	}
+	// if none found do not change historic behaviour, for error messages
+	return DefaultHost
+}

--- a/opts/hosts_windows.go
+++ b/opts/hosts_windows.go
@@ -4,3 +4,8 @@ package opts
 
 // DefaultHost constant defines the default host string used by docker on Windows
 var DefaultHost = "npipe://" + DefaultNamedPipe
+
+// DefaultOrAltHost function returns the name of either the default host if found or the alternate Unix socket
+func DefaultOrAltHost() string {
+	return DefaultHost
+}


### PR DESCRIPTION
This PR makes the Docker client connect to `~/.docker/docker.sock` if there is no socket at `/var/run/docker.sock` and no `DOCKER_HOST` is specified, on Unix platforms.

On platforms such as OSX there is never a local Docker daemon. With Docker for Mac, so as to make the client not need environment variables to configure, we add a socket (actually a symlink to a socket) in the default location, but doing this requires root access, and we wish to remove the requirement for root access to just run a client.

Another use case is if you want to use a remote Docker host as if it were a local one. Now that openssh supports Unix socket forwarding this is really easy:

```
ssh -f -N -C -L$HOME/.docker/docker.sock:/var/run/docker.sock user@dockerhost
```

Without this PR you have to do this as root in order to open a socket in `/var/run/docker`, with this patch it works as a normal user. This then gives access without setting environment variables.

I have made this as unobtrusive as possible, so it only takes effect if `/var/run/docker.sock` is not present, and if `~/.docker/docker.sock` is present and is a socket. Perhaps it should check if the sockets are connected too?

cc @djs55 @nathanleclaire

![goaty](https://cloud.githubusercontent.com/assets/482364/18716126/8de93ed8-8013-11e6-9336-4ee6d1a2c755.jpg)
