### PR TITLE
Convert Markdown frontmatter to YAML

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,14 +1,9 @@
-<!--[metadata]>
-+++
-aliases = ["/engine/misc/deprecated/"]
-title = "Deprecated Engine Features"
-description = "Deprecated Features."
-keywords = ["docker, documentation, about, technology, deprecate"]
-[menu.main]
-parent = "engine_use"
-weight=80
-+++
-<![end-metadata]-->
+---
+aliases: ["/engine/misc/deprecated/"]
+title: "Deprecated Engine Features"
+description: "Deprecated Features."
+keywords: ["docker, documentation, about, technology, deprecate"]
+---
 
 # Deprecated Engine Features
 
@@ -192,7 +187,7 @@ The single-dash (`-help`) was removed, in favor of the double-dash `--help`
 
 **Removed In Release: [v1.13.0](https://github.com/docker/docker/releases/)**
 
-The flag `--run` of the docker commit (and its short version `-run`) were deprecated in favor 
+The flag `--run` of the docker commit (and its short version `-run`) were deprecated in favor
 of the `--changes` flag that allows to pass `Dockerfile` commands.
 
 

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -1,17 +1,12 @@
-<!--[metadata]>
-+++
-aliases = [
+---
+aliases: [
 "/engine/extend/"
 ]
-title = "Managed plugin system"
-description = "How develop and use a plugin with the managed plugin system"
-keywords = ["API, Usage, plugins, documentation, developer"]
-advisory = "experimental"
-[menu.main]
-parent = "engine_extend"
-weight=1
-+++
-<![end-metadata]-->
+title: "Managed plugin system"
+description: "How develop and use a plugin with the managed plugin system"
+keywords: ["API, Usage, plugins, documentation, developer"]
+advisory: "experimental"
+---
 
 # Docker Engine managed plugin system
 

--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -1,14 +1,9 @@
-<!--[metadata]>
-+++
-aliases = "/engine/extend/plugins/"
-title = "Use Docker Engine plugins"
-description = "How to add additional functionality to Docker with plugins extensions"
-keywords = ["Examples, Usage, plugins, docker, documentation, user guide"]
-[menu.main]
-parent = "engine_extend"
-weight=3
-+++
-<![end-metadata]-->
+---
+aliases: "/engine/extend/plugins/"
+title: "Use Docker Engine plugins"
+description: "How to add additional functionality to Docker with plugins extensions"
+keywords: ["Examples, Usage, plugins, docker, documentation, user guide"]
+---
 
 # Use Docker Engine plugins
 

--- a/docs/extend/manifest.md
+++ b/docs/extend/manifest.md
@@ -1,17 +1,12 @@
-<!--[metadata]>
-+++
-aliases = [
+---
+aliases: [
 "/engine/extend/"
 ]
-title = "Plugin manifest"
-description = "How develop and use a plugin with the managed plugin system"
-keywords = ["API, Usage, plugins, documentation, developer"]
-advisory = "experimental"
-[menu.main]
-parent = "engine_extend"
-weight=1
-+++
-<![end-metadata]-->
+title: "Plugin manifest"
+description: "How develop and use a plugin with the managed plugin system"
+keywords: ["API, Usage, plugins, documentation, developer"]
+advisory: "experimental"
+---
 
 # Plugin Manifest Version 0 of Plugin V2
 
@@ -47,7 +42,7 @@ Manifest provides the base accessible fields for working with V0 plugin format
 - **`interface`** *PluginInterface*
 
    interface implemented by the plugins, struct consisting of the following fields
-      
+
     - **`types`** *string array*
 
       types indicate what interface(s) the plugin currently implements.
@@ -55,9 +50,9 @@ Manifest provides the base accessible fields for working with V0 plugin format
       currently supported:
 
       	- **docker.volumedriver/1.0**
-      
+
     - **`socket`** *string*
-      
+
       socket is the name of the socket the engine should use to communicate with the plugins.
       the socket will be created in `/run/docker/plugins`.
 
@@ -73,7 +68,7 @@ Manifest provides the base accessible fields for working with V0 plugin format
 - **`network`** *PluginNetwork*
 
    network of the plugin, struct consisting of the following fields
-      
+
     - **`type`** *string*
 
       network type.
@@ -83,11 +78,11 @@ Manifest provides the base accessible fields for working with V0 plugin format
       	- **bridge**
       	- **host**
       	- **none**
-      
+
 - **`capabilities`** *array*
 
    capabilities of the plugin (*Linux only*), see list [`here`](https://github.com/opencontainers/runc/blob/master/libcontainer/SPEC.md#security)
-    
+
 - **`mounts`** *PluginMount array*
 
    mount of the plugin, struct consisting of the following fields, see [`MOUNTS`](https://github.com/opencontainers/runtime-spec/blob/master/config.md#mounts)
@@ -95,27 +90,27 @@ Manifest provides the base accessible fields for working with V0 plugin format
     - **`name`** *string*
 
 	  name of the mount.
-      
+
     - **`description`** *string*
-	
+
       description of the mount.
-   
+
     - **`source`** *string*
 
 	  source of the mount.
-    
+
     - **`destination`** *string*
 
 	  destination of the mount.
-   
+
     - **`type`** *string*
 
       mount type.
-      
+
     - **`options`** *string array*
 
 	  options of the mount.
-      
+
 - **`devices`** *PluginDevice array*
 
     device of the plugin, (*Linux only*), struct consisting of the following fields, see [`DEVICES`](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#devices)
@@ -123,11 +118,11 @@ Manifest provides the base accessible fields for working with V0 plugin format
     - **`name`** *string*
 
 	  name of the device.
-      
+
     - **`description`** *string*
 
       description of the device.
-      
+
     - **`path`** *string*
 
 	  path of the device.
@@ -139,15 +134,15 @@ Manifest provides the base accessible fields for working with V0 plugin format
     - **`name`** *string*
 
 	  name of the env.
-      
+
     - **`description`** *string*
-	
+
       description of the env.
-   
+
     - **`value`** *string*
 
 	  value of the env.
-    
+
 - **`args`** *PluginArgs*
 
    args of the plugin, struct consisting of the following fields
@@ -155,16 +150,16 @@ Manifest provides the base accessible fields for working with V0 plugin format
     - **`name`** *string*
 
 	  name of the env.
-      
+
     - **`description`** *string*
-	
+
       description of the env.
-   
+
     - **`value`** *string array*
 
 	  values of the args.
-    
-    
+
+
 ## Example Manifest
 
 *Example showing the 'tiborvass/no-remove' plugin manifest.*

--- a/docs/extend/menu.md
+++ b/docs/extend/menu.md
@@ -1,15 +1,10 @@
-<!--[metadata]>
-+++
-title = "Implement plugins"
-description = "Develop plugins and use existing plugins for Docker Engine"
-keywords = ["extend, plugins, docker, documentation, developer"]
-type="menu"
-[menu.main]
-identifier = "engine_extend"
-parent="engine_use"
-weight = 0
-+++
-<![end-metadata]-->
+---
+title: "Implement plugins"
+description: "Develop plugins and use existing plugins for Docker Engine"
+keywords: ["extend, plugins, docker, documentation, developer"]
+type: "menu"
+identifier: "engine_extend"
+---
 
 
 <!--menu page not rendered-->

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Plugins API"
-description = "How to write Docker plugins extensions "
-keywords = ["API, Usage, plugins, documentation, developer"]
-[menu.main]
-parent = "engine_extend"
-weight=7
-+++
-<![end-metadata]-->
+---
+title: "Plugins API"
+description: "How to write Docker plugins extensions "
+keywords: ["API, Usage, plugins, documentation, developer"]
+---
 
 # Docker Plugin API
 

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -1,14 +1,9 @@
-<!--[metadata]>
-+++
-title = "Access authorization plugin"
-description = "How to create authorization plugins to manage access control to your Docker daemon."
-keywords = ["security, authorization, authentication, docker, documentation, plugin, extend"]
-aliases = ["/engine/extend/authorization/"]
-[menu.main]
-parent = "engine_extend"
-weight = 4
-+++
-<![end-metadata]-->
+---
+title: "Access authorization plugin"
+description: "How to create authorization plugins to manage access control to your Docker daemon."
+keywords: ["security, authorization, authentication, docker, documentation, plugin, extend"]
+aliases: ["/engine/extend/authorization/"]
+---
 
 
 # Create an authorization plugin

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Docker network driver plugins"
-description = "Network driver plugins."
-keywords = ["Examples, Usage, plugins, docker, documentation, user guide"]
-[menu.main]
-parent = "engine_extend"
-weight=5
-+++
-<![end-metadata]-->
+---
+title: "Docker network driver plugins"
+description: "Network driver plugins."
+keywords: ["Examples, Usage, plugins, docker, documentation, user guide"]
+---
 
 # Engine network driver plugins
 

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Volume plugins"
-description = "How to manage data with external volume plugins"
-keywords = ["Examples, Usage, volume, docker, data, volumes, plugin, api"]
-[menu.main]
-parent = "engine_extend"
-weight=6
-+++
-<![end-metadata]-->
+---
+title: "Volume plugins"
+description: "How to manage data with external volume plugins"
+keywords: ["Examples, Usage, volume, docker, data, volumes, plugin, api"]
+---
 
 # Write a volume plugin
 

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -1,8 +1,6 @@
-<!--[metadata]>
-+++
-draft = true
-+++
-<![end-metadata]-->
+---
+published: false
+---
 
 This directory holds the authoritative specifications of APIs defined and implemented by Docker. Currently this includes:
 

--- a/docs/reference/api/docker-io_api.md
+++ b/docs/reference/api/docker-io_api.md
@@ -1,14 +1,9 @@
-<!--[metadata]>
-+++
-draft = true
-title = "Docker Hub API"
-description = "API Documentation for the Docker Hub API"
-keywords = ["API, Docker, index, REST, documentation, Docker Hub,  registry"]
-[menu.main]
-parent = "engine_remoteapi"
-weight = 99
-+++
-<![end-metadata]-->
+---
+published: false
+title: "Docker Hub API"
+description: "API Documentation for the Docker Hub API"
+keywords: ["API, Docker, index, REST, documentation, Docker Hub,  registry"]
+---
 
 # Docker Hub API
 

--- a/docs/reference/api/docker_io_accounts_api.md
+++ b/docs/reference/api/docker_io_accounts_api.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "docker.io accounts API"
-description = "API Documentation for docker.io accounts."
-keywords = ["API, Docker, accounts, REST,  documentation"]
-[menu.main]
-parent = "engine_remoteapi"
-weight=90
-+++
-<![end-metadata]-->
+---
+title: "docker.io accounts API"
+description: "API Documentation for docker.io accounts."
+keywords: ["API, Docker, accounts, REST,  documentation"]
+---
 
 # docker.io accounts API
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent = "engine_remoteapi"
-weight=-99
-+++
-<![end-metadata]-->
+---
+title: "Remote API"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API
 

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.18"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent = "engine_remoteapi"
-weight = 3
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.18"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.18
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.19"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent = "engine_remoteapi"
-weight = 2
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.19"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.19
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.20"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent="engine_remoteapi"
-weight = 1
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.20"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.20
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.21"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent="engine_remoteapi"
-weight=-2
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.21"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.21
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.22"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent="engine_remoteapi"
-weight=-3
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.22"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.22
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.23"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent="engine_remoteapi"
-weight=-4
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.23"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.23
 
@@ -2688,7 +2683,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example response**:
 
-If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress 
+If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress
 details are suppressed, and only a confirmation message is returned once the
 action completes.
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.24"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent="engine_remoteapi"
-weight=-5
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.24"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.24
 
@@ -2702,7 +2697,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example response**:
 
-If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress 
+If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress
 details are suppressed, and only a confirmation message is returned once the
 action completes.
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API v1.25"
-description = "API Documentation for Docker"
-keywords = ["API, Docker, rcli, REST,  documentation"]
-[menu.main]
-parent="engine_remoteapi"
-weight=-6
-+++
-<![end-metadata]-->
+---
+title: "Remote API v1.25"
+description: "API Documentation for Docker"
+keywords: ["API, Docker, rcli, REST,  documentation"]
+---
 
 # Docker Remote API v1.25
 
@@ -3095,7 +3090,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example response**:
 
-If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress 
+If the "quiet" query parameter is set to `true` / `1` (`?quiet=1`), progress
 details are suppressed, and only a confirmation message is returned once the
 action completes.
 

--- a/docs/reference/api/hub_registry_spec.md
+++ b/docs/reference/api/hub_registry_spec.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-draft = true
-title = "The Docker Hub and the Registry v1"
-description = "Documentation for docker Registry and Registry API"
-keywords = ["docker, registry, api,  hub"]
-[menu.main]
-parent="smn_hub_ref"
-+++
-<![end-metadata]-->
+---
+published: false
+title: "The Docker Hub and the Registry v1"
+description: "Documentation for docker Registry and Registry API"
+keywords: ["docker, registry, api,  hub"]
+---
 
 # The Docker Hub and the Registry v1
 

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,13 +1,9 @@
-<!-- [metadata]>
-+++
-title = "API Reference"
-description = "Reference"
-keywords = ["Engine"]
-[menu.main]
-identifier="engine_remoteapi"
-parent="engine_ref"
-+++
-<![end-metadata]-->
+---
+title: "API Reference"
+description: "Reference"
+keywords: ["Engine"]
+identifier: "engine_remoteapi"
+---
 
 
 # API Reference

--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Remote API client libraries"
-description = "Various client libraries available to use with the Docker remote API"
-keywords = ["API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust,  Scala"]
-[menu.main]
-parent="engine_remoteapi"
-weight = 90
-+++
-<![end-metadata]-->
+---
+title: "Remote API client libraries"
+description: "Various client libraries available to use with the Docker remote API"
+keywords: ["API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust,  Scala"]
+---
 
 # Docker Remote API client libraries
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Dockerfile reference"
-description = "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
-keywords = ["builder, docker, Dockerfile, automation,  image creation"]
-[menu.main]
-parent = "engine_ref"
-weight=-90
-+++
-<![end-metadata]-->
+---
+title: "Dockerfile reference"
+description: "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
+keywords: ["builder, docker, Dockerfile, automation,  image creation"]
+---
 
 # Dockerfile reference
 
@@ -698,7 +693,7 @@ To view an image's labels, use the `docker inspect` command.
 
     MAINTAINER <name>
 
-The `MAINTAINER` instruction sets the *Author* field of the generated images. 
+The `MAINTAINER` instruction sets the *Author* field of the generated images.
 The `LABEL` instruction is a much more flexible version of this and you should use
 it instead, as it enables setting any metadata you require, and can be viewed
 easily, for example with `docker inspect`. To set a label corresponding to the

--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "attach"
-description = "The attach command description and usage"
-keywords = ["attach, running, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "attach"
+description: "The attach command description and usage"
+keywords: ["attach, running, container"]
+---
 
 # attach
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "build"
-description = "The build command description and usage"
-keywords = ["build, docker, image"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "build"
+description: "The build command description and usage"
+keywords: ["build, docker, image"]
+---
 
 # build
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Use the Docker command line"
-description = "Docker's CLI command description and usage"
-keywords = ["Docker, Docker documentation, CLI,  command line"]
-[menu.main]
-parent = "smn_cli"
-weight = -2
-+++
-<![end-metadata]-->
+---
+title: "Use the Docker command line"
+description: "Docker's CLI command description and usage"
+keywords: ["Docker, Docker documentation, CLI,  command line"]
+---
 
 # Use the Docker command line
 
@@ -122,7 +117,7 @@ directives, see the
 Once attached to a container, users detach from it and leave it running using
 the using `CTRL-p CTRL-q` key sequence. This detach key sequence is customizable
 using the `detachKeys` property. Specify a `<sequence>` value for the
-property. The format of the `<sequence>` is a comma-separated list of either 
+property. The format of the `<sequence>` is a comma-separated list of either
 a letter [a-Z], or the `ctrl-` combined with any of the following:
 
 * `a-z` (a single lowercase alpha character )

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "commit"
-description = "The commit command description and usage"
-keywords = ["commit, file, changes"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "commit"
+description: "The commit command description and usage"
+keywords: ["commit, file, changes"]
+---
 
 # commit
 

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "container prune"
-description = "Remove all stopped containers"
-keywords = [container, prune, delete, remove]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "container prune"
+description: "Remove all stopped containers"
+keywords: [container, prune, delete, remove]
+---
 
 # container prune
 

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "cp"
-description = "The cp command description and usage"
-keywords = ["copy, container, files, folders"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "cp"
+description: "The cp command description and usage"
+keywords: ["copy, container, files, folders"]
+---
 
 # cp
 

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "create"
-description = "The create command description and usage"
-keywords = ["docker, create, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "create"
+description: "The create command description and usage"
+keywords: ["docker, create, container"]
+---
 
 # create
 

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "deploy"
-description = "The deploy command description and usage"
-keywords = ["stack, deploy"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "deploy"
+description: "The deploy command description and usage"
+keywords: ["stack, deploy"]
+advisory: "experimental"
+---
 
 # stack deploy (experimental)
 

--- a/docs/reference/commandline/diff.md
+++ b/docs/reference/commandline/diff.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "diff"
-description = "The diff command description and usage"
-keywords = ["list, changed, files, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "diff"
+description: "The diff command description and usage"
+keywords: ["list, changed, files, container"]
+---
 
 # diff
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1,14 +1,9 @@
-<!--[metadata]>
-+++
-title = "dockerd"
-aliases = ["/engine/reference/commandline/daemon/"]
-description = "The daemon command description and usage"
-keywords = ["container, daemon, runtime"]
-[menu.main]
-parent = "smn_cli"
-weight = -1
-+++
-<![end-metadata]-->
+---
+title: "dockerd"
+aliases: ["/engine/reference/commandline/daemon/"]
+description: "The daemon command description and usage"
+keywords: ["container, daemon, runtime"]
+---
 
 # daemon
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "events"
-description = "The events command description and usage"
-keywords = ["events, container, report"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "events"
+description: "The events command description and usage"
+keywords: ["events, container, report"]
+---
 
 # events
 

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "exec"
-description = "The exec command description and usage"
-keywords = ["command, container, run, execute"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "exec"
+description: "The exec command description and usage"
+keywords: ["command, container, run, execute"]
+---
 
 # exec
 

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "export"
-description = "The export command description and usage"
-keywords = ["export, file, system, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "export"
+description: "The export command description and usage"
+keywords: ["export, file, system, container"]
+---
 
 # export
 

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "history"
-description = "The history command description and usage"
-keywords = ["docker, image, history"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "history"
+description: "The history command description and usage"
+keywords: ["docker, image, history"]
+---
 
 # history
 

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "image prune"
-description = "Remove all stopped images"
-keywords = [image, prune, delete, remove]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "image prune"
+description: "Remove all stopped images"
+keywords: [image, prune, delete, remove]
+---
 
 # image prune
 

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "images"
-description = "The images command description and usage"
-keywords = ["list, docker, images"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "images"
+description: "The images command description and usage"
+keywords: ["list, docker, images"]
+---
 
 # images
 

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "import"
-description = "The import command description and usage"
-keywords = ["import, file, system, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "import"
+description: "The import command description and usage"
+keywords: ["import, file, system, container"]
+---
 
 # import
 

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -1,14 +1,9 @@
-<!-- [metadata]>
-+++
-title = "Docker commands"
-description = "Docker's CLI command description and usage"
-keywords = ["Docker, Docker documentation, CLI,  command line"]
-[menu.main]
-identifier= "smn_cli_guide"
-parent = "smn_cli"
-weight=-70
-+++
-<![end-metadata]-->
+---
+title: "Docker commands"
+description: "Docker's CLI command description and usage"
+keywords: ["Docker, Docker documentation, CLI,  command line"]
+identifier: "smn_cli_guide"
+---
 
 
 

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "info"
-description = "The info command description and usage"
-keywords = ["display, docker, information"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "info"
+description: "The info command description and usage"
+keywords: ["display, docker, information"]
+---
 
 # info
 

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "inspect"
-description = "The inspect command description and usage"
-keywords = ["inspect, container, json"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "inspect"
+description: "The inspect command description and usage"
+keywords: ["inspect, container, json"]
+---
 
 # inspect
 

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "kill"
-description = "The kill command description and usage"
-keywords = ["container, kill, signal"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "kill"
+description: "The kill command description and usage"
+keywords: ["container, kill, signal"]
+---
 
 # kill
 

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "load"
-description = "The load command description and usage"
-keywords = ["stdin, tarred, repository"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "load"
+description: "The load command description and usage"
+keywords: ["stdin, tarred, repository"]
+---
 
 # load
 

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "login"
-description = "The login command description and usage"
-keywords = ["registry, login, image"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "login"
+description: "The login command description and usage"
+keywords: ["registry, login, image"]
+---
 
 # login
 

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "logout"
-description = "The logout command description and usage"
-keywords = ["logout, docker, registry"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "logout"
+description: "The logout command description and usage"
+keywords: ["logout, docker, registry"]
+---
 
 # logout
 

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "logs"
-description = "The logs command description and usage"
-keywords = ["logs, retrieve, docker"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "logs"
+description: "The logs command description and usage"
+keywords: ["logs, retrieve, docker"]
+---
 
 # logs
 

--- a/docs/reference/commandline/menu.md
+++ b/docs/reference/commandline/menu.md
@@ -1,14 +1,9 @@
-<!-- [metadata]>
-+++
-title = "Command line reference"
-description = "Docker's CLI command description and usage"
-keywords = ["Docker, Docker documentation, CLI,  command line"]
-[menu.main]
-identifier= "smn_cli"
-parent = "engine_ref"
-weight=-75
-+++
-<![end-metadata]-->
+---
+title: "Command line reference"
+description: "Docker's CLI command description and usage"
+keywords: ["Docker, Docker documentation, CLI,  command line"]
+identifier:  "smn_cli"
+---
 
 
 

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "network connect"
-description = "The network connect command description and usage"
-keywords = ["network, connect, user-defined"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "network connect"
+description: "The network connect command description and usage"
+keywords: ["network, connect, user-defined"]
+---
 
 # network connect
 

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "network create"
-description = "The network create command description and usage"
-keywords = ["network, create"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "network create"
+description: "The network create command description and usage"
+keywords: ["network, create"]
+---
 
 # network create
 

--- a/docs/reference/commandline/network_disconnect.md
+++ b/docs/reference/commandline/network_disconnect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "network disconnect"
-description = "The network disconnect command description and usage"
-keywords = ["network, disconnect, user-defined"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "network disconnect"
+description: "The network disconnect command description and usage"
+keywords: ["network, disconnect, user-defined"]
+---
 
 # network disconnect
 

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "network inspect"
-description = "The network inspect command description and usage"
-keywords = ["network, inspect, user-defined"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "network inspect"
+description: "The network inspect command description and usage"
+keywords: ["network, inspect, user-defined"]
+---
 
 # network inspect
 

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "network ls"
-description = "The network ls command description and usage"
-keywords = ["network, list, user-defined"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "network ls"
+description: "The network ls command description and usage"
+keywords: ["network, list, user-defined"]
+---
 
 # docker network ls
 

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "network rm"
-description = "the network rm command description and usage"
-keywords = ["network, rm, user-defined"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "network rm"
+description: "the network rm command description and usage"
+keywords: ["network, rm, user-defined"]
+---
 
 # network rm
 

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "node demote"
-description = "The node demote command description and usage"
-keywords = ["node, demote"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node demote"
+description: "The node demote command description and usage"
+keywords: ["node, demote"]
+---
 
 # node demote
 

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "node inspect"
-description = "The node inspect command description and usage"
-keywords = ["node, inspect"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node inspect"
+description: "The node inspect command description and usage"
+keywords: ["node, inspect"]
+---
 
 # node inspect
 

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "node ls"
-description = "The node ls command description and usage"
-keywords = ["node, list"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node ls"
+description: "The node ls command description and usage"
+keywords: ["node, list"]
+---
 
 # node ls
 

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "node promote"
-description = "The node promote command description and usage"
-keywords = ["node, promote"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node promote"
+description: "The node promote command description and usage"
+keywords: ["node, promote"]
+---
 
 # node promote
 

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "node ps"
-description = "The node ps command description and usage"
-keywords = ["node, tasks", "ps"]
-aliases = ["/engine/reference/commandline/node_tasks/"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node ps"
+description: "The node ps command description and usage"
+keywords: ["node, tasks", "ps"]
+aliases: ["/engine/reference/commandline/node_tasks/"]
+---
 
 # node ps
 

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "node rm"
-description = "The node rm command description and usage"
-keywords = ["node, remove"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node rm"
+description: "The node rm command description and usage"
+keywords: ["node, remove"]
+---
 
 # node rm
 

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "node update"
-description = "The node update command description and usage"
-keywords = ["resources, update, dynamically"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "node update"
+description: "The node update command description and usage"
+keywords: ["resources, update, dynamically"]
+---
 
 ## update
 

--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "pause"
-description = "The pause command description and usage"
-keywords = ["cgroups, container, suspend, SIGSTOP"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "pause"
+description: "The pause command description and usage"
+keywords: ["cgroups, container, suspend, SIGSTOP"]
+---
 
 # pause
 

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "plugin disable"
-description = "the plugin disable command description and usage"
-keywords = ["plugin, disable"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "plugin disable"
+description: "the plugin disable command description and usage"
+keywords: ["plugin, disable"]
+advisory: "experimental"
+---
 
 # plugin disable (experimental)
 

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "plugin enable"
-description = "the plugin enable command description and usage"
-keywords = ["plugin, enable"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "plugin enable"
+description: "the plugin enable command description and usage"
+keywords: ["plugin, enable"]
+advisory: "experimental"
+---
 
 # plugin enable (experimental)
 

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "plugin inspect"
-description = "The plugin inspect command description and usage"
-keywords = ["plugin, inspect"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "plugin inspect"
+description: "The plugin inspect command description and usage"
+keywords: ["plugin, inspect"]
+advisory: "experimental"
+---
 
 # plugin inspect (experimental)
 

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "plugin install"
-description = "the plugin install command description and usage"
-keywords = ["plugin, install"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "plugin install"
+description: "the plugin install command description and usage"
+keywords: ["plugin, install"]
+advisory: "experimental"
+---
 
 # plugin install (experimental)
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "plugin ls"
-description = "The plugin ls command description and usage"
-keywords = ["plugin, list"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "plugin ls"
+description: "The plugin ls command description and usage"
+keywords: ["plugin, list"]
+advisory: "experimental"
+---
 
 # plugin ls (experimental)
 

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "plugin rm"
-description = "the plugin rm command description and usage"
-keywords = ["plugin, rm"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "plugin rm"
+description: "the plugin rm command description and usage"
+keywords: ["plugin, rm"]
+advisory: "experimental"
+---
 
 # plugin rm (experimental)
 

--- a/docs/reference/commandline/port.md
+++ b/docs/reference/commandline/port.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "port"
-description = "The port command description and usage"
-keywords = ["port, mapping, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "port"
+description: "The port command description and usage"
+keywords: ["port, mapping, container"]
+---
 
 # port
 

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "ps"
-description = "The ps command description and usage"
-keywords = ["container, running, list"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "ps"
+description: "The ps command description and usage"
+keywords: ["container, running, list"]
+---
 
 # ps
 

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "pull"
-description = "The pull command description and usage"
-keywords = ["pull, image, hub, docker"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "pull"
+description: "The pull command description and usage"
+keywords: ["pull, image, hub, docker"]
+---
 
 # pull
 

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "push"
-description = "The push command description and usage"
-keywords = ["share, push, image"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "push"
+description: "The push command description and usage"
+keywords: ["share, push, image"]
+---
 
 # push
 

--- a/docs/reference/commandline/rename.md
+++ b/docs/reference/commandline/rename.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "rename"
-description = "The rename command description and usage"
-keywords = ["rename, docker, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "rename"
+description: "The rename command description and usage"
+keywords: ["rename, docker, container"]
+---
 
 # rename
 

--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "restart"
-description = "The restart command description and usage"
-keywords = ["restart, container, Docker"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "restart"
+description: "The restart command description and usage"
+keywords: ["restart, container, Docker"]
+---
 
 # restart
 

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "rm"
-description = "The rm command description and usage"
-keywords = ["remove, Docker, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "rm"
+description: "The rm command description and usage"
+keywords: ["remove, Docker, container"]
+---
 
 # rm
 

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "rmi"
-description = "The rmi command description and usage"
-keywords = ["remove, image, Docker"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "rmi"
+description: "The rmi command description and usage"
+keywords: ["remove, image, Docker"]
+---
 
 # rmi
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "run"
-description = "The run command description and usage"
-keywords = ["run, command, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "run"
+description: "The run command description and usage"
+keywords: ["run, command, container"]
+---
 
 # run
 

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "save"
-description = "The save command description and usage"
-keywords = ["tarred, repository, backup"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "save"
+description: "The save command description and usage"
+keywords: ["tarred, repository, backup"]
+---
 
 # save
 

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "search"
-description = "The search command description and usage"
-keywords = ["search, hub, images"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "search"
+description: "The search command description and usage"
+keywords: ["search, hub, images"]
+---
 
 # search
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "service create"
-description = "The service create command description and usage"
-keywords = ["service, create"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service create"
+description: "The service create command description and usage"
+keywords: ["service, create"]
+---
 
 # service create
 

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "service inspect"
-description = "The service inspect command description and usage"
-keywords = ["service, inspect"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service inspect"
+description: "The service inspect command description and usage"
+keywords: ["service, inspect"]
+---
 
 # service inspect
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "service ls"
-description = "The service ls command description and usage"
-keywords = ["service, ls"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service ls"
+description: "The service ls command description and usage"
+keywords: ["service, ls"]
+---
 
 # service ls
 

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "service ps"
-description = "The service ps command description and usage"
-keywords = ["service, tasks", "ps"]
-aliases = ["/engine/reference/commandline/service_tasks/"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service ps"
+description: "The service ps command description and usage"
+keywords: ["service, tasks", "ps"]
+aliases: ["/engine/reference/commandline/service_tasks/"]
+---
 
 # service ps
 

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "service rm"
-description = "The service rm command description and usage"
-keywords = ["service, rm"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service rm"
+description: "The service rm command description and usage"
+keywords: ["service, rm"]
+---
 
 # service rm
 

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "service scale"
-description = "The service scale command description and usage"
-keywords = ["service, scale"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service scale"
+description: "The service scale command description and usage"
+keywords: ["service, scale"]
+---
 
 # service scale
 

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "service update"
-description = "The service update command description and usage"
-keywords = ["service, update"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "service update"
+description: "The service update command description and usage"
+keywords: ["service, update"]
+---
 
 # service update
 

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "stack config"
-description = "The stack config command description and usage"
-keywords = ["stack, config"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stack config"
+description: "The stack config command description and usage"
+keywords: ["stack, config"]
+advisory: "experimental"
+---
 
 # stack config (experimental)
 

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "stack deploy"
-description = "The stack deploy command description and usage"
-keywords = ["stack, deploy, up"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stack deploy"
+description: "The stack deploy command description and usage"
+keywords: ["stack, deploy, up"]
+advisory: "experimental"
+---
 
 # stack deploy (experimental)
 

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "stack ls"
-description = "The stack ls command description and usage"
-keywords = ["stack, ls"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stack ls"
+description: "The stack ls command description and usage"
+keywords: ["stack, ls"]
+advisory: "experimental"
+---
 
 # stack ls (experimental)
 

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "stack ps"
-description = "The stack ps command description and usage"
-keywords = ["stack, ps"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stack ps"
+description: "The stack ps command description and usage"
+keywords: ["stack, ps"]
+advisory: "experimental"
+---
 
 # stack ps (experimental)
 

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -1,13 +1,11 @@
-<!--[metadata]>
-+++
-title = "stack rm"
-description = "The stack rm command description and usage"
-keywords = ["stack, rm, remove, down"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stack rm"
+description: "The stack rm command description and usage"
+keywords: ["stack, rm, remove, down"]
+advisory: "experimental"
+
+
+---
 
 # stack rm (experimental)
 

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-title = "stack services"
-description = "The stack services command description and usage"
-keywords = ["stack, services"]
-advisory = "experimental"
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stack services"
+description: "The stack services command description and usage"
+keywords: ["stack, services"]
+advisory: "experimental"
+---
 
 # stack services (experimental)
 

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "start"
-description = "The start command description and usage"
-keywords = ["Start, container, stopped"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "start"
+description: "The start command description and usage"
+keywords: ["Start, container, stopped"]
+---
 
 # start
 

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "stats"
-description = "The stats command description and usage"
-keywords = ["container, resource, statistics"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stats"
+description: "The stats command description and usage"
+keywords: ["container, resource, statistics"]
+---
 
 # stats
 

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "stop"
-description = "The stop command description and usage"
-keywords = ["stop, SIGKILL, SIGTERM"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "stop"
+description: "The stop command description and usage"
+keywords: ["stop, SIGKILL, SIGTERM"]
+---
 
 # stop
 

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "swarm init"
-description = "The swarm init command description and usage"
-keywords = ["swarm, init"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "swarm init"
+description: "The swarm init command description and usage"
+keywords: ["swarm, init"]
+---
 
 # swarm init
 

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "swarm join"
-description = "The swarm join command description and usage"
-keywords = ["swarm, join"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "swarm join"
+description: "The swarm join command description and usage"
+keywords: ["swarm, join"]
+---
 
 # swarm join
 

--- a/docs/reference/commandline/swarm_join_token.md
+++ b/docs/reference/commandline/swarm_join_token.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "swarm join-token"
-description = "The swarm join-token command description and usage"
-keywords = ["swarm, join-token"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "swarm join-token"
+description: "The swarm join-token command description and usage"
+keywords: ["swarm, join-token"]
+---
 
 # swarm join-token
 

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "swarm leave"
-description = "The swarm leave command description and usage"
-keywords = ["swarm, leave"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "swarm leave"
+description: "The swarm leave command description and usage"
+keywords: ["swarm, leave"]
+---
 
 # swarm leave
 

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "swarm update"
-description = "The swarm update command description and usage"
-keywords = ["swarm, update"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "swarm update"
+description: "The swarm update command description and usage"
+keywords: ["swarm, update"]
+---
 
 # swarm update
 

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "system df"
-description = "The system df command description and usage"
-keywords = [system, data, usage, disk]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "system df"
+description: "The system df command description and usage"
+keywords: [system, data, usage, disk]
+---
 
 # system df
 

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "system prune"
-description = "Remove unused data"
-keywords = [system, prune, delete, remove]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "system prune"
+description: "Remove unused data"
+keywords: [system, prune, delete, remove]
+---
 
 # system prune
 

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "tag"
-description = "The tag command description and usage"
-keywords = ["tag, name, image"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "tag"
+description: "The tag command description and usage"
+keywords: ["tag, name, image"]
+---
 
 # tag
 

--- a/docs/reference/commandline/top.md
+++ b/docs/reference/commandline/top.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "top"
-description = "The top command description and usage"
-keywords = ["container, running, processes"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "top"
+description: "The top command description and usage"
+keywords: ["container, running, processes"]
+---
 
 # top
 

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "unpause"
-description = "The unpause command description and usage"
-keywords = ["cgroups, suspend, container"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "unpause"
+description: "The unpause command description and usage"
+keywords: ["cgroups, suspend, container"]
+---
 
 # unpause
 

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "update"
-description = "The update command description and usage"
-keywords = ["resources, update, dynamically"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "update"
+description: "The update command description and usage"
+keywords: ["resources, update, dynamically"]
+---
 
 ## update
 
@@ -31,8 +27,8 @@ Options:
 ```
 
 The `docker update` command dynamically updates container configuration.
-You can use this command to prevent containers from consuming too many 
-resources from their Docker host.  With a single command, you can place 
+You can use this command to prevent containers from consuming too many
+resources from their Docker host.  With a single command, you can place
 limits on a single container or on many. To specify more than one container,
 provide space-separated list of container names or IDs.
 

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "version"
-description = "The version command description and usage"
-keywords = ["version, architecture, api"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "version"
+description: "The version command description and usage"
+keywords: ["version, architecture, api"]
+---
 
 # version
 

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "volume create"
-description = "The volume create command description and usage"
-keywords = ["volume, create"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "volume create"
+description: "The volume create command description and usage"
+keywords: ["volume, create"]
+---
 
 # volume create
 
@@ -57,7 +53,7 @@ different volume drivers may do different things (or nothing at all).
 The built-in `local` driver on Windows does not support any options.
 
 The built-in `local` driver on Linux accepts options similar to the linux `mount` command. You can provide multiple options by passing the `--opt` flag multiple times. Some `mount` options (such as the `o` option) can take a comma-separated list of options. Complete list of available mount options can be found [here](http://man7.org/linux/man-pages/man8/mount.8.html).
- 
+
 For example, the following creates a `tmpfs` volume called `foo` with a size of 100 megabyte and `uid` of 1000.
 
 ```bash

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "volume inspect"
-description = "The volume inspect command description and usage"
-keywords = ["volume, inspect"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "volume inspect"
+description: "The volume inspect command description and usage"
+keywords: ["volume, inspect"]
+---
 
 # volume inspect
 

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "volume ls"
-description = "The volume ls command description and usage"
-keywords = ["volume, list"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "volume ls"
+description: "The volume ls command description and usage"
+keywords: ["volume, list"]
+---
 
 # volume ls
 

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "volume prune"
-description = "Remove unused volumes"
-keywords = [volume, prune, delete]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "volume prune"
+description: "Remove unused volumes"
+keywords: [volume, prune, delete]
+---
 
 # volume prune
 

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -1,12 +1,9 @@
-<!--[metadata]>
-+++
-title = "volume rm"
-description = "the volume rm command description and usage"
-keywords = ["volume, rm"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "volume rm"
+description: "the volume rm command description and usage"
+keywords: ["volume, rm"]
+---
+
 
 # volume rm
 

--- a/docs/reference/commandline/wait.md
+++ b/docs/reference/commandline/wait.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "wait"
-description = "The wait command description and usage"
-keywords = ["container, stop, wait"]
-[menu.main]
-parent = "smn_cli"
-+++
-<![end-metadata]-->
+---
+title: "wait"
+description: "The wait command description and usage"
+keywords: ["container, stop, wait"]
+---
 
 # wait
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Docker Glossary"
-description = "Glossary of terms used around Docker"
-keywords = ["glossary, docker, terms,  definitions"]
-[menu.main]
-parent = "mn_about"
-weight = "50"
-+++
-<![end-metadata]-->
+---
+title: "Docker Glossary"
+description: "Glossary of terms used around Docker"
+keywords: ["glossary, docker, terms,  definitions"]
+---
 
 # Glossary
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,14 +1,8 @@
-<!-- [metadata]>
-+++
-title = "Engine reference"
-description = "Docker Engine reference"
-keywords = ["Engine"]
-[menu.main]
-parent="engine_use"
-identifier="engine_ref"
-weight=70
-+++
-<![end-metadata]-->
+---
+title: "Engine reference"
+description: "Docker Engine reference"
+keywords: ["Engine"]
+---
 
 # Engine reference
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Docker run reference"
-description = "Configure containers at runtime"
-keywords = ["docker, run, configure,  runtime"]
-[menu.main]
-parent = "engine_ref"
-weight=-80
-+++
-<![end-metadata]-->
+---
+title: "Docker run reference"
+description: "Configure containers at runtime"
+keywords: ["docker, run, configure,  runtime"]
+---
 
 # Docker run reference
 
@@ -181,7 +176,7 @@ Images using the v2 or later image format have a content-addressable identifier
 called a digest. As long as the input used to generate the image is unchanged,
 the digest value is predictable and referenceable.
 
-The following example runs a container from the `alpine` image with the 
+The following example runs a container from the `alpine` image with the
 `sha256:9cacb71397b640eca97488cf08582ae4e4068513101088e9f96c9814bfda95e0` digest:
 
     $ docker run alpine@sha256:9cacb71397b640eca97488cf08582ae4e4068513101088e9f96c9814bfda95e0 date


### PR DESCRIPTION
Some frontmatter such as the weights, menu stuff, etc is no longer used
'draft=true' becomes 'published: false'

This is necessary to be compatible with Jekyll. @thaJeztah PTAL
