### PR TITLE
Add manifest command to docker cli

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/cli/command/checkpoint"
 	"github.com/docker/docker/cli/command/container"
 	"github.com/docker/docker/cli/command/image"
+	"github.com/docker/docker/cli/command/manifest"
 	"github.com/docker/docker/cli/command/network"
 	"github.com/docker/docker/cli/command/node"
 	"github.com/docker/docker/cli/command/plugin"
@@ -34,11 +35,14 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		image.NewImageCommand(dockerCli),
 		image.NewBuildCommand(dockerCli),
 
-		// node
-		node.NewNodeCommand(dockerCli),
+		// manfiest
+		manifest.NewManifestCommand(dockerCli),
 
 		// network
 		network.NewNetworkCommand(dockerCli),
+
+		// node
+		node.NewNodeCommand(dockerCli),
 
 		// plugin
 		plugin.NewPluginCommand(dockerCli),

--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -1,0 +1,126 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type annotateOptions struct {
+	target      string // the target manifest list name (also transaction ID)
+	image       string // the manifest to annotate within the list
+	variant     string // an architecture variant
+	os          string
+	arch        string
+	cpuFeatures []string
+	osFeatures  []string
+}
+
+// NewAnnotateCommand creates a new `docker manifest annotate` command
+func newAnnotateCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts annotateOptions
+
+	cmd := &cobra.Command{
+		Use:   "annotate NAME[:TAG] [OPTIONS]",
+		Short: "Add additional information to an image's manifest.",
+		Args:  cli.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.target = args[0]
+			opts.image = args[1]
+			return runManifestAnnotate(dockerCli, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&opts.os, "os", "", "Add ios info to a manifest before pushing it.")
+	flags.StringVar(&opts.arch, "arch", "", "Add arch info to a manifest before pushing it.")
+	flags.StringSliceVar(&opts.cpuFeatures, "cpuFeatures", []string{}, "Add feature info to a manifest before pushing it.")
+	flags.StringSliceVar(&opts.osFeatures, "osFeatures", []string{}, "Add feature info to a manifest before pushing it.")
+	flags.StringVar(&opts.variant, "variant", "", "Add arch variant to a manifest before pushing it.")
+
+	return cmd
+}
+
+func runManifestAnnotate(dockerCli *command.DockerCli, opts annotateOptions) error {
+
+	// Make sure the manifests are pulled, find the file you need, unmarshal the json, edit the file, and done.
+	targetRef, err := reference.ParseNormalizedNamed(opts.target)
+	if err != nil {
+		return fmt.Errorf("Annotate: Error parsing name for manifest list (%s): %s", opts.target, err)
+	}
+	imgRef, err := reference.ParseNormalizedNamed(opts.image)
+	if err != nil {
+		return fmt.Errorf("Annotate: Error prasing name for manifest (%s): %s:", opts.image, err)
+	}
+
+	// Make sure we've got tags or digests:
+	if _, isDigested := targetRef.(reference.Canonical); !isDigested {
+		targetRef = reference.TagNameOnly(targetRef)
+	}
+	if _, isDigested := imgRef.(reference.Canonical); !isDigested {
+		imgRef = reference.TagNameOnly(imgRef)
+	}
+	transactionID := makeFilesafeName(targetRef.String())
+	imgID := makeFilesafeName(imgRef.String())
+	logrus.Debugf("Beginning annotate for %s/%s", transactionID, imgID)
+
+	imgInspect, _, err := getImageData(dockerCli, imgRef.String(), targetRef.String(), false)
+	if err != nil {
+		return err
+	}
+
+	if len(imgInspect) > 1 {
+		return fmt.Errorf("Cannot annotate manifest list. Please pass an image (not list) name")
+	}
+
+	mf := imgInspect[0]
+
+	newMf, err := unmarshalIntoManifestInspect(imgID, transactionID)
+	if err != nil {
+		return err
+	}
+
+	// Update the mf
+	if opts.os != "" {
+		newMf.OS = opts.os
+	}
+	if opts.arch != "" {
+		newMf.Architecture = opts.arch
+	}
+	for _, cpuFeature := range opts.cpuFeatures {
+		newMf.Features = appendIfUnique(mf.Features, cpuFeature)
+	}
+	for _, osFeature := range opts.osFeatures {
+		newMf.OSFeatures = appendIfUnique(mf.OSFeatures, osFeature)
+	}
+	if opts.variant != "" {
+		newMf.Variant = opts.variant
+	}
+
+	// validate os/arch input
+	if !isValidOSArch(newMf.OS, newMf.Architecture) {
+		return fmt.Errorf("Manifest entry for image has unsupported os/arch combination: %s/%s", opts.os, opts.arch)
+	}
+	// @TODO
+	// dgst := digest.FromBytes(b) can't use b/c not of the json.
+
+	if err := updateMfFile(newMf, imgID, transactionID); err != nil {
+		return err
+	}
+
+	logrus.Debugf("Annotated %s with options %v", mf.RefName, opts)
+	return nil
+}
+func appendIfUnique(list []string, str string) []string {
+	for _, s := range list {
+		if s == str {
+			return list
+		}
+	}
+	return append(list, str)
+}

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -1,0 +1,43 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+)
+
+// NewManifestCommand returns a cobra command for `manifest` subcommands
+func NewManifestCommand(dockerCli *command.DockerCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manifest COMMAND",
+		Short: "Manage Docker image manifests and lists",
+		Long:  manifestDescription,
+		Args:  cli.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
+		},
+	}
+	cmd.AddCommand(
+		//newListFetchCommand(dockerCli),
+		newCreateListCommand(dockerCli),
+		newInspectCommand(dockerCli),
+		newAnnotateCommand(dockerCli),
+		newPushListCommand(dockerCli),
+	)
+	return cmd
+}
+
+var manifestDescription = `
+The **docker manifest** command has subcommands for managing image manifests and 
+manifest lists. A manifest list allows you to use one name to refer to the same image 
+built for multiple architectures.
+
+To see help for a subcommand, use:
+
+    docker manifest CMD help
+
+For full details on using docker manifest lists view the registry v2 specification.
+
+`

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -1,0 +1,60 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/registry"
+)
+
+func newCreateListCommand(dockerCli *command.DockerCli) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "create newRef manifest [manifest...]",
+		Short: "Create a local manifest list for annotating and pushing to a registry",
+		Args:  cli.RequiresMinArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createManifestList(dockerCli, args)
+		},
+	}
+
+	return cmd
+}
+
+func createManifestList(dockerCli *command.DockerCli, args []string) error {
+
+	// Just do some basic verification here, and leave the rest for when the user pushes the list
+	newRef := args[0]
+	targetRef, err := reference.ParseNormalizedNamed(newRef)
+	if err != nil {
+		return fmt.Errorf("Error parsing name for manifest list (%s): %v", newRef, err)
+	}
+	_, err = registry.ParseRepositoryInfo(targetRef)
+	if err != nil {
+		return fmt.Errorf("Error parsing repository name for manifest list (%s): %v", newRef, err)
+	}
+
+	// Now create the local manifest list transaction by looking up the manifest schemas
+	// for the constituent images:
+	manifests := args[1:]
+	logrus.Info("Retrieving digests of images...")
+	for _, manifestRef := range manifests {
+
+		mfstData, _, err := getImageData(dockerCli, manifestRef, targetRef.String(), false)
+		if err != nil {
+			return err
+		}
+
+		if len(mfstData) > 1 {
+			// too many responses--can only happen if a manifest list was returned for the name lookup
+			return fmt.Errorf("You specified a manifest list entry from a digest that points to a current manifest list. Manifest lists do not allow recursion.")
+		}
+
+	}
+	return nil
+}

--- a/cli/command/manifest/ensurehome_linux.go
+++ b/cli/command/manifest/ensurehome_linux.go
@@ -1,0 +1,28 @@
+// +build linux
+
+package manifest
+
+import (
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/homedir"
+)
+
+// ensureHomeIfIAmStatic ensure $HOME to be set if dockerversion.IAmStatic is "true".
+// In a static binary, os/user.Current() leads to segfault due to a glibc issue that won't be fixed
+// in the foreseeable future. (golang/go#13470, https://sourceware.org/bugzilla/show_bug.cgi?id=19341)
+// So we forcibly set HOME so as to avoid call to os/user/Current()
+func ensureHomeIfIAmStatic() error {
+	// Note: dockerversion.IAmStatic and homedir.GetStatic() is only available for linux.
+	if dockerversion.IAmStatic == "true" && os.Getenv("HOME") == "" {
+		home, err := homedir.GetStatic()
+		if err != nil {
+			return err
+		}
+		logrus.Warnf("docker manifest requires HOME to be set for static client binary. Forcibly setting HOME to %s.", home)
+		os.Setenv("HOME", home)
+	}
+	return nil
+}

--- a/cli/command/manifest/ensurehome_others.go
+++ b/cli/command/manifest/ensurehome_others.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package manifest
+
+func ensureHomeIfIAmStatic() error {
+	return nil
+}

