### PR TITLE
add documentation for `docker stack ps`, Fixes #26227 

### DIFF
--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -28,5 +28,5 @@ Displays the configuration of a stack.
 * [stack deploy](stack_deploy.md)
 * [stack rm](stack_rm.md)
 * [stack services](stack_services.md)
-* [stack tasks](stack_tasks.md)
+* [stack ps](stack_ps.md)
 * [stack ls](stack_ls.md)

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -57,5 +57,5 @@ axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-co
 * [stack config](stack_config.md)
 * [stack rm](stack_rm.md)
 * [stack services](stack_services.md)
-* [stack tasks](stack_tasks.md)
+* [stack ps](stack_ps.md)
 * [stack ls](stack_ls.md)

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -34,4 +34,4 @@ myapp              2
 * [stack config](stack_config.md)
 * [stack deploy](stack_deploy.md)
 * [stack rm](stack_rm.md)
-* [stack tasks](stack_tasks.md)
+* [stack ps](stack_ps.md)

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -1,26 +1,26 @@
 <!--[metadata]>
 +++
-title = "stack tasks"
-description = "The stack tasks command description and usage"
-keywords = ["stack, tasks"]
+title = "stack ps"
+description = "The stack ps command description and usage"
+keywords = ["stack, ps"]
 advisory = "experimental"
 [menu.main]
 parent = "smn_cli"
 +++
 <![end-metadata]-->
 
-# stack tasks (experimental)
+# stack ps (experimental)
 
 ```markdown
-Usage:  docker stack tasks [OPTIONS] STACK
+Usage:  docker stack ps [OPTIONS] STACK
 
 List the tasks in the stack
 
 Options:
   -a, --all            Display all tasks
   -f, --filter value   Filter output based on conditions provided
-      --help           Print usage
       --no-resolve     Do not map IDs to Names
+      --no-trunc       Do not truncate output
 ```
 
 Lists the tasks that are running as part of the specified stack. This

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -31,5 +31,5 @@ a manager node.
 * [stack config](stack_config.md)
 * [stack deploy](stack_deploy.md)
 * [stack services](stack_services.md)
-* [stack tasks](stack_tasks.md)
+* [stack ps](stack_ps.md)
 * [stack ls](stack_ls.md)

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -39,7 +39,7 @@ dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c8
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
-Multiple filter flags are combined as an `OR` filter. 
+Multiple filter flags are combined as an `OR` filter.
 
 The following command shows both the `web` and `db` services:
 
@@ -62,5 +62,5 @@ The currently supported filters are:
 * [stack config](stack_config.md)
 * [stack deploy](stack_deploy.md)
 * [stack rm](stack_rm.md)
-* [stack tasks](stack_tasks.md)
+* [stack ps](stack_ps.md)
 * [stack ls](stack_ls.md)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
As mentioned in https://github.com/docker/docker/issues/26227 , stack_ps is missing docs while stack_tasks is missing a command definition.

Added documentation for `docker stack ps` command, and removed documentation for `docker stack tasks`. Also updated related docs linking to `stack_tasks.md` to instead link to `stack_ps.md` 
**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added docs for `docker stack ps` command

**\- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/1327886/19363602/0f3ef152-9159-11e6-8655-961a510ee01d.png)
