### PR TITLE
add code 200 of network rm in api docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3399,6 +3399,7 @@ Instruct the driver to remove the network (`id`).
 
 **Status codes**:
 
+-   **200** - no error
 -   **204** - no error
 -   **404** - no such network
 -   **500** - server error
@@ -4672,7 +4673,9 @@ Stop and remove the service `id`
 
 **Example response**:
 
-    HTTP/1.1 200 No Content
+    HTTP/1.1 200 OK
+    Content-Length: 0
+    Content-Type: text/plain; charset=utf-8
 
 **Status codes**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3549,6 +3549,7 @@ Instruct the driver to remove the network (`id`).
 
 **Status codes**:
 
+-   **200** - no error
 -   **204** - no error
 -   **404** - no such network
 -   **500** - server error
@@ -4839,7 +4840,9 @@ Stop and remove the service `id`
 
 **Example response**:
 
-    HTTP/1.1 200 No Content
+    HTTP/1.1 200 OK
+    Content-Length: 0
+    Content-Type: text/plain; charset=utf-8
 
 **Status codes**:
 


### PR DESCRIPTION
related to PR https://github.com/docker/docker/pull/26960

This PR fixes existing mistake in `DELETE /networks/(id)` api in doc

Signed-off-by: allencloud allen.sun@daocloud.io
