### PR TITLE
Reduce TestRunCommandWithTimeoutKilled flakiness

### DIFF
--- a/pkg/integration/cmd/command_test.go
+++ b/pkg/integration/cmd/command_test.go
@@ -63,12 +63,12 @@ func TestRunCommandWithTimeoutKilled(t *testing.T) {
 		t.Skip("Needs porting to Windows")
 	}
 
-	command := []string{"sh", "-c", "while true ; do echo 1 ; sleep .1 ; done"}
-	result := RunCmd(Cmd{Command: command, Timeout: 500 * time.Millisecond})
+	command := []string{"sh", "-c", "while true ; do echo 1 ; sleep .5 ; done"}
+	result := RunCmd(Cmd{Command: command, Timeout: 1250 * time.Millisecond})
 	result.Assert(t, Expected{Timeout: true})
 
 	ones := strings.Split(result.Stdout(), "\n")
-	assert.Equal(t, len(ones), 6)
+	assert.Equal(t, len(ones), 4)
 }
 
 func TestRunCommandWithErrors(t *testing.T) {


### PR DESCRIPTION
Failed in https://jenkins.dockerproject.org/job/Docker%20Master%20(arm)/3349/console

Increase the timeout so it would not happen again. Also, set the timeouts in the middle of the sleep iterations.

cc @dnephin 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
