### PR TITLE
Fix typo in build documentation

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -98,6 +98,7 @@ or pipe the file in via `STDIN`. To pipe a Dockerfile from `STDIN`:
 
 ```bash
 $ docker build http://server/context.tar.gz
+```
 
 The download operation will be performed on the host the Docker daemon is
 running on, which is not necessarily the same host from which the build command


### PR DESCRIPTION
**\- What I did**

While reading [build](https://docs.docker.com/engine/reference/commandline/build/) documentation I saw typo and proposed fix.

**\- How I did it**

Fixed markdown.

**\- How to verify it**

Eye-ball markdown.

**\- Description for the changelog**

(No entry in changelog.)
