### PR TITLE
Add KernelMemory to API changelog

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -236,6 +236,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `GET /info` now lists engine version information and return the information of `CPUShares` and `Cpuset`.
 * `GET /containers/json` will return `ImageID` of the image used by container.
 * `POST /exec/(name)/start` will now return an HTTP 409 when the container is either stopped or paused.
+* `POST /containers/create` now takes `KernelMemory` in HostConfig to specify kernel memory limit.
 * `GET /containers/(name)/json` now accepts a `size` parameter. Setting this parameter to '1' returns container size information in the `SizeRw` and `SizeRootFs` fields.
 * `GET /containers/(name)/json` now returns a `NetworkSettings.Networks` field,
   detailing network settings per network. This field deprecates the


### PR DESCRIPTION
Going through old notes/todo's :smile:

Commit 9bd8a9b66bb493026599d22c7637909cb460d039 (https://github.com/docker/docker/pull/14006)
added KernelMemory to the API, but forgot
to include this in the API changelog.

This adds the missing entry in the API
changelog.

ping @vdemeester ptal
