### PR TITLE
Prevent faulty autocomplete in zsh for docker rmi

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -151,6 +151,10 @@ __docker_complete_info_plugins() {
 
 __docker_images() {
     [[ $PREFIX = -* ]] && return 1
+
+    # Prevent autocomplete when there are no images
+    [[ $(_call_program commands docker $docker_options images --format "{{.ID}}") ]] || return 1
+
     integer ret=1
     declare -a images
     images=(${${${(f)"$(_call_program commands docker $docker_options images)"}[2,-1]}/(#b)([^ ]##) ##([^ ]##) ##([^ ]##)*/${match[3]}:${(r:15:: :::)match[2]} in ${match[1]}})


### PR DESCRIPTION
# Bug

When there are no docker images available, after typing `docker rmi` and pressing Tab, a faulty autocomplete list appeared:
![image](https://cloud.githubusercontent.com/assets/506532/19378050/343e9576-91f3-11e6-8b01-5656444e2d2d.png)
# Fix

Ensure there are available docker images before returning the autocomplete list.
