### PR TITLE
Add session identifier header

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/distribution/uuid"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 )
@@ -23,6 +24,9 @@ var (
 	// ErrAlreadyExists is an error returned if an image being pushed
 	// already exists on the remote side
 	ErrAlreadyExists = errors.New("Image already exists")
+	// SessionID is a UUID that identifies the current execution context
+	// and is added to the docker headers in all requests against a registry
+	SessionID = uuid.Generate().String()
 )
 
 func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
@@ -107,7 +111,8 @@ func DockerHeaders(userAgent string, metaHeaders http.Header) []transport.Reques
 	modifiers := []transport.RequestModifier{}
 	if userAgent != "" {
 		modifiers = append(modifiers, transport.NewHeaderRequestModifier(http.Header{
-			"User-Agent": []string{userAgent},
+			"User-Agent":        []string{userAgent},
+			"Docker-Session-ID": []string{SessionID},
 		}))
 	}
 	if metaHeaders != nil {


### PR DESCRIPTION
**\- What I did**
This is an attempt at tackling #27507.

I added an additional header to the list of headers added by `registry.DockerHeaders()`. It only contains a UUID value that's supposed to help correlate events in the registry's logs. This is part 1 of a 2 part change, the next one being having the registry add this session id to the request logs.

**\- How I did it**
- Generate a new global UUID value in `registry.go`
- Send it as part of the docker headers used to talk to both v1 and v2 endpoints.

**\- How to verify it**
- Have a registry service that logs the value of this header, as described in #27507.

**\- Description for the changelog**
Added a session ID header to be sent to the registry for telemetry purposes.

**\- A picture of a cute animal (not mandatory but encouraged)**
![zaida](https://cloud.githubusercontent.com/assets/950290/19495038/8f55b368-9536-11e6-9a1c-74e6470302db.jpg)

Signed-off-by: David Obando daobando@microsoft.com