--- a/cli/command/manifest/fetch.go
+++ b/cli/command/manifest/fetch.go
@@ -1,0 +1,326 @@
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/opencontainers/go-digest"
+	"golang.org/x/net/context"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/distribution/registry/client"
+	"github.com/docker/docker/api/types"
+	//"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/distribution"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/registry"
+	//"github.com/spf13/cobra"
+	//	"github.com/spf13/pflag"
+)
+
+type fetchOptions struct {
+	remote string
+}
+
+type manifestFetcher interface {
+	Fetch(ctx context.Context, ref reference.Named) ([]ImgManifestInspect, error)
+}
+
+func loadManifest(manifest string, transaction string) ([]ImgManifestInspect, error) {
+
+	// Load either a single manifest (if transaction is "", that's fine), or a
+	// manifest list
+	var foundImages []ImgManifestInspect
+	fd, err := getManifestFd(manifest, transaction)
+	if err != nil {
+		return nil, err
+	}
+	if fd != nil {
+		defer fd.Close()
+		fileInfo, err := fd.Stat()
+		if err != nil {
+			return nil, err
+		}
+		if fileInfo.IsDir() { // manifest list transaction
+			logrus.Errorf("Not supported: loading manifest list directory")
+			return nil, fmt.Errorf("Not supported: loading manifest list directory")
+		}
+		// An individual manifest
+		mfInspect, err := unmarshalIntoManifestInspect(manifest, transaction)
+		if err != nil {
+			return nil, err
+		}
+		return append(foundImages, mfInspect), nil
+	}
+	return nil, nil
+}
+
+func storeManifest(imgInspect ImgManifestInspect, name, transaction string) error {
+	// Store this image manifest so that it can be annotated.
+	// Store the manifests in a user's home to prevent conflict.
+	manifestBase, err := buildBaseFilename()
+	transaction = makeFilesafeName(transaction)
+	if err != nil {
+		return err
+	}
+	os.MkdirAll(filepath.Join(manifestBase, transaction), 0755)
+	logrus.Debugf("Storing  %s", name)
+	if err = updateMfFile(imgInspect, name, transaction); err != nil {
+		fmt.Printf("Error writing local manifest copy: %s\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func getImageData(dockerCli *command.DockerCli, name string, transactionID string, fetchOnly bool) ([]ImgManifestInspect, *registry.RepositoryInfo, error) {
+
+	var (
+		lastErr                    error
+		discardNoSupportErrors     bool
+		foundImages                []ImgManifestInspect
+		confirmedV2                bool
+		confirmedTLSRegistries     = make(map[string]struct{})
+		namedRef, transactionNamed reference.Named
+		err                        error
+		normalName                 string
+	)
+
+	if namedRef, err = reference.ParseNormalizedNamed(name); err != nil {
+		return nil, nil, fmt.Errorf("Error parsing reference for %s: %s\n", name, err)
+	}
+	if transactionID != "" {
+		if transactionNamed, err = reference.ParseNormalizedNamed(transactionID); err != nil {
+			return nil, nil, fmt.Errorf("Error parsing reference for %s: %s\n", transactionID, err)
+		}
+		if _, isDigested := transactionNamed.(reference.Canonical); !isDigested {
+			transactionNamed = reference.TagNameOnly(transactionNamed)
+		}
+		transactionID = makeFilesafeName(transactionNamed.String())
+	}
+
+	// Make sure these have a tag, as long as it's not a digest
+	if _, isDigested := namedRef.(reference.Canonical); !isDigested {
+		namedRef = reference.TagNameOnly(namedRef)
+	}
+	normalName = namedRef.String()
+	logrus.Debugf("getting image data for ref: %s", normalName)
+
+	// Resolve the Repository name from fqn to RepositoryInfo
+	// This calls TrimNamed, which removes the tag, so always use namedRef for the image.
+	repoInfo, err := registry.ParseRepositoryInfo(namedRef)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// First check to see if stored locally, either a single manfiest or list:
+	if !fetchOnly {
+		logrus.Debugf("Checking locally for %s", normalName)
+		foundImages, err = loadManifest(makeFilesafeName(normalName), transactionID)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	// Great, no reason to pull from the registry.
+	if len(foundImages) > 0 {
+		return foundImages, repoInfo, nil
+	}
+
+	ctx := context.Background()
+
+	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+
+	options := registry.ServiceOptions{}
+	registryService := registry.NewService(options)
+
+	// a list of registry.APIEndpoint, which could be mirrors, etc., of locally-configured
+	// repo endpoints. The list will be ordered by priority (v2, https, v1).
+	endpoints, err := registryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	if err != nil {
+		return nil, nil, err
+	}
+	logrus.Debugf("manifest pull: endpoints: %v", endpoints)
+
+	// Try to find the first endpoint that is *both* v2 and using TLS.
+	for _, endpoint := range endpoints {
+		// make sure I can reach the registry, same as docker pull does
+		v1endpoint, err := endpoint.ToV1Endpoint(dockerversion.DockerUserAgent(nil), nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, err := v1endpoint.Ping(); err != nil {
+			if strings.Contains(err.Error(), "timeout") {
+				return nil, nil, err
+			}
+			continue
+		}
+
+		if confirmedV2 && endpoint.Version == registry.APIVersion1 {
+			logrus.Debugf("Skipping v1 endpoint %s because v2 registry was detected", endpoint.URL)
+			continue
+		}
+
+		if endpoint.URL.Scheme != "https" {
+			if _, confirmedTLS := confirmedTLSRegistries[endpoint.URL.Host]; confirmedTLS {
+				logrus.Debugf("Skipping non-TLS endpoint %s for host/port that appears to use TLS", endpoint.URL)
+				continue
+			}
+		}
+
+		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", normalName, endpoint.URL, endpoint.Version)
+
+		fetcher, err := newManifestFetcher(endpoint, repoInfo, authConfig, registryService)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if foundImages, err = fetcher.Fetch(ctx, namedRef); err != nil {
+			// Was this fetch cancelled? If so, don't try to fall back.
+			fallback := false
+			select {
+			case <-ctx.Done():
+			default:
+				if fallbackErr, ok := err.(fallbackError); ok {
+					fallback = true
+					confirmedV2 = confirmedV2 || fallbackErr.confirmedV2
+					if fallbackErr.transportOK && endpoint.URL.Scheme == "https" {
+						confirmedTLSRegistries[endpoint.URL.Host] = struct{}{}
+					}
+					err = fallbackErr.err
+				}
+			}
+			if fallback {
+				if _, ok := err.(distribution.ErrNoSupport); !ok {
+					// Because we found an error that's not ErrNoSupport, discard all subsequent ErrNoSupport errors.
+					discardNoSupportErrors = true
+					// save the current error
+					lastErr = err
+				} else if !discardNoSupportErrors {
+					// Save the ErrNoSupport error, because it's either the first error or all encountered errors
+					// were also ErrNoSupport errors.
+					lastErr = err
+				}
+				continue
+			}
+			logrus.Errorf("Not continuing with pull after error: %v", err)
+			return nil, nil, err
+		}
+
+		if transactionID == "" && len(foundImages) > 1 {
+			transactionID = normalName
+		}
+		// Additionally, we're never storing on inspect, so if we're asked to save images it's for a create,
+		// and this function will have been called for each image in the create. In that case we'll have an
+		// image name *and* a transaction ID. IOW, foundImages will be only one image.
+		if !fetchOnly {
+			if err := storeManifest(foundImages[0], makeFilesafeName(normalName), transactionID); err != nil {
+				logrus.Errorf("Error storing manifests: %s\n", err)
+			}
+		}
+		return foundImages, repoInfo, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no endpoints found for %s\n", normalName)
+	}
+
+	return nil, nil, lastErr
+
+}
+
+func newManifestFetcher(endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, authConfig types.AuthConfig, registryService registry.Service) (manifestFetcher, error) {
+	switch endpoint.Version {
+	case registry.APIVersion2:
+		return &v2ManifestFetcher{
+			endpoint:   endpoint,
+			authConfig: authConfig,
+			service:    registryService,
+			repoInfo:   repoInfo,
+		}, nil
+	case registry.APIVersion1:
+		return &v1ManifestFetcher{
+			endpoint:   endpoint,
+			authConfig: authConfig,
+			service:    registryService,
+			repoInfo:   repoInfo,
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
+}
+
+func makeImgManifestInspect(name string, img *image.Image, tag string, mfInfo manifestInfo, mediaType string, tagList []string) *ImgManifestInspect {
+	var digest digest.Digest
+	if err := mfInfo.digest.Validate(); err == nil {
+		digest = mfInfo.digest
+	}
+
+	if mediaType == manifestlist.MediaTypeManifestList {
+		return &ImgManifestInspect{
+			MediaType: mediaType,
+			Digest:    digest,
+		}
+	}
+
+	var digests []string
+	for _, blobDigest := range mfInfo.blobDigests {
+		digests = append(digests, blobDigest.String())
+	}
+	return &ImgManifestInspect{
+		RefName:         name,
+		Size:            mfInfo.length,
+		MediaType:       mediaType,
+		Tag:             tag,
+		Digest:          digest,
+		RepoTags:        tagList,
+		Comment:         img.Comment,
+		Created:         img.Created.Format(time.RFC3339Nano),
+		ContainerConfig: &img.ContainerConfig,
+		DockerVersion:   img.DockerVersion,
+		Author:          img.Author,
+		Config:          img.Config,
+		Architecture:    mfInfo.platform.Architecture,
+		OS:              mfInfo.platform.OS,
+		OSVersion:       mfInfo.platform.OSVersion,
+		OSFeatures:      mfInfo.platform.OSFeatures,
+		Variant:         mfInfo.platform.Variant,
+		Features:        mfInfo.platform.Features,
+		References:      digests,
+		LayerDigests:    mfInfo.layers,
+		CanonicalJSON:   mfInfo.jsonBytes,
+	}
+}
+
+func continueOnError(err error) bool {
+	switch v := err.(type) {
+	case errcode.Errors:
+		if len(v) == 0 {
+			return true
+		}
+		return continueOnError(v[0])
+	case distribution.ErrNoSupport:
+		return continueOnError(v.Err)
+	case errcode.Error:
+		return shouldV2Fallback(v)
+	case *client.UnexpectedHTTPResponseError:
+		return true
+	case ImageConfigPullError:
+		return false
+	case error:
+		return !strings.Contains(err.Error(), strings.ToLower(syscall.ENOSPC.Error()))
+	}
+	// let's be nice and fallback if the error is a completely
+	// unexpected one.
+	// If new errors have to be handled in some way, please
+	// add them to the switch above.
+	return true
+}

--- a/cli/command/manifest/fetch_v1.go
+++ b/cli/command/manifest/fetch_v1.go
@@ -1,0 +1,240 @@
+package manifest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/docker/api/types"
+	dockerdistribution "github.com/docker/docker/distribution"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/image/v1"
+	"github.com/docker/docker/registry"
+	"golang.org/x/net/context"
+)
+
+type v1ManifestFetcher struct {
+	endpoint    registry.APIEndpoint
+	repoInfo    *registry.RepositoryInfo
+	repo        distribution.Repository
+	confirmedV2 bool
+	// wrap in a config?
+	authConfig types.AuthConfig
+	// Leaving this as a pointer to an interface won't compile for me
+	service registry.Service
+	session *registry.Session
+}
+
+func (mf *v1ManifestFetcher) Fetch(ctx context.Context, ref reference.Named) ([]ImgManifestInspect, error) {
+	// @TODO: Re-test the v1 registry stuff after pulling in all the consolidated reference stuff.
+	// Pre-condition: ref has to be tagged (e.g. using ParseNormalizedNamed)
+	if _, isCanonical := ref.(reference.Canonical); isCanonical {
+		// Allowing fallback, because HTTPS v1 is before HTTP v2
+		return nil, fallbackError{
+			err: dockerdistribution.ErrNoSupport{errors.New("Cannot pull by digest with v1 registry")},
+		}
+	}
+	tlsConfig, err := mf.service.TLSConfig(mf.repoInfo.Index.Name)
+	if err != nil {
+		return nil, err
+	}
+	// Adds Docker-specific headers as well as user-specified headers (metaHeaders)
+	tr := transport.NewTransport(
+		registry.NewTransport(tlsConfig),
+		//registry.DockerHeaders(mf.config.MetaHeaders)...,
+		registry.DockerHeaders(dockerversion.DockerUserAgent(nil), nil)...,
+	)
+	client := registry.HTTPClient(tr)
+	//v1Endpoint, err := mf.endpoint.ToV1Endpoint(mf.config.MetaHeaders)
+	v1Endpoint, err := mf.endpoint.ToV1Endpoint(dockerversion.DockerUserAgent(nil), nil)
+	if err != nil {
+		logrus.Debugf("Could not get v1 endpoint: %v", err)
+		return nil, fallbackError{err: err}
+	}
+	mf.session, err = registry.NewSession(client, &mf.authConfig, v1Endpoint)
+	if err != nil {
+		logrus.Debugf("Fallback from error: %s", err)
+		return nil, fallbackError{err: err}
+	}
+
+	imgsInspect, err := mf.fetchWithSession(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	if len(imgsInspect) > 1 {
+		return nil, fmt.Errorf("Found more than one image in V1 fetch!? %v", imgsInspect)
+	}
+	imgsInspect[0].MediaType = schema1.MediaTypeManifest
+	return imgsInspect, nil
+}
+
+func (mf *v1ManifestFetcher) fetchWithSession(ctx context.Context, ref reference.Named) ([]ImgManifestInspect, error) {
+	// Pre-Condition: ref should always be tagged (e.g. using ParseNormalizedNamed)
+	var (
+		imageList = []ImgManifestInspect{}
+		pulledImg *image.Image
+		tagsMap   map[string]string
+	)
+	logrus.Debugf("Fetching v1 manifest for %s", mf.repoInfo.Name)
+	repoData, err := mf.session.GetRepositoryData(mf.repoInfo.Name)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP code: 404") {
+			return nil, fmt.Errorf("Error: image %s not found", reference.Path(mf.repoInfo.Name))
+		}
+		// Unexpected HTTP error
+		return nil, err
+	}
+
+	// GetRemoteTags gets all tags & corresponding image IDs for a repo, returned in a map
+	logrus.Debugf("Retrieving the tag list")
+	tagsMap, err = mf.session.GetRemoteTags(repoData.Endpoints, mf.repoInfo.Name)
+	if err != nil {
+		logrus.Errorf("unable to get remote tags: %s", err)
+		return nil, err
+	}
+
+	tagged, isTagged := ref.(reference.NamedTagged)
+	if !isTagged {
+		logrus.Errorf("No tag in image name! Christy messed up.")
+		return nil, fmt.Errorf("fws: No tag in image name")
+	}
+	tag := tagged.Tag()
+	tagID, err := mf.session.GetRemoteTag(repoData.Endpoints, mf.repoInfo.Name, tag)
+	if err == registry.ErrRepoNotFound {
+		return nil, fmt.Errorf("Tag %s not found in repository %s", tag, mf.repoInfo.Name.Name())
+	}
+	if err != nil {
+		logrus.Errorf("unable to get remote tags: %s", err)
+		return nil, err
+	}
+	tagsMap[tagged.Tag()] = tagID
+
+	// Pull the tags from the tag/imgID map:
+	tagList := []string{}
+	for tag := range tagsMap {
+		tagList = append(tagList, tag)
+	}
+
+	img := repoData.ImgList[tagID]
+
+	for _, ep := range mf.repoInfo.Index.Mirrors {
+		if pulledImg, err = mf.pullImageJSON(img.ID, ep); err != nil {
+			// Don't report errors when pulling from mirrors.
+			logrus.Debugf("Error pulling image json of %s:%s, mirror: %s, %s", mf.repoInfo.Name.Name(), img.Tag, ep, err)
+			continue
+		}
+		break
+	}
+	if pulledImg == nil {
+		for _, ep := range repoData.Endpoints {
+			if pulledImg, err = mf.pullImageJSON(img.ID, ep); err != nil {
+				// It's not ideal that only the last error is returned, it would be better to concatenate the errors.
+				logrus.Infof("Error pulling image json of %s:%s, endpoint: %s, %v", mf.repoInfo.Name.Name(), img.Tag, ep, err)
+				continue
+			}
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Error pulling image (%s) from %s, %v", img.Tag, mf.repoInfo.Name.Name(), err)
+	}
+	if pulledImg == nil {
+		return nil, fmt.Errorf("No such image %s:%s", mf.repoInfo.Name.Name(), tag)
+	}
+
+	imageInsp := makeImgManifestInspect(ref.String(), pulledImg, tag, manifestInfo{}, schema1.MediaTypeManifest, tagList)
+	imageList = append(imageList, *imageInsp)
+	return imageList, nil
+}
+
+func (mf *v1ManifestFetcher) pullImageJSON(imgID, endpoint string) (*image.Image, error) {
+	imgJSON, _, err := mf.session.GetRemoteImageJSON(imgID, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	h, err := v1.HistoryFromConfig(imgJSON, false)
+	if err != nil {
+		return nil, err
+	}
+	configRaw, err := makeRawConfigFromV1Config(imgJSON, image.NewRootFS(), []image.History{h})
+	if err != nil {
+		return nil, err
+	}
+	config, err := json.Marshal(configRaw)
+	if err != nil {
+		return nil, err
+	}
+	img, err := image.NewFromJSON(config)
+	if err != nil {
+		return nil, err
+	}
+	return img, nil
+}
+
+func makeRawConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []image.History) (map[string]*json.RawMessage, error) {
+	var dver struct {
+		DockerVersion string `json:"docker_version"`
+	}
+
+	if err := json.Unmarshal(imageJSON, &dver); err != nil {
+		return nil, err
+	}
+
+	// the Version pkg was removed, so find a better way to do this
+	useFallback := false
+	cPoint := [3]int{1, 8, 3}
+	for i, dPoint := range strings.Split(dver.DockerVersion, ".") {
+		if x, _ := strconv.Atoi(dPoint); x < cPoint[i] {
+			useFallback = true
+		}
+	}
+
+	if useFallback {
+		var v1Image image.V1Image
+		err := json.Unmarshal(imageJSON, &v1Image)
+		if err != nil {
+			return nil, err
+		}
+		imageJSON, err = json.Marshal(v1Image)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var c map[string]*json.RawMessage
+	if err := json.Unmarshal(imageJSON, &c); err != nil {
+		return nil, err
+	}
+
+	c["rootfs"] = rawJSON(rootfs)
+	c["history"] = rawJSON(history)
+
+	return c, nil
+}
+
+// shouldV2Fallback returns true if this error is a reason to fall back to v1.
+func shouldV2Fallback(err errcode.Error) bool {
+	switch err.Code {
+	case errcode.ErrorCodeUnauthorized, v2.ErrorCodeManifestUnknown, v2.ErrorCodeNameUnknown:
+		return true
+	}
+	return false
+}
+
+func rawJSON(value interface{}) *json.RawMessage {
+	jsonval, err := json.Marshal(value)
+	if err != nil {
+		return nil
+	}
+	return (*json.RawMessage)(&jsonval)
+}

--- a/cli/command/manifest/fetch_v2.go
+++ b/cli/command/manifest/fetch_v2.go
@@ -1,0 +1,522 @@
+package manifest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime"
+
+	digest "github.com/opencontainers/go-digest"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/docker/api/types"
+	dockerdistribution "github.com/docker/docker/distribution"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/image/v1"
+	"github.com/docker/docker/registry"
+	"golang.org/x/net/context"
+)
+
+type v2ManifestFetcher struct {
+	endpoint    registry.APIEndpoint
+	repoInfo    *registry.RepositoryInfo
+	repo        distribution.Repository
+	confirmedV2 bool
+	authConfig  types.AuthConfig
+	// Leaving this as a pointer to an interface won't compile for me
+	service registry.Service
+}
+
+type manifestInfo struct {
+	blobDigests []digest.Digest
+	layers      []string
+	digest      digest.Digest
+	platform    manifestlist.PlatformSpec
+	length      int64
+	jsonBytes   []byte
+}
+
+func (mf *v2ManifestFetcher) Fetch(ctx context.Context, ref reference.Named) ([]ImgManifestInspect, error) {
+	// Pre-condition: ref has to be tagged (e.g. using ParseNormalizedNamed)
+	var err error
+
+	mf.repo, mf.confirmedV2, err = dockerdistribution.NewV2Repository(ctx, mf.repoInfo, mf.endpoint, nil, &mf.authConfig, "pull")
+	if err != nil {
+		logrus.Debugf("Error getting v2 registry: %v", err)
+		return nil, err
+	}
+
+	images, err := mf.fetchWithRepository(ctx, ref)
+	if err != nil {
+		if _, ok := err.(fallbackError); ok {
+			return nil, err
+		}
+		if continueOnError(err) {
+			logrus.Errorf("Error trying v2 registry: %v", err)
+			return nil, fallbackError{err: err, confirmedV2: mf.confirmedV2, transportOK: true}
+		}
+	}
+	for _, img := range images {
+		img.MediaType = schema2.MediaTypeManifest
+	}
+	return images, err
+}
+
+func (mf *v2ManifestFetcher) fetchWithRepository(ctx context.Context, ref reference.Named) ([]ImgManifestInspect, error) {
+	var (
+		manifest    distribution.Manifest
+		tagOrDigest string // Used for logging/progress only
+		tagList     = []string{}
+		imageList   = []ImgManifestInspect{}
+	)
+
+	manSvc, err := mf.repo.Manifests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
+		// NOTE: not using TagService.Get, since it uses HEAD requests
+		// against the manifests endpoint, which are not supported by
+		// all registry versions.
+		manifest, err = manSvc.Get(ctx, "", distribution.WithTag(tagged.Tag()))
+		if err != nil {
+			return nil, allowV1Fallback(err)
+		}
+		tagOrDigest = tagged.Tag()
+	} else if digested, isDigested := ref.(reference.Canonical); isDigested {
+		manifest, err = manSvc.Get(ctx, digested.Digest())
+		if err != nil {
+			return nil, err
+		}
+		tagOrDigest = digested.Digest().String()
+	} else {
+		return nil, fmt.Errorf("internal error: reference has neither a tag nor a digest: %s", ref.String())
+	}
+
+	if manifest == nil {
+		return nil, fmt.Errorf("image manifest does not exist for tag or digest %q", tagOrDigest)
+	}
+
+	// If manSvc.Get succeeded, we can be confident that the registry on
+	// the other side speaks the v2 protocol.
+	mf.confirmedV2 = true
+
+	tagList, err = mf.repo.Tags(ctx).All(ctx)
+	if err != nil {
+		// If this repository doesn't exist on V2, we should
+		// permit a fallback to V1.
+		return nil, allowV1Fallback(err)
+	}
+
+	var (
+		images    []*image.Image
+		mfInfos   []manifestInfo
+		mediaType []string
+	)
+
+	switch v := manifest.(type) {
+	case *schema1.SignedManifest:
+		image, mfInfo, err := mf.pullSchema1(ctx, ref, v)
+		images = append(images, image)
+		mfInfos = append(mfInfos, mfInfo)
+		mediaType = append(mediaType, schema1.MediaTypeManifest)
+		if err != nil {
+			return nil, err
+		}
+	case *schema2.DeserializedManifest:
+		image, mfInfo, err := mf.pullSchema2(ctx, ref, v)
+		images = append(images, image)
+		mfInfos = append(mfInfos, mfInfo)
+		mediaType = append(mediaType, schema2.MediaTypeManifest)
+		if err != nil {
+			return nil, err
+		}
+	case *manifestlist.DeserializedManifestList:
+		images, mfInfos, mediaType, err = mf.pullManifestList(ctx, ref, v)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("unsupported manifest format")
+	}
+
+	for idx, img := range images {
+		imgReturn := makeImgManifestInspect(ref.String(), img, tagOrDigest, mfInfos[idx], mediaType[idx], tagList)
+		imageList = append(imageList, *imgReturn)
+	}
+	return imageList, nil
+}
+
+func (mf *v2ManifestFetcher) pullSchema1(ctx context.Context, ref reference.Named, unverifiedManifest *schema1.SignedManifest) (img *image.Image, mfInfo manifestInfo, err error) {
+	mfInfo = manifestInfo{}
+	var verifiedManifest *schema1.Manifest
+	verifiedManifest, err = verifySchema1Manifest(unverifiedManifest, ref)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+
+	// remove duplicate layers and check parent chain validity
+	err = fixManifestLayers(verifiedManifest)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+
+	// Image history converted to the new format
+	var history []image.History
+
+	// Note that the order of this loop is in the direction of bottom-most
+	// to top-most, so that the downloads slice gets ordered correctly.
+	for i := len(verifiedManifest.FSLayers) - 1; i >= 0; i-- {
+		var throwAway struct {
+			ThrowAway bool `json:"throwaway,omitempty"`
+		}
+		if err := json.Unmarshal([]byte(verifiedManifest.History[i].V1Compatibility), &throwAway); err != nil {
+			return nil, mfInfo, err
+		}
+
+		h, err := v1.HistoryFromConfig([]byte(verifiedManifest.History[i].V1Compatibility), throwAway.ThrowAway)
+		if err != nil {
+			return nil, mfInfo, err
+		}
+		history = append(history, h)
+		mfInfo.blobDigests = append(mfInfo.blobDigests, verifiedManifest.FSLayers[i].BlobSum)
+	}
+
+	rootFS := image.NewRootFS()
+	configRaw, err := makeRawConfigFromV1Config([]byte(verifiedManifest.History[0].V1Compatibility), rootFS, history)
+
+	config, err := json.Marshal(configRaw)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+
+	img, err = image.NewFromJSON(config)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+
+	mfInfo.digest = digest.FromBytes(unverifiedManifest.Canonical)
+	// add the size of the manifest to the info struct; needed for assembling proper
+	// manifest lists
+	mfInfo.length = int64(len(unverifiedManifest.Canonical))
+	mfInfo.jsonBytes, err = unverifiedManifest.MarshalJSON()
+	if err != nil {
+		return nil, mfInfo, err
+	}
+	return img, mfInfo, nil
+}
+
+func verifySchema1Manifest(signedManifest *schema1.SignedManifest, ref reference.Named) (m *schema1.Manifest, err error) {
+	// If pull by digest, then verify the manifest digest. NOTE: It is
+	// important to do this first, before any other content validation. If the
+	// digest cannot be verified, don't even bother with those other things.
+	if digested, isCanonical := ref.(reference.Canonical); isCanonical {
+		verifier := digested.Digest().Verifier()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := verifier.Write(signedManifest.Canonical); err != nil {
+			return nil, err
+		}
+		if !verifier.Verified() {
+			err := fmt.Errorf("image verification failed for digest %s", digested.Digest())
+			logrus.Error(err)
+			return nil, err
+		}
+	}
+	m = &signedManifest.Manifest
+
+	if m.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported schema version %d for %q", m.SchemaVersion, ref.String())
+	}
+	if len(m.FSLayers) != len(m.History) {
+		return nil, fmt.Errorf("length of history not equal to number of layers for %q", ref.String())
+	}
+	if len(m.FSLayers) == 0 {
+		return nil, fmt.Errorf("no FSLayers in manifest for %q", ref.String())
+	}
+	return m, nil
+}
+
+func fixManifestLayers(m *schema1.Manifest) error {
+	imgs := make([]*image.V1Image, len(m.FSLayers))
+	for i := range m.FSLayers {
+		img := &image.V1Image{}
+
+		if err := json.Unmarshal([]byte(m.History[i].V1Compatibility), img); err != nil {
+			return err
+		}
+
+		imgs[i] = img
+		if err := v1.ValidateID(img.ID); err != nil {
+			return err
+		}
+	}
+
+	if imgs[len(imgs)-1].Parent != "" && runtime.GOOS != "windows" {
+		// Windows base layer can point to a base layer parent that is not in manifest.
+		return errors.New("Invalid parent ID in the base layer of the image.")
+	}
+
+	// check general duplicates to error instead of a deadlock
+	idmap := make(map[string]struct{})
+
+	var lastID string
+	for _, img := range imgs {
+		// skip IDs that appear after each other, we handle those later
+		if _, exists := idmap[img.ID]; img.ID != lastID && exists {
+			return fmt.Errorf("ID %+v appears multiple times in manifest", img.ID)
+		}
+		lastID = img.ID
+		idmap[lastID] = struct{}{}
+	}
+
+	// backwards loop so that we keep the remaining indexes after removing items
+	for i := len(imgs) - 2; i >= 0; i-- {
+		if imgs[i].ID == imgs[i+1].ID { // repeated ID. remove and continue
+			m.FSLayers = append(m.FSLayers[:i], m.FSLayers[i+1:]...)
+			m.History = append(m.History[:i], m.History[i+1:]...)
+		} else if imgs[i].Parent != imgs[i+1].ID {
+			return fmt.Errorf("Invalid parent ID. Expected %v, got %v.", imgs[i+1].ID, imgs[i].Parent)
+		}
+	}
+
+	return nil
+}
+
+// pullSchema2 pulls an image using a schema2 manifest
+func (mf *v2ManifestFetcher) pullSchema2(ctx context.Context, ref reference.Named, mfst *schema2.DeserializedManifest) (img *image.Image, mfInfo manifestInfo, err error) {
+	mfInfo.digest, err = schema2ManifestDigest(ref, mfst)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+	target := mfst.Target()
+
+	configChan := make(chan []byte, 1)
+	errChan := make(chan error, 1)
+	var cancel func()
+	ctx, cancel = context.WithCancel(ctx)
+
+	// Pull the image config
+	go func() {
+		configJSON, err := mf.pullSchema2ImageConfig(ctx, target.Digest)
+		if err != nil {
+			errChan <- ImageConfigPullError{Err: err}
+			cancel()
+			return
+		}
+		configChan <- configJSON
+	}()
+
+	var (
+		configJSON         []byte      // raw serialized image config
+		unmarshalledConfig image.Image // deserialized image config
+	)
+	if runtime.GOOS == "windows" {
+		configJSON, unmarshalledConfig, err = receiveConfig(configChan, errChan)
+		if err != nil {
+			return nil, mfInfo, err
+		}
+		if unmarshalledConfig.RootFS == nil {
+			return nil, mfInfo, errors.New("image config has no rootfs section")
+		}
+	}
+
+	if configJSON == nil {
+		configJSON, unmarshalledConfig, err = receiveConfig(configChan, errChan)
+		if err != nil {
+			return nil, mfInfo, err
+		}
+	}
+
+	for _, descriptor := range mfst.References() {
+		mfInfo.blobDigests = append(mfInfo.blobDigests, descriptor.Digest)
+	}
+	for _, layer := range mfst.Layers {
+		mfInfo.layers = append(mfInfo.layers, layer.Digest.String())
+	}
+
+	img, err = image.NewFromJSON(configJSON)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+	// add the size of the manifest to the image response; needed for assembling proper
+	// manifest lists
+	_, mfBytes, err := mfst.Payload()
+	if err != nil {
+		return nil, mfInfo, err
+	}
+	mfInfo.length = int64(len(mfBytes))
+	mfInfo.jsonBytes = mfBytes
+	mfInfo.platform = manifestlist.PlatformSpec{
+		OS:           img.OS,
+		Architecture: img.Architecture,
+		OSVersion:    img.OSVersion,
+		OSFeatures:   img.OSFeatures,
+	}
+	return img, mfInfo, nil
+}
+
+func (mf *v2ManifestFetcher) pullSchema2ImageConfig(ctx context.Context, dgst digest.Digest) (configJSON []byte, err error) {
+	blobs := mf.repo.Blobs(ctx)
+	configJSON, err = blobs.Get(ctx, dgst)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify image config digest
+	verifier := dgst.Verifier()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := verifier.Write(configJSON); err != nil {
+		return nil, err
+	}
+	if !verifier.Verified() {
+		err := fmt.Errorf("image config verification failed for digest %s", dgst)
+		logrus.Error(err)
+		return nil, err
+	}
+
+	return configJSON, nil
+}
+
+func receiveConfig(configChan <-chan []byte, errChan <-chan error) ([]byte, image.Image, error) {
+	select {
+	case configJSON := <-configChan:
+		var unmarshalledConfig image.Image
+		if err := json.Unmarshal(configJSON, &unmarshalledConfig); err != nil {
+			return nil, image.Image{}, err
+		}
+		return configJSON, unmarshalledConfig, nil
+	case err := <-errChan:
+		return nil, image.Image{}, err
+		// Don't need a case for ctx.Done in the select because cancellation
+		// will trigger an error in p.pullSchema2ImageConfig.
+	}
+}
+
+// ImageConfigPullError is an error pulling the image config blob
+// (only applies to schema2).
+type ImageConfigPullError struct {
+	Err error
+}
+
+// Error returns the error string for ImageConfigPullError.
+func (e ImageConfigPullError) Error() string {
+	return "error pulling image configuration: " + e.Err.Error()
+}
+
+// allowV1Fallback checks if the error is a possible reason to fallback to v1
+// (even if confirmedV2 has been set already), and if so, wraps the error in
+// a fallbackError with confirmedV2 set to false. Otherwise, it returns the
+// error unmodified.
+func allowV1Fallback(err error) error {
+	switch v := err.(type) {
+	case errcode.Errors:
+		if len(v) != 0 {
+			if v0, ok := v[0].(errcode.Error); ok && shouldV2Fallback(v0) {
+				return fallbackError{err: err, confirmedV2: false, transportOK: true}
+			}
+		}
+	case errcode.Error:
+		if shouldV2Fallback(v) {
+			return fallbackError{err: err, confirmedV2: false, transportOK: true}
+		}
+	}
+	return err
+}
+
+// schema2ManifestDigest computes the manifest digest, and, if pulling by
+// digest, ensures that it matches the requested digest.
+func schema2ManifestDigest(ref reference.Named, mfst distribution.Manifest) (digest.Digest, error) {
+	_, canonical, err := mfst.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	// If pull by digest, then verify the manifest digest.
+	if digested, isDigested := ref.(reference.Canonical); isDigested {
+		verifier := digested.Digest().Verifier()
+		if err != nil {
+			return "", err
+		}
+		if _, err := verifier.Write(canonical); err != nil {
+			return "", err
+		}
+		if !verifier.Verified() {
+			err := fmt.Errorf("manifest verification failed for digest %s", digested.Digest())
+			logrus.Error(err)
+			return "", err
+		}
+		return digested.Digest(), nil
+	}
+
+	return digest.FromBytes(canonical), nil
+}
+
+// pullManifestList handles "manifest lists" which point to various
+// platform-specifc manifests.
+func (mf *v2ManifestFetcher) pullManifestList(ctx context.Context, ref reference.Named, mfstList *manifestlist.DeserializedManifestList) ([]*image.Image, []manifestInfo, []string, error) {
+	var (
+		imageList = []*image.Image{}
+		mfInfos   = []manifestInfo{}
+		mediaType = []string{}
+	)
+	manifestListDigest, err := schema2ManifestDigest(ref, mfstList)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	logrus.Debugf("Pulling manifest list entries for ML digest %v", manifestListDigest)
+
+	for _, manifestDescriptor := range mfstList.Manifests {
+		manSvc, err := mf.repo.Manifests(ctx)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		thisDigest := manifestDescriptor.Digest
+		thisPlatform := manifestDescriptor.Platform
+		manifest, err := manSvc.Get(ctx, thisDigest)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		manifestRef, err := reference.WithDigest(ref, thisDigest)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		switch v := manifest.(type) {
+		case *schema1.SignedManifest:
+			img, mfInfo, err := mf.pullSchema1(ctx, manifestRef, v)
+			imageList = append(imageList, img)
+			mfInfo.platform = thisPlatform
+			mfInfos = append(mfInfos, mfInfo)
+			mediaType = append(mediaType, schema1.MediaTypeManifest)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		case *schema2.DeserializedManifest:
+			img, mfInfo, err := mf.pullSchema2(ctx, manifestRef, v)
+			imageList = append(imageList, img)
+			mfInfo.platform = thisPlatform
+			mfInfos = append(mfInfos, mfInfo)
+			mediaType = append(mediaType, schema2.MediaTypeManifest)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		default:
+			return nil, nil, nil, errors.New("unsupported manifest format")
+		}
+	}
+
+	return imageList, mfInfos, mediaType, err
+}

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -1,0 +1,168 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/registry"
+)
+
+type inspectOptions struct {
+	remote  string
+	verbose bool
+}
+
+// NewInspectCommand creates a new `docker manifest inspect` command
+func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts inspectOptions
+
+	cmd := &cobra.Command{
+		Use:   "inspect [OPTIONS] NAME[:TAG]",
+		Short: "Display an image's manifest, or a remote manifest list.",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.remote = args[0]
+			return runListInspect(dockerCli, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.BoolVarP(&opts.verbose, "verbose", "v", false, "Output additional info including layers and platform")
+
+	return cmd
+}
+
+func runListInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
+
+	// Get the data and then format it
+	var (
+		imgInspect []ImgManifestInspect
+		prettyJSON bytes.Buffer
+	)
+
+	named, err := reference.ParseNormalizedNamed(opts.remote)
+	if err != nil {
+		return err
+	}
+	targetRepo, err := registry.ParseRepositoryInfo(named)
+	if err != nil {
+		return err
+	}
+
+	// For now, always pull as there' no reason to store an inspect. They're quick to get.
+	// When the engine is multi-arch image aware, we can store these in a universal location to
+	// save a little bandwidth.
+	imgInspect, _, err = getImageData(dockerCli, named.String(), "", true)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	// output basic informative details about the image
+	if len(imgInspect) == 1 {
+		// this is a basic single manifest
+		err = json.Indent(&prettyJSON, imgInspect[0].CanonicalJSON, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(dockerCli.Out(), "%s\n", prettyJSON.String())
+		if !opts.verbose {
+			return nil
+		}
+		mfd, _, err := buildManifestObj(targetRepo, imgInspect[0])
+		if err != nil {
+			return err
+		}
+		jsonBytes, err := json.Marshal(mfd)
+		if err != nil {
+			return err
+		}
+		prettyJSON.Reset()
+		err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(dockerCli.Out(), "%s\n", prettyJSON.String())
+		return nil
+	}
+
+	manifests := []manifestlist.ManifestDescriptor{}
+	// More than one response. This is a manifest list.
+	for _, img := range imgInspect {
+		mfd, _, err := buildManifestObj(targetRepo, img)
+		if err != nil {
+			return fmt.Errorf("Error assembling ManifestDescriptor")
+		}
+		manifests = append(manifests, mfd)
+	}
+	deserializedML, err := manifestlist.FromDescriptors(manifests)
+	if err != nil {
+		return err
+	}
+	jsonBytes, err := deserializedML.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(dockerCli.Out(), "%s\n", prettyJSON.String())
+	if !opts.verbose {
+		return nil
+	}
+	for _, img := range imgInspect {
+		switch img.MediaType {
+		case schema1.MediaTypeManifest:
+			var manifestv1 schema1.Manifest
+			err := json.Unmarshal(img.CanonicalJSON, &manifestv1)
+			if err != nil {
+				return err
+			}
+			jsonBytes, err := json.Marshal(manifestv1)
+			if err != nil {
+				return err
+			}
+			prettyJSON.Reset()
+			err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(dockerCli.Out(), "%s\n", prettyJSON.String())
+		case schema2.MediaTypeManifest:
+			var manifestv2 schema2.Manifest
+			err := json.Unmarshal(img.CanonicalJSON, &manifestv2)
+			if err != nil {
+				return err
+			}
+			jsonBytes, err := json.Marshal(manifestv2)
+			if err != nil {
+				return err
+			}
+			prettyJSON.Reset()
+			err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(dockerCli.Out(), "%s\n", prettyJSON.String())
+		}
+		/*
+			prettyJSON.Reset()
+			err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(dockerCli.Out(), "%s\n", prettyJSON.String())
+		*/
+	}
+	return nil
+}

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -1,0 +1,589 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+	"gopkg.in/yaml.v2"
+
+	digest "github.com/opencontainers/go-digest"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/transport"
+
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/cli/config/configfile"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/docker/docker/registry"
+)
+
+type pushOpts struct {
+	newRef string
+	file   string
+	purge  bool
+}
+
+type existingTokenHandler struct {
+	token string
+}
+
+func (th *existingTokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", th.token))
+	return nil
+}
+
+func (th *existingTokenHandler) Scheme() string {
+	return "bearer"
+}
+
+type dumbCredentialStore struct {
+	auth *types.AuthConfig
+}
+
+// YamlInput represents the YAML format input to the pushml
+// command.
+type YamlInput struct {
+	Image     string
+	Manifests []YamlManifestEntry
+}
+
+// YamlManifestEntry represents an entry in the list of manifests to
+// be combined into a manifest list, provided via the YAML input
+type YamlManifestEntry struct {
+	Image    string
+	Platform manifestlist.PlatformSpec
+}
+
+// we will store up a list of blobs we must ask the registry
+// to cross-mount into our target namespace
+type blobMount struct {
+	FromRepo string
+	Digest   string
+}
+
+// if we have mounted blobs referenced from manifests from
+// outside the target repository namespace we will need to
+// push them to our target's repo as they will be references
+// from the final manifest list object we push
+type manifestPush struct {
+	Name      string
+	Digest    string
+	JSONBytes []byte
+	MediaType string
+}
+
+func newPushListCommand(dockerCli *command.DockerCli) *cobra.Command {
+
+	opts := pushOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "push [newRef | --file pre-annotated-yaml]",
+		Short: "Push a manifest list for an image to a repository",
+		Args:  cli.RequiresMinArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return putManifestList(dockerCli, opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.file, "file", "f", "", "Path to a file containing a manifest list and its annotated constituent manifests")
+	flags.BoolVarP(&opts.purge, "purge", "p", true, "After pushing, delete the user's locally-stored manifest list info")
+
+	return cmd
+}
+
+func putManifestList(dockerCli *command.DockerCli, opts pushOpts, args []string) error {
+	var (
+		manifests         []string
+		manifestList      manifestlist.ManifestList
+		targetRef         reference.Named
+		blobMountRequests []blobMount
+		manifestRequests  []manifestPush
+		err               error
+		yamlInput         YamlInput
+		targetFilename    string
+	)
+
+	// First get all the info we'll need from either a yaml file, or a user's locally-creatd manifest transation.
+	numArgs := len(args)
+	if numArgs > 1 {
+		return fmt.Errorf("More than one argument provided to 'manifest push'")
+	}
+	if (numArgs == 0) && (opts.file == "") {
+		return fmt.Errorf("Please push using a yaml file or a list created using 'manifest create.'")
+	}
+	if opts.file != "" {
+		yamlInput, err = getYamlInput(dockerCli, opts.file)
+		if err != nil {
+			return fmt.Errorf("Error retrieving manifests from YAML file: %s", err)
+		}
+		targetRef, err = reference.ParseNormalizedNamed(yamlInput.Image)
+		if err != nil {
+			return fmt.Errorf("Error parsing name for manifest list (%s): %v", yamlInput.Image, err)
+		}
+		if _, isDigested := targetRef.(reference.Canonical); !isDigested {
+			targetRef = reference.TagNameOnly(targetRef)
+		}
+	} else {
+		targetRef, err = reference.ParseNormalizedNamed(args[0])
+		if err != nil {
+			return fmt.Errorf("Error parsing name for manifest list (%s): %v", args[0], err)
+		}
+		if _, isDigested := targetRef.(reference.Canonical); !isDigested {
+			targetRef = reference.TagNameOnly(targetRef)
+		}
+		manifests, err = getListFilenames(targetRef.String())
+		if err != nil {
+			return err
+		}
+		// Set this now, for purging the dir later, because we alter it below to use for the pushURL
+		targetFilename, _ = mfToFilename(targetRef.String(), "")
+	}
+	targetRepo, err := registry.ParseRepositoryInfo(targetRef)
+	if err != nil {
+		return fmt.Errorf("Error parsing repository name for manifest list (%s): %v", opts.newRef, err)
+	}
+	targetEndpoint, targetRepoName, err := setupRepo(targetRepo)
+	if err != nil {
+		return fmt.Errorf("Error setting up repository endpoint and references for %q: %v", targetRef, err)
+	}
+
+	// Now that targetRepo is set, jump through a lot of hoops to get a Named reference without
+	// the domain included (targetRef), and one without the tag (bareRef)
+	tagIndex := strings.LastIndex(targetRef.String(), ":")
+	if tagIndex < 0 {
+		targetRef = reference.TagNameOnly(targetRef)
+		tagIndex = strings.IndexRune(targetRef.String(), ':')
+	}
+	tag := targetRef.String()[tagIndex+1:]
+	bareRef, err := reference.WithName(reference.Path(targetRef))
+	if err != nil {
+		return err
+	}
+	targetRef, _ = reference.WithTag(bareRef, tag)
+
+	logrus.Debugf("Creating target ref: %s", targetRef.String())
+
+	ctx := context.Background()
+
+	// Now create the manifest list payload by looking up the manifest schemas
+	// for the constituent images:
+	logrus.Info("Retrieving digests of images...")
+	if opts.file == "" {
+		// manifests is a list of file paths
+		for _, manifestFile := range manifests {
+			fileParts := strings.Split(manifestFile, string(filepath.Separator))
+			numParts := len(fileParts)
+			mfstInspect, err := unmarshalIntoManifestInspect(fileParts[numParts-1], fileParts[numParts-2])
+			if err != nil {
+				return err
+			}
+			if mfstInspect.Architecture == "" || mfstInspect.OS == "" {
+				return fmt.Errorf("Malformed manifest object. Cannot push to registry.")
+			}
+			manifest, repoInfo, err := buildManifestObj(targetRepo, mfstInspect)
+			if err != nil {
+				return err
+			}
+			manifestList.Manifests = append(manifestList.Manifests, manifest)
+
+			// if this image is in a different repo, we need to add the layer/blob digests to the list of
+			// requested blob mounts (cross-repository push) before pushing the manifest list
+			manifestRepoName := reference.Path(repoInfo.Name)
+			if targetRepoName != manifestRepoName {
+				bmr, mr := buildBlobMountRequestLists(mfstInspect, targetRepoName, manifestRepoName)
+				blobMountRequests = append(blobMountRequests, bmr...)
+				manifestRequests = append(manifestRequests, mr...)
+			}
+		}
+		// @TODO: Pull the dup parts out from these two if/else blocks. Make a list of Manifest objects and run through that
+		// doing the dup parts.
+	}
+
+	// Set the schema version
+	manifestList.Versioned = manifestlist.SchemaVersion
+
+	urlBuilder, err := v2.NewURLBuilderFromString(targetEndpoint.URL.String(), false)
+	logrus.Infof("manifest: put: target endpoint url: %s", targetEndpoint.URL.String())
+	if err != nil {
+		return fmt.Errorf("Can't create URL builder from endpoint (%s): %v", targetEndpoint.URL.String(), err)
+	}
+	pushURL, err := createManifestURLFromRef(targetRef, urlBuilder)
+	if err != nil {
+		return fmt.Errorf("Error setting up repository endpoint and references for %q: %v", targetRef, err)
+	}
+	logrus.Debugf("Manifest list push url: %s", pushURL)
+
+	deserializedManifestList, err := manifestlist.FromDescriptors(manifestList.Manifests)
+	if err != nil {
+		return fmt.Errorf("Cannot deserialize manifest list: %v", err)
+	}
+	mediaType, p, err := deserializedManifestList.Payload()
+	logrus.Debugf("mediaType of manifestList: %s", mediaType)
+	if err != nil {
+		return fmt.Errorf("Cannot retrieve payload for HTTP PUT of manifest list: %v", err)
+
+	}
+	putRequest, err := http.NewRequest("PUT", pushURL, bytes.NewReader(p))
+	if err != nil {
+		return fmt.Errorf("HTTP PUT request creation failed: %v", err)
+	}
+	putRequest.Header.Set("Content-Type", mediaType)
+
+	httpClient, err := getHTTPClient(ctx, dockerCli, targetRepo, targetEndpoint, targetRepoName)
+	if err != nil {
+		return fmt.Errorf("Failed to setup HTTP client to repository: %v", err)
+	}
+
+	// before we push the manifest list, if we have any blob mount requests, we need
+	// to ask the registry to mount those blobs in our target so they are available
+	// as references
+	if err := mountBlobs(httpClient, urlBuilder, targetRef, blobMountRequests); err != nil {
+		return fmt.Errorf("Couldn't mount blobs for cross-repository push: %v", err)
+	}
+
+	// we also must push any manifests that are referenced in the manifest list into
+	// the target namespace
+	// Use the untagged target for this so the digest is used
+	if err := pushReferences(httpClient, urlBuilder, bareRef, manifestRequests); err != nil {
+		return fmt.Errorf("Couldn't push manifests referenced in our manifest list: %v", err)
+	}
+
+	resp, err := httpClient.Do(putRequest)
+	if err != nil {
+		return fmt.Errorf("V2 registry PUT of manifest list failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if statusSuccess(resp.StatusCode) {
+		dgstHeader := resp.Header.Get("Docker-Content-Digest")
+		dgst, err := digest.Parse(dgstHeader)
+		if err != nil {
+			return err
+		}
+		if opts.purge == true {
+			logrus.Debugf("Deleting files at %s", targetFilename)
+			if err := os.RemoveAll(targetFilename); err != nil {
+				// Not a fatal error
+				logrus.Info("Unable to clean up manifest files in %s", targetFilename)
+			}
+		}
+		logrus.Infof("Succesfully pushed manifest list %s with digest %s", targetRef, dgst)
+		return nil
+	}
+	return fmt.Errorf("Registry push unsuccessful: response %d: %s", resp.StatusCode, resp.Status)
+}
+
+func getYamlInput(dockerCli *command.DockerCli, yamlFile string) (YamlInput, error) {
+	logrus.Debugf("YAML file: %s", yamlFile)
+
+	if _, err := os.Stat(yamlFile); err != nil {
+		logrus.Debugf("Unable to open file: %s", yamlFile)
+	}
+
+	var yamlInput YamlInput
+	yamlBuf, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		logrus.Fatalf(fmt.Sprintf("Can't read YAML file %q: %v", yamlFile, err))
+	}
+	err = yaml.Unmarshal(yamlBuf, &yamlInput)
+	if err != nil {
+		logrus.Fatalf(fmt.Sprintf("Can't unmarshal YAML file %q: %v", yamlFile, err))
+	}
+	return yamlInput, nil
+}
+
+func buildManifestObj(targetRepo *registry.RepositoryInfo, mfInspect ImgManifestInspect) (manifestlist.ManifestDescriptor, *registry.RepositoryInfo, error) {
+
+	manifestRef, err := reference.ParseNormalizedNamed(mfInspect.RefName)
+	if err != nil {
+		return manifestlist.ManifestDescriptor{}, nil, err
+	}
+	repoInfo, err := registry.ParseRepositoryInfo(manifestRef)
+	if err != nil {
+		return manifestlist.ManifestDescriptor{}, nil, err
+	}
+
+	manifestRepoHostname := reference.Domain(repoInfo.Name)
+	targetRepoHostname := reference.Domain(targetRepo.Name)
+	if manifestRepoHostname != targetRepoHostname {
+		return manifestlist.ManifestDescriptor{}, nil, fmt.Errorf("Cannot use source images from a different registry than the target image: %s != %s", manifestRepoHostname, targetRepoHostname)
+	}
+
+	manifest := manifestlist.ManifestDescriptor{
+		Platform: manifestlist.PlatformSpec{
+			Architecture: mfInspect.Architecture,
+			OS:           mfInspect.OS,
+			OSVersion:    mfInspect.OSVersion,
+			OSFeatures:   mfInspect.OSFeatures,
+			Variant:      mfInspect.Variant,
+			Features:     mfInspect.Features,
+		},
+	}
+	manifest.Descriptor.Digest = mfInspect.Digest
+	manifest.Size = mfInspect.Size
+	manifest.MediaType = mfInspect.MediaType
+
+	err = manifest.Descriptor.Digest.Validate()
+	if err != nil {
+		return manifestlist.ManifestDescriptor{}, nil, fmt.Errorf("Digest parse of image %q failed with error: %v", manifestRef, err)
+	}
+
+	return manifest, repoInfo, nil
+}
+
+func buildBlobMountRequestLists(mfstInspect ImgManifestInspect, targetRepoName, mfRepoName string) ([]blobMount, []manifestPush) {
+
+	var (
+		blobMountRequests []blobMount
+		manifestRequests  []manifestPush
+	)
+
+	logrus.Debugf("Adding manifest references of %q to blob mount requests to %s", mfRepoName, targetRepoName)
+	for _, layer := range mfstInspect.References {
+		blobMountRequests = append(blobMountRequests, blobMount{FromRepo: mfRepoName, Digest: layer})
+	}
+	// also must add the manifest to be pushed in the target namespace
+	logrus.Debugf("Adding manifest %q -> to be pushed to %q as a manifest reference", mfRepoName, targetRepoName)
+	manifestRequests = append(manifestRequests, manifestPush{
+		Name:      mfRepoName,
+		Digest:    mfstInspect.Digest.String(),
+		JSONBytes: mfstInspect.CanonicalJSON,
+		MediaType: mfstInspect.MediaType,
+	})
+
+	return blobMountRequests, manifestRequests
+}
+
+func getHTTPClient(ctx context.Context, dockerCli *command.DockerCli, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, repoName string) (*http.Client, error) {
+	// get the http transport, this will be used in a client to upload manifest
+	// TODO - add separate function get client
+	base := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     endpoint.TLSConfig,
+		DisableKeepAlives:   true,
+	}
+
+	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+	modifiers := registry.DockerHeaders(dockerversion.DockerUserAgent(nil), http.Header{})
+	authTransport := transport.NewTransport(base, modifiers...)
+	challengeManager, _, err := registry.PingV2Registry(endpoint.URL, authTransport)
+	if err != nil {
+		return nil, fmt.Errorf("Ping of V2 registry failed: %v", err)
+	}
+	if authConfig.RegistryToken != "" {
+		passThruTokenHandler := &existingTokenHandler{token: authConfig.RegistryToken}
+		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, passThruTokenHandler))
+	} else {
+		creds := registry.NewStaticCredentialStore(&authConfig)
+		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, "*")
+		basicHandler := auth.NewBasicHandler(creds)
+		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
+	}
+	tr := transport.NewTransport(base, modifiers...)
+
+	httpClient := &http.Client{
+		Transport: tr,
+		// @TODO: Use the default (leave CheckRedirect nil), or write a generic one
+		// and put it somewhere? (There's one in docker/distribution/registry/client/repository.go)
+		// CheckRedirect: checkHTTPRedirect,
+	}
+	return httpClient, nil
+}
+
+func createManifestURLFromRef(targetRef reference.Named, urlBuilder *v2.URLBuilder) (string, error) {
+
+	manifestURL, err := urlBuilder.BuildManifestURL(targetRef)
+	if err != nil {
+		return "", fmt.Errorf("Failed to build manifest URL from target reference: %v", err)
+	}
+	return manifestURL, nil
+}
+
+func setupRepo(repoInfo *registry.RepositoryInfo) (registry.APIEndpoint, string, error) {
+	endpoint, err := selectPushEndpoint(repoInfo)
+	if err != nil {
+		return endpoint, "", err
+	}
+	logrus.Debugf("manifest: create: endpoint: %v", endpoint)
+	repoName := repoInfo.Name.Name()
+	// If endpoint does not support CanonicalName, use the RemoteName instead
+	if endpoint.TrimHostname {
+		repoName = reference.Path(repoInfo.Name)
+		logrus.Debugf("repoName: %v", repoName)
+	}
+	return endpoint, repoName, nil
+}
+
+func selectPushEndpoint(repoInfo *registry.RepositoryInfo) (registry.APIEndpoint, error) {
+	var err error
+
+	options := registry.ServiceOptions{}
+	// By default (unless deprecated), loopback (IPv4 at least...) is automatically added as an insecure registry.
+	options.InsecureRegistries, err = loadLocalInsecureRegistries()
+	if err != nil {
+		return registry.APIEndpoint{}, err
+	}
+	registryService := registry.NewService(options)
+	endpoints, err := registryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
+	if err != nil {
+		return registry.APIEndpoint{}, err
+	}
+	logrus.Debugf("manifest: potential push endpoints: %v\n", endpoints)
+	// Default to the highest priority endpoint to return
+	endpoint := endpoints[0]
+	if !repoInfo.Index.Secure {
+		for _, ep := range endpoints {
+			if ep.URL.Scheme == "http" {
+				endpoint = ep
+			}
+		}
+	}
+	return endpoint, nil
+}
+
+func loadLocalInsecureRegistries() ([]string, error) {
+	insecureRegistries := []string{}
+	// Check $HOME/.docker/config.json. There may be mismatches between what the user has in their
+	// local config and what the daemon they're talking to allows, but we can be okay with that.
+	userHome := homedir.Get()
+	if userHome == "" {
+		// I don't think this can happen, but I'm being cautious.
+		return []string{}, fmt.Errorf("manifest: User $HOME not set. Unable to read $HOME/.docker/config.json")
+	}
+
+	jsonData, err := ioutil.ReadFile(fmt.Sprintf("%s/.docker/config.json", userHome))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return []string{}, fmt.Errorf("manifest: Unable to read $HOME/.docker/config.json: %s", err)
+		}
+		// If the file just doesn't exist, no insecure registries were specified.
+		logrus.Debug("manifest: No insecure registries were specified via $HOME/.docker/config.json")
+		return []string{}, nil
+	}
+
+	if jsonData != nil {
+		cf := configfile.ConfigFile{}
+		if err := json.Unmarshal(jsonData, &cf); err != nil {
+			logrus.Debugf("manifest: Unable to unmarshal insecure registries from $HOME/.docker/config.json: %s", err)
+			return []string{}, nil
+		}
+		if cf.InsecureRegistries == nil {
+			return []string{}, nil
+		}
+		// @TODO: Add tests for a) specifying in config.json, b) invalid entries
+		for _, reg := range cf.InsecureRegistries {
+			if err := net.ParseIP(reg); err == nil {
+				insecureRegistries = append(insecureRegistries, reg)
+			} else if _, _, err := net.ParseCIDR(reg); err == nil {
+				insecureRegistries = append(insecureRegistries, reg)
+			} else if ips, err := net.LookupHost(reg); err == nil {
+				insecureRegistries = append(insecureRegistries, ips...)
+			} else {
+				return []string{}, fmt.Errorf("manifest: Invalid registry (%s) specified in ~/.docker/config.json: %s", reg, err)
+			}
+		}
+	}
+
+	return insecureRegistries, nil
+}
+
+func pushReferences(httpClient *http.Client, urlBuilder *v2.URLBuilder, ref reference.Named, manifests []manifestPush) error {
+	for _, manifest := range manifests {
+		dgst, err := digest.Parse(manifest.Digest)
+		logrus.Debugf("pushing ref digest %s", dgst)
+		if err != nil {
+			return fmt.Errorf("Error parsing manifest digest (%s) for referenced manifest %q: %v", manifest.Digest, manifest.Name, err)
+		}
+		targetRef, err := reference.WithDigest(ref, dgst)
+		logrus.Debugf("pushing ref %v", targetRef)
+		if err != nil {
+			return fmt.Errorf("Error creating manifest digest target for referenced manifest %q: %v", manifest.Name, err)
+		}
+		pushURL, err := urlBuilder.BuildManifestURL(targetRef)
+		if err != nil {
+			return fmt.Errorf("Error setting up manifest push URL for manifest references for %q: %v", manifest.Name, err)
+		}
+		logrus.Debugf("manifest reference push URL: %s", pushURL)
+
+		pushRequest, err := http.NewRequest("PUT", pushURL, bytes.NewReader(manifest.JSONBytes))
+		if err != nil {
+			return fmt.Errorf("HTTP PUT request creation for manifest reference push failed: %v", err)
+		}
+		pushRequest.Header.Set("Content-Type", manifest.MediaType)
+		resp, err := httpClient.Do(pushRequest)
+		if err != nil {
+			return fmt.Errorf("PUT of manifest reference failed: %v", err)
+		}
+
+		resp.Body.Close()
+		if !statusSuccess(resp.StatusCode) {
+			return fmt.Errorf("Referenced manifest push unsuccessful: response %d: %s", resp.StatusCode, resp.Status)
+		}
+		dgstHeader := resp.Header.Get("Docker-Content-Digest")
+		dgstResult, err := digest.Parse(dgstHeader)
+		if err != nil {
+			return fmt.Errorf("Couldn't parse pushed manifest digest response: %v", err)
+		}
+		if string(dgstResult) != manifest.Digest {
+			return fmt.Errorf("Pushed referenced manifest received a different digest: expected %s, got %s", manifest.Digest, string(dgst))
+		}
+		logrus.Debugf("referenced manifest %q pushed; digest matches: %s", manifest.Name, string(dgst))
+	}
+	return nil
+}
+
+func mountBlobs(httpClient *http.Client, urlBuilder *v2.URLBuilder, ref reference.Named, blobsRequested []blobMount) error {
+
+	for _, blob := range blobsRequested {
+		// create URL request
+		url, err := urlBuilder.BuildBlobUploadURL(ref, url.Values{"from": {blob.FromRepo}, "mount": {blob.Digest}})
+		if err != nil {
+			return fmt.Errorf("Failed to create blob mount URL: %v", err)
+		}
+		mountRequest, err := http.NewRequest("POST", url, nil)
+		if err != nil {
+			return fmt.Errorf("HTTP POST request creation for blob mount failed: %v", err)
+		}
+		mountRequest.Header.Set("Content-Length", "0")
+		resp, err := httpClient.Do(mountRequest)
+		if err != nil {
+			return fmt.Errorf("V2 registry POST of blob mount failed: %v", err)
+		}
+
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+			return fmt.Errorf("Blob mount failed to url %s: HTTP status %d", url, resp.StatusCode)
+		}
+		logrus.Debugf("Mount of blob %s succeeded, location: %q", blob.Digest, resp.Header.Get("Location"))
+	}
+	return nil
+}
+
+func statusSuccess(status int) bool {
+	return status >= 200 && status <= 399
+}

