### PR TITLE
Add --user flag to Dockerfile ADD and COPY

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -137,7 +137,7 @@ type Backend interface {
 	// with Context.Walk
 	//ContainerCopy(name string, res string) (io.ReadCloser, error)
 	// TODO: use copyBackend api
-	CopyOnBuild(containerID string, destPath string, src FileInfo, decompress bool) error
+	CopyOnBuild(containerID string, destPath string, src FileInfo, decompress bool, usergrp string) error
 }
 
 // Image represents a Docker image used by the builder.

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -158,11 +158,13 @@ func add(b *Builder, args []string, attributes map[string]bool, original string)
 		return errAtLeastTwoArguments("ADD")
 	}
 
+	userStr := b.flags.AddString("user", "")
+
 	if err := b.flags.Parse(); err != nil {
 		return err
 	}
 
-	return b.runContextCommand(args, true, true, "ADD")
+	return b.runContextCommand(args, true, true, "ADD", userStr.Value)
 }
 
 // COPY foo /path
@@ -174,11 +176,13 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, origina
 		return errAtLeastTwoArguments("COPY")
 	}
 
+	userStr := b.flags.AddString("user", "")
+
 	if err := b.flags.Parse(); err != nil {
 		return err
 	}
 
-	return b.runContextCommand(args, false, false, "COPY")
+	return b.runContextCommand(args, false, false, "COPY", userStr.Value)
 }
 
 // FROM imagename

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -91,7 +91,7 @@ type copyInfo struct {
 	decompress bool
 }
 
-func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalDecompression bool, cmdName string) error {
+func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalDecompression bool, cmdName string, usergrp string) error {
 	if b.context == nil {
 		return fmt.Errorf("No context given. Impossible to use %s", cmdName)
 	}
@@ -171,7 +171,11 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	}
 
 	cmd := b.runConfig.Cmd
-	b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s %s in %s ", cmdName, srcHash, dest)))
+	if usergrp != "" {
+		b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s --user=%s %s in %s ", cmdName, usergrp, srcHash, dest)))
+	} else {
+		b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s %s in %s ", cmdName, srcHash, dest)))
+	}
 	defer func(cmd strslice.StrSlice) { b.runConfig.Cmd = cmd }(cmd)
 
 	if hit, err := b.probeCache(); err != nil {
@@ -186,7 +190,12 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	}
 	b.tmpContainers[container.ID] = struct{}{}
 
-	comment := fmt.Sprintf("%s %s in %s", cmdName, origPaths, dest)
+	var comment string
+	if usergrp != "" {
+		comment = fmt.Sprintf("%s --user=%s %s in %s", cmdName, usergrp, origPaths, dest)
+	} else {
+		comment = fmt.Sprintf("%s %s in %s", cmdName, origPaths, dest)
+	}
 
 	// Twiddle the destination when its a relative path - meaning, make it
 	// relative to the WORKINGDIR
