### PR TITLE
[1.14] deprecation - remove `:` separator of `--security-opt`

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -177,9 +177,6 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 		var con []string
 		if strings.Contains(opt, "=") {
 			con = strings.SplitN(opt, "=", 2)
-		} else if strings.Contains(opt, ":") {
-			con = strings.SplitN(opt, ":", 2)
-			logrus.Warn("Security options with `:` as a separator are deprecated and will be completely unsupported in 1.14, use `=` instead.")
 		}
 
 		if len(con) != 2 {

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -103,7 +103,7 @@ The docker login command is removing the ability to automatically register for a
 ### Separator (`:`) of `--security-opt` flag on `docker run`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
-**Target For Removal In Release: v1.14**
+**Removed In Release: [v1.14.0](https://github.com/docker/docker/releases/)**
 
 The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consistency with other similar flags, like `--storage-opt`.
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Happened to notice this deprecation notice still in the 1.13 code base.
