### PR TITLE
Windows: Calculate PID file after root

### DIFF
--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/cli"
@@ -60,6 +62,11 @@ func runDaemon(opts daemonOptions) error {
 	}
 
 	daemonCli := NewDaemonCli()
+
+	// On Windows, if there's no explicit pidfile set, set to under the daemon root
+	if runtime.GOOS == "windows" && opts.daemonConfig.Pidfile == "" {
+		opts.daemonConfig.Pidfile = filepath.Join(opts.daemonConfig.Root, "docker.pid")
+	}
 
 	// On Windows, this may be launching as a service or with an option to
 	// register the service.

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -2,14 +2,15 @@ package daemon
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/pflag"
 )
 
 var (
-	defaultPidFile = os.Getenv("programdata") + string(os.PathSeparator) + "docker.pid"
-	defaultGraph   = os.Getenv("programdata") + string(os.PathSeparator) + "docker"
+	defaultPidFile string
+	defaultGraph   = filepath.Join(os.Getenv("programdata"), "docker")
 )
 
 // bridgeConfig stores all the bridge driver specific


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Astonished this hasn't been noticed before (even by me....). Does later binding of the default PID file - currently the Windows daemon always writes the PID file to c:\programdata\docker.pid (rather than c:\programdata\docker\docker.pid where the default root is), unless an explicit pidfile option is set, even if the root is set to elsewhere such as running `dockerd -g c:\control`.
