### PR TITLE
Modify function name from SetDaemonLogLevel to SetLogLevel

### DIFF
--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -101,9 +101,8 @@ func (commonOpts *CommonOptions) SetDefaultOptions(flags *pflag.FlagSet) {
 	}
 }
 
-// SetDaemonLogLevel sets the logrus logging level
-// TODO: this is a bad name, it applies to the client as well.
-func SetDaemonLogLevel(logLevel string) {
+// SetLogLevel sets the logrus logging level
+func SetLogLevel(logLevel string) {
 	if logLevel != "" {
 		lvl, err := logrus.ParseLevel(logLevel)
 		if err != nil {

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -99,7 +99,7 @@ func showVersion() {
 }
 
 func dockerPreRun(opts *cliflags.ClientOptions) {
-	cliflags.SetDaemonLogLevel(opts.Common.LogLevel)
+	cliflags.SetLogLevel(opts.Common.LogLevel)
 
 	if opts.ConfigDir != "" {
 		cliconfig.SetConfigDir(opts.ConfigDir)

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -395,7 +395,7 @@ func loadDaemonCliConfig(opts daemonOptions) (*daemon.Config, error) {
 	}
 
 	// ensure that the log level is the one set after merging configurations
-	cliflags.SetDaemonLogLevel(config.LogLevel)
+	cliflags.SetLogLevel(config.LogLevel)
 
 	return config, nil
 }


### PR DESCRIPTION
**\- What I did**
Modify function name from SetDaemonLogLevel to SetLogLevel.

**\- How I did it**
Modify code.

**\- Description for the changelog**
According to TODO, This is a bad name, it applies to the client as well. Therefore, update function name from SetDaemonLogLevel to SetLogLevel.

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
