### PR TITLE
Fixing error reporting on servicing failure

### DIFF
--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -1,6 +1,7 @@
 package libcontainerd
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"syscall"
@@ -105,8 +106,10 @@ func (ctr *container) start() error {
 		exitCode := ctr.waitProcessExitCode(&ctr.process)
 
 		if exitCode != 0 {
-			logrus.Warnf("libcontainerd: servicing container %s returned non-zero exit code %d", ctr.containerID, exitCode)
-			return ctr.terminate()
+			if err := ctr.terminate(); err != nil {
+				logrus.Warnf("libcontainerd: terminating servicing container %s failed: %s", ctr.containerID, err)
+			}
+			return fmt.Errorf("libcontainerd: servicing container %s returned non-zero exit code %d", ctr.containerID, exitCode)
 		}
 
 		return ctr.hcsContainer.WaitTimeout(time.Minute * 5)


### PR DESCRIPTION
@jhowardmsft @jstarks 

The code that handles waiting for the servicing container to complete correctly grabs the exit code and logs a failure, but doesn't return that failure to the caller, mistakenly causing servicing operations to look successful when they really failed during processing.

Signed-off-by: Stefan J. Wernli swernli@microsoft.com
