### PR TITLE
Improve --log-level help text

### DIFF
--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -53,7 +53,7 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	}
 
 	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "Enable debug mode")
-	flags.StringVarP(&commonOpts.LogLevel, "log-level", "l", "info", "Set the logging level")
+	flags.StringVarP(&commonOpts.LogLevel, "log-level", "l", "info", "Set the logging level (debug, info, warn, error, fatal)")
 	flags.BoolVar(&commonOpts.TLS, "tls", false, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&commonOpts.TLSVerify, FlagTLSVerify, dockerTLSVerify, "Use TLS and verify the remote")
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -23,17 +23,17 @@ A self-sufficient runtime for containers.
 
 Options:
 
-  --config=~/.docker              Location of client config files
-  -D, --debug                     Enable debug mode
-  -H, --host=[]                   Daemon socket(s) to connect to
-  --help                          Print usage
-  -l, --log-level=info            Set the logging level
-  --tls                           Use TLS; implied by --tlsverify
-  --tlscacert=~/.docker/ca.pem    Trust certs signed only by this CA
-  --tlscert=~/.docker/cert.pem    Path to TLS certificate file
-  --tlskey=~/.docker/key.pem      Path to TLS key file
-  --tlsverify                     Use TLS and verify the remote
-  -v, --version                   Print version information and quit
+      --config string      Location of client config files (default "/root/.docker")
+  -D, --debug              Enable debug mode
+      --help               Print usage
+  -H, --host value         Daemon socket(s) to connect to (default [])
+  -l, --log-level string   Set the logging level (debug, info, warn, error, fatal) (default "info")
+      --tls                Use TLS; implied by --tlsverify
+      --tlscacert string   Trust certs signed only by this CA (default "/root/.docker/ca.pem")
+      --tlscert string     Path to TLS certificate file (default "/root/.docker/cert.pem")
+      --tlskey string      Path to TLS key file (default "/root/.docker/key.pem")
+      --tlsverify          Use TLS and verify the remote
+  -v, --version            Print version information and quit
 
 Commands:
     attach    Attach to a running container

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -19,68 +19,68 @@ A self-sufficient runtime for containers.
 
 Options:
 
