### PR TITLE
add awscli to arm Dockerfile

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -46,7 +46,8 @@ RUN apt-get update && apt-get install -y \
 	python-websocket \
 	xfsprogs \
 	tar \
-	--no-install-recommends
+	--no-install-recommends \
+	&& pip install awscli==1.10.15
 
 # Get lvm2 source for compiling statically
 ENV LVM2_VERSION 2.02.103


### PR DESCRIPTION
Since we are now publishing the arm binaries, we need aws in the Dockerfile to push on s3.

**\- A picture of a cute animal (not mandatory but encouraged)**

![peyj](https://cloud.githubusercontent.com/assets/1032519/19096130/06c1880c-8a4f-11e6-9b6a-f42b47acdec1.jpg)

ping @andrewhsu @mlaventure 
