### PR TITLE
Fixing servicing bug by always specifying LayerFolderPath

### DIFF
--- a/daemon/monitor_windows.go
+++ b/daemon/monitor_windows.go
@@ -22,13 +22,22 @@ func (daemon *Daemon) postRunProcessing(container *container.Container, e libcon
 			return err
 		}
 
-		servicingOption := &libcontainerd.ServicingOption{
+		newOpts := []libcontainerd.CreateOption{&libcontainerd.ServicingOption{
 			IsServicing: true,
+		}}
+
+		copts, err := daemon.getLibcontainerdCreateOptions(container)
+		if err != nil {
+			return err
+		}
+
+		if copts != nil {
+			newOpts = append(newOpts, *copts...)
 		}
 
 		// Create a new servicing container, which will start, complete the update, and merge back the
 		// results if it succeeded, all as part of the below function call.
-		if err := daemon.containerd.Create((container.ID + "_servicing"), "", "", *spec, servicingOption); err != nil {
+		if err := daemon.containerd.Create((container.ID + "_servicing"), "", "", *spec, newOpts...); err != nil {
 			container.SetExitCode(-1)
 			return fmt.Errorf("Post-run update servicing failed: %s", err)
 		}

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -30,9 +30,9 @@ func (daemon *Daemon) getLibcontainerdCreateOptions(container *container.Contain
 	}
 	if hvOpts.IsHyperV {
 		hvOpts.SandboxPath = filepath.Dir(m["dir"])
-	} else {
-		layerOpts.LayerFolderPath = m["dir"]
 	}
+
+	layerOpts.LayerFolderPath = m["dir"]
 
 	// Generate the layer paths of the layer options
 	img, err := daemon.imageStore.Get(container.ImageID)

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -40,15 +40,15 @@ const defaultOwner = "docker"
 // Create is the entrypoint to create a container from a spec, and if successfully
 // created, start it too. Table below shows the fields required for HCS JSON calling parameters,
 // where if not populated, is omitted.
-// +-----------------+--------------------------------------------+--------------------------------------------+
-// |                 | Isolation=Process                          | Isolation=Hyper-V                          |
-// +-----------------+--------------------------------------------+--------------------------------------------+
-// | VolumePath      | \\?\\Volume{GUIDa}                         |                                            |
-// | LayerFolderPath | %root%\windowsfilter\containerID           |                                            |
-// | Layers[]        | ID=GUIDb;Path=%root%\windowsfilter\layerID | ID=GUIDb;Path=%root%\windowsfilter\layerID |
-// | SandboxPath     |                                            | %root%\windowsfilter                       |
-// | HvRuntime       |                                            | ImagePath=%root%\BaseLayerID\UtilityVM     |
-// +-----------------+--------------------------------------------+--------------------------------------------+
+// +-----------------+--------------------------------------------+---------------------------------------------------+
+// |                 | Isolation=Process                          | Isolation=Hyper-V                                 |
+// +-----------------+--------------------------------------------+---------------------------------------------------+
+// | VolumePath      | \\?\\Volume{GUIDa}                         |                                                   |
+// | LayerFolderPath | %root%\windowsfilter\containerID           | %root%\windowsfilter\containerID (servicing only) |
+// | Layers[]        | ID=GUIDb;Path=%root%\windowsfilter\layerID | ID=GUIDb;Path=%root%\windowsfilter\layerID        |
+// | SandboxPath     |                                            | %root%\windowsfilter                              |
+// | HvRuntime       |                                            | ImagePath=%root%\BaseLayerID\UtilityVM            |
+// +-----------------+--------------------------------------------+---------------------------------------------------+
 //
 // Isolation=Process example:
 //
@@ -170,8 +170,9 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 		}
 	} else {
 		configuration.VolumePath = spec.Root.Path
-		configuration.LayerFolderPath = layerOpt.LayerFolderPath
 	}
+
+	configuration.LayerFolderPath = layerOpt.LayerFolderPath
 
 	for _, layerPath := range layerOpt.LayerPaths {
 		_, filename := filepath.Split(layerPath)


### PR DESCRIPTION
During the recent OCI changes, I mistakenly thought LayerFolderPath is only needed for Windows Server containers (isolation=process) and not for Hyper-V Containers, but it turns out it is also required for servicing containers used to finish installing updates.  Since the servicing containers need to reuse the container's create options, this change makes it so that LayerFolderPath is always filled in for all containers as part of constructing the create options.

@jhowardmsft @jstarks @brian-young