-      --add-runtime=[]                       Register an additional OCI compatible runtime
-      --api-cors-header                      Set CORS headers in the remote API
-      --authorization-plugin=[]              Authorization plugins to load
-      -b, --bridge                           Attach containers to a network bridge
-      --bip                                  Specify network bridge IP
-      --cgroup-parent                        Set parent cgroup for all containers
-      --cluster-advertise                    Address or interface name to advertise
-      --cluster-store                        URL of the distributed storage backend
-      --cluster-store-opt=map[]              Set cluster store options
-      --config-file=/etc/docker/daemon.json  Daemon configuration file
-      --containerd                           Path to containerd socket
-      -D, --debug                            Enable debug mode
-      --default-gateway                      Container default gateway IPv4 address
-      --default-gateway-v6                   Container default gateway IPv6 address
-      --default-runtime=runc                 Default OCI runtime for containers
-      --default-ulimit=[]                    Default ulimits for containers
-      --disable-legacy-registry              Disable contacting legacy registries
-      --dns=[]                               DNS server to use
-      --dns-opt=[]                           DNS options to use
-      --dns-search=[]                        DNS search domains to use
-      --exec-opt=[]                          Runtime execution options
-      --exec-root=/var/run/docker            Root directory for execution state files
-      --fixed-cidr                           IPv4 subnet for fixed IPs
-      --fixed-cidr-v6                        IPv6 subnet for fixed IPs
-      -G, --group=docker                     Group for the unix socket
-      -g, --graph=/var/lib/docker            Root of the Docker runtime
-      -H, --host=[]                          Daemon socket(s) to connect to
-      --help                                 Print usage
-      --icc=true                             Enable inter-container communication
-      --init                                 Run an init inside containers to forward signals and reap processes
-      --init-path                            Path to the docker-init binary
-      --insecure-registry=[]                 Enable insecure registry communication
-      --ip=0.0.0.0                           Default IP when binding container ports
-      --ip-forward=true                      Enable net.ipv4.ip_forward
-      --ip-masq=true                         Enable IP masquerading
-      --iptables=true                        Enable addition of iptables rules
-      --ipv6                                 Enable IPv6 networking
-      -l, --log-level=info                   Set the logging level
-      --label=[]                             Set key=value labels to the daemon
-      --live-restore                         Enables keeping containers alive during daemon downtime
-      --log-driver=json-file                 Default driver for container logs
-      --log-opt=map[]                        Default log driver options for containers
-      --max-concurrent-downloads=3           Set the max concurrent downloads for each pull
-      --max-concurrent-uploads=5             Set the max concurrent uploads for each push
-      --mtu                                  Set the containers network MTU
-      --oom-score-adjust=-500                Set the oom_score_adj for the daemon
-      -p, --pidfile=/var/run/docker.pid      Path to use for daemon PID file
-      --raw-logs                             Full timestamps without ANSI coloring
-      --registry-mirror=[]                   Preferred Docker registry mirror
-      -s, --storage-driver                   Storage driver to use
-      --selinux-enabled                      Enable selinux support
-      --storage-opt=[]                       Storage driver options
-      --swarm-default-advertise-addr         Set default address or interface for swarm advertised address
-      --tls                                  Use TLS; implied by --tlsverify
-      --tlscacert=~/.docker/ca.pem           Trust certs signed only by this CA
-      --tlscert=~/.docker/cert.pem           Path to TLS certificate file
-      --tlskey=~/.docker/key.pem             Path to TLS key file
-      --tlsverify                            Use TLS and verify the remote
-      --userland-proxy=true                  Use userland proxy for loopback traffic
-      --userland-proxy-path=""               Path to the userland proxy binary
-      --userns-remap                         User/Group setting for user namespaces
-      -v, --version                          Print version information and quit
+      --add-runtime value                     Register an additional OCI compatible runtime (default [])
+      --api-cors-header string                Set CORS headers in the remote API
+      --authorization-plugin value            Authorization plugins to load (default [])
+      --bip string                            Specify network bridge IP
+  -b, --bridge string                         Attach containers to a network bridge
+      --cgroup-parent string                  Set parent cgroup for all containers
+      --cluster-advertise string              Address or interface name to advertise
+      --cluster-store string                  URL of the distributed storage backend
+      --cluster-store-opt value               Set cluster store options (default map[])
+      --config-file string                    Daemon configuration file (default "/etc/docker/daemon.json")
+      --containerd string                     Path to containerd socket
+  -D, --debug                                 Enable debug mode
+      --default-gateway value                 Container default gateway IPv4 address
+      --default-gateway-v6 value              Container default gateway IPv6 address
+      --default-runtime string                Default OCI runtime for containers (default "runc")
+      --default-ulimit value                  Default ulimits for containers (default [])
+      --disable-legacy-registry               Disable contacting legacy registries
+      --dns value                             DNS server to use (default [])
+      --dns-opt value                         DNS options to use (default [])
+      --dns-search value                      DNS search domains to use (default [])
+      --exec-opt value                        Runtime execution options (default [])
+      --exec-root string                      Root directory for execution state files (default "/var/run/docker")
+      --fixed-cidr string                     IPv4 subnet for fixed IPs
+      --fixed-cidr-v6 string                  IPv6 subnet for fixed IPs
+  -g, --graph string                          Root of the Docker runtime (default "/var/lib/docker")
+  -G, --group string                          Group for the unix socket (default "docker")
+      --help                                  Print usage
+  -H, --host value                            Daemon socket(s) to connect to (default [])
+      --icc                                   Enable inter-container communication (default true)
+      --init                                  Run an init in the container to forward signals and reap processes
+      --init-path string                      Path to the docker-init binary
+      --insecure-registry value               Enable insecure registry communication (default [])
+      --ip value                              Default IP when binding container ports (default 0.0.0.0)
+      --ip-forward                            Enable net.ipv4.ip_forward (default true)
+      --ip-masq                               Enable IP masquerading (default true)
+      --iptables                              Enable addition of iptables rules (default true)
+      --ipv6                                  Enable IPv6 networking
+      --label value                           Set key=value labels to the daemon (default [])
+      --live-restore                          Enable live restore of docker when containers are still running
+      --log-driver string                     Default driver for container logs (default "json-file")
+  -l, --log-level string                      Set the logging level (debug, info, warn, error, fatal) (default "info")
+      --log-opt value                         Default log driver options for containers (default map[])
+      --max-concurrent-downloads int          Set the max concurrent downloads for each pull (default 3)
+      --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
+      --mtu int                               Set the containers network MTU
+      --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
+  -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
+      --raw-logs                              Full timestamps without ANSI coloring
+      --registry-mirror value                 Preferred Docker registry mirror (default [])
+      --selinux-enabled                       Enable selinux support
+  -s, --storage-driver string                 Storage driver to use
+      --storage-opt value                     Storage driver options (default [])
+      --swarm-default-advertise-addr string   Set default address or interface for swarm advertised address
+      --tls                                   Use TLS; implied by --tlsverify
+      --tlscacert string                      Trust certs signed only by this CA (default "/root/.docker/ca.pem")
+      --tlscert string                        Path to TLS certificate file (default "/root/.docker/cert.pem")
+      --tlskey string                         Path to TLS key file (default "/root/.docker/key.pem")
+      --tlsverify                             Use TLS and verify the remote
+      --userland-proxy                        Use userland proxy for loopback traffic (default true)
+      --userland-proxy-path string            Path to the userland proxy binary
+      --userns-remap string                   User/Group setting for user namespaces
+  -v, --version                               Print version information and quit
 ```
 
 Options with [] may be specified multiple times.


### PR DESCRIPTION
This information was added in 1efc940e6f547760e5e8f4648acb120ff19fdc58 (https://github.com/docker/docker/pull/10124), but removed again in
a271eaeba224652e3a12af0287afbae6f82a9333 (https://github.com/docker/docker/pull/10547) to make the help-output fit in a 80-chars terminal.

This adds the available options again in the help output, and updates the CLI reference documentation to match actual output.

fixes https://github.com/docker/docker/issues/26888
