### PR TITLE
debian package: update buildtags for armhf ubuntu-trusty

### DIFF
--- a/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
@@ -1,10 +1,12 @@
 FROM armhf/ubuntu:trusty
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.7.1
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS apparmor selinux
+
+ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV RUNC_BUILDTAGS apparmor selinux


### PR DESCRIPTION
Build the armhf ubuntu-trusty debian package with the proper RUNC buildtags

Signed-off-by: Felix Ruess felix.ruess@gmail.com
