### PR TITLE
cli: Add more nil checking to service pretty-printer

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -21,7 +21,7 @@ Labels:
 {{- end }}{{ end }}
 Mode:
 {{- if .IsModeGlobal }}		Global
-{{- else }}		Replicated
+{{- else if .IsModeReplicated }}		Replicated
 {{- if .ModeReplicatedReplicas }}
  Replicas:	{{ .ModeReplicatedReplicas }}
 {{- end }}{{ end }}
@@ -73,22 +73,20 @@ Mounts:
 Resources:
 {{- if .HasResourceReservations }}
  Reservations:
-{{- end }}
 {{- if gt .ResourceReservationNanoCPUs 0.0 }}
   CPU:		{{ .ResourceReservationNanoCPUs }}
 {{- end }}
 {{- if .ResourceReservationMemory }}
   Memory:	{{ .ResourceReservationMemory }}
-{{- end }}
+{{- end }}{{ end }}
 {{- if .HasResourceLimits }}
  Limits:
-{{- end }}
 {{- if gt .ResourceLimitsNanoCPUs 0.0 }}
   CPU:		{{ .ResourceLimitsNanoCPUs }}
 {{- end }}
 {{- if .ResourceLimitMemory }}
   Memory:	{{ .ResourceLimitMemory }}
-{{- end }}{{ end }}
+{{- end }}{{ end }}{{ end }}
 {{- if .Networks }}
 Networks:
 {{- range $network := .Networks }} {{ $network }}{{ end }} {{ end }}
@@ -154,6 +152,10 @@ func (ctx *serviceInspectContext) Labels() map[string]string {
 
 func (ctx *serviceInspectContext) IsModeGlobal() bool {
 	return ctx.Service.Spec.Mode.Global != nil
+}
+
+func (ctx *serviceInspectContext) IsModeReplicated() bool {
+	return ctx.Service.Spec.Mode.Replicated != nil
 }
 
 func (ctx *serviceInspectContext) ModeReplicatedReplicas() *uint64 {


### PR DESCRIPTION
Currently, if the service mode is not "global", this code assumes that
`Replicated` is non-nil. This assumption may not be true in the future.
Instead of making the assumption, explicitly check that `Replicated` is
non-nil before using it.

Similarly, for limits and reservations, enclose methods that read from
`Limits` and `Reservations` within checks that those fields are non-nil.
