### PR TITLE
Update docs to add `Size` and `RefCount` to types.Volumes in sample output.

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -3323,7 +3323,9 @@ Return low-level information about the `exec` command `id`.
             "com.example.some-label": "some-value",
             "com.example.some-other-label": "some-other-value"
           },
-          "Scope": "local"
+          "Scope": "local",
+          "Size": 0,
+          "RefCount": 0
         }
       ],
       "Warnings": []
@@ -3377,7 +3379,9 @@ Create a volume
         "com.example.some-label": "some-value",
         "com.example.some-other-label": "some-other-value"
       },
-      "Scope": "local"
+      "Scope": "local",
+      "Size": 0,
+      "RefCount": 0
     }
 
 **Status codes**:
@@ -3424,7 +3428,9 @@ Return low-level information on the volume `name`
           "com.example.some-label": "some-value",
           "com.example.some-other-label": "some-other-value"
       },
-      "Scope": "local"
+      "Scope": "local",
+      "Size": 0,
+      "RefCount": 0
     }
 
 **Status codes**:
@@ -3449,6 +3455,8 @@ response.
 - **Labels** - Labels set on the volume, specified as a map: `{"key":"value","key2":"value2"}`.
 - **Scope** - Scope describes the level at which the volume exists, can be one of
     `global` for cluster-wide or `local` for machine level. The default is `local`.
+- **Size** - Size holds how much disk space is used by the (local driver only). Sets to -1 if not provided.
+- **RefCount** - RefCount holds the number of containers having this volume attached to them. Sets to -1 if not provided.
 
 ### Remove a volume
 


### PR DESCRIPTION
`Size` and `RefCount` have been added to `types.Volumes` (#26108) though some of the remote API docs were not updated.

This fix updates the related docs to add `Size` and `RefCount` to `types.Volumes` in sample output.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
