### PR TITLE
api/server/httputils: compile with go < 1.7 (WriteJSON)

### DIFF
--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -1,7 +1,6 @@
 package httputils
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -75,15 +74,6 @@ func ParseForm(r *http.Request) error {
 		return err
 	}
 	return nil
-}
-
-// WriteJSON writes the value v to the http response stream as json with standard json encoding.
-func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	return enc.Encode(v)
 }
 
 // VersionFromContext returns an API version from the context using APIVersionKey.

--- a/api/server/httputils/httputils_write_json.go
+++ b/api/server/httputils/httputils_write_json.go
@@ -1,0 +1,17 @@
+// +build go1.7
+
+package httputils
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// WriteJSON writes the value v to the http response stream as json with standard json encoding.
+func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(v)
+}

--- a/api/server/httputils/httputils_write_json_go16.go
+++ b/api/server/httputils/httputils_write_json_go16.go
@@ -1,0 +1,16 @@
+// +build go1.6,!go1.7
+
+package httputils
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// WriteJSON writes the value v to the http response stream as json with standard json encoding.
+func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	enc := json.NewEncoder(w)
+	return enc.Encode(v)
+}


### PR DESCRIPTION
See https://github.com/docker/docker/pull/27060#issuecomment-251342716
#27060 broke compatibility with golang < 1.7. This patch should restore it. Testing with golang 1.6.x, 1.7.x and master.

@vdemeester @thaJeztah PTAL
