### PR TITLE
return error when create volume with existing name

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -158,6 +158,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /images/prune` prunes unused images.
 * `POST /volumes/prune` prunes unused volumes.
 * Every API response now includes a `Docker-Experimental` header specifying if experimental features are enabled (value can be `true` or `false`).
+* `POST /volumes/create` now returns an error if the given volume name already exists. 
 
 ### v1.24 API changes
 

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -40,13 +40,11 @@ The mount is created inside the container's `/world` directory. Docker does not 
 
 Multiple containers can use the same volume in the same time period. This is useful if two containers need access to shared data. For example, if one container writes and the other reads the data.
 
-Volume names must be unique among drivers.  This means you cannot use the same volume name with two different drivers.  If you attempt this `docker` returns an error:
+Volume names must be unique. This means you cannot use the same name with two different volumes. If you attempt this `docker` returns an error:
 
 ```
-A volume named  "hello"  already exists with the "some-other" driver. Choose a different volume name.
-```
-
-If you specify a volume name already in use on the current driver, Docker assumes you want to re-use the existing volume and does not return an error.   
+A volume named hello already exists. Choose a different volume name.
+```  
 
 ## Driver specific options
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -17,7 +17,7 @@ func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {
 	dockerCmd(c, "volume", "create")
 
 	_, err := runCommand(exec.Command(dockerBinary, "volume", "create", "-d", "nosuchdriver"))
-	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err, check.NotNil)
 
 	// test using hidden --name option
 	out, _ := dockerCmd(c, "volume", "create", "--name=test")
@@ -32,12 +32,14 @@ func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {
 func (s *DockerSuite) TestVolumeCLICreateOptionConflict(c *check.C) {
 	dockerCmd(c, "volume", "create", "test")
 	out, _, err := dockerCmdWithError("volume", "create", "test", "--driver", "nosuchdriver")
-	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use with another driver"))
+	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use"))
 	c.Assert(out, checker.Contains, "A volume named test already exists")
 
 	out, _ = dockerCmd(c, "volume", "inspect", "--format={{ .Driver }}", "test")
-	_, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
-	c.Assert(err, check.IsNil)
+	out, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use"))
+	c.Assert(out, checker.Contains, "A volume named test already exists")
 
 	// make sure hidden --name option conflicts with positional arg name
 	out, _, err = dockerCmdWithError("volume", "create", "--name", "test2", "test2")

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -179,11 +179,18 @@ func GetDriverList() []string {
 
 // GetAllDrivers lists all the registered drivers
 func GetAllDrivers() ([]volume.Driver, error) {
-	plugins, err := drivers.plugingetter.GetAllByCap(extName)
-	if err != nil {
-		return nil, fmt.Errorf("error listing plugins: %v", err)
+	var (
+		plugins []getter.CompatPlugin
+		ds      []volume.Driver
+		err     error
+	)
+
+	if drivers.plugingetter != nil {
+		plugins, err = drivers.plugingetter.GetAllByCap(extName)
+		if err != nil {
+			return nil, fmt.Errorf("error listing plugins: %v", err)
+		}
 	}
-	var ds []volume.Driver
 
 	drivers.Lock()
 	defer drivers.Unlock()

--- a/volume/store/errors.go
+++ b/volume/store/errors.go
@@ -12,7 +12,7 @@ var (
 	errNoSuchVolume = errors.New("no such volume")
 	// errInvalidName is a typed error returned when creating a volume with a name that is not valid on the platform
 	errInvalidName = errors.New("volume name is not valid on this platform")
-	// errNameConflict is a typed error returned on create when a volume exists with the given name, but for a different driver
+	// errNameConflict is a typed error returned on create when a volume exists with the given name
 	errNameConflict = errors.New("conflict: volume name must be unique")
 )
 


### PR DESCRIPTION
fixes #16068

Currently, `docker volume create --name volumeA` will not return error when volumeA already exists in daemon side, and it will return some info about the existing volume.
In addition, `docker volume create --name volumeA --label a=b` will not add label for volumeA which seems a little improper.

In the code implemented related to this Part. I think it is not so reasonable that volume name can be the same while with different volume drivers. Since it will also affect `docker volume inspect volumeA` if volumeA has two.

This PR addressed the above issue.

**\- What I did**
1. make creating volume with existing name return an error
2. make volume name unique among all volume drivers.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
