### PR TITLE
Inconsistency: "on_failure" vs "on-failure" 

### DIFF
--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -272,7 +272,7 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 	var rp *swarmapi.RestartPolicy
 	if p != nil {
 		rp = &swarmapi.RestartPolicy{}
-		sanatizedCondition := strings.ToUpper(p.Condition.String())
+		sanatizedCondition := strings.ToUpper(string(p.Condition))
 		if condition, ok := swarmapi.RestartPolicy_RestartCondition_value[sanatizedCondition]; ok {
 			rp.Condition = swarmapi.RestartPolicy_RestartCondition(condition)
 		} else if string(p.Condition) == "" {

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -272,7 +272,7 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 	var rp *swarmapi.RestartPolicy
 	if p != nil {
 		rp = &swarmapi.RestartPolicy{}
-		sanatizedCondition := strings.ToUpper(strings.Replace(string(p.Condition), "-", "_", -1))
+		sanatizedCondition := strings.ToUpper(p.Condition.String())
 		if condition, ok := swarmapi.RestartPolicy_RestartCondition_value[sanatizedCondition]; ok {
 			rp.Condition = swarmapi.RestartPolicy_RestartCondition(condition)
 		} else if string(p.Condition) == "" {

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -253,7 +253,7 @@ func restartPolicyFromGRPC(p *swarmapi.RestartPolicy) *types.RestartPolicy {
 	var rp *types.RestartPolicy
 	if p != nil {
 		rp = &types.RestartPolicy{}
-		
+
 		switch p.Condition {
 		case swarmapi.RestartOnNone:
 			rp.Condition = types.RestartPolicyConditionNone
@@ -264,7 +264,7 @@ func restartPolicyFromGRPC(p *swarmapi.RestartPolicy) *types.RestartPolicy {
 		default:
 			rp.Condition = types.RestartPolicyConditionAny
 		}
-		
+
 		if p.Delay != nil {
 			delay, _ := ptypes.Duration(p.Delay)
 			rp.Delay = &delay
@@ -283,7 +283,7 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 	var rp *swarmapi.RestartPolicy
 	if p != nil {
 		rp = &swarmapi.RestartPolicy{}
-		
+
 		switch p.Condition {
 		case types.RestartPolicyConditionNone:
 			rp.Condition = swarmapi.RestartOnNone

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -253,7 +253,18 @@ func restartPolicyFromGRPC(p *swarmapi.RestartPolicy) *types.RestartPolicy {
 	var rp *types.RestartPolicy
 	if p != nil {
 		rp = &types.RestartPolicy{}
-		rp.Condition = types.RestartPolicyCondition(strings.ToLower(p.Condition.String()))
+		
+		switch p.Condition {
+		case swarmapi.RestartOnNone:
+			rp.Condition = types.RestartPolicyConditionNone
+		case swarmapi.RestartOnFailure:
+			rp.Condition = types.RestartPolicyConditionOnFailure
+		case swarmapi.RestartOnAny:
+			rp.Condition = types.RestartPolicyConditionAny
+		default:
+			rp.Condition = types.RestartPolicyConditionAny
+		}
+		
 		if p.Delay != nil {
 			delay, _ := ptypes.Duration(p.Delay)
 			rp.Delay = &delay
@@ -272,13 +283,19 @@ func restartPolicyToGRPC(p *types.RestartPolicy) (*swarmapi.RestartPolicy, error
 	var rp *swarmapi.RestartPolicy
 	if p != nil {
 		rp = &swarmapi.RestartPolicy{}
-		sanatizedCondition := strings.ToUpper(string(p.Condition))
-		if condition, ok := swarmapi.RestartPolicy_RestartCondition_value[sanatizedCondition]; ok {
-			rp.Condition = swarmapi.RestartPolicy_RestartCondition(condition)
-		} else if string(p.Condition) == "" {
+		
+		switch p.Condition {
+		case types.RestartPolicyConditionNone:
+			rp.Condition = swarmapi.RestartOnNone
+		case types.RestartPolicyConditionOnFailure:
+			rp.Condition = swarmapi.RestartOnFailure
+		case types.RestartPolicyConditionAny:
 			rp.Condition = swarmapi.RestartOnAny
-		} else {
-			return nil, fmt.Errorf("invalid RestartCondition: %q", p.Condition)
+		default:
+			if string(p.Condition) != "" {
+				return nil, fmt.Errorf("invalid RestartCondition: %q", p.Condition)
+			}
+			rp.Condition = swarmapi.RestartOnAny
 		}
 
 		if p.Delay != nil {


### PR DESCRIPTION
I use "on-failure" to update service , but I got "on_failure".

Related to docker/docker#24369 🐳

/cc @tiborvass @cpuguy83 @thaJeztah

🐸

Signed-off-by: Kay Yan kay.yan@daocloud.io
