### PR TITLE
Improve TestAttachClosedOnContainerStop

### DIFF
--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bufio"
+	"io/ioutil"
 	"os/exec"
 	"strings"
 	"time"
@@ -23,7 +24,7 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 
-	_, tty, err := pty.Open()
+	pty, tty, err := pty.Open()
 	c.Assert(err, check.IsNil)
 
 	attachCmd := exec.Command(dockerBinary, "attach", id)
@@ -35,6 +36,7 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 
 	errChan := make(chan error)
 	go func() {
+		time.Sleep(300 * time.Millisecond)
 		defer close(errChan)
 		// Container is waiting for us to signal it to stop
 		dockerCmd(c, "stop", id)
@@ -48,7 +50,9 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 
 	select {
 	case err := <-errChan:
-		c.Assert(err, check.IsNil)
+		tty.Close()
+		out, _ := ioutil.ReadAll(pty)
+		c.Assert(err, check.IsNil, check.Commentf("out: %v", string(out)))
 	case <-time.After(attachWait):
 		c.Fatal("timed out without attach returning")
 	}


### PR DESCRIPTION
fixes #26573

My best guess is that this is caused by stop command reaching daemon before attach and causing attach to fail with "container not running". I could never reproduce locally though.

Even if this is not the right fix we should now get an error message with a failed test.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
