### PR TITLE
The first letter should be small in error of remote.go

### DIFF
--- a/builder/remote.go
+++ b/builder/remote.go
@@ -33,7 +33,7 @@ var mimeRe = regexp.MustCompile(acceptableRemoteMIME)
 func MakeRemoteContext(remoteURL string, contentTypeHandlers map[string]func(io.ReadCloser) (io.ReadCloser, error)) (ModifiableContext, error) {
 	f, err := httputils.Download(remoteURL)
 	if err != nil {
-		return nil, fmt.Errorf("Error downloading remote context %s: %v", remoteURL, err)
+		return nil, fmt.Errorf("error downloading remote context %s: %v", remoteURL, err)
 	}
 	defer f.Body.Close()
 
@@ -44,7 +44,7 @@ func MakeRemoteContext(remoteURL string, contentTypeHandlers map[string]func(io.
 
 		contentType, contextReader, err = inspectResponse(contentType, f.Body, clen)
 		if err != nil {
-			return nil, fmt.Errorf("Error detecting content type for remote %s: %v", remoteURL, err)
+			return nil, fmt.Errorf("error detecting content type for remote %s: %v", remoteURL, err)
 		}
 		defer contextReader.Close()
 
@@ -118,7 +118,7 @@ func inspectResponse(ct string, r io.ReadCloser, clen int64) (string, io.ReadClo
 	preamble := make([]byte, plen, plen)
 	rlen, err := r.Read(preamble)
 	if rlen == 0 {
-		return ct, r, errors.New("Empty response")
+		return ct, r, errors.New("empty response")
 	}
 	if err != nil && err != io.EOF {
 		return ct, r, err


### PR DESCRIPTION
**\- What I did**
Fix the typo of the first letter in error
**\- How I did it**
Modify the first letter capital to lowercase

Signed-off-by: YuPengZTE yu.peng36@zte.com.cn
