### PR TITLE
Align bash completion of volumes to completion of nodes and services

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -179,8 +179,25 @@ __docker_complete_containers_in_network() {
 	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
 }
 
+# Returns a list of all volumes. Additional arguments to `docker volume ls`
+# may be specified in order to filter the list, e.g.
+# `__docker_volumes --filter dangling=true`
+# Because volumes do not have IDs, this function does not distinguish between
+# IDs and names.
+__docker_volumes() {
+	__docker_q volume ls -q "$@"
+}
+
+# Applies completion of volumes based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# Additional filters may be appended, see `__docker_volumes`.
 __docker_complete_volumes() {
-	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_volumes "$@")" -- "$current") )
 }
 
 __docker_plugins() {
@@ -1145,8 +1162,7 @@ _docker_events() {
 			return
 			;;
 		volume)
-			cur="${cur##*=}"
-			__docker_complete_volumes
+			__docker_complete_volumes --cur "${cur##*=}"
 			return
 			;;
 	esac
@@ -2204,8 +2220,7 @@ _docker_ps() {
 			return
 			;;
 		volume)
-			cur="${cur##*=}"
-			__docker_complete_volumes
+			__docker_complete_volumes --cur "${cur##*=}"
 			return
 			;;
 	esac
@@ -2850,8 +2865,7 @@ _docker_volume_ls() {
 			return
 			;;
 		name)
-			cur=${cur##*=}
-			__docker_complete_volumes
+			__docker_complete_volumes --cur "${cur##*=}"
 			return
 			;;
 	esac


### PR DESCRIPTION
A preparing step for creating bash completion for #23614: Eliminate inconsistencies between various completion helper functions.

In detail:
- a new function `__docker_volumes` for easier debugging
- use `--cur` instead of modifying the global variable $cur
- allow generic Docker arguments to be passed to `docker volume ls`, e.g. `--filter dangling=true`

Related to #27235
