### PR TITLE
add lock in libcontainerd client AddProcess

### DIFF
--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -101,6 +101,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 	clnt.unlock(containerID)
 
 	if err := clnt.backend.AttachStreams(processFriendlyName, *iopipe); err != nil {
+		clnt.lock(containerID)
 		return err
 	}
 	clnt.lock(containerID)

--- a/libcontainerd/types_linux.go
+++ b/libcontainerd/types_linux.go
@@ -22,9 +22,9 @@ type Process struct {
 	Capabilities []string `json:"capabilities,omitempty"`
 	// Rlimits specifies rlimit options to apply to the process.
 	Rlimits []specs.Rlimit `json:"rlimits,omitempty"`
-	// ApparmorProfile specified the apparmor profile for the container.
+	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile *string `json:"apparmorProfile,omitempty"`
-	// SelinuxProcessLabel specifies the selinux context that the container process is run as.
+	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel *string `json:"selinuxLabel,omitempty"`
 }
 


### PR DESCRIPTION
As in func `AddProcess`, the second line of code is `defer clnt.unlock(containerID)`, before `clnt.backend.AttachStreams(processFriendlyName, *iopipe)`, code has called `clnt.unlock(containerID)` in Line 101.

As a result, before return, we should lock again.

Please tell me if I missed something.

**\- What I did**
1. add lock
2. fix some typos

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
