### PR TITLE
Add GoDoc for client package

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,37 +1,35 @@
-## Client
+## Go client for the Docker Remote API
 
-The client package implements a fully featured http client to interact with the Docker engine. It's modeled after the requirements of the Docker engine CLI, but it can also serve other purposes.
+The `docker` command uses this package to communicate with the daemon. It can also be used by your own Go applications to do anything the command-line interface does – running containers, pulling images, managing swarms, etc.
 
-### Usage
-
-You can use this client package in your applications by creating a new client object. Then use that object to execute operations against the remote server. Follow the example below to see how to list all the containers running in a Docker engine host:
+For example, to list running containers (the equivalent of `docker ps`):
 
 ```go
 package main
 
 import (
-	"fmt"
 	"context"
+	"fmt"
 
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 func main() {
-	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	cli, err := client.NewClient("unix:///var/run/docker.sock", "v1.22", nil, defaultHeaders)
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
 
-	options := types.ContainerListOptions{All: true}
-	containers, err := cli.ContainerList(context.Background(), options)
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
 		panic(err)
 	}
 
-	for _, c := range containers {
-		fmt.Println(c.ID)
+	for _, container := range containers {
+		fmt.Printf("%s %s\n", container.ID[:10], container.Image)
 	}
 }
 ```
+
+[Full documentation is available on GoDoc.](https://godoc.org/github.com/docker/docker/client)

--- a/client/client.go
+++ b/client/client.go
@@ -1,3 +1,48 @@
+/*
+Package client is a Go client for the Docker Remote API.
+
+The "docker" command uses this package to communicate with the daemon. It can also
+be used by your own Go applications to do anything the command-line interface does
+– running containers, pulling images, managing swarms, etc.
+
+For more information about the Remote API, see the documentation:
+https://docs.docker.com/engine/reference/api/docker_remote_api/
+
+Usage
+
+You use the library by creating a client object and calling methods on it. The
+client can be created either from environment variables with NewEnvClient, or
+configured manually with NewClient.
+
+For example, to list running containers (the equivalent of "docker ps"):
+
+	package main
+
+	import (
+		"context"
+		"fmt"
+
+		"github.com/docker/docker/api/types"
+		"github.com/docker/docker/client"
+	)
+
+	func main() {
+		cli, err := client.NewEnvClient()
+		if err != nil {
+			panic(err)
+		}
+
+		containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
+		if err != nil {
+			panic(err)
+		}
+
+		for _, container := range containers {
+			fmt.Printf("%s %s\n", container.ID[:10], container.Image)
+		}
+	}
+
+*/
 package client
 
 import (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

This makes the GoDoc documentation a useful thing to point to as the landing page for the Go client: https://godoc.org/github.com/docker/docker/client

There is a whole load more that can be improved about that (better docs for methods, examples, etc) but this is the lowest hanging fruit.

**\- How I did it**
- Tightened up copy in README
- Make usage example in README a bit simpler
- Put README copy in GoDoc and extended it a bit
- Update README to point at GoDoc
