### PR TITLE
Windows: Stop expanding sandbox size when no new size is specified

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -37,10 +37,6 @@ import (
 const filterDriver = 1
 
 var (
-	vmcomputedll            = syscall.NewLazyDLL("vmcompute.dll")
-	hcsExpandSandboxSize    = vmcomputedll.NewProc("ExpandSandboxSize")
-	hcsSandboxSizeSupported = hcsExpandSandboxSize.Find() == nil
-
 	// mutatedFiles is a list of files that are mutated by the import process
 	// and must be backed up and restored.
 	mutatedFiles = map[string]string{
@@ -212,7 +208,7 @@ func (d *Driver) create(id, parent, mountLabel string, readOnly bool, storageOpt
 			return fmt.Errorf("Failed to parse storage options - %s", err)
 		}
 
-		if hcsSandboxSizeSupported {
+		if storageOptions.size != 0 {
 			if err := hcsshim.ExpandSandboxSize(d.info, id, storageOptions.size); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Stop attempting to expand the sandbox when a 0 size is given. This is a no-op in HCS.

Also no need to check for capability of expanding sandbox size, as all supported Windows versions can expand sandbox size.

**\- How to verify it**

As long as CI still passes, it's good.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

Signed-off-by: Darren Stahl darst@microsoft.com
