### PR TITLE
Enhancements and improved consistency for various completions

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -150,66 +150,124 @@ __docker_complete_containers_and_images() {
 	COMPREPLY+=( "${containers[@]}" )
 }
 
-# Returns the names and optionally IDs of networks.
-# The selection can be narrowed by an optional filter parameter, e.g. 'type=custom'
+# Returns a list of all networks. Additional arguments to `docker network ls`
+# may be specified in order to filter the list, e.g.
+# `__docker_networks --filter type=custom`
+# By default, only names are returned.
+# Set DOCKER_COMPLETION_SHOW_NETWORK_IDS=yes to also complete IDs.
+# An optional first option `--id|--name` may be used to limit the
+# output to the IDs or names of matching items. This setting takes
+# precedence over the environment setting.
 __docker_networks() {
-	local filter="$1"
-	# By default, only network names are completed.
-	# Set DOCKER_COMPLETION_SHOW_NETWORK_IDS=yes to also complete network IDs.
-	local fields='$2'
-	[ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS}" = yes ] && fields='$1,$2'
-	__docker_q network ls --no-trunc ${filter:+-f "$filter"} | awk "NR>1 {print $fields}"
-	#__docker_q network ls --no-trunc | awk "NR>1 {print $fields}"
+	local format='{{.Name}}'
+	if [ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS}" = yes ] ; then
+		format='{{.ID}} {{.Name}}'
+	fi
+
+	if [ "$1" = "--id" ] ; then
+		format='{{.ID}}'
+		shift
+	elif [ "$1" = "--name" ] ; then
+		format='{{.Name}}'
+		shift
+	fi
+	__docker_q network ls --format "$format" "$@"
 }
 
+# Applies completion of networks based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# Additional filters may be appended, see `__docker_networks`.
 __docker_complete_networks() {
-	COMPREPLY=( $(compgen -W "$(__docker_networks $@)" -- "$cur") )
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_networks "$@")" -- "$current") )
 }
 
-__docker_complete_network_ids() {
-	COMPREPLY=( $(compgen -W "$(__docker_q network ls -q --no-trunc)" -- "$cur") )
-}
-
-__docker_complete_network_names() {
-	COMPREPLY=( $(compgen -W "$(__docker_q network ls | awk 'NR>1 {print $2}')" -- "$cur") )
+__docker_containers_in_network() {
+	__docker_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1"
 }
 
 __docker_complete_containers_in_network() {
-	local containers=$(__docker_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1")
-	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
+	COMPREPLY=( $(compgen -W "$(__docker_containers_in_network "$@")" -- "$cur") )
 }
 
+# Returns a list of all volumes. Additional arguments to `docker volume ls`
+# may be specified in order to filter the list, e.g.
+# `__docker_volumes --filter dangling=true`
+# Because volumes do not have IDs, this function does not distinguish between
+# IDs and names.
+__docker_volumes() {
+	__docker_q volume ls -q "$@"
+}
+
+# Applies completion of volumes based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# Additional filters may be appended, see `__docker_volumes`.
 __docker_complete_volumes() {
-	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_volumes "$@")" -- "$current") )
 }
 
+# Returns a list of all plugins of a given type.
+# The type has to be specified as the value of a mandatory first option
+# `--type`.
+# Valid types are: Network, Volume, Authorization.
 __docker_plugins() {
-	__docker_q info | sed -n "/^Plugins/,/^[^ ]/s/ $1: //p"
+	local type
+	if [ "$1" = "--type" ] ; then
+		type="$2"
+		shift 2
+	fi
+	__docker_q info | sed -n "/^Plugins/,/^[^ ]/s/ $type: //p"
 }
 
+# Applies completion of plugins based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# The plugin type has to be specified with the next option `--type`.
 __docker_complete_plugins() {
-	COMPREPLY=( $(compgen -W "$(__docker_plugins $1)" -- "$cur") )
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_plugins "$@")" -- "$current") )
 }
 
 __docker_runtimes() {
 	__docker_q info | sed -n 's/^Runtimes: \(.*\)/\1/p'
 }
 
+# Applies completion of runtimes based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
 __docker_complete_runtimes() {
-	COMPREPLY=( $(compgen -W "$(__docker_runtimes)" -- "$cur") )
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_runtimes)" -- "$current") )
 }
 
