### PR TITLE
[nit] integration-cli: obey Go's naming convention

### DIFF
--- a/integration-cli/docker_api_auth_test.go
+++ b/integration-cli/docker_api_auth_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Test case for #22244
-func (s *DockerSuite) TestAuthApi(c *check.C) {
+func (s *DockerSuite) TestAuthAPI(c *check.C) {
 	testRequires(c, Network)
 	config := types.AuthConfig{
 		Username: "no-user",

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestBuildApiDockerFileRemote(c *check.C) {
+func (s *DockerSuite) TestBuildAPIDockerFileRemote(c *check.C) {
 	testRequires(c, NotUserNamespace)
 	var testD string
 	if daemonPlatform == "windows" {
@@ -44,7 +44,7 @@ RUN find /tmp/`
 	c.Assert(out, checker.Not(checker.Contains), "baz")
 }
 
-func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
+func (s *DockerSuite) TestBuildAPIRemoteTarballContext(c *check.C) {
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
 	defer tw.Close()
@@ -77,7 +77,7 @@ func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
 	b.Close()
 }
 
-func (s *DockerSuite) TestBuildApiRemoteTarballContextWithCustomDockerfile(c *check.C) {
+func (s *DockerSuite) TestBuildAPIRemoteTarballContextWithCustomDockerfile(c *check.C) {
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
 	defer tw.Close()
@@ -132,7 +132,7 @@ RUN echo 'right'
 	c.Assert(string(content), checker.Not(checker.Contains), "wrong")
 }
 
-func (s *DockerSuite) TestBuildApiLowerDockerfile(c *check.C) {
+func (s *DockerSuite) TestBuildAPILowerDockerfile(c *check.C) {
 	git, err := newFakeGit("repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
@@ -151,7 +151,7 @@ RUN echo from dockerfile`,
 	c.Assert(out, checker.Contains, "from dockerfile")
 }
 
-func (s *DockerSuite) TestBuildApiBuildGitWithF(c *check.C) {
+func (s *DockerSuite) TestBuildAPIBuildGitWithF(c *check.C) {
 	git, err := newFakeGit("repo", map[string]string{
 		"baz": `FROM busybox
 RUN echo from baz`,
@@ -173,7 +173,7 @@ RUN echo from Dockerfile`,
 	c.Assert(out, checker.Contains, "from baz")
 }
 
-func (s *DockerSuite) TestBuildApiDoubleDockerfile(c *check.C) {
+func (s *DockerSuite) TestBuildAPIDoubleDockerfile(c *check.C) {
 	testRequires(c, UnixCli) // dockerfile overwrites Dockerfile on Windows
 	git, err := newFakeGit("repo", map[string]string{
 		"Dockerfile": `FROM busybox
@@ -196,7 +196,7 @@ RUN echo from dockerfile`,
 	c.Assert(out, checker.Contains, "from Dockerfile")
 }
 
-func (s *DockerSuite) TestBuildApiUnnormalizedTarPaths(c *check.C) {
+func (s *DockerSuite) TestBuildAPIUnnormalizedTarPaths(c *check.C) {
 	// Make sure that build context tars with entries of the form
 	// x/./y don't cause caching false positives.
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestContainerApiGetAll(c *check.C) {
+func (s *DockerSuite) TestContainerAPIGetAll(c *check.C) {
 	startCount, err := getContainerCount()
 	c.Assert(err, checker.IsNil, check.Commentf("Cannot query container count"))
 
@@ -54,7 +54,7 @@ func (s *DockerSuite) TestContainerApiGetAll(c *check.C) {
 }
 
 // regression test for empty json field being omitted #13691
-func (s *DockerSuite) TestContainerApiGetJSONNoFieldsOmitted(c *check.C) {
+func (s *DockerSuite) TestContainerAPIGetJSONNoFieldsOmitted(c *check.C) {
 	dockerCmd(c, "run", "busybox", "true")
 
 	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
@@ -91,7 +91,7 @@ type containerPs struct {
 }
 
 // regression test for non-empty fields from #13901
-func (s *DockerSuite) TestContainerApiPsOmitFields(c *check.C) {
+func (s *DockerSuite) TestContainerAPIPsOmitFields(c *check.C) {
 	// Problematic for Windows porting due to networking not yet being passed back
 	testRequires(c, DaemonIsLinux)
 	name := "pstest"
@@ -124,7 +124,7 @@ func (s *DockerSuite) TestContainerApiPsOmitFields(c *check.C) {
 	c.Assert(ok, checker.Not(checker.Equals), true)
 }
 
-func (s *DockerSuite) TestContainerApiGetExport(c *check.C) {
+func (s *DockerSuite) TestContainerAPIGetExport(c *check.C) {
 	// TODO: Investigate why this fails on Windows to Windows CI
 	testRequires(c, DaemonIsLinux)
 	name := "exportcontainer"
@@ -148,7 +148,7 @@ func (s *DockerSuite) TestContainerApiGetExport(c *check.C) {
 	c.Assert(found, checker.True, check.Commentf("The created test file has not been found in the exported image"))
 }
 
-func (s *DockerSuite) TestContainerApiGetChanges(c *check.C) {
+func (s *DockerSuite) TestContainerAPIGetChanges(c *check.C) {
 	// Not supported on Windows as Windows does not support docker diff (/containers/name/changes)
 	testRequires(c, DaemonIsLinux)
 	name := "changescontainer"
@@ -343,7 +343,7 @@ func (s *DockerSuite) TestGetStoppedContainerStats(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestContainerApiPause(c *check.C) {
+func (s *DockerSuite) TestContainerAPIPause(c *check.C) {
 	// Problematic on Windows as Windows does not support pause
 	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
@@ -370,7 +370,7 @@ func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 	c.Assert(pausedContainers, checker.IsNil, check.Commentf("There should be no paused container."))
 }
 
-func (s *DockerSuite) TestContainerApiTop(c *check.C) {
+func (s *DockerSuite) TestContainerAPITop(c *check.C) {
 	// Problematic on Windows as Windows does not support top
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "top")
@@ -396,7 +396,7 @@ func (s *DockerSuite) TestContainerApiTop(c *check.C) {
 	c.Assert(top.Processes[1][10], checker.Equals, "top")
 }
 
-func (s *DockerSuite) TestContainerApiCommit(c *check.C) {
+func (s *DockerSuite) TestContainerAPICommit(c *check.C) {
 	cName := "testapicommit"
 	dockerCmd(c, "run", "--name="+cName, "busybox", "/bin/sh", "-c", "touch /test")
 
@@ -418,7 +418,7 @@ func (s *DockerSuite) TestContainerApiCommit(c *check.C) {
 	dockerCmd(c, "run", img.ID, "ls", "/test")
 }
 
-func (s *DockerSuite) TestContainerApiCommitWithLabelInConfig(c *check.C) {
+func (s *DockerSuite) TestContainerAPICommitWithLabelInConfig(c *check.C) {
 	cName := "testapicommitwithconfig"
 	dockerCmd(c, "run", "--name="+cName, "busybox", "/bin/sh", "-c", "touch /test")
 
@@ -450,7 +450,7 @@ func (s *DockerSuite) TestContainerApiCommitWithLabelInConfig(c *check.C) {
 	dockerCmd(c, "run", img.ID, "ls", "/test")
 }
 
-func (s *DockerSuite) TestContainerApiBadPort(c *check.C) {
+func (s *DockerSuite) TestContainerAPIBadPort(c *check.C) {
 	// TODO Windows to Windows CI - Port this test
 	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
@@ -475,7 +475,7 @@ func (s *DockerSuite) TestContainerApiBadPort(c *check.C) {
 	c.Assert(getErrorMessage(c, body), checker.Equals, `invalid port specification: "aa80"`, check.Commentf("Incorrect error msg: %s", body))
 }
 
-func (s *DockerSuite) TestContainerApiCreate(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreate(c *check.C) {
 	config := map[string]interface{}{
 		"Image": "busybox",
 		"Cmd":   []string{"/bin/sh", "-c", "touch /test && ls /test"},
@@ -495,7 +495,7 @@ func (s *DockerSuite) TestContainerApiCreate(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Equals, "/test")
 }
 
-func (s *DockerSuite) TestContainerApiCreateEmptyConfig(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateEmptyConfig(c *check.C) {
 	config := map[string]interface{}{}
 
 	status, body, err := sockRequest("POST", "/containers/create", config)
@@ -506,7 +506,7 @@ func (s *DockerSuite) TestContainerApiCreateEmptyConfig(c *check.C) {
 	c.Assert(getErrorMessage(c, body), checker.Equals, expected)
 }
 
-func (s *DockerSuite) TestContainerApiCreateMultipleNetworksConfig(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateMultipleNetworksConfig(c *check.C) {
 	// Container creation must fail if client specified configurations for more than one network
 	config := map[string]interface{}{
 		"Image": "busybox",
@@ -530,7 +530,7 @@ func (s *DockerSuite) TestContainerApiCreateMultipleNetworksConfig(c *check.C) {
 	c.Assert(msg, checker.Contains, "net3")
 }
 
-func (s *DockerSuite) TestContainerApiCreateWithHostName(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateWithHostName(c *check.C) {
 	hostName := "test-host"
 	config := map[string]interface{}{
 		"Image":    "busybox",
@@ -553,7 +553,7 @@ func (s *DockerSuite) TestContainerApiCreateWithHostName(c *check.C) {
 	c.Assert(containerJSON.Config.Hostname, checker.Equals, hostName, check.Commentf("Mismatched Hostname"))
 }
 
-func (s *DockerSuite) TestContainerApiCreateWithDomainName(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateWithDomainName(c *check.C) {
 	domainName := "test-domain"
 	config := map[string]interface{}{
 		"Image":      "busybox",
@@ -576,13 +576,13 @@ func (s *DockerSuite) TestContainerApiCreateWithDomainName(c *check.C) {
 	c.Assert(containerJSON.Config.Domainname, checker.Equals, domainName, check.Commentf("Mismatched Domainname"))
 }
 
-func (s *DockerSuite) TestContainerApiCreateBridgeNetworkMode(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateBridgeNetworkMode(c *check.C) {
 	// Windows does not support bridge
 	testRequires(c, DaemonIsLinux)
 	UtilCreateNetworkMode(c, "bridge")
 }
 
-func (s *DockerSuite) TestContainerApiCreateOtherNetworkModes(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateOtherNetworkModes(c *check.C) {
 	// Windows does not support these network modes
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	UtilCreateNetworkMode(c, "host")
@@ -611,7 +611,7 @@ func UtilCreateNetworkMode(c *check.C, networkMode string) {
 	c.Assert(containerJSON.HostConfig.NetworkMode, checker.Equals, containertypes.NetworkMode(networkMode), check.Commentf("Mismatched NetworkMode"))
 }
 
-func (s *DockerSuite) TestContainerApiCreateWithCpuSharesCpuset(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateWithCpuSharesCpuset(c *check.C) {
 	// TODO Windows to Windows CI. The CpuShares part could be ported.
 	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
@@ -642,7 +642,7 @@ func (s *DockerSuite) TestContainerApiCreateWithCpuSharesCpuset(c *check.C) {
 	c.Assert(outCpuset, checker.Equals, "0")
 }
 
-func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {
+func (s *DockerSuite) TestContainerAPIVerifyHeader(c *check.C) {
 	config := map[string]interface{}{
 		"Image": "busybox",
 	}
@@ -673,7 +673,7 @@ func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {
 }
 
 //Issue 14230. daemon should return 500 for invalid port syntax
-func (s *DockerSuite) TestContainerApiInvalidPortSyntax(c *check.C) {
+func (s *DockerSuite) TestContainerAPIInvalidPortSyntax(c *check.C) {
 	config := `{
 				  "Image": "busybox",
 				  "HostConfig": {
@@ -695,7 +695,7 @@ func (s *DockerSuite) TestContainerApiInvalidPortSyntax(c *check.C) {
 	c.Assert(string(b[:]), checker.Contains, "invalid port")
 }
 
-func (s *DockerSuite) TestContainerApiInvalidRestartPolicyName(c *check.C) {
+func (s *DockerSuite) TestContainerAPIInvalidRestartPolicyName(c *check.C) {
 	config := `{
 		"Image": "busybox",
 		"HostConfig": {
@@ -715,7 +715,7 @@ func (s *DockerSuite) TestContainerApiInvalidRestartPolicyName(c *check.C) {
 	c.Assert(string(b[:]), checker.Contains, "invalid restart policy")
 }
 
-func (s *DockerSuite) TestContainerApiInvalidRestartPolicyRetryMismatch(c *check.C) {
+func (s *DockerSuite) TestContainerAPIInvalidRestartPolicyRetryMismatch(c *check.C) {
 	config := `{
 		"Image": "busybox",
 		"HostConfig": {
@@ -735,7 +735,7 @@ func (s *DockerSuite) TestContainerApiInvalidRestartPolicyRetryMismatch(c *check
 	c.Assert(string(b[:]), checker.Contains, "maximum restart count not valid with restart policy")
 }
 
-func (s *DockerSuite) TestContainerApiInvalidRestartPolicyPositiveRetryCount(c *check.C) {
+func (s *DockerSuite) TestContainerAPIInvalidRestartPolicyPositiveRetryCount(c *check.C) {
 	config := `{
 		"Image": "busybox",
 		"HostConfig": {
@@ -757,7 +757,7 @@ func (s *DockerSuite) TestContainerApiInvalidRestartPolicyPositiveRetryCount(c *
 
 // Issue 7941 - test to make sure a "null" in JSON is just ignored.
 // W/o this fix a null in JSON would be parsed into a string var as "null"
-func (s *DockerSuite) TestContainerApiPostCreateNull(c *check.C) {
+func (s *DockerSuite) TestContainerAPIPostCreateNull(c *check.C) {
 	config := `{
 		"Hostname":"",
 		"Domainname":"",
@@ -821,11 +821,11 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 	c.Assert(string(b), checker.Contains, "Minimum memory limit allowed is 4MB")
 }
 
-func (s *DockerSuite) TestContainerApiRename(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--name", "TestContainerApiRename", "-d", "busybox", "sh")
+func (s *DockerSuite) TestContainerAPIRename(c *check.C) {
+	out, _ := dockerCmd(c, "run", "--name", "TestContainerAPIRename", "-d", "busybox", "sh")
 
 	containerID := strings.TrimSpace(out)
-	newName := "TestContainerApiRenameNew"
+	newName := "TestContainerAPIRenameNew"
 	statusCode, _, err := sockRequest("POST", "/containers/"+containerID+"/rename?name="+newName, nil)
 	c.Assert(err, checker.IsNil)
 	// 204 No Content is expected, not 200
@@ -835,7 +835,7 @@ func (s *DockerSuite) TestContainerApiRename(c *check.C) {
 	c.Assert(name, checker.Equals, "/"+newName, check.Commentf("Failed to rename container"))
 }
 
-func (s *DockerSuite) TestContainerApiKill(c *check.C) {
+func (s *DockerSuite) TestContainerAPIKill(c *check.C) {
 	name := "test-api-kill"
 	runSleepingContainer(c, "-i", "--name", name)
 
@@ -847,7 +847,7 @@ func (s *DockerSuite) TestContainerApiKill(c *check.C) {
 	c.Assert(state, checker.Equals, "false", check.Commentf("got wrong State from container %s: %q", name, state))
 }
 
-func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
+func (s *DockerSuite) TestContainerAPIRestart(c *check.C) {
 	// TODO Windows to Windows CI. This is flaky due to the timing
 	testRequires(c, DaemonIsLinux)
 	name := "test-api-restart"
@@ -859,7 +859,7 @@ func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
 	c.Assert(waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 5*time.Second), checker.IsNil)
 }
 
-func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
+func (s *DockerSuite) TestContainerAPIRestartNotimeoutParam(c *check.C) {
 	// TODO Windows to Windows CI. This is flaky due to the timing
 	testRequires(c, DaemonIsLinux)
 	name := "test-api-restart-no-timeout-param"
@@ -873,7 +873,7 @@ func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
 	c.Assert(waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 5*time.Second), checker.IsNil)
 }
 
-func (s *DockerSuite) TestContainerApiStart(c *check.C) {
+func (s *DockerSuite) TestContainerAPIStart(c *check.C) {
 	name := "testing-start"
 	config := map[string]interface{}{
 		"Image":     "busybox",
@@ -899,7 +899,7 @@ func (s *DockerSuite) TestContainerApiStart(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestContainerApiStop(c *check.C) {
+func (s *DockerSuite) TestContainerAPIStop(c *check.C) {
 	name := "test-api-stop"
 	runSleepingContainer(c, "-i", "--name", name)
 
@@ -914,7 +914,7 @@ func (s *DockerSuite) TestContainerApiStop(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNotModified)
 }
 
-func (s *DockerSuite) TestContainerApiWait(c *check.C) {
+func (s *DockerSuite) TestContainerAPIWait(c *check.C) {
 	name := "test-api-wait"
 
 	sleepCmd := "/bin/sleep"
@@ -933,7 +933,7 @@ func (s *DockerSuite) TestContainerApiWait(c *check.C) {
 	c.Assert(waitres.StatusCode, checker.Equals, 0)
 }
 
-func (s *DockerSuite) TestContainerApiCopyNotExistsAnyMore(c *check.C) {
+func (s *DockerSuite) TestContainerAPICopyNotExistsAnyMore(c *check.C) {
 	name := "test-container-api-copy"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
 
@@ -946,7 +946,7 @@ func (s *DockerSuite) TestContainerApiCopyNotExistsAnyMore(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 }
 
-func (s *DockerSuite) TestContainerApiCopyPre124(c *check.C) {
+func (s *DockerSuite) TestContainerAPICopyPre124(c *check.C) {
 
 	name := "test-container-api-copy"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
@@ -976,7 +976,7 @@ func (s *DockerSuite) TestContainerApiCopyPre124(c *check.C) {
 	c.Assert(found, checker.True)
 }
 
-func (s *DockerSuite) TestContainerApiCopyResourcePathEmptyPr124(c *check.C) {
+func (s *DockerSuite) TestContainerAPICopyResourcePathEmptyPr124(c *check.C) {
 	name := "test-container-api-copy-resource-empty"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
 
@@ -990,7 +990,7 @@ func (s *DockerSuite) TestContainerApiCopyResourcePathEmptyPr124(c *check.C) {
 	c.Assert(string(body), checker.Matches, "Path cannot be empty\n")
 }
 
-func (s *DockerSuite) TestContainerApiCopyResourcePathNotFoundPre124(c *check.C) {
+func (s *DockerSuite) TestContainerAPICopyResourcePathNotFoundPre124(c *check.C) {
 	name := "test-container-api-copy-resource-not-found"
 	dockerCmd(c, "run", "--name", name, "busybox")
 
@@ -1004,7 +1004,7 @@ func (s *DockerSuite) TestContainerApiCopyResourcePathNotFoundPre124(c *check.C)
 	c.Assert(string(body), checker.Matches, "Could not find the file /notexist in container "+name+"\n")
 }
 
-func (s *DockerSuite) TestContainerApiCopyContainerNotFoundPr124(c *check.C) {
+func (s *DockerSuite) TestContainerAPICopyContainerNotFoundPr124(c *check.C) {
 	postData := types.CopyConfig{
 		Resource: "/something",
 	}
@@ -1014,7 +1014,7 @@ func (s *DockerSuite) TestContainerApiCopyContainerNotFoundPr124(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 }
 
-func (s *DockerSuite) TestContainerApiDelete(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDelete(c *check.C) {
 	out, _ := runSleepingContainer(c)
 
 	id := strings.TrimSpace(out)
@@ -1027,14 +1027,14 @@ func (s *DockerSuite) TestContainerApiDelete(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 }
 
-func (s *DockerSuite) TestContainerApiDeleteNotExist(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDeleteNotExist(c *check.C) {
 	status, body, err := sockRequest("DELETE", "/containers/doesnotexist", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 	c.Assert(getErrorMessage(c, body), checker.Matches, "No such container: doesnotexist")
 }
 
-func (s *DockerSuite) TestContainerApiDeleteForce(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDeleteForce(c *check.C) {
 	out, _ := runSleepingContainer(c)
 
 	id := strings.TrimSpace(out)
@@ -1045,7 +1045,7 @@ func (s *DockerSuite) TestContainerApiDeleteForce(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 }
 
-func (s *DockerSuite) TestContainerApiDeleteRemoveLinks(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDeleteRemoveLinks(c *check.C) {
 	// Windows does not support links
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--name", "tlink1", "busybox", "top")
@@ -1069,7 +1069,7 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveLinks(c *check.C) {
 	c.Assert(linksPostRm, checker.Equals, "null", check.Commentf("call to api deleteContainer links should have removed the specified links"))
 }
 
-func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDeleteConflict(c *check.C) {
 	out, _ := runSleepingContainer(c)
 
 	id := strings.TrimSpace(out)
@@ -1080,7 +1080,7 @@ func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusConflict)
 }
 
-func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDeleteRemoveVolume(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	vol := "/testvolume"
@@ -1105,7 +1105,7 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
 }
 
 // Regression test for https://github.com/docker/docker/issues/6231
-func (s *DockerSuite) TestContainerApiChunkedEncoding(c *check.C) {
+func (s *DockerSuite) TestContainerAPIChunkedEncoding(c *check.C) {
 	conn, err := sockConn(time.Duration(10*time.Second), "")
 	c.Assert(err, checker.IsNil)
 	client := httputil.NewClientConn(conn, nil)
@@ -1133,7 +1133,7 @@ func (s *DockerSuite) TestContainerApiChunkedEncoding(c *check.C) {
 	c.Assert(resp.StatusCode, checker.Equals, http.StatusCreated)
 }
 
-func (s *DockerSuite) TestContainerApiPostContainerStop(c *check.C) {
+func (s *DockerSuite) TestContainerAPIPostContainerStop(c *check.C) {
 	out, _ := runSleepingContainer(c)
 
 	containerID := strings.TrimSpace(out)
@@ -1147,7 +1147,7 @@ func (s *DockerSuite) TestContainerApiPostContainerStop(c *check.C) {
 }
 
 // #14170
-func (s *DockerSuite) TestPostContainerApiCreateWithStringOrSliceEntrypoint(c *check.C) {
+func (s *DockerSuite) TestPostContainerAPICreateWithStringOrSliceEntrypoint(c *check.C) {
 	config := struct {
 		Image      string
 		Entrypoint string
@@ -1215,7 +1215,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCapAddDrop(c *che
 }
 
 // #14915
-func (s *DockerSuite) TestContainerApiCreateNoHostConfig118(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateNoHostConfig118(c *check.C) {
 	config := struct {
 		Image string
 	}{"busybox"}
@@ -1259,7 +1259,7 @@ func (s *DockerSuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRootfs(
 	}
 }
 
-func (s *DockerSuite) TestContainerApiGetContainersJSONEmpty(c *check.C) {
+func (s *DockerSuite) TestContainerAPIGetContainersJSONEmpty(c *check.C) {
 	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK)
@@ -1463,14 +1463,14 @@ func (s *DockerSuite) TestPostContainersCreateWithOomScoreAdjInvalidRange(c *che
 }
 
 // test case for #22210 where an empty container name caused panic.
-func (s *DockerSuite) TestContainerApiDeleteWithEmptyName(c *check.C) {
+func (s *DockerSuite) TestContainerAPIDeleteWithEmptyName(c *check.C) {
 	status, out, err := sockRequest("DELETE", "/containers/", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusBadRequest)
 	c.Assert(string(out), checker.Contains, "No container name or ID supplied")
 }
 
-func (s *DockerSuite) TestContainerApiStatsWithNetworkDisabled(c *check.C) {
+func (s *DockerSuite) TestContainerAPIStatsWithNetworkDisabled(c *check.C) {
 	// Problematic on Windows as Windows does not support stats
 	testRequires(c, DaemonIsLinux)
 
@@ -1522,7 +1522,7 @@ func (s *DockerSuite) TestContainerApiStatsWithNetworkDisabled(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestContainersApiCreateMountsValidation(c *check.C) {
+func (s *DockerSuite) TestContainersAPICreateMountsValidation(c *check.C) {
 	type m mounttypes.Mount
 	type hc struct{ Mounts []m }
 	type cfg struct {
@@ -1577,7 +1577,7 @@ func (s *DockerSuite) TestContainersApiCreateMountsValidation(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestContainerApiCreateMountsBindRead(c *check.C) {
+func (s *DockerSuite) TestContainerAPICreateMountsBindRead(c *check.C) {
 	testRequires(c, NotUserNamespace, SameHostDaemon)
 	// also with data in the host side
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
@@ -1602,7 +1602,7 @@ func (s *DockerSuite) TestContainerApiCreateMountsBindRead(c *check.C) {
 }
 
 // Test Mounts comes out as expected for the MountPoint
-func (s *DockerSuite) TestContainersApiCreateMountsCreate(c *check.C) {
+func (s *DockerSuite) TestContainersAPICreateMountsCreate(c *check.C) {
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 	destPath := prefix + slash + "foo"
 

--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestApiCreateWithNotExistImage(c *check.C) {
+func (s *DockerSuite) TestAPICreateWithNotExistImage(c *check.C) {
 	name := "test"
 	config := map[string]interface{}{
 		"Image":   "test456:v1",

--- a/integration-cli/docker_api_events_test.go
+++ b/integration-cli/docker_api_events_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestEventsApiEmptyOutput(c *check.C) {
+func (s *DockerSuite) TestEventsAPIEmptyOutput(c *check.C) {
 	type apiResp struct {
 		resp *http.Response
 		err  error
@@ -35,7 +35,7 @@ func (s *DockerSuite) TestEventsApiEmptyOutput(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestEventsApiBackwardsCompatible(c *check.C) {
+func (s *DockerSuite) TestEventsAPIBackwardsCompatible(c *check.C) {
 	since := daemonTime(c).Unix()
 	ts := strconv.FormatInt(since, 10)
 

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
+func (s *DockerSuite) TestExecResizeAPIHeightWidthNoInt(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Regression test for #9414
-func (s *DockerSuite) TestExecApiCreateNoCmd(c *check.C) {
+func (s *DockerSuite) TestExecAPICreateNoCmd(c *check.C) {
 	name := "exec_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
@@ -27,7 +27,7 @@ func (s *DockerSuite) TestExecApiCreateNoCmd(c *check.C) {
 	c.Assert(getErrorMessage(c, body), checker.Contains, "No exec command specified", comment)
 }
 
-func (s *DockerSuite) TestExecApiCreateNoValidContentType(c *check.C) {
+func (s *DockerSuite) TestExecAPICreateNoValidContentType(c *check.C) {
 	name := "exec_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestExecApiCreateNoValidContentType(c *check.C) {
 	c.Assert(getErrorMessage(c, b), checker.Contains, "Content-Type specified", comment)
 }
 
-func (s *DockerSuite) TestExecApiCreateContainerPaused(c *check.C) {
+func (s *DockerSuite) TestExecAPICreateContainerPaused(c *check.C) {
 	// Not relevant on Windows as Windows containers cannot be paused
 	testRequires(c, DaemonIsLinux)
 	name := "exec_create_test"
@@ -62,7 +62,7 @@ func (s *DockerSuite) TestExecApiCreateContainerPaused(c *check.C) {
 	c.Assert(getErrorMessage(c, body), checker.Contains, "Container "+name+" is paused, unpause the container before exec", comment)
 }
 
-func (s *DockerSuite) TestExecApiStart(c *check.C) {
+func (s *DockerSuite) TestExecAPIStart(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Uses pause/unpause but bits may be salvagable to Windows to Windows CI
 	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
 
@@ -85,7 +85,7 @@ func (s *DockerSuite) TestExecApiStart(c *check.C) {
 	startExec(c, id, http.StatusOK)
 }
 
-func (s *DockerSuite) TestExecApiStartBackwardsCompatible(c *check.C) {
+func (s *DockerSuite) TestExecAPIStartBackwardsCompatible(c *check.C) {
 	runSleepingContainer(c, "-d", "--name", "test")
 	id := createExec(c, "test")
 
@@ -99,7 +99,7 @@ func (s *DockerSuite) TestExecApiStartBackwardsCompatible(c *check.C) {
 }
 
 // #19362
-func (s *DockerSuite) TestExecApiStartMultipleTimesError(c *check.C) {
+func (s *DockerSuite) TestExecAPIStartMultipleTimesError(c *check.C) {
 	runSleepingContainer(c, "-d", "--name", "test")
 	execID := createExec(c, "test")
 	startExec(c, execID, http.StatusOK)
@@ -123,7 +123,7 @@ func (s *DockerSuite) TestExecApiStartMultipleTimesError(c *check.C) {
 }
 
 // #20638
-func (s *DockerSuite) TestExecApiStartWithDetach(c *check.C) {
+func (s *DockerSuite) TestExecAPIStartWithDetach(c *check.C) {
 	name := "foo"
 	runSleepingContainer(c, "-d", "-t", "--name", name)
 	data := map[string]interface{}{

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
+func (s *DockerSuite) TestAPIImagesFilter(c *check.C) {
 	name := "utest:tag1"
 	name2 := "utest/docker:tag2"
 	name3 := "utest:5000/docker:tag3"
@@ -47,7 +47,7 @@ func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 	c.Assert(images[0].RepoTags, checker.HasLen, 1)
 }
 
-func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
+func (s *DockerSuite) TestAPIImagesSaveAndLoad(c *check.C) {
 	// TODO Windows to Windows CI: Investigate further why this test fails.
 	testRequires(c, Network)
 	testRequires(c, DaemonIsLinux)
@@ -71,7 +71,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 	c.Assert(strings.TrimSpace(string(inspectOut)), checker.Equals, id, check.Commentf("load did not work properly"))
 }
 
-func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
+func (s *DockerSuite) TestAPIImagesDelete(c *check.C) {
 	if daemonPlatform != "windows" {
 		testRequires(c, Network)
 	}
@@ -95,7 +95,7 @@ func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusOK)
 }
 
-func (s *DockerSuite) TestApiImagesHistory(c *check.C) {
+func (s *DockerSuite) TestAPIImagesHistory(c *check.C) {
 	if daemonPlatform != "windows" {
 		testRequires(c, Network)
 	}
@@ -118,7 +118,7 @@ func (s *DockerSuite) TestApiImagesHistory(c *check.C) {
 }
 
 // #14846
-func (s *DockerSuite) TestApiImagesSearchJSONContentType(c *check.C) {
+func (s *DockerSuite) TestAPIImagesSearchJSONContentType(c *check.C) {
 	testRequires(c, Network)
 
 	res, b, err := sockRequestRaw("GET", "/images/search?term=test", nil, "application/json")

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestInfoApi(c *check.C) {
+func (s *DockerSuite) TestInfoAPI(c *check.C) {
 	endpoint := "/info"
 
 	status, body, err := sockRequest("GET", endpoint, nil)

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
+func (s *DockerSuite) TestInspectAPIContainerResponse(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -56,7 +56,7 @@ func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestInspectApiContainerVolumeDriverLegacy(c *check.C) {
+func (s *DockerSuite) TestInspectAPIContainerVolumeDriverLegacy(c *check.C) {
 	// No legacy implications for Windows
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
@@ -75,11 +75,11 @@ func (s *DockerSuite) TestInspectApiContainerVolumeDriverLegacy(c *check.C) {
 		c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
 		cfg := config.(map[string]interface{})
 		_, ok = cfg["VolumeDriver"]
-		c.Assert(ok, checker.True, check.Commentf("Api version %s expected to include VolumeDriver in 'Config'", version))
+		c.Assert(ok, checker.True, check.Commentf("API version %s expected to include VolumeDriver in 'Config'", version))
 	}
 }
 
-func (s *DockerSuite) TestInspectApiContainerVolumeDriver(c *check.C) {
+func (s *DockerSuite) TestInspectAPIContainerVolumeDriver(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "--volume-driver", "local", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -94,16 +94,16 @@ func (s *DockerSuite) TestInspectApiContainerVolumeDriver(c *check.C) {
 	c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
 	cfg := config.(map[string]interface{})
 	_, ok = cfg["VolumeDriver"]
-	c.Assert(ok, checker.False, check.Commentf("Api version 1.21 expected to not include VolumeDriver in 'Config'"))
+	c.Assert(ok, checker.False, check.Commentf("API version 1.21 expected to not include VolumeDriver in 'Config'"))
 
 	config, ok = inspectJSON["HostConfig"]
 	c.Assert(ok, checker.True, check.Commentf("Unable to find 'HostConfig'"))
 	cfg = config.(map[string]interface{})
 	_, ok = cfg["VolumeDriver"]
-	c.Assert(ok, checker.True, check.Commentf("Api version 1.21 expected to include VolumeDriver in 'HostConfig'"))
+	c.Assert(ok, checker.True, check.Commentf("API version 1.21 expected to include VolumeDriver in 'HostConfig'"))
 }
 
-func (s *DockerSuite) TestInspectApiImageResponse(c *check.C) {
+func (s *DockerSuite) TestInspectAPIImageResponse(c *check.C) {
 	dockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
 
 	endpoint := "/images/busybox/json"
@@ -122,7 +122,7 @@ func (s *DockerSuite) TestInspectApiImageResponse(c *check.C) {
 }
 
 // #17131, #17139, #17173
-func (s *DockerSuite) TestInspectApiEmptyFieldsInConfigPre121(c *check.C) {
+func (s *DockerSuite) TestInspectAPIEmptyFieldsInConfigPre121(c *check.C) {
 	// Not relevant on Windows
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
@@ -141,12 +141,12 @@ func (s *DockerSuite) TestInspectApiEmptyFieldsInConfigPre121(c *check.C) {
 		cfg := config.(map[string]interface{})
 		for _, f := range []string{"MacAddress", "NetworkDisabled", "ExposedPorts"} {
 			_, ok := cfg[f]
-			c.Check(ok, checker.True, check.Commentf("Api version %s expected to include %s in 'Config'", version, f))
+			c.Check(ok, checker.True, check.Commentf("API version %s expected to include %s in 'Config'", version, f))
 		}
 	}
 }
 
-func (s *DockerSuite) TestInspectApiBridgeNetworkSettings120(c *check.C) {
+func (s *DockerSuite) TestInspectAPIBridgeNetworkSettings120(c *check.C) {
 	// Not relevant on Windows, and besides it doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -163,7 +163,7 @@ func (s *DockerSuite) TestInspectApiBridgeNetworkSettings120(c *check.C) {
 	c.Assert(settings.IPAddress, checker.Not(checker.HasLen), 0)
 }
 
-func (s *DockerSuite) TestInspectApiBridgeNetworkSettings121(c *check.C) {
+func (s *DockerSuite) TestInspectAPIBridgeNetworkSettings121(c *check.C) {
 	// Windows doesn't have any bridge network settings
 	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")

--- a/integration-cli/docker_api_inspect_unix_test.go
+++ b/integration-cli/docker_api_inspect_unix_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // #16665
-func (s *DockerSuite) TestInspectApiCpusetInConfigPre120(c *check.C) {
+func (s *DockerSuite) TestInspectAPICpusetInConfigPre120(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, cgroupCpuset)
 
@@ -31,5 +31,5 @@ func (s *DockerSuite) TestInspectApiCpusetInConfigPre120(c *check.C) {
 	c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
 	cfg := config.(map[string]interface{})
 	_, ok = cfg["Cpuset"]
-	c.Assert(ok, checker.True, check.Commentf("Api version 1.19 expected to include Cpuset in 'Config'"))
+	c.Assert(ok, checker.True, check.Commentf("API version 1.19 expected to include Cpuset in 'Config'"))
 }

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
+func (s *DockerSuite) TestLogsAPIWithStdout(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 1; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), checker.IsNil)
@@ -51,7 +51,7 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
+func (s *DockerSuite) TestLogsAPINoStdoutNorStderr(c *check.C) {
 	name := "logs_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
@@ -64,7 +64,7 @@ func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
 }
 
 // Regression test for #12704
-func (s *DockerSuite) TestLogsApiFollowEmptyOutput(c *check.C) {
+func (s *DockerSuite) TestLogsAPIFollowEmptyOutput(c *check.C) {
 	name := "logs_test"
 	t0 := time.Now()
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")
@@ -79,7 +79,7 @@ func (s *DockerSuite) TestLogsApiFollowEmptyOutput(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestLogsApiContainerNotFound(c *check.C) {
+func (s *DockerSuite) TestLogsAPIContainerNotFound(c *check.C) {
 	name := "nonExistentContainer"
 	resp, _, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "")
 	c.Assert(err, checker.IsNil)

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestApiNetworkGetDefaults(c *check.C) {
+func (s *DockerSuite) TestAPINetworkGetDefaults(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// By default docker daemon creates 3 networks. check if they are present
 	defaults := []string{"bridge", "host", "none"}
@@ -24,7 +24,7 @@ func (s *DockerSuite) TestApiNetworkGetDefaults(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestApiNetworkCreateDelete(c *check.C) {
+func (s *DockerSuite) TestAPINetworkCreateDelete(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// Create a network
 	name := "testnetwork"
@@ -42,7 +42,7 @@ func (s *DockerSuite) TestApiNetworkCreateDelete(c *check.C) {
 	c.Assert(isNetworkAvailable(c, name), checker.Equals, false)
 }
 
-func (s *DockerSuite) TestApiNetworkCreateCheckDuplicate(c *check.C) {
+func (s *DockerSuite) TestAPINetworkCreateCheckDuplicate(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	name := "testcheckduplicate"
 	configOnCheck := types.NetworkCreateRequest{
@@ -69,13 +69,13 @@ func (s *DockerSuite) TestApiNetworkCreateCheckDuplicate(c *check.C) {
 	createNetwork(c, configNotCheck, true)
 }
 
-func (s *DockerSuite) TestApiNetworkFilter(c *check.C) {
+func (s *DockerSuite) TestAPINetworkFilter(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	nr := getNetworkResource(c, getNetworkIDByName(c, "bridge"))
 	c.Assert(nr.Name, checker.Equals, "bridge")
 }
 
-func (s *DockerSuite) TestApiNetworkInspect(c *check.C) {
+func (s *DockerSuite) TestAPINetworkInspect(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// Inspect default bridge network
 	nr := getNetworkResource(c, "bridge")
@@ -129,7 +129,7 @@ func (s *DockerSuite) TestApiNetworkInspect(c *check.C) {
 	c.Assert(isNetworkAvailable(c, "br0"), checker.Equals, false)
 }
 
-func (s *DockerSuite) TestApiNetworkConnectDisconnect(c *check.C) {
+func (s *DockerSuite) TestAPINetworkConnectDisconnect(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// Create test network
 	name := "testnetwork"
@@ -170,7 +170,7 @@ func (s *DockerSuite) TestApiNetworkConnectDisconnect(c *check.C) {
 	deleteNetwork(c, nr.ID, true)
 }
 
-func (s *DockerSuite) TestApiNetworkIpamMultipleBridgeNetworks(c *check.C) {
+func (s *DockerSuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	// test0 bridge network
 	ipam0 := &network.IPAM{
@@ -235,7 +235,7 @@ func (s *DockerSuite) TestApiNetworkIpamMultipleBridgeNetworks(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestApiCreateDeletePredefinedNetworks(c *check.C) {
+func (s *DockerSuite) TestAPICreateDeletePredefinedNetworks(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	createDeletePredefinedNetwork(c, "bridge")
 	createDeletePredefinedNetwork(c, "none")

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
+func (s *DockerSuite) TestResizeAPIResponse(c *check.C) {
 	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -18,7 +18,7 @@ func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
+func (s *DockerSuite) TestResizeAPIHeightWidthNoInt(c *check.C) {
 	out, _ := runSleepingContainer(c, "-d")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
+func (s *DockerSuite) TestResizeAPIResponseWhenContainerNotStarted(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 

--- a/integration-cli/docker_api_service_update_test.go
+++ b/integration-cli/docker_api_service_update_test.go
@@ -17,7 +17,7 @@ func setPortConfig(portConfig []swarm.PortConfig) serviceConstructor {
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiServiceUpdatePort(c *check.C) {
+func (s *DockerSwarmSuite) TestAPIServiceUpdatePort(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	// Create a service with a port mapping of 8080:8081.

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -19,7 +19,7 @@ import (
 
 var expectedNetworkInterfaceStats = strings.Split("rx_bytes rx_dropped rx_errors rx_packets tx_bytes tx_dropped tx_errors tx_packets", " ")
 
-func (s *DockerSuite) TestApiStatsNoStreamGetCpu(c *check.C) {
+func (s *DockerSuite) TestAPIStatsNoStreamGetCpu(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
 
 	id := strings.TrimSpace(out)
@@ -59,7 +59,7 @@ func (s *DockerSuite) TestApiStatsNoStreamGetCpu(c *check.C) {
 	c.Assert(cpuPercent, check.Not(checker.Equals), 0.0, check.Commentf("docker stats with no-stream get cpu usage failed: was %v", cpuPercent))
 }
 
-func (s *DockerSuite) TestApiStatsStoppedContainerInGoroutines(c *check.C) {
+func (s *DockerSuite) TestAPIStatsStoppedContainerInGoroutines(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1")
 	id := strings.TrimSpace(out)
 
@@ -94,7 +94,7 @@ func (s *DockerSuite) TestApiStatsStoppedContainerInGoroutines(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestApiStatsNetworkStats(c *check.C) {
+func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	out, _ := runSleepingContainer(c)
@@ -161,7 +161,7 @@ func (s *DockerSuite) TestApiStatsNetworkStats(c *check.C) {
 		check.Commentf("Reported less Txbytes than expected. Expected >= %d. Found %d. %s", expRxPkts, postRxPackets, pingouts))
 }
 
-func (s *DockerSuite) TestApiStatsNetworkStatsVersioning(c *check.C) {
+func (s *DockerSuite) TestAPIStatsNetworkStatsVersioning(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	out, _ := runSleepingContainer(c)
@@ -257,7 +257,7 @@ func jsonBlobHasGTE121NetworkStats(blob map[string]interface{}) bool {
 	return true
 }
 
-func (s *DockerSuite) TestApiStatsContainerNotFound(c *check.C) {
+func (s *DockerSuite) TestAPIStatsContainerNotFound(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	status, _, err := sockRequest("GET", "/containers/nonexistent/stats", nil)
@@ -269,7 +269,7 @@ func (s *DockerSuite) TestApiStatsContainerNotFound(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNotFound)
 }
 
-func (s *DockerSuite) TestApiStatsNoStreamConnectedContainers(c *check.C) {
+func (s *DockerSuite) TestAPIStatsNoStreamConnectedContainers(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	out1, _ := runSleepingContainer(c)

--- a/integration-cli/docker_api_stats_unix_test.go
+++ b/integration-cli/docker_api_stats_unix_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestApiStatsContainerGetMemoryLimit(c *check.C) {
+func (s *DockerSuite) TestAPIStatsContainerGetMemoryLimit(c *check.C) {
 	testRequires(c, DaemonIsLinux, memoryLimitSupport)
 
 	resp, body, err := sockRequestRaw("GET", "/info", nil, "application/json")

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -20,7 +20,7 @@ import (
 
 var defaultReconciliationTimeout = 30 * time.Second
 
-func (s *DockerSwarmSuite) TestApiSwarmInit(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmInit(c *check.C) {
 	// todo: should find a better way to verify that components are running than /info
 	d1 := s.AddDaemon(c, true, true)
 	info, err := d1.info()
@@ -71,7 +71,7 @@ func (s *DockerSwarmSuite) TestApiSwarmInit(c *check.C) {
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateActive)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmJoinToken(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmJoinToken(c *check.C) {
 	d1 := s.AddDaemon(c, false, false)
 	c.Assert(d1.Init(swarm.InitRequest{}), checker.IsNil)
 
@@ -142,7 +142,7 @@ func (s *DockerSwarmSuite) TestApiSwarmJoinToken(c *check.C) {
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmCAHash(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmCAHash(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, false, false)
 	splitToken := strings.Split(d1.joinTokens(c).Worker, "-")
@@ -153,7 +153,7 @@ func (s *DockerSwarmSuite) TestApiSwarmCAHash(c *check.C) {
 	c.Assert(err.Error(), checker.Contains, "remote CA does not match fingerprint")
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmPromoteDemote(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmPromoteDemote(c *check.C) {
 	d1 := s.AddDaemon(c, false, false)
 	c.Assert(d1.Init(swarm.InitRequest{}), checker.IsNil)
 	d2 := s.AddDaemon(c, true, false)
@@ -196,7 +196,7 @@ func (s *DockerSwarmSuite) TestApiSwarmPromoteDemote(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, d2.checkControlAvailable, checker.True)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesEmptyList(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesEmptyList(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	services := d.listServices(c)
@@ -204,7 +204,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesEmptyList(c *check.C) {
 	c.Assert(len(services), checker.Equals, 0, check.Commentf("services: %#v", services))
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesCreate(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -220,7 +220,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesCreate(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 0)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesMultipleAgents(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesMultipleAgents(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
@@ -248,7 +248,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesMultipleAgents(c *check.C) {
 
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesCreateGlobal(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesCreateGlobal(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
@@ -266,7 +266,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesCreateGlobal(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, d5.checkActiveContainerCount, checker.Equals, 1)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesUpdate(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *check.C) {
 	const nodeCount = 3
 	var daemons [nodeCount]*SwarmDaemon
 	for i := 0; i < nodeCount; i++ {
@@ -312,7 +312,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesUpdate(c *check.C) {
 		map[string]int{image2: instances})
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServiceConstraintRole(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintRole(c *check.C) {
 	const nodeCount = 3
 	var daemons [nodeCount]*SwarmDaemon
 	for i := 0; i < nodeCount; i++ {
@@ -364,7 +364,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServiceConstraintRole(c *check.C) {
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServiceConstraintLabel(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintLabel(c *check.C) {
 	const nodeCount = 3
 	var daemons [nodeCount]*SwarmDaemon
 	for i := 0; i < nodeCount; i++ {
@@ -459,7 +459,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServiceConstraintLabel(c *check.C) {
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesStateReporting(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *check.C) {
 	testRequires(c, SameHostDaemon)
 	testRequires(c, DaemonIsLinux)
 
@@ -533,7 +533,7 @@ func (s *DockerSwarmSuite) TestApiSwarmServicesStateReporting(c *check.C) {
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmLeaderProxy(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmLeaderProxy(c *check.C) {
 	// add three managers, one of these is leader
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, true)
@@ -558,7 +558,7 @@ func (s *DockerSwarmSuite) TestApiSwarmLeaderProxy(c *check.C) {
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmLeaderElection(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmLeaderElection(c *check.C) {
 	// Create 3 nodes
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, true)
@@ -621,7 +621,7 @@ func (s *DockerSwarmSuite) TestApiSwarmLeaderElection(c *check.C) {
 	c.Assert(leader.NodeID, checker.Equals, stableleader.NodeID)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmRaftQuorum(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, true)
 	d3 := s.AddDaemon(c, true, true)
@@ -659,7 +659,7 @@ func (s *DockerSwarmSuite) TestApiSwarmRaftQuorum(c *check.C) {
 	})
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmListNodes(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmListNodes(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 	d3 := s.AddDaemon(c, true, false)
@@ -678,7 +678,7 @@ loop0:
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmNodeUpdate(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmNodeUpdate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	nodes := d.listNodes(c)
@@ -691,7 +691,7 @@ func (s *DockerSwarmSuite) TestApiSwarmNodeUpdate(c *check.C) {
 	c.Assert(n.Spec.Availability, checker.Equals, swarm.NodeAvailabilityPause)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmNodeRemove(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmNodeRemove(c *check.C) {
 	testRequires(c, Network)
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
@@ -722,7 +722,7 @@ func (s *DockerSwarmSuite) TestApiSwarmNodeRemove(c *check.C) {
 	c.Assert(len(nodes), checker.Equals, 2, check.Commentf("nodes: %#v", nodes))
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmNodeDrainPause(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmNodeDrainPause(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, false)
 
@@ -776,7 +776,7 @@ func (s *DockerSwarmSuite) TestApiSwarmNodeDrainPause(c *check.C) {
 
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmLeaveRemovesContainer(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmLeaveRemovesContainer(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -799,7 +799,7 @@ func (s *DockerSwarmSuite) TestApiSwarmLeaveRemovesContainer(c *check.C) {
 }
 
 // #23629
-func (s *DockerSwarmSuite) TestApiSwarmLeaveOnPendingJoin(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmLeaveOnPendingJoin(c *check.C) {
 	s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, false, false)
 
@@ -827,7 +827,7 @@ func (s *DockerSwarmSuite) TestApiSwarmLeaveOnPendingJoin(c *check.C) {
 }
 
 // #23705
-func (s *DockerSwarmSuite) TestApiSwarmRestoreOnPendingJoin(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmRestoreOnPendingJoin(c *check.C) {
 	d := s.AddDaemon(c, false, false)
 	err := d.Join(swarm.JoinRequest{
 		RemoteAddrs: []string{"123.123.123.123:1234"},
@@ -845,7 +845,7 @@ func (s *DockerSwarmSuite) TestApiSwarmRestoreOnPendingJoin(c *check.C) {
 	c.Assert(info.LocalNodeState, checker.Equals, swarm.LocalNodeStateInactive)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmManagerRestore(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmManagerRestore(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -874,7 +874,7 @@ func (s *DockerSwarmSuite) TestApiSwarmManagerRestore(c *check.C) {
 	d3.getService(c, id)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmScaleNoRollingUpdate(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmScaleNoRollingUpdate(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2
@@ -898,7 +898,7 @@ loop0:
 	}
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmInvalidAddress(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmInvalidAddress(c *check.C) {
 	d := s.AddDaemon(c, false, false)
 	req := swarm.InitRequest{
 		ListenAddr: "",
@@ -916,7 +916,7 @@ func (s *DockerSwarmSuite) TestApiSwarmInvalidAddress(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusInternalServerError)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmForceNewCluster(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmForceNewCluster(c *check.C) {
 	d1 := s.AddDaemon(c, true, true)
 	d2 := s.AddDaemon(c, true, true)
 
@@ -1099,7 +1099,7 @@ func checkClusterHealth(c *check.C, cl []*SwarmDaemon, managerCount, workerCount
 	c.Assert(totalWCount, checker.Equals, workerCount)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmRestartCluster(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmRestartCluster(c *check.C) {
 	mCount, wCount := 5, 1
 
 	var nodes []*SwarmDaemon
@@ -1169,7 +1169,7 @@ func (s *DockerSwarmSuite) TestApiSwarmRestartCluster(c *check.C) {
 	checkClusterHealth(c, nodes, mCount, wCount)
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesUpdateWithName(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	instances := 2

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestApiOptionsRoute(c *check.C) {
+func (s *DockerSuite) TestAPIOptionsRoute(c *check.C) {
 	status, _, err := sockRequest("OPTIONS", "/", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusOK)
 }
 
-func (s *DockerSuite) TestApiGetEnabledCors(c *check.C) {
+func (s *DockerSuite) TestAPIGetEnabledCORS(c *check.C) {
 	res, body, err := sockRequestRaw("GET", "/version", nil, "")
 	c.Assert(err, checker.IsNil)
 	c.Assert(res.StatusCode, checker.Equals, http.StatusOK)
@@ -33,7 +33,7 @@ func (s *DockerSuite) TestApiGetEnabledCors(c *check.C) {
 	//c.Assert(res.Header.Get("Access-Control-Allow-Headers"), check.Equals, "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
 }
 
-func (s *DockerSuite) TestApiVersionStatusCode(c *check.C) {
+func (s *DockerSuite) TestAPIVersionStatusCode(c *check.C) {
 	conn, err := sockConn(time.Duration(10*time.Second), "")
 	c.Assert(err, checker.IsNil)
 
@@ -48,7 +48,7 @@ func (s *DockerSuite) TestApiVersionStatusCode(c *check.C) {
 	c.Assert(res.StatusCode, checker.Equals, http.StatusBadRequest)
 }
 
-func (s *DockerSuite) TestApiClientVersionNewerThanServer(c *check.C) {
+func (s *DockerSuite) TestAPIClientVersionNewerThanServer(c *check.C) {
 	v := strings.Split(api.DefaultVersion, ".")
 	vMinInt, err := strconv.Atoi(v[1])
 	c.Assert(err, checker.IsNil)
@@ -63,7 +63,7 @@ func (s *DockerSuite) TestApiClientVersionNewerThanServer(c *check.C) {
 	c.Assert(getErrorMessage(c, body), checker.Equals, expected)
 }
 
-func (s *DockerSuite) TestApiClientVersionOldNotSupported(c *check.C) {
+func (s *DockerSuite) TestAPIClientVersionOldNotSupported(c *check.C) {
 	v := strings.Split(api.MinVersion, ".")
 	vMinInt, err := strconv.Atoi(v[1])
 	c.Assert(err, checker.IsNil)
@@ -78,7 +78,7 @@ func (s *DockerSuite) TestApiClientVersionOldNotSupported(c *check.C) {
 	c.Assert(strings.TrimSpace(string(body)), checker.Equals, expected)
 }
 
-func (s *DockerSuite) TestApiDockerApiVersion(c *check.C) {
+func (s *DockerSuite) TestAPIDockerAPIVersion(c *check.C) {
 	var svrVersion string
 
 	server := httptest.NewServer(http.HandlerFunc(
@@ -97,7 +97,7 @@ func (s *DockerSuite) TestApiDockerApiVersion(c *check.C) {
 	c.Assert(svrVersion, check.Equals, "/vxxx/version", check.Commentf("%s", result.Compare(icmd.Success)))
 }
 
-func (s *DockerSuite) TestApiErrorJSON(c *check.C) {
+func (s *DockerSuite) TestAPIErrorJSON(c *check.C) {
 	httpResp, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(`{}`), "application/json")
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
@@ -107,7 +107,7 @@ func (s *DockerSuite) TestApiErrorJSON(c *check.C) {
 	c.Assert(getErrorMessage(c, b), checker.Equals, "Config cannot be empty in order to create a container")
 }
 
-func (s *DockerSuite) TestApiErrorPlainText(c *check.C) {
+func (s *DockerSuite) TestAPIErrorPlainText(c *check.C) {
 	httpResp, body, err := sockRequestRaw("POST", "/v1.23/containers/create", strings.NewReader(`{}`), "application/json")
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)
@@ -117,7 +117,7 @@ func (s *DockerSuite) TestApiErrorPlainText(c *check.C) {
 	c.Assert(strings.TrimSpace(string(b)), checker.Equals, "Config cannot be empty in order to create a container")
 }
 
-func (s *DockerSuite) TestApiErrorNotFoundJSON(c *check.C) {
+func (s *DockerSuite) TestAPIErrorNotFoundJSON(c *check.C) {
 	// 404 is a different code path to normal errors, so test separately
 	httpResp, body, err := sockRequestRaw("GET", "/notfound", nil, "application/json")
 	c.Assert(err, checker.IsNil)
@@ -128,7 +128,7 @@ func (s *DockerSuite) TestApiErrorNotFoundJSON(c *check.C) {
 	c.Assert(getErrorMessage(c, b), checker.Equals, "page not found")
 }
 
-func (s *DockerSuite) TestApiErrorNotFoundPlainText(c *check.C) {
+func (s *DockerSuite) TestAPIErrorNotFoundPlainText(c *check.C) {
 	httpResp, body, err := sockRequestRaw("GET", "/v1.23/notfound", nil, "application/json")
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusNotFound)

--- a/integration-cli/docker_api_update_unix_test.go
+++ b/integration-cli/docker_api_update_unix_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestApiUpdateContainer(c *check.C) {
+func (s *DockerSuite) TestAPIUpdateContainer(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, memoryLimitSupport)
 	testRequires(c, swapMemorySupport)

--- a/integration-cli/docker_api_volumes_test.go
+++ b/integration-cli/docker_api_volumes_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestVolumesApiList(c *check.C) {
+func (s *DockerSuite) TestVolumesAPIList(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "run", "-v", prefix+"/foo", "busybox")
 
@@ -24,7 +24,7 @@ func (s *DockerSuite) TestVolumesApiList(c *check.C) {
 	c.Assert(len(volumes.Volumes), checker.Equals, 1, check.Commentf("\n%v", volumes.Volumes))
 }
 
-func (s *DockerSuite) TestVolumesApiCreate(c *check.C) {
+func (s *DockerSuite) TestVolumesAPICreate(c *check.C) {
 	config := types.VolumeCreateRequest{
 		Name: "test",
 	}
@@ -39,7 +39,7 @@ func (s *DockerSuite) TestVolumesApiCreate(c *check.C) {
 	c.Assert(filepath.Base(filepath.Dir(vol.Mountpoint)), checker.Equals, config.Name)
 }
 
-func (s *DockerSuite) TestVolumesApiRemove(c *check.C) {
+func (s *DockerSuite) TestVolumesAPIRemove(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "run", "-v", prefix+"/foo", "--name=test", "busybox")
 
@@ -63,7 +63,7 @@ func (s *DockerSuite) TestVolumesApiRemove(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestVolumesApiInspect(c *check.C) {
+func (s *DockerSuite) TestVolumesAPIInspect(c *check.C) {
 	config := types.VolumeCreateRequest{
 		Name: "test",
 	}

--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -276,8 +276,8 @@ func (s *DockerAuthzSuite) TestAuthZPluginDenyRequest(c *check.C) {
 	c.Assert(res, check.Equals, fmt.Sprintf("Error response from daemon: authorization denied by plugin %s: %s\n", testAuthZPlugin, unauthorizedMessage))
 }
 
-// TestAuthZPluginApiDenyResponse validates that when authorization plugin deny the request, the status code is forbidden
-func (s *DockerAuthzSuite) TestAuthZPluginApiDenyResponse(c *check.C) {
+// TestAuthZPluginAPIDenyResponse validates that when authorization plugin deny the request, the status code is forbidden
+func (s *DockerAuthzSuite) TestAuthZPluginAPIDenyResponse(c *check.C) {
 	err := s.d.Start("--authorization-plugin=" + testAuthZPlugin)
 	c.Assert(err, check.IsNil)
 	s.ctrl.reqRes.Allow = false

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4001,7 +4001,7 @@ func (s *DockerSuite) TestBuildAddTarXzGz(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
+func (s *DockerSuite) TestBuildFromGit(c *check.C) {
 	name := "testbuildfromgit"
 	git, err := newFakeGit("repo", map[string]string{
 		"Dockerfile": `FROM busybox
@@ -4025,7 +4025,7 @@ func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
+func (s *DockerSuite) TestBuildFromGitWithContext(c *check.C) {
 	name := "testbuildfromgit"
 	git, err := newFakeGit("repo", map[string]string{
 		"docker/Dockerfile": `FROM busybox
@@ -4050,7 +4050,7 @@ func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestBuildFromGITwithF(c *check.C) {
+func (s *DockerSuite) TestBuildFromGitwithF(c *check.C) {
 	name := "testbuildfromgitwithf"
 	git, err := newFakeGit("repo", map[string]string{
 		"myApp/myDockerfile": `FROM busybox

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestConfigHttpHeader(c *check.C) {
+func (s *DockerSuite) TestConfigHTTPHeader(c *check.C) {
 	testRequires(c, UnixCli) // Can't set/unset HOME on windows right now
 	// We either need a level of Go that supports Unsetenv (for cases
 	// when HOME/USERPROFILE isn't set), or we need to be able to use

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1409,8 +1409,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartKillWait(c *check.C) {
 	}
 }
 
-// TestHttpsInfo connects via two-way authenticated HTTPS to the info endpoint
-func (s *DockerDaemonSuite) TestHttpsInfo(c *check.C) {
+// TestHTTPSInfo connects via two-way authenticated HTTPS to the info endpoint
+func (s *DockerDaemonSuite) TestHTTPSInfo(c *check.C) {
 	const (
 		testDaemonHTTPSAddr = "tcp://localhost:4271"
 	)
@@ -1433,9 +1433,9 @@ func (s *DockerDaemonSuite) TestHttpsInfo(c *check.C) {
 	}
 }
 
-// TestHttpsRun connects via two-way authenticated HTTPS to the create, attach, start, and wait endpoints.
+// TestHTTPSRun connects via two-way authenticated HTTPS to the create, attach, start, and wait endpoints.
 // https://github.com/docker/docker/issues/19280
-func (s *DockerDaemonSuite) TestHttpsRun(c *check.C) {
+func (s *DockerDaemonSuite) TestHTTPSRun(c *check.C) {
 	const (
 		testDaemonHTTPSAddr = "tcp://localhost:4271"
 	)
@@ -1462,17 +1462,17 @@ func (s *DockerDaemonSuite) TestHttpsRun(c *check.C) {
 	}
 }
 
-// TestTlsVerify verifies that --tlsverify=false turns on tls
-func (s *DockerDaemonSuite) TestTlsVerify(c *check.C) {
+// TestTLSVerify verifies that --tlsverify=false turns on tls
+func (s *DockerDaemonSuite) TestTLSVerify(c *check.C) {
 	out, err := exec.Command(dockerdBinary, "--tlsverify=false").CombinedOutput()
 	if err == nil || !strings.Contains(string(out), "Could not load X509 key pair") {
 		c.Fatalf("Daemon should not have started due to missing certs: %v\n%s", err, string(out))
 	}
 }
 
-// TestHttpsInfoRogueCert connects via two-way authenticated HTTPS to the info endpoint
+// TestHTTPSInfoRogueCert connects via two-way authenticated HTTPS to the info endpoint
 // by using a rogue client certificate and checks that it fails with the expected error.
-func (s *DockerDaemonSuite) TestHttpsInfoRogueCert(c *check.C) {
+func (s *DockerDaemonSuite) TestHTTPSInfoRogueCert(c *check.C) {
 	const (
 		errBadCertificate   = "bad certificate"
 		testDaemonHTTPSAddr = "tcp://localhost:4271"
@@ -1496,9 +1496,9 @@ func (s *DockerDaemonSuite) TestHttpsInfoRogueCert(c *check.C) {
 	}
 }
 
-// TestHttpsInfoRogueServerCert connects via two-way authenticated HTTPS to the info endpoint
+// TestHTTPSInfoRogueServerCert connects via two-way authenticated HTTPS to the info endpoint
 // which provides a rogue server certificate and checks that it fails with the expected error
-func (s *DockerDaemonSuite) TestHttpsInfoRogueServerCert(c *check.C) {
+func (s *DockerDaemonSuite) TestHTTPSInfoRogueServerCert(c *check.C) {
 	const (
 		errCaUnknown             = "x509: certificate signed by unknown authority"
 		testDaemonRogueHTTPSAddr = "tcp://localhost:4272"
@@ -1696,7 +1696,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
 }
 
 // tests regression detailed in #13964 where DOCKER_TLS_VERIFY env is ignored
-func (s *DockerDaemonSuite) TestDaemonNoTlsCliTlsVerifyWithEnv(c *check.C) {
+func (s *DockerDaemonSuite) TestDaemonTLSVerifyIssue13964(c *check.C) {
 	host := "tcp://localhost:4271"
 	c.Assert(s.d.Start("-H", host), check.IsNil)
 	cmd := exec.Command(dockerBinary, "-H", host, "info")
@@ -1846,7 +1846,7 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutHost(c *check.C) {
 	c.Assert(s.d.Start(), check.IsNil)
 }
 
-func (s *DockerDaemonSuite) TestDaemonStartWithDefalutTlsHost(c *check.C) {
+func (s *DockerDaemonSuite) TestDaemonStartWithDefalutTLSHost(c *check.C) {
 	s.d.useDefaultTLSHost = true
 	defer func() {
 		s.d.useDefaultTLSHost = false

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const dummyNetworkDriver = "dummy-network-driver"
-const dummyIpamDriver = "dummy-ipam-driver"
+const dummyIPAMDriver = "dummy-ipam-driver"
 
 var remoteDriverNetworkRequest remoteapi.CreateNetworkRequest
 
@@ -59,7 +59,7 @@ func (s *DockerNetworkSuite) SetUpSuite(c *check.C) {
 	mux := http.NewServeMux()
 	s.server = httptest.NewServer(mux)
 	c.Assert(s.server, check.NotNil, check.Commentf("Failed to start an HTTP Server"))
-	setupRemoteNetworkDrivers(c, mux, s.server.URL, dummyNetworkDriver, dummyIpamDriver)
+	setupRemoteNetworkDrivers(c, mux, s.server.URL, dummyNetworkDriver, dummyIPAMDriver)
 }
 
 func setupRemoteNetworkDrivers(c *check.C, mux *http.ServeMux, url, netDrv, ipamDrv string) {
@@ -120,7 +120,7 @@ func setupRemoteNetworkDrivers(c *check.C, mux *http.ServeMux, url, netDrv, ipam
 		fmt.Fprintf(w, "null")
 	})
 
-	// Ipam Driver implementation
+	// IPAM Driver implementation
 	var (
 		poolRequest       remoteipam.RequestPoolRequest
 		poolReleaseReq    remoteipam.ReleasePoolRequest
@@ -601,7 +601,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectDisconnect(c *check.C) {
 	assertNwNotAvailable(c, "test")
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkIpamMultipleNetworks(c *check.C) {
+func (s *DockerNetworkSuite) TestDockerNetworkIPAMMultipleNetworks(c *check.C) {
 	// test0 bridge network
 	dockerCmd(c, "network", "create", "--subnet=192.168.0.0/16", "test1")
 	assertNwIsAvailable(c, "test1")
@@ -641,24 +641,24 @@ func (s *DockerNetworkSuite) TestDockerNetworkIpamMultipleNetworks(c *check.C) {
 	}
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkCustomIpam(c *check.C) {
+func (s *DockerNetworkSuite) TestDockerNetworkCustomIPAM(c *check.C) {
 	// Create a bridge network using custom ipam driver
-	dockerCmd(c, "network", "create", "--ipam-driver", dummyIpamDriver, "br0")
+	dockerCmd(c, "network", "create", "--ipam-driver", dummyIPAMDriver, "br0")
 	assertNwIsAvailable(c, "br0")
 
 	// Verify expected network ipam fields are there
 	nr := getNetworkResource(c, "br0")
 	c.Assert(nr.Driver, checker.Equals, "bridge")
-	c.Assert(nr.IPAM.Driver, checker.Equals, dummyIpamDriver)
+	c.Assert(nr.IPAM.Driver, checker.Equals, dummyIPAMDriver)
 
 	// remove network and exercise remote ipam driver
 	dockerCmd(c, "network", "rm", "br0")
 	assertNwNotAvailable(c, "br0")
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkIpamOptions(c *check.C) {
+func (s *DockerNetworkSuite) TestDockerNetworkIPAMOptions(c *check.C) {
 	// Create a bridge network using custom ipam driver and options
-	dockerCmd(c, "network", "create", "--ipam-driver", dummyIpamDriver, "--ipam-opt", "opt1=drv1", "--ipam-opt", "opt2=drv2", "br0")
+	dockerCmd(c, "network", "create", "--ipam-driver", dummyIPAMDriver, "--ipam-opt", "opt1=drv1", "--ipam-opt", "opt2=drv2", "br0")
 	assertNwIsAvailable(c, "br0")
 
 	// Verify expected network ipam options
@@ -734,7 +734,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkInspectCustomSpecified(c *check.C)
 	assertNwNotAvailable(c, "test01")
 }
 
-func (s *DockerNetworkSuite) TestDockerNetworkIpamInvalidCombinations(c *check.C) {
+func (s *DockerNetworkSuite) TestDockerNetworkIPAMInvalidCombinations(c *check.C) {
 	// network with ip-range out of subnet range
 	_, _, err := dockerCmdWithError("network", "create", "--subnet=192.168.0.0/16", "--ip-range=192.170.0.0/16", "test")
 	c.Assert(err, check.NotNil)
@@ -1014,7 +1014,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkMacInspect(c *check.C) {
 	c.Assert(mac, checker.Equals, "a0:b1:c2:d3:e4:f5")
 }
 
-func (s *DockerSuite) TestInspectApiMultipleNetworks(c *check.C) {
+func (s *DockerSuite) TestInspectAPIMultipleNetworks(c *check.C) {
 	dockerCmd(c, "network", "create", "mybridge1")
 	dockerCmd(c, "network", "create", "mybridge2")
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestCliProxyDisableProxyUnixSock(c *check.C) {
+func (s *DockerSuite) TestCLIProxyDisableProxyUnixSock(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon) // test is valid when DOCKER_HOST=unix://..
 
@@ -23,7 +23,7 @@ func (s *DockerSuite) TestCliProxyDisableProxyUnixSock(c *check.C) {
 
 // Can't use localhost here since go has a special case to not use proxy if connecting to localhost
 // See https://golang.org/pkg/net/http/#ProxyFromEnvironment
-func (s *DockerDaemonSuite) TestCliProxyProxyTCPSock(c *check.C) {
+func (s *DockerDaemonSuite) TestCLIProxyProxyTCPSock(c *check.C) {
 	testRequires(c, SameHostDaemon)
 	// get the IP to use to connect since we can't use localhost
 	addrs, err := net.InterfaceAddrs()

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -184,7 +184,7 @@ func (s *DockerSuite) TestRunLinksContainerWithContainerName(c *check.C) {
 }
 
 //test --link use container id to link target
-func (s *DockerSuite) TestRunLinksContainerWithContainerId(c *check.C) {
+func (s *DockerSuite) TestRunLinksContainerWithContainerID(c *check.C) {
 	// TODO Windows: This test cannot run on a Windows daemon as the networking
 	// settings are not populated back yet on inspect.
 	testRequires(c, DaemonIsLinux)
@@ -1709,7 +1709,7 @@ func (s *DockerSuite) TestRunState(c *check.C) {
 }
 
 // Test for #1737
-func (s *DockerSuite) TestRunCopyVolumeUidGid(c *check.C) {
+func (s *DockerSuite) TestRunCopyVolumeUIDGID(c *check.C) {
 	// Not applicable on Windows as it does not support uid or gid in this way
 	testRequires(c, DaemonIsLinux)
 	name := "testrunvolumesuidgid"
@@ -2484,7 +2484,7 @@ func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunModePidContainer(c *check.C) {
+func (s *DockerSuite) TestRunModePIDContainer(c *check.C) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
@@ -2509,7 +2509,7 @@ func (s *DockerSuite) TestRunModePidContainer(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunModePidContainerNotExists(c *check.C) {
+func (s *DockerSuite) TestRunModePIDContainerNotExists(c *check.C) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "--pid", "container:abcd1234", "busybox", "top")
@@ -2518,7 +2518,7 @@ func (s *DockerSuite) TestRunModePidContainerNotExists(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunModePidContainerNotRunning(c *check.C) {
+func (s *DockerSuite) TestRunModePIDContainerNotRunning(c *check.C) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
@@ -2576,7 +2576,7 @@ func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunModePidHost(c *check.C) {
+func (s *DockerSuite) TestRunModePIDHost(c *check.C) {
 	// Not applicable on Windows as uses Unix-specific capabilities
 	testRequires(c, SameHostDaemon, DaemonIsLinux, NotUserNamespace)
 
@@ -2958,7 +2958,7 @@ func (s *DockerSuite) TestRunContainerWithRmFlagCannotStartContainer(c *check.C)
 	}
 }
 
-func (s *DockerSuite) TestRunPidHostWithChildIsKillable(c *check.C) {
+func (s *DockerSuite) TestRunPIDHostWithChildIsKillable(c *check.C) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	name := "ibuildthecloud"

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1229,8 +1229,8 @@ func (s *DockerSuite) TestRunDeviceSymlink(c *check.C) {
 	c.Assert(strings.Trim(out, "\r\n"), checker.Contains, "bb7df04e1b0a2570657527a7e108ae23", check.Commentf("expected output bb7df04e1b0a2570657527a7e108ae23"))
 }
 
-// TestRunPidsLimit makes sure the pids cgroup is set with --pids-limit
-func (s *DockerSuite) TestRunPidsLimit(c *check.C) {
+// TestRunPIDsLimit makes sure the pids cgroup is set with --pids-limit
+func (s *DockerSuite) TestRunPIDsLimit(c *check.C) {
 	testRequires(c, pidsLimit)
 
 	file := "/sys/fs/cgroup/pids/pids.max"

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
+func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {
 	dockerCmd(c, "volume", "create")
 
 	_, err := runCommand(exec.Command(dockerBinary, "volume", "create", "-d", "nosuchdriver"))
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
 	c.Assert(name, check.Equals, "test2")
 }
 
-func (s *DockerSuite) TestVolumeCliCreateOptionConflict(c *check.C) {
+func (s *DockerSuite) TestVolumeCLICreateOptionConflict(c *check.C) {
 	dockerCmd(c, "volume", "create", "test")
 	out, _, err := dockerCmdWithError("volume", "create", "test", "--driver", "nosuchdriver")
 	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use with another driver"))
@@ -43,7 +43,7 @@ func (s *DockerSuite) TestVolumeCliCreateOptionConflict(c *check.C) {
 	c.Assert(err, check.NotNil, check.Commentf("Conflicting options: either specify --name or provide positional arg, not both"))
 }
 
-func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
+func (s *DockerSuite) TestVolumeCLIInspect(c *check.C) {
 	c.Assert(
 		exec.Command(dockerBinary, "volume", "inspect", "doesntexist").Run(),
 		check.Not(check.IsNil),
@@ -60,7 +60,7 @@ func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
 	c.Assert(strings.TrimSpace(out), check.Equals, "test")
 }
 
-func (s *DockerSuite) TestVolumeCliInspectMulti(c *check.C) {
+func (s *DockerSuite) TestVolumeCLIInspectMulti(c *check.C) {
 	dockerCmd(c, "volume", "create", "test1")
 	dockerCmd(c, "volume", "create", "test2")
 	dockerCmd(c, "volume", "create", "not-shown")
@@ -80,7 +80,7 @@ func (s *DockerSuite) TestVolumeCliInspectMulti(c *check.C) {
 	c.Assert(out, checker.Not(checker.Contains), "not-shown")
 }
 
-func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
+func (s *DockerSuite) TestVolumeCLILs(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "volume", "create", "aaa")
 
@@ -154,7 +154,7 @@ func assertVolList(c *check.C, out string, expectVols []string) {
 	c.Assert(volList, checker.DeepEquals, expectVols)
 }
 
-func (s *DockerSuite) TestVolumeCliLsFilterDangling(c *check.C) {
+func (s *DockerSuite) TestVolumeCLILsFilterDangling(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	dockerCmd(c, "volume", "create", "testnotinuse1")
 	dockerCmd(c, "volume", "create", "testisinuse1")
@@ -217,19 +217,19 @@ func (s *DockerSuite) TestVolumeCliLsFilterDangling(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestVolumeCliLsErrorWithInvalidFilterName(c *check.C) {
+func (s *DockerSuite) TestVolumeCLILsErrorWithInvalidFilterName(c *check.C) {
 	out, _, err := dockerCmdWithError("volume", "ls", "-f", "FOO=123")
 	c.Assert(err, checker.NotNil)
 	c.Assert(out, checker.Contains, "Invalid filter")
 }
 
-func (s *DockerSuite) TestVolumeCliLsWithIncorrectFilterValue(c *check.C) {
+func (s *DockerSuite) TestVolumeCLILsWithIncorrectFilterValue(c *check.C) {
 	out, _, err := dockerCmdWithError("volume", "ls", "-f", "dangling=invalid")
 	c.Assert(err, check.NotNil)
 	c.Assert(out, checker.Contains, "Invalid filter")
 }
 
-func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
+func (s *DockerSuite) TestVolumeCLIRm(c *check.C) {
 	prefix, _ := getPrefixAndSlashFromDaemonPlatform()
 	out, _ := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
@@ -268,7 +268,7 @@ func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
 	)
 }
 
-func (s *DockerSuite) TestVolumeCliNoArgs(c *check.C) {
+func (s *DockerSuite) TestVolumeCLINoArgs(c *check.C) {
 	out, _ := dockerCmd(c, "volume")
 	// no args should produce the cmd usage output
 	usage := "Usage:	docker volume COMMAND"
@@ -286,7 +286,7 @@ func (s *DockerSuite) TestVolumeCliNoArgs(c *check.C) {
 	c.Assert(stderr, checker.Contains, "unknown flag: --no-such-flag")
 }
 
-func (s *DockerSuite) TestVolumeCliInspectTmplError(c *check.C) {
+func (s *DockerSuite) TestVolumeCLIInspectTmplError(c *check.C) {
 	out, _ := dockerCmd(c, "volume", "create")
 	name := strings.TrimSpace(out)
 
@@ -296,7 +296,7 @@ func (s *DockerSuite) TestVolumeCliInspectTmplError(c *check.C) {
 	c.Assert(out, checker.Contains, "Template parsing error")
 }
 
-func (s *DockerSuite) TestVolumeCliCreateWithOpts(c *check.C) {
+func (s *DockerSuite) TestVolumeCLICreateWithOpts(c *check.C) {
 	testRequires(c, DaemonIsLinux)
 
 	dockerCmd(c, "volume", "create", "-d", "local", "test", "--opt=type=tmpfs", "--opt=device=tmpfs", "--opt=o=size=1m,uid=1000")
@@ -319,7 +319,7 @@ func (s *DockerSuite) TestVolumeCliCreateWithOpts(c *check.C) {
 	c.Assert(found, checker.Equals, true)
 }
 
-func (s *DockerSuite) TestVolumeCliCreateLabel(c *check.C) {
+func (s *DockerSuite) TestVolumeCLICreateLabel(c *check.C) {
 	testVol := "testvolcreatelabel"
 	testLabel := "foo"
 	testValue := "bar"
@@ -331,7 +331,7 @@ func (s *DockerSuite) TestVolumeCliCreateLabel(c *check.C) {
 	c.Assert(strings.TrimSpace(out), check.Equals, testValue)
 }
 
-func (s *DockerSuite) TestVolumeCliCreateLabelMultiple(c *check.C) {
+func (s *DockerSuite) TestVolumeCLICreateLabelMultiple(c *check.C) {
 	testVol := "testvolcreatelabel"
 
 	testLabels := map[string]string{
@@ -358,7 +358,7 @@ func (s *DockerSuite) TestVolumeCliCreateLabelMultiple(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestVolumeCliLsFilterLabels(c *check.C) {
+func (s *DockerSuite) TestVolumeCLILsFilterLabels(c *check.C) {
 	testVol1 := "testvolcreatelabel-1"
 	out, _, err := dockerCmdWithError("volume", "create", "--label", "foo=bar1", testVol1)
 	c.Assert(err, check.IsNil)
@@ -388,7 +388,7 @@ func (s *DockerSuite) TestVolumeCliLsFilterLabels(c *check.C) {
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("\n%s", out))
 }
 
-func (s *DockerSuite) TestVolumeCliRmForceUsage(c *check.C) {
+func (s *DockerSuite) TestVolumeCLIRmForceUsage(c *check.C) {
 	out, _ := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 
@@ -400,7 +400,7 @@ func (s *DockerSuite) TestVolumeCliRmForceUsage(c *check.C) {
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("%s\n", out))
 }
 
-func (s *DockerSuite) TestVolumeCliRmForce(c *check.C) {
+func (s *DockerSuite) TestVolumeCLIRmForce(c *check.C) {
 	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	name := "test"

--- a/integration-cli/docker_deprecated_api_v124_test.go
+++ b/integration-cli/docker_deprecated_api_v124_test.go
@@ -15,7 +15,7 @@ func formatV123StartAPIURL(url string) string {
 	return "/v1.23" + url
 }
 
-func (s *DockerSuite) TestDeprecatedContainerApiStartHostConfig(c *check.C) {
+func (s *DockerSuite) TestDeprecatedContainerAPIStartHostConfig(c *check.C) {
 	name := "test-deprecated-api-124"
 	dockerCmd(c, "create", "--name", name, "busybox")
 	config := map[string]interface{}{
@@ -27,7 +27,7 @@ func (s *DockerSuite) TestDeprecatedContainerApiStartHostConfig(c *check.C) {
 	c.Assert(string(body), checker.Contains, "was deprecated since v1.10")
 }
 
-func (s *DockerSuite) TestDeprecatedContainerApiStartVolumeBinds(c *check.C) {
+func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumeBinds(c *check.C) {
 	// TODO Windows CI: Investigate further why this fails on Windows to Windows CI.
 	testRequires(c, DaemonIsLinux)
 	path := "/foo"
@@ -58,7 +58,7 @@ func (s *DockerSuite) TestDeprecatedContainerApiStartVolumeBinds(c *check.C) {
 }
 
 // Test for GH#10618
-func (s *DockerSuite) TestDeprecatedContainerApiStartDupVolumeBinds(c *check.C) {
+func (s *DockerSuite) TestDeprecatedContainerAPIStartDupVolumeBinds(c *check.C) {
 	// TODO Windows to Windows CI - Port this
 	testRequires(c, DaemonIsLinux)
 	name := "testdups"
@@ -83,7 +83,7 @@ func (s *DockerSuite) TestDeprecatedContainerApiStartDupVolumeBinds(c *check.C) 
 	c.Assert(string(body), checker.Contains, "Duplicate mount point", check.Commentf("Expected failure due to duplicate bind mounts to same path, instead got: %q with error: %v", string(body), err))
 }
 
-func (s *DockerSuite) TestDeprecatedContainerApiStartVolumesFrom(c *check.C) {
+func (s *DockerSuite) TestDeprecatedContainerAPIStartVolumesFrom(c *check.C) {
 	// TODO Windows to Windows CI - Port this
 	testRequires(c, DaemonIsLinux)
 	volName := "voltst"
@@ -91,7 +91,7 @@ func (s *DockerSuite) TestDeprecatedContainerApiStartVolumesFrom(c *check.C) {
 
 	dockerCmd(c, "run", "--name", volName, "-v", volPath, "busybox")
 
-	name := "TestContainerApiStartVolumesFrom"
+	name := "TestContainerAPIStartVolumesFrom"
 	config := map[string]interface{}{
 		"Image":   "busybox",
 		"Volumes": map[string]struct{}{volPath: {}},


### PR DESCRIPTION
No substantial code change.
- Api         --> API (suggested by @stevvooe https://github.com/docker/docker/pull/26837#discussion_r80552544)
- Cli         --> CLI
- Http, Https --> HTTP, HTTPS
- Id          --> ID
- Uid,Gid,Pid --> UID,PID,PID
- Ipam      --> IPAM
- Tls         --> TLS (TestDaemonNoTlsCliTlsVerifyWithEnv --> TestDaemonTLSVerifyIssue13964)

Didn't touch in this commit:
- Git: because it is officially "Git": https://git-scm.com/
- Tar: because it is officially "Tar" (in GNU implementation, at least): https://www.gnu.org/software/tar/
- Cpu, Nat, Mac, Ipc, Shm: for keeping a consistency with existing production code (not changable, for compatibility)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
