### PR TITLE
Add support for ambient capabilities

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1220,6 +1220,10 @@ since Docker 1.12. In Docker 1.10 and 1.11 this did not happen and it may be nec
 to use a custom seccomp profile or use `--security-opt seccomp=unconfined` when adding
 capabilities.
 
+It is only possible to grant capabilities to a container running as a user other than `root`
+on a system with a Linux kernel version of 4.3 or later, as this requires "ambient capabilities"
+to be granted. These will be added if the kernel allows it from Docker version 1.13.
+
 ## Logging drivers (--log-driver)
 
 The container can have a different logging driver than the Docker daemon. Use

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -212,6 +212,14 @@ capability removal, or less secure through the addition of capabilities.
 The best practice for users would be to remove all capabilities except
 those explicitly required for their processes.
 
+Linux kernel versions since 4.3 allow Docker to grant capabilities to
+container processes running as a non root user. This adds an extra
+layer of protection as the process can then be denied access to be able
+to write files belonging to the root uid, for example. User namespaces
+also allow capabilities to be granted to processes that are effectively
+non root, but these capabilities are limited to resources created in the
+user namespace, so they have limitations.
+
 ## Other kernel security features
 
 Capabilities are just one of the many security features provided by

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -112,6 +112,16 @@ var (
 		},
 		"Test cannot be run with 'sysctl kernel.unprivileged_userns_clone' = 0",
 	}
+	ambientCapabilities = testRequirement{
+		func() bool {
+			content, err := ioutil.ReadFile("/proc/self/status")
+			if err == nil && strings.Contains(string(content), "CapAmb:") {
+				return true
+			}
+			return false
+		},
+		"Test cannot be run without a kernel (4.3+) supporting ambient capabilities",
+	}
 )
 
 func init() {


### PR DESCRIPTION
### This change was reverted for docker 1.13 (see https://github.com/docker/docker/pull/27737)

Linux kernel 4.3 and later supports "ambient capabilities" which are the
only way to pass capabilities to containers running as a non root uid.

Previously there was no way to allow containers not running as root
capabilities in a useful way.

Fix #8460

Signed-off-by: Justin Cormack justin.cormack@docker.com

NOTE: actual `runc` update was included in #27160 so this is just a docs and tests change now.

NOTE: This will grant the default capabilities to containers that are run as a non root user. This might be surprising, for example we grant `cap_chown` by default, so with this PR `docker run -u 1000 busybox chown 100 /tmp` will just work. We could grant fewer capabilities to containers not running as root, by default, but this might break users who expect `sudo chown ...` to work. In general as running as non root is strictly better than running as root, I think it is best to leave this, as the default capabilities are mostly harmless, and I am planning other patches to allow reducing the default capability set globally. Open to discussion on this.

Chill Out with Ambient Capabilities

![chill out](https://cloud.githubusercontent.com/assets/482364/18914394/e2dd65c4-8584-11e6-93c9-862022fd8618.jpeg)
