### PR TITLE
Windows: Factor out unused fields in container

### DIFF
--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -17,9 +17,6 @@ import (
 type Container struct {
 	CommonContainer
 
-	HostnamePath   string
-	HostsPath      string
-	ResolvConfPath string
 	// Fields below here are platform specific.
 }
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -63,17 +63,9 @@ func (daemon *Daemon) buildSandboxOptions(container *container.Container) ([]lib
 		sboxOptions = append(sboxOptions, libnetwork.OptionUseExternalKey())
 	}
 
-	container.HostsPath, err = container.GetRootResourcePath("hosts")
-	if err != nil {
+	if err = setupPathsAndSandboxOptions(container, &sboxOptions); err != nil {
 		return nil, err
 	}
-	sboxOptions = append(sboxOptions, libnetwork.OptionHostsPath(container.HostsPath))
-
-	container.ResolvConfPath, err = container.GetRootResourcePath("resolv.conf")
-	if err != nil {
-		return nil, err
-	}
-	sboxOptions = append(sboxOptions, libnetwork.OptionResolvConfPath(container.ResolvConfPath))
 
 	if len(container.HostConfig.DNS) > 0 {
 		dns = container.HostConfig.DNS
@@ -809,9 +801,7 @@ func (daemon *Daemon) initializeNetworking(container *container.Container) error
 		if err != nil {
 			return err
 		}
-		container.HostnamePath = nc.HostnamePath
-		container.HostsPath = nc.HostsPath
-		container.ResolvConfPath = nc.ResolvConfPath
+		initializeNetworkingPaths(container, nc)
 		container.Config.Hostname = nc.Config.Hostname
 		container.Config.Domainname = nc.Config.Domainname
 		return nil

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/runconfig"
+	"github.com/docker/libnetwork"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/label"
@@ -329,4 +330,27 @@ func enableIPOnPredefinedNetwork() bool {
 
 func (daemon *Daemon) isNetworkHotPluggable() bool {
 	return true
+}
+
+func setupPathsAndSandboxOptions(container *container.Container, sboxOptions *[]libnetwork.SandboxOption) error {
+	var err error
+
+	container.HostsPath, err = container.GetRootResourcePath("hosts")
+	if err != nil {
+		return err
+	}
+	*sboxOptions = append(*sboxOptions, libnetwork.OptionHostsPath(container.HostsPath))
+
+	container.ResolvConfPath, err = container.GetRootResourcePath("resolv.conf")
+	if err != nil {
+		return err
+	}
+	*sboxOptions = append(*sboxOptions, libnetwork.OptionResolvConfPath(container.ResolvConfPath))
+	return nil
+}
+
+func initializeNetworkingPaths(container *container.Container, nc *container.Container) {
+	container.HostnamePath = nc.HostnamePath
+	container.HostsPath = nc.HostsPath
+	container.ResolvConfPath = nc.ResolvConfPath
 }

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -2,7 +2,10 @@
 
 package daemon
 
-import "github.com/docker/docker/container"
+import (
+	"github.com/docker/docker/container"
+	"github.com/docker/libnetwork"
+)
 
 func (daemon *Daemon) setupLinkedContainers(container *container.Container) ([]string, error) {
 	return nil, nil
@@ -46,4 +49,11 @@ func enableIPOnPredefinedNetwork() bool {
 
 func (daemon *Daemon) isNetworkHotPluggable() bool {
 	return false
+}
+
+func setupPathsAndSandboxOptions(container *container.Container, sboxOptions *[]libnetwork.SandboxOption) error {
+	return nil
+}
+
+func initializeNetworkingPaths(container *container.Container, nc *container.Container) {
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Removes the three unused fields from the `Windows` version of the `container` structure which were introduced in https://github.com/docker/docker/commit/e8026d8a98ef30ff0ada303404e02567caebb1b0, and are only relevant on *nix platforms. 
- `HostnamePath`
- `HostsPath` and
- `ResolvConfPath`
