### PR TITLE
Fix datarace in ApiStatsNetworkStatsVersioning

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -169,9 +169,15 @@ func (s *DockerSuite) TestApiStatsNetworkStatsVersioning(c *check.C) {
 	c.Assert(waitRun(id), checker.IsNil)
 	wg := sync.WaitGroup{}
 
-	for i := 17; i <= 21; i++ {
+	// Windows API versions prior to 1.21 doesn't support stats.
+	startAt := 17
+	if daemonPlatform == "windows" {
+		startAt = 21
+	}
+
+	for i := startAt; i <= 21; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			apiVersion := fmt.Sprintf("v1.%d", i)
 			statsJSONBlob := getVersionedStats(c, id, apiVersion)
@@ -182,7 +188,7 @@ func (s *DockerSuite) TestApiStatsNetworkStatsVersioning(c *check.C) {
 				c.Assert(jsonBlobHasGTE121NetworkStats(statsJSONBlob), checker.Equals, true,
 					check.Commentf("Stats JSON blob from API %s %#v does not look like a >=v1.21 API stats structure", apiVersion, statsJSONBlob))
 			}
-		}()
+		}(i)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes the following data race in `TestApiStatsNetworkStatsVersioning` cli test.

```
WARNING: DATA RACE
Read at 0x00c0421872b8 by goroutine 8:
  github.com/docker/docker/integration-cli.(*DockerSuite).TestApiStatsNetworkStatsVersioning.func1()
      e:/go/src/github.com/docker/docker/integration-cli/docker_api_stats_test.go:176 +0xaf

Previous write at 0x00c0421872b8 by goroutine 17:
  github.com/docker/docker/integration-cli.(*DockerSuite).TestApiStatsNetworkStatsVersioning()
      e:/go/src/github.com/docker/docker/integration-cli/docker_api_stats_test.go:172 +0x307
  runtime.call32()
      C:/go/src/runtime/asm_amd64.s:479 +0x52
  reflect.Value.Call()
      C:/go/src/reflect/value.go:302 +0xc7
  github.com/go-check/check.(*suiteRunner).forkTest.func1()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:816 +0xab7
  github.com/go-check/check.(*suiteRunner).forkCall.func1()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:672 +0x90

Goroutine 8 (running) created at:
  github.com/docker/docker/integration-cli.(*DockerSuite).TestApiStatsNetworkStatsVersioning()
      e:/go/src/github.com/docker/docker/integration-cli/docker_api_stats_test.go:185 +0x2dd
  runtime.call32()
      C:/go/src/runtime/asm_amd64.s:479 +0x52
  reflect.Value.Call()
      C:/go/src/reflect/value.go:302 +0xc7
  github.com/go-check/check.(*suiteRunner).forkTest.func1()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:816 +0xab7
  github.com/go-check/check.(*suiteRunner).forkCall.func1()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:672 +0x90

Goroutine 17 (running) created at:
  github.com/go-check/check.(*suiteRunner).forkCall()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:673 +0x429
  github.com/go-check/check.(*suiteRunner).forkTest()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:850 +0x138
  github.com/go-check/check.(*suiteRunner).runTest()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:859 +0x9e
  github.com/go-check/check.(*suiteRunner).run()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/check.go:621 +0x1cc
  github.com/go-check/check.Run()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/run.go:100 +0x61
  github.com/go-check/check.RunAll()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/run.go:92 +0x119
  github.com/go-check/check.TestingT()
      e:/go/src/github.com/docker/docker/vendor/src/github.com/go-check/check/run.go:80 +0x758
  github.com/docker/docker/integration-cli.Test()
      e:/go/src/github.com/docker/docker/integration-cli/check_test.go:29 +0x14b
  testing.tRunner()
      C:/go/src/testing/testing.go:610 +0xd0
```
