### PR TITLE
make every node and plugin removal call api

### DIFF
--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -35,12 +36,21 @@ func newRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runRemove(dockerCli *command.DockerCli, args []string, opts removeOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
+
+	var errs []string
+
 	for _, nodeID := range args {
 		err := client.NodeRemove(ctx, nodeID, types.NodeRemoveOptions{Force: opts.force})
 		if err != nil {
-			return err
+			errs = append(errs, err.Error())
+			continue
 		}
 		fmt.Fprintf(dockerCli.Out(), "%s\n", nodeID)
 	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+
 	return nil
 }

--- a/cli/command/plugin/remove.go
+++ b/cli/command/plugin/remove.go
@@ -45,14 +45,16 @@ func runRemove(dockerCli *command.DockerCli, opts *rmOptions) error {
 	for _, name := range opts.plugins {
 		named, err := reference.ParseNamed(name) // FIXME: validate
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		if reference.IsNameOnly(named) {
 			named = reference.WithDefaultTag(named)
 		}
 		ref, ok := named.(reference.NamedTagged)
 		if !ok {
-			return fmt.Errorf("invalid name: %s", named.String())
+			errs = append(errs, fmt.Errorf("invalid name: %s", named.String()))
+			continue
 		}
 		// TODO: pass names to api instead of making multiple api calls
 		if err := dockerCli.Client().PluginRemove(ctx, ref.String(), types.PluginRemoveOptions{Force: opts.force}); err != nil {


### PR DESCRIPTION
I found that when removing multi node, one node fails will make docker cli return. I think this is not so reasonable. This is not consistent with container, volume, service....

the same as plugin.

**\- What I did**
1. make every node removal from cli call api.
2. make every plugin removal from cli call api.

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