--- a/cli/command/manifest/types.go
+++ b/cli/command/manifest/types.go
@@ -1,0 +1,51 @@
+package manifest
+
+import (
+	containerTypes "github.com/docker/docker/api/types/container"
+	"github.com/opencontainers/go-digest"
+)
+
+// fallbackError wraps an error that can possibly allow fallback to a different
+// endpoint.
+type fallbackError struct {
+	// err is the error being wrapped.
+	err error
+	// confirmedV2 is set to true if it was confirmed that the registry
+	// supports the v2 protocol. This is used to limit fallbacks to the v1
+	// protocol.
+	confirmedV2 bool
+	transportOK bool
+}
+
+// Error renders the FallbackError as a string.
+func (f fallbackError) Error() string {
+	return f.err.Error()
+}
+
+// ImgManifestInspect contains info to output for a manifest object.
+type ImgManifestInspect struct {
+	RefName         string                 `json:"ref"`
+	Size            int64                  `json:"size"`
+	MediaType       string                 `json:"media_type"`
+	Tag             string                 `json:"tag"`
+	Digest          digest.Digest          `json:"digest"`
+	RepoTags        []string               `json:"repotags"`
+	Comment         string                 `json:"comment"`
+	Created         string                 `json:"created"`
+	ContainerConfig *containerTypes.Config `json:"container_config"`
+	DockerVersion   string                 `json:"docker_version"`
+	Author          string                 `json:"author"`
+	Config          *containerTypes.Config `json:"config"`
+	References      []string               `json:"references"`
+	LayerDigests    []string               `json:"layers_digests"`
+	// The following are top-level objects because nested json from a file
+	// won't unmarshal correctly.
+	Architecture string   `json:"architecture"`
+	OS           string   `json:"os"`
+	OSVersion    string   `json:"os.version,omitempty"`
+	OSFeatures   []string `json:"os.features,omitempty"`
+	Variant      string   `json:"variant,omitempty"`
+	Features     []string `json:"features,omitempty"`
+	// This one's prettier at the end
+	CanonicalJSON []byte `json:"json"`
+}

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -1,0 +1,180 @@
+package manifest
+
+// list of valid os/arch values (see "Optional Environment Variables" section
+// of https://golang.org/doc/install/source
+// Added linux/s390x as we know System z support already exists
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/homedir"
+	//"github.com/opencontainers/go-digest"
+	//"github.com/docker/distribution/manifest/manifestlist"
+)
+
+type osArch struct {
+	os   string
+	arch string
+}
+
+//Remove any unsupported os/arch combo
+var validOSArches = map[osArch]bool{
+	osArch{os: "darwin", arch: "386"}:      true,
+	osArch{os: "darwin", arch: "amd64"}:    true,
+	osArch{os: "darwin", arch: "arm"}:      true,
+	osArch{os: "darwin", arch: "arm64"}:    true,
+	osArch{os: "dragonfly", arch: "amd64"}: true,
+	osArch{os: "freebsd", arch: "386"}:     true,
+	osArch{os: "freebsd", arch: "amd64"}:   true,
+	osArch{os: "freebsd", arch: "arm"}:     true,
+	osArch{os: "linux", arch: "386"}:       true,
+	osArch{os: "linux", arch: "amd64"}:     true,
+	osArch{os: "linux", arch: "arm"}:       true,
+	osArch{os: "linux", arch: "arm64"}:     true,
+	osArch{os: "linux", arch: "ppc64"}:     true,
+	osArch{os: "linux", arch: "ppc64le"}:   true,
+	osArch{os: "linux", arch: "mips64"}:    true,
+	osArch{os: "linux", arch: "mips64le"}:  true,
+	osArch{os: "linux", arch: "s390x"}:     true,
+	osArch{os: "netbsd", arch: "386"}:      true,
+	osArch{os: "netbsd", arch: "amd64"}:    true,
+	osArch{os: "netbsd", arch: "arm"}:      true,
+	osArch{os: "openbsd", arch: "386"}:     true,
+	osArch{os: "openbsd", arch: "amd64"}:   true,
+	osArch{os: "openbsd", arch: "arm"}:     true,
+	osArch{os: "plan9", arch: "386"}:       true,
+	osArch{os: "plan9", arch: "amd64"}:     true,
+	osArch{os: "solaris", arch: "amd64"}:   true,
+	osArch{os: "windows", arch: "386"}:     true,
+	osArch{os: "windows", arch: "amd64"}:   true,
+}
+
+func isValidOSArch(os string, arch string) bool {
+	// check for existence of this combo
+	_, ok := validOSArches[osArch{os, arch}]
+	return ok
+}
+
+func makeFilesafeName(ref string) string {
+	// Make sure the ref is a normalized name before calling this func
+	fileName := strings.Replace(ref, ":", "-", -1)
+	return strings.Replace(fileName, "/", "_", -1)
+}
+
+func getListFilenames(transaction string) ([]string, error) {
+	baseDir, err := buildBaseFilename()
+	if err != nil {
+		return nil, err
+	}
+	transactionDir := filepath.Join(baseDir, makeFilesafeName(transaction))
+	if err != nil {
+		return nil, err
+	}
+	fd, err := os.Open(transactionDir)
+	if err != nil {
+		return nil, err
+	}
+	fileNames, err := fd.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	fd.Close()
+	for i, f := range fileNames {
+		fileNames[i] = filepath.Join(transactionDir, f)
+	}
+	return fileNames, nil
+}
+
+func getManifestFd(manifest, transaction string) (*os.File, error) {
+
+	fileName, err := mfToFilename(manifest, transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	return getFdGeneric(fileName)
+}
+
+func getFdGeneric(file string) (*os.File, error) {
+	_, err := os.Stat(file)
+	if err != nil && os.IsNotExist(err) {
+		logrus.Debugf("Manifest file %s not found.", file)
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	fd, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return fd, nil
+}
+
+func buildBaseFilename() (string, error) {
+	// Store the manifests in a user's home to prevent conflict. The HOME dir needs to be set,
+	// but can only be forcibly set on Linux at this time.
+	// See https://github.com/docker/docker/pull/29478 for more background on why this approach
+	// is being used.
+	if err := ensureHomeIfIAmStatic(); err != nil {
+		return "", err
+	}
+	userHome := homedir.Get()
+	return filepath.Join(userHome, ".docker", "manifests"), nil
+}
+
+func mfToFilename(manifest, transaction string) (string, error) {
+
+	baseDir, err := buildBaseFilename()
+	if err != nil {
+		return "", nil
+	}
+	return filepath.Join(baseDir, makeFilesafeName(transaction), makeFilesafeName(manifest)), nil
+}
+
+func unmarshalIntoManifestInspect(manifest, transaction string) (ImgManifestInspect, error) {
+
+	var newMf ImgManifestInspect
+	filename, err := mfToFilename(manifest, transaction)
+	if err != nil {
+		return ImgManifestInspect{}, err
+	}
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return ImgManifestInspect{}, err
+	}
+
+	if err := json.Unmarshal(buf, &newMf); err != nil {
+		return ImgManifestInspect{}, err
+	}
+
+	return newMf, nil
+}
+
+func updateMfFile(newMf ImgManifestInspect, mfName, transaction string) error {
+	fileName, err := mfToFilename(mfName, transaction)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(fileName); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	fd, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	theBytes, err := json.Marshal(newMf)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fd.Write(theBytes); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -40,6 +40,7 @@ type ConfigFile struct {
 	SecretFormat         string                      `json:"secretFormat,omitempty"`
 	NodesFormat          string                      `json:"nodesFormat,omitempty"`
 	PruneFilters         []string                    `json:"pruneFilters,omitempty"`
+	InsecureRegistries   []string                    `json:"insecure-registries,omitempty"`
 }
 
 // LegacyLoadFromReader reads the non-nested configuration data given and sets up the

--- a/integration-cli/docker_cli_manifest_test.go
+++ b/integration-cli/docker_cli_manifest_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/docker/docker/integration-cli/checker"
+	"github.com/docker/docker/integration-cli/registry"
+	"github.com/go-check/check"
+)
+
+func init() {
+	check.Suite(&DockerManifestSuite{
+		ds: &DockerSuite{},
+	})
+}
+
+type DockerManifestSuite struct {
+	ds  *DockerSuite
+	reg *registry.V2
+}
+
+func (s *DockerManifestSuite) SetUpSuite(c *check.C) {
+	// make config.json if it doesn't exist, and add insecure registry to it
+	os.Mkdir("/root/.docker/", 0770)
+	if _, err := os.Stat("/root/.docker/config.json"); os.IsNotExist(err) {
+		os.Create("/root/.docker/config.json")
+	}
+	f, err := os.OpenFile("/root/.docker/config.json", os.O_APPEND|os.O_WRONLY, 0600)
+	c.Assert(err, checker.IsNil)
+	defer f.Close()
+
+	insecureRegistry := "{\"insecure-registries\" : [\"127.0.0.1:5000\"]}"
+	_, err = f.WriteString(insecureRegistry)
+	c.Assert(err, checker.IsNil)
+
+	configLocation := "/root/.docker/config.json"
+	_, err = os.Stat(configLocation)
+	c.Assert(err, checker.IsNil)
+
+}
+
+func (s *DockerManifestSuite) TearDownSuite(c *check.C) {
+	// intetionally empty
+}
+
+func (s *DockerManifestSuite) SetUpTest(c *check.C) {
+	testRequires(c, DaemonIsLinux, registry.Hosting)
+
+	// setup registry and populate it with two busybox images
+	s.reg = setupRegistry(c, false, "", privateRegistryURL)
+
+	image1 := fmt.Sprintf("%s/busybox", privateRegistryURL)
+	image2 := fmt.Sprintf("%s/busybox2", privateRegistryURL)
+
+	dockerCmd(c, "tag", "busybox", image1)
+	dockerCmd(c, "tag", "busybox", image2)
+
+	_, _, err := dockerCmdWithError("push", image1)
+	c.Assert(err, checker.IsNil)
+
+	_, _, err = dockerCmdWithError("push", image2)
+	c.Assert(err, checker.IsNil)
+}
+
+func (s *DockerManifestSuite) TearDownTest(c *check.C) {
+	if s.reg != nil {
+		s.reg.Close()
+	}
+	s.ds.TearDownTest(c)
+}
+
+func (s *DockerManifestSuite) TestManifestInspectUntagged(c *check.C) {
+	testRepo := "testrepo"
+	testRepoRegistry := fmt.Sprintf("%s/%s", privateRegistryURL, testRepo)
+
+	image1 := fmt.Sprintf("%s/busybox", testRepoRegistry)
+
+	dockerCmd(c, "tag", "busybox", image1)
+	dockerCmd(c, "push", image1)
+
+	out, _, err := dockerCmdWithError("manifest", "inspect", image1)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), "not found")
+}
+
+func (s *DockerManifestSuite) TestManifestInspectTagged(c *check.C) {
+	testRepo := "testrepo"
+	testRepoRegistry := fmt.Sprintf("%s/%s", privateRegistryURL, testRepo)
+
+	imageFound := fmt.Sprintf("%s/busybox:push", testRepoRegistry)
+	imageNotfound := fmt.Sprintf("%s/busybox:nopush", testRepoRegistry)
+
+	dockerCmd(c, "tag", "busybox", imageFound)
+	dockerCmd(c, "push", imageFound)
+
+	// Make sure the error message always contains "not found"
+	out, _, err := dockerCmdWithError("manifest", "inspect", imageNotfound)
+	c.Assert(err, checker.Not(checker.IsNil))
+	c.Assert(out, checker.Contains, "not found")
+
+	// Make sure tags are kept
+	out, _, err = dockerCmdWithError("manifest", "inspect", imageFound)
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Not(checker.Contains), "not found")
+}
+
+func (s *DockerManifestSuite) TestManifestCreate(c *check.C) {
+	testRepo := "testrepo/busybox"
+
+	out, _, _ := dockerCmdWithError("manifest", "create", testRepo, "busybox", "busybox:thisdoesntexist")
+	c.Assert(out, checker.Contains, "manifest unknown")
+
+	_, _, err := dockerCmdWithError("manifest", "create", testRepo, "busybox", "debian:jessie")
+	c.Assert(err, checker.IsNil)
+
+	splitRepo := strings.Split(testRepo, "/")
+	c.Assert(len(splitRepo), checker.Equals, 2)
+
+	manifestLocation := "/root/.docker/manifests/docker.io_" + splitRepo[0] + "_" + splitRepo[1] + "-latest"
+	_, err = os.Stat(manifestLocation)
+	c.Assert(err, checker.IsNil, check.Commentf("Manifest not found in ", manifestLocation))
+
+}
+
+func (s *DockerManifestSuite) TestManifestPush(c *check.C) {
+	testRepo := "testrepo"
+	testRepoRegistry := fmt.Sprintf("%s/%s", privateRegistryURL, testRepo)
+
+	image1 := fmt.Sprintf("%s/busybox", privateRegistryURL)
+	image2 := fmt.Sprintf("%s/busybox2", privateRegistryURL)
+
+	dockerCmd(c, "manifest", "create", testRepoRegistry, image1, image2)
+
+	dockerCmd(c, "manifest", "annotate", testRepoRegistry, image1, "--os", runtime.GOOS, "--arch", runtime.GOARCH)
+	dockerCmd(c, "manifest", "annotate", testRepoRegistry, image2, "--os", runtime.GOOS, "--arch", runtime.GOARCH)
+
+	out, _, err := dockerCmdWithError("manifest", "push", testRepoRegistry)
+	c.Assert(err, checker.IsNil)
+	successfulPush := "Succesfully pushed manifest list " + testRepo
+	c.Assert(out, checker.Contains, successfulPush)
+}
+
+func (s *DockerManifestSuite) TestManifestAnnotatePushInspect(c *check.C) {
+	testRepo := "testrepo"
+	testRepoRegistry := fmt.Sprintf("%s/%s", privateRegistryURL, testRepo)
+
+	image1 := fmt.Sprintf("%s/busybox", privateRegistryURL)
+	image2 := fmt.Sprintf("%s/busybox2", privateRegistryURL)
+
+	dockerCmd(c, "manifest", "create", testRepoRegistry, image1, image2)
+
+	// test with bad os / arch
+	out, _, _ := dockerCmdWithError("manifest", "annotate", testRepoRegistry, image1, "--os", "bados", "--arch", "amd64")
+	c.Assert(out, checker.Contains, "Manifest entry for image has unsupported os/arch combination")
+
+	out, _, _ = dockerCmdWithError("manifest", "annotate", testRepoRegistry, image2, "--os", "linux", "--arch", "badarch")
+	c.Assert(out, checker.Contains, "Manifest entry for image has unsupported os/arch combination")
+
+	// now annotate correctly, but give duplicate cpu and os features
+	_, _, err := dockerCmdWithError("manifest", "annotate", testRepoRegistry, image1, "--os", "linux", "--arch", "amd64", "--cpuFeatures", "sse1, sse1", "--osFeatures", "osf1, osf1")
+	c.Assert(err, checker.IsNil)
+	_, _, err = dockerCmdWithError("manifest", "annotate", testRepoRegistry, image2, "--os", "freebsd", "--arch", "arm", "--cpuFeatures", "sse2", "--osFeatures", "osf2")
+	c.Assert(err, checker.IsNil)
+
+	dockerCmd(c, "manifest", "push", testRepoRegistry)
+
+	out, _ = dockerCmd(c, "manifest", "inspect", testRepoRegistry)
+	c.Assert(out, checker.Contains, "linux")
+	c.Assert(out, checker.Contains, "freebsd")
+	c.Assert(out, checker.Contains, "amd64")
+	c.Assert(out, checker.Contains, "arm")
+	c.Assert(out, checker.Contains, "sse1")
+	c.Assert(out, checker.Contains, "sse2")
+	c.Assert(out, checker.Contains, "osf1")
+	c.Assert(out, checker.Contains, "osf2")
+	c.Assert(strings.Count(out, "sse1"), checker.Equals, 1)
+	c.Assert(strings.Count(out, "osf1"), checker.Equals, 1)
+
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Porting the manifest tool code from https://github.com/estesp/manifest-tool

**Version One workflow:**
- manifest inspect:
`docker manifest inspect busybox:latest`

- manifest create list:
0) Create a yaml file, e.g.
```
image: docker.io/clnperez/hello-world:latest
manifests:
  -
    image: docker.io/ppc64le/hello-world:latest
    platform:
      architecture: ppc64le
      os: linux
  -
    image: docker.io/hello-world:latest
    platform:
      architecture: amd64
      features:
        - sse
      variant: v_a
      os: linux

```

