### PR TITLE
Fix documentation of nocopy option in remote API and man pages (fixes #27046, relates #27029)

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -397,11 +397,15 @@ Create a container
            + `host-src:container-dest:ro` to make the bind-mount read-only
              inside the container. Both `host-src`, and `container-dest` must be
              an _absolute_ path.
-           + `volume-name:container-dest` to bind-mount a volume managed by a
+           + `volume-name:container-dest[:nocopy]` to bind-mount a volume managed by a
              volume driver into the container. `container-dest` must be an
-             _absolute_ path.
-           + `volume-name:container-dest:ro` to mount the volume read-only
-             inside the container.  `container-dest` must be an _absolute_ path.
+             _absolute_ path. Volume contents are initialized with data from `container-dest`, 
+	     provided that the volume is empty. Such an initialization can be avoided by using 
+	     the `nocopy` option.
+           + `volume-name:container-dest:ro[,nocopy]` to mount the volume read-only
+             inside the container.  `container-dest` must be an _absolute_ path. Volume 
+	     contents are initialized with data from `container-dest`, provided that the volume 
+	     is empty. Such an initialization can be avoided by using the `nocopy` option.
     -   **Links** - A list of links for the container. Each link entry should be
           in the form of `container_name:alias`.
     -   **Memory** - Memory limit in bytes.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -406,9 +406,14 @@ Create a container
              an _absolute_ path.
            + `volume-name:container-dest` to bind-mount a volume managed by a
              volume driver into the container. `container-dest` must be an
-             _absolute_ path.
+             _absolute_ path. Volume contents are initialized with data from `container-dest`,
+             provided that the volume is empty. Such an initialization can be avoided by 
+	     using the `nocopy` option.
            + `volume-name:container-dest:ro` to mount the volume read-only
              inside the container.  `container-dest` must be an _absolute_ path.
+	     Volume contents are initialized with data from `container-dest`, provided 
+	     that the volume is empty. Such an initialization can be avoided by 
+	     using the `nocopy` option.
     -   **Links** - A list of links for the container. Each link entry should be
           in the form of `container_name:alias`.
     -   **Memory** - Memory limit in bytes.

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -477,7 +477,7 @@ change propagation properties of source mount. Say `/` is source mount for
 
 
 To disable automatic copying of data from the container path to the volume, use
-the `nocopy` flag. The `nocopy` flag can be set on bind mounts and named volumes.
+the `nocopy` flag. The `nocopy` flag can only be set on named volumes.
 
 **--volume-driver**=""
    Container's volume driver. This driver creates volumes specified either from

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -640,7 +640,7 @@ change propagation properties of source mount. Say `/` is source mount for
 > a volume.
 
 To disable automatic copying of data from the container path to the volume, use
-the `nocopy` flag. The `nocopy` flag can be set on bind mounts and named volumes.
+the `nocopy` flag. The `nocopy` flag can only be set on named volumes.
 
 **--volume-driver**=""
    Container's volume driver. This driver creates volumes specified either from


### PR DESCRIPTION
**Description**
- Docker remote API v1.24 and v1.25 do not mention `nocopy` option
- manual pages do not mention the data initialization of volume contents and the use of `nocopy` to avoid this. 
