### PR TITLE
Add setupInitLayer() placeholder for Solaris

### DIFF
--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -43,6 +43,10 @@ func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error
 	return nil
 }
 
+func (daemon *Daemon) getLayerInit() func(string) error {
+	return nil
+}
+
 // setupInitLayer populates a directory with mountpoints suitable
 // for bind-mounting dockerinit into the container. The mountpoint is simply an
 // empty file at /.dockerinit


### PR DESCRIPTION
Commit d2bc5d62761c24866e4b0ff4099dd54264bd9325 (https://github.com/docker/docker/pull/26756) added
a setupInitLayer() for all platforms, but did not
add a placeholder for Solaris https://github.com/docker/docker/pull/26756#discussion_r79938294.

This adds the missing placeholder.

ping @amitkris @rhvgoyal ptal
