### PR TITLE
oci/defaults_linux.go: mask /sys/firmware

### DIFF
--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -83,6 +83,7 @@ func DefaultSpec() specs.Spec {
 			"/proc/timer_list",
 			"/proc/timer_stats",
 			"/proc/sched_debug",
+			"/sys/firmware",
 		},
 		ReadonlyPaths: []string{
 			"/proc/asound",


### PR DESCRIPTION
Some firmware information including SMBIOS and ACPI tables were unexpectedly exposed.
Basically they shouldn't contain sensitive information, but some exceptions:
-   `/sys/firmware/acpi/tables/{SLIC,MSDM}`: Windows license information: http://feishare.com/attachments/article/265/microsoft-software-licensing-tables.pdf (original copy at microsoft.com seems [404](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/dn653305%28v=vs.85%29.aspx))
- `/sys/firmware/ibft/target0/chap-secret`: iSCSI CHAP secret: ftp://ftp.software.ibm.com/systems/support/bladecenter/iscsi_boot_firmware_table_v1.03.pdf
- Other vendor-specific information (Anyone know? DMI can be a vulnerability in some specific case?)

PR https://github.com/docker/docker/pull/26618 masks `/sys/firmware` using apparmor, but it was not effective for systems that doesn't use apparmor.

Corresponding PR for runc (merged): https://github.com/opencontainers/runc/pull/1068

**\- What I did**
mask `/sys/firmware`

**\- How I did it**
Add `/sys/firmware` to the `MaskedPath` field of the default OCI spec

**\- How to verify it**

``` console
$ docker run --rm busybox ls /sys/firmware
$ docker run --rm busybox touch /sys/firmware/foo
touch: /sys/firmware/foo: Read-only file system
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

oci/defaults_linux.go: mask /sys/firmware

**\- A picture of a cute animal (not mandatory but encouraged)**

![penguin](https://upload.wikimedia.org/wikipedia/commons/5/54/Automated_weighbridge_for_Ad%C3%A9lie_penguins_-_journal.pone.0085291.g002.png)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
