### PR TITLE
Improve error message

### DIFF
--- a/daemon/names.go
+++ b/daemon/names.go
@@ -73,9 +73,9 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 				logrus.Errorf("got unexpected error while looking up reserved name: %v", err)
 				return "", err
 			}
-			return "", fmt.Errorf("Conflict. The container name %q is already in use by container %s. You have to remove (or rename) that container to be able to reuse that name.", name, id)
+			return "", fmt.Errorf("Conflict. The container name %q is already in use by container %q. You have to remove (or rename) that container to be able to reuse that name.", name, id)
 		}
-		return "", fmt.Errorf("error reserving name: %s, error: %v", name, err)
+		return "", fmt.Errorf("error reserving name: %q, error: %v", name, err)
 	}
 	return name, nil
 }


### PR DESCRIPTION
**\- What I did**
Add single quotes around container name and container id to improve copy-paste avoiding the extra `.` that slips into the clipboard

**\- How I did it**
Adding the single quotes directly editing the file

**\- How to verify it**
docker run --name busybox_container busybox echo hello
docker run --name busybox_container busybox echo hello
Check error message

**\- Description for the changelog**
Add single quotes around container name and container id to improve copy-paste avoiding the extra `.` that slips into the clipboard

**\- A picture of a cute animal (not mandatory but encouraged)**

Add single quotes around container name and container id to improve copy-paste avoiding the extra `.` that slips into the clipboard

Signed-off-by: Jorge Marin chipironcin@users.noreply.github.com
