### PR TITLE
Share rootfs for read-only containers

### DIFF
--- a/contrib/docker-device-tool/device_tool.go
+++ b/contrib/docker-device-tool/device_tool.go
@@ -159,7 +159,7 @@ func main() {
 			usage()
 		}
 
-		err := devices.MountDevice(args[1], args[2], "")
+		_, err := devices.MountDevice(args[1], args[2], "")
 		if err != nil {
 			fmt.Println("Can't create snap device: ", err)
 			os.Exit(1)

--- a/contrib/docker-device-tool/device_tool.go
+++ b/contrib/docker-device-tool/device_tool.go
@@ -137,7 +137,7 @@ func main() {
 			usage()
 		}
 
-		err := devices.AddDevice(args[1], args[2], nil)
+		err := devices.AddDevice(args[1], args[2], nil, false)
 		if err != nil {
 			fmt.Println("Can't create snap device: ", err)
 			os.Exit(1)

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -36,6 +36,7 @@ type Config struct {
 	Init                 bool                     `json:"init,omitempty"`
 	InitPath             string                   `json:"init-path,omitempty"`
 	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
+	SharedRootFs         bool                     `json:"shared-rootfs,omitempty"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -89,6 +90,7 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 	flags.Int64Var(&config.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds")
 	flags.Int64Var(&config.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds")
 	flags.StringVar(&config.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
+	flags.BoolVar(&config.SharedRootFs, "shared-rootfs", false, "For read-only containers share root filesystem")
 
 	config.attachExperimentalFlags(flags)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -111,6 +111,7 @@ type Daemon struct {
 
 	seccompProfile     []byte
 	seccompProfilePath string
+	sharedRootFs       bool
 }
 
 // HasExperimental returns whether the experimental features of the daemon are enabled or not
@@ -533,6 +534,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 		logrus.Warnf("Failed to configure golang's threads limit: %v", err)
 	}
 
+	d.setupSharedRootFs(config)
 	installDefaultAppArmorProfile()
 	daemonRepo := filepath.Join(config.Root, "containers")
 	if err := idtools.MkdirAllAs(daemonRepo, 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {

--- a/daemon/daemon_solaris.go
+++ b/daemon/daemon_solaris.go
@@ -528,6 +528,9 @@ func setupDaemonProcess(config *Config) error {
 	return nil
 }
 
+func (daemon *Daemon) setupSharedRootFs(config *Config) {
+}
+
 func (daemon *Daemon) setupSeccompProfile() error {
 	return nil
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1217,6 +1217,12 @@ func setupDaemonProcess(config *Config) error {
 	return setupOOMScoreAdj(config.OOMScoreAdjust)
 }
 
+func (daemon *Daemon) setupSharedRootFs(config *Config) {
+	if config.SharedRootFs {
+		daemon.sharedRootFs = true
+	}
+}
+
 func setupOOMScoreAdj(score int) error {
 	f, err := os.OpenFile("/proc/self/oom_score_adj", os.O_WRONLY, 0)
 	if err != nil {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -588,6 +588,9 @@ func setupDaemonProcess(config *Config) error {
 	return nil
 }
 
+func (daemon *Daemon) setupSharedRootFs(config *Config) {
+}
+
 // verifyVolumesInfo is a no-op on windows.
 // This is called during daemon initialization to migrate volumes from pre-1.7.
 // volumes were not supported on windows pre-1.7

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -213,6 +213,10 @@ func (a *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // mnt, layers, and diff
 func (a *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 
+	if opts != nil && opts.Shared {
+		return graphdriver.CreateSharedNotSupported("aufs")
+	}
+
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		return fmt.Errorf("--storage-opt is not supported for aufs")
 	}

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -382,6 +382,10 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 
 // Create the filesystem with given id.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+	if opts != nil && opts.Shared {
+		return graphdriver.CreateSharedNotSupported("btrfs")
+	}
+
 	subvolumes := path.Join(d.home, "subvolumes")
 	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
 	if err != nil {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -480,11 +480,10 @@ func (devices *DeviceSet) loadDeviceFilesOnStart() error {
 }
 
 // Should be called with devices.Lock() held.
-func (devices *DeviceSet) unregisterDevice(id int, hash string) error {
-	logrus.Debugf("devmapper: unregisterDevice(%v, %v)", id, hash)
+func (devices *DeviceSet) unregisterDevice(hash string) error {
+	logrus.Debugf("devmapper: unregisterDevice(%v)", hash)
 	info := &devInfo{
-		Hash:     hash,
-		DeviceID: id,
+		Hash: hash,
 	}
 
 	delete(devices.Devices, hash)
@@ -832,7 +831,7 @@ func (devices *DeviceSet) createRegisterDevice(hash string) (*devInfo, error) {
 	}
 
 	if err := devices.closeTransaction(); err != nil {
-		devices.unregisterDevice(deviceID, hash)
+		devices.unregisterDevice(hash)
 		devicemapper.DeleteDevice(devices.getPoolDevName(), deviceID)
 		devices.markDeviceIDFree(deviceID)
 		return nil, err
@@ -932,7 +931,7 @@ func (devices *DeviceSet) createRegisterSnapDevice(hash string, baseInfo *devInf
 	}
 
 	if err := devices.closeTransaction(); err != nil {
-		devices.unregisterDevice(deviceID, hash)
+		devices.unregisterDevice(hash)
 		devicemapper.DeleteDevice(devices.getPoolDevName(), deviceID)
 		devices.markDeviceIDFree(deviceID)
 		return err
@@ -2010,7 +2009,7 @@ func (devices *DeviceSet) deleteTransaction(info *devInfo, syncDelete bool) erro
 	}
 
 	if err == nil {
-		if err := devices.unregisterDevice(info.DeviceID, info.Hash); err != nil {
+		if err := devices.unregisterDevice(info.Hash); err != nil {
 			return err
 		}
 		// If device was already in deferred delete state that means

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -2445,6 +2445,12 @@ func (devices *DeviceSet) UnmountDevice(hash, mountPath string) error {
 	info.lock.Lock()
 	defer info.lock.Unlock()
 
+	if info.Shared {
+		if err := devices.driver.Put(info.ParentHash); err != nil {
+			return err
+		}
+	}
+
 	devices.Lock()
 	defer devices.Unlock()
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -2101,6 +2101,10 @@ func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
 	return nil
 }
 
+func (devices *DeviceSet) deleteSharedDevice(info *devInfo) error {
+	return devices.unregisterDevice(info.Hash)
+}
+
 // DeleteDevice will return success if device has been marked for deferred
 // removal. If one wants to override that and want DeleteDevice() to fail if
 // device was busy and could not be deleted, set syncDelete=true.
@@ -2117,6 +2121,10 @@ func (devices *DeviceSet) DeleteDevice(hash string, syncDelete bool) error {
 
 	devices.Lock()
 	defer devices.Unlock()
+
+	if info.Shared {
+		return devices.deleteSharedDevice(info)
+	}
 
 	return devices.deleteDevice(info, syncDelete)
 }

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -129,11 +129,13 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // Create adds a device with a given id and the parent.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	var storageOpt map[string]string
+	shared := false
 	if opts != nil {
 		storageOpt = opts.StorageOpt
+		shared = opts.Shared
 	}
 
-	if err := d.DeviceSet.AddDevice(id, parent, storageOpt); err != nil {
+	if err := d.DeviceSet.AddDevice(id, parent, storageOpt, shared); err != nil {
 		return err
 	}
 

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -41,6 +41,7 @@ var (
 type CreateOpts struct {
 	MountLabel string
 	StorageOpt map[string]string
+	Shared     bool
 }
 
 // InitFunc initializes the storage driver.
@@ -256,4 +257,10 @@ func scanPriorDrivers(root string) map[string]bool {
 		}
 	}
 	return driversMap
+}
+
+// CreateSharedNotSupported is helper function for graph drivers to flag error
+// if they don't support creation of shared rootfs devices.
+func CreateSharedNotSupported(graphdriver string) error {
+	return fmt.Errorf("Create with shared=true is not supported by graphdriver %v", graphdriver)
 }

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -239,6 +239,10 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // The parent filesystem is used to configure these directories for the overlay.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
 
+	if opts != nil && opts.Shared {
+		return graphdriver.CreateSharedNotSupported("overlay")
+	}
+
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		return fmt.Errorf("--storage-opt is not supported for overlay")
 	}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -305,6 +305,10 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // The parent filesystem is used to configure these directories for the overlay.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
 
+	if opts != nil && opts.Shared {
+		return graphdriver.CreateSharedNotSupported("overlay2")
+	}
+
 	if opts != nil && len(opts.StorageOpt) != 0 && !projectQuotaSupported {
 		return fmt.Errorf("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
 	}

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -54,6 +54,13 @@ func (d *graphDriverProxy) String() string {
 }
 
 func (d *graphDriverProxy) CreateReadWrite(id, parent string, opts *CreateOpts) error {
+	// Current API does not seem to allow passing additional arguments
+	// in graphDriverRequest. So for now, if shared rootfs is requested,
+	// error out here itself.
+	if opts != nil && opts.Shared {
+		return fmt.Errorf("Create with shared=true is not supported by graphdriver %v", d.name)
+	}
+
 	mountLabel := ""
 	if opts != nil {
 		mountLabel = opts.MountLabel

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -76,6 +76,10 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 
 // Create prepares the filesystem for the VFS driver and copies the directory for the given id under the parent.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+	if opts != nil && opts.Shared {
+		return graphdriver.CreateSharedNotSupported("vfs")
+	}
+
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		return fmt.Errorf("--storage-opt is not supported for vfs")
 	}

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -164,22 +164,26 @@ func (d *Driver) Exists(id string) bool {
 // file system.
 func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
 	if opts != nil {
-		return d.create(id, parent, opts.MountLabel, false, opts.StorageOpt)
+		return d.create(id, parent, opts.MountLabel, false, opts.StorageOpt, opts.Shared)
 	} else {
-		return d.create(id, parent, "", false, nil)
+		return d.create(id, parent, "", false, nil, false)
 	}
 }
 
 // Create creates a new read-only layer with the given id.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	if opts != nil {
-		return d.create(id, parent, opts.MountLabel, true, opts.StorageOpt)
+		return d.create(id, parent, opts.MountLabel, true, opts.StorageOpt, opts.Shared)
 	} else {
-		return d.create(id, parent, "", true, nil)
+		return d.create(id, parent, "", true, nil, false)
 	}
 }
 
-func (d *Driver) create(id, parent, mountLabel string, readOnly bool, storageOpt map[string]string) error {
+func (d *Driver) create(id, parent, mountLabel string, readOnly bool, storageOpt map[string]string, shared bool) error {
+	if shared {
+		return graphdriver.CreateSharedNotSupported("WindowsGraphDriver")
+	}
+
 	rPId, err := d.resolveID(parent)
 	if err != nil {
 		return err

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -263,6 +263,9 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	var storageOpt map[string]string
 	if opts != nil {
+		if opts.Shared {
+			return graphdriver.CreateSharedNotSupported("zfs")
+		}
 		storageOpt = opts.StorageOpt
 	}
 

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -171,9 +171,10 @@ type MountInit func(root string) error
 
 // CreateRWLayerOpts contains optional arguments to be passed to CreateRWLayer
 type CreateRWLayerOpts struct {
-	MountLabel string
-	InitFunc   MountInit
-	StorageOpt map[string]string
+	MountLabel   string
+	InitFunc     MountInit
+	StorageOpt   map[string]string
+	SharedRootFs bool
 }
 
 // Store represents a backend for managing both
@@ -232,11 +233,15 @@ type MetadataStore interface {
 
 	SetMountID(string, string) error
 	SetInitID(string, string) error
+	SetInitName(string, string) error
 	SetMountParent(string, ChainID) error
+	SetMountShared(string) error
 
 	GetMountID(string) (string, error)
 	GetInitID(string) (string, error)
+	GetInitName(string) (string, error)
 	GetMountParent(string) (ChainID, error)
+	GetMountShared(string) (bool, error)
 
 	// List returns the full list of referenced
 	// read-only and read-write layers

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/opencontainers/runc/libcontainer/label"
 )
 
 type mountedLayer struct {
@@ -93,7 +94,7 @@ type referencedRWLayer struct {
 func (rl *referencedRWLayer) Mount(mountLabel string) (string, error) {
 	if rl.mountedLayer.sharedRootFs {
 		// For shared Layers, call get on -init layer first.
-		_, err := rl.mountedLayer.initRWLayer.Mount(mountLabel)
+		_, err := rl.mountedLayer.initRWLayer.Mount(label.GetROMountLabel())
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Hi,

This is a proposal for sharing rootfs for read-only containers. This description mostly is in context of devicemapper graph driver. Some of it might apply to other graph drivers too and I have not looked
closely yet.

We have a big problem with devicemapper graph driver, and that is page cache is not shared between containers. And reason being that we take a thin device snapshot of image to create a container rootfs and there is no mechanism in kernel to detect this. So two inodes on two thin devices have their own page cache.

This is very limiting in terms of scalability and one can launch only so many containers.

During conversation this idea came that why are we always taking snapshot when creating read-only containers. Why these containers can't share same root filesystem (read-only bind mounted).  That way  all read-only containers launched from same image will share page cache.

Ideally, we should be able to just mount image device and ro bind mount for read-only containers. But right now we have this notion of -init layer where we write bunch of things, in these patches I am sharing -init layer instead. 

So while idea is very simple, patches are not so small as I had to introduce quite a few changes in layer code. 

We have got very encouraging results in internal testing with proof of concept patches. For read-only containers, devicemapper was faster than even overlay2.

Please consider these patches for merging.

Vivek
