### PR TITLE
integration test for missing arg error code

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -902,3 +902,8 @@ func (s *DockerSuite) TestPsByOrder(c *check.C) {
 	c.Assert(err, checker.NotNil)
 	c.Assert(strings.TrimSpace(out), checker.Equals, fmt.Sprintf("%s\n%s", container2, container1))
 }
+
+func (s *DockerSuite) TestPsFilterMissingArgErrorCode(c *check.C) {
+	_, errCode, _ := dockerCmdWithError("ps", "--filter")
+	c.Assert(errCode, checker.Equals, 125)
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Added an integration test to verify #26777 because an integration test was missing with the merged PR. This test will prevent future regression of the same bug.

**\- How I did it**

With my fingers.

**\- How to verify it**

To run just the one test:

```
bash$ make BIND_DIR=. shell
bash# hack/make.sh binary
bash# TESTFLAGS='-check.f DockerSuite.TestPsFilterMissingArgErrorCode' KEEPBUNDLE=1 hack/make.sh test-integration-cli
```

Applying this patch to a branch off of `v1.12.1` tag and running the test will produce a failure.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

_Should just use the one-line summary that would go with_ #26777 

**\- A picture of a cute animal (not mandatory but encouraged)**

🐶 

Signed-off-by: Andrew Hsu andrewhsu@docker.com
