### PR TITLE
Fix incorrect aux-address examples and test

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -136,8 +136,8 @@ $ docker network create -d overlay \
   --gateway=192.168.0.100 \ 
   --gateway=192.170.0.100 \
   --ip-range=192.168.1.0/24 \
-  --aux-address a=192.168.1.5 --aux-address b=192.168.1.6 \
-  --aux-address a=192.170.1.5 --aux-address b=192.170.1.6 \
+  --aux-address="my-router=192.168.1.5" --aux-address="my-switch=192.168.1.6" \
+  --aux-address="my-printer=192.170.1.5" --aux-address="my-nas=192.170.1.6" \
   my-multihost-network
 ```
 

--- a/docs/userguide/networking/work-with-networks.md
+++ b/docs/userguide/networking/work-with-networks.md
@@ -106,8 +106,8 @@ $ docker network create -d overlay \
   --gateway=192.168.0.100 \
   --gateway=192.170.0.100 \
   --ip-range=192.168.1.0/24 \
-  --aux-address a=192.168.1.5 --aux-address b=192.168.1.6 \
-  --aux-address a=192.170.1.5 --aux-address b=192.170.1.6 \
+  --aux-address="my-router=192.168.1.5" --aux-address="my-switch=192.168.1.6" \
+  --aux-address="my-printer=192.170.1.5" --aux-address="my-nas=192.170.1.6" \
   my-multihost-network
 ```
 

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -631,7 +631,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkIpamMultipleNetworks(c *check.C) {
 		"--gateway=192.168.0.100", "--gateway=192.170.0.100",
 		"--ip-range=192.168.1.0/24",
 		"--aux-address", "a=192.168.1.5", "--aux-address", "b=192.168.1.6",
-		"--aux-address", "a=192.170.1.5", "--aux-address", "b=192.170.1.6",
+		"--aux-address", "c=192.170.1.5", "--aux-address", "d=192.170.1.6",
 		"test7")
 	assertNwIsAvailable(c, "test7")
 

--- a/man/docker-network-create.1.md
+++ b/man/docker-network-create.1.md
@@ -127,8 +127,8 @@ $ docker network create -d overlay \
   --gateway=192.168.0.100 \ 
   --gateway=192.170.0.100 \
   --ip-range=192.168.1.0/24 \
-  --aux-address a=192.168.1.5 --aux-address b=192.168.1.6 \
-  --aux-address a=192.170.1.5 --aux-address b=192.170.1.6 \
+  --aux-address="my-router=192.168.1.5" --aux-address="my-switch=192.168.1.6" \
+  --aux-address="my-printer=192.170.1.5" --aux-address="my-nas=192.170.1.6" \
   my-multihost-network
 ```
 


### PR DESCRIPTION
The (host)name for aux-addresses should
be unique, otherwise later values overwrite
earlier values.

Before this change, the example command
would send this API request;

```
{
  "Attachable": false,
  "CheckDuplicate": true,
  "Driver": "overlay",
  "EnableIPv6": false,
  "IPAM": {
    "Config": [
      {
        "Gateway": "192.168.0.100",
        "IPRange": "192.168.1.0/24",
        "Subnet": "192.168.0.0/16"
      },
      {
        "AuxiliaryAddresses": {
          "c": "192.170.1.5",
          "d": "192.170.1.6"
        },
        "Gateway": "192.170.0.100",
        "Subnet": "192.170.0.0/16"
      }
    ],
    "Driver": "default",
    "Options": {}
  },
  "Internal": false,
  "Labels": {},
  "Name": "my-multihost-network",
  "Options": {}
}
```

After this change, the request looks
like this (all aux-addresses preserved);

```
{
  "Attachable": false,
  "CheckDuplicate": true,
  "Driver": "overlay",
  "EnableIPv6": false,
  "IPAM": {
    "Config": [
      {
        "AuxiliaryAddresses": {
          "my-router": "192.168.1.5",
          "my-switch": "192.168.1.6"
        },
        "Gateway": "192.168.0.100",
        "IPRange": "192.168.1.0/24",
        "Subnet": "192.168.0.0/16"
      },
      {
        "AuxiliaryAddresses": {
          "my-printer": "192.170.1.5",
          "my-nas": "192.170.1.6"
        },
        "Gateway": "192.170.0.100",
        "Subnet": "192.170.0.0/16"
      }
    ],
    "Driver": "default",
    "Options": {}
  },
  "Internal": false,
  "Labels": {},
  "Name": "my-multihost-network",
  "Options": {}
}
```
