### PR TITLE
Update fluent-logger-golang to v1.2.1

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -118,7 +118,7 @@ clone git github.com/golang/protobuf 1f49d83d9aa00e6ce4fc8258c71cc7786aec968a
 # gelf logging driver deps
 clone git github.com/Graylog2/go-gelf aab2f594e4585d43468ac57287b0dece9d806883
 
-clone git github.com/fluent/fluent-logger-golang v1.2.0
+clone git github.com/fluent/fluent-logger-golang v1.2.1
 # fluent-logger-golang deps
 clone git github.com/philhofer/fwd 899e4efba8eaa1fea74175308f3fae18ff3319fa
 clone git github.com/tinylib/msgp 75ee40d2601edf122ef667e2a07d600d4c44490c

--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
@@ -78,7 +78,7 @@ func New(config Config) (f *Fluent, err error) {
 	}
 	if config.AsyncConnect {
 		f = &Fluent{Config: config, reconnecting: true}
-		f.reconnect()
+		go f.reconnect()
 	} else {
 		f = &Fluent{Config: config, reconnecting: false}
 		err = f.connect()
@@ -254,7 +254,7 @@ func (f *Fluent) connect() (err error) {
 		err = net.UnknownNetworkError(f.Config.FluentNetwork)
 	}
 
-	if err != nil {
+	if err == nil {
 		f.reconnecting = false
 	}
 	return

--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/version.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/version.go
@@ -1,3 +1,3 @@
 package fluent
 
-const Version = "1.1.0"
+const Version = "1.2.1"


### PR DESCRIPTION
**\- What I did**
Updated fluent-logger-golang (for fluentd logging driver) to 1.2.1. This fixes #27374.

This fixes a regression bug not to connect the destination node twice or more.
That regression was brought by v1.2.0, and it also makes many goroutines for
first reconnection (these will finish after first reconnection established).

**\- How to verify it**
1. Write `test.conf`
2. Build docker in dev container with this patch
3. Run docker daemon `docker daemon -D &`
4. Run fluentd container `docker run -d -p 24224:24224 --name fluentd -v $PWD/test.conf:/fluentd/etc/test.conf -e FLUENTD_CONF=test.conf fluent/fluentd:latest`
5. Verify fluentd is running `docker logs fluentd`
6. Run a container to logs per second `docker run -d --log-driver=fluentd --name ping-1 --log-opt tag="docker.ping-1" -- debian perl -e '$|=1; while(sleep 1){ print "yay\n"; }'`
7. Show logs `docker logs -f fluentd`
8. Stop fluentd container, and verify errors are reported about logging
9. Start fluentd container, and verify errors stop
10. Repeat the last 2 steps twice or more times

``` apache
# test.conf
<source>
  @type forward
</source>
<match docker.**>
  @type stdout
</match>
```

**\- Description for the changelog**
Update fluent-logger-golang to v1.2.1 to fix a bug not to reconnect destination twice or more.
