### PR TITLE
Use ListOpt for `docker network create --label` and `docker volume create --label`

### DIFF
--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -20,7 +20,7 @@ type createOptions struct {
 	name       string
 	driver     string
 	driverOpts opts.MapOpts
-	labels     []string
+	labels     opts.ListOpts
 	internal   bool
 	ipv6       bool
 	attachable bool
@@ -36,6 +36,7 @@ type createOptions struct {
 func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := createOptions{
 		driverOpts: *opts.NewMapOpts(nil, nil),
+		labels:     opts.NewListOpts(runconfigopts.ValidateEnv),
 		ipamAux:    *opts.NewMapOpts(nil, nil),
 		ipamOpt:    *opts.NewMapOpts(nil, nil),
 	}
@@ -53,7 +54,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.driver, "driver", "d", "bridge", "Driver to manage the Network")
 	flags.VarP(&opts.driverOpts, "opt", "o", "Set driver specific options")
-	flags.StringSliceVar(&opts.labels, "label", []string{}, "Set metadata on a network")
+	flags.Var(&opts.labels, "label", "Set metadata on a network")
 	flags.BoolVar(&opts.internal, "internal", false, "Restrict external access to the network")
 	flags.BoolVar(&opts.ipv6, "ipv6", false, "Enable IPv6 networking")
 	flags.BoolVar(&opts.attachable, "attachable", false, "Enable manual container attachment")
@@ -90,7 +91,7 @@ func runCreate(dockerCli *command.DockerCli, opts createOptions) error {
 		Internal:       opts.internal,
 		EnableIPv6:     opts.ipv6,
 		Attachable:     opts.attachable,
-		Labels:         runconfigopts.ConvertKVStringsToMap(opts.labels),
+		Labels:         runconfigopts.ConvertKVStringsToMap(opts.labels.GetAll()),
 	}
 
 	resp, err := client.NetworkCreate(context.Background(), opts.name, nc)

--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -17,12 +17,13 @@ type createOptions struct {
 	name       string
 	driver     string
 	driverOpts opts.MapOpts
-	labels     []string
+	labels     opts.ListOpts
 }
 
 func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := createOptions{
 		driverOpts: *opts.NewMapOpts(nil, nil),
+		labels:     opts.NewListOpts(runconfigopts.ValidateEnv),
 	}
 
 	cmd := &cobra.Command{
@@ -46,7 +47,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&opts.name, "name", "", "Specify volume name")
 	flags.Lookup("name").Hidden = true
 	flags.VarP(&opts.driverOpts, "opt", "o", "Set driver specific options")
-	flags.StringSliceVar(&opts.labels, "label", []string{}, "Set metadata for a volume")
+	flags.Var(&opts.labels, "label", "Set metadata for a volume")
 
 	return cmd
 }
@@ -58,7 +59,7 @@ func runCreate(dockerCli *command.DockerCli, opts createOptions) error {
 		Driver:     opts.driver,
 		DriverOpts: opts.driverOpts.GetAll(),
 		Name:       opts.name,
-		Labels:     runconfigopts.ConvertKVStringsToMap(opts.labels),
+		Labels:     runconfigopts.ConvertKVStringsToMap(opts.labels.GetAll()),
 	}
 
 	vol, err := client.VolumeCreate(context.Background(), volReq)


### PR DESCRIPTION
This fix is related to #27049 and #27047. For `--label` flag, if string slice is used (like #27047), then quote can not be used in command and will result in an error :

```
line 1, column 14: bare " in non-quoted-field
```

The issue #27047 has been fixed by #27049.

Recently I found out that both `docker network create --label` and `docker volume create --label` still use string slice and will return the same error when quotes are used.

This fix fixes `docker network create --label` and `docker volume create --label` by using `ListOpt` (as #27049) as well.

This fix has been tested and verified manually.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
