### PR TITLE
Fix the typo of link in devmapper

### DIFF
--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -92,5 +92,5 @@ This uses the `dm` prefix and would be used something like `docker daemon --stor
 
 These options are currently documented both in [the man
 page](../../../man/docker.1.md) and in [the online
-documentation](https://docs.docker.com/reference/commandline/daemon/#storage-driver-options).
+documentation](https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/).
 If you add an options, update both the `man` page and the documentation.


### PR DESCRIPTION
**\- What I did**
Fix the typo of link 
**\- How I did it**
Find the right link
**\- How to verify it**
Click the link

Signed-off-by: YuPengZTE yu.peng36@zte.com.cn
