### PR TITLE
Windows: Don't set PATH/TERM on exec

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"time"
 
@@ -123,11 +124,15 @@ func (d *Daemon) ContainerExecCreate(name string, config *types.ExecConfig) (str
 	execConfig.Tty = config.Tty
 	execConfig.Privileged = config.Privileged
 	execConfig.User = config.User
-	execConfig.Env = []string{
-		"PATH=" + system.DefaultPathEnv,
-	}
-	if config.Tty {
-		execConfig.Env = append(execConfig.Env, "TERM=xterm")
+
+	// On Windows, don't default the path, let the platform do it. Also TERM isn't meaningful
+	if runtime.GOOS != "windows" {
+		execConfig.Env = []string{
+			"PATH=" + system.DefaultPathEnv,
+		}
+		if config.Tty {
+			execConfig.Env = append(execConfig.Env, "TERM=xterm")
+		}
 	}
 	execConfig.Env = utils.ReplaceOrAppendEnvValues(execConfig.Env, container.Config.Env)
 	if len(execConfig.User) == 0 {

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -509,3 +509,14 @@ func (s *DockerSuite) TestExecStartFails(c *check.C) {
 	c.Assert(err, checker.NotNil, check.Commentf(out))
 	c.Assert(out, checker.Contains, "executable file not found")
 }
+
+// Fix regression in https://github.com/docker/docker/pull/26461#issuecomment-250287297
+func (s *DockerSuite) TestExecWindowsPathNotWiped(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	out, _ := dockerCmd(c, "run", "-d", "--name", "testing", minimalBaseImage(), "powershell", "start-sleep", "60")
+	c.Assert(waitRun(strings.TrimSpace(out)), check.IsNil)
+
+	out, _ = dockerCmd(c, "exec", "testing", "powershell", "write-host", "$env:PATH")
+	out = strings.ToLower(strings.Trim(out, "\r\n"))
+	c.Assert(out, checker.Contains, `windowspowershell\v1.0`)
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@friism @mavenugo @dmp42 FYI.

@crosbymichael https://github.com/docker/docker/pull/26461 regressed exec on Windows where the default path is blank (we can't pre-predict a path for a container on Windows - the platform does it instead). Hence an exec'd process on Windows after this change had the PATH explicitly set to blank, which ends up breaking many things. 

Added a test to ensure this doesn't regress in the future.
