### PR TITLE
integration: wait for task running in TestServiceHealthRun

### DIFF
--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -47,7 +47,7 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 	waitAndAssert(c, defaultReconciliationTimeout, func(c *check.C) (interface{}, check.CommentInterface) {
 		task = d.getTask(c, task.ID)
 		return task.Status.State, nil
-	}, checker.Equals, swarm.TaskStateStarting)
+	}, checker.Equals, swarm.TaskStateRunning)
 	containerID := task.Status.ContainerStatus.ContainerID
 
 	// wait for container to be healthy


### PR DESCRIPTION
Test can miss Starting state, so wait until its Running

ping @tonistiigi @aaronlehmann 
