### PR TITLE
all: use strings.Contains instead Index

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -180,7 +180,7 @@ func regexpMatch(pattern, path string) (bool, error) {
 		} else if ch == '?' {
 			// "?" is any char except "/"
 			regStr += "[^" + escSL + "]"
-		} else if strings.Index(".$", string(ch)) != -1 {
+		} else if ch == '.' || ch == '$' {
 			// Escape some regexp special chars that have no meaning
 			// in golang's filepath.Match
 			regStr += `\` + string(ch)

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -697,7 +697,7 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 	for key, opt := range securityOpts {
 		con := strings.SplitN(opt, "=", 2)
 		if len(con) == 1 && con[0] != "no-new-privileges" {
-			if strings.Index(opt, ":") != -1 {
+			if strings.Contains(opt, ":") {
 				con = strings.SplitN(opt, ":", 2)
 			} else {
 				return securityOpts, fmt.Errorf("Invalid --security-opt: %q", opt)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Use  strings.Contains instead strings.Index
**\- How I did it**

**\- How to verify it**
Compile docker daemon.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](http://24.media.tumblr.com/b054299a62335bba3257d16265fee795/tumblr_mibdmlOiCu1s5rsdao1_500.jpg)
