### PR TITLE
Add --user-agent daemon flag

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -14,9 +14,6 @@ import (
 // APIVersionKey is the client's requested API version.
 const APIVersionKey = "api-version"
 
-// UAStringKey is used as key type for user-agent string in net/context struct
-const UAStringKey = "upstream-user-agent"
-
 // APIFunc is an adapter to allow the use of ordinary functions as Docker API endpoints.
 // Any function that has the appropriate signature can be registered as an API endpoint (e.g. getVersion).
 type APIFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error

--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -11,9 +11,6 @@ import (
 	"github.com/docker/docker/api"
 )
 
-// APIVersionKey is the client's requested API version.
-const APIVersionKey = "api-version"
-
 // APIFunc is an adapter to allow the use of ordinary functions as Docker API endpoints.
 // Any function that has the appropriate signature can be registered as an API endpoint (e.g. getVersion).
 type APIFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error
@@ -71,17 +68,4 @@ func ParseForm(r *http.Request) error {
 		return err
 	}
 	return nil
-}
-
-// VersionFromContext returns an API version from the context using APIVersionKey.
-// It panics if the context value does not have version.Version type.
-func VersionFromContext(ctx context.Context) (ver string) {
-	if ctx == nil {
-		return
-	}
-	val := ctx.Value(APIVersionKey)
-	if val == nil {
-		return
-	}
-	return val.(string)
 }

--- a/api/server/middleware/user_agent.go
+++ b/api/server/middleware/user_agent.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/useragent"
 	"golang.org/x/net/context"
 )
 
-// UserAgentMiddleware is a middleware that
-// validates the client user-agent.
+// UserAgentMiddleware is a middleware that validates the client user-agent and
+// wraps it with additional version information.
 type UserAgentMiddleware struct {
 	serverVersion string
 }
@@ -30,7 +31,9 @@ func (u UserAgentMiddleware) WrapHandler(handler func(ctx context.Context, w htt
 		upstreamUA := r.Header.Get("User-Agent")
 		validate(upstreamUA, u.serverVersion)
 
-		ctx = useragent.NewContext(ctx, upstreamUA)
+		dockerUA := dockerversion.DockerUserAgent(upstreamUA)
+		ctx = useragent.NewContext(ctx, dockerUA)
+
 		return handler(ctx, w, r, vars)
 	}
 }

--- a/api/server/middleware/user_agent.go
+++ b/api/server/middleware/user_agent.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/useragent"
 	"golang.org/x/net/context"
 )
 
@@ -27,21 +28,27 @@ func NewUserAgentMiddleware(s string) UserAgentMiddleware {
 // WrapHandler returns a new handler function wrapping the previous one in the request chain.
 func (u UserAgentMiddleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-		ctx = context.WithValue(ctx, httputils.UAStringKey, r.Header.Get("User-Agent"))
+		upstreamUA := r.Header.Get("User-Agent")
+		validate(upstreamUA, u.serverVersion)
 
-		if strings.Contains(r.Header.Get("User-Agent"), "Docker-Client/") {
-			userAgent := strings.Split(r.Header.Get("User-Agent"), "/")
-
-			// v1.20 onwards includes the GOOS of the client after the version
-			// such as Docker/1.7.0 (linux)
-			if len(userAgent) == 2 && strings.Contains(userAgent[1], " ") {
-				userAgent[1] = strings.Split(userAgent[1], " ")[0]
-			}
-
-			if len(userAgent) == 2 && !versions.Equal(u.serverVersion, userAgent[1]) {
-				logrus.Debugf("Client and server don't have the same version (client: %s, server: %s)", userAgent[1], u.serverVersion)
-			}
-		}
+		ctx = useragent.NewContext(ctx, upstreamUA)
 		return handler(ctx, w, r, vars)
+	}
+}
+
+// Verify that the client and server have the same docker version.
+func validate(ua string, v string) {
+	if strings.Contains(ua, "Docker-Client/") {
+		userAgent := strings.Split(ua, "/")
+
+		// v1.20 onwards includes the GOOS of the client after the version
+		// such as Docker/1.7.0 (linux)
+		if len(userAgent) == 2 && strings.Contains(userAgent[1], " ") {
+			userAgent[1] = strings.Split(userAgent[1], " ")[0]
+		}
+
+		if len(userAgent) == 2 && !versions.Equal(v, userAgent[1]) {
+			logrus.Debugf("Client and server don't have the same version (client: %s, server: %s)", userAgent[1], v)
+		}
 	}
 }

