### PR TITLE
Windows: Don't resolve volume dest

### DIFF
--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -55,12 +55,10 @@ func (container *Container) UnmountVolumes(forceSyscall bool, volumeEventLog fun
 	)
 
 	for _, mntPoint := range container.MountPoints {
-		dest, err := container.GetResourcePath(mntPoint.Destination)
-		if err != nil {
-			return err
-		}
-		volumeMounts = append(volumeMounts, volume.MountPoint{Destination: dest, Volume: mntPoint.Volume, ID: mntPoint.ID})
-
+		// Do not attempt to get the mountpoint destination on the host as it
+		// is not accessible on Windows in the case that a container is running.
+		// (It's a special reparse point which doesn't have any contextual meaning).
+		volumeMounts = append(volumeMounts, volume.MountPoint{Volume: mntPoint.Volume, ID: mntPoint.ID})
 	}
 
 	// atm, this is a no-op.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @anusha-ragunathan @cpuguy83. This fixes a regression on Windows introduced by https://github.com/docker/docker/pull/26843. Fixes https://github.com/docker/docker/issues/27050.

On Windows, the destination of a mount is not resolvable on the host when a container is running. The architecture is very different to Linux. The destination in this case wasn't actually used anyway, so safe to remove and not attempt to resolve. The destination is a special reparse point which cannot be resolved to a host path.
