### PR TITLE
Add bash completion for `docker {run,create} --stop-timeout`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2387,6 +2387,7 @@ _docker_run() {
 		--security-opt
 		--shm-size
 		--stop-signal
+		--stop-timeout
 		--storage-opt
 		--tmpfs
 		--sysctl


### PR DESCRIPTION
Ref: #22566