-# Returns a list of all nodes. Additional arguments to `docker node`
-# may be specified in order to filter the node list, e.g.
+# Returns a list of all nodes. Additional arguments to `docker node ls`
+# may be specified in order to filter the list, e.g.
 # `__docker_nodes --filter role=manager`
-# By default, only node names are completed.
-# Set DOCKER_COMPLETION_SHOW_NODE_IDS=yes to also complete node IDs.
-# An optional first argument `--id|--name` may be used to limit
-# the output to the IDs or names of matching nodes. This setting takes
+# By default, only names are returned.
+# Set DOCKER_COMPLETION_SHOW_NODE_IDS=yes to also complete IDs.
+# An optional first option `--id|--name` may be used to limit the
+# output to the IDs or names of matching items. This setting takes
 # precedence over the environment setting.
 __docker_nodes() {
-	local fields='$2'  # default: node name only
-	[ "${DOCKER_COMPLETION_SHOW_NODE_IDS}" = yes ] && fields='$1,$2' # ID and name
+	local fields='$2'  # default: name only
+	if [ "${DOCKER_COMPLETION_SHOW_NODE_IDS}" = yes ] ; then
+		fields='$1,$2' # ID and name
+	fi
 
 	if [ "$1" = "--id" ] ; then
 		fields='$1' # IDs only
@@ -222,33 +280,37 @@ __docker_nodes() {
 }
 
 # Applies completion of nodes based on the current value of `$cur` or
-# the value of the optional first argument `--cur`, if given.
+# the value of the optional first option `--cur`, if given.
 # Additional filters may be appended, see `__docker_nodes`.
+# Additional completions may be added with `--add`.
 __docker_complete_nodes() {
-	local current=$cur
+	local current="$cur"
 	if [ "$1" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
-	COMPREPLY=( $(compgen -W "$(__docker_nodes "$@")" -- "$current") )
-}
+	local additional_completions
+	while [ "$1" = "--add" ] ; do
+		additional_completions+="$2 "
+		shift 2
+	done
 
-__docker_complete_nodes_plus_self() {
-	__docker_complete_nodes "$@"
-	COMPREPLY+=( self )
+	COMPREPLY=( $(compgen -W "$(__docker_nodes "$@") $additional_completions" -- "$current") )
 }
 
 # Returns a list of all services. Additional arguments to `docker service ls`
 # may be specified in order to filter the service list, e.g.
 # `__docker_services --filter name=xxx`
-# By default, only node names are completed.
-# Set DOCKER_COMPLETION_SHOW_SERVICE_IDS=yes to also complete service IDs.
-# An optional first argument `--id|--name` may be used to limit
-# the output to the IDs or names of matching services. This setting takes
+# By default, only names are returned.
+# Set DOCKER_COMPLETION_SHOW_SERVICE_IDS=yes to also complete IDs.
+# An optional first option `--id|--name` may be used to limit the
+# output to the IDs or names of matching items. This setting takes
 # precedence over the environment setting.
 __docker_services() {
-	local fields='$2'  # default: service name only
-	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && fields='$1,$2' # ID & name
+	local fields='$2'  # default: name only
+	if [ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] ; then
+		fields='$1,$2' # ID & name
+	fi
 
 	if [ "$1" = "--id" ] ; then
 		fields='$1' # IDs only
@@ -261,10 +323,10 @@ __docker_services() {
 }
 
 # Applies completion of services based on the current value of `$cur` or
-# the value of the optional first argument `--cur`, if given.
+# the value of the optional first option `--cur`, if given.
 # Additional filters may be appended, see `__docker_services`.
 __docker_complete_services() {
-	local current=$cur
+	local current="$cur"
 	if [ "$1" = "--cur" ] ; then
 		current="$2"
 		shift 2
@@ -273,7 +335,8 @@ __docker_complete_services() {
 }
 
 # Appends the word passed as an argument to every word in `$COMPREPLY`.
-# Normally you do this with `compgen -S`. This function exists so that you can use
+# Normally you do this with `compgen -S` while generating the completions.
+# This function allows you to append a suffix later. It allows you to use
 # the __docker_complete_XXX functions in cases where you need a suffix.
 __docker_append_to_completions() {
 	COMPREPLY=( ${COMPREPLY[@]/%/"$1"} )
@@ -419,13 +482,22 @@ __docker_local_interfaces() {
 	ip addr show scope global 2>/dev/null | sed -n 's| \+inet \([0-9.]\+\).* \([^ ]\+\)|\1 \2|p'
 }
 
+# Applies completion of local network interfaces based on the current value of
+# `$cur` or the value of the optional first option `--cur`, if given.
+# Additional completions may be added with `--add`.
 __docker_complete_local_interfaces() {
-	local additional_interface
-	if [ "$1" = "--add" ] ; then
-		additional_interface="$2"
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
 	fi
+	local additional_completions
+	while [ "$1" = "--add" ] ; do
+		additional_completions+="$2 "
+		shift 2
+	done
 
-	COMPREPLY=( $( compgen -W "$(__docker_local_interfaces) $additional_interface" -- "$cur" ) )
+	COMPREPLY=( $( compgen -W "$(__docker_local_interfaces) $additional_completions" -- "$curent" ) )
 }
 
 __docker_complete_capabilities() {
@@ -969,7 +1041,7 @@ _docker_daemon() {
 
 	case "$prev" in
 		--authorization-plugin)
-			__docker_complete_plugins Authorization
+			__docker_complete_plugins --type Authorization
 			return
 			;;
 		--cluster-store)
@@ -1135,8 +1207,7 @@ _docker_events() {
 			return
 			;;
 		network)
-			cur="${cur##*=}"
-			__docker_complete_networks
+			__docker_complete_networks --cur "${cur##*=}"
 			return
 			;;
 		type)
@@ -1144,8 +1215,7 @@ _docker_events() {
 			return
 			;;
 		volume)
-			cur="${cur##*=}"
-			__docker_complete_volumes
+			__docker_complete_volumes --cur "${cur##*=}"
 			return
 			;;
 	esac
@@ -1471,7 +1541,7 @@ _docker_network_create() {
 			return
 			;;
 		--driver|-d)
-			local plugins="$(__docker_plugins Network) macvlan"
+			local plugins="$(__docker_plugins --type Network) macvlan"
 			# remove drivers that allow one instance only
 			plugins=${plugins/ host / }
 			plugins=${plugins/ null / }
@@ -1526,18 +1596,16 @@ _docker_network_ls() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		driver)
-			local plugins=" $(__docker_plugins Network) "
+			local plugins=" $(__docker_plugins --type Network) "
 			COMPREPLY=( $(compgen -W "$plugins" -- "${cur##*=}") )
 			return
 			;;
 		id)
-			cur="${cur##*=}"
-			__docker_complete_network_ids
+			__docker_complete_networks --cur "${cur##*=}" --id
 			return
 			;;
 		name)
-			cur="${cur##*=}"
-			__docker_complete_network_names
+			__docker_complete_networks --cur "${cur##*=}" --name
 			return
 			;;
 		type)
