### PR TITLE
Force input stream ANSI emulation for ConsoleZ

### DIFF
--- a/pkg/term/term_windows.go
+++ b/pkg/term/term_windows.go
@@ -71,8 +71,8 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 		}
 	}
 
-	if os.Getenv("ConEmuANSI") == "ON" {
-		// The ConEmu terminal emulates ANSI on output streams well.
+	if os.Getenv("ConEmuANSI") == "ON" || os.Getenv("ConsoleZVersion") != "" {
+		// The ConEmu and ConsoleZ terminals emulate ANSI on output streams well.
 		emulateStdin = true
 		emulateStdout = false
 		emulateStderr = false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Enabled arrow-key navigation in docker container terminals from a Windows docker client running from a ConsoleZ terminal. Closes #26991 

**\- How I did it**
I amended the recently added `ConEmuANSI=ON` check for forcing stdin ANSI emulation to also check for the presence of the `ConsoleZVersion` enviroment variable, which ConsoleZ injects into its terminal environments.

**\- How to verify it**
Start up the docker client in a ConsoleZ terminal and shell into a docker container. Verify that the arrow keys move the cursor and navigate through the command history (assuming a `sh`-like shell).

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**Windows**
- Fix an issue where arrow-navigation did not work when running the docker client in ConsoleZ
