### PR TITLE
Fix apparmor profile installation

### DIFF
--- a/pkg/aaparser/aaparser.go
+++ b/pkg/aaparser/aaparser.go
@@ -26,7 +26,7 @@ func GetVersion() (int, error) {
 // LoadProfile runs `apparmor_parser -r` on a specified apparmor profile to
 // replace the profile.
 func LoadProfile(profilePath string) error {
-	_, err := cmd("-r", filepath.Dir(profilePath))
+	_, err := cmd("", "-r", filepath.Dir(profilePath))
 	if err != nil {
 		return err
 	}

--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -66,8 +66,8 @@ func macroExists(m string) bool {
 	return err == nil
 }
 
-// InstallDefault generates a default profile and installs it in the
-// ProfileDirectory with `apparmor_parser`.
+// InstallDefault generates a default profile in a temp directory determined by
+// os.TempDir(), then loads the profile into the kernel using 'apparmor_parser'.
 func InstallDefault(name string) error {
 	p := profileData{
 		Name: name,


### PR DESCRIPTION
Fixes #26823

Fixes an issue where apparmor was not loaded into the kernel, because
apparmor_parser was being called incorrectly. This is because cmd in aaparser
takes in a directory as the first arg. 

Tested by making a deb, moving that to a machine with no apparmor profiles / docker, and then installing from a deb.

``` sh
$ cat /sys/kernel/security/apparmor/profiles | grep docker-default

$ dpkg -i docker-engine_1.13.0~dev~git20160929.210531.0.1a70211-0~xenial_amd64.deb

$ cat /sys/kernel/security/apparmor/profiles | grep docker-default
docker-default (enforce)
```

ping @justincormack @cyphar

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

![aligator snapping turtle](https://upload.wikimedia.org/wikipedia/commons/8/88/Alligator_snapping_turtle.jpg)