@@ -1570,7 +1638,7 @@ _docker_network_rm() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_networks type=custom
+			__docker_complete_networks --filter type=custom
 	esac
 }
 
@@ -2018,7 +2086,7 @@ _docker_node_inspect() {
 			COMPREPLY=( $( compgen -W "--format -f --help --pretty" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_nodes_plus_self
+			__docker_complete_nodes --add self
 	esac
 }
 
@@ -2104,7 +2172,7 @@ _docker_node_ps() {
 			COMPREPLY=( $( compgen -W "--all -a --filter -f --help --no-resolve --no-trunc" -- "$cur" ) )
 			;;
 		*)
-			__docker_complete_nodes_plus_self
+			__docker_complete_nodes --add self
 			;;
 	esac
 }
@@ -2189,8 +2257,7 @@ _docker_ps() {
 			return
 			;;
 		network)
-			cur="${cur##*=}"
-			__docker_complete_networks
+			__docker_complete_networks --cur "${cur##*=}"
 			return
 			;;
 		since)
@@ -2203,8 +2270,7 @@ _docker_ps() {
 			return
 			;;
 		volume)
-			cur="${cur##*=}"
-			__docker_complete_volumes
+			__docker_complete_volumes --cur "${cur##*=}"
 			return
 			;;
 	esac
@@ -2535,7 +2601,7 @@ _docker_run() {
 					__docker_complete_containers_all
 					;;
 				*)
-					COMPREPLY=( $( compgen -W "$(__docker_plugins Network) $(__docker_networks) container:" -- "$cur") )
+					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
 					if [ "${COMPREPLY[*]}" = "container:" ] ; then
 						__docker_nospace
 					fi
