### PR TITLE
Bugfix systemd docker daemon conflicting with daemon.json

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -9,7 +9,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

On Ubuntu package:

```
# apt-cache show docker.io
Package: docker.io
Priority: optional
Section: universe/admin
Installed-Size: 54232
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Paul Tagliamonte <paultag@debian.org>
Architecture: amd64
Version: 1.12.1-0ubuntu13~16.04.1
Replaces: docker (<< 1.5~)
Depends: adduser, containerd (>= 0.2.3~), iptables, runc (>= 1.0.0~rc1~), init-system-helpers (>= 1.18~), lsb-base (>= 4.1+Debian11ubuntu7), libapparmor1 (>= 2.6~devel), libc6 (>= 2.14), libdevmapper1.02.1 (>= 2:1.02.97)
Recommends: ca-certificates, cgroupfs-mount | cgroup-lite, git, ubuntu-fan, xz-utils, apparmor
Suggests: aufs-tools, btrfs-tools, debootstrap, docker-doc, rinse, zfs-fuse | zfsutils
Breaks: docker (<< 1.5~)
Filename: pool/universe/d/docker.io/docker.io_1.12.1-0ubuntu13~16.04.1_amd64.deb
Size: 10581186
MD5sum: 08676d065c43fc6bcb450cf52c782ed5
SHA1: 8f51b8c7b0fbc3eb879e13a76286cbe13b096d34
SHA256: 0987a665d090d90b0096fbdcab7d18316cad6a1754dbc70f56ab74c36ba53c51
...
```

I created `/etc/default/daemon.json` with the contents.

``` json
{
    "hosts": ["tcp://127.0.0.1:2700"],
    "tlsverify": true,
    "tlscacert": "/etc/docker/ca.pem",
    "tlscert": "/etc/docker/cert.pem",
    "tlskey": "/etc/docker/key.pem"
}
```

Starting the docker daemon (`systemctl start docker.service`) causes the error

> unable to configure the Docker daemon with file
> /etc/docker/daemon.json: the following directives are specified both as
> a flag and in the configuration file: hosts: (from flag: [fd://], from
> file: [tcp://127.0.0.1:2700])

**\- How I did it**

Patch the `docker.service` and the error goes away.

**\- How to verify it**
1. Install the above mentioned `docker.io` package in Ubuntu 16.04.
2. Patch `/lib/systemd/system/docker.service` with the changes in this PR.
3. Restart the daemon and it should succeed.
4. Configure the hosts field of `/etc/docker/daemon.json`.  Restart and watch restart success.

**\- Description for the changelog**

> systemd: fix conflicting hosts option between docker.service and daemon.json

![cute cat](https://s-media-cache-ak0.pinimg.com/originals/c2/9e/8b/c29e8ba60e752a81cc9e82265f97c66a.jpg)

fixes #22339
