### PR TITLE
Allow `docker deploy` command accept stack with/without extension

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -4,6 +4,7 @@ package stack
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -34,7 +35,7 @@ func newDeployCommand(dockerCli *command.DockerCli) *cobra.Command {
 		Short:   "Create and update a stack from a Distributed Application Bundle (DAB)",
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.namespace = args[0]
+			opts.namespace = strings.TrimSuffix(args[0], ".dab")
 			return runDeploy(dockerCli, opts)
 		},
 	}

--- a/integration-cli/docker_cli_stack_test.go
+++ b/integration-cli/docker_cli_stack_test.go
@@ -90,3 +90,20 @@ func (s *DockerSwarmSuite) TestStackWithDAB(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, check.Equals, "NAME  SERVICES\n")
 }
+
+func (s *DockerSwarmSuite) TestStackWithDABExtension(c *check.C) {
+	// setup
+	testStackName := "test.dab"
+	testDABFileName := testStackName
+	defer os.RemoveAll(testDABFileName)
+	err := ioutil.WriteFile(testDABFileName, []byte(testDAB), 0444)
+	c.Assert(err, checker.IsNil)
+	d := s.AddDaemon(c, true, true)
+	// deploy
+	stackArgs := []string{"stack", "deploy", testStackName}
+	out, err := d.Cmd(stackArgs...)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, "Loading bundle from test.dab\n")
+	c.Assert(out, checker.Contains, "Creating service test_srv1\n")
+	c.Assert(out, checker.Contains, "Creating service test_srv2\n")
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #25855 where the command `docker deploy` can only accept a STACK without extension of `.dab`. In other words, `docker deploy hellojavaee.dab` gives an error:

```
Bundle hellojavaee.dab.dab not found. Specify the path with --file
```

**\- How I did it**

This fix updates the way namespace STACK is taken so that in case `STACK.dab` is provided with `docker deploy`:

```
$ docker deploy STACK.dab
```

The `STACK` is used as namespace (instead of `STACK.dab`).

NOTE: This fix will only allows `.dab` extension in namespace, because it is not possible to have a namespace with `.` in the middle. In other words, a namespace `hello.java.ee` will not work anyway (whether the file `hello.java.ee` exists or not).

**\- How to verify it**

An additional integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25855.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
