### PR TITLE
make service endpoint mode default none

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -274,6 +274,8 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 	if anyChanged(flags, flagPublishAdd, flagPublishRemove, flagPortAdd, flagPortRemove) {
 		if spec.EndpointSpec == nil {
 			spec.EndpointSpec = &swarm.EndpointSpec{}
+			// if the original EndpointSpec is nil, port change means it should add a endpoint mode of vip
+			spec.EndpointSpec.Mode = swarm.ResolutionMode("vip")
 		}
 		if err := updatePorts(flags, &spec.EndpointSpec.Ports); err != nil {
 			return err

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -185,15 +185,18 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 	}
 
 	if s.EndpointSpec != nil {
-		if s.EndpointSpec.Mode != "" &&
-			s.EndpointSpec.Mode != types.ResolutionModeVIP &&
-			s.EndpointSpec.Mode != types.ResolutionModeDNSRR {
-			return swarmapi.ServiceSpec{}, fmt.Errorf("invalid resolution mode: %q", s.EndpointSpec.Mode)
+		esMode := s.EndpointSpec.Mode
+		if esMode != "" &&
+			esMode != types.ResolutionModeVIP &&
+			esMode != types.ResolutionModeDNSRR {
+			return swarmapi.ServiceSpec{}, fmt.Errorf("invalid resolution mode: %q (only vip and dnsrr supported)", esMode)
+		} else if esMode == "" {
+			return swarmapi.ServiceSpec{}, fmt.Errorf("resolution mode cannot be empty in a non-nil endpoint spec")
 		}
 
 		spec.Endpoint = &swarmapi.EndpointSpec{}
 
-		spec.Endpoint.Mode = swarmapi.EndpointSpec_ResolutionMode(swarmapi.EndpointSpec_ResolutionMode_value[strings.ToUpper(string(s.EndpointSpec.Mode))])
+		spec.Endpoint.Mode = swarmapi.EndpointSpec_ResolutionMode(swarmapi.EndpointSpec_ResolutionMode_value[strings.ToUpper(string(esMode))])
 
 		for _, portConfig := range s.EndpointSpec.Ports {
 			spec.Endpoint.Ports = append(spec.Endpoint.Ports, &swarmapi.PortConfig{

--- a/integration-cli/docker_api_service_update_test.go
+++ b/integration-cli/docker_api_service_update_test.go
@@ -13,6 +13,8 @@ func setPortConfig(portConfig []swarm.PortConfig) serviceConstructor {
 		if s.Spec.EndpointSpec == nil {
 			s.Spec.EndpointSpec = &swarm.EndpointSpec{}
 		}
+		// if we set port config, the resolution mode is vip as default.
+		s.Spec.EndpointSpec.Mode = swarm.ResolutionMode("vip")
 		s.Spec.EndpointSpec.Ports = portConfig
 	}
 }


### PR DESCRIPTION
fixes #26899 

**\- What I did**
1. add StringOpt in service options, since we need to make endpoint mode optional, default none.
2. make cli default with no endpoint mode specified;
3. make engine detect empty endpoint mode.

This PR changed two parts: 
- docker remote api
- docker cli

In first part, **DOCKER REMOTE API**,
This PR makes engine to detect empty string of `endpoint mode` in non-nil `EndpointSpec`.

In second part, `DOCKER CLI`,
This PR makes cli not to specify empty string to endpoint mode in EndpointSpec, since if endpoint mode in empty string, without this pr, engine will make it to be vip as default, in the following code:

```
spec.Endpoint.Mode = swarmapi.EndpointSpec_ResolutionMode(swarmapi.EndpointSpec_ResolutionMode_value[strings.ToUpper(string(s.EndpointSpec.Mode))])
```

although 

```
var EndpointSpec_ResolutionMode_value = map[string]int32{
    "VIP":   0,
    "DNSRR": 1,
}
```

EndpointSpec_ResolutionMode_value[""] will be 0, too.

Making endpoint mode not to be empty string, we need to add a type of `StringOpt` as showed in this PR.

Signed-off-by: allencloud allen.sun@daocloud.io
