### PR TITLE
Windows: fix rounding error in container resources

### DIFF
--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -113,12 +113,12 @@ func (clnt *client) Create(containerID string, checkpoint string, checkpointDir 
 				configuration.ProcessorWeight = uint64(*spec.Windows.Resources.CPU.Shares)
 			}
 			if spec.Windows.Resources.CPU.Percent != nil {
-				configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Percent * 100) // ProcessorMaximum is a value between 1 and 10000
+				configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Percent) * 100 // ProcessorMaximum is a value between 1 and 10000
 			}
 		}
 		if spec.Windows.Resources.Memory != nil {
 			if spec.Windows.Resources.Memory.Limit != nil {
-				configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit / 1024 / 1024)
+				configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit) / 1024 / 1024
 			}
 		}
 		if spec.Windows.Resources.Storage != nil {


### PR DESCRIPTION
Fixes an overflow error causing issues with CPU percent and Memory limits.

/cc @jhowardmsft @jstarks 

Signed-off-by: Darren Stahl darst@microsoft.com
