### PR TITLE
client: pedantic checking of tlsconfig

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -86,15 +86,16 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 		return nil, err
 	}
 
-	if client == nil {
-		client = &http.Client{}
-	}
-
-	if client.Transport == nil {
-		// setup the transport, if not already present
+	if client != nil {
+		if _, ok := client.Transport.(*http.Transport); !ok {
+			return nil, fmt.Errorf("unable to verify TLS configuration, invalid transport %v", client.Transport)
+		}
+	} else {
 		transport := new(http.Transport)
 		sockets.ConfigureTransport(transport, proto, addr)
-		client.Transport = transport
+		client = &http.Client{
+			Transport: transport,
+		}
 	}
 
 	return &Client{

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -47,12 +47,7 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 
-	tlsConfig, err := resolveTLSConfig(cli.client.Transport)
-	if err != nil {
-		return types.HijackedResponse{}, err
-	}
-
-	conn, err := dial(cli.proto, cli.addr, tlsConfig)
+	conn, err := dial(cli.proto, cli.addr, resolveTLSConfig(cli.client.Transport))
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return types.HijackedResponse{}, fmt.Errorf("Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?")

--- a/client/request.go
+++ b/client/request.go
@@ -99,10 +99,7 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 		req.Host = "docker"
 	}
 
-	scheme, err := resolveScheme(cli.client.Transport)
-	if err != nil {
-		return serverResp, err
-	}
+	scheme := resolveScheme(cli.client.Transport)
 
 	req.URL.Host = cli.addr
 	req.URL.Scheme = scheme
@@ -113,8 +110,7 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 
 	resp, err := ctxhttp.Do(ctx, cli.client, req)
 	if err != nil {
-
-		if scheme == "https" && strings.Contains(err.Error(), "malformed HTTP response") {
+		if scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)
 		}
 

--- a/client/transport.go
+++ b/client/transport.go
@@ -18,14 +18,12 @@ func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // resolveTLSConfig attempts to resolve the tls configuration from the
 // RoundTripper.
-func resolveTLSConfig(transport http.RoundTripper) (*tls.Config, error) {
+func resolveTLSConfig(transport http.RoundTripper) *tls.Config {
 	switch tr := transport.(type) {
 	case *http.Transport:
-		return tr.TLSClientConfig, nil
-	case transportFunc:
-		return nil, nil // detect this type for testing.
+		return tr.TLSClientConfig
 	default:
-		return nil, errTLSConfigUnavailable
+		return nil
 	}
 }
 
@@ -37,15 +35,11 @@ func resolveTLSConfig(transport http.RoundTripper) (*tls.Config, error) {
 // Unfortunately, the model of having a host-ish/url-thingy as the connection
 // string has us confusing protocol and transport layers. We continue doing
 // this to avoid breaking existing clients but this should be addressed.
-func resolveScheme(transport http.RoundTripper) (string, error) {
-	c, err := resolveTLSConfig(transport)
-	if err != nil {
-		return "", err
-	}
-
+func resolveScheme(transport http.RoundTripper) string {
+	c := resolveTLSConfig(transport)
 	if c != nil {
-		return "https", nil
+		return "https"
 	}
 
-	return "http", nil
+	return "http"
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2628,7 +2628,7 @@ func (s *DockerSuite) TestRunModeUTSHost(c *check.C) {
 	c.Assert(out, checker.Contains, runconfig.ErrConflictUTSHostname.Error())
 }
 
-func (s *DockerSuite) TestRunTLSverify(c *check.C) {
+func (s *DockerSuite) TestRunTLSVerify(c *check.C) {
 	// Remote daemons use TLS and this test is not applicable when TLS is required.
 	testRequires(c, SameHostDaemon)
 	if out, code, err := dockerCmdWithError("ps"); err != nil || code != 0 {


### PR DESCRIPTION
Under the convoluted code path for the transport configuration,
TLSConfig was being set even though the socket type is unix. This caused
other code detecting the TLSConfig to assume https, rather than using
the http scheme. This led to a situation where if `DOCKER_CERT_PATH` is
set, unix sockets start reverting to https.

We do a few things to mitigate this. The first is to always call
`sockets.ConfigureTransport`, ensuring the two code paths are more
similar. We then clear the `TLSClientConfig` on the transport if there
is the proto is unix. Then, when `resolveScheme` now takes the protocol
into account. This still lets us resolve the TLSConfig, which may be
necessary in the future.

This code is way to convoluted for an http client. We'll need to fix
this but the Go API will break to do it.

Closes #26781

Signed-off-by: Stephen J Day stephen.day@docker.com
