### PR TITLE
Use the mirror in China for Azure China environment

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -34,6 +34,27 @@ pgp.mit.edu
 keyserver.ubuntu.com
 "
 
+mirror=''
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--mirror)
+			mirror="$2"
+			shift
+			;;
+		*)
+			echo "Illegal option $1"
+			;;
+	esac
+	shift $(( $# > 0 ? 1 : 0 ))
+done
+
+case "$mirror" in
+	AzureChinaCloud)
+		apt_url="https://mirror.azure.cn/docker-engine/apt"
+		yum_url="https://mirror.azure.cn/docker-engine/yum"
+		;;
+esac
+
 command_exists() {
 	command -v "$@" > /dev/null 2>&1
 }


### PR DESCRIPTION
We've set up a mirror of docker installation packages in Azure China, which syncs with docker repo every day, to mitigate the pain due to connection issues from China to docker official repo.
A new parameter is added in this change. If '-e AzureChinaCloud' is specified, the script will use the packages from the mirror in Azure China.
