### PR TITLE
Fix some places where low-level errors bubbled up

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -12,6 +12,8 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/mount"
@@ -93,7 +95,7 @@ func New(scope string, rootUID, rootGID int) (*Root, error) {
 		if b, err := ioutil.ReadFile(optsFilePath); err == nil {
 			opts := optsConfig{}
 			if err := json.Unmarshal(b, &opts); err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "error while unmarshaling volume options for volume: %s", name)
 			}
 			// Make sure this isn't an empty optsConfig.
 			// This could be empty due to buggy behavior in older versions of Docker.
@@ -168,7 +170,7 @@ func (r *Root) Create(name string, opts map[string]string) (volume.Volume, error
 		if os.IsExist(err) {
 			return nil, fmt.Errorf("volume already exists under %s", filepath.Dir(path))
 		}
-		return nil, err
+		return nil, errors.Wrapf(err, "error while creating volume path '%s'", path)
 	}
 
 	var err error
@@ -194,7 +196,7 @@ func (r *Root) Create(name string, opts map[string]string) (volume.Volume, error
 			return nil, err
 		}
 		if err = ioutil.WriteFile(filepath.Join(filepath.Dir(path), "opts.json"), b, 600); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "error while persisting volume options")
 		}
 	}
 
@@ -240,7 +242,7 @@ func removePath(path string) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return err
+		return errors.Wrapf(err, "error removing volume path '%s'", path)
 	}
 	return nil
 }
@@ -327,7 +329,7 @@ func (v *localVolume) Unmount(id string) error {
 		if v.active.count == 0 {
 			if err := mount.Unmount(v.path); err != nil {
 				v.active.count++
-				return err
+				return errors.Wrapf(err, "error while unmounting volume path '%s'", v.path)
 			}
 			v.active.mounted = false
 		}

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"src/github.com/pkg/errors"
+
 	"github.com/docker/docker/pkg/mount"
 )
 
@@ -27,6 +29,10 @@ type optsConfig struct {
 	MountType   string
 	MountOpts   string
 	MountDevice string
+}
+
+func (o *optsConfig) String() string {
+	return fmt.Sprintf("type='%s' device='%s' o='%s'", o.MountType, o.MountDevice, o.MountOpts)
 }
 
 // scopedPath verifies that the path where the volume is located
@@ -65,5 +71,6 @@ func (v *localVolume) mount() error {
 	if v.opts.MountDevice == "" {
 		return fmt.Errorf("missing device in volume options")
 	}
-	return mount.Mount(v.opts.MountDevice, v.path, v.opts.MountType, v.opts.MountOpts)
+	err := mount.Mount(v.opts.MountDevice, v.path, v.opts.MountType, v.opts.MountOpts)
+	return errors.Wrapf(err, "error while mounting volume with options: %s", v.opts)
 }

--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/docker/docker/pkg/locker"
@@ -70,13 +72,13 @@ func New(rootPath string) (*VolumeStore, error) {
 		var err error
 		vs.db, err = bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "error while opening volume store metadata database")
 		}
 
 		// initialize volumes bucket
 		if err := vs.db.Update(func(tx *bolt.Tx) error {
 			if _, err := tx.CreateBucketIfNotExists([]byte(volumeBucketName)); err != nil {
-				return err
+				return errors.Wrap(err, "error while setting up volume store metadata database")
 			}
 
 			return nil
@@ -299,7 +301,7 @@ func (s *VolumeStore) create(name, driverName string, opts, labels map[string]st
 			err := b.Put([]byte(name), volData)
 			return err
 		}); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "error while persisting volume metadata")
 		}
 	}
 


### PR DESCRIPTION
Found a couple of places where pretty low level errors were never being
wrapped with any sort of context.

For example, if you try to create a local volume using some bad mount
options, the kernel will return `invalid argument` when we try to mount
it at container start.
What would happen is a user would `docker run` with this volume and get
an error like `Error response from daemon: invalid argument`.

This uses github.com/pkg/errors to provide some context to the error
message without masking the original error.

Signed-off-by: Brian Goff cpuguy83@gmail.com
