### PR TITLE
Reset health status to starting when a container is restarted

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -251,7 +251,10 @@ func (d *Daemon) initHealthMonitor(c *container.Container) {
 	// This is needed in case we're auto-restarting
 	d.stopHealthchecks(c)
 
-	if c.State.Health == nil {
+	if h := c.State.Health; h != nil {
+		h.Status = types.Starting
+		h.FailingStreak = 0
+	} else {
 		h := &container.Health{}
 		h.Status = types.Starting
 		c.State.Health = h


### PR DESCRIPTION
**\- What I did**

Added code to set the health status to starting when a container is restarted. Previously, the status was only initialised when the container started for the first time. The comment on `initHealthMonitor` indicates that restarting a container was supposed to reset the state.

**\- How I did it**

**\- How to verify it**

Follow the steps in #27361.

**\- Description for the changelog**

Reset health status to Starting when a container is restarted.

**\- A picture of a cute animal (not mandatory but encouraged)**

Fixes #27361.

Signed-off-by: Thomas Leonard thomas.leonard@docker.com
