### PR TITLE
Add SELinux options to security opt even when it is not empty

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -248,12 +248,11 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 		hostConfig.ShmSize = container.DefaultSHMSize
 	}
 	var err error
-	if hostConfig.SecurityOpt == nil {
-		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode, hostConfig.Privileged)
-		if err != nil {
-			return err
-		}
+	opts, err := daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode, hostConfig.Privileged)
+	if err != nil {
+		return err
 	}
+	hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, opts...)
 	if hostConfig.MemorySwappiness == nil {
 		defaultSwappiness := int64(-1)
 		hostConfig.MemorySwappiness = &defaultSwappiness

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -78,8 +78,10 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.Hos
 	}
 	// Adapt for old containers in case we have updates in this function and
 	// old containers never have chance to call the new function in create stage.
-	if err := daemon.adaptContainerSettings(container.HostConfig, false); err != nil {
-		return err
+	if hostConfig != nil {
+		if err := daemon.adaptContainerSettings(container.HostConfig, false); err != nil {
+			return err
+		}
 	}
 
 	return daemon.containerStart(container, checkpoint, checkpointDir, true)


### PR DESCRIPTION
Fix for #26790 

I am trying to figure out why adaptContainerSettings is called twice (create.go and start.go). Because of that, the labels are getting added twice. 

Signed-off-by: Mrunal Patel mrunalp@gmail.com