@@ -195,7 +204,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 	}
 
 	for _, info := range infos {
-		if err := b.docker.CopyOnBuild(container.ID, dest, info.FileInfo, info.decompress); err != nil {
+		if err := b.docker.CopyOnBuild(container.ID, dest, info.FileInfo, info.decompress, usergrp); err != nil {
 			return err
 		}
 	}

--- a/container/container.go
+++ b/container/container.go
@@ -40,6 +40,7 @@ import (
 	"github.com/docker/libnetwork/options"
 	"github.com/docker/libnetwork/types"
 	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/runc/libcontainer/user"
 )
 
 const configFileName = "config.v2.json"
@@ -292,6 +293,36 @@ func (container *Container) GetRootResourcePath(path string) (string, error) {
 	// any filepath operations must be done in an OS agnostic way.
 	cleanPath := filepath.Join(string(os.PathSeparator), path)
 	return symlink.FollowSymlinkInScope(filepath.Join(container.Root, cleanPath), container.Root)
+}
+
+// ParseUserGrp takes `username` in the format of username, uid, username:groupname,
+// uid:gid, username:gid, or uid:groupname and parses the passwd file in the container
+// to return the ExecUser referred to by `username`.
+func (container *Container) ParseUserGrp(username string) (*user.ExecUser, error) {
+	passwdPath, err := user.GetPasswdPath()
+	if err != nil {
+		return nil, err
+	}
+	passwdPath, err = container.GetResourcePath(passwdPath)
+	if err != nil {
+		return nil, err
+	}
+
+	groupPath, err := user.GetGroupPath()
+	if err != nil {
+		return nil, err
+	}
+	groupPath, err = container.GetResourcePath(groupPath)
+	if err != nil {
+		return nil, err
+	}
+
+	execUser, err := user.GetExecUserPath(username, nil, passwdPath, groupPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return execUser, nil
 }
 
 // ExitOnNext signals to the monitor that it should not restart the container

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -146,7 +146,7 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 		}
 		c.ShmPath = "/dev/shm"
 	} else {
-		rootUID, rootGID := daemon.GetRemappedUIDGID()
+		rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 		if !c.HasMountFor("/dev/shm") {
 			shmPath, err := c.ShmResourcePath()
 			if err != nil {

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -22,7 +22,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 	}
 	defer daemon.Unmount(container)
 
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	if err := container.SetupWorkingDirectory(rootUID, rootGID); err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -917,12 +917,20 @@ func (daemon *Daemon) GetUIDGIDMaps() ([]idtools.IDMap, []idtools.IDMap) {
 	return daemon.uidMaps, daemon.gidMaps
 }
 
-// GetRemappedUIDGID returns the current daemon's uid and gid values
+// GetRemappedRootUIDGID returns the current daemon's uid and gid values
 // if user namespaces are in use for this daemon instance.  If not
 // this function will return "real" root values of 0, 0.
-func (daemon *Daemon) GetRemappedUIDGID() (int, int) {
+func (daemon *Daemon) GetRemappedRootUIDGID() (int, int) {
 	uid, gid, _ := idtools.GetRootUIDGID(daemon.uidMaps, daemon.gidMaps)
 	return uid, gid
+}
+
+// GetRemappedUIDGID returns the current daemon's uid and gid values for
+// the specified user and group, if user namespaces are in use for this
+// daemon instance. If not, this function will return the passed in values.
+func (daemon *Daemon) GetRemappedUIDGID(uid, gid int) (int, int) {
+	mappedUID, mappedGID, _ := idtools.GetUIDGID(uid, gid, daemon.uidMaps, daemon.gidMaps)
+	return mappedUID, mappedGID
 }
 
 // tempDir returns the default directory to use for temporary files.
@@ -935,7 +943,7 @@ func tempDir(rootDir string, rootUID, rootGID int) (string, error) {
 }
 
 func (daemon *Daemon) setupInitLayer(initPath string) error {
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	return setupInitLayer(initPath, rootUID, rootGID)
 }
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -576,7 +576,7 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 		Path:     c.BaseFS,
 		Readonly: c.HostConfig.ReadonlyRootfs,
 	}
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
 		return err
 	}

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -18,7 +18,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	}
 
 	// TODO Windows - this can be removed. Not used (UID/GID)
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
 		return nil, err
 	}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -34,7 +34,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		if err := daemon.lazyInitializeVolume(c.ID, m); err != nil {
 			return nil, err
 		}
