### PR TITLE
Add template support to awslog driver options like the fluentd log driver

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/daemon/logger/loggerutils"
 	"github.com/docker/docker/dockerversion"
 )
 
@@ -87,10 +88,18 @@ func init() {
 // AWS_SECRET_ACCESS_KEY, the shared credentials file (~/.aws/credentials), and
 // the EC2 Instance Metadata Service.
 func New(ctx logger.Context) (logger.Logger, error) {
+	var err error
 	logGroupName := ctx.Config[logGroupKey]
+	logGroupName, err = loggerutils.ParseLogTag(ctx, ctx.Config[logGroupKey])
+	if err != nil {
+		return nil, err
+	}
 	logStreamName := ctx.ContainerID
 	if ctx.Config[logStreamKey] != "" {
-		logStreamName = ctx.Config[logStreamKey]
+		logStreamName, err = loggerutils.ParseLogTag(ctx, ctx.Config[logStreamKey])
+		if err != nil {
+			return nil, err
+		}
 	}
 	client, err := newAWSLogsClient(ctx)
 	if err != nil {


### PR DESCRIPTION
Added template parsing to the awslogs logger, based on how the fluentd logger does it. Specifically, the --log-opt parameters awslogs-group and awslogs-stream are now treated as logger template expressions. This change is safe because the template markup {{ cannot be used in existing parameters because they are not valid in AWS CloudWatch log groups or streams.

Fixes #27362 

Signed-off-by: Jamie Briant james.briant@thermofisher.com
