### PR TITLE
[WIP] Add `--insecure-registry` to `docker pull`

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -37,7 +37,7 @@ type importExportBackend interface {
 }
 
 type registryBackend interface {
-	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, insecureRegistries []string, outStream io.Writer) error
 	PushImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
 	SearchRegistryForImages(ctx context.Context, filtersArgs string, term string, limit int, authConfig *types.AuthConfig, metaHeaders map[string][]string) (*registry.SearchResults, error)
 }

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -75,12 +75,13 @@ func (s *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrite
 	}
 
 	var (
-		image   = r.Form.Get("fromImage")
-		repo    = r.Form.Get("repo")
-		tag     = r.Form.Get("tag")
-		message = r.Form.Get("message")
-		err     error
-		output  = ioutils.NewWriteFlusher(w)
+		image              = r.Form.Get("fromImage")
+		repo               = r.Form.Get("repo")
+		tag                = r.Form.Get("tag")
+		message            = r.Form.Get("message")
+		insecureRegistries = strings.Split(r.Form.Get("insecure-registries"), ",")
+		err                error
+		output             = ioutils.NewWriteFlusher(w)
 	)
 	defer output.Close()
 
@@ -105,7 +106,7 @@ func (s *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrite
 			}
 		}
 
-		err = s.backend.PullImage(ctx, image, tag, metaHeaders, authConfig, output)
+		err = s.backend.PullImage(ctx, image, tag, metaHeaders, authConfig, insecureRegistries, output)
 	} else { //import
 		src := r.Form.Get("fromSrc")
 		// 'err' MUST NOT be defined within this block, we need any error

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -195,9 +195,10 @@ type ImageLoadResponse struct {
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {
-	All           bool
-	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
-	PrivilegeFunc RequestPrivilegeFunc
+	All                bool
+	RegistryAuth       string // RegistryAuth is the base64 encoded credentials for the registry
+	PrivilegeFunc      RequestPrivilegeFunc
+	InsecureRegistries []string
 }
 
 // RequestPrivilegeFunc is a function interface that

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -232,7 +232,7 @@ func imagePushPrivileged(ctx context.Context, cli *command.DockerCli, authConfig
 }
 
 // trustedPull handles content trust pulling of an image
-func trustedPull(ctx context.Context, cli *command.DockerCli, repoInfo *registry.RepositoryInfo, ref registry.Reference, authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc) error {
+func trustedPull(ctx context.Context, cli *command.DockerCli, repoInfo *registry.RepositoryInfo, ref registry.Reference, authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc, insecureRegistries []string) error {
 	var refs []target
 
 	notaryRepo, err := GetNotaryRepository(cli, repoInfo, authConfig, "pull")
@@ -294,7 +294,12 @@ func trustedPull(ctx context.Context, cli *command.DockerCli, repoInfo *registry
 		if err != nil {
 			return err
 		}
-		if err := imagePullPrivileged(ctx, cli, authConfig, ref.String(), requestPrivilege, false); err != nil {
+
+		// TODO(icecrime): Should we allow per-pull insecure registries overrides for trusted pull
+		// operations? It seems contradictory, and would possibly even be better to error out when
+		// `--insecure-registry` is specified for a pull operation with Docker Content Trust
+		// enabled.
+		if err := imagePullPrivileged(ctx, cli, authConfig, ref.String(), requestPrivilege, false, insecureRegistries); err != nil {
 			return err
 		}
 
@@ -317,16 +322,17 @@ func trustedPull(ctx context.Context, cli *command.DockerCli, repoInfo *registry
 }
 
 // imagePullPrivileged pulls the image and displays it to the output
-func imagePullPrivileged(ctx context.Context, cli *command.DockerCli, authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc, all bool) error {
+func imagePullPrivileged(ctx context.Context, cli *command.DockerCli, authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc, all bool, insecureRegistries []string) error {
 
 	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}
 	options := types.ImagePullOptions{
-		RegistryAuth:  encodedAuth,
-		PrivilegeFunc: requestPrivilege,
-		All:           all,
+		RegistryAuth:       encodedAuth,
+		PrivilegeFunc:      requestPrivilege,
+		All:                all,
+		InsecureRegistries: insecureRegistries,
 	}
 
 	responseBody, err := cli.Client().ImagePull(ctx, ref, options)

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -29,6 +30,9 @@ func (cli *Client) ImagePull(ctx context.Context, ref string, options types.Imag
 	query.Set("fromImage", repository)
 	if tag != "" && !options.All {
 		query.Set("tag", tag)
+	}
+	if len(options.InsecureRegistries) > 0 {
+		query.Set("insecure-registries", strings.Join(options.InsecureRegistries, ","))
 	}
 
 	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -22,7 +22,7 @@ type Backend interface {
 	DeleteManagedNetwork(name string) error
 	FindNetwork(idName string) (libnetwork.Network, error)
 	SetupIngress(req clustertypes.NetworkCreateRequest, nodeIP string) error
-	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, insecureRegistries []string, outStream io.Writer) error
 	CreateManagedContainer(config types.ContainerCreateConfig, validateHostname bool) (types.ContainerCreateResponse, error)
 	ContainerStart(name string, hostConfig *container.HostConfig, validateHostname bool, checkpoint string) error
 	ContainerStop(name string, seconds int) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -61,7 +61,8 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 	pr, pw := io.Pipe()
 	metaHeaders := map[string][]string{}
 	go func() {
-		err := c.backend.PullImage(ctx, c.container.image(), "", metaHeaders, authConfig, pw)
+		// There's no insecure registry overrides in the context of a Swarm-initiated pull.
+		err := c.backend.PullImage(ctx, c.container.image(), "", metaHeaders, authConfig, []string{}, pw)
 		pw.CloseWithError(err)
 	}()
 

--- a/daemon/image_pull.go
+++ b/daemon/image_pull.go
@@ -16,7 +16,7 @@ import (
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (daemon *Daemon) PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+func (daemon *Daemon) PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, insecureRegistries []string, outStream io.Writer) error {
 	// Special case: "pull -a" may send an image name with a
 	// trailing :. This is ugly, but let's not break API
 	// compatibility.
@@ -41,7 +41,7 @@ func (daemon *Daemon) PullImage(ctx context.Context, image, tag string, metaHead
 		}
 	}
 
-	return daemon.pullImageWithReference(ctx, ref, metaHeaders, authConfig, outStream)
+	return daemon.pullImageWithReference(ctx, ref, metaHeaders, authConfig, insecureRegistries, outStream)
 }
 
 // PullOnBuild tells Docker to pull image referenced by `name`.
@@ -67,13 +67,14 @@ func (daemon *Daemon) PullOnBuild(ctx context.Context, name string, authConfigs 
 		pullRegistryAuth = &resolvedConfig
 	}
 
-	if err := daemon.pullImageWithReference(ctx, ref, nil, pullRegistryAuth, output); err != nil {
+	// There's no insecure registry overrides in the context of a build-initiated pull.
+	if err := daemon.pullImageWithReference(ctx, ref, nil, pullRegistryAuth, []string{}, output); err != nil {
 		return nil, err
 	}
 	return daemon.GetImage(name)
 }
 
-func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error {
+func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig, insecureRegistries []string, outStream io.Writer) error {
 	// Include a buffer so that slow client connections don't affect
 	// transfer performance.
 	progressChan := make(chan progress.Progress, 100)
@@ -88,15 +89,16 @@ func (daemon *Daemon) pullImageWithReference(ctx context.Context, ref reference.
 	}()
 
 	imagePullConfig := &distribution.ImagePullConfig{
-		MetaHeaders:      metaHeaders,
-		AuthConfig:       authConfig,
-		ProgressOutput:   progress.ChanOutput(progressChan),
-		RegistryService:  daemon.RegistryService,
-		ImageEventLogger: daemon.LogImageEvent,
-		MetadataStore:    daemon.distributionMetadataStore,
-		ImageStore:       daemon.imageStore,
-		ReferenceStore:   daemon.referenceStore,
-		DownloadManager:  daemon.downloadManager,
+		MetaHeaders:        metaHeaders,
+		AuthConfig:         authConfig,
+		ProgressOutput:     progress.ChanOutput(progressChan),
+		RegistryService:    daemon.RegistryService,
+		ImageEventLogger:   daemon.LogImageEvent,
+		MetadataStore:      daemon.distributionMetadataStore,
+		ImageStore:         daemon.imageStore,
+		ReferenceStore:     daemon.referenceStore,
+		DownloadManager:    daemon.downloadManager,
+		InsecureRegistries: insecureRegistries,
 	}
 
 	err := distribution.Pull(ctx, ref, imagePullConfig)

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -40,6 +40,9 @@ type ImagePullConfig struct {
 	ReferenceStore reference.Store
 	// DownloadManager manages concurrent pulls.
 	DownloadManager *xfer.LayerDownloadManager
+	// InsecureRegistries is the list of endpoints with which insecure registry
+	// communication is allowed.
+	InsecureRegistries []string
 }
 
 // Puller is an interface that abstracts pulling for different API versions.
@@ -89,7 +92,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
 		return err
 	}
 
-	endpoints, err := imagePullConfig.RegistryService.LookupPullEndpoints(repoInfo.Hostname())
+	endpoints, err := imagePullConfig.RegistryService.LookupPullEndpoints(repoInfo.Hostname(), imagePullConfig.InsecureRegistries)
 	if err != nil {
 		return err
 	}

--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -41,7 +41,7 @@ func (p *v1Puller) Pull(ctx context.Context, ref reference.Named) error {
 		return fallbackError{err: ErrNoSupport{Err: errors.New("Cannot pull by digest with v1 registry")}}
 	}
 
-	tlsConfig, err := p.config.RegistryService.TLSConfig(p.repoInfo.Index.Name)
+	tlsConfig, err := p.config.RegistryService.TLSConfig(p.repoInfo.Index.Name, p.config.InsecureRegistries)
 	if err != nil {
 		return err
 	}

--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -30,7 +30,8 @@ type v1Pusher struct {
 }
 
 func (p *v1Pusher) Push(ctx context.Context) error {
-	tlsConfig, err := p.config.RegistryService.TLSConfig(p.repoInfo.Index.Name)
+	// There's no insecure registries override for push.
+	tlsConfig, err := p.config.RegistryService.TLSConfig(p.repoInfo.Index.Name, []string{})
 	if err != nil {
 		return err
 	}

--- a/registry/service.go
+++ b/registry/service.go
@@ -24,13 +24,17 @@ const (
 // Service is the interface defining what a registry service should implement.
 type Service interface {
 	Auth(ctx context.Context, authConfig *types.AuthConfig, userAgent string) (status, token string, err error)
-	LookupPullEndpoints(hostname string) (endpoints []APIEndpoint, err error)
+	LookupPullEndpoints(hostname string, insecureRegistries []string) (endpoints []APIEndpoint, err error)
 	LookupPushEndpoints(hostname string) (endpoints []APIEndpoint, err error)
 	ResolveRepository(name reference.Named) (*RepositoryInfo, error)
 	ResolveIndex(name string) (*registrytypes.IndexInfo, error)
 	Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error)
 	ServiceConfig() *registrytypes.ServiceConfig
-	TLSConfig(hostname string) (*tls.Config, error)
+
+	// TLSConfig returns the TLS settings for a particular hostname. TLS
+	// settings are potentially overriden by a local set of insecure registries
+	// specifications, in which case InsecureSkipVerify will be enabled.
+	TLSConfig(hostname string, insecureRegistries []string) (*tls.Config, error)
 }
 
 // DefaultService is a registry service. It tracks configuration data such as a list
@@ -210,26 +214,28 @@ func (e APIEndpoint) ToV1Endpoint(userAgent string, metaHeaders http.Header) (*V
 }
 
 // TLSConfig constructs a client TLS configuration based on server defaults
-func (s *DefaultService) TLSConfig(hostname string) (*tls.Config, error) {
-	return newTLSConfig(hostname, isSecureIndex(s.config, hostname))
+func (s *DefaultService) TLSConfig(hostname string, insecureRegistries []string) (*tls.Config, error) {
+	return newTLSConfig(hostname, isSecureIndex(s.config, hostname, insecureRegistries))
 }
 
 func (s *DefaultService) tlsConfigForMirror(mirrorURL *url.URL) (*tls.Config, error) {
-	return s.TLSConfig(mirrorURL.Host)
+	// There's no insecure registries overrides for registry mirrors.
+	return s.TLSConfig(mirrorURL.Host, []string{})
 }
 
 // LookupPullEndpoints creates a list of endpoints to try to pull from, in order of preference.
 // It gives preference to v2 endpoints over v1, mirrors over the actual
 // registry, and HTTPS over plain HTTP.
-func (s *DefaultService) LookupPullEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
-	return s.lookupEndpoints(hostname)
+func (s *DefaultService) LookupPullEndpoints(hostname string, insecureRegistries []string) (endpoints []APIEndpoint, err error) {
+	return s.lookupEndpoints(hostname, insecureRegistries)
 }
 
 // LookupPushEndpoints creates a list of endpoints to try to push to, in order of preference.
 // It gives preference to v2 endpoints over v1, and HTTPS over plain HTTP.
 // Mirrors are not included.
 func (s *DefaultService) LookupPushEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
-	allEndpoints, err := s.lookupEndpoints(hostname)
+	// There's no insecure registries override for push.
+	allEndpoints, err := s.lookupEndpoints(hostname, []string{})
 	if err == nil {
 		for _, endpoint := range allEndpoints {
 			if !endpoint.Mirror {
@@ -240,8 +246,8 @@ func (s *DefaultService) LookupPushEndpoints(hostname string) (endpoints []APIEn
 	return endpoints, err
 }
 
-func (s *DefaultService) lookupEndpoints(hostname string) (endpoints []APIEndpoint, err error) {
-	endpoints, err = s.lookupV2Endpoints(hostname)
+func (s *DefaultService) lookupEndpoints(hostname string, insecureRegistries []string) (endpoints []APIEndpoint, err error) {
+	endpoints, err = s.lookupV2Endpoints(hostname, insecureRegistries)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +256,7 @@ func (s *DefaultService) lookupEndpoints(hostname string) (endpoints []APIEndpoi
 		return endpoints, nil
 	}
 
-	legacyEndpoints, err := s.lookupV1Endpoints(hostname)
+	legacyEndpoints, err := s.lookupV1Endpoints(hostname, insecureRegistries)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *DefaultService) lookupV1Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *DefaultService) lookupV1Endpoints(hostname string, insecureRegistries []string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
 	if hostname == DefaultNamespace {
 		endpoints = append(endpoints, APIEndpoint{
@@ -19,7 +19,7 @@ func (s *DefaultService) lookupV1Endpoints(hostname string) (endpoints []APIEndp
 		return endpoints, nil
 	}
 
-	tlsConfig, err = s.TLSConfig(hostname)
+	tlsConfig, err = s.TLSConfig(hostname, insecureRegistries)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *DefaultService) lookupV2Endpoints(hostname string, insecureRegistries []string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
 	if hostname == DefaultNamespace || hostname == DefaultV1Registry.Host {
 		// v2 mirrors
@@ -44,7 +44,7 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 		return endpoints, nil
 	}
 
-	tlsConfig, err = s.TLSConfig(hostname)
+	tlsConfig, err = s.TLSConfig(hostname, insecureRegistries)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**\- What I did**

Add the ability to override the set of insecure registries (that is, the registries with which communication is allowed over HTTP, or HTTPS using a certificate from an unknown CA) at pull invocation.

This is heavily work in progress: I'm not familiar with this part of the code, so I want to make sure I'm not going in the wrong direction.

Open questions:
1. Is it ok to support overriding `--insecure-registry` for pull only, and not for push?
2. Am I correct that `newIndexInfo` will only be used for `docker search`, and is not much of an issue in that context?

Ping @aaronlehmann @dmcgowan @stevvooe @tonistiigi :heartbeat: 