1) `docker manifest create busybox-manifest.yaml`

**Version ~~Two~~ Three Workflow:**

- inspect: will pull down and print out a manifest or manifest list
- annotate: will modify the locally-stored manifest list by adding
  variants, os features, cpu features, an os kind, and/or an archicture

    
The inspect, fetch, and annotate commands are optional if all a user
wants to do is create a multi-arch manifest list based on existing
images.
  
Things left to do:

- [x] Add support for plain http registries. 
- [x] ~~Probably move the manifest storage out from \~/.docker/manifests (and
  figure out how to handle multiple users possibly doing simultaneous
 annotations of the same image manifest).~~
- [ ] Lots of cleanup.
- [ ] Lots more tests (and make existing ones much more thorough).
- [x] Fix a the user lookup issue when running a static binary ~~(probably fixed by moving manifests outside a user dir).~~
- [ ] Move borrowed/duplicated code from docker/docker/pull/29478 into a sharable place (in a separate PR)


**\- How to verify it**
- make binary
- Create a new unaltered fat manifest: 
`./bundles/latest/dynbinary-client/docker manifest create --name reponame/busybox busybox ppc64le/busybox`

- Annotate a manifest inside of the new list context:
`./bundles/latest/dynbinary-client/docker manifest annotate reponame/busybox ppc64le/busybox --os linux --arch ppc64le`
`./bundles/latest/dynbinary-client/docker manifest annotate reponame/busybox busybox --osFeatures osf1,osf2`

- Push the manifest list to a registry:
`./bundles/latest/dynbinary-client/docker manifest push reponame/busybox`

- Display [committed] manifest or manifest list details:
`./bundles/latest/dynbinary-client/docker manifest inspect ppc64le/busybox`
`./bundles/latest/dynbinary-client/docker manifest inspect reponame/busybox`

- Pull (to verify)
`docker run --rm reponame/busybox uname -m`
Will pull the correct image down for your platform, and print your system's hw name.
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

![manatee pulling baby manatee](https://static1.squarespace.com/static/53deba14e4b04da19f29b426/t/56cd0f021bbee035649d5f07/1456279382206/)
