### PR TITLE
docfix runon code block in device-mapper-driver.md

### DIFF
--- a/docs/userguide/storagedriver/device-mapper-driver.md
+++ b/docs/userguide/storagedriver/device-mapper-driver.md
@@ -194,7 +194,7 @@ Storage Driver: devicemapper
  Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
  Library Version: 1.02.93-RHEL7 (2015-01-28)
  [...]
- ```
+```
 
 The output above shows a Docker host running with the `devicemapper` storage
 driver operating in `loop-lvm` mode. This is indicated by the fact that the


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

When viewing URL https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/

We see a "run on" beginning with phrase, "You can detect the mode by viewing the docker info command:" begins code block, but the code block does not end when intended, at phrase "The output above shows" -- it continues as a code block.

Perhaps this extra space before closing triple-backtick is at fault.
