### PR TITLE
ppc64le: update dockerfile golang dl link

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -93,7 +93,7 @@ RUN set -x \
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.1
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
+ENV GO_DOWNLOAD_URL https://storage.googleapis.com/golang/go${GO_VERSION}.src.tar.gz
 
 RUN set -x \
 	&& TEMPDIR="$(mktemp -d)" \


### PR DESCRIPTION
Updates golang download link to be more consistent with other dockerfiles. Note there still aren't any official ppc64le binaries, so it's still necessary to download and build from source.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com
