### PR TITLE
Fix error reporting in `CopyFileWithTar`

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1050,7 +1050,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 		return nil
 	})
 	defer func() {
-		if er := <-errC; err != nil {
+		if er := <-errC; err == nil && er != nil {
 			err = er
 		}
 	}()


### PR DESCRIPTION
Currently, errors from `Untar` were always overridden.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
