### PR TITLE
Wait until tasks have been created in TestSwarmTaskListFilter

### DIFF
--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -287,6 +287,15 @@ func (s *DockerSwarmSuite) TestSwarmTaskListFilter(c *check.C) {
 
 	filter := "name=redis-cluster"
 
+	checkNumTasks := func(*check.C) (interface{}, check.CommentInterface) {
+		out, err := d.Cmd("service", "ps", "--filter", filter, name)
+		c.Assert(err, checker.IsNil)
+		return len(strings.Split(out, "\n")) - 2, nil // includes header and nl in last line
+	}
+
+	// wait until all tasks have been created
+	waitAndAssert(c, defaultReconciliationTimeout, checkNumTasks, checker.Equals, 3)
+
 	out, err = d.Cmd("service", "ps", "--filter", filter, name)
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, name+".1")
@@ -309,6 +318,8 @@ func (s *DockerSwarmSuite) TestSwarmTaskListFilter(c *check.C) {
 	out, err = d.Cmd("service", "create", "--name", name, "--mode=global", "busybox", "top")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+
+	waitAndAssert(c, defaultReconciliationTimeout, checkNumTasks, checker.Equals, 1)
 
 	filter = "name=redis-cluster"
 	out, err = d.Cmd("service", "ps", "--filter", filter, name)


### PR DESCRIPTION
Fix falky test https://jenkins.dockerproject.org/job/Docker%20Master%20(arm)/3361/console

Successful service creation doesn't mean tasks have already been created. So wait for the condition first. 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
