### PR TITLE
Windows: Move to latest OCI spec

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -71,20 +71,22 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 
 	// In s.Windows.Resources
 	// @darrenstahlmsft implement these resources
-	cpuShares := uint64(c.HostConfig.CPUShares)
+	cpuShares := uint16(c.HostConfig.CPUShares)
+	cpuPercent := uint8(c.HostConfig.CPUPercent)
+	memoryLimit := uint64(c.HostConfig.Memory)
 	s.Windows.Resources = &windowsoci.WindowsResources{
-		CPU: &windowsoci.WindowsCPU{
-			Percent: &c.HostConfig.CPUPercent,
+		CPU: &windowsoci.WindowsCPUResources{
+			Percent: &cpuPercent,
 			Shares:  &cpuShares,
 		},
-		Memory: &windowsoci.WindowsMemory{
-			Limit: &c.HostConfig.Memory,
+		Memory: &windowsoci.WindowsMemoryResources{
+			Limit: &memoryLimit,
 			//TODO Reservation: ...,
 		},
-		Network: &windowsoci.WindowsNetwork{
+		Network: &windowsoci.WindowsNetworkResources{
 		//TODO Bandwidth: ...,
 		},
-		Storage: &windowsoci.WindowsStorage{
+		Storage: &windowsoci.WindowsStorageResources{
 			Bps:  &c.HostConfig.IOMaximumBandwidth,
 			Iops: &c.HostConfig.IOMaximumIOps,
 		},

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -109,15 +109,15 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 	if spec.Windows.Resources != nil {
 		if spec.Windows.Resources.CPU != nil {
 			if spec.Windows.Resources.CPU.Shares != nil {
-				configuration.ProcessorWeight = *spec.Windows.Resources.CPU.Shares
+				configuration.ProcessorWeight = uint64(*spec.Windows.Resources.CPU.Shares)
 			}
 			if spec.Windows.Resources.CPU.Percent != nil {
-				configuration.ProcessorMaximum = *spec.Windows.Resources.CPU.Percent * 100 // ProcessorMaximum is a value between 1 and 10000
+				configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Percent * 100) // ProcessorMaximum is a value between 1 and 10000
 			}
 		}
 		if spec.Windows.Resources.Memory != nil {
 			if spec.Windows.Resources.Memory.Limit != nil {
-				configuration.MemoryMaximumInMB = *spec.Windows.Resources.Memory.Limit / 1024 / 1024
+				configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit / 1024 / 1024)
 			}
 		}
 		if spec.Windows.Resources.Storage != nil {

--- a/libcontainerd/windowsoci/oci_windows.go
+++ b/libcontainerd/windowsoci/oci_windows.go
@@ -4,7 +4,7 @@ package windowsoci
 // writing, Windows does not have a spec defined in opencontainers/specs,
 // hence this is an interim workaround. TODO Windows: FIXME @jhowardmsft
 
-import "fmt"
+import "os"
 
 // Spec is the base configuration for the container.
 type Spec struct {
@@ -33,16 +33,12 @@ type Spec struct {
 	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 }
 
-// Windows contains platform specific configuration for Windows based containers.
-type Windows struct {
-	// Resources contains information for handling resource constraints for the container
-	Resources *WindowsResources `json:"resources,omitempty"`
-}
-
 // Process contains information to start a specific application inside the container.
 type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
+	// ConsoleSize specifies the size of the console.
+	ConsoleSize Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
@@ -55,21 +51,21 @@ type Process struct {
 	// Capabilities are Linux capabilities that are kept for the container.
 	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []Rlimit `json:"rlimits,omitempty" platform:"linux"`
+	Rlimits []LinuxRlimit `json:"rlimits,omitempty" platform:"linux"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
-	// ConsoleSize contains the initial size of the console.
-	ConsoleSize Box `json:"consoleSize" platform:"windows"`
 }
 
-// Box specifies height and width dimensions. Used for sizing of a console.
+// Box specifies dimensions of a rectangle. Used for specifying the size of a console.
 type Box struct {
-	Height uint
-	Width  uint
+	// Height is the vertical dimension of a box.
+	Height uint `json:"height"`
+	// Width is the horizontal dimension of a box.
+	Width uint `json:"width"`
 }
 
 // User specifies specific user (and group) information for the container process.
@@ -89,7 +85,7 @@ type Root struct {
 	// Path is the absolute path to the container's root filesystem.
 	Path string `json:"path"`
 	// Readonly makes the root filesystem for the container readonly before the process is executed.
-	Readonly bool `json:"readonly"`
+	Readonly bool `json:"readonly,omitempty"`
 }
 
 // Platform specifies OS and arch information for the host system that the container
@@ -114,86 +110,430 @@ type Mount struct {
 	Options []string `json:"options,omitempty"`
 }
 
-// WindowsStorage contains storage resource management settings
-type WindowsStorage struct {
-	// Specifies maximum Iops for the system drive
-	Iops *uint64 `json:"iops,omitempty"`
-	// Specifies maximum bytes per second for the system drive
-	Bps *uint64 `json:"bps,omitempty"`
-	// Sandbox size indicates the size to expand the system drive to if it is currently smaller
-	SandboxSize *uint64 `json:"sandbox_size,omitempty"`
-}
-
-// WindowsMemory contains memory settings for the container
-type WindowsMemory struct {
-	// Memory limit (in bytes).
-	Limit *int64 `json:"limit,omitempty"`
-	// Memory reservation (in bytes).
-	Reservation *uint64 `json:"reservation,omitempty"`
-}
-
-// WindowsCPU contains information for cpu resource management
-type WindowsCPU struct {
-	// Number of CPUs available to the container. This is an appoximation for Windows Server Containers.
-	Count *uint64 `json:"count,omitempty"`
-	// CPU shares (relative weight (ratio) vs. other containers with cpu shares). Range is from 1 to 10000.
-	Shares *uint64 `json:"shares,omitempty"`
-	// Percent of available CPUs usable by the container.
-	Percent *int64 `json:"percent,omitempty"`
-}
-
-// WindowsNetwork contains network resource management information
-type WindowsNetwork struct {
-	// Bandwidth is the maximum egress bandwidth in bytes per second
-	Bandwidth *uint64 `json:"bandwidth,omitempty"`
-}
-
-// WindowsResources has container runtime resource constraints
-// TODO Windows containerd. This structure needs ratifying with the old resources
-// structure used on Windows and the latest OCI spec.
-type WindowsResources struct {
-	// Memory restriction configuration
-	Memory *WindowsMemory `json:"memory,omitempty"`
-	// CPU resource restriction configuration
-	CPU *WindowsCPU `json:"cpu,omitempty"`
-	// Storage restriction configuration
-	Storage *WindowsStorage `json:"storage,omitempty"`
-	// Network restriction configuration
-	Network *WindowsNetwork `json:"network,omitempty"`
-}
-
-const (
-	// VersionMajor is for an API incompatible changes
-	VersionMajor = 0
-	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 3
-	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
-
-	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
-)
-
-// Version is the specification version that the package types support.
-var Version = fmt.Sprintf("%d.%d.%d%s (Windows)", VersionMajor, VersionMinor, VersionPatch, VersionDev)
-
-//
-// Temporary structures. Ultimately this whole file will be removed.
-//
-
-// Linux contains platform specific configuration for Linux based containers.
-type Linux struct {
-}
-
-// Solaris contains platform specific configuration for Solaris application containers.
-type Solaris struct {
+// Hook specifies a command that is run at a particular event in the lifecycle of a container
+type Hook struct {
+	Path    string   `json:"path"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	Timeout *int     `json:"timeout,omitempty"`
 }
 
 // Hooks for container setup and teardown
 type Hooks struct {
+	// Prestart is a list of hooks to be run before the container process is executed.
+	// On Linux, they are run after the container namespaces are created.
+	Prestart []Hook `json:"prestart,omitempty"`
+	// Poststart is a list of hooks to be run after the container process is started.
+	Poststart []Hook `json:"poststart,omitempty"`
+	// Poststop is a list of hooks to be run after the container process exits.
+	Poststop []Hook `json:"poststop,omitempty"`
 }
 
-// Rlimit type and restrictions. Placeholder only to support the Process structure.
-// Not used on Windows, only present for compilation purposes.
-type Rlimit struct {
+// Linux contains platform specific configuration for Linux based containers.
+type Linux struct {
+	// UIDMapping specifies user mappings for supporting user namespaces on Linux.
+	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty"`
+	// GIDMapping specifies group mappings for supporting user namespaces on Linux.
+	GIDMappings []LinuxIDMapping `json:"gidMappings,omitempty"`
+	// Sysctl are a set of key value pairs that are set for the container on start
+	Sysctl map[string]string `json:"sysctl,omitempty"`
+	// Resources contain cgroup information for handling resource constraints
+	// for the container
+	Resources *LinuxResources `json:"resources,omitempty"`
+	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
+	// The path is expected to be relative to the cgroups mountpoint.
+	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
+	CgroupsPath *string `json:"cgroupsPath,omitempty"`
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
+	// Devices are a list of device nodes that are created for the container
+	Devices []LinuxDevice `json:"devices,omitempty"`
+	// Seccomp specifies the seccomp security settings for the container.
+	Seccomp *LinuxSeccomp `json:"seccomp,omitempty"`
+	// RootfsPropagation is the rootfs mount propagation mode for the container.
+	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
+	// MaskedPaths masks over the provided paths inside the container.
+	MaskedPaths []string `json:"maskedPaths,omitempty"`
+	// ReadonlyPaths sets the provided paths as RO inside the container.
+	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
+	// MountLabel specifies the selinux context for the mounts in the container.
+	MountLabel string `json:"mountLabel,omitempty"`
+}
+
+// LinuxNamespace is the configuration for a Linux namespace
+type LinuxNamespace struct {
+	// Type is the type of Linux namespace
+	Type LinuxNamespaceType `json:"type"`
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	Path string `json:"path,omitempty"`
+}
+
+// LinuxNamespaceType is one of the Linux namespaces
+type LinuxNamespaceType string
+
+const (
+	// PIDNamespace for isolating process IDs
+	PIDNamespace LinuxNamespaceType = "pid"
+	// NetworkNamespace for isolating network devices, stacks, ports, etc
+	NetworkNamespace = "network"
+	// MountNamespace for isolating mount points
+	MountNamespace = "mount"
+	// IPCNamespace for isolating System V IPC, POSIX message queues
+	IPCNamespace = "ipc"
+	// UTSNamespace for isolating hostname and NIS domain name
+	UTSNamespace = "uts"
+	// UserNamespace for isolating user and group IDs
+	UserNamespace = "user"
+	// CgroupNamespace for isolating cgroup hierarchies
+	CgroupNamespace = "cgroup"
+)
+
+// LinuxIDMapping specifies UID/GID mappings
+type LinuxIDMapping struct {
+	// HostID is the UID/GID of the host user or group
+	HostID uint32 `json:"hostID"`
+	// ContainerID is the UID/GID of the container's user or group
+	ContainerID uint32 `json:"containerID"`
+	// Size is the length of the range of IDs mapped between the two namespaces
+	Size uint32 `json:"size"`
+}
+
+// LinuxRlimit type and restrictions
+type LinuxRlimit struct {
+	// Type of the rlimit to set
+	Type string `json:"type"`
+	// Hard is the hard limit for the specified type
+	Hard uint64 `json:"hard"`
+	// Soft is the soft limit for the specified type
+	Soft uint64 `json:"soft"`
+}
+
+// LinuxHugepageLimit structure corresponds to limiting kernel hugepages
+type LinuxHugepageLimit struct {
+	// Pagesize is the hugepage size
+	Pagesize *string `json:"pageSize,omitempty"`
+	// Limit is the limit of "hugepagesize" hugetlb usage
+	Limit *uint64 `json:"limit,omitempty"`
+}
+
+// LinuxInterfacePriority for network interfaces
+type LinuxInterfacePriority struct {
+	// Name is the name of the network interface
+	Name string `json:"name"`
+	// Priority for the interface
+	Priority uint32 `json:"priority"`
+}
+
+// linuxBlockIODevice holds major:minor format supported in blkio cgroup
+type linuxBlockIODevice struct {
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+}
+
+// LinuxWeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+type LinuxWeightDevice struct {
+	linuxBlockIODevice
+	// Weight is the bandwidth rate for the device, range is from 10 to 1000
+	Weight *uint16 `json:"weight,omitempty"`
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	LeafWeight *uint16 `json:"leafWeight,omitempty"`
+}
+
+// LinuxThrottleDevice struct holds a `major:minor rate_per_second` pair
+type LinuxThrottleDevice struct {
+	linuxBlockIODevice
+	// Rate is the IO rate limit per cgroup per device
+	Rate *uint64 `json:"rate,omitempty"`
+}
+
+// LinuxBlockIO for Linux cgroup 'blkio' resource management
+type LinuxBlockIO struct {
+	// Specifies per cgroup weight, range is from 10 to 1000
+	Weight *uint16 `json:"blkioWeight,omitempty"`
+	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
+	// Weight per cgroup per device, can override BlkioWeight
+	WeightDevice []LinuxWeightDevice `json:"blkioWeightDevice,omitempty"`
+	// IO read rate limit per cgroup per device, bytes per second
+	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
+	// IO write rate limit per cgroup per device, bytes per second
+	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
+	// IO read rate limit per cgroup per device, IO per second
+	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
+	// IO write rate limit per cgroup per device, IO per second
+	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
+}
+
+// LinuxMemory for Linux cgroup 'memory' resource management
+type LinuxMemory struct {
+	// Memory limit (in bytes).
+	Limit *uint64 `json:"limit,omitempty"`
+	// Memory reservation or soft_limit (in bytes).
+	Reservation *uint64 `json:"reservation,omitempty"`
+	// Total memory limit (memory + swap).
+	Swap *uint64 `json:"swap,omitempty"`
+	// Kernel memory limit (in bytes).
+	Kernel *uint64 `json:"kernel,omitempty"`
+	// Kernel memory limit for tcp (in bytes)
+	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
+	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
+	Swappiness *uint64 `json:"swappiness,omitempty"`
+}
+
+// LinuxCPU for Linux cgroup 'cpu' resource management
+type LinuxCPU struct {
+	// CPU shares (relative weight (ratio) vs. other cgroups with cpu shares).
+	Shares *uint64 `json:"shares,omitempty"`
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	Quota *uint64 `json:"quota,omitempty"`
+	// CPU period to be used for hardcapping (in usecs).
+	Period *uint64 `json:"period,omitempty"`
+	// How much time realtime scheduling may use (in usecs).
+	RealtimeRuntime *uint64 `json:"realtimeRuntime,omitempty"`
+	// CPU period to be used for realtime scheduling (in usecs).
+	RealtimePeriod *uint64 `json:"realtimePeriod,omitempty"`
+	// CPUs to use within the cpuset. Default is to use any CPU available.
+	Cpus *string `json:"cpus,omitempty"`
+	// List of memory nodes in the cpuset. Default is to use any available memory node.
+	Mems *string `json:"mems,omitempty"`
+}
+
+// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)
+type LinuxPids struct {
+	// Maximum number of PIDs. Default is "no limit".
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+// LinuxNetwork identification and priority configuration
+type LinuxNetwork struct {
+	// Set class identifier for container's network packets
+	ClassID *uint32 `json:"classID,omitempty"`
+	// Set priority of network traffic for container
+	Priorities []LinuxInterfacePriority `json:"priorities,omitempty"`
+}
+
+// LinuxResources has container runtime resource constraints
+type LinuxResources struct {
+	// Devices configures the device whitelist.
+	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
+	// Specify an oom_score_adj for the container.
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
+	// Memory restriction configuration
+	Memory *LinuxMemory `json:"memory,omitempty"`
+	// CPU resource restriction configuration
+	CPU *LinuxCPU `json:"cpu,omitempty"`
+	// Task resource restriction configuration.
+	Pids *LinuxPids `json:"pids,omitempty"`
+	// BlockIO restriction configuration
+	BlockIO *LinuxBlockIO `json:"blockIO,omitempty"`
+	// Hugetlb limit (in bytes)
+	HugepageLimits []LinuxHugepageLimit `json:"hugepageLimits,omitempty"`
+	// Network restriction configuration
+	Network *LinuxNetwork `json:"network,omitempty"`
+}
+
+// LinuxDevice represents the mknod information for a Linux special device file
+type LinuxDevice struct {
+	// Path to the device.
+	Path string `json:"path"`
+	// Device type, block, char, etc.
+	Type string `json:"type"`
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+	// FileMode permission bits for the device.
+	FileMode *os.FileMode `json:"fileMode,omitempty"`
+	// UID of the device.
+	UID *uint32 `json:"uid,omitempty"`
+	// Gid of the device.
+	GID *uint32 `json:"gid,omitempty"`
+}
+
+// LinuxDeviceCgroup represents a device rule for the whitelist controller
+type LinuxDeviceCgroup struct {
+	// Allow or deny
+	Allow bool `json:"allow"`
+	// Device type, block, char, etc.
+	Type *string `json:"type,omitempty"`
+	// Major is the device's major number.
+	Major *int64 `json:"major,omitempty"`
+	// Minor is the device's minor number.
+	Minor *int64 `json:"minor,omitempty"`
+	// Cgroup access permissions format, rwm.
+	Access *string `json:"access,omitempty"`
+}
+
+// LinuxSeccomp represents syscall restrictions
+type LinuxSeccomp struct {
+	DefaultAction LinuxSeccompAction `json:"defaultAction"`
+	Architectures []Arch             `json:"architectures"`
+	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
+}
+
+// Solaris contains platform specific configuration for Solaris application containers.
+type Solaris struct {
+	// SMF FMRI which should go "online" before we start the container process.
+	Milestone string `json:"milestone,omitempty"`
+	// Maximum set of privileges any process in this container can obtain.
+	LimitPriv string `json:"limitpriv,omitempty"`
+	// The maximum amount of shared memory allowed for this container.
+	MaxShmMemory string `json:"maxShmMemory,omitempty"`
+	// Specification for automatic creation of network resources for this container.
+	Anet []SolarisAnet `json:"anet,omitempty"`
+	// Set limit on the amount of CPU time that can be used by container.
+	CappedCPU *SolarisCappedCPU `json:"cappedCPU,omitempty"`
+	// The physical and swap caps on the memory that can be used by this container.
+	CappedMemory *SolarisCappedMemory `json:"cappedMemory,omitempty"`
+}
+
+// SolarisCappedCPU allows users to set limit on the amount of CPU time that can be used by container.
+type SolarisCappedCPU struct {
+	Ncpus string `json:"ncpus,omitempty"`
+}
+
+// SolarisCappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
+type SolarisCappedMemory struct {
+	Physical string `json:"physical,omitempty"`
+	Swap     string `json:"swap,omitempty"`
+}
+
+// SolarisAnet provides the specification for automatic creation of network resources for this container.
+type SolarisAnet struct {
+	// Specify a name for the automatically created VNIC datalink.
+	Linkname string `json:"linkname,omitempty"`
+	// Specify the link over which the VNIC will be created.
+	Lowerlink string `json:"lowerLink,omitempty"`
+	// The set of IP addresses that the container can use.
+	Allowedaddr string `json:"allowedAddress,omitempty"`
+	// Specifies whether allowedAddress limitation is to be applied to the VNIC.
+	Configallowedaddr string `json:"configureAllowedAddress,omitempty"`
+	// The value of the optional default router.
+	Defrouter string `json:"defrouter,omitempty"`
+	// Enable one or more types of link protection.
+	Linkprotection string `json:"linkProtection,omitempty"`
+	// Set the VNIC's macAddress
+	Macaddress string `json:"macAddress,omitempty"`
+}
+
+// Windows defines the runtime configuration for Windows based containers, including Hyper-V containers.
+type Windows struct {
+	// Resources contains information for handling resource constraints for the container.
+	Resources *WindowsResources `json:"resources,omitempty"`
+}
+
+// WindowsResources has container runtime resource constraints for containers running on Windows.
+type WindowsResources struct {
+	// Memory restriction configuration.
+	Memory *WindowsMemoryResources `json:"memory,omitempty"`
+	// CPU resource restriction configuration.
+	CPU *WindowsCPUResources `json:"cpu,omitempty"`
+	// Storage restriction configuration.
+	Storage *WindowsStorageResources `json:"storage,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetworkResources `json:"network,omitempty"`
+}
+
+// WindowsMemoryResources contains memory resource management settings.
+type WindowsMemoryResources struct {
+	// Memory limit in bytes.
+	Limit *uint64 `json:"limit,omitempty"`
+	// Memory reservation in bytes.
+	Reservation *uint64 `json:"reservation,omitempty"`
+}
+
+// WindowsCPUResources contains CPU resource management settings.
+type WindowsCPUResources struct {
+	// Number of CPUs available to the container.
+	Count *uint64 `json:"count,omitempty"`
+	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
+	Shares *uint16 `json:"shares,omitempty"`
+	// Percent of available CPUs usable by the container.
+	Percent *uint8 `json:"percent,omitempty"`
+}
+
+// WindowsStorageResources contains storage resource management settings.
+type WindowsStorageResources struct {
+	// Specifies maximum Iops for the system drive.
+	Iops *uint64 `json:"iops,omitempty"`
+	// Specifies maximum bytes per second for the system drive.
+	Bps *uint64 `json:"bps,omitempty"`
+	// Sandbox size specifies the minimum size of the system drive in bytes.
+	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
+}
+
+// WindowsNetworkResources contains network resource management settings.
+type WindowsNetworkResources struct {
+	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
+	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
+}
+
+// Arch used for additional architectures
+type Arch string
+
+// Additional architectures permitted to be used for system calls
+// By default only the native architecture of the kernel is permitted
+const (
+	ArchX86         Arch = "SCMP_ARCH_X86"
+	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
+	ArchX32         Arch = "SCMP_ARCH_X32"
+	ArchARM         Arch = "SCMP_ARCH_ARM"
+	ArchAARCH64     Arch = "SCMP_ARCH_AARCH64"
+	ArchMIPS        Arch = "SCMP_ARCH_MIPS"
+	ArchMIPS64      Arch = "SCMP_ARCH_MIPS64"
+	ArchMIPS64N32   Arch = "SCMP_ARCH_MIPS64N32"
+	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
+	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
+	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+	ArchPPC         Arch = "SCMP_ARCH_PPC"
+	ArchPPC64       Arch = "SCMP_ARCH_PPC64"
+	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
+	ArchS390        Arch = "SCMP_ARCH_S390"
+	ArchS390X       Arch = "SCMP_ARCH_S390X"
+)
+
+// LinuxSeccompAction taken upon Seccomp rule match
+type LinuxSeccompAction string
+
+// Define actions for Seccomp rules
+const (
+	ActKill  LinuxSeccompAction = "SCMP_ACT_KILL"
+	ActTrap  LinuxSeccompAction = "SCMP_ACT_TRAP"
+	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
+	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
+	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
+)
+
+// LinuxSeccompOperator used to match syscall arguments in Seccomp
+type LinuxSeccompOperator string
+
+// Define operators for syscall arguments in Seccomp
+const (
+	OpNotEqual     LinuxSeccompOperator = "SCMP_CMP_NE"
+	OpLessThan     LinuxSeccompOperator = "SCMP_CMP_LT"
+	OpLessEqual    LinuxSeccompOperator = "SCMP_CMP_LE"
+	OpEqualTo      LinuxSeccompOperator = "SCMP_CMP_EQ"
+	OpGreaterEqual LinuxSeccompOperator = "SCMP_CMP_GE"
+	OpGreaterThan  LinuxSeccompOperator = "SCMP_CMP_GT"
+	OpMaskedEqual  LinuxSeccompOperator = "SCMP_CMP_MASKED_EQ"
+)
+
+// LinuxSeccompArg used for matching specific syscall arguments in Seccomp
+type LinuxSeccompArg struct {
+	Index    uint                 `json:"index"`
+	Value    uint64               `json:"value"`
+	ValueTwo uint64               `json:"valueTwo"`
+	Op       LinuxSeccompOperator `json:"op"`
+}
+
+// LinuxSyscall is used to match a syscall in Seccomp
+type LinuxSyscall struct {
+	Name   string             `json:"name"`
+	Action LinuxSeccompAction `json:"action"`
+	Args   []LinuxSeccompArg  `json:"args,omitempty"`
 }

--- a/oci/defaults_windows.go
+++ b/oci/defaults_windows.go
@@ -9,7 +9,6 @@ import (
 // DefaultSpec returns default spec used by docker.
 func DefaultSpec() windowsoci.Spec {
 	return windowsoci.Spec{
-		Version: windowsoci.Version,
 		Platform: windowsoci.Platform{
 			OS:   runtime.GOOS,
 			Arch: runtime.GOARCH,


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@mlaventure @tonistiigi @thaJeztah 

This PR refreshes the contents of the hacked OCI spec used on Windows to exactly what would be in the opencontainers runtime spec once https://github.com/opencontainers/runtime-spec/pull/567 and https://github.com/opencontainers/runtime-spec/pull/573 are merged. The other changes are purely compile fixups. No functional changes in this PR.

This is the final stage of the Windows OCI manipulation (I hope!) before the file can be removed entirely and Windows uses the actual spec.
