### PR TITLE
(Windows) Inspect image populate OSVersion

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -131,6 +131,7 @@ type ImageInspect struct {
 	Config          *container.Config
 	Architecture    string
 	Os              string
+	OsVersion       string `json:",omitempty"`
 	Size            int64
 	VirtualSize     int64
 	GraphDriver     GraphDriverData

--- a/daemon/image_inspect.go
+++ b/daemon/image_inspect.go
@@ -68,6 +68,7 @@ func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
 		Config:          img.Config,
 		Architecture:    img.Architecture,
 		Os:              img.OS,
+		OsVersion:       img.OSVersion,
 		Size:            size,
 		VirtualSize:     size, // TODO: field unused, deprecate
 		RootFS:          rootFSToAPIType(img.RootFS),

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -116,6 +116,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
+* `GET /images/(name)/json` now returns `OsVersion` if populated
 * `GET /info` now returns `Isolation`.
 * `POST /containers/create` now takes `AutoRemove` in HostConfig, to enable auto-removal of the container on daemon side when the container's process exits.
 * `GET /containers/json` and `GET /containers/(id or name)/json` now return `"removing"` as a value for the `State.Status` field if the container is being removed. Previously, "exited" was returned as status.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1884,7 +1884,7 @@ Return low-level information on the image `name`
 
     GET /images/example/json HTTP/1.1
 
-**Example response**:
+**Example response (Linux daemon)**:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
@@ -1985,6 +1985,86 @@ Return low-level information on the image `name`
            ]
        }
     }
+
+**Example response (Windows daemon)**:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    [
+        {
+            "Id": "sha256:105d76d0f40e38427c63023ffe649bf36fa85058d3469551e43e4dcc2431fb31",
+            "RepoTags": [
+                "microsoft/nanoserver:latest"
+            ],
+            "RepoDigests": [
+                "microsoft/nanoserver@sha256:aee7d4330fe3dc5987c808f647441c16ed2fa1c7d9c6ef49d6498e5c9860b50b"
+            ],
+            "Parent": "",
+            "Comment": "",
+            "Created": "2016-09-22T02:39:30.9154862-07:00",
+            "Container": "",
+            "ContainerConfig": {
+                "Hostname": "",
+                "Domainname": "",
+                "User": "",
+                "AttachStdin": false,
+                "AttachStdout": false,
+                "AttachStderr": false,
+                "Tty": false,
+                "OpenStdin": false,
+                "StdinOnce": false,
+                "Env": null,
+                "Cmd": null,
+                "Image": "",
+                "Volumes": null,
+                "WorkingDir": "",
+                "Entrypoint": null,
+                "OnBuild": null,
+                "Labels": null
+            },
+            "DockerVersion": "",
+            "Author": "",
+            "Config": {
+                "Hostname": "",
+                "Domainname": "",
+                "User": "",
+                "AttachStdin": false,
+                "AttachStdout": false,
+                "AttachStderr": false,
+                "Tty": false,
+                "OpenStdin": false,
+                "StdinOnce": false,
+                "Env": null,
+                "Cmd": [
+                    "c:\\windows\\system32\\cmd.exe"
+                ],
+                "Image": "",
+                "Volumes": null,
+                "WorkingDir": "",
+                "Entrypoint": null,
+                "OnBuild": null,
+                "Labels": null
+            },
+            "Architecture": "",
+            "Os": "windows",
+            "OsVersion": "10.0.14393",
+            "Size": 651862727,
+            "VirtualSize": 651862727,
+            "GraphDriver": {
+                "Name": "windowsfilter",
+                "Data": {
+                    "dir": "C:\\control\\windowsfilter\\6fe6a289b98276a6a5ca0345156ca61d7b38f3da6bb49ef95af1d0f1ac37e5bf"
+                }
+            },
+            "RootFS": {
+                "Type": "layers",
+                "Layers": [
+                    "sha256:342d4e407550c52261edd20cd901b5ce438f0b1e940336de3978210612365063"
+                ]
+            }
+        }
+    ]
 
 **Status codes**:
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

As we distribute more versions of the Windows base packages, without being able to see the OS version of the image in `docker inspect`, it's going to be increasingly difficult to determine which image is which. This fix though isn't Windows specific.

Note currently the base images (up to and including 9D) only have the OS versions populated as a triple (such as 10.0.14393) rather than a quadtuple (such as 10.0.14393.206 for 9D). For future pushes of the base images, we'll populate the OSVersion field fully. From that point on, it will be able to use docker inspect to determine the version of the base image at the time it was `docker pull`ed.

Sample output:

```
PS E:\go\src\github.com\docker\docker> docker inspect 105d
[
    {
        "Id": "sha256:105d76d0f40e38427c63023ffe649bf36fa85058d3469551e43e4dcc2431fb31",
        "RepoTags": [
            "microsoft/nanoserver:latest"
        ],
        "RepoDigests": [
            "microsoft/nanoserver@sha256:aee7d4330fe3dc5987c808f647441c16ed2fa1c7d9c6ef49d6498e5c9860b50b"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2016-09-22T02:39:30.9154862-07:00",
        "Container": "",
        "ContainerConfig": {
...
        },
        "DockerVersion": "",
        "Author": "",
        "Config": {
...
        },
        "Architecture": "",
        "Os": "windows",
        "OsVersion": "10.0.14393",
        "Size": 651862727,
        "VirtualSize": 651862727,
        "GraphDriver": {
            "Name": "windowsfilter",
...
        },
        "RootFS": {
...
        }
    }
]
```

@jstarks PTAL

@dmp42 @mavenugo @friism FYI
