### PR TITLE
Call the AuthZRes function also when the daemon  returns error

### DIFF
--- a/pkg/authorization/middleware.go
+++ b/pkg/authorization/middleware.go
@@ -55,15 +55,21 @@ func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.Respon
 
 		rw := NewResponseModifier(w)
 
-		if err := handler(ctx, rw, r, vars); err != nil {
-			logrus.Errorf("Handler for %s %s returned error: %s", r.Method, r.RequestURI, err)
-			return err
+		var errD error
+
+		if errD = handler(ctx, rw, r, vars); errD != nil {
+			logrus.Errorf("Handler for %s %s returned error: %s", r.Method, r.RequestURI, errD)
 		}
 
-		if err := authCtx.AuthZResponse(rw, r); err != nil {
+		if err := authCtx.AuthZResponse(rw, r); errD == nil && err != nil {
 			logrus.Errorf("AuthZResponse for %s %s returned error: %s", r.Method, r.RequestURI, err)
 			return err
 		}
+
+		if errD != nil {
+			return errD
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
For each call the authorization plugin was called twice through 2 APIs
1) Before the request is executed on the daemon 
2) After the command was executed and before the response was sent back to the client
On each of this calls the plugin could return either Allow or Deny 
(see [https://docs.docker.com/engine/extend/plugins_authorization/])

The problem was that the plugin was not called on the response in case the operation on the server returned an error . In that case the error returned directly to the client without calling the plugin.

This made it almost impossible for plugins to monitor and log more advanced access usage patterns that take into account the outcome of the operation (e,g,m limit the number or frequency  of created containers by a user)

The plugin itself can check the authZReq.ResponseStatusCode  when handling the response to understand whether there was a server error or not. 

Signed-off-by: Ezra Silvera ezra@il.ibm.com
