### PR TITLE
Update experimental/README link to binary installation instructions

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -54,7 +54,7 @@ use the following URLs:
     https://experimental.docker.com/builds/Linux/x86_64/docker-latest.tgz
 
 After downloading the appropriate binary, you can follow the instructions
-[here](https://docs.docker.com/installation/binaries/#get-the-docker-binary) to run the `docker` daemon.
+[here](https://docs.docker.com/engine/installation/binaries/#/get-the-docker-engine-binaries) to run the `docker` daemon.
 
 > **Note**
 >


### PR DESCRIPTION
**\- What I did**
`experimental/README` referenced an outdated link for updating the binary. I updated the link to point to the doc's new home.

**\- How I did it**
via the power of Google, and the docs nav bar.

**\- How to verify it**
The link will bring you to the correct docs page, hooray!

**\- Description for the changelog**
Update experimental/README link to binary installation instructions

**\- A picture of a cute animal (not mandatory but encouraged)**
![](https://thebewildered20somethingwriter.files.wordpress.com/2013/10/ar127975627484243.jpg)

Signed-off-by: Laura Frank ljfrank@gmail.com