@@ -2583,7 +2649,7 @@ _docker_run() {
 			return
 			;;
 		--volume-driver)
-			__docker_complete_plugins Volume
+			__docker_complete_plugins --type Volume
 			return
 			;;
 		--volumes-from)
@@ -2804,7 +2870,7 @@ _docker_version() {
 _docker_volume_create() {
 	case "$prev" in
 		--driver|-d)
-			__docker_complete_plugins Volume
+			__docker_complete_plugins --type Volume
 			return
 			;;
 		--label|--opt|-o)
@@ -2844,13 +2910,11 @@ _docker_volume_ls() {
 			return
 			;;
 		driver)
-			cur=${cur##*=}
-			__docker_complete_plugins Volume
+			__docker_complete_plugins --cur "${cur##*=}" --type Volume
 			return
 			;;
 		name)
-			cur=${cur##*=}
-			__docker_complete_volumes
+			__docker_complete_volumes --cur "${cur##*=}"
 			return
 			;;
 	esac

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -20,6 +20,7 @@
 # For several commands, the amount of completions can be configured by
 # setting environment variables.
 #
+# DOCKER_COMPLETION_SHOW_CONTAINER_IDS
 # DOCKER_COMPLETION_SHOW_NETWORK_IDS
 # DOCKER_COMPLETION_SHOW_NODE_IDS
 # DOCKER_COMPLETION_SHOW_SERVICE_IDS
@@ -58,96 +59,115 @@ __docker_q() {
 	docker ${host:+-H "$host"} ${config:+--config "$config"} 2>/dev/null "$@"
 }
 
-__docker_complete_containers_all() {
-	local IFS=$'\n'
-	local containers=( $(__docker_q ps -aq --no-trunc) )
-	if [ "$1" ]; then
-		containers=( $(__docker_q inspect --format "{{if $1}}{{.Id}}{{end}}" "${containers[@]}") )
+# Returns a list of containers. Additional arguments to `docker ps`
+# may be specified in order to filter the list, e.g.
+# `__docker_containers --filter status=running`
+# By default, only names are returned.
+# Set DOCKER_COMPLETION_SHOW_CONTAINER_IDS=yes to also complete IDs.
+# An optional first option `--id|--name` may be used to limit the
+# output to the IDs or names of matching items. This setting takes
+# precedence over the environment setting.
+__docker_containers() {
+	local format='{{.Names}}'
+	if [ "${DOCKER_COMPLETION_SHOW_CONTAINER_IDS}" = yes ] ; then
+		format='{{.ID}} {{.Names}}'
 	fi
-	local names=( $(__docker_q inspect --format '{{.Name}}' "${containers[@]}") )
-	names=( "${names[@]#/}" ) # trim off the leading "/" from the container names
-	unset IFS
-	COMPREPLY=( $(compgen -W "${names[*]} ${containers[*]}" -- "$cur") )
+
+	if [ "$1" = "--id" ] ; then
+		format='{{.ID}}'
+		shift
+	elif [ "$1" = "--name" ] ; then
+		format='{{.Names}}'
+		shift
+	fi
+	__docker_q ps --format "$format" "$@"
+}
+
+# Applies completion of containers based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# Additional filters may be appended, see `__docker_containers`.
+__docker_complete_containers() {
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_containers "$@")" -- "$current") )
+}
+
+__docker_complete_containers_all() {
+	__docker_complete_containers "$@" --all
 }
 
 __docker_complete_containers_running() {
-	__docker_complete_containers_all '.State.Running'
+	__docker_complete_containers "$@" --filter status=running
 }
 
 __docker_complete_containers_stopped() {
-	__docker_complete_containers_all 'not .State.Running'
-}
-
-__docker_complete_containers_pauseable() {
-	__docker_complete_containers_all 'and .State.Running (not .State.Paused)'
+	__docker_complete_containers "$@" --filter status=exited
 }
 
 __docker_complete_containers_unpauseable() {
-	__docker_complete_containers_all '.State.Paused'
+	__docker_complete_containers "$@" --filter status=paused
 }
 
-__docker_complete_container_names() {
-	local containers=( $(__docker_q ps -aq --no-trunc) )
-	local names=( $(__docker_q inspect --format '{{.Name}}' "${containers[@]}") )
-	names=( "${names[@]#/}" ) # trim off the leading "/" from the container names
-	COMPREPLY=( $(compgen -W "${names[*]}" -- "$cur") )
-}
-
-__docker_complete_container_ids() {
-	local containers=( $(__docker_q ps -aq) )
-	COMPREPLY=( $(compgen -W "${containers[*]}" -- "$cur") )
-}
-
-__docker_complete_images() {
-	local images_args=""
-
-	case "$DOCKER_COMPLETION_SHOW_IMAGE_IDS" in
-		all)
-			images_args="--no-trunc -a"
-			;;
-		non-intermediate)
-			images_args="--no-trunc"
-			;;
-	esac
-
-	local repo_print_command
-	if [ "${DOCKER_COMPLETION_SHOW_TAGS:-yes}" = "yes" ]; then
-		repo_print_command='print $1; print $1":"$2'
-	else
-		repo_print_command='print $1'
+# Returns a list of images. Additional arguments to `docker images`
+# may be specified in order to filter the list, e.g.
+# `__docker_containers --filter dangling=true`.
+# By default, names and tags are returned.
+# Set DOCKER_COMPLETION_SHOW_IMAGE_IDS=all|non-intermediate to also complete IDs.
+# Set DOCKER_COMPLETION_SHOW_TAGS=no to exclude tags.
+# If you specify a custom `--format`, it will override the settings from the
+# environment variables.
+__docker_images() {
+	local all=""
+	if [ "$DOCKER_COMPLETION_SHOW_IMAGE_IDS" = "all" ] ; then
+		# if a `--format` option is given, we do not automatically set
+		#`--all` so that the caller can decide whether `--all` is needed.
+		if [[ ! " $@" =~ " --format" ]] ; then
+			all="--all"
+		fi
 	fi
 
-	local awk_script
+	local format='{{.Repository}}'
+	if [ "${DOCKER_COMPLETION_SHOW_TAGS:-yes}" = "yes" ]; then
+		format+=' {{.Repository}}:{{.Tag}}'
+	fi
+
 	case "$DOCKER_COMPLETION_SHOW_IMAGE_IDS" in
 		all|non-intermediate)
