### PR TITLE
Update docs for `Size` and `RefCount` for `UsageData`

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -2663,8 +2663,10 @@ Return docker data usage information
                     "Mountpoint": "",
                     "Labels": null,
                     "Scope": "",
-                    "Size": 0,
-                    "RefCount": 0
+                    "UsageData": {
+                        "Size": 0,
+                        "RefCount": 0
+                    }
                 }
         ]
     }


### PR DESCRIPTION
In #27294, `Size` and `RefCount` has been wrapped into `UsageData` and is only exposed in `GET system/df`. Though the docs was not updated in `docker_remote_api_v1.25.md`.

This fix updates the docs to refect the needed changes related to `UsageData`.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
