### PR TITLE
Windows: Update go-winio to 0.3.5

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -49,7 +49,7 @@ esac
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 clone git github.com/Microsoft/hcsshim v0.5.1
-clone git github.com/Microsoft/go-winio v0.3.4
+clone git github.com/Microsoft/go-winio v0.3.5
 clone git github.com/Sirupsen/logrus v0.10.0 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 clone git github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git

--- a/vendor/src/github.com/Microsoft/go-winio/backup.go
+++ b/vendor/src/github.com/Microsoft/go-winio/backup.go
@@ -257,7 +257,7 @@ func OpenForBackup(path string, access uint32, share uint32, createmode uint32) 
 	if err != nil {
 		return nil, err
 	}
-	h, err := syscall.CreateFile(&winPath[0], access, share, nil, createmode, syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	h, err := syscall.CreateFile(&winPath[0], access, share, nil, createmode, syscall.FILE_FLAG_BACKUP_SEMANTICS|syscall.FILE_FLAG_OPEN_REPARSE_POINT, 0)
 	if err != nil {
 		err = &os.PathError{Op: "open", Path: path, Err: err}
 		return nil, err


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Updates go-winio to v0.3.5. This contains a critical bug fix for the 10B release.

@jstarks @friism @dmp42 @mavenugo 
