### PR TITLE
Implement Pause Resume support for Windows

### DIFF
--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -19,11 +19,12 @@ Options:
       --help   Print usage
 ```
 
-The `docker pause` command uses the cgroups freezer to suspend all processes in
-a container. Traditionally, when suspending a process the `SIGSTOP` signal is
-used, which is observable by the process being suspended. With the cgroups freezer
-the process is unaware, and unable to capture, that it is being suspended,
-and subsequently resumed.
+The `docker pause` command suspends all processes in a container. On Linux,
+this uses the cgroups freezer. Traditionally, when suspending a process the
+`SIGSTOP` signal is used, which is observable by the process being suspended.
+With the cgroups freezer the process is unaware, and unable to capture,
+that it is being suspended, and subsequently resumed. On Windows, only Hyper-V
+containers can be paused.
 
 See the
 [cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -19,8 +19,8 @@ Options:
       --help   Print usage
 ```
 
-The `docker unpause` command uses the cgroups freezer to un-suspend all
-processes in a container.
+The `docker unpause` command un-suspends all processes in a container.
+On Linux, it does this using the cgroups freezer.
 
 See the
 [cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -154,9 +154,9 @@ func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachPausedContainer(c *check.C) {
-	testRequires(c, DaemonIsLinux) // Containers cannot be paused on Windows
+	testRequires(c, IsPausable)
 	defer unpauseAllContainers()
-	dockerCmd(c, "run", "-d", "--name=test", "busybox", "top")
+	runSleepingContainer(c, "-d", "--name=test")
 	dockerCmd(c, "pause", "test")
 
 	result := dockerCmdWithResult("attach", "test")

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -127,11 +127,10 @@ func (s *DockerSuite) TestExecExitStatus(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecPausedContainer(c *check.C) {
-	// Windows does not support pause
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, IsPausable)
 	defer unpauseAllContainers()
 
-	out, _ := dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
+	out, _ := runSleepingContainer(c, "-d", "--name", "testing")
 	ContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "pause", "testing")

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -138,9 +138,9 @@ func (s *DockerSuite) TestInfoDisplaysRunningContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestInfoDisplaysPausedContainers(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, IsPausable)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "pause", cleanedContainerID)

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (s *DockerSuite) TestPause(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, IsPausable)
 	defer unpauseAllContainers()
 
 	name := "testeventpause"
-	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
+	runSleepingContainer(c, "-d", "--name", name)
 
 	dockerCmd(c, "pause", name)
 	pausedContainers, err := getSliceOfPausedContainers()
@@ -30,7 +30,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 }
 
 func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, IsPausable)
 	defer unpauseAllContainers()
 
 	containers := []string{
@@ -38,7 +38,7 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 		"testpausewithmorecontainers2",
 	}
 	for _, name := range containers {
-		dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
+		runSleepingContainer(c, "-d", "--name", name)
 	}
 	dockerCmd(c, append([]string{"pause"}, containers...)...)
 	pausedContainers, err := getSliceOfPausedContainers()
@@ -58,9 +58,9 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestPauseFailsOnWindows(c *check.C) {
-	testRequires(c, DaemonIsWindows)
-	dockerCmd(c, "run", "-d", "--name=test", "busybox", "sleep 3")
+func (s *DockerSuite) TestPauseFailsOnWindowsServerContainers(c *check.C) {
+	testRequires(c, DaemonIsWindows, NotPausable)
+	runSleepingContainer(c, "-d", "--name=test")
 	out, _, _ := dockerCmdWithError("pause", "test")
-	c.Assert(out, checker.Contains, "Windows: Containers cannot be paused")
+	c.Assert(out, checker.Contains, "cannot pause Windows Server Containers")
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -95,10 +95,10 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 
 func (s *DockerSuite) TestStartPausedContainer(c *check.C) {
 	// Windows does not support pausing containers
-	testRequires(c, DaemonIsLinux)
+	testRequires(c, IsPausable)
 	defer unpauseAllContainers()
 
-	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
+	runSleepingContainer(c, "-d", "--name", "testing")
 
 	dockerCmd(c, "pause", "testing")
 

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -201,6 +201,24 @@ var (
 		},
 		"Test cannot be run when remapping root",
 	}
+	IsPausable = testRequirement{
+		func() bool {
+			if daemonPlatform == "windows" {
+				return isolation == "hyperv"
+			}
+			return true
+		},
+		"Test requires containers are pausable.",
+	}
+	NotPausable = testRequirement{
+		func() bool {
+			if daemonPlatform == "windows" {
+				return isolation == "process"
+			}
+			return false
+		},
+		"Test requires containers are not pausable.",
+	}
 )
 
 // testRequires checks if the environment satisfies the requirements

--- a/man/docker-pause.1.md
+++ b/man/docker-pause.1.md
@@ -10,11 +10,12 @@ CONTAINER [CONTAINER...]
 
 # DESCRIPTION
 
-The `docker pause` command uses the cgroups freezer to suspend all processes in
-a container.  Traditionally when suspending a process the `SIGSTOP` signal is
-used, which is observable by the process being suspended. With the cgroups freezer
-the process is unaware, and unable to capture, that it is being suspended,
-and subsequently resumed.
+The `docker pause` command suspends all processes in a container. On Linux,
+this uses the cgroups freezer. Traditionally, when suspending a process the
+`SIGSTOP` signal is used, which is observable by the process being suspended.
+With the cgroups freezer the process is unaware, and unable to capture,
+that it is being suspended, and subsequently resumed. On Windows, only Hyper-V
+containers can be paused.
 
 See the [cgroups freezer documentation]
 (https://www.kernel.org/doc/Documentation/cgroups/freezer-subsystem.txt) for

--- a/man/docker-unpause.1.md
+++ b/man/docker-unpause.1.md
@@ -10,8 +10,8 @@ CONTAINER [CONTAINER...]
 
 # DESCRIPTION
 
-The `docker unpause` command uses the cgroups freezer to un-suspend all
-processes in a container.
+The `docker unpause` command un-suspends all processes in a container.
+On Linux, it does this using the cgroups freezer.
 
 See the [cgroups freezer documentation]
 (https://www.kernel.org/doc/Documentation/cgroups/freezer-subsystem.txt) for


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Enable Pause/Resume of containers on Windows. This only works with Hyper-V containers.

**\- How to verify it**

This requires Hyper-V containers, so can not currently be testing in CI, but here are some screenshots of it working locally:
Paused:
![paused](https://cloud.githubusercontent.com/assets/14114019/18727678/97e62c9e-7ffe-11e6-80e6-a5c228d71eb7.png)

Running again:
![running](https://cloud.githubusercontent.com/assets/14114019/18727682/a23bde50-7ffe-11e6-8441-b0e98ffa6ff7.png)

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Enabled pausing of Hyper-V containers on Windows.

Signed-off-by: Darren Stahl darst@microsoft.com
