### PR TITLE
Improve dockerfile directive parsing

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -71,7 +71,6 @@ type Builder struct {
 	disableCommit    bool
 	cacheBusted      bool
 	allowedBuildArgs map[string]bool // list of build-time args that are allowed for expansion/substitution and passing to commands in 'run'.
-	directive        parser.Directive
 
 	// TODO: remove once docker.Commit can receive a tag
 	id string
@@ -133,19 +132,13 @@ func NewBuilder(clientCtx context.Context, config *types.ImageBuildOptions, back
 		tmpContainers:    map[string]struct{}{},
 		id:               stringid.GenerateNonCryptoID(),
 		allowedBuildArgs: make(map[string]bool),
-		directive: parser.Directive{
-			EscapeSeen:           false,
-			LookingForDirectives: true,
-		},
 	}
 	if icb, ok := backend.(builder.ImageCacheBuilder); ok {
 		b.imageCache = icb.MakeImageCache(config.CacheFrom)
 	}
 
-	parser.SetEscapeToken(parser.DefaultEscapeToken, &b.directive) // Assume the default token for escape
-
 	if dockerfile != nil {
-		b.dockerfile, err = parser.Parse(dockerfile, &b.directive)
+		b.dockerfile, err = parser.Parse(dockerfile)
 		if err != nil {
 			return nil, err
 		}
@@ -231,7 +224,7 @@ func (b *Builder) build(stdout io.Writer, stderr io.Writer, out io.Writer) (stri
 		for k, v := range b.options.Labels {
 			line += fmt.Sprintf("%q=%q ", k, v)
 		}
-		_, node, err := parser.ParseLine(line, &b.directive)
+		_, node, err := parser.ParseLine(line, parser.DefaultDirectives())
 		if err != nil {
 			return "", err
 		}
@@ -317,7 +310,7 @@ func BuildFromConfig(config *container.Config, changes []string) (*container.Con
 		return nil, err
 	}
 
-	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")), &b.directive)
+	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")))
 	if err != nil {
 		return nil, err
 	}

--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -171,9 +171,7 @@ func executeTestCase(t *testing.T, testCase dispatchTestCase) {
 	}()
 
 	r := strings.NewReader(testCase.dockerfile)
-	d := parser.Directive{}
-	parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-	n, err := parser.Parse(r, &d)
+	n, err := parser.Parse(r)
 
 	if err != nil {
 		t.Fatalf("Error when parsing Dockerfile: %s", err)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -416,7 +416,7 @@ func (b *Builder) processImageFrom(img builder.Image) error {
 
 	// parse the ONBUILD triggers by invoking the parser
 	for _, step := range onBuildTriggers {
-		ast, err := parser.Parse(strings.NewReader(step), &b.directive)
+		ast, err := parser.Parse(strings.NewReader(step))
 		if err != nil {
 			return err
 		}
@@ -647,7 +647,7 @@ func (b *Builder) parseDockerfile() error {
 			return fmt.Errorf("The Dockerfile (%s) cannot be empty", b.options.Dockerfile)
 		}
 	}
-	b.dockerfile, err = parser.Parse(f, &b.directive)
+	b.dockerfile, err = parser.Parse(f)
 	if err != nil {
 		return err
 	}

--- a/builder/dockerfile/parser/dumper/main.go
+++ b/builder/dockerfile/parser/dumper/main.go
@@ -23,10 +23,7 @@ func main() {
 		}
 		defer f.Close()
 
-		d := parser.Directive{LookingForDirectives: true}
-		parser.SetEscapeToken(parser.DefaultEscapeToken, &d)
-
-		ast, err := parser.Parse(f, &d)
+		ast, err := parser.Parse(f)
 		if err != nil {
 			panic(err)
 		} else {

--- a/builder/dockerfile/parser/json_test.go
+++ b/builder/dockerfile/parser/json_test.go
@@ -28,10 +28,7 @@ var validJSONArraysOfStrings = map[string][]string{
 
 func TestJSONArraysOfStrings(t *testing.T) {
 	for json, expected := range validJSONArraysOfStrings {
-		d := Directive{}
-		SetEscapeToken(DefaultEscapeToken, &d)
-
-		if node, _, err := parseJSON(json, &d); err != nil {
+		if node, _, err := parseJSON(json, DefaultDirectives()); err != nil {
 			t.Fatalf("%q should be a valid JSON array of strings, but wasn't! (err: %q)", json, err)
 		} else {
 			i := 0
@@ -51,10 +48,7 @@ func TestJSONArraysOfStrings(t *testing.T) {
 		}
 	}
 	for _, json := range invalidJSONArraysOfStrings {
-		d := Directive{}
-		SetEscapeToken(DefaultEscapeToken, &d)
-
-		if _, _, err := parseJSON(json, &d); err != errDockerfileNotStringArray {
+		if _, _, err := parseJSON(json, DefaultDirectives()); err != errDockerfileNotStringArray {
 			t.Fatalf("%q should be an invalid JSON array of strings, but wasn't!", json)
 		}
 	}

--- a/builder/dockerfile/parser/line_parsers.go
+++ b/builder/dockerfile/parser/line_parsers.go
@@ -21,7 +21,7 @@ var (
 
 // ignore the current argument. This will still leave a command parsed, but
 // will not incorporate the arguments into the ast.
-func parseIgnore(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseIgnore(rest string, d Directives) (*Node, map[string]bool, error) {
 	return &Node{}, nil, nil
 }
 
@@ -30,7 +30,7 @@ func parseIgnore(rest string, d *Directive) (*Node, map[string]bool, error) {
 //
 // ONBUILD RUN foo bar -> (onbuild (run foo bar))
 //
-func parseSubCommand(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseSubCommand(rest string, d Directives) (*Node, map[string]bool, error) {
 	if rest == "" {
 		return nil, nil, nil
 	}
@@ -46,7 +46,7 @@ func parseSubCommand(rest string, d *Directive) (*Node, map[string]bool, error) 
 // helper to parse words (i.e space delimited or quoted strings) in a statement.
 // The quotes are preserved as part of this function and they are stripped later
 // as part of processWords().
-func parseWords(rest string, d *Directive) []string {
+func parseWords(rest string, d Directives) []string {
 	const (
 		inSpaces = iota // looking for start of a word
 		inWord
@@ -133,7 +133,7 @@ func parseWords(rest string, d *Directive) []string {
 
 // parse environment like statements. Note that this does *not* handle
 // variable interpolation, which will be handled in the evaluator.
-func parseNameVal(rest string, key string, d *Directive) (*Node, map[string]bool, error) {
+func parseNameVal(rest string, key string, d Directives) (*Node, map[string]bool, error) {
 	// This is kind of tricky because we need to support the old
 	// variant:   KEY name value
 	// as well as the new one:    KEY name=value ...
@@ -187,11 +187,11 @@ func parseNameVal(rest string, key string, d *Directive) (*Node, map[string]bool
 	return rootnode, nil, nil
 }
 
-func parseEnv(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseEnv(rest string, d Directives) (*Node, map[string]bool, error) {
 	return parseNameVal(rest, "ENV", d)
 }
 
-func parseLabel(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseLabel(rest string, d Directives) (*Node, map[string]bool, error) {
 	return parseNameVal(rest, "LABEL", d)
 }
 
@@ -203,7 +203,7 @@ func parseLabel(rest string, d *Directive) (*Node, map[string]bool, error) {
 // In addition, a keyword definition alone is of the form `keyword` like `name1`
 // above. And the assignments `name2=` and `name3=""` are equivalent and
 // assign an empty value to the respective keywords.
-func parseNameOrNameVal(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseNameOrNameVal(rest string, d Directives) (*Node, map[string]bool, error) {
 	words := parseWords(rest, d)
 	if len(words) == 0 {
 		return nil, nil, nil
@@ -229,7 +229,7 @@ func parseNameOrNameVal(rest string, d *Directive) (*Node, map[string]bool, erro
 
 // parses a whitespace-delimited set of arguments. The result is effectively a
 // linked list of string arguments.
-func parseStringsWhitespaceDelimited(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseStringsWhitespaceDelimited(rest string, d Directives) (*Node, map[string]bool, error) {
 	if rest == "" {
 		return nil, nil, nil
 	}
@@ -253,7 +253,7 @@ func parseStringsWhitespaceDelimited(rest string, d *Directive) (*Node, map[stri
 }
 
 // parsestring just wraps the string in quotes and returns a working node.
-func parseString(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseString(rest string, d Directives) (*Node, map[string]bool, error) {
 	if rest == "" {
 		return nil, nil, nil
 	}
@@ -263,7 +263,7 @@ func parseString(rest string, d *Directive) (*Node, map[string]bool, error) {
 }
 
 // parseJSON converts JSON arrays to an AST.
-func parseJSON(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseJSON(rest string, d Directives) (*Node, map[string]bool, error) {
 	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
 	if !strings.HasPrefix(rest, "[") {
 		return nil, nil, fmt.Errorf(`Error parsing "%s" as a JSON array`, rest)
@@ -296,7 +296,7 @@ func parseJSON(rest string, d *Directive) (*Node, map[string]bool, error) {
 // parseMaybeJSON determines if the argument appears to be a JSON array. If
 // so, passes to parseJSON; if not, quotes the result and returns a single
 // node.
-func parseMaybeJSON(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseMaybeJSON(rest string, d Directives) (*Node, map[string]bool, error) {
 	if rest == "" {
 		return nil, nil, nil
 	}
@@ -318,7 +318,7 @@ func parseMaybeJSON(rest string, d *Directive) (*Node, map[string]bool, error) {
 // parseMaybeJSONToList determines if the argument appears to be a JSON array. If
 // so, passes to parseJSON; if not, attempts to parse it as a whitespace
 // delimited string.
-func parseMaybeJSONToList(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseMaybeJSONToList(rest string, d Directives) (*Node, map[string]bool, error) {
 	node, attrs, err := parseJSON(rest, d)
 
 	if err == nil {
@@ -332,7 +332,7 @@ func parseMaybeJSONToList(rest string, d *Directive) (*Node, map[string]bool, er
 }
 
 // The HEALTHCHECK command is like parseMaybeJSON, but has an extra type argument.
-func parseHealthConfig(rest string, d *Directive) (*Node, map[string]bool, error) {
+func parseHealthConfig(rest string, d Directives) (*Node, map[string]bool, error) {
 	// Find end of first argument
 	var sep int
 	for ; sep < len(rest); sep++ {

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -32,8 +32,8 @@ type Node struct {
 	Attributes map[string]bool // special attributes for this node
 	Original   string          // original line used before parsing
 	Flags      []string        // only top Node should have this set
-	StartLine  int             // the line in the original dockerfile where the node begins
-	EndLine    int             // the line in the original dockerfile where the node ends
+	startLine  int             // the line in the original dockerfile where the node begins (used in tests)
+	endLine    int             // the line in the original dockerfile where the node ends (used in tests)
 }
 
 // Directive is the structure used during a build run to hold the state of
@@ -153,7 +153,7 @@ func ParseLine(line string, d *Directive) (string, *Node, error) {
 func Parse(rwc io.Reader, d *Directive) (*Node, error) {
 	currentLine := 0
 	root := &Node{}
-	root.StartLine = -1
+	root.startLine = -1
 	scanner := bufio.NewScanner(rwc)
 
 	utf8bom := []byte{0xEF, 0xBB, 0xBF}
@@ -199,14 +199,14 @@ func Parse(rwc io.Reader, d *Directive) (*Node, error) {
 
 		if child != nil {
 			// Update the line information for the current child.
-			child.StartLine = startLine
-			child.EndLine = currentLine
+			child.startLine = startLine
+			child.endLine = currentLine
 			// Update the line information for the root. The starting line of the root is always the
 			// starting line of the first child and the ending line is the ending line of the last child.
-			if root.StartLine < 0 {
-				root.StartLine = currentLine
+			if root.startLine < 0 {
+				root.startLine = currentLine
 			}
-			root.EndLine = currentLine
+			root.endLine = currentLine
 			root.Children = append(root.Children, child)
 		}
 	}

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -4,6 +4,7 @@ package parser
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -36,27 +37,36 @@ type Node struct {
 	endLine    int             // the line in the original dockerfile where the node ends (used in tests)
 }
 
-// Directive is the structure used during a build run to hold the state of
+// Directives is the structure used during a build run to hold the state of
 // parsing directives.
-type Directive struct {
-	EscapeToken           rune           // Current escape token
-	LineContinuationRegex *regexp.Regexp // Current line contination regex
-	LookingForDirectives  bool           // Whether we are currently looking for directives
-	EscapeSeen            bool           // Whether the escape directive has been seen
+type Directives struct {
+	EscapeToken           rune                // Current escape token
+	LineContinuationRegex *regexp.Regexp      // Current line contination regex
+	usedDirectives        map[string]struct{} // Whether a directive has been seen
 }
 
 var (
-	dispatch           map[string]func(string, *Directive) (*Node, map[string]bool, error)
-	tokenWhitespace    = regexp.MustCompile(`[\t\v\f\r ]+`)
-	tokenEscapeCommand = regexp.MustCompile(`^#[ \t]*escape[ \t]*=[ \t]*(?P<escapechar>.).*$`)
-	tokenComment       = regexp.MustCompile(`^#.*$`)
+	dispatch        map[string]func(string, Directives) (*Node, map[string]bool, error)
+	tokenWhitespace = regexp.MustCompile(`[\t\v\f\r ]+`)
+	directiveRegexp = regexp.MustCompile(`^#[ \t]*([a-z0-9]+)[ \t]*=[ \t]*(.*)$`)
+	tokenComment    = regexp.MustCompile(`^#.*$`)
+	errNoDirective  = errors.New("not a directive")
 )
 
 // DefaultEscapeToken is the default escape token
 const DefaultEscapeToken = "\\"
 
+// DefaultDirectives returns directives struct with default properties
+func DefaultDirectives() Directives {
+	d := &Directives{usedDirectives: make(map[string]struct{})}
+	if err := d.SetEscapeToken(DefaultEscapeToken); err != nil {
+		panic(err)
+	}
+	return *d
+}
+
 // SetEscapeToken sets the default token for escaping characters in a Dockerfile.
-func SetEscapeToken(s string, d *Directive) error {
+func (d *Directives) SetEscapeToken(s string) error {
 	if s != "`" && s != "\\" {
 		return fmt.Errorf("invalid ESCAPE '%s'. Must be ` or \\", s)
 	}
@@ -72,7 +82,7 @@ func init() {
 	// reformulating the arguments according to the rules in the parser
 	// functions. Errors are propagated up by Parse() and the resulting AST can
 	// be incorporated directly into the existing AST as a next.
-	dispatch = map[string]func(string, *Directive) (*Node, map[string]bool, error){
+	dispatch = map[string]func(string, Directives) (*Node, map[string]bool, error){
 		command.Add:         parseMaybeJSONToList,
 		command.Arg:         parseNameOrNameVal,
 		command.Cmd:         parseMaybeJSON,
@@ -95,33 +105,10 @@ func init() {
 }
 
 // ParseLine parses a line and returns the remainder.
-func ParseLine(line string, d *Directive) (string, *Node, error) {
-	// Handle the parser directive '# escape=<char>. Parser directives must precede
-	// any builder instruction or other comments, and cannot be repeated.
-	if d.LookingForDirectives {
-		tecMatch := tokenEscapeCommand.FindStringSubmatch(strings.ToLower(line))
-		if len(tecMatch) > 0 {
-			if d.EscapeSeen == true {
-				return "", nil, fmt.Errorf("only one escape parser directive can be used")
-			}
-			for i, n := range tokenEscapeCommand.SubexpNames() {
-				if n == "escapechar" {
-					if err := SetEscapeToken(tecMatch[i], d); err != nil {
-						return "", nil, err
-					}
-					d.EscapeSeen = true
-					return "", nil, nil
-				}
-			}
-		}
-	}
-
-	d.LookingForDirectives = false
-
+func ParseLine(line string, d Directives) (string, *Node, error) {
 	if line = stripComments(line); line == "" {
 		return "", nil, nil
 	}
-
 	if d.LineContinuationRegex.MatchString(line) {
 		line = d.LineContinuationRegex.ReplaceAllString(line, "")
 		return line, nil, nil
@@ -148,56 +135,47 @@ func ParseLine(line string, d *Directive) (string, *Node, error) {
 	return "", node, nil
 }
 
+// ParseDirectives attempts to parse a directive from input line
+func ParseDirectives(line string, d *Directives) (err error) {
+	tecMatch := directiveRegexp.FindStringSubmatch(strings.ToLower(line))
+	if len(tecMatch) > 2 {
+		if _, ok := d.usedDirectives[tecMatch[1]]; ok {
+			return fmt.Errorf("only one %v parser directive can be used", tecMatch[1])
+		}
+		defer func() {
+			if err != nil {
+				d.usedDirectives[tecMatch[1]] = struct{}{}
+			}
+		}()
+		switch tecMatch[1] {
+		case "escape":
+			return d.SetEscapeToken(tecMatch[2])
+		}
+	}
+	return errNoDirective
+}
+
 // Parse is the main parse routine.
 // It handles an io.ReadWriteCloser and returns the root of the AST.
-func Parse(rwc io.Reader, d *Directive) (*Node, error) {
-	currentLine := 0
+func Parse(r io.Reader) (*Node, error) {
+	startLine, currentLine := 0, 0
+	parseDirectives := true
 	root := &Node{}
 	root.startLine = -1
-	scanner := bufio.NewScanner(rwc)
-
+	scanner := bufio.NewScanner(r)
+	d := DefaultDirectives()
 	utf8bom := []byte{0xEF, 0xBB, 0xBF}
-	for scanner.Scan() {
-		scannedBytes := scanner.Bytes()
-		// We trim UTF8 BOM
-		if currentLine == 0 {
-			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
-		}
-		scannedLine := strings.TrimLeftFunc(string(scannedBytes), unicode.IsSpace)
-		currentLine++
-		line, child, err := ParseLine(scannedLine, d)
+	partialLine := ""
+
+	parse := func(line string) error { // iterate line and accumulate children
+		line, child, err := ParseLine(line, d)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		startLine := currentLine
-
-		if line != "" && child == nil {
-			for scanner.Scan() {
-				newline := scanner.Text()
-				currentLine++
-
-				if stripComments(strings.TrimSpace(newline)) == "" {
-					continue
-				}
-
-				line, child, err = ParseLine(line+newline, d)
-				if err != nil {
-					return nil, err
-				}
-
-				if child != nil {
-					break
-				}
-			}
-			if child == nil && line != "" {
-				_, child, err = ParseLine(line, d)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
+		partialLine = line
 
 		if child != nil {
+			partialLine = ""
 			// Update the line information for the current child.
 			child.startLine = startLine
 			child.endLine = currentLine
@@ -208,6 +186,43 @@ func Parse(rwc io.Reader, d *Directive) (*Node, error) {
 			}
 			root.endLine = currentLine
 			root.Children = append(root.Children, child)
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		scannedBytes := scanner.Bytes()
+		// We trim UTF8 BOM
+		if currentLine == 0 {
+			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
+		}
+		currentLine++
+		if parseDirectives {
+			if err := ParseDirectives(string(scannedBytes), &d); err != nil {
+				if err == errNoDirective {
+					parseDirectives = false
+				} else {
+					return nil, err
+				}
+			}
+		}
+
+		scannedLine := string(scannedBytes)
+		if len(partialLine) == 0 {
+			startLine = currentLine
+			scannedLine = strings.TrimLeftFunc(scannedLine, unicode.IsSpace)
+		}
+		if line := stripComments(scannedLine); line == "" {
+			continue
+		}
+		partialLine += scannedLine
+		if err := parse(partialLine); err != nil {
+			return nil, err
+		}
+	}
+	if partialLine != "" {
+		if err := parse(partialLine); err != nil {
+			return nil, err
 		}
 	}
 

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -150,8 +150,8 @@ func TestLineInformation(t *testing.T) {
 		t.Fatalf("Error parsing dockerfile %s: %v", testFileLineInfo, err)
 	}
 
-	if ast.StartLine != 5 || ast.EndLine != 31 {
-		fmt.Fprintf(os.Stderr, "Wrong root line information: expected(%d-%d), actual(%d-%d)\n", 5, 31, ast.StartLine, ast.EndLine)
+	if ast.startLine != 5 || ast.endLine != 31 {
+		fmt.Fprintf(os.Stderr, "Wrong root line information: expected(%d-%d), actual(%d-%d)\n", 5, 31, ast.startLine, ast.endLine)
 		t.Fatalf("Root line information doesn't match result.")
 	}
 	if len(ast.Children) != 3 {
@@ -164,9 +164,9 @@ func TestLineInformation(t *testing.T) {
 		{17, 31},
 	}
 	for i, child := range ast.Children {
-		if child.StartLine != expected[i][0] || child.EndLine != expected[i][1] {
+		if child.startLine != expected[i][0] || child.endLine != expected[i][1] {
 			t.Logf("Wrong line information for child %d: expected(%d-%d), actual(%d-%d)\n",
-				i, expected[i][0], expected[i][1], child.StartLine, child.EndLine)
+				i, expected[i][0], expected[i][1], child.startLine, child.endLine)
 			t.Fatalf("Root line information doesn't match result.")
 		}
 	}

--- a/builder/dockerfile/parser/parser_test.go
+++ b/builder/dockerfile/parser/parser_test.go
@@ -40,9 +40,7 @@ func TestTestNegative(t *testing.T) {
 		}
 		defer df.Close()
 
-		d := Directive{LookingForDirectives: true}
-		SetEscapeToken(DefaultEscapeToken, &d)
-		_, err = Parse(df, &d)
+		_, err = Parse(df)
 		if err == nil {
 			t.Fatalf("No error parsing broken dockerfile for %s", dir)
 		}
@@ -60,9 +58,7 @@ func TestTestData(t *testing.T) {
 		}
 		defer df.Close()
 
-		d := Directive{LookingForDirectives: true}
-		SetEscapeToken(DefaultEscapeToken, &d)
-		ast, err := Parse(df, &d)
+		ast, err := Parse(df)
 		if err != nil {
 			t.Fatalf("Error parsing %s's dockerfile: %v", dir, err)
 		}
@@ -122,9 +118,7 @@ func TestParseWords(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		d := Directive{LookingForDirectives: true}
-		SetEscapeToken(DefaultEscapeToken, &d)
-		words := parseWords(test["input"][0], &d)
+		words := parseWords(test["input"][0], DefaultDirectives())
 		if len(words) != len(test["expect"]) {
 			t.Fatalf("length check failed. input: %v, expect: %q, output: %q", test["input"][0], test["expect"], words)
 		}
@@ -143,9 +137,7 @@ func TestLineInformation(t *testing.T) {
 	}
 	defer df.Close()
 
-	d := Directive{LookingForDirectives: true}
-	SetEscapeToken(DefaultEscapeToken, &d)
-	ast, err := Parse(df, &d)
+	ast, err := Parse(df)
 	if err != nil {
 		t.Fatalf("Error parsing dockerfile %s: %v", testFileLineInfo, err)
 	}

--- a/builder/dockerfile/parser/testfiles/escape-nonewline/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/escape-nonewline/Dockerfile
@@ -1,4 +1,4 @@
-# escape = ``
+# escape = `
 # There is no white space line after the directives. This still succeeds, but goes
 # against best practices.
 FROM image

--- a/builder/dockerfile/parser/testfiles/escape_whitespace/Dockerfile
+++ b/builder/dockerfile/parser/testfiles/escape_whitespace/Dockerfile
@@ -1,0 +1,5 @@
+  #escape = `
+
+FROM image
+ENV foo `
+ENV bar baz

--- a/builder/dockerfile/parser/testfiles/escape_whitespace/result
+++ b/builder/dockerfile/parser/testfiles/escape_whitespace/result
@@ -1,0 +1,3 @@
+(from "image")
+(env "foo" "`")
+(env "bar" "baz")

--- a/builder/dockerfile/parser/utils.go
+++ b/builder/dockerfile/parser/utils.go
@@ -36,7 +36,7 @@ func (node *Node) Dump() string {
 
 // performs the dispatch based on the two primal strings, cmd and args. Please
 // look at the dispatch table in parser.go to see how these dispatchers work.
-func fullDispatch(cmd, args string, d *Directive) (*Node, map[string]bool, error) {
+func fullDispatch(cmd, args string, d Directives) (*Node, map[string]bool, error) {
 	fn := dispatch[cmd]
 
 	// Ignore invalid Dockerfile instructions

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3577,8 +3577,8 @@ RUN [ "$(id -u):$(id -g)/$(id -un):$(id -gn)/$(id -G):$(id -Gn)" = '1001:1001/do
 
 # Switch back to root and double check that worked exactly as we might expect it to
 USER root
+# Add a "supplementary" group for our dockerio user
 RUN [ "$(id -u):$(id -g)/$(id -un):$(id -gn)/$(id -G):$(id -Gn)" = '0:0/root:root/0 10:root wheel' ] && \
-	# Add a "supplementary" group for our dockerio user \
 	echo 'supplementary:x:1002:dockerio' >> /etc/group
 
 # ... and then go verify that we get it like we expect


### PR DESCRIPTION
Refactor so that new directives can be easily added in the future by just adding a new lines in https://github.com/tonistiigi/docker/blob/parse-directives/builder/dockerfile/parser/parser.go#L150-L152 . Simplify so that there is no need to store an instance of directives with the builder or pass it to the `Parse()` function. 

Fix bug where directive with whitespace prefix would still be applied.

In current version, error handling was inconsistent. Specifying invalid escape character would not produce an error but using escape directive twice would. Changed it so that if the directive has correct syntax and valid directive key, it will fail with a proper error.

cc @jhowardmsft 
