### PR TITLE
#26346: docker volume inspect doesn't do partial ID matching

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -213,19 +213,6 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, err
 	}, nil
 }
 
-// VolumeInspect looks up a volume by name. An error is returned if
-// the volume cannot be found.
-func (daemon *Daemon) VolumeInspect(name string) (*types.Volume, error) {
-	v, err := daemon.volumes.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	apiV := volumeToAPIType(v)
-	apiV.Mountpoint = v.Path()
-	apiV.Status = v.Status()
-	return apiV, nil
-}
-
 func (daemon *Daemon) getBackwardsCompatibleNetworkSettings(settings *network.Settings) *v1p20.NetworkSettings {
 	result := &v1p20.NetworkSettings{
 		NetworkSettingsBase: types.NetworkSettingsBase{


### PR DESCRIPTION
fixes #26346

**\- What I did**
Implemented code for performing partial ID matching for docker volumes (ID is name for volumes)

**\- How I did it**
Added method GetVolumesByName. It iterates over all volumes in daemon volume store and returns the list of volumes whose names match with passed prefix

**\- How to verify it**
1. Build a developer container with latest docker/master and this PR
2. Create binaries in container with hack/make.sh binary
3. Copy binaries in /usr/bin
4. Start docker daemon
5. Create docker volume with "docker volume create test1"
6. Try docker volume inspect with complete name
docker volume inspect test1
docker inspect test1
7. Try docker volume inspect with first part of volume name
docker volume inspect te
docker inspect te
8. Try volume inspect with non existing volume name and ensure you get error
docker volume inspect abc -> no such volume: abc
docker inspect abc -> no such container/network/volume/service 
9. If more and one volumes with same first initial characters exists, inspect will be performed for first one.

**\- Description for the changelog**
1. Removed a VolumeInspect method from daemon/inspect.go
2. Added this method in daemon/volumes.go
3. Added new method getVolumesByName in daemon/volumes.go which does partial name matching and returns list of matching volumes
4. Replaced method call in VolumeInspect that looks-up volume with complete name, with new method getVolumesByName.  

**\- A picture of a cute animal (not mandatory but encouraged)**
![adorable-giraffe-family](https://cloud.githubusercontent.com/assets/10231863/19310259/dfb593d0-90a6-11e6-9c01-d7a49064461f.jpg)
