### PR TITLE
Don't env-var evaluate labels from docker build cmd line

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -229,7 +229,7 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 	if len(b.options.Labels) > 0 {
 		line := "LABEL "
 		for k, v := range b.options.Labels {
-			line += fmt.Sprintf("%q=%q ", k, v)
+			line += fmt.Sprintf("%q='%s' ", k, v)
 		}
 		_, node, err := parser.ParseLine(line, &b.directive)
 		if err != nil {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6638,6 +6638,19 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 		c.Fatalf("Labels %s, expected %s", res, expected)
 	}
 
+	// Command line option labels with env var
+	name = "scratchz"
+	expected = `{"bar":"$PATH"}`
+	_, err = buildImage(name,
+		`FROM scratch`,
+		true, "--label", "bar=$PATH")
+	c.Assert(err, check.IsNil)
+
+	res = inspectFieldJSON(c, name, "Config.Labels")
+	if res != expected {
+		c.Fatalf("Labels %s, expected %s", res, expected)
+	}
+
 }
 
 // Test case for #22855


### PR DESCRIPTION
Fixes #26027

Signed-off-by: Doug Davis dug@us.ibm.com