-			awk_script='NR>1 { print $3; if ($1 != "<none>") { '"$repo_print_command"' } }'
-			;;
-		none|*)
-			awk_script='NR>1 && $1 != "<none>" { '"$repo_print_command"' }'
+			format+='\n{{.ID}}'
 			;;
 	esac
 
-	local images=$(__docker_q images $images_args | awk "$awk_script")
-	COMPREPLY=( $(compgen -W "$images" -- "$cur") )
-	__ltrim_colon_completions "$cur"
+	__docker_q images --no-trunc --format "$format" $all "$@" | grep -v '^<none>'
+}
+
+# Applies completion of images based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# Additional filters may be appended, see `__docker_images`.
+__docker_complete_images() {
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_images "$@")" -- "$current") )
+	__ltrim_colon_completions "$current"
 }
 
 __docker_complete_image_repos() {
-	local repos="$(__docker_q images | awk 'NR>1 && $1 != "<none>" { print $1 }')"
-	COMPREPLY=( $(compgen -W "$repos" -- "$cur") )
+	COMPREPLY=( $(compgen -W "$(__docker_images --format '{{.Repository}}')" -- "$cur") )
 }
 
 __docker_complete_image_repos_and_tags() {
-	local reposAndTags="$(__docker_q images | awk 'NR>1 && $1 != "<none>" { print $1; print $1":"$2 }')"
-	COMPREPLY=( $(compgen -W "$reposAndTags" -- "$cur") )
+	COMPREPLY=( $(compgen -W "$(__docker_images --format '{{.Repository}} {{.Repository}}:{{.Tag}}')" -- "$cur") )
 	__ltrim_colon_completions "$cur"
 }
 
 __docker_complete_containers_and_images() {
-	__docker_complete_containers_all
-	local containers=( "${COMPREPLY[@]}" )
-	__docker_complete_images
-	COMPREPLY+=( "${containers[@]}" )
+	COMPREPLY=( $(compgen -W "$(__docker_containers --all) $(__docker_images)" -- "$cur") )
+	__ltrim_colon_completions "$cur"
 }
 
 # Returns a list of all networks. Additional arguments to `docker network ls`
