### PR TITLE
Remove service update name flag

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -27,6 +27,8 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.mode, flagMode, "replicated", "Service mode (replicated or global)")
+	flags.StringVar(&opts.name, flagName, "", "Service name")
+
 	addServiceFlags(cmd, opts)
 
 	flags.VarP(&opts.labels, flagLabel, "l", "Service labels")

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -490,7 +490,6 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 // Any flags that are not common are added separately in the individual command
 func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags := cmd.Flags()
-	flags.StringVar(&opts.name, flagName, "", "Service name")
 
 	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -172,7 +172,6 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 		return task.Resources
 	}
 
-	updateString(flagName, &spec.Name)
 	updateLabels(flags, &spec.Labels)
 	updateContainerLabels(flags, &cspec.Labels)
 	updateString("image", &cspec.Image)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2672,7 +2672,6 @@ _docker_service_update() {
 		--log-driver
 		--log-opt
 		--mount
-		--name
 		--network
 		--publish -p
 		--replicas
@@ -2704,6 +2703,7 @@ _docker_service_update() {
 		options_with_args="$options_with_args
 			--container-label
 			--mode
+			--name
 		"
 
 		case "$prev" in

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1095,7 +1095,6 @@ __docker_service_subcommand() {
         "($help)--log-driver=[Logging driver for service]:logging driver:__docker_log_drivers"
         "($help)*--log-opt=[Logging driver options]:log driver options:__docker_log_options"
         "($help)*--mount=[Attach a mount to the service]:mount: "
-        "($help)--name=[Service name]:name: "
         "($help)*--network=[Network attachments]:network: "
         "($help)*"{-p=,--publish=}"[Publish a port as a node port]:port: "
         "($help)--replicas=[Number of tasks]:replicas: "
@@ -1123,6 +1122,7 @@ __docker_service_subcommand() {
                 $opts_create_update \
                 "($help)*--container-label=[Container labels]:label: " \
                 "($help)--mode=[Service Mode]:mode:(global replicated)" \
+                "($help)--name=[Service name]:name: " \
                 "($help -): :__docker_images" \
                 "($help -):command: _command_names -e" \
                 "($help -)*::arguments: _normal" && ret=0

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4846,7 +4846,7 @@ image](#create-an-image) section for more details.
 
 **JSON Parameters**:
 
-- **Name** – User-defined name for the service.
+- **Name** – User-defined name for the service. Note that renaming services is not supported.
 - **Labels** – A map of labels to associate with the service (e.g., `{"key":"value", "key2":"value2"}`).
 - **TaskTemplate** – Specification of the tasks to start as part of the new service.
     - **ContainerSpec** - Container settings for containers started as part of this task.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -5375,7 +5375,7 @@ image](#create-an-image) section for more details.
 
 **JSON Parameters**:
 
-- **Name** – User-defined name for the service.
+- **Name** – User-defined name for the service. Note that renaming services is not supported.
 - **Labels** – A map of labels to associate with the service (e.g., `{"key":"value", "key2":"value2"}`).
 - **TaskTemplate** – Specification of the tasks to start as part of the new service.
     - **ContainerSpec** - Container settings for containers started as part of this task.

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -42,7 +42,6 @@ Options:
       --log-opt value                    Logging driver options (default [])
       --mount-add value                  Add or update a mount on a service
       --mount-rm value                   Remove a mount by its target path (default [])
-      --name string                      Service name
       --publish-add value                Add or update a published port (default [])
       --publish-rm value                 Remove a published port by its target port (default [])
       --replicas value                   Number of tasks (default none)


### PR DESCRIPTION
The `--name` flag was inadvertently added to `docker service update`, but is not supported, as it has various side-effects (e.g., existing tasks are not renamed).

This removes the flag from the service update command and API documentation.

fixes https://github.com/docker/docker/issues/25483

**Note for reviewing**

I opened this PR for discussion, but as it is a change in both the CLI _and_ the API, I'm not sure what the best way forward is. I don't know if this can be seen as a regular bugfix, or if we need to start a deprecation traject.

ping @stevvooe @aluzzardi PTAL
