### PR TITLE
Mention deploy alias in command help

### DIFF
--- a/cli/command/stack/cmd_experimental.go
+++ b/cli/command/stack/cmd_experimental.go
@@ -33,7 +33,6 @@ func NewStackCommand(dockerCli *command.DockerCli) *cobra.Command {
 // NewTopLevelDeployCommand returns a command for `docker deploy`
 func NewTopLevelDeployCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := newDeployCommand(dockerCli)
-	// Remove the aliases at the top level
-	cmd.Aliases = []string{}
+	cmd.Aliases = []string{"docker stack deploy"}
 	return cmd
 }

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -30,7 +30,7 @@ func newDeployCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "deploy [OPTIONS] STACK",
-		Aliases: []string{"up"},
+		Aliases: []string{"up", "docker deploy"},
 		Short:   "Create and update a stack from a Distributed Application Bundle (DAB)",
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Maybe fixes #24799

Here's what it looks like:

```
Usage:  docker deploy [OPTIONS] STACK

Create and update a stack from a Distributed Application Bundle (DAB)

Aliases:
  deploy, docker stack deploy

...
```

```
Usage:  docker stack deploy [OPTIONS] STACK

Create and update a stack from a Distributed Application Bundle (DAB)

Aliases:
  deploy, up, docker deploy
...
```

Cobra kind of assumes that aliases will be at the same command "level" as itself, so it adds the canonical name to the list of aliases. That makes it look a little weird.

We could change this in our fork to remove adding the self, or to even have it list the full command of the alias (so `docker deploy`, `docker stack up`, etc).

What do you think?
