### PR TITLE
Windows: Set correct root path logic

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -65,9 +65,19 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	s.Process.Terminal = c.Config.Tty
 	s.Process.User.Username = c.Config.User
 
-	// In spec.Root
-	s.Root.Path = c.BaseFS
-	s.Root.Readonly = c.HostConfig.ReadonlyRootfs
+	// In spec.Root. This is not set for Hyper-V containers
+	isHyperV := false
+	if c.HostConfig.Isolation.IsDefault() {
+		// Container using default isolation, so take the default from the daemon configuration
+		isHyperV = daemon.defaultIsolation.IsHyperV()
+	} else {
+		// Container may be requesting an explicit isolation mode.
+		isHyperV = c.HostConfig.Isolation.IsHyperV()
+	}
+	if !isHyperV {
+		s.Root.Path = c.BaseFS
+	}
+	s.Root.Readonly = false // Windows does not support a read-only root filesystem
 
 	// In s.Windows.Resources
 	// @darrenstahlmsft implement these resources


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes a correctness issue after discussion with @swernli. Only set the `Root.Path` in the OCI spec on Windows if the container is NOT a Hyper-V Container.

Also set the `Root.Readonly` to `false` explicitly, as a read-only root FS is not supported on Windows.

@swernli PTAL.
