### PR TITLE
Windows: Mark run-service flag as hidden

### DIFF
--- a/cmd/dockerd/service_windows.go
+++ b/cmd/dockerd/service_windows.go
@@ -49,6 +49,7 @@ func installServiceFlags(flags *pflag.FlagSet) {
 	flRegisterService = flags.Bool("register-service", false, "Register the service and exit")
 	flUnregisterService = flags.Bool("unregister-service", false, "Unregister the service and exit")
 	flRunService = flags.Bool("run-service", false, "")
+	flags.MarkHidden("run-service")
 }
 
 type handler struct {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Avoids `--run-service` appearing in help on Windows when running `dockerd --help`. eg without this change, here's part of the output.

```
...
  -H, --host value                            Daemon socket(s) to connect to (default [])
      --insecure-registry value               Enable insecure registry communication (default [])
      --label value                           Set key=value labels to the daemon (default [])
      --log-driver string                     Default driver for container logs (default "json-file")
  -l, --log-level string                      Set the logging level (debug, info, warn, error, fatal) (default "info")
      --log-opt value                         Default log driver options for containers (default map[])
      --max-concurrent-downloads int          Set the max concurrent downloads for each pull (default 3)
      --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
      --mtu int                               Set the containers network MTU
  -p, --pidfile string                        Path to use for daemon PID file
      --raw-logs                              Full timestamps without ANSI coloring
      --register-service                      Register the service and exit
      --registry-mirror value                 Preferred Docker registry mirror (default [])
      --run-service
      --service-name string                   Set the Windows service name (default "docker")
  -s, --storage-driver string                 Storage driver to use
      --storage-opt value                     Storage driver options (default [])
...
```

And after

```
...
  -H, --host value                            Daemon socket(s) to connect to (default [])
      --insecure-registry value               Enable insecure registry communication (default [])
      --label value                           Set key=value labels to the daemon (default [])
      --log-driver string                     Default driver for container logs (default "json-file")
  -l, --log-level string                      Set the logging level (debug, info, warn, error, fatal) (default "info")
      --log-opt value                         Default log driver options for containers (default map[])
      --max-concurrent-downloads int          Set the max concurrent downloads for each pull (default 3)
      --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
      --mtu int                               Set the containers network MTU
  -p, --pidfile string                        Path to use for daemon PID file (default "C:\\ProgramData\\docker.pid")
      --raw-logs                              Full timestamps without ANSI coloring
      --register-service                      Register the service and exit
      --registry-mirror value                 Preferred Docker registry mirror (default [])
      --service-name string                   Set the Windows service name (default "docker")
  -s, --storage-driver string                 Storage driver to use
      --storage-opt value                     Storage driver options (default [])
      --swarm-default-advertise-addr string   Set default address or interface for swarm advertised address
      --tls                                   Use TLS; implied by --tlsverify
...
```

@jstarks PTAL
