### PR TITLE
configure docker-init binary path

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -324,4 +324,7 @@ type HostConfig struct {
 
 	// Run a custom init inside the container, if null, use the daemon's configured settings
 	Init *bool `json:",omitempty"`
+
+	// Custom init path
+	InitPath string `json:",omitempty"`
 }

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -36,6 +36,7 @@ type Config struct {
 	DefaultRuntime       string                   `json:"default-runtime,omitempty"`
 	OOMScoreAdjust       int                      `json:"oom-score-adjust,omitempty"`
 	Init                 bool                     `json:"init,omitempty"`
+	InitPath             string                   `json:"init-path,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -93,6 +94,7 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&config.DefaultRuntime, "default-runtime", stockRuntimeName, "Default OCI runtime for containers")
 	flags.IntVar(&config.OOMScoreAdjust, "oom-score-adjust", -500, "Set the oom_score_adj for the daemon")
 	flags.BoolVar(&config.Init, "init", false, "Run an init in the container to forward signals and reap processes")
+	flags.StringVar(&config.InitPath, "init-path", "", "Path to the docker-init binary")
 
 	config.attachExperimentalFlags(flags)
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -594,9 +594,18 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 		if (c.HostConfig.Init != nil && *c.HostConfig.Init) ||
 			(c.HostConfig.Init == nil && daemon.configStore.Init) {
 			s.Process.Args = append([]string{"/dev/init", c.Path}, c.Args...)
-			path, err := exec.LookPath("docker-init")
-			if err != nil {
-				return err
+			var path string
+			if daemon.configStore.InitPath == "" && c.HostConfig.InitPath == "" {
+				path, err = exec.LookPath("docker-init")
+				if err != nil {
+					return err
+				}
+			}
+			if daemon.configStore.InitPath != "" {
+				path = daemon.configStore.InitPath
+			}
+			if c.HostConfig.InitPath != "" {
+				path = c.HostConfig.InitPath
 			}
 			s.Mounts = append(s.Mounts, specs.Mount{
 				Destination: "/dev/init",

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -49,6 +49,7 @@ Options:
       --help                                 Print usage
       --icc=true                             Enable inter-container communication
       --init                                 Run an init inside containers to forward signals and reap processes
+      --init-path                            Path to the docker-init binary
       --insecure-registry=[]                 Enable insecure registry communication
       --ip=0.0.0.0                           Default IP when binding container ports
       --ip-forward=true                      Enable net.ipv4.ip_forward
@@ -1142,6 +1143,7 @@ This is a full example of the allowed configuration options on Linux:
 	"cgroup-parent": "",
 	"default-ulimits": {},
 	"init": false,
+	"init-path": "/usr/libexec/docker-init",
 	"ipv6": false,
 	"iptables": false,
 	"ip-forward": false,

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -35,6 +35,7 @@ dockerd - Enable daemon mode
 [**--help**]
 [**--icc**[=*true*]]
 [**--init**[=*false*]]
+[**--init-path**[=*""*]]
 [**--insecure-registry**[=*[]*]]
 [**--ip**[=*0.0.0.0*]]
 [**--ip-forward**[=*true*]]
@@ -169,6 +170,9 @@ unix://[/path/to/socket] to use.
 
 **--init**
 Run an init process inside containers for signal forwarding and process reaping.
+
+**--init-path**
+Path to the docker-init binary.
 
 **--insecure-registry**=[]
   Enable insecure registry communication, i.e., enable un-encrypted and/or untrusted communication.

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -104,6 +104,7 @@ type ContainerOptions struct {
 	runtime           string
 	autoRemove        bool
 	init              bool
+	initPath          string
 
 	Image string
 	Args  []string
@@ -246,6 +247,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.StringVar(&copts.runtime, "runtime", "", "Runtime to use for this container")
 
 	flags.BoolVar(&copts.init, "init", false, "Run an init inside the container that forwards signals and reaps processes")
+	flags.StringVar(&copts.initPath, "init-path", "", "Path to the docker-init binary")
 	return copts
 }
 


### PR DESCRIPTION
Following the discussion on https://github.com/docker/docker/pull/26061/files#r80361337

I've added a new contianer and daemon flag `--init-path` which configures the `docker-init` path.

/cc @justincormack @crosbymichael 

Signed-off-by: Antonio Murdaca runcom@redhat.com
