### PR TITLE
zsh: allow restarting stopped containers by id

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1878,11 +1878,17 @@ __docker_subcommand() {
                 "($help -):old name:__docker_containers" \
                 "($help -):new name: " && ret=0
             ;;
-        (restart|stop)
+        (stop)
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -t --time)"{-t=,--time=}"[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)" \
                 "($help -)*:containers:__docker_runningcontainers" && ret=0
+            ;;
+        (restart)
+            _arguments $(__docker_arguments) \
+                $opts_help \
+                "($help -t --time)"{-t=,--time=}"[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)" \
+                "($help -)*:containers:__docker_containers_ids" && ret=0
             ;;
         (rm)
             _arguments $(__docker_arguments) \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
zsh completion: allow `restart` command to be applied to stopped containers with their id

**\- How I did it**
Modify `_docker` completion script.

**\- How to verify it**
1. `cp _docker ~/.oh-my-zsh/plugin/docker/_docker`
2. open a new shell
3. `docker restart <TAB>` and you should see all containers with id instead of only running containers.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Wenzhi Liang wenzhi.liang@gmail.com
