### PR TITLE
Windows: Remove hard coded base image in TestBuildCopyFileWithWhitespace

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -830,7 +830,7 @@ RUN [ $(cat "/test dir/test_file5") = 'test5' ]
 RUN [ $(cat "/test dir/test_file6") = 'test6' ]`
 
 	if daemonPlatform == "windows" {
-		dockerfile = `FROM windowsservercore
+		dockerfile = `FROM ` + WindowsBaseImage + `
 RUN mkdir "C:/test dir"
 RUN mkdir "C:/test_dir"
 COPY [ "test file1", "/test_file1" ]


### PR DESCRIPTION
<Signed-off-by: John Howard <jhoward@microsoft.com>

TestBuildCopyFileWithWhitespace had a hardcoded base image. Updated to use the default to allow this test to work on nanoserver as well.
