### PR TITLE
install: fix debian stretch

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -440,6 +440,11 @@ do_install() {
 				( set -x; $sh_c 'sleep 3; apt-get install -y -q curl ca-certificates' )
 				curl='curl -sSL'
 			fi
+			if [ ! -e /usr/bin/gpg ]; then
+				apt_get_update
+				( set -x; $sh_c 'sleep 3; apt-get install -y -q gnupg2 || apt-get install -y -q gnupg' )
+			fi
+
 			(
 			set -x
 			for key_server in $key_servers ; do


### PR DESCRIPTION
Apparently, Debian stretch does not come with gnupg installed by
default. This patch ensures that gnupg is installed.

Signed-off-by: Tibor Vass tibor@docker.com

Ping @tianon @mlaventure @vieux 

I'm not sure if this is the right fix but at least it works.
