### PR TITLE
Add short aliases for management commands

### DIFF
--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -12,9 +12,10 @@ import (
 // NewContainerCommand returns a cobra command for `container` subcommands
 func NewContainerCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "container",
-		Short: "Manage containers",
-		Args:  cli.NoArgs,
+		Use:     "container",
+		Short:   "Manage containers",
+		Args:    cli.NoArgs,
+		Aliases: []string{"con"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
 		},

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -12,9 +12,10 @@ import (
 // NewImageCommand returns a cobra command for `image` subcommands
 func NewImageCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "image",
-		Short: "Manage images",
-		Args:  cli.NoArgs,
+		Use:     "image",
+		Short:   "Manage images",
+		Args:    cli.NoArgs,
+		Aliases: []string{"img"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
 		},

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -12,9 +12,10 @@ import (
 // NewNetworkCommand returns a cobra command for `network` subcommands
 func NewNetworkCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "network",
-		Short: "Manage networks",
-		Args:  cli.NoArgs,
+		Use:     "network",
+		Short:   "Manage networks",
+		Args:    cli.NoArgs,
+		Aliases: []string{"net"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
 		},

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -12,9 +12,10 @@ import (
 // NewServiceCommand returns a cobra command for `service` subcommands
 func NewServiceCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "service",
-		Short: "Manage services",
-		Args:  cli.NoArgs,
+		Use:     "service",
+		Short:   "Manage services",
+		Args:    cli.NoArgs,
+		Aliases: []string{"srv"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
 		},

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -12,10 +12,11 @@ import (
 // NewVolumeCommand returns a cobra command for `volume` subcommands
 func NewVolumeCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "volume COMMAND",
-		Short: "Manage volumes",
-		Long:  volumeDescription,
-		Args:  cli.NoArgs,
+		Use:     "volume COMMAND",
+		Short:   "Manage volumes",
+		Long:    volumeDescription,
+		Args:    cli.NoArgs,
+		Aliases: []string{"vol"},
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
 		},


### PR DESCRIPTION
Adds three letter aliases for the docker management commands to reduce the typing required to get to the new canonical commands.
