### PR TITLE
Docker inspect "AppArmorProfile" field now shows "docker-default" when AppArmor is enabled and no other profile was defined 

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -1,0 +1,29 @@
+//+build !windows
+
+package daemon
+
+import (
+	"github.com/docker/docker/container"
+)
+
+func (daemon *Daemon) saveApparmorConfig(container *container.Container) error {
+	container.AppArmorProfile = "" //we don't care about the previous value.
+
+	if !daemon.apparmorEnabled {
+		return nil // if apparmor is disabled there is nothing to do here.
+	}
+
+	if err := parseSecurityOpt(container, container.HostConfig); err != nil {
+		return err
+	}
+
+	if !container.HostConfig.Privileged {
+		if container.AppArmorProfile == "" {
+			container.AppArmorProfile = defaultApparmorProfile
+		}
+
+	} else {
+		container.AppArmorProfile = "unconfined"
+	}
+	return nil
+}

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -1,0 +1,11 @@
+//+build windows
+
+package daemon
+
+import (
+	"github.com/docker/docker/container"
+)
+
+func (daemon *Daemon) saveApparmorConfig(container *container.Container) error {
+	return nil
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -92,6 +92,7 @@ type Daemon struct {
 	discoveryWatcher          discoveryReloader
 	root                      string
 	seccompEnabled            bool
+	apparmorEnabled           bool
 	shutdown                  bool
 	uidMaps                   []idtools.IDMap
 	gidMaps                   []idtools.IDMap
@@ -683,6 +684,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 	d.uidMaps = uidMaps
 	d.gidMaps = gidMaps
 	d.seccompEnabled = sysInfo.Seccomp
+	d.apparmorEnabled = sysInfo.AppArmor
 
 	d.nameIndex = registrar.NewRegistrar()
 	d.linkIndex = newLinkIndex()

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -164,6 +164,10 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 		checkpointDir = container.CheckpointDir()
 	}
 
+	if daemon.saveApparmorConfig(container); err != nil {
+		return err
+	}
+
 	if err := daemon.containerd.Create(container.ID, checkpoint, checkpointDir, *spec, container.InitializeStdio, createOptions...); err != nil {
 		errDesc := grpc.ErrorDesc(err)
 		contains := func(s1, s2 string) bool {


### PR DESCRIPTION
This pull request fixes #25935 showing "AppArmorProfile" in docker inspect filled with "docker-default" when AppArmor is enabled and no other profile was defined using --security-opt.
