### PR TITLE
Deprecate repo:shortid syntax

### DIFF
--- a/daemon/image.go
+++ b/daemon/image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/reference"
 )
 
@@ -34,11 +35,15 @@ func (daemon *Daemon) GetImageID(refOrID string) (image.ID, error) {
 	if id, err := daemon.referenceStore.Get(ref); err == nil {
 		return image.IDFromDigest(id), nil
 	}
+
+	// deprecated: repo:shortid https://github.com/docker/docker/pull/799
 	if tagged, ok := ref.(reference.NamedTagged); ok {
-		if id, err := daemon.imageStore.Search(tagged.Tag()); err == nil {
-			for _, namedRef := range daemon.referenceStore.References(id.Digest()) {
-				if namedRef.Name() == ref.Name() {
-					return id, nil
+		if tag := tagged.Tag(); stringid.IsShortID(stringid.TruncateID(tag)) {
+			if id, err := daemon.imageStore.Search(tag); err == nil {
+				for _, namedRef := range daemon.referenceStore.References(id.Digest()) {
+					if namedRef.Name() == ref.Name() {
+						return id, nil
+					}
 				}
 			}
 		}

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -17,6 +17,13 @@ To learn more about Docker Engine's deprecation policy,
 see [Feature Deprecation Policy](index.md#feature-deprecation-policy).
 
 
+### `repository:shortid` image references
+**Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/)**
+
+**Target For Removal In Release: v1.16**
+
+`repository:shortid` syntax for referencing images is very little used, collides with with tag references can be confused with digest references.
+
 ### `docker daemon` subcommand
 **Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/)**
 


### PR DESCRIPTION
fixes #22112

Per discussion in #22112 deprecate this little known feature. The minimum length requirement from `v1.9` has also been restored. 

@thaJeztah @duglin 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
