### PR TITLE
Fix cli/command/service/opts_test.go, and add some extra test cases

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -235,10 +235,6 @@ func (m *MountOpt) Set(value string) error {
 		return fmt.Errorf("target is required")
 	}
 
-	if mount.VolumeOptions != nil && mount.Source == "" {
-		return fmt.Errorf("source is required when specifying volume-* options")
-	}
-
 	if mount.Type == mounttypes.TypeBind && mount.VolumeOptions != nil {
 		return fmt.Errorf("cannot mix 'volume-*' options with mount type '%s'", mounttypes.TypeBind)
 	}

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -76,7 +76,7 @@ func TestMountOptString(t *testing.T) {
 	assert.Equal(t, mount.String(), expected)
 }
 
-func TestMountOptSetNoError(t *testing.T) {
+func TestMountOptSetBindNoErrorBind(t *testing.T) {
 	for _, testcase := range []string{
 		// tests several aliases that should have same result.
 		"type=bind,target=/target,source=/source",
@@ -92,6 +92,28 @@ func TestMountOptSetNoError(t *testing.T) {
 		assert.Equal(t, len(mounts), 1)
 		assert.Equal(t, mounts[0], mounttypes.Mount{
 			Type:   mounttypes.TypeBind,
+			Source: "/source",
+			Target: "/target",
+		})
+	}
+}
+
+func TestMountOptSetVolumeNoError(t *testing.T) {
+	for _, testcase := range []string{
+		// tests several aliases that should have same result.
+		"type=volume,target=/target,source=/source",
+		"type=volume,src=/source,dst=/target",
+		"type=volume,source=/source,dst=/target",
+		"type=volume,src=/source,target=/target",
+	} {
+		var mount MountOpt
+
+		assert.NilError(t, mount.Set(testcase))
+
+		mounts := mount.Value()
+		assert.Equal(t, len(mounts), 1)
+		assert.Equal(t, mounts[0], mounttypes.Mount{
+			Type:   mounttypes.TypeVolume,
 			Source: "/source",
 			Target: "/target",
 		})
@@ -141,13 +163,18 @@ func TestMountOptDefaultEnableReadOnly(t *testing.T) {
 	assert.Equal(t, m.values[0].ReadOnly, true)
 
 	m = MountOpt{}
+	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=true"))
+	assert.Equal(t, m.values[0].ReadOnly, true)
+
+	m = MountOpt{}
 	assert.NilError(t, m.Set("type=bind,target=/foo,source=/foo,readonly=0"))
 	assert.Equal(t, m.values[0].ReadOnly, false)
 }
 
 func TestMountOptVolumeNoCopy(t *testing.T) {
 	var m MountOpt
-	assert.Error(t, m.Set("type=volume,target=/foo,volume-nocopy"), "source is required")
+	assert.NilError(t, m.Set("type=volume,target=/foo,volume-nocopy"))
+	assert.Equal(t, m.values[0].Source, "")
 
 	m = MountOpt{}
 	assert.NilError(t, m.Set("type=volume,target=/foo,source=foo"))


### PR DESCRIPTION
For suggestions from @stevvooe 
https://github.com/docker/docker/pull/26825/files/563986b0a9d2b07777f2ee9ca9462f13208fa2d8#r80338930: add test cases for volumes
https://github.com/docker/docker/pull/26825/files/563986b0a9d2b07777f2ee9ca9462f13208fa2d8#r80338995: add a test case for `readonly=true`
https://github.com/docker/docker/pull/26825/files/563986b0a9d2b07777f2ee9ca9462f13208fa2d8#r80339035: `m.Set("type=volume,target=/foo,volume-nocopy")` is valid even though it lacks "source"
#26825 depends on this PR

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
