### PR TITLE
pkg/authorization: send request's TLS peer certificates to plugins

### DIFF
--- a/pkg/authorization/api.go
+++ b/pkg/authorization/api.go
@@ -1,5 +1,11 @@
 package authorization
 
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+)
+
 const (
 	// AuthZApiRequest is the url for daemon request authorization
 	AuthZApiRequest = "AuthZPlugin.AuthZReq"
@@ -10,6 +16,31 @@ const (
 	// AuthZApiImplements is the name of the interface all AuthZ plugins implement
 	AuthZApiImplements = "authz"
 )
+
+// PeerCertificate is a wrapper around x509.Certificate which provides a sane
+// enconding/decoding to/from PEM format and JSON.
+type PeerCertificate x509.Certificate
+
+// MarshalJSON returns the JSON encoded pem bytes of a PeerCertificate.
+func (pc *PeerCertificate) MarshalJSON() ([]byte, error) {
+	b := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: pc.Raw})
+	return json.Marshal(b)
+}
+
+// UnmarshalJSON populates a new PeerCertificate struct from JSON data.
+func (pc *PeerCertificate) UnmarshalJSON(b []byte) error {
+	var buf []byte
+	if err := json.Unmarshal(b, &buf); err != nil {
+		return err
+	}
+	derBytes, _ := pem.Decode(buf)
+	c, err := x509.ParseCertificate(derBytes.Bytes)
+	if err != nil {
+		return err
+	}
+	*pc = PeerCertificate(*c)
+	return nil
+}
 
 // Request holds data required for authZ plugins
 type Request struct {
@@ -30,6 +61,9 @@ type Request struct {
 
 	// RequestHeaders stores the raw request headers sent to the docker daemon
 	RequestHeaders map[string]string `json:"RequestHeaders,omitempty"`
+
+	// RequestPeerCertificates stores the request's TLS peer certificates in PEM format
+	RequestPeerCertificates []*PeerCertificate `json:"RequestPeerCertificates,omitempty"`
 
 	// ResponseStatusCode stores the status code returned from docker daemon
 	ResponseStatusCode int `json:"ResponseStatusCode,omitempty"`

--- a/pkg/authorization/authz.go
+++ b/pkg/authorization/authz.go
@@ -78,6 +78,13 @@ func (ctx *Ctx) AuthZRequest(w http.ResponseWriter, r *http.Request) error {
 		RequestHeaders:  headers(r.Header),
 	}
 
+	if r.TLS != nil {
+		for _, c := range r.TLS.PeerCertificates {
+			pc := PeerCertificate(*c)
+			ctx.authReq.RequestPeerCertificates = append(ctx.authReq.RequestPeerCertificates, &pc)
+		}
+	}
+
 	for i, plugin := range ctx.plugins {
 		logrus.Debugf("AuthZ request using plugin %s", plugin.Name())
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

I've add added a new field to the authorization request sent to plugins in order for a plugin to inspect and make decision based on that (much like Apache does for instance https://httpd.apache.org/docs/trunk/ssl/ssl_howto.html). I thought this would be better instead of hardcoding this decision makings on certs DNs inside docker when --tls-verify=true, otherwise, let me know and I'll change this patch to do that _into_ docker.

**\- How I did it**

vim

**\- How to verify it**

Create a test plugin and dump `req.RequestPeerCertificates` from the authz request.

**\- Description for the changelog**

pkg/authorization: send request's TLS peer certificates to plugins

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: Antonio Murdaca runcom@redhat.com
