### PR TITLE
Windows: Add cred spec test with well form credentials

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4539,6 +4539,16 @@ func (s *DockerSuite) TestRunCredentialSpecFailures(c *check.C) {
 	}
 }
 
+// Windows specific test to validate credential specs with a well-formed spec.
+// Note it won't actually do anything in CI configuration with the spec, but
+// it should not fail to run a container.
+func (s *DockerSuite) TestRunCredentialSpecWellFormed(c *check.C) {
+	testRequires(c, DaemonIsWindows, SameHostDaemon)
+	validCS := readFile(`fixtures\credentialspecs\valid.json`, c)
+	writeFile(filepath.Join(dockerBasePath, `credentialspecs\valid.json`), validCS, c)
+	dockerCmd(c, "run", `--security-opt=credentialspec=file://valid.json`, "busybox", "true")
+}
+
 // Windows specific test to ensure that a servicing app container is started
 // if necessary once a container exits. It does this by forcing a no-op
 // servicing event and verifying the event from Hyper-V-Compute

--- a/integration-cli/fixtures/credentialspecs/valid.json
+++ b/integration-cli/fixtures/credentialspecs/valid.json
@@ -1,0 +1,25 @@
+{
+    "CmsPlugins":  [
+                       "ActiveDirectory"
+                   ],
+    "DomainJoinConfig":  {
+                             "Sid":  "S-1-5-21-4288985-3632099173-1864715694",
+                             "MachineAccountName":  "MusicStoreAcct",
+                             "Guid":  "3705d4c3-0b80-42a9-ad97-ebc1801c74b9",
+                             "DnsTreeName":  "hyperv.local",
+                             "DnsName":  "hyperv.local",
+                             "NetBiosName":  "hyperv"
+                         },
+    "ActiveDirectoryConfig":  {
+                                  "GroupManagedServiceAccounts":  [
+                                                                      {
+                                                                          "Name":  "MusicStoreAcct",
+                                                                          "Scope":  "hyperv.local"
+                                                                      },
+                                                                      {
+                                                                          "Name":  "MusicStoreAcct",
+                                                                          "Scope":  "hyperv"
+                                                                      }
+                                                                  ]
+                              }
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Adds a Windows-specific CI test with a well-formed credential spec. 

@patricklang FYI.
