### PR TITLE
Fix a link for feature deprecation policy

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -9,7 +9,7 @@ keywords: ["docker, documentation, about, technology, deprecate"]
 
 The following list of features are deprecated in Engine.
 To learn more about Docker Engine's deprecation policy,
-see [Feature Deprecation Policy](index.md#feature-deprecation-policy).
+see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-deprecation-policy).
 
 
 ### `repository:shortid` image references


### PR DESCRIPTION
**\- What I did**
Fix a link for feature deprecation policy which can't to access

**\- How I did it**
Update a link for feature deprecation policy

**\- How to verify it**
access to the page

**\- Description for the changelog**
The new link is https://docs.docker.com/engine/#feature-deprecation-policyt.

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
