### PR TITLE
Warn if kernel does not support overlay with selinux

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -596,11 +597,56 @@ func configureMaxThreads(config *Config) error {
 	return nil
 }
 
+func overlaySupportsSelinux() (bool, error) {
+	f, err := os.Open("/proc/kallsyms")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	var symAddr, symType, symName, text string
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return false, err
+		}
+
+		text = s.Text()
+		if _, err := fmt.Sscanf(text, "%s %s %s", &symAddr, &symType, &symName); err != nil {
+			return false, fmt.Errorf("Scanning '%s' failed: %s", text, err)
+		}
+
+		// Check for presence of symbol security_inode_copy_up.
+		if symName == "security_inode_copy_up" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // configureKernelSecuritySupport configures and validates security support for the kernel
 func configureKernelSecuritySupport(config *Config, driverName string) error {
 	if config.EnableSelinuxSupport {
 		if !selinuxEnabled() {
 			logrus.Warn("Docker could not enable SELinux on the host system")
+			return nil
+		}
+
+		if driverName == "overlay" || driverName == "overlay2" {
+			// If driver is overlay or overlay2, make sure kernel
+			// supports selinux with overlay.
+			supported, err := overlaySupportsSelinux()
+			if err != nil {
+				return err
+			}
+
+			if !supported {
+				logrus.Warnf("SELinux is not supported with the %s graph driver on this kernel", driverName)
+			}
 		}
 	} else {
 		selinuxSetDisabled()


### PR DESCRIPTION
We first added error to not allow overlay with selinux enabled. Then later
we removed it as kernel was getting close to get the support. But this 
means user does not get meaningful message on old kernels.

This patch reintrouces error back. Difference is that it dynamically
tries to detect if underlying kernel supports overlayfs with selinux
or not. And if it does not, it errors out.

It will not error out if it detects that kernel supports overlayfs with
selinux.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
