### PR TITLE
Don’t attempt to reconnect swarm on failed join after timeout

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -481,8 +481,15 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 
 	select {
 	case <-time.After(swarmConnectTimeout):
-		// attempt to connect will continue in background, also reconnecting
-		go c.reconnectOnFailure(n)
+		// attempt to connect will continue in background, but reconnect only if it didn't fail
+		go func() {
+			select {
+			case <-n.Ready():
+				c.reconnectOnFailure(n)
+			case <-n.done:
+				logrus.Errorf("failed to join the cluster: %+v", c.err)
+			}
+		}()
 		return ErrSwarmJoinTimeoutReached
 	case <-n.Ready():
 		go c.reconnectOnFailure(n)


### PR DESCRIPTION
fixes #26646

The reproducible part of the bug was already fixed with the grpc changes in swarmkit, but this makes it more robust and makes it not rely on swarmkit timeouts.

The issue appeared because reconnecting expects state from remote hosts. There was no state because the join failed.

cc @mrjana 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
