### PR TITLE
make remove cloudprovider network return 204

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -139,7 +139,11 @@ func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 	if _, err := n.clusterProvider.GetNetwork(vars["id"]); err == nil {
-		return n.clusterProvider.RemoveNetwork(vars["id"])
+		if err = n.clusterProvider.RemoveNetwork(vars["id"]); err != nil {
+			return err
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return nil
 	}
 	if err := n.backend.DeleteNetwork(vars["id"]); err != nil {
 		return err

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4672,7 +4672,9 @@ Stop and remove the service `id`
 
 **Example response**:
 
-    HTTP/1.1 200 No Content
+    HTTP/1.1 200 OK
+    Content-Length: 0
+    Content-Type: text/plain; charset=utf-8
 
 **Status codes**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -5040,7 +5040,9 @@ Stop and remove the service `id`
 
 **Example response**:
 
-    HTTP/1.1 200 No Content
+    HTTP/1.1 200 OK
+    Content-Length: 0
+    Content-Type: text/plain; charset=utf-8
 
 **Status codes**:
 


### PR DESCRIPTION
In docker engine, removing network will involving two parts: 1. cloud provider to remove; 2, backend to remove.

While in the original code, when succeed in removing network from cloud provider, it returns a code of 200 rather than 204, while 204 in removing backend network.

If we do not change this, the versioned api docs needs to add a status code of 200 implemented in the original code.

**\- What I did**
This pr changed the original code, make it return 204.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
