### PR TITLE
Changed the way to detect if a valid TLSConfig has been set

### DIFF
--- a/client/transport.go
+++ b/client/transport.go
@@ -21,7 +21,10 @@ func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 func resolveTLSConfig(transport http.RoundTripper) (*tls.Config, error) {
 	switch tr := transport.(type) {
 	case *http.Transport:
-		return tr.TLSClientConfig, nil
+		if tr.DialTLS != nil {
+			return tr.TLSClientConfig, nil
+		}
+		return nil, nil
 	case transportFunc:
 		return nil, nil // detect this type for testing.
 	default:


### PR DESCRIPTION
closes #26793 
closes #26781

**\- What I did**
Replace the check for nil TLSClientConfig (which is changed by go for a default structure on http request) by checking the pointer DialTLS pointer in the transport struct

**\- How to verify it**
Tried to run the client example

Signed-off-by: Alexandre ACEBEDO alexandre@acebedo.fr
