### PR TITLE
Fix link to non-existent file

### DIFF
--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -43,7 +43,7 @@ To remove `worker2`, issue the following command from `worker2` itself:
 $ docker swarm leave
 Node left the default swarm.
 ```
-To remove an inactive node, use the [`node rm`](swarm_rm.md) command instead.
+To remove an inactive node, use the [`node rm`](node_rm.md) command instead.
 
 ## Related information
 


### PR DESCRIPTION
Fix incorrect reference to `swarm_rm.md` which should be `node_rm.md`. This was introduced by #26125. @thaJeztah @SvenDowideit PTAL, this is blocking us from publishing. Needs cherry-pick as well.
