### PR TITLE
[test] fix failure of TestBuildLabelsOverride on Windows

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6636,7 +6636,7 @@ func (s *DockerSuite) TestBuildLabelsOverride(c *check.C) {
 	name = "scratchz"
 	expected = `{"bar":"$PATH"}`
 	_, err = buildImage(name,
-		`FROM scratch`,
+		`FROM `+minimalBaseImage(),
 		true, "--label", "bar=$PATH")
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
TestBuildLabelsOverride was consistently failing due to "Windows does not support FROM scratch" error

e.g. https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/4401/console (https://github.com/docker/docker/pull/27412), https://jenkins.dockerproject.org/job/Docker-PRs-WoW-RS1/4402/console (#26130)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
