### PR TITLE
Separate IPAM config/operational data in nw inspect 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,10 +191,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 886e6ff9ea61a5c2177be1b64af397fedf420750
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Install yamllint for validating swagger.yaml

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -129,10 +129,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 886e6ff9ea61a5c2177be1b64af397fedf420750
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -137,10 +137,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 886e6ff9ea61a5c2177be1b64af397fedf420750
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -142,10 +142,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 886e6ff9ea61a5c2177be1b64af397fedf420750
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -135,10 +135,11 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT e2655f658408f9ad1f62abdef3eb6ed43c0cf324
+ENV DOCKER_PY_COMMIT 886e6ff9ea61a5c2177be1b64af397fedf420750
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT \
+	&& pip install docker-pycreds==0.2.1 \
 	&& pip install -r test-requirements.txt
 
 # Set user.email so crosbymichael's in-container merge commits go smoothly

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1089,6 +1089,8 @@ definitions:
         Driver: "default"
         Config:
           - Subnet: "172.19.0.0/16"
+        State:
+          - Subnet: "172.19.0.0/16"
             Gateway: "172.19.0.1"
         Options:
           foo: "bar"
@@ -1119,6 +1121,13 @@ definitions:
         default: "default"
       Config:
         description: "List of IPAM configuration options, specified as a map: `{\"Subnet\": <CIDR>, \"IPRange\": <CIDR>, \"Gateway\": <IP address>, \"AuxAddress\": <device_name:IP address>}`"
+        type: "array"
+        items:
+          type: "object"
+          additionalProperties:
+            type: "string"
+      State:
+        description: "Current IPAM state, specified as a map: `{\"Subnet\": <CIDR>, \"Gateway\": <IP address>}`"
         type: "array"
         items:
           type: "object"

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -11,6 +11,7 @@ type IPAM struct {
 	Driver  string
 	Options map[string]string //Per network IPAM driver options
 	Config  []IPAMConfig
+	State   []IPAMConfig // IPAM operational state
 }
 
 // IPAMConfig represents IPAM configurations

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -164,6 +164,8 @@ equivalent docker daemon flags used for docker0 bridge:
 | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
 | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
 
+The `com.docker.network.driver.mtu` option is also supported by the `overlay` driver.
+
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to `docker daemon`.
 

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -63,6 +63,12 @@ $ sudo docker network inspect bridge
                     "Subnet": "172.17.42.1/16",
                     "Gateway": "172.17.42.1"
                 }
+            ],
+            "State": [
+                {
+                    "Subnet": "172.17.42.1/16",
+                    "Gateway": "172.17.42.1"
+                }
             ]
         },
         "Internal": false,
@@ -111,6 +117,12 @@ $ docker network inspect simple-network
         "IPAM": {
             "Driver": "default",
             "Config": [
+                {
+                    "Subnet": "172.22.0.0/16",
+                    "Gateway": "172.22.0.1"
+                }
+            ],
+            "State": [
                 {
                     "Subnet": "172.22.0.0/16",
                     "Gateway": "172.22.0.1"

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -122,6 +122,9 @@ func (s *DockerSuite) TestAPINetworkInspect(c *check.C) {
 	c.Assert(nr.IPAM.Config[0].Subnet, checker.Equals, "172.28.0.0/16")
 	c.Assert(nr.IPAM.Config[0].IPRange, checker.Equals, "172.28.5.0/24")
 	c.Assert(nr.IPAM.Config[0].Gateway, checker.Equals, "172.28.5.254")
+	c.Assert(len(nr.IPAM.State), checker.Equals, 1)
+	c.Assert(nr.IPAM.State[0].Subnet, checker.Equals, "172.28.0.0/16")
+	c.Assert(nr.IPAM.State[0].Gateway, checker.Equals, "172.28.5.254")
 	c.Assert(nr.Options["foo"], checker.Equals, "bar")
 	c.Assert(nr.Options["opts"], checker.Equals, "dopts")
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -677,6 +677,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkInspectDefault(c *check.C) {
 	c.Assert(nr.EnableIPv6, checker.Equals, false)
 	c.Assert(nr.IPAM.Driver, checker.Equals, "default")
 	c.Assert(len(nr.IPAM.Config), checker.Equals, 0)
+	c.Assert(len(nr.IPAM.State), checker.Equals, 0)
 
 	nr = getNetworkResource(c, "host")
 	c.Assert(nr.Driver, checker.Equals, "host")
@@ -685,6 +686,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkInspectDefault(c *check.C) {
 	c.Assert(nr.EnableIPv6, checker.Equals, false)
 	c.Assert(nr.IPAM.Driver, checker.Equals, "default")
 	c.Assert(len(nr.IPAM.Config), checker.Equals, 0)
+	c.Assert(len(nr.IPAM.State), checker.Equals, 0)
 
 	nr = getNetworkResource(c, "bridge")
 	c.Assert(nr.Driver, checker.Equals, "bridge")
@@ -695,6 +697,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkInspectDefault(c *check.C) {
 	c.Assert(len(nr.IPAM.Config), checker.Equals, 1)
 	c.Assert(nr.IPAM.Config[0].Subnet, checker.NotNil)
 	c.Assert(nr.IPAM.Config[0].Gateway, checker.NotNil)
+	c.Assert(len(nr.IPAM.State), checker.Equals, 1)
+	c.Assert(nr.IPAM.State[0].Subnet, checker.NotNil)
+	c.Assert(nr.IPAM.State[0].Gateway, checker.NotNil)
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkInspectCustomUnspecified(c *check.C) {

--- a/man/src/network/inspect.md
+++ b/man/src/network/inspect.md
@@ -29,6 +29,12 @@ $ sudo docker network inspect bridge
                     "Subnet": "172.17.42.1/16",
                     "Gateway": "172.17.42.1"
                 }
+            ],
+            "State": [
+                {
+                    "Subnet": "172.17.42.1/16",
+                    "Gateway": "172.17.42.1"
+                }
             ]
         },
         "Internal": false,
@@ -75,6 +81,12 @@ $ docker network inspect simple-network
         "IPAM": {
             "Driver": "default",
             "Config": [
+                {
+                    "Subnet": "172.22.0.0/16",
+                    "Gateway": "172.22.0.1"
+                }
+            ],
+            "State": [
                 {
                     "Subnet": "172.22.0.0/16",
                     "Gateway": "172.22.0.1"


### PR DESCRIPTION
Currently `IPAM.Config` entry in `docker network inspect` output  is being filled with the network ipam configuration data if present, otherwise with the ipam operationional data.

It was decided to finally separate config from operational state.
This means now the IPAM field in the network object will contain `Config` as well as `Data` field.

An excerpt from a `docker networ inspect` would look like this:

```
 "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "5.5.0.0/16",
                    "IPRange": "5.5.2.0/24",
                    "Gateway": "5.5.254.254",
                    "AuxiliaryAddresses": {
                        "my_router": "5.5.2.2",
                        "my_switch": "5.5.2.1"
                    }
                },
                {
                    "Subnet": "2001:db8:abcd:1234::/64",
                    "IPRange": "2001:db8:abcd:1234:5678::/80"
                }
            ],
            "Data": [
                {
                    "Subnet": "5.5.0.0/16",
                    "Gateway": "5.5.254.254"
                },
                {
                    "Subnet": "2001:db8:abcd:1234::/64",
                    "Gateway": "2001:db8:abcd:1234:5678::"
                }
            ]
        },
```

Fixes #26799 
Fixes #26933 

Signed-off-by: Alessandro Boch aboch@docker.com
