### PR TITLE
Windows: Stop returning errors that should be ignored while closing stdin

### DIFF
--- a/libcontainerd/process_windows.go
+++ b/libcontainerd/process_windows.go
@@ -38,17 +38,14 @@ func createStdInCloser(pipe io.WriteCloser, process hcsshim.Process) io.WriteClo
 			return err
 		}
 
-		// We do not need to lock container ID here, even though
-		// we are calling into hcsshim. This is safe, because the
-		// only place that closes this process handle is this method.
 		err := process.CloseStdin()
-		if err != nil && !hcsshim.IsNotExist(err) {
+		if err != nil && !hcsshim.IsNotExist(err) && !hcsshim.IsAlreadyClosed(err) {
 			// This error will occur if the compute system is currently shutting down
 			if perr, ok := err.(*hcsshim.ProcessError); ok && perr.Err != hcsshim.ErrVmcomputeOperationInvalidState {
 				return err
 			}
 		}
 
-		return err
+		return nil
 	})
 }


### PR DESCRIPTION
This stops returning errors when they should be ignored while closing Stdin pipes, it also ignores InvalidHandle errors, since that means that the handle is already closed, which closes Stdin.

Signed-off-by: Darren Stahl darst@microsoft.com
