### PR TITLE
Add plugingetter to pkg.

### DIFF
--- a/pkg/plugingetter/getter.go
+++ b/pkg/plugingetter/getter.go
@@ -1,0 +1,26 @@
+package plugingetter
+
+import "github.com/docker/docker/pkg/plugins"
+
+const (
+	// LOOKUP doesn't update RefCount
+	LOOKUP = 0
+	// CREATE increments RefCount
+	CREATE = 1
+	// REMOVE decrements RefCount
+	REMOVE = -1
+)
+
+// CompatPlugin is a abstraction to handle both v2(new) and v1(legacy) plugins.
+type CompatPlugin interface {
+	Client() *plugins.Client
+	Name() string
+	IsV1() bool
+}
+
+// PluginGetter is the interface implemented by Store
+type PluginGetter interface {
+	Get(name, capability string, mode int) (CompatPlugin, error)
+	GetAllByCap(capability string) ([]CompatPlugin, error)
+	Handle(capability string, callback func(string, *plugins.Client))
+}


### PR DESCRIPTION
plugingetter is indepedent of docker/docker packages, so it can be
moved to pkg. This is also necessary for authorization plugins (part of
pkg) to use pluginv2. The original path at plugin/getter will be
eventually removed, when external repos (eg. libnetwork) update their
import paths.

Signed-off-by: Anusha Ragunathan anusha@docker.com
