### PR TITLE
Add `LoggingConfig` field in `docker info`

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -190,6 +190,7 @@ type Info struct {
 	NGoroutines        int
 	SystemTime         string
 	LoggingDriver      string
+	LoggingConfig      map[string]string
 	CgroupDriver       string
 	NEventsListener    int
 	KernelVersion      string

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -80,6 +80,12 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 		}
 	}
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "Logging Driver: %s\n", info.LoggingDriver)
+	if len(info.LoggingConfig) > 0 {
+		fmt.Fprintf(dockerCli.Out(), "Logging Config:\n")
+		for k, v := range info.LoggingConfig {
+			fmt.Fprintf(dockerCli.Out(), " %s: %s\n", k, v)
+		}
+	}
 	ioutils.FprintfIfNotEmpty(dockerCli.Out(), "Cgroup Driver: %s\n", info.CgroupDriver)
 
 	fmt.Fprintf(dockerCli.Out(), "Plugins: \n")

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/debug"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/parsers/kernel"
@@ -89,6 +90,8 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		securityOptions = append(securityOptions, "name=userns")
 	}
 
+	loggingConfig, _ := logger.OutputLogOpts(daemon.defaultLogConfig.Type, daemon.defaultLogConfig.Config)
+
 	v := &types.Info{
 		ID:                 daemon.ID,
 		Containers:         int(cRunning + cPaused + cStopped),
@@ -107,6 +110,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		NGoroutines:        runtime.NumGoroutine(),
 		SystemTime:         time.Now().Format(time.RFC3339Nano),
 		LoggingDriver:      daemon.defaultLogConfig.Type,
+		LoggingConfig:      loggingConfig,
 		CgroupDriver:       daemon.getCgroupDriver(),
 		NEventsListener:    daemon.EventsService.SubscribersCount(),
 		KernelVersion:      kernelVersion,

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -12,9 +12,13 @@ type Creator func(Info) (Logger, error)
 // logging implementation.
 type LogOptValidator func(cfg map[string]string) error
 
+// LogOptOutput generates the displayable options for `docker info`.
+type LogOptOutput func(cfg map[string]string) (map[string]string, error)
+
 type logdriverFactory struct {
 	registry     map[string]Creator
 	optValidator map[string]LogOptValidator
+	optOutput    map[string]LogOptOutput
 	m            sync.Mutex
 }
 
@@ -47,6 +51,17 @@ func (lf *logdriverFactory) registerLogOptValidator(name string, l LogOptValidat
 	return nil
 }
 
+func (lf *logdriverFactory) registerLogOptOutput(name string, l LogOptOutput) error {
+	lf.m.Lock()
+	defer lf.m.Unlock()
+
+	if _, ok := lf.optOutput[name]; ok {
+		return fmt.Errorf("logger: log output named '%s' is already registered", name)
+	}
+	lf.optOutput[name] = l
+	return nil
+}
+
 func (lf *logdriverFactory) get(name string) (Creator, error) {
 	lf.m.Lock()
 	defer lf.m.Unlock()
@@ -66,7 +81,19 @@ func (lf *logdriverFactory) getLogOptValidator(name string) LogOptValidator {
 	return c
 }
 
-var factory = &logdriverFactory{registry: make(map[string]Creator), optValidator: make(map[string]LogOptValidator)} // global factory instance
+func (lf *logdriverFactory) getLogOptOutput(name string) LogOptOutput {
+	lf.m.Lock()
+	defer lf.m.Unlock()
+
+	c, _ := lf.optOutput[name]
+	return c
+}
+
+var factory = &logdriverFactory{
+	registry:     make(map[string]Creator),
+	optValidator: make(map[string]LogOptValidator),
+	optOutput:    make(map[string]LogOptOutput),
+} // global factory instance
 
 // RegisterLogDriver registers the given logging driver builder with given logging
 // driver name.
@@ -78,6 +105,12 @@ func RegisterLogDriver(name string, c Creator) error {
 // the given logging driver name.
 func RegisterLogOptValidator(name string, l LogOptValidator) error {
 	return factory.registerLogOptValidator(name, l)
+}
+
+// RegisterLogOptOutput registers the logging option output with
+// the given logging driver name.
+func RegisterLogOptOutput(name string, l LogOptOutput) error {
+	return factory.registerLogOptOutput(name, l)
 }
 
 // GetLogDriver provides the logging driver builder for a logging driver name.
@@ -101,4 +134,26 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 		return validator(cfg)
 	}
 	return nil
+}
+
+// OutputLogOpts takes the options for the given log driver, and
+// generate the displayable options for `docker info`.
+// This is useful in case some of the information in the options
+// is not suitable for `docker info` (e.g., tokens for splunk)
+// A log driver could register the OutputLogOpts to customerize
+// the information to output. Otherwise all options will be output.
+func OutputLogOpts(name string, cfg map[string]string) (map[string]string, error) {
+	if name == "none" {
+		return nil, nil
+	}
+
+	if !factory.driverRegistered(name) {
+		return nil, fmt.Errorf("logger: no log driver named '%s' is registered", name)
+	}
+
+	output := factory.getLogOptOutput(name)
+	if output != nil {
+		return output(cfg)
+	}
+	return cfg, nil
 }

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -137,6 +137,9 @@ func init() {
 	if err := logger.RegisterLogOptValidator(driverName, ValidateLogOpt); err != nil {
 		logrus.Fatal(err)
 	}
+	if err := logger.RegisterLogOptOutput(driverName, OutputLogOpt); err != nil {
+		logrus.Fatal(err)
+	}
 }
 
 // New creates splunk logger driver using configuration passed in context
@@ -545,6 +548,36 @@ func ValidateLogOpt(cfg map[string]string) error {
 		}
 	}
 	return nil