-		rootUID, rootGID := daemon.GetRemappedUIDGID()
+		rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 		path, err := m.Setup(c.MountLabel, rootUID, rootGID)
 		if err != nil {
 			return nil, err
@@ -65,7 +65,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 	// if we are going to mount any of the network files from container
 	// metadata, the ownership must be set properly for potential container
 	// remapped root (user namespaces)
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	for _, mount := range netMounts {
 		if err := os.Chown(mount.Source, rootUID, rootGID); err != nil {
 			return nil, err

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -793,7 +793,12 @@ the source will be copied inside the destination container.
     ADD test relativeDir/          # adds "test" to `WORKDIR`/relativeDir/
     ADD test /absoluteDir/         # adds "test" to /absoluteDir/
 
-All new files and directories are created with a UID and GID of 0.
+If the `--user` flag is specified (e.g., `ADD --user=john:john`), new files and
+directories will be created with the UID and GID corresponding to the specified
+user and group. Formats allowed are `user`, `uid`, `user:group`,
+`user:gid`, `uid:group`, and `uid:gid`
+If `--user` is not specified, all new files and directories are created with a
+UID and GID of 0.
 
 In the case where `<src>` is a remote file URL, the destination will
 have permissions of 600. If the remote file being retrieved has an HTTP
@@ -905,7 +910,12 @@ the source will be copied inside the destination container.
     COPY test relativeDir/   # adds "test" to `WORKDIR`/relativeDir/
     COPY test /absoluteDir/  # adds "test" to /absoluteDir/
 
-All new files and directories are created with a UID and GID of 0.
+If the `--user` flag is specified (e.g., `COPY --user=john:john`), new files and
+directories will be created with the UID and GID corresponding to the specified
+user and group. Formats allowed are `user`, `uid`, `user:group`,
+`user:gid`, `uid:group`, and `uid:gid`
+If `--user` is not specified, all new files and directories are created with a
+UID and GID of 0.
 
 > **Note**:
 > If you build using STDIN (`docker build - < somefile`), there is no

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -770,6 +770,78 @@ RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'root:root' ]`, true);
 	}
 }
 
+func (s *DockerSuite) TestBuildAddUserFlag(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Linux specific test
+	name := "testaddtonewdest"
+	ctx, err := fakeContext(`FROM busybox
+RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
+RUN echo 'test1:x:1001:' >> /etc/group
+RUN echo 'test2:x:1002:' >> /etc/group
+ADD --user=test1:1002 . /new_dir
+RUN ls -l /
+RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
+		map[string]string{
+			"test_dir/test_file": "test file",
+		})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerDaemonSuite) TestBuildAddUserFlagUserNamespace(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Linux specific test
+
+	c.Assert(s.d.StartWithBusybox("--userns-remap", "default"), checker.IsNil)
+
+	name := "testaddtonewdest"
+	ctx, err := fakeContext(`FROM busybox
+RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
+RUN echo 'test1:x:1001:' >> /etc/group
+RUN echo 'test2:x:1002:' >> /etc/group
+ADD --user=test1:1002 . /new_dir
+RUN ls -l /
+RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
+		map[string]string{
+			"test_dir/test_file": "test file",
+		})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerSuite) TestBuildCopyUserFlag(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Linux specific test
+	name := "testaddtonewdest"
+	ctx, err := fakeContext(`FROM busybox
+RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
+RUN echo 'test1:x:1001:' >> /etc/group
+RUN echo 'test2:x:1002:' >> /etc/group
+COPY --user=test1:1002 . /new_dir
+RUN ls -l /
+RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
+		map[string]string{
+			"test_dir/test_file": "test file",
+		})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}
+
 func (s *DockerSuite) TestBuildAddFileWithWhitespace(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Not currently passing on Windows
 	name := "testaddfilewithwhitespace"

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -54,6 +54,29 @@ func MkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int) error {
 	return mkdirAs(path, mode, ownerUID, ownerGID, false, true)
 }
 
+// GetUIDGID retrieves the remapped uid/gid pair from the set of maps.
+// If the maps are empty, If no map is provided, then the translation
+// assumes a 1-to-1 mapping and returns the passed in uid and gid.
+func GetUIDGID(uid, gid int, uidMap, gidMap []IDMap) (int, int, error) {
+	mappedUID, mappedGID := uid, gid
+
+	if uidMap != nil {
+		xUID, err := ToHost(uid, uidMap)
+		if err != nil {
+			return -1, -1, err
+		}
+		mappedUID = xUID
+	}
+	if gidMap != nil {
+		xGID, err := ToHost(gid, gidMap)
+		if err != nil {
+			return -1, -1, err
+		}
+		mappedGID = xGID
+	}
+	return mappedUID, mappedGID, nil
+}
+
 // GetRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.
 // If the maps are empty, then the root uid/gid will default to "real" 0/0
 func GetRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {


### PR DESCRIPTION
**\- What I did**
Add a `--user` flag to Dockerfile ADD and COPY instructions, proposed by #13600

**\- How I did it**
Added flag to `add` and `disptachCopy` of `builder/dockerfile/dispatchers.go`, and passed the relevant information through to the daemon which looks up the user/group using a new function on the container object.

**\- How to verify it**
Create a Dockerfile that uses the `--user` flag on an ADD or COPY instruction, and check that the file is listed as having the appropriate owner

**\- Description for the changelog**
add `--user` flag to Dockerfile ADD and COPY instructions

**\- A picture of a cute animal (not mandatory but encouraged)**
![Capybara on grass](http://static.theglobeandmail.ca/a63/news/toronto/article30639614.ece/ALTERNATES/w620/web-to-capybara-0628.JPG)

Signed-off-by: Kara Alexandra kalexandra@us.ibm.com
