### PR TITLE
Vendoring libnetwork @7b74403

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -70,7 +70,7 @@ clone git github.com/RackSec/srslog 365bf33cd9acc21ae1c355209865f17228ca534e
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 66764992b5bff765a5aa2318ca3768ad22c4ce95
+clone git github.com/docker/libnetwork 7b74403be4241aea5b01b56adab5eab82a80698b
 clone git github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/src/github.com/docker/libnetwork/Dockerfile.build
+++ b/vendor/src/github.com/docker/libnetwork/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.5.4
+FROM golang:1.7.1
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \

--- a/vendor/src/github.com/docker/libnetwork/controller.go
+++ b/vendor/src/github.com/docker/libnetwork/controller.go
@@ -75,6 +75,9 @@ type NetworkController interface {
 	// ID provides a unique identity for the controller
 	ID() string
 
+	// BuiltinDrivers returns list of builtin drivers
+	BuiltinDrivers() []string
+
 	// Config method returns the bootup configuration for the controller
 	Config() config.Config
 
@@ -324,27 +327,7 @@ func (c *controller) clusterAgentInit() {
 			c.agentClose()
 			c.cleanupServiceBindings("")
 
-			c.Lock()
-			ingressSandbox := c.ingressSandbox
-			c.ingressSandbox = nil
-			c.Unlock()
-
-			if ingressSandbox != nil {
-				if err := ingressSandbox.Delete(); err != nil {
-					log.Warnf("Could not delete ingress sandbox while leaving: %v", err)
-				}
-			}
-
-			n, err := c.NetworkByName("ingress")
-			if err != nil {
-				log.Warnf("Could not find ingress network while leaving: %v", err)
-			}
-
-			if n != nil {
-				if err := n.Delete(); err != nil {
-					log.Warnf("Could not delete ingress network while leaving: %v", err)
-				}
-			}
+			c.clearIngress(true)
 
 			return
 		}
@@ -481,6 +464,17 @@ func (c *controller) ReloadConfiguration(cfgOptions ...config.Option) error {
 
 func (c *controller) ID() string {
 	return c.id
+}
+
+func (c *controller) BuiltinDrivers() []string {
+	drivers := []string{}
+	for _, i := range getInitializers() {
+		if i.ntype == "remote" {
+			continue
+		}
+		drivers = append(drivers, i.ntype)
+	}
+	return drivers
 }
 
 func (c *controller) validateHostDiscoveryConfig() bool {
@@ -1108,7 +1102,32 @@ func (c *controller) getIPAMDriver(name string) (ipamapi.Ipam, *ipamapi.Capabili
 }
 
 func (c *controller) Stop() {
+	c.clearIngress(false)
 	c.closeStores()
 	c.stopExternalKeyListener()
 	osl.GC()
+}
+
+func (c *controller) clearIngress(clusterLeave bool) {
+	c.Lock()
+	ingressSandbox := c.ingressSandbox
+	c.ingressSandbox = nil
+	c.Unlock()
+
+	if ingressSandbox != nil {
+		if err := ingressSandbox.Delete(); err != nil {
+			log.Warnf("Could not delete ingress sandbox while leaving: %v", err)
+		}
+	}
+
+	n, err := c.NetworkByName("ingress")
+	if err != nil && clusterLeave {
+		log.Warnf("Could not find ingress network while leaving: %v", err)
+	}
+
+	if n != nil {
+		if err := n.Delete(); err != nil {
+			log.Warnf("Could not delete ingress network while leaving: %v", err)
+		}
+	}
 }

--- a/vendor/src/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/macvlan/macvlan_network.go
@@ -44,8 +44,8 @@ func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo 
 	case "", modeBridge:
 		// default to macvlan bridge mode if -o macvlan_mode is empty
 		config.MacvlanMode = modeBridge
-	case modeOpt:
-		config.MacvlanMode = modeOpt
+	case modePrivate:
+		config.MacvlanMode = modePrivate
 	case modePassthru:
 		config.MacvlanMode = modePassthru
 	case modeVepa:

--- a/vendor/src/github.com/docker/libnetwork/drivers/remote/api/api.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/remote/api/api.go
@@ -27,6 +27,38 @@ type GetCapabilityResponse struct {
 	Scope string
 }
 
+// AllocateNetworkRequest requests allocation of new network by manager
+type AllocateNetworkRequest struct {
+	// A network ID that remote plugins are expected to store for future
+	// reference.
+	NetworkID string
+
+	// A free form map->object interface for communication of options.
+	Options map[string]string
+
+	// IPAMData contains the address pool information for this network
+	IPv4Data, IPv6Data []driverapi.IPAMData
+}
+
+// AllocateNetworkResponse is the response to the AllocateNetworkRequest.
+type AllocateNetworkResponse struct {
+	Response
+	// A free form plugin specific string->string object to be sent in
+	// CreateNetworkRequest call in the libnetwork agents
+	Options map[string]string
+}
+
+// FreeNetworkRequest is the request to free allocated network in the manager
+type FreeNetworkRequest struct {
+	// The ID of the network to be freed.
+	NetworkID string
+}
+
+// FreeNetworkResponse is the response to a request for freeing a network.
+type FreeNetworkResponse struct {
+	Response
+}
+
 // CreateNetworkRequest requests a new network.
 type CreateNetworkRequest struct {
 	// A network ID that remote plugins are expected to store for future

--- a/vendor/src/github.com/docker/libnetwork/drivers/remote/driver.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/remote/driver.go
@@ -88,12 +88,21 @@ func (d *driver) call(methodName string, arg interface{}, retVal maybeError) err
 	return nil
 }
 
-func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
-	return nil, types.NotImplementedErrorf("not implemented")
+func (d *driver) NetworkAllocate(id string, options map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
+	create := &api.AllocateNetworkRequest{
+		NetworkID: id,
+		Options:   options,
+		IPv4Data:  ipV4Data,
+		IPv6Data:  ipV6Data,
+	}
+	retVal := api.AllocateNetworkResponse{}
+	err := d.call("AllocateNetwork", create, &retVal)
+	return retVal.Options, err
 }
 
 func (d *driver) NetworkFree(id string) error {
-	return types.NotImplementedErrorf("not implemented")
+	fr := &api.FreeNetworkRequest{NetworkID: id}
+	return d.call("FreeNetwork", fr, &api.FreeNetworkResponse{})
 }
 
 func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {

--- a/vendor/src/github.com/docker/libnetwork/network.go
+++ b/vendor/src/github.com/docker/libnetwork/network.go
@@ -1059,6 +1059,12 @@ func delNameToIP(svcMap map[string][]net.IP, name string, epIP net.IP) {
 }
 
 func (n *network) addSvcRecords(name string, epIP net.IP, epIPv6 net.IP, ipMapUpdate bool) {
+	// Do not add service names for ingress network as this is a
+	// routing only network
+	if n.ingress {
+		return
+	}
+
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()
@@ -1086,6 +1092,12 @@ func (n *network) addSvcRecords(name string, epIP net.IP, epIPv6 net.IP, ipMapUp
 }
 
 func (n *network) deleteSvcRecords(name string, epIP net.IP, epIPv6 net.IP, ipMapUpdate bool) {
+	// Do not delete service names from ingress network as this is a
+	// routing only network
+	if n.ingress {
+		return
+	}
+
 	c := n.getController()
 	c.Lock()
 	defer c.Unlock()

--- a/vendor/src/github.com/docker/libnetwork/networkdb/cluster.go
+++ b/vendor/src/github.com/docker/libnetwork/networkdb/cluster.go
@@ -112,14 +112,20 @@ func (nDB *NetworkDB) clusterInit() error {
 
 	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{
 		NumNodes: func() int {
-			return len(nDB.nodes)
+			nDB.RLock()
+			num := len(nDB.nodes)
+			nDB.RUnlock()
+			return num
 		},
 		RetransmitMult: config.RetransmitMult,
 	}
 
 	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{
 		NumNodes: func() int {
-			return len(nDB.nodes)
+			nDB.RLock()
+			num := len(nDB.nodes)
+			nDB.RUnlock()
+			return num
 		},
 		RetransmitMult: config.RetransmitMult,
 	}
@@ -559,10 +565,6 @@ func (nDB *NetworkDB) bulkSyncNode(networks []string, node string, unsolicited b
 		case <-t.C:
 			logrus.Errorf("Bulk sync to node %s timed out", node)
 		case <-ch:
-			nDB.Lock()
-			delete(nDB.bulkSyncAckTbl, node)
-			nDB.Unlock()
-
 			logrus.Debugf("%s: Bulk sync to node %s took %s", nDB.config.NodeName, node, time.Now().Sub(startTime))
 		}
 		t.Stop()

--- a/vendor/src/github.com/docker/libnetwork/networkdb/delegate.go
+++ b/vendor/src/github.com/docker/libnetwork/networkdb/delegate.go
@@ -318,12 +318,13 @@ func (nDB *NetworkDB) handleBulkSync(buf []byte) {
 
 	// Don't respond to a bulk sync which was not unsolicited
 	if !bsm.Unsolicited {
-		nDB.RLock()
+		nDB.Lock()
 		ch, ok := nDB.bulkSyncAckTbl[bsm.NodeName]
-		nDB.RUnlock()
 		if ok {
 			close(ch)
+			delete(nDB.bulkSyncAckTbl, bsm.NodeName)
 		}
+		nDB.Unlock()
 
 		return
 	}


### PR DESCRIPTION
Fixes an issue where when you restart all manager nodes cluster, the gossip join fails on the first try which results in ingress network/sandbox not getting plumbed even after the transient failure is cleared.

Fixes #27109 
Fixes #26404

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
