### PR TITLE
Volume name conflict error message to include the driver name

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -220,7 +220,7 @@ func (daemon *Daemon) VolumeCreate(name, driverName string, opts, labels map[str
 	v, err := daemon.volumes.Create(name, driverName, opts, labels)
 	if err != nil {
 		if volumestore.IsNameConflict(err) {
-			return nil, fmt.Errorf("A volume named %s already exists. Choose a different volume name.", name)
+			return nil, fmt.Errorf("A volume named \"%s\" already exists with the \"%s\" driver. Choose a different volume name.", name, v.DriverName())
 		}
 		return nil, err
 	}

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -158,6 +158,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /images/prune` prunes unused images.
 * `POST /volumes/prune` prunes unused volumes.
 * Every API response now includes a `Docker-Experimental` header specifying if experimental features are enabled (value can be `true` or `false`).
+* `POST /volumes/create` now returns an error if the given volume name already exists. 
 
 ### v1.24 API changes
 

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -43,7 +43,7 @@ Multiple containers can use the same volume in the same time period. This is use
 Volume names must be unique. This means you cannot use the same name with two different volumes. If you attempt this `docker` returns an error:
 
 ```
-A volume named hello already exists. Choose a different volume name.
+A volume named  "hello"  already exists with the "some-other" driver. Choose a different volume name.
 ```  
 
 ## Driver specific options

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -40,13 +40,11 @@ The mount is created inside the container's `/world` directory. Docker does not 
 
 Multiple containers can use the same volume in the same time period. This is useful if two containers need access to shared data. For example, if one container writes and the other reads the data.
 
-Volume names must be unique among drivers.  This means you cannot use the same volume name with two different drivers.  If you attempt this `docker` returns an error:
+Volume names must be unique. This means you cannot use the same name with two different volumes. If you attempt this `docker` returns an error:
 
 ```
-A volume named  "hello"  already exists with the "some-other" driver. Choose a different volume name.
-```
-
-If you specify a volume name already in use on the current driver, Docker assumes you want to re-use the existing volume and does not return an error.   
+A volume named hello already exists. Choose a different volume name.
+```  
 
 ## Driver specific options
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -17,7 +17,7 @@ func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {
 	dockerCmd(c, "volume", "create")
 
 	_, err := runCommand(exec.Command(dockerBinary, "volume", "create", "-d", "nosuchdriver"))
-	c.Assert(err, check.Not(check.IsNil))
+	c.Assert(err, check.NotNil)
 
 	// test using hidden --name option
 	out, _ := dockerCmd(c, "volume", "create", "--name=test")
@@ -32,12 +32,14 @@ func (s *DockerSuite) TestVolumeCLICreate(c *check.C) {
 func (s *DockerSuite) TestVolumeCLICreateOptionConflict(c *check.C) {
 	dockerCmd(c, "volume", "create", "test")
 	out, _, err := dockerCmdWithError("volume", "create", "test", "--driver", "nosuchdriver")
-	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use with another driver"))
+	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use"))
 	c.Assert(out, checker.Contains, "A volume named test already exists")
 
 	out, _ = dockerCmd(c, "volume", "inspect", "--format={{ .Driver }}", "test")
-	_, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
-	c.Assert(err, check.IsNil)
+	out, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use"))
+	c.Assert(out, checker.Contains, "A volume named test already exists")
 
 	// make sure hidden --name option conflicts with positional arg name
 	out, _, err = dockerCmdWithError("volume", "create", "--name", "test2", "test2")

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -33,13 +33,13 @@ func (s *DockerSuite) TestVolumeCLICreateOptionConflict(c *check.C) {
 	dockerCmd(c, "volume", "create", "test")
 	out, _, err := dockerCmdWithError("volume", "create", "test", "--driver", "nosuchdriver")
 	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use"))
-	c.Assert(out, checker.Contains, "A volume named test already exists")
+	c.Assert(out, checker.Contains, "Error response from daemon: A volume named \"test\" already exists with the \"local\" driver. Choose a different volume name.")
 
 	out, _ = dockerCmd(c, "volume", "inspect", "--format={{ .Driver }}", "test")
 	out, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.NotNil, check.Commentf("volume create exception name already in use"))
-	c.Assert(out, checker.Contains, "A volume named test already exists")
+	c.Assert(out, checker.Contains, "Error response from daemon: A volume named \"test\" already exists with the \"local\" driver. Choose a different volume name.")
 
 	// make sure hidden --name option conflicts with positional arg name
 	out, _, err = dockerCmdWithError("volume", "create", "--name", "test2", "test2")

--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -179,11 +179,18 @@ func GetDriverList() []string {
 
 // GetAllDrivers lists all the registered drivers
 func GetAllDrivers() ([]volume.Driver, error) {
-	plugins, err := drivers.plugingetter.GetAllByCap(extName)
-	if err != nil {
-		return nil, fmt.Errorf("error listing plugins: %v", err)
+	var (
+		plugins []getter.CompatPlugin
+		ds      []volume.Driver
+		err     error
+	)
+
+	if drivers.plugingetter != nil {
+		plugins, err = drivers.plugingetter.GetAllByCap(extName)
+		if err != nil {
+			return nil, fmt.Errorf("error listing plugins: %v", err)
+		}
 	}
-	var ds []volume.Driver
 
 	drivers.Lock()
 	defer drivers.Unlock()

--- a/volume/store/errors.go
+++ b/volume/store/errors.go
@@ -12,7 +12,7 @@ var (
 	errNoSuchVolume = errors.New("no such volume")
 	// errInvalidName is a typed error returned when creating a volume with a name that is not valid on the platform
 	errInvalidName = errors.New("volume name is not valid on this platform")
-	// errNameConflict is a typed error returned on create when a volume exists with the given name, but for a different driver
+	// errNameConflict is a typed error returned on create when a volume exists with the given name
 	errNameConflict = errors.New("conflict: volume name must be unique")
 )
 

--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -60,6 +60,19 @@ func (v volumeWrapper) CachedPath() string {
 	return v.Volume.Path()
 }
 
+// VolumeStore is a struct that stores the list of volumes available and keeps track of their usage counts
+type VolumeStore struct {
+	locks      *locker.Locker
+	globalLock sync.Mutex
+	// names stores the volume name -> specified volume relationship.
+	names map[string]volume.Volume
+	// refs stores the volume name and the list of things referencing it
+	refs map[string][]string
+	// labels stores volume labels for each volume
+	labels map[string]map[string]string
+	db     *bolt.DB
+}
+
 // New initializes a VolumeStore to keep
 // reference counting of volumes in the system.
 func New(rootPath string) (*VolumeStore, error) {
@@ -163,12 +176,12 @@ func (s *VolumeStore) List() ([]volume.Volume, []string, error) {
 		// deleted before we acquire a lock on its name
 		if exists && storedV.DriverName() != v.DriverName() {
 			logrus.Warnf("Volume name %s already exists for driver %s, not including volume returned by %s", v.Name(), storedV.DriverName(), v.DriverName())
-			s.locks.Unlock(v.Name())
+			s.locks.Unlock(name)
 			continue
 		}
 
 		out = append(out, v)
-		s.locks.Unlock(v.Name())
+		s.locks.Unlock(name)
 	}
 	return out, warnings, nil
 }
@@ -236,24 +249,37 @@ func (s *VolumeStore) CreateWithRef(name, driverName, ref string, opts, labels m
 	s.locks.Lock(name)
 	defer s.locks.Unlock(name)
 
-	v, err := s.create(name, driverName, opts, labels)
-	if err != nil {
-		return nil, &OpErr{Err: err, Name: name, Op: "create"}
-	}
+	var err error
 
+	v, exist := s.getNamed(name)
+	if !exist {
+		// it means no volume with name exists, we should create one
+		v, err = s.create(name, driverName, opts, labels)
+		if err != nil {
+			return nil, &OpErr{Err: err, Name: name, Op: "create"}
+		}
+
+	}
 	s.setNamed(v, ref)
+
 	return v, nil
 }
 
 // Create creates a volume with the given name and driver.
 // This is just like CreateWithRef() except we don't store a reference while holding the lock.
 func (s *VolumeStore) Create(name, driverName string, opts, labels map[string]string) (volume.Volume, error) {
+	name = normaliseVolumeName(name)
+
+	if _, exists := s.getNamed(name); exists {
+		// if given name exists, return errNameConflict
+		return nil, errNameConflict
+	}
+
 	return s.CreateWithRef(name, driverName, "", opts, labels)
 }
 
 // create asks the given driver to create a volume with the name/opts.
-// If a volume with the name is already known, it will ask the stored driver for the volume.
-// If the passed in driver name does not match the driver name which is stored for the given volume name, an error is returned.
+// If a volume with the given name is already known, a conflict error will be returned.
 // It is expected that callers of this function hold any necessary locks.
 func (s *VolumeStore) create(name, driverName string, opts, labels map[string]string) (volume.Volume, error) {
 	// Validate the name in a platform-specific manner
@@ -265,23 +291,7 @@ func (s *VolumeStore) create(name, driverName string, opts, labels map[string]st
 		return nil, &OpErr{Err: errInvalidName, Name: name, Op: "create"}
 	}
 
-	if v, exists := s.getNamed(name); exists {
-		if v.DriverName() != driverName && driverName != "" && driverName != volume.DefaultDriverName {
-			return nil, errNameConflict
-		}
-		return v, nil
-	}
-
-	// Since there isn't a specified driver name, let's see if any of the existing drivers have this volume name
-	if driverName == "" {
-		v, _ := s.getVolume(name)
-		if v != nil {
-			return v, nil
-		}
-	}
-
 	vd, err := volumedrivers.CreateDriver(driverName)
-
 	if err != nil {
 		return nil, &OpErr{Op: "create", Name: name, Err: err}
 	}

--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -270,9 +270,9 @@ func (s *VolumeStore) CreateWithRef(name, driverName, ref string, opts, labels m
 func (s *VolumeStore) Create(name, driverName string, opts, labels map[string]string) (volume.Volume, error) {
 	name = normaliseVolumeName(name)
 
-	if _, exists := s.getNamed(name); exists {
+	if v, exists := s.getNamed(name); exists {
 		// if given name exists, return errNameConflict
-		return nil, errNameConflict
+		return v, errNameConflict
 	}
 
 	return s.CreateWithRef(name, driverName, "", opts, labels)


### PR DESCRIPTION
The error message that is displayed on creating a volume with an already existing name would include the conflicting volume driver name. Fixes #26831.
