### PR TITLE
overlay: warn if overlay backing fs doesn't support d_type

### DIFF
--- a/daemon/graphdriver/overlayutils/overlayutils.go
+++ b/daemon/graphdriver/overlayutils/overlayutils.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package overlayutils
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrDTypeNotSupported denotes that the backing filesystem doesn't support d_type.
+func ErrDTypeNotSupported(driver, backingFs string) error {
+	msg := fmt.Sprintf("%s: the backing %s filesystem is formatted without d_type support, which leads to incorrect behavior.", driver, backingFs)
+	if backingFs == "xfs" {
+		msg += " Reformat the filesystem with ftype=1 to enable d_type support."
+	}
+	msg += " Running without d_type support will no longer be supported in Docker 1.16."
+	return errors.New(msg)
+}

--- a/pkg/fsutils/fsutils_linux.go
+++ b/pkg/fsutils/fsutils_linux.go
@@ -1,0 +1,89 @@
+// +build linux
+
+package fsutils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func locateDummyIfEmpty(path string) (string, error) {
+	children, err := ioutil.ReadDir(path)
+	if err != nil {
+		return "", err
+	}
+	if len(children) != 0 {
+		return "", nil
+	}
+	dummyFile, err := ioutil.TempFile(path, "fsutils-dummy")
+	if err != nil {
+		return "", err
+	}
+	name := dummyFile.Name()
+	if err = dummyFile.Close(); err != nil {
+		return name, err
+	}
+	return name, nil
+}
+
+// SupportsDType returns whether the filesystem mounted on path supports d_type
+func SupportsDType(path string) (bool, error) {
+	// locate dummy so that we have at least one dirent
+	dummy, err := locateDummyIfEmpty(path)
+	if err != nil {
+		return false, err
+	}
+	if dummy != "" {
+		defer os.Remove(dummy)
+	}
+
+	visited := 0
+	supportsDType := true
+	fn := func(ent *syscall.Dirent) bool {
+		visited++
+		if ent.Type == syscall.DT_UNKNOWN {
+			supportsDType = false
+			// stop iteration
+			return true
+		}
+		// continue iteration
+		return false
+	}
+	if err = iterateReadDir(path, fn); err != nil {
+		return false, err
+	}
+	if visited == 0 {
+		return false, fmt.Errorf("did not hit any dirent during iteration %s", path)
+	}
+	return supportsDType, nil
+}
+
+func iterateReadDir(path string, fn func(*syscall.Dirent) bool) error {
+	d, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	fd := int(d.Fd())
+	buf := make([]byte, 4096)
+	for {
+		nbytes, err := syscall.ReadDirent(fd, buf)
+		if err != nil {
+			return err
+		}
+		if nbytes == 0 {
+			break
+		}
+		for off := 0; off < nbytes; {
+			ent := (*syscall.Dirent)(unsafe.Pointer(&buf[off]))
+			if stop := fn(ent); stop {
+				return nil
+			}
+			off += int(ent.Reclen)
+		}
+	}
+	return nil
+}

--- a/pkg/fsutils/fsutils_linux_test.go
+++ b/pkg/fsutils/fsutils_linux_test.go
@@ -1,0 +1,91 @@
+// +build linux
+
+package fsutils
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func testSupportsDType(t *testing.T, expected bool, mkfsCommand string, mkfsArg ...string) {
+	// check whether mkfs is installed
+	if _, err := exec.LookPath(mkfsCommand); err != nil {
+		t.Skipf("%s not installed: %v", mkfsCommand, err)
+	}
+
+	// create a sparse image
+	imageSize := int64(32 * 1024 * 1024)
+	imageFile, err := ioutil.TempFile("", "fsutils-image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageFileName := imageFile.Name()
+	defer os.Remove(imageFileName)
+	if _, err = imageFile.Seek(imageSize-1, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = imageFile.Write([]byte{0}); err != nil {
+		t.Fatal(err)
+	}
+	if err = imageFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// create a mountpoint
+	mountpoint, err := ioutil.TempDir("", "fsutils-mountpoint")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(mountpoint)
+
+	// format the image
+	args := append(mkfsArg, imageFileName)
+	t.Logf("Executing `%s %v`", mkfsCommand, args)
+	out, err := exec.Command(mkfsCommand, args...).CombinedOutput()
+	if len(out) > 0 {
+		t.Log(string(out))
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// loopback-mount the image.
+	// for ease of setting up loopback device, we use os/exec rather than syscall.Mount
+	out, err = exec.Command("mount", "-o", "loop", imageFileName, mountpoint).CombinedOutput()
+	if len(out) > 0 {
+		t.Log(string(out))
+	}
+	if err != nil {
+		t.Skip("skipping the test because mount failed")
+	}
+	defer func() {
+		if err := syscall.Unmount(mountpoint, 0); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// check whether it supports d_type
+	result, err := SupportsDType(mountpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Supports d_type: %v", result)
+	if result != expected {
+		t.Fatalf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestSupportsDTypeWithFType0XFS(t *testing.T) {
+	testSupportsDType(t, false, "mkfs.xfs", "-m", "crc=0", "-n", "ftype=0")
+}
+
+func TestSupportsDTypeWithFType1XFS(t *testing.T) {
+	testSupportsDType(t, true, "mkfs.xfs", "-m", "crc=0", "-n", "ftype=1")
+}
+
+func TestSupportsDTypeWithExt4(t *testing.T) {
+	testSupportsDType(t, true, "mkfs.ext4")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Print a warning if the backing fs for overlay/overlay2 doesn't support `d_type`.
Close #27358 

Considering the discussion at https://github.com/docker/docker/issues/22937, the warning is not treated as an error.
However, I still think it is useful to treat it as an error in some future version (1.14? 1.15?).

Note that recent kernel prints a similar message: https://github.com/torvalds/linux/commit/e7c0b5991dd1be7b6f6dc2b54a15a0f47b64b007
However I think there are advantages to print the message as well in Docker:
- Can support older kernels
- Can provide much more user-friendly information (e.g. "You need to reformat with f_type=1" for XFS)
- Can be switched to an error in future Docker versions

It also shows information in `docker info`.

**\- How I did it**
Please refer to the source of `pkg/fsutils.SupportsDType`.

**\- How to verify it**
For example, XFS with ftype=0 prints this warning.

``` console
$ qemu-img create /xfs-ftype0.img 10G
$ mkfs.xfs -m crc=0 -n ftype=0 /xfs-ftype0.img
$ mount -o loop /xfs-ftype0.img /mnt
$ dockerd -s overlay2 -g /mnt
WARN[0001] overlay2 won't work properly because the backing filesystem xfs is not configured to support d_type. (The backing filesystem seems formatted with f_type=0. Please r
eformat the filesytem with f_type=1.) Note that this warning is planned to be treated as a fatal error in v1.16 

```

The warning should not be shown if ftype=1.

`docker info` shows `f_type Supported` information:

``` console
$ docker info
...
Storage Driver: overlay2
 Backing Filesystem: xfs
 Supports d_type: false
...
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

TODO
- [ ] PR for doc (after this PR gets merged)

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
