### PR TITLE
Make the RPM spec compatible with downstream packages

### DIFF
--- a/hack/make/.build-rpm/docker-engine-selinux.spec
+++ b/hack/make/.build-rpm/docker-engine-selinux.spec
@@ -34,8 +34,8 @@ Packager: Docker <support@docker.com>
 Requires(post): selinux-policy-base >= %{selinux_policyver}, selinux-policy-targeted >= %{selinux_policyver}, policycoreutils, policycoreutils-python libselinux-utils
 BuildRequires: selinux-policy selinux-policy-devel
 
-# conflicting packages
-Conflicts: docker-selinux
+# be compatible with distro packages
+Provides: docker-selinux = %{version}-%{release}
 
 # Usage: _format var format
 #   Expand 'modulenames' into various formats as needed

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -89,8 +89,12 @@ Requires: selinux-policy >= %{selinux_policyver}
 Requires(pre): %{name}-selinux >= %{version}-%{release}
 %endif # with_selinux
 
+# be compatible with downstream packages
+Provides: docker = %{version}-%{release}
+Conflicts: docker-common
+Conflicts: docker-latest
+
 # conflicting packages
-Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-engine-cs
 


### PR DESCRIPTION
**\- What I did**
I edited the RPM spec to provide `docker` so it's a drop-in replacement for downstream packages.
Related issue: docker#26059

**\- How I did it**
I used rpmrebuild to test the package as I got an unexpected error trying to do a full build:
`error: %changelog not in descending chronological order`

**\- How to verify it**
You should be able to do this on Fedora and CentOS without conflicts:
`dnf/yum install atomic kubernetes-node` 

**\- Description for the changelog**
Provide docker to be compatible with downstream packages

**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](https://media3.giphy.com/media/AheZDLIrOKu2Y/200_s.gif)

Signed-off-by: David Osztertag