--- a/api/server/middleware/user_agent.go
+++ b/api/server/middleware/user_agent.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/useragent"
 	"golang.org/x/net/context"
 )

--- a/api/server/middleware/user_agent.go
+++ b/api/server/middleware/user_agent.go
@@ -15,13 +15,15 @@ import (
 // wraps it with additional version information.
 type UserAgentMiddleware struct {
 	serverVersion string
+	customUA      string
 }
 
 // NewUserAgentMiddleware creates a new UserAgentMiddleware
-// with the server version.
-func NewUserAgentMiddleware(s string) UserAgentMiddleware {
+// with the server version and a custom useragent annotation.
+func NewUserAgentMiddleware(s string, ua string) UserAgentMiddleware {
 	return UserAgentMiddleware{
 		serverVersion: s,
+		customUA:      ua,
 	}
 }
 
@@ -31,7 +33,7 @@ func (u UserAgentMiddleware) WrapHandler(handler func(ctx context.Context, w htt
 		upstreamUA := r.Header.Get("User-Agent")
 		validate(upstreamUA, u.serverVersion)
 
-		dockerUA := dockerversion.DockerUserAgent(upstreamUA)
+		dockerUA := dockerversion.DockerUserAgent(upstreamUA, u.customUA)
 		ctx = useragent.NewContext(ctx, dockerUA)
 
 		return handler(ctx, w, r, vars)

--- a/api/server/middleware/user_agent_test.go
+++ b/api/server/middleware/user_agent_test.go
@@ -20,7 +20,30 @@ func TestUserAgentMiddleware(t *testing.T) {
 	}
 
 	serverVersion := "1.9.1"
-	m := NewUserAgentMiddleware(serverVersion)
+	m := NewUserAgentMiddleware(serverVersion, "")
+	h := m.WrapHandler(handler)
+
+	req, _ := http.NewRequest("GET", "/containers/json", nil)
+	req.Header.Set("User-Agent", "Docker-Client/1.9.1")
+	resp := httptest.NewRecorder()
+	ctx := context.Background()
+
+	if err := h(ctx, resp, req, map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUserAgentMiddlewareWithCustomUA(t *testing.T) {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		ua := useragent.FromContext(ctx)
+		if !strings.Contains(ua, "custom/my-annotation") {
+			t.Fatalf("Expected `custom/my-annotation` in user-agent, got: %s", ua)
+		}
+		return nil
+	}
+
+	serverVersion := "1.9.1"
+	m := NewUserAgentMiddleware(serverVersion, "my-annotation")
 	h := m.WrapHandler(handler)
 
 	req, _ := http.NewRequest("GET", "/containers/json", nil)

--- a/api/server/middleware/user_agent_test.go
+++ b/api/server/middleware/user_agent_test.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/pkg/useragent"
+	"golang.org/x/net/context"
+)
+
+func TestUserAgentMiddleware(t *testing.T) {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		if !strings.Contains(useragent.FromContext(ctx), "Docker-Client/1.9.1") {
+			return errors.New("Missing upstream useragent from context")
+		}
+		return nil
+	}
+
+	serverVersion := "1.9.1"
+	m := NewUserAgentMiddleware(serverVersion)
+	h := m.WrapHandler(handler)
+
+	req, _ := http.NewRequest("GET", "/containers/json", nil)
+	req.Header.Set("User-Agent", "Docker-Client/1.9.1")
+	resp := httptest.NewRecorder()
+	ctx := context.Background()
+
+	if err := h(ctx, resp, req, map[string]string{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/api/server/middleware/version.go
+++ b/api/server/middleware/version.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/errors"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"golang.org/x/net/context"
 )
 
@@ -45,7 +46,7 @@ func (v VersionMiddleware) WrapHandler(handler func(ctx context.Context, w http.
 
 		header := fmt.Sprintf("Docker/%s (%s)", v.serverVersion, runtime.GOOS)
 		w.Header().Set("Server", header)
-		ctx = context.WithValue(ctx, "api-version", apiVersion)
+		ctx = dockerversion.NewContext(ctx, apiVersion)
 		return handler(ctx, w, r, vars)
 	}
 

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/dockerversion"
 	"golang.org/x/net/context"
 )
 
 func TestVersionMiddleware(t *testing.T) {
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-		if httputils.VersionFromContext(ctx) == "" {
+		if dockerversion.FromContext(ctx) == "" {
 			t.Fatalf("Expected version, got empty string")
 		}
 		return nil
@@ -33,7 +33,7 @@ func TestVersionMiddleware(t *testing.T) {
 
 func TestVersionMiddlewareWithErrors(t *testing.T) {
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-		if httputils.VersionFromContext(ctx) == "" {
+		if dockerversion.FromContext(ctx) == "" {
 			t.Fatalf("Expected version, got empty string")
 		}
 		return nil

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -26,7 +27,7 @@ import (
 )
 
 func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBuildOptions, error) {
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	options := &types.ImageBuildOptions{}
 	if httputils.BoolValue(r, "forcerm") && versions.GreaterThanOrEqualTo(version, "1.12") {
 		options.Remove = true

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
 	"golang.org/x/net/context"
@@ -68,7 +69,7 @@ func (s *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 	config := &backend.ContainerStatsConfig{
 		Stream:    stream,
 		OutStream: w,
-		Version:   string(httputils.VersionFromContext(ctx)),
+		Version:   dockerversion.FromContext(ctx),
 	}
 
 	return s.backend.ContainerStats(ctx, vars["name"], config)
@@ -131,7 +132,7 @@ func (s *containerRouter) postContainersStart(ctx context.Context, w http.Respon
 	// including r.TransferEncoding
 	// allow a nil body for backwards compatibility
 
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	var hostConfig *container.HostConfig
 	// A non-nil json object is at least 7 characters.
 	if r.ContentLength > 7 || r.ContentLength == -1 {
@@ -216,7 +217,7 @@ func (s *containerRouter) postContainersKill(ctx context.Context, w http.Respons
 		// Return error that's not caused because the container is stopped.
 		// Return error if the container is not running and the api is >= 1.20
 		// to keep backwards compatibility.
-		version := httputils.VersionFromContext(ctx)
+		version := dockerversion.FromContext(ctx)
 		if versions.GreaterThanOrEqualTo(version, "1.20") || !isStopped {
 			return fmt.Errorf("Cannot kill container %s: %v", name, err)
 		}
@@ -332,7 +333,7 @@ func (s *containerRouter) postContainerUpdate(ctx context.Context, w http.Respon
 		return err
 	}
 
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	var updateConfig container.UpdateConfig
 
 	decoder := json.NewDecoder(r.Body)
@@ -369,7 +370,7 @@ func (s *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 	if err != nil {
 		return err
 	}
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	adjustCPUShares := versions.LessThan(version, "1.19")
 
 	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")

--- a/api/server/router/container/copy.go
+++ b/api/server/router/container/copy.go
@@ -12,13 +12,14 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"golang.org/x/net/context"
 )
 
 // postContainersCopy is deprecated in favor of getContainersArchive.
 func (s *containerRouter) postContainersCopy(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	// Deprecated since 1.8, Errors out since 1.12
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	if versions.GreaterThanOrEqualTo(version, "1.24") {
 		w.WriteHeader(http.StatusNotFound)
 		return nil

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/stdcopy"
 	"golang.org/x/net/context"
 )
@@ -60,7 +61,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		return err
 	}
 
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	if versions.GreaterThan(version, "1.21") {
 		if err := httputils.CheckForJSON(r); err != nil {
 			return err

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/dockerversion"
 	"golang.org/x/net/context"
 )
 
@@ -11,7 +12,7 @@ import (
 func (s *containerRouter) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	displaySize := httputils.BoolValue(r, "size")
 
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	json, err := s.backend.ContainerInspect(vars["name"], displaySize, version)
 	if err != nil {
 		return err

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/registry"
@@ -32,7 +33,7 @@ func (s *imageRouter) postCommit(ctx context.Context, w http.ResponseWriter, r *
 	cname := r.Form.Get("container")
 
 	pause := httputils.BoolValue(r, "pause")
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	if r.FormValue("pause") == "" && versions.GreaterThanOrEqualTo(version, "1.13") {
 		pause = true
 	}

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/ioutils"
 	"golang.org/x/net/context"
 )
@@ -39,7 +40,7 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		info.Swarm = s.clusterProvider.Info()
 	}
 
-	if versions.LessThan(httputils.VersionFromContext(ctx), "1.25") {
+	if versions.LessThan(dockerversion.FromContext(ctx), "1.25") {
 		// TODO: handle this conversion in engine-api
 		type oldInfo struct {
 			*types.Info

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -25,6 +25,7 @@ type Config struct {
 	Logging     bool
 	EnableCors  bool
 	CorsHeaders string
+	UserAgent   string
 	Version     string
 	SocketGroup string
 	TLSConfig   *tls.Config

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api"
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"
+	"github.com/docker/docker/dockerversion"
 
 	"golang.org/x/net/context"
 )
@@ -28,7 +28,7 @@ func TestMiddlewares(t *testing.T) {
 	ctx := context.Background()
 
 	localHandler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-		if httputils.VersionFromContext(ctx) == "" {
+		if dockerversion.FromContext(ctx) == "" {
 			t.Fatalf("Expected version, got empty string")
 		}
 

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -167,6 +167,7 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		Version:     dockerversion.Version,
 		EnableCors:  cli.Config.EnableCors,
 		CorsHeaders: cli.Config.CorsHeaders,
+		UserAgent:   cli.Config.UserAgent,
 	}
 
 	if cli.Config.TLS {
@@ -480,7 +481,7 @@ func (cli *DaemonCli) initMiddlewares(s *apiserver.Server, cfg *apiserver.Config
 		s.UseMiddleware(c)
 	}
 
-	u := middleware.NewUserAgentMiddleware(v)
+	u := middleware.NewUserAgentMiddleware(v, cfg.UserAgent)
 	s.UseMiddleware(u)
 
 	if err := validateAuthzPlugins(cli.Config.AuthorizationPlugins, cli.d.PluginStore); err != nil {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1703,6 +1703,7 @@ _docker_daemon() {
 		--shutdown-timeout
 		--storage-driver -s
 		--storage-opt
+		--user-agent
 		--userns-remap
 	"
 

--- a/daemon/auth.go
+++ b/daemon/auth.go
@@ -4,10 +4,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/dockerversion"
 )
 
 // AuthenticateToRegistry checks the validity of credentials in authConfig
 func (daemon *Daemon) AuthenticateToRegistry(ctx context.Context, authConfig *types.AuthConfig) (string, string, error) {
-	return daemon.RegistryService.Auth(ctx, authConfig, dockerversion.DockerUserAgent(ctx))
+	return daemon.RegistryService.Auth(ctx, authConfig)
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/versions"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
+	"github.com/docker/docker/dockerversion"
 	"github.com/docker/libnetwork"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
@@ -190,7 +190,7 @@ func (c *containerAdapter) waitForDetach(ctx context.Context) error {
 func (c *containerAdapter) create(ctx context.Context) error {
 	var cr containertypes.ContainerCreateCreatedBody
 	var err error
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")
 
 	if cr, err = c.backend.CreateManagedContainer(types.ContainerCreateConfig{
@@ -223,7 +223,7 @@ func (c *containerAdapter) create(ctx context.Context) error {
 }
 
 func (c *containerAdapter) start(ctx context.Context) error {
-	version := httputils.VersionFromContext(ctx)
+	version := dockerversion.FromContext(ctx)
 	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")
 	return c.backend.ContainerStart(c.container.name(), nil, validateHostname, "", "")
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -100,6 +100,7 @@ type CommonConfig struct {
 	TrustKeyPath         string              `json:"-"`
 	CorsHeaders          string              `json:"api-cors-header,omitempty"`
 	EnableCors           bool                `json:"api-enable-cors,omitempty"`
+	UserAgent            string              `json:"user-agent"`
 
 	// LiveRestoreEnabled determines whether we should keep containers
 	// alive upon daemon shutdown/start
@@ -185,6 +186,7 @@ func (config *Config) InstallCommonFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&config.ClusterStore, "cluster-store", "", "URL of the distributed storage backend")
 	flags.Var(opts.NewNamedMapOpts("cluster-store-opts", config.ClusterOpts, nil), "cluster-store-opt", "Set cluster store options")
 	flags.StringVar(&config.CorsHeaders, "api-cors-header", "", "Set CORS headers in the remote API")
+	flags.StringVar(&config.UserAgent, "user-agent", "", "Set custom user-agent annotation")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", defaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", defaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
 	flags.IntVar(&config.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "Set the default shutdown timeout")

--- a/daemon/search.go
+++ b/daemon/search.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	registrytypes "github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/dockerversion"
 )
 
 var acceptedSearchFilterTags = map[string]bool{
@@ -61,7 +60,7 @@ func (daemon *Daemon) SearchRegistryForImages(ctx context.Context, filtersArgs s
 		}
 	}
 
-	unfilteredResult, err := daemon.RegistryService.Search(ctx, term, limit, authConfig, dockerversion.DockerUserAgent(ctx), headers)
+	unfilteredResult, err := daemon.RegistryService.Search(ctx, term, limit, authConfig, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/search_test.go
+++ b/daemon/search_test.go
@@ -21,7 +21,7 @@ type FakeService struct {
 	results []registrytypes.SearchResult
 }
 
-func (s *FakeService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, userAgent string, headers map[string][]string) (*registrytypes.SearchResults, error) {
+func (s *FakeService) Search(ctx context.Context, term string, limit int, authConfig *types.AuthConfig, headers map[string][]string) (*registrytypes.SearchResults, error) {
 	if s.shouldReturnError {
 		return nil, fmt.Errorf("Search unknown error")
 	}

--- a/distribution/pull_v1.go
+++ b/distribution/pull_v1.go
@@ -15,13 +15,13 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/image/v1"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/pkg/useragent"
 	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"golang.org/x/net/context"
@@ -49,10 +49,10 @@ func (p *v1Puller) Pull(ctx context.Context, ref reference.Named) error {
 	tr := transport.NewTransport(
 		// TODO(tiborvass): was ReceiveTimeout
 		registry.NewTransport(tlsConfig),
-		registry.DockerHeaders(dockerversion.DockerUserAgent(ctx), p.config.MetaHeaders)...,
+		registry.DockerHeaders(useragent.FromContext(ctx), p.config.MetaHeaders)...,
 	)
 	client := registry.HTTPClient(tr)
-	v1Endpoint, err := p.endpoint.ToV1Endpoint(dockerversion.DockerUserAgent(ctx), p.config.MetaHeaders)
+	v1Endpoint, err := p.endpoint.ToV1Endpoint(useragent.FromContext(ctx), p.config.MetaHeaders)
 	if err != nil {
 		logrus.Debugf("Could not get v1 endpoint: %v", err)
 		return fallbackError{err: err}

--- a/distribution/push_v1.go
+++ b/distribution/push_v1.go
@@ -8,13 +8,13 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/distribution/metadata"
-	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/image/v1"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/pkg/useragent"
 	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"golang.org/x/net/context"
@@ -38,10 +38,10 @@ func (p *v1Pusher) Push(ctx context.Context) error {
 	tr := transport.NewTransport(
 		// TODO(tiborvass): was NoTimeout
 		registry.NewTransport(tlsConfig),
-		registry.DockerHeaders(dockerversion.DockerUserAgent(ctx), p.config.MetaHeaders)...,
+		registry.DockerHeaders(useragent.FromContext(ctx), p.config.MetaHeaders)...,
 	)
 	client := registry.HTTPClient(tr)
-	v1Endpoint, err := p.endpoint.ToV1Endpoint(dockerversion.DockerUserAgent(ctx), p.config.MetaHeaders)
+	v1Endpoint, err := p.endpoint.ToV1Endpoint(useragent.FromContext(ctx), p.config.MetaHeaders)
 	if err != nil {
 		logrus.Debugf("Could not get v1 endpoint: %v", err)
 		return fallbackError{err: err}

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/useragent"
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/sockets"
 	"golang.org/x/net/context"
@@ -49,7 +49,7 @@ func NewV2Repository(ctx context.Context, repoInfo *registry.RepositoryInfo, end
 		base.Dial = proxyDialer.Dial
 	}
 
-	modifiers := registry.DockerHeaders(dockerversion.DockerUserAgent(ctx), metaHeaders)
+	modifiers := registry.DockerHeaders(useragent.FromContext(ctx), metaHeaders)
 	authTransport := transport.NewTransport(base, modifiers...)
 
 	challengeManager, foundVersion, err := registry.PingV2Registry(endpoint.URL, authTransport)

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/pkg/useragent"
 	"github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
@@ -80,7 +81,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 		t.Fatal(err)
 	}
 	p := puller.(*v2Puller)
-	ctx := context.Background()
+	ctx := useragent.NewContext(context.Background(), "useragent/foo")
 	p.repo, _, err = NewV2Repository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/useragent"
-	"golang.org/x/net/context"
 )
 
 // DockerUserAgent is the User-Agent the Docker client uses to identify itself.
 // In accordance with RFC 7231 (5.5.3) is of the form:
 //    [docker client's UA] UpstreamClient([upstream client's UA])
-func DockerUserAgent(ctx context.Context) string {
+func DockerUserAgent(upstreamUA string) string {
 	httpVersion := make([]useragent.VersionInfo, 0, 6)
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "docker", Version: Version})
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "go", Version: runtime.Version()})
@@ -25,7 +24,6 @@ func DockerUserAgent(ctx context.Context) string {
 
 	dockerUA := useragent.AppendVersions("", httpVersion...)
 
-	upstreamUA := useragent.FromContext(ctx)
 	if len(upstreamUA) > 0 {
 		dockerUA = insertUpstreamUserAgent(upstreamUA, dockerUA)
 	}

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/useragent"
 	"golang.org/x/net/context"
@@ -25,24 +24,13 @@ func DockerUserAgent(ctx context.Context) string {
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "arch", Version: runtime.GOARCH})
 
 	dockerUA := useragent.AppendVersions("", httpVersion...)
-	upstreamUA := getUserAgentFromContext(ctx)
-	if len(upstreamUA) > 0 {
-		ret := insertUpstreamUserAgent(upstreamUA, dockerUA)
-		return ret
-	}
-	return dockerUA
-}
 
-// getUserAgentFromContext returns the previously saved user-agent context stored in ctx, if one exists
-func getUserAgentFromContext(ctx context.Context) string {
-	var upstreamUA string
-	if ctx != nil {
-		var ki interface{} = ctx.Value(httputils.UAStringKey)
-		if ki != nil {
-			upstreamUA = ctx.Value(httputils.UAStringKey).(string)
-		}
+	upstreamUA := useragent.FromContext(ctx)
+	if len(upstreamUA) > 0 {
+		dockerUA = insertUpstreamUserAgent(upstreamUA, dockerUA)
 	}
-	return upstreamUA
+
+	return dockerUA
 }
 
 // escapeStr returns s with every rune in charsToEscape escaped by a backslash

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -11,7 +11,7 @@ import (
 // DockerUserAgent is the User-Agent the Docker client uses to identify itself.
 // In accordance with RFC 7231 (5.5.3) is of the form:
 //    [docker client's UA] UpstreamClient([upstream client's UA])
-func DockerUserAgent(upstreamUA string) string {
+func DockerUserAgent(upstreamUA string, customUA string) string {
 	httpVersion := make([]useragent.VersionInfo, 0, 6)
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "docker", Version: Version})
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "go", Version: runtime.Version()})
@@ -21,6 +21,10 @@ func DockerUserAgent(upstreamUA string) string {
 	}
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "os", Version: runtime.GOOS})
 	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "arch", Version: runtime.GOARCH})
+
+	if len(customUA) > 0 {
+		httpVersion = append(httpVersion, useragent.VersionInfo{Name: "custom", Version: customUA})
+	}
 
 	dockerUA := useragent.AppendVersions("", httpVersion...)
 

--- a/dockerversion/version.go
+++ b/dockerversion/version.go
@@ -1,0 +1,21 @@
+package dockerversion
+
+import (
+	"golang.org/x/net/context"
+)
+
+// APIVersionKey is the client's requested API version.
+const APIVersionKey = "api-version"
+
+// FromContext returns the API version stored in ctx, if one exists.
+func FromContext(ctx context.Context) (v string) {
+	if v, ok := ctx.Value(APIVersionKey).(string); ok {
+		return v
+	}
+	return
+}
+
+// NewContext returns a new Context that carries the API version.
+func NewContext(ctx context.Context, version string) context.Context {
+	return context.WithValue(ctx, APIVersionKey, version)
+}

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -84,6 +84,7 @@ Options:
       --tlscert string                        Path to TLS certificate file (default "/root/.docker/cert.pem")
       --tlskey string                         Path to TLS key file (default "/root/.docker/key.pem")
       --tlsverify                             Use TLS and verify the remote
+      --user-agent                            Set custom user-agent annotation
       --userland-proxy                        Use userland proxy for loopback traffic (default true)
       --userland-proxy-path string            Path to the userland proxy binary
       --userns-remap string                   User/Group setting for user namespaces
@@ -1199,6 +1200,7 @@ This is a full example of the allowed configuration options on Linux:
 	"disable-legacy-registry": false,
 	"default-runtime": "runc",
 	"oom-score-adjust": -500,
+	"user-agent": "",
 	"runtimes": {
 		"runc": {
 			"path": "runc"

--- a/integration-cli/docker_cli_registry_user_agent_test.go
+++ b/integration-cli/docker_cli_registry_user_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/go-check/check"
 )
@@ -44,6 +45,9 @@ func regexpCheckUA(c *check.C, ua string) {
 	reUpstreamUA := regexp.MustCompile("^\\(Docker-Client/[0-9A-Za-z+]")
 	bMatchUpstreamUA := reUpstreamUA.MatchString(upstreamUA)
 	c.Assert(bMatchUpstreamUA, check.Equals, true, check.Commentf("(Upstream) Docker Client User-Agent malformed"))
+
+	// check that --user-agent annotation is present
+	c.Assert(strings.Contains(ua, "custom/my-annotation"), check.Equals, true, check.Commentf("Docker Engine User-Agent missing custom annotation"))
 }
 
 func registerUserAgentHandler(reg *testRegistry, result *string) {
@@ -90,6 +94,7 @@ func (s *DockerRegistrySuite) TestUserAgentPassThrough(c *check.C) {
 	registerUserAgentHandler(loginReg, &loginUA)
 
 	err = s.d.Start(
+		"--user-agent", "my-annotation",
 		"--insecure-registry", buildReg.hostport,
 		"--insecure-registry", pullReg.hostport,
 		"--insecure-registry", pushReg.hostport,

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -4,7 +4,12 @@ package useragent
 
 import (
 	"strings"
+
+	"golang.org/x/net/context"
 )
+
+// UAStringKey is used as key type for the user-agent string in net/context struct.
+const UAStringKey = "user-agent"
 
 // VersionInfo is used to model UserAgent versions.
 type VersionInfo struct {
@@ -52,4 +57,17 @@ func AppendVersions(base string, versions ...VersionInfo) string {
 		verstrs = append(verstrs, v.Name+"/"+v.Version)
 	}
 	return strings.Join(verstrs, " ")
+}
+
+// FromContext returns the user-agent stored in ctx, if one exists.
+func FromContext(ctx context.Context) (ua string) {
+	if ua, ok := ctx.Value(UAStringKey).(string); ok {
+		return ua
+	}
+	return
+}
+
+// NewContext returns a new Context that carries the user-agent.
+func NewContext(ctx context.Context, ua string) context.Context {
+	return context.WithValue(ctx, UAStringKey, ua)
 }


### PR DESCRIPTION
**\- What I did**

Added `--user-agent` flag to daemon that adds an annotation to the User-Agent header.

For example, the flag `--user-agent "my-annotation"` yields this user-agent:

`docker/1.13.0-dev go/go1.7.1 git-commit/c2a6ba7 kernel/3.13.0-95-generic os/linux arch/amd64 custom/my-annotation UpstreamClient(Docker-Client/1.13.0-dev \\(linux\\))`

Note the new "custom/my-annotation". I'm open to suggestions on a better name than "custom" or a nice method for specifying the [product](https://tools.ietf.org/html/rfc7231#section-5.5.3). :)

Why is this useful?

We have multiple runtime environments using docker, but no simple way to distinguish between these environments and normal docker users (for analytics and debugging purposes). This flag solves that.

Are you aware of the [HttpHeaders](https://docs.docker.com/engine/reference/commandline/cli/#/configuration-files) config property?

Yes. This isn't a great solution for us, since it requires modifying the client configuration file. AFAICT, there's no programmatic way to manipulate the client config file, so this isn't a particularly robust option. It's also much simpler to add this to the daemon than try to plumb it through clients, since we have more control over the daemon configuration.

**\- How I did it**

To make this a simpler change, I broke it into four commits.

The first two move context handling for the user-agent and docker version from `httputils` to `pkg/useragent` and `dockerversion`. I also renamed the functions to `NewContext` and `FromContext`, which [I believe is more idiomatic](https://blog.golang.org/context):
- `getUserAgentFromContext` becomes `useragent.FromContext`
- `httputils.VersionFromContext` becomes `dockerversion.FromContext`

The third commit re-centralizes the user-agent logic to effectively undo parts of #19057. That PR pulled the user-agent logic out of the `registry` package and added the user-agent as a parameter to a bunch of functions. In #21373, a context parameter was added back to most of those functions (or their callers), and an implicit dependency on the user_agent middleware (`api/server/middleware/user_agent.go`) was introduced; i.e. calls to `dockerversion.DockerUserAgent` expect the user_agent middleware to have previously populated ctx with the upstream client's user-agent.

I think it's cleaner to have the user_agent middleware just construct the user-agent and add it to the context instead. This makes `dockerversion.DockerUserAgent`'s dependency on the user_agent middleware explicit and IMO makes it much simpler to reason about how the user-agent is constructed, since it all happens in one place. As a happy side effect, we can remove the user-agent parameter from any functions that take a context.

The final commit actually adds the flag. I'm happy to squash these into one commit or break them apart into multiple PRs -- not sure what the protocol is.

**\- How to verify it**

Run the integration test:

```
TESTFLAGS='-check.f DockerRegistrySuite.TestUserAgentPassThrough' make test-integration-cli
```

Or start dockerd with the flag:

```
dockerd --user-agent "my-annotation" &
```

and check the logs of a push against a local registry:

```
docker run -d -p 5000:5000 registry:2 && \
 docker pull busybox && \
 docker tag busybox localhost:5000/busybox && \
 docker push localhost:5000/busybox && \
 docker logs `docker ps -q` # assuming no other running containers
```

You should see "custom/my-annotation". 

**\- Description for the changelog**

Add `--user-agent` daemon flag to annotate the user-agent with additional info (for debugging, analytics).

**\- A picture of a cute animal (not mandatory but encouraged)**

Say hi to Toxic!

![803730612_64614](https://cloud.githubusercontent.com/assets/17863526/18856877/d2507e3e-8413-11e6-9344-00b38e007125.jpg)
