### PR TITLE
1.12 Revert "Merge pull request #26030 from yongtang/08252016-doc-doc…

### DIFF
--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -90,7 +90,6 @@ Options:
       --read-only                   Mount the container's root filesystem as read only
       --restart string              Restart policy to apply when a container exits (default "no")
                                     Possible values are: no, on-failure[:max-retry], always, unless-stopped
-      --rm                          Automatically remove the container when it exits
       --runtime string              Runtime to use for this container
       --security-opt value          Security Options (default [])
       --shm-size string             Size of /dev/shm, default value is 64MB.


### PR DESCRIPTION
This reverts commit 44180a48e9cdef0ced94ef1aceac3fbcfc6c830a (https://github.com/docker/docker/pull/26030) in the 1.12.x branch,
as `docker create --rm` is part of docker 1.13, so should not be in the 1.12 branch

It was cherry-picked by mistake in https://github.com/docker/docker/pull/26343
