### PR TITLE
Deprecate "daemon" subcommand

### DIFF
--- a/cmd/docker/daemon_unix.go
+++ b/cmd/docker/daemon_unix.go
@@ -24,6 +24,7 @@ func newDaemonCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemon()
 		},
+		Deprecated: "and will be removed in Docker 1.16. Please run `dockerd` directly.",
 	}
 	cmd.SetHelpFunc(helpFunc)
 	return cmd

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -17,6 +17,13 @@ To learn more about Docker Engine's deprecation policy,
 see [Feature Deprecation Policy](index.md#feature-deprecation-policy).
 
 
+### `docker daemon` subcommand
+**Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/)**
+
+**Target For Removal In Release: v1.16**
+
+The daemon is moved to a separate binary (`dockerd`), and should be used instead.
+
 ### Three argument form in `docker import`
 **Deprecated In Release: [v0.6.7](https://github.com/docker/docker/releases/tag/v0.6.7)**
 

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -86,14 +86,8 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 		cmds := []string{}
 		// Grab all chars starting at "Commands:"
 		helpOut := strings.Split(out[i:], "\n")
-		// First line is just "Commands:"
-		if isLocalDaemon {
-			// Replace first line with "daemon" command since it's not part of the list of commands.
-			helpOut[0] = " daemon"
-		} else {
-			// Skip first line
-			helpOut = helpOut[1:]
-		}
+		// Skip first line, it is just "Commands:"
+		helpOut = helpOut[1:]
 
 		// Create the list of commands we want to test
 		cmdsToTest := []string{}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

Build docker, and run `docker daemon`. Check that the output shows;

```
docker daemon
Command "daemon" is deprecated, and will be removed in docker 1.16. Please run `dockerd` directly.

```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

The daemon is in a separate (dockerd) binary
since docker 1.12, so should no longer be
used.

This marks the command as deprecated, and
adds it to the deprecated features list.

ping @jhowardmsft @dnephin PTAL
