### PR TITLE
WIP : Ability to attach docker service to node-local networks

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -21,6 +21,7 @@ type Backend interface {
 	CreateManagedNetwork(clustertypes.NetworkCreateRequest) error
 	DeleteManagedNetwork(name string) error
 	FindNetwork(idName string) (libnetwork.Network, error)
+	GetNetworks() []libnetwork.Network
 	SetupIngress(req clustertypes.NetworkCreateRequest, nodeIP string) error
 	PullImage(ctx context.Context, image, tag string, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
 	CreateManagedContainer(config types.ContainerCreateConfig, validateHostname bool) (types.ContainerCreateResponse, error)

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -12,7 +12,9 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/libnetwork"
@@ -182,18 +184,54 @@ func (c *containerAdapter) waitForDetach(ctx context.Context) error {
 	return c.backend.WaitForDetachment(ctx, networkName, networkID, c.container.taskID(), c.container.id())
 }
 
+func (c *containerAdapter) nodeLocalNetworks() []string {
+	ln := []string{}
+	selector, ok := c.container.task.ServiceAnnotations.Labels["com.docker.swarm.network.selector"]
+	if !ok {
+		return ln
+	}
+
+	sel := strings.Split(selector, ",")
+	epConfig := make(map[string]*network.EndpointSettings)
+	for _, s := range sel {
+		for _, n := range c.backend.GetNetworks() {
+			if epConfig[n.Name()] != nil {
+				continue
+			}
+			_, ok := n.Info().Labels()[s]
+			if n.Info().Scope() == "local" && ok {
+				epConfig[n.Name()] = &network.EndpointSettings{}
+				ln = append(ln, n.Name())
+			}
+		}
+	}
+	return ln
+}
+
 func (c *containerAdapter) create(ctx context.Context) error {
 	var cr types.ContainerCreateResponse
 	var err error
 	version := httputils.VersionFromContext(ctx)
 	validateHostname := versions.GreaterThanOrEqualTo(version, "1.24")
 
+	// Use only the first network in container create
+	cnc := c.container.createNetworkingConfig()
+	localNetworks := c.nodeLocalNetworks()
+	connectIndex := 0
+	hostConfig := c.container.hostConfig()
+	if len(cnc.EndpointsConfig) == 0 && len(localNetworks) > 0 {
+		epConfig := make(map[string]*network.EndpointSettings)
+		epConfig[localNetworks[0]] = &network.EndpointSettings{}
+		cnc = &network.NetworkingConfig{EndpointsConfig: epConfig}
+		connectIndex = 1
+		hostConfig.NetworkMode = container.NetworkMode(localNetworks[0])
+	}
+
 	if cr, err = c.backend.CreateManagedContainer(types.ContainerCreateConfig{
-		Name:       c.container.name(),
-		Config:     c.container.config(),
-		HostConfig: c.container.hostConfig(),
-		// Use the first network in container create
-		NetworkingConfig: c.container.createNetworkingConfig(),
+		Name:             c.container.name(),
+		Config:           c.container.config(),
+		HostConfig:       hostConfig,
+		NetworkingConfig: cnc,
 	}, validateHostname); err != nil {
 		return err
 	}
@@ -204,6 +242,15 @@ func (c *containerAdapter) create(ctx context.Context) error {
 
 	if nc != nil {
 		for n, ep := range nc.EndpointsConfig {
+			if err := c.backend.ConnectContainerToNetwork(cr.ID, n, ep); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(localNetworks) > connectIndex {
+		for _, n := range localNetworks[connectIndex:] {
+			ep := &network.EndpointSettings{}
 			if err := c.backend.ConnectContainerToNetwork(cr.ID, n, ep); err != nil {
 				return err
 			}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -633,7 +633,12 @@ func (daemon *Daemon) initNetworkController(config *Config, activeSandboxes map[
 
 	// Initialize default network on "host"
 	if n, _ := controller.NetworkByName("host"); n == nil {
-		if _, err := controller.NewNetwork("host", "host", "", libnetwork.NetworkOptionPersist(true)); err != nil {
+		hostLabels := make(map[string]string)
+		hostLabels["host"] = ""
+		options := []libnetwork.NetworkOption{}
+		options = append(options, libnetwork.NetworkOptionPersist(true))
+		options = append(options, libnetwork.NetworkOptionLabels(hostLabels))
+		if _, err := controller.NewNetwork("host", "host", "", options...); err != nil {
 			return nil, fmt.Errorf("Error creating default \"host\" network: %v", err)
 		}
 	}


### PR DESCRIPTION
As of 1.12.x, `docker services` can be attached only to `overlay` networks. This guarantees the intra-service connectivity and Service Discovery across multiple hosts in the cluster.

But there are many cases where the users can handle the Service Discovery externally and the node-local network (via plugins or `host` network) can provide the multi-host connectivity.

In this PR, the idea is to provide a `selector` like approach using service and network labels to choose node-local networks :

```
docker network create -d bridge --label red localNet
docker network create -d bridge --label red myOtherNet
sudo docker service create --label com.docker.swarm.network.selector=red --name=srv6 busybox sleep 60000
```

Service `srv6` will be connected to both `localNet` and `myOtherNet` on the node where the networks are available.

Also, we can use the same approach for node-local `host` network.

```
sudo docker service create --label com.docker.swarm.network.selector=host --name=srv7 busybox sleep 60000
```

The above command will connect the containers in `host` network.

Also, this change is purely a docker side change with no changes required in swarmkit or libnetwork as it is simply reusing the existing APIs.

Please share inputs/feedback.

Fixes https://github.com/docker/docker/issues/27082
