### PR TITLE
Revert "Add direct link to event chart image"

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -94,7 +94,7 @@ wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem \
 
 The following diagram depicts the container states accessible through the API.
 
-[![States](images/event_state.png)](../images/event_state.png)
+![States](images/event_state.png)
 
 Some container-related events are not affected by container state, so they are not included in this diagram. These events are:
 


### PR DESCRIPTION
This reverts commit 86de72fef244b3fe209e5793deb40fb26f5b318e.

The link seems malformed and is breaking the overall docs build.
