### PR TITLE
#26639: Local NFS volumes do not resolve hostnames

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -348,4 +349,16 @@ func validateOpts(opts map[string]string) error {
 
 func (v *localVolume) Status() map[string]interface{} {
 	return nil
+}
+
+// getAddress finds out address/hostname from options
+func getAddress(opts string) string {
+	optsList := strings.Split(opts, ",")
+	for i := 0; i < len(optsList); i++ {
+		if strings.HasPrefix(optsList[i], "addr=") {
+			addr := (strings.SplitN(optsList[i], "=", 2)[1])
+			return addr
+		}
+	}
+	return ""
 }

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -12,6 +12,22 @@ import (
 	"github.com/docker/docker/pkg/mount"
 )
 
+func TestGetAddress(t *testing.T) {
+	cases := map[string]string{
+		"addr=11.11.11.1":   "11.11.11.1",
+		" ":                 "",
+		"addr=":             "",
+		"addr=2001:db8::68": "2001:db8::68",
+	}
+	for name, success := range cases {
+		v := getAddress(name)
+		if v != success {
+			t.Errorf("Test case failed for %s actual: %s expected : %s", name, v, success)
+		}
+	}
+
+}
+
 func TestRemove(t *testing.T) {
 	// TODO Windows: Investigate why this test fails on Windows under CI
 	//               but passes locally.

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -7,6 +7,7 @@ package local
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 
@@ -71,6 +72,16 @@ func (v *localVolume) mount() error {
 	if v.opts.MountDevice == "" {
 		return fmt.Errorf("missing device in volume options")
 	}
-	err := mount.Mount(v.opts.MountDevice, v.path, v.opts.MountType, v.opts.MountOpts)
+	mountOpts := v.opts.MountOpts
+	if v.opts.MountType == "nfs" {
+		if addrValue := getAddress(v.opts.MountOpts); addrValue != "" && net.ParseIP(addrValue).To4() == nil {
+			ipAddr, err := net.ResolveIPAddr("ip", addrValue)
+			if err != nil {
+				return errors.Wrapf(err, "error resolving passed in nfs address")
+			}
+			mountOpts = strings.Replace(mountOpts, "addr="+addrValue, "addr="+ipAddr.String(), 1)
+		}
+	}
+	err := mount.Mount(v.opts.MountDevice, v.path, v.opts.MountType, mountOpts)
 	return errors.Wrapf(err, "error while mounting volume with options: %s", v.opts)
 }


### PR DESCRIPTION
fixes #26639

**\- What I did**
Implemented code for mounting local NFS with hostname
- **How I did it**
  Added method GetAddress, to get address/hostname from options. Added another Method IsIP, to verify if option has IP or Address. If option has hostname then used LookupHost built in function to convert to IPAddress.

**\- How to verify it**
1. Build a developer container with latest docker/master and this PR
2. Start docker daemon with copying binaries with hack/make.sh binary.
3. Create docker volume with "docker volume create -o type=nfs -o o=addr=nfs-server,rw -o device=:/nfsdir --name test4"
  Note. Please make sure “nfs-server” is resolvable with Ip address.
4. Create container with “docker run -it  --rm -v test4:/storage datkumbh/nfs sh”
5. Verify that container created successfully and nfsdir mounted in /storage.

**\- Description for the changelog**
1. Added a GetAddress  method in volume/local/local_unix.go
2. Added a IsIP method in volume/local/local_unix.go to verify if hostname is IP or return blank
3. Added a support to convert hostname to IpAddress if option is wit hostname 

*_\- A picture of a cute animal *_

![image](https://cloud.githubusercontent.com/assets/21226676/19326029/6927a6dc-90e6-11e6-9a6d-e7fe1e845065.png)
