### PR TITLE
17.04 deprecation: email from login

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -35,13 +35,8 @@ func NewLoginCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	flags.StringVarP(&opts.user, "username", "u", "", "Username")
 	flags.StringVarP(&opts.password, "password", "p", "", "Password")
-
-	// Deprecated in 1.11: Should be removed in docker 1.14
-	flags.StringVarP(&opts.email, "email", "e", "", "Email")
-	flags.MarkDeprecated("email", "will be removed in 1.14.")
 
 	return cmd
 }

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -96,7 +96,7 @@ on all subcommands (due to it conflicting with, e.g. `-h` / `--hostname` on
 ### `-e` and `--email` flags on `docker login`
 **Deprecated In Release: [v1.11.0](https://github.com/docker/docker/releases/tag/v1.11.0)**
 
-**Target For Removal In Release: v1.14**
+**Removed In Release: [v1.14.0](https://github.com/docker/docker/releases/)**
 
 The docker login command is removing the ability to automatically register for an account with the target registry if the given username doesn't exist. Due to this change, the email flag is no longer required, and will be deprecated.
 

--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -28,17 +28,3 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *check.C)
 	// now it's fine
 	dockerCmd(c, "login", "-u", s.reg.username, "-p", s.reg.password, privateRegistryURL)
 }
-
-func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistryDeprecatedEmailFlag(c *check.C) {
-	// Test to make sure login still works with the deprecated -e and --email flags
-	// wrong credentials
-	out, _, err := dockerCmdWithError("login", "-u", s.reg.username, "-p", "WRONGPASSWORD", "-e", s.reg.email, privateRegistryURL)
-	c.Assert(err, checker.NotNil, check.Commentf(out))
-	c.Assert(out, checker.Contains, "401 Unauthorized")
-
-	// now it's fine
-	// -e flag
-	dockerCmd(c, "login", "-u", s.reg.username, "-p", s.reg.password, "-e", s.reg.email, privateRegistryURL)
-	// --email flag
-	dockerCmd(c, "login", "-u", s.reg.username, "-p", s.reg.password, "--email", s.reg.email, privateRegistryURL)
-}

--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -103,7 +103,7 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
 	s.d.Cmd("build", "--file", dockerfileName, ".")
 	regexpCheckUA(c, buildUA)
 
-	s.d.Cmd("login", "-u", "richard", "-p", "testtest", "-e", "testuser@testdomain.com", loginReg.hostport)
+	s.d.Cmd("login", "-u", "richard", "-p", "testtest", loginReg.hostport)
 	regexpCheckUA(c, loginUA)
 
 	s.d.Cmd("pull", pullRepoName)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

After stumbling across https://github.com/docker/docker/pull/26863, I did a quick git grep and noticed this planned deprecation too - the use of email on login. Removing.

Haven't run CI locally - some tests may need fixing up still.
