### PR TITLE
[1.12.x] Hide API v1.25 docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1,12 +1,12 @@
 <!--[metadata]>
 +++
+draft = true
 title = "Remote API v1.25"
 description = "API Documentation for Docker"
 keywords = ["API, Docker, rcli, REST,  documentation"]
 [menu.main]
 parent="engine_remoteapi"
 weight=-6
-draft = true
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
API v1.25 is for Docker 1.13. Commit 4da24ca1e3f5af8c149c10dbffdcb6858460f70a was meant
to put it in draft mode, but added this option in the "menu" section.
