### PR TITLE
Revert docker volume column name to VOLUME_NAME

### DIFF
--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -12,6 +12,7 @@ const (
 	defaultVolumeQuietFormat = "{{.Name}}"
 	defaultVolumeTableFormat = "table {{.Driver}}\t{{.Name}}"
 
+	volumeNameHeader = "VOLUME NAME"
 	mountpointHeader = "MOUNTPOINT"
 	linksHeader      = "LINKS"
 	// Status header ?
@@ -53,7 +54,7 @@ type volumeContext struct {
 }
 
 func (c *volumeContext) Name() string {
-	c.AddHeader(nameHeader)
+	c.AddHeader(volumeNameHeader)
 	return c.v.Name
 }
 

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -22,7 +22,7 @@ func TestVolumeContext(t *testing.T) {
 	}{
 		{volumeContext{
 			v: types.Volume{Name: volumeName},
-		}, volumeName, nameHeader, ctx.Name},
+		}, volumeName, volumeNameHeader, ctx.Name},
 		{volumeContext{
 			v: types.Volume{Driver: "driver_name"},
 		}, "driver_name", driverHeader, ctx.Driver},
@@ -76,7 +76,7 @@ func TestVolumeContextWrite(t *testing.T) {
 		// Table format
 		{
 			Context{Format: NewVolumeFormat("table", false)},
-			`DRIVER              NAME
+			`DRIVER              VOLUME NAME
 foo                 foobar_baz
 bar                 foobar_bar
 `,
@@ -89,14 +89,14 @@ foobar_bar
 		},
 		{
 			Context{Format: NewVolumeFormat("table {{.Name}}", false)},
-			`NAME
+			`VOLUME NAME
 foobar_baz
 foobar_bar
 `,
 		},
 		{
 			Context{Format: NewVolumeFormat("table {{.Name}}", true)},
-			`NAME
+			`VOLUME NAME
 foobar_baz
 foobar_bar
 `,


### PR DESCRIPTION
See https://github.com/docker/docker/pull/27440#discussion_r83657350. Changing `VOLUME_NAME` header to `NAME` was unintenionnal in #23475 so reverting to the current header.

As @thaJeztah I do like `NAME` though, as it is common to other `ls` commands.

/cc @thaJeztah @cpuguy83 @dnephin 

Signed-off-by: Vincent Demeester vincent@sbr.pm
