### PR TITLE
Fix an incorrect `WARNING` output in `docker run/create`

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -351,7 +351,7 @@ func verifyContainerResources(resources *containertypes.Resources, sysInfo *sysi
 		return warnings, fmt.Errorf("CPU cfs quota can not be less than 1ms (i.e. 1000)")
 	}
 	if resources.CPUPercent > 0 {
-		warnings = append(warnings, "%s does not support CPU percent. Percent discarded.", runtime.GOOS)
+		warnings = append(warnings, fmt.Sprintf("%s does not support CPU percent. Percent discarded.", runtime.GOOS))
 		logrus.Warnf("%s does not support CPU percent. Percent discarded.", runtime.GOOS)
 		resources.CPUPercent = 0
 	}


### PR DESCRIPTION
This fix tries to fix an incorrect `WARNING` output in `docker run/create`, notice the `%s` and additional line `linux`:

```
ubuntu@ubuntu:~/docker$ docker run -d --cpu-percent 80 busybox top
WARNING: %s does not support CPU percent. Percent discarded.
WARNING: linux
e963d1108e455e7f8f57626ca1305b5f1999e46025d2865b9a21fc8abc51a546
```

The reason was that in `daemon/daemon_unix.go`, the warning string
was not combined with `fmt.Sprintf` before appended to the output.

This fix fixes this issue.

This fix has been manually tested and verified:

```
ubuntu@ubuntu:~/docker$ docker run -d --cpu-percent 80 busybox top
WARNING: linux does not support CPU percent. Percent discarded.
fcf53f79d389235bae846d3d40804834659ac025edbc0d075ed91841a8e4c740
```

Signed-off-by: Yong Tang yong.tang.github@outlook.com
