### PR TITLE
make health check log more readable

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -94,7 +94,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, container *container.Cont
 		return nil, err
 	}
 	if info.ExitCode == nil {
-		return nil, fmt.Errorf("Healthcheck has no exit code!")
+		return nil, fmt.Errorf("Healthcheck for container %s has no exit code!", container.ID)
 	}
 	// Note: Go's json package will handle invalid UTF-8 for us
 	out := output.String()
@@ -149,17 +149,17 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 	for {
 		select {
 		case <-stop:
-			logrus.Debug("Stop healthcheck monitoring (received while idle)")
+			logrus.Debugf("Stop healthcheck monitoring for container %s (received while idle)", c.ID)
 			return
 		case <-time.After(probeInterval):
-			logrus.Debug("Running health check...")
+			logrus.Debugf("Running health check for container %s ...", c.ID)
 			startTime := time.Now()
 			ctx, cancelProbe := context.WithTimeout(context.Background(), probeTimeout)
 			results := make(chan *types.HealthcheckResult)
 			go func() {
 				result, err := probe.run(ctx, d, c)
 				if err != nil {
-					logrus.Warnf("Health check error: %v", err)
+					logrus.Warnf("Health check for container %s error: %v", c.ID, err)
 					results <- &types.HealthcheckResult{
 						ExitCode: -1,
 						Output:   err.Error(),
@@ -168,14 +168,14 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 					}
 				} else {
 					result.Start = startTime
-					logrus.Debugf("Health check done (exitCode=%d)", result.ExitCode)
+					logrus.Debugf("Health check for container %s done (exitCode=%d)", c.ID, result.ExitCode)
 					results <- result
 				}
 				close(results)
 			}()
 			select {
 			case <-stop:
-				logrus.Debug("Stop healthcheck monitoring (received while probing)")
+				logrus.Debugf("Stop healthcheck monitoring for container %s (received while probing)", c.ID)
 				// Stop timeout and kill probe, but don't wait for probe to exit.
 				cancelProbe()
 				return
@@ -184,7 +184,7 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 				// Stop timeout
 				cancelProbe()
 			case <-ctx.Done():
-				logrus.Debug("Health check taking too long")
+				logrus.Debugf("Health check for container %s taking too long", c.ID)
 				handleProbeResult(d, c, &types.HealthcheckResult{
 					ExitCode: -1,
 					Output:   fmt.Sprintf("Health check exceeded timeout (%v)", probeTimeout),
@@ -213,7 +213,7 @@ func getProbe(c *container.Container) probe {
 	case "CMD-SHELL":
 		return &cmdProbe{shell: true}
 	default:
-		logrus.Warnf("Unknown healthcheck type '%s' (expected 'CMD')", config.Test[0])
+		logrus.Warnf("Unknown healthcheck type '%s' (expected 'CMD') in container %s", config.Test[0], c.ID)
 		return nil
 	}
 }

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -30,7 +30,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		daemon.updateHealthMonitor(c)
 		daemon.LogContainerEvent(c, "oom")
 	case libcontainerd.StateExit:
-		// if containers AutoRemove flag is set, remove it after clean up
+		// if container's AutoRemove flag is set, remove it after clean up
 		if c.HostConfig.AutoRemove {
 			defer func() {
 				if err := daemon.ContainerRm(c.ID, &types.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {


### PR DESCRIPTION
fixes #26971 

As every health check is corresponding to each container, each health check log has to get container id in it, so that log will not be confusing.

**\- What I did**
1. add container id in health check log and error
2. fix a typo in monitor.go

Signed-off-by: allencloud allen.sun@daocloud.io
