### PR TITLE
Fix name collision handling in restore

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -152,13 +152,15 @@ func (daemon *Daemon) restore() error {
 	removeContainers := make(map[string]*container.Container)
 	restartContainers := make(map[*container.Container]chan struct{})
 	activeSandboxes := make(map[string]interface{})
-	for _, c := range containers {
+	for id, c := range containers {
 		if err := daemon.registerName(c); err != nil {
 			logrus.Errorf("Failed to register container %s: %s", c.ID, err)
+			delete(containers, id)
 			continue
 		}
 		if err := daemon.Register(c); err != nil {
 			logrus.Errorf("Failed to register container %s: %s", c.ID, err)
+			delete(containers, id)
 			continue
 		}
 


### PR DESCRIPTION
If container caught name collision error on restore it would still be started but because it's not registered it would not be able to receive any signals back from containerd. That means that at least before #26744 there would be a running container that can't be controlled from docker.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
