### PR TITLE
projectquota: fix build failure with new kernels

### DIFF
--- a/daemon/graphdriver/projectquota.go
+++ b/daemon/graphdriver/projectquota.go
@@ -17,6 +17,8 @@ package graphdriver
 #include <linux/fs.h>
 #include <linux/quota.h>
 #include <linux/dqblk_xfs.h>
+
+#ifndef FS_XFLAG_PROJINHERIT
 struct fsxattr {
 	__u32		fsx_xflags;
 	__u32		fsx_extsize;
@@ -25,13 +27,26 @@ struct fsxattr {
 	unsigned char	fsx_pad[12];
 };
 #define FS_XFLAG_PROJINHERIT	0x00000200
+#endif
+#ifndef FS_IOC_FSGETXATTR
 #define FS_IOC_FSGETXATTR		_IOR ('X', 31, struct fsxattr)
+#endif
+#ifndef FS_IOC_FSSETXATTR
 #define FS_IOC_FSSETXATTR		_IOW ('X', 32, struct fsxattr)
+#endif
 
+#ifndef PRJQUOTA
 #define PRJQUOTA	2
+#endif
+#ifndef XFS_PROJ_QUOTA
 #define XFS_PROJ_QUOTA	2
+#endif
+#ifndef Q_XSETPQLIM
 #define Q_XSETPQLIM QCMD(Q_XSETQLIM, PRJQUOTA)
+#endif
+#ifndef Q_XGETPQUOTA
 #define Q_XGETPQUOTA QCMD(Q_XGETQUOTA, PRJQUOTA)
+#endif
 */
 import "C"
 import (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

@dmcgowan @runcom 

**\- What I did**
Fixes build breakage of just merged  #24771 

**\- How I did it**
Added some ifdefs

**\- How to verify it**
Build on Fedora 23/24

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

In kernel version >= v4.5 the project quota ioctl definitions
have been made public via the include/uapi/linux/fs.h API, so
that ext4 could use the same API.

Avoid re-defining the ioctl API if it is already defined in fs.h.

Signed-off-by: Amir Goldstein amir73il@aquasec.com
