### PR TITLE
Require continuation char to be last char in a line

### DIFF
--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -61,7 +61,7 @@ func SetEscapeToken(s string, d *Directive) error {
 		return fmt.Errorf("invalid ESCAPE '%s'. Must be ` or \\", s)
 	}
 	d.EscapeToken = rune(s[0])
-	d.LineContinuationRegex = regexp.MustCompile(`\` + s + `[ \t]*$`)
+	d.LineContinuationRegex = regexp.MustCompile(`\` + s + `$`)
 	return nil
 }
 

--- a/builder/dockerfile/parser/testfiles/continueIndent/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/continueIndent/Dockerfile
@@ -13,8 +13,6 @@ world
 RUN echo hello \
 goodbye\
 frog
-RUN echo hello  \  
-world
 RUN echo hi \
  \
  world \

--- a/builder/dockerfile/parser/testfiles/continueIndent/result
+++ b/builder/dockerfile/parser/testfiles/continueIndent/result
@@ -3,7 +3,6 @@
 (run "echo hello    world")
 (run "echo hello  world")
 (run "echo hello goodbyefrog")
-(run "echo hello  world")
 (run "echo hi   world  goodnight")
 (run "echo goodbyefrog")
 (run "echo goodbyefrog")

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6901,6 +6901,17 @@ func (s *DockerSuite) TestBuildCmdShellArgsEscaped(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestContinueCharSpace(c *check.C) {
+	// Test to make sure that we don't treat a \ as a continuation
+	// character IF there are spaces (or tabs) after it on the same line
+	name := "testbuildcont"
+	_, err := buildImage(name, "FROM busybox\nRUN echo hi \\\t\nbye", true)
+	c.Assert(err, check.NotNil, check.Commentf("Build 1 should fail - didn't"))
+
+	_, err = buildImage(name, "FROM busybox\nRUN echo hi \\ \nbye", true)
+	c.Assert(err, check.NotNil, check.Commentf("Build 2 should fail - didn't"))
+}
+
 // Test case for #24912.
 func (s *DockerSuite) TestBuildStepsWithProgress(c *check.C) {
 	name := "testbuildstepswithprogress"


### PR DESCRIPTION
While looking at #27039 I noticed that we allow for whitespace after
the continuation char (\) which is wrong. It needs to be the very
last char in the line.

Signed-off-by: Doug Davis dug@us.ibm.com
