### PR TITLE
added better Docker Machine links to Swarm tutorial d4mac, d4win, cop…

### DIFF
--- a/docs/getstarted/index.md
+++ b/docs/getstarted/index.md
@@ -58,6 +58,7 @@ If you are using Docker for Mac, Docker for Windows, or Docker on Linux, you wil
 
 The getting started tour uses Docker Engine CLI commands entered on the command line of a terminal window. You don't need to be a wizard at the command line, but you should be familiar with how to open your favorite shell or terminal, and run basic commands in that environment. It helps (but isn't required) to know how to navigate a directory tree, manipulate files, list running process, and so forth.
 
+## Where to go next
 
 Go to [the next page to install](step_one.md).
 

--- a/docs/swarm/swarm-tutorial/index.md
+++ b/docs/swarm/swarm-tutorial/index.md
@@ -87,7 +87,7 @@ will serve as the single swarm node.
 
 * Currently, you cannot use Docker for Mac or Windows alone to test a
 _multi-node_ swarm. However, you can use the included version of [Docker
-Machine](/machine/overview.md) to create the swarm nodes, then follow the
+Machine](/machine/overview.md) to create the swarm nodes (see [Get started with Docker Machine and a local VM](/machine/get-started.md)), then follow the
 tutorial for all multi-node features. For this scenario, you run commands from
 a Docker for Mac or Docker for Windows host, but that Docker host itself is
 _not_ participating in the swarm (i.e., it will not be `manager1`, `worker1`,


### PR DESCRIPTION
**\- What I did**
In Swarm tutorial getting started, under the Docker for Mac / Docker for Windows notes, added another Docker Machine link to a topic specific to using Machine to create local VM's.

Also copy-edited a page in the Getting Started tutorial (beginner Docker) to include a "Where to go next" topic, like all the others in that tutorial.

**\- How to verify it**
Review the changed files.

**\- Description for the changelog**
Updated Swarm getting started tutorial to help Docker for Mac and Windows users.

**\- picture of a cute animal**
![elephant](https://cloud.githubusercontent.com/assets/11660803/18892550/ba7b9676-84be-11e6-9e2f-edc43df40dfa.png)

Signed-off-by: Victoria Bialas victoria.bialas@docker.com
