### PR TITLE
Windows: Data race in libcontainerd (si)

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -274,6 +274,9 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 	if err := ctr.client.backend.StateChanged(ctr.containerID, si); err != nil {
 		logrus.Error(err)
 	}
+
+	logrus.Debugf("libcontainerd: waitExit() completed OK, %+v", si)
+
 	if si.State == StateRestart {
 		go func() {
 			err := <-waitRestart
@@ -292,7 +295,6 @@ func (ctr *container) waitExit(process *process, isFirstProcessToStart bool) err
 		}()
 	}
 
-	logrus.Debugf("libcontainerd: waitExit() completed OK, %+v", si)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Interesting exercise running CI locally with race detection enabled.... This fixes a very simple one, the worst case of which can happen is, I believe, the daemon may debug log an incorrect "waitExit() completed OK" log.

```
WARNING: DATA RACE
Write at 0x00c0428b8960 by goroutine 10:
  github.com/docker/docker/libcontainerd.(*container).waitExit.func1()
      e:/go/src/github.com/docker/docker/libcontainerd/container_windows.go:287 +0x13a

Previous read at 0x00c0428b8960 by goroutine 106:
  github.com/docker/docker/libcontainerd.(*container).waitExit()
      e:/go/src/github.com/docker/docker/libcontainerd/container_windows.go:295 +0xff4

Goroutine 10 (running) created at:
  github.com/docker/docker/libcontainerd.(*container).waitExit()
      e:/go/src/github.com/docker/docker/libcontainerd/container_windows.go:292 +0xfd8

Goroutine 106 (finished) created at:
  github.com/docker/docker/libcontainerd.(*container).start()
      e:/go/src/github.com/docker/docker/libcontainerd/container_windows.go:152 +0x2055
  github.com/docker/docker/libcontainerd.(*client).Create()
      e:/go/src/github.com/docker/docker/libcontainerd/client_windows.go:170 +0x2326
  github.com/docker/docker/libcontainerd.(*container).waitExit.func1()
      e:/go/src/github.com/docker/docker/libcontainerd/container_windows.go:282 +0x45b
```

@darrenstahlmsft FYI.
