### PR TITLE
Align bash completion of plugins to completion of nodes and services

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -183,12 +183,49 @@ __docker_complete_volumes() {
 	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
 }
 
+# Returns a list of all plugins of a given type.
+# The type has to be specified with the mandatory option `--type`.
+# Valid types are: Network, Volume, Authorization.
+# Completions may be added or removed with `--add` and `--remove`
 __docker_plugins() {
-	__docker_q info | sed -n "/^Plugins/,/^[^ ]/s/ $1: //p"
+	local type add=() remove=()
+	while true ; do
+		case "$1" in
+			--type)
+				type="$2"
+				shift 2
+				;;
+			--add)
+				add+=("$2")
+				shift 2
+				;;
+			--remove)
+				remove+=("$2")
+				shift 2
+				;;
+			*)
+				break
+				;;
+		esac
+	done
+
+	local plugins=($(__docker_q info | sed -n "/^Plugins/,/^[^ ]/s/ $type: //p"))
+	for del in "${remove[@]}" ; do
+		plugins=(${plugins[@]/$del/})
+	done
+	echo "${plugins[@]} ${add[@]}"
 }
 
+# Applies completion of plugins based on the current value of `$cur` or
+# the value of the optional first option `--cur`, if given.
+# The plugin type has to be specified with the next option `--type`.
 __docker_complete_plugins() {
-	COMPREPLY=( $(compgen -W "$(__docker_plugins $1)" -- "$cur") )
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_plugins "$@")" -- "$current") )
 }
 
 __docker_runtimes() {
@@ -970,7 +1007,7 @@ _docker_daemon() {
 
 	case "$prev" in
 		--authorization-plugin)
-			__docker_complete_plugins Authorization
+			__docker_complete_plugins --type Authorization
 			return
 			;;
 		--cluster-store)
@@ -1472,11 +1509,8 @@ _docker_network_create() {
 			return
 			;;
 		--driver|-d)
-			local plugins="$(__docker_plugins Network) macvlan"
-			# remove drivers that allow one instance only
-			plugins=${plugins/ host / }
-			plugins=${plugins/ null / }
-			COMPREPLY=( $(compgen -W "$plugins" -- "$cur") )
+			# remove drivers that allow one instance only, add drivers missing in `docker info`
+			__docker_complete_plugins --type Network --remove host --remove null --add macvlan
 			return
 			;;
 		--label)
@@ -1527,8 +1561,7 @@ _docker_network_ls() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		driver)
-			local plugins=" $(__docker_plugins Network) "
-			COMPREPLY=( $(compgen -W "$plugins" -- "${cur##*=}") )
+			__docker_complete_plugins --cur "${cur##*=}" --type Network --add macvlan
 			return
 			;;
 		id)
@@ -2536,7 +2569,7 @@ _docker_run() {
 					__docker_complete_containers_all
 					;;
 				*)
-					COMPREPLY=( $( compgen -W "$(__docker_plugins Network) $(__docker_networks) container:" -- "$cur") )
+					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
 					if [ "${COMPREPLY[*]}" = "container:" ] ; then
 						__docker_nospace
 					fi
@@ -2584,7 +2617,7 @@ _docker_run() {
 			return
 			;;
 		--volume-driver)
-			__docker_complete_plugins Volume
+			__docker_complete_plugins --type Volume
 			return
 			;;
 		--volumes-from)
@@ -2805,7 +2838,7 @@ _docker_version() {
 _docker_volume_create() {
 	case "$prev" in
 		--driver|-d)
-			__docker_complete_plugins Volume
+			__docker_complete_plugins --type Volume
 			return
 			;;
 		--label|--opt|-o)
@@ -2845,8 +2878,7 @@ _docker_volume_ls() {
 			return
 			;;
 		driver)
-			cur=${cur##*=}
-			__docker_complete_plugins Volume
+			__docker_complete_plugins --cur "${cur##*=}" --type Volume
 			return
 			;;
 		name)


### PR DESCRIPTION
Changes:
- specify plugin type with new `--type` option instead of just an argument, thus allowing richer syntax for the helper functions
- move logic to add or remove networks into the helper function with new `--add` and `--remove` options
- do not modify global variable `$cur`, work with a copy in `--cur` instead
- `macvlan` driver was missing in completion for `docker network ls -f driver=`

Related: #27239, #27235.