@@ -1151,8 +1171,7 @@ _docker_events() {
 	local key=$(__docker_map_key_of_current_option '-f|--filter')
 	case "$key" in
 		container)
-			cur="${cur##*=}"
-			__docker_complete_containers_all
+			__docker_complete_containers_all --cur "${cur##*=}"
 			return
 			;;
 		daemon)
@@ -1202,8 +1221,7 @@ _docker_events() {
 			return
 			;;
 		image)
-			cur="${cur##*=}"
-			__docker_complete_images
+			__docker_complete_images --cur "${cur##*=}"
 			return
 			;;
 		network)
@@ -1297,8 +1315,7 @@ _docker_images() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		before)
-			cur="${cur##*=}"
-			__docker_complete_images
+			__docker_complete_images --cur "${cur##*=}"
 			return
 			;;
 		dangling)
@@ -1309,8 +1326,7 @@ _docker_images() {
 			return
 			;;
 		since)
-			cur="${cur##*=}"
-			__docker_complete_images
+			__docker_complete_images --cur "${cur##*=}"
 			return
 			;;
 	esac
@@ -2209,7 +2225,7 @@ _docker_pause() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_pauseable
+				__docker_complete_containers_running
 			fi
 			;;
 	esac
@@ -2233,18 +2249,15 @@ _docker_ps() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		ancestor)
-			cur="${cur##*=}"
-			__docker_complete_images
+			__docker_complete_images --cur "${cur##*=}"
 			return
 			;;
 		before)
-			cur="${cur##*=}"
-			__docker_complete_containers_all
+			__docker_complete_containers_all --cur "${cur##*=}"
 			return
 			;;
 		id)
-			cur="${cur##*=}"
-			__docker_complete_container_ids
+			__docker_complete_containers_all --cur "${cur##*=}" --id
 			return
 			;;
 		is-task)
@@ -2252,8 +2265,7 @@ _docker_ps() {
 			return
 			;;
 		name)
-			cur="${cur##*=}"
-			__docker_complete_container_names
+			__docker_complete_containers_all --cur "${cur##*=}" --name
 			return
 			;;
 		network)
@@ -2261,8 +2273,7 @@ _docker_ps() {
 			return
 			;;
 		since)
-			cur="${cur##*=}"
-			__docker_complete_containers_all
+			__docker_complete_containers_all --cur "${cur##*=}"
 			return
 			;;
 		status)
@@ -2558,8 +2569,7 @@ _docker_run() {
 		--ipc)
 			case "$cur" in
 				*:*)
-					cur="${cur#*:}"
-					__docker_complete_containers_running
+					__docker_complete_containers_running --cur "${cur#*:}"
 					;;
 				*)
 					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
@@ -2597,8 +2607,7 @@ _docker_run() {
 		--network)
 			case "$cur" in
 				container:*)
-					local cur=${cur#*:}
-					__docker_complete_containers_all
+					__docker_complete_containers_all --cur "${cur##*=}"
 					;;
 				*)
 					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
@@ -2612,8 +2621,7 @@ _docker_run() {
 		--pid)
 			case "$cur" in
 				*:*)
-					cur="${cur#*:}"
-					__docker_complete_containers_running
+					__docker_complete_containers_running --cur "${cur#*:}"
 					;;
 				*)
 					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )


### PR DESCRIPTION
## Background
### docker inspect changes
- #23614 enhances `docker inspect` to complete images, containers, networks, nodes, services, tasks, and volumes. 
- In #24119 I introduced enhanced completion functions for the new `swarm` commands. The existing completions for other items have not yet been adjusted.

In order to efficiently update bash completion for `docker inspect`, a preparing refactoring is required.
### Performance problems

Completion of containers currently works by enumarating **all** container IDs, then inspecting all corresponding containers and conditionally outputting some stuff. With `--format` and `--filter`, this can be done more efficiently.
## Changes
- make use of new CLI features, e.g. `--format` and `--filter`
- less completion functions that are customizable with options and environment variables
- move some low-level completion logic into the helper functions so that the primary completion functions are easier to understand
- do not modify global state: get rid of `cur="${cur##*=}` idioms
- easy debugging and development by introducing companion `__docker_<items>` functions for the `__docker_complete_<items>` functions

I did not apply all concepts to all functions, only in cases where they paid off.

@tianon , @jfrazelle PTAL. This one's a bit more complex.
