### PR TITLE
Move /x/net/context to context in docker client README

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -11,10 +11,10 @@ package main
 
 import (
 	"fmt"
+	"context"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func main() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Move the golang.org/x/net/context to context to comply with golang 1.7

**\- How I did it**
Made some text changes

**\- How to verify it**
Look

**\- Description for the changelog**
Text change

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Move /x/net/context to context in docker client README

Signed-off-by: Josh Chorlton jchorlton@gmail.com