+}
+
+// OutputLogOpt output the splunk driver options that are only suitable
+// for `docker info` (No Token Key)
+func OutputLogOpt(cfg map[string]string) (map[string]string, error) {
+	output := map[string]string{}
+	for key, value := range cfg {
+		switch key {
+		case splunkURLKey:
+		case splunkTokenKey:
+			continue
+		case splunkSourceKey:
+		case splunkSourceTypeKey:
+		case splunkIndexKey:
+		case splunkCAPathKey:
+		case splunkCANameKey:
+		case splunkInsecureSkipVerifyKey:
+		case splunkFormatKey:
+		case splunkVerifyConnectionKey:
+		case splunkGzipCompressionKey:
+		case splunkGzipCompressionLevelKey:
+		case envKey:
+		case labelsKey:
+		case tagKey:
+		default:
+			return nil, fmt.Errorf("unknown log opt '%s' for %s log driver", key, driverName)
+		}
+		output[key] = value
+	}
+	return output, nil
 }
 
 func parseURL(info logger.Info) (*url.URL, error) {

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -237,3 +237,26 @@ func (s *DockerDaemonSuite) TestInfoLabels(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, "WARNING: labels with duplicate keys and conflicting values have been deprecated")
 }
+
+func (s *DockerDaemonSuite) TestInfoLoggingDriver(c *check.C) {
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
+
+	loggingDriver := "json-file"
+	loggingConfig := map[string]string{
+		"max-file": "5",
+		"labels":   "label1,label2,label3",
+		"env":      "ENV1,ENV2,ENV3",
+	}
+	s.d.Start(c, "--log-driver", loggingDriver,
+		"--log-opt", "max-file="+loggingConfig["max-file"],
+		"--log-opt", "labels="+loggingConfig["labels"],
+		"--log-opt", "env="+loggingConfig["env"])
+
+	out, err := s.d.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, fmt.Sprintf("Logging Driver: %s\n", loggingDriver))
+	c.Assert(out, checker.Contains, "Logging Config:\n")
+	c.Assert(out, checker.Contains, fmt.Sprintf(" max-file: %s\n", loggingConfig["max-file"]))
+	c.Assert(out, checker.Contains, fmt.Sprintf(" labels: %s\n", loggingConfig["labels"]))
+	c.Assert(out, checker.Contains, fmt.Sprintf(" env: %s\n", loggingConfig["env"]))
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #25508 where it is not possible to get daemon default logging information from remote API.

**\- How I did it**

Currently there is already a `LoggingDriver` field in `docker info`/`GET /info` which shows the logging driver. Though logging options is not there yet.

This fix adds a `LoggingConfig` field in `types.Info` and output the content of `LoggingConfig` for `docker info`:

```
...
Storage Driver: aufs
 Root Dir: /go/src/github.com/docker/docker/bundles/1.13.0-dev/test-integration-cli/d297a43eaec75/root/aufs
 Backing Filesystem: extfs
 Dirs: 0
 Dirperm1 Supported: true
Logging Driver: json-file
Logging Config:
 env: ENV1,ENV2,ENV3
 labels: label1,label2,label3
 max-file: 5
Cgroup Driver: cgroupfs
Plugins:
...
```

**\- How to verify it**

An integraton test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #25508.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
