### PR TITLE
Disable HTML escaping for JSON strings in `docker inspect`

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -81,7 +81,9 @@ func ParseForm(r *http.Request) error {
 func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	return json.NewEncoder(w).Encode(v)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
 }
 
 // VersionFromContext returns an API version from the context using APIVersionKey.

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -407,3 +407,13 @@ func (s *DockerSuite) TestInspectRootFS(c *check.C) {
 
 	c.Assert(len(imageJSON[0].RootFS.Layers), checker.GreaterOrEqualThan, 1)
 }
+
+func (s *DockerSuite) TestInspectAmpersand(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	name := "test"
+	out, _ := dockerCmd(c, "run", "--name", name, "--env", `TEST_ENV="soanni&rtr"`, "busybox", "env")
+	c.Assert(out, checker.Contains, `soanni&rtr`)
+	out, _ = dockerCmd(c, "inspect", name)
+	c.Assert(out, checker.Contains, `soanni&rtr`)
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #27021 where HTML strings like (`&, >, <, etc`) in environmental variables are escaped for JSON output for `docker inspect`. For example, `TEST_ENV="soanni&rtr"` has been escaped to `TEST_ENV="soanni\u0026rtr"`

**\- How I did it**

This fix disabled HTML escaping with `SetEscapeHTML`, which is available in golang. This changes will be applied to all JSON output that utilize `httputils.WriteJSON`.

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #27021.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
