### PR TITLE
Windows: export not supported

### DIFF
--- a/daemon/export.go
+++ b/daemon/export.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/archive"
@@ -12,6 +13,10 @@ import (
 // ContainerExport writes the contents of the container to the given
 // writer. An error is returned if the container cannot be found.
 func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("the daemon on this platform does not support export of a container")
+	}
+
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jstarks. Blocks attempts to export a container on Windows where the platform cannot support this. Avoids confusion and misleading errors such as in https://github.com/docker/docker/issues/25893#ref-commit-5f224b4.

@friism @dmp42 @mavenugo FYI.
