### PR TITLE
use the canonical base image name

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -29,7 +29,7 @@
 #
 # The steps are minimised dramatically to improve performance
 
-FROM windowsservercore
+FROM microsoft/windowsservercore
 
 # Environment variable notes:
 #  - GO_VERSION must consistent with 'Dockerfile' used by Linux'.


### PR DESCRIPTION
**\- What I did**

Update the Windows Dockerfile to use the default name for the Windows base image

**\- How to verify it**

On a Windows system:

`docker build -t docker -f Dockerfile.windows .`

cc @jhowardmsft 

Signed-off-by: Michael Friis friism@gmail.com
