### PR TITLE
Remove amd64 assumption in release.sh, cross and tgz scripts

### DIFF
--- a/hack/make/cross
+++ b/hack/make/cross
@@ -10,13 +10,14 @@ daemonSupporting=(
 
 # if we have our linux/amd64 version compiled, let's symlink it in
 if [ -x "$DEST/../binary-daemon/dockerd-$VERSION" ]; then
-	mkdir -p "$DEST/linux/amd64"
+	arch=$(go env GOHOSTARCH)
+	mkdir -p "$DEST/linux/${arch}"
 	(
-		cd "$DEST/linux/amd64"
+		cd "$DEST/linux/${arch}"
 		ln -s ../../../binary-daemon/* ./
 		ln -s ../../../binary-client/* ./
 	)
-	echo "Created symlinks:" "$DEST/linux/amd64/"*
+	echo "Created symlinks:" "$DEST/linux/${arch}/"*
 fi
 
 for platform in $DOCKER_CROSSPLATFORMS; do

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -4,7 +4,8 @@ CROSS="$DEST/../cross"
 
 set -e
 
-if [ ! -d "$CROSS/linux/amd64" ]; then
+arch=$(go env GOHOSTARCH)
+if [ ! -d "$CROSS/linux/${arch}" ]; then
 	echo >&2 'error: binary and cross must be run before tgz'
 	false
 fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -258,7 +258,7 @@ release_build() {
 
 # Upload binaries and tgz files to S3
 release_binaries() {
-	[ -e "bundles/$VERSION/cross/linux/amd64/docker-$VERSION" ] || {
+	[ "$(find bundles/$VERSION -path "bundles/$VERSION/cross/*/*/docker-$VERSION")" != "" ] || {
 		echo >&2 './hack/make.sh must be run before release_binaries'
 		exit 1
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

This was breaking generation of the `tgz` archive on arm

ping @andrewhsu @tianon @tiborvass @vieux
