### PR TITLE
add \n in engine labels display in docker node inspect xxx --pretty

### DIFF
--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -137,8 +137,7 @@ func printNode(out io.Writer, node swarm.Node) {
 	if len(node.Description.Engine.Labels) != 0 {
 		fmt.Fprintln(out, "Engine Labels:")
 		for k, v := range node.Description.Engine.Labels {
-			fmt.Fprintf(out, " - %s = %s", k, v)
+			fmt.Fprintf(out, " - %s = %s\n", k, v)
 		}
 	}
-
 }


### PR DESCRIPTION
When docker engine has multiple labels, `docker node inspect self --pretty` has the following output:

```
root@ubuntu:~# docker node inspect self --pretty
ID:             bq7s60u2mvmcqgc6grxqsx4rm
Hostname:           ubuntu
Joined at:          2016-09-27 17:35:55.526870468 +0000 utc
Status:
 State:         Ready
 Availability:      Active
Manager Status:
 Address:           192.168.59.103:2377
 Raft Status:       Reachable
 Leader:            Yes
Platform:
 Operating System:      linux
 Architecture:      x86_64
Resources:
 CPUs:          1
 Memory:            1.954 GiB
Plugins:
  Network:          bridge, host, null, overlay
  Volume:           local
Engine Version:     1.12.1
Engine Labels:
 - a = b - c = droot@ubuntu:~#
```

We can find that in the bottom line, labels are not separated.
And the `root@ubuntu:~#` should be in another line which is already fixed in #26282 

**\- What I did**
Add \n to line wrap when having several lines.

Signed-off-by: allencloud allen.sun@daocloud.io
