### PR TITLE
Fix the link for sharing images via repositories

### DIFF
--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -29,7 +29,7 @@ periods and dashes. A tag name may not start with a period or a dash and may
 contain a maximum of 128 characters.
 
 You can group your images together using names and tags, and then upload them
-to [*Share Images via Repositories*](../../tutorials/dockerrepos.md#contributing-to-docker-hub).
+to [*Share Images via Repositories*](https://docs.docker.com/docker-hub/repos/).
 
 # Examples
 


### PR DESCRIPTION
**\- What I did**
Fix the link for sharing images via repositories

**\- How I did it**
Update the link from docs.docker.com

**\- How to verify it**

**\- Description for the changelog**
The new link is https://docs.docker.com/docker-hub/repos/

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
