### PR TITLE
docs: add missing 'on' in Oracle installation guide

### DIFF
--- a/docs/installation/linux/oracle.md
+++ b/docs/installation/linux/oracle.md
@@ -11,7 +11,7 @@ parent = "engine_linux"
 
 # Oracle Linux
 
-Docker is supported Oracle Linux 6 and 7. You do not require an Oracle Linux
+Docker is supported on Oracle Linux 6 and 7. You do not require an Oracle Linux
 Support subscription to install Docker on Oracle Linux.
 
 ## Prerequisites


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Added a missing `on` in the Oracle Linux installation guide.

**\- How I did it**

Opened the file in GitHub, edited and submitted this PR.

**\- How to verify it**

Look [here](.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

docs: add missing 'on' in Oracle installation guide

**\- A picture of a cute animal (not mandatory but encouraged)**

![Cat](http://38.media.tumblr.com/f4774e7f5f6c10e0c2deb833e9a9b9eb/tumblr_n8ifhtBZRv1tgx1goo1_500.gif)
