### PR TITLE
Add limit to page size used by overlay2 driver

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -473,6 +473,15 @@ func (d *Driver) Get(id string, mountLabel string) (s string, err error) {
 
 	pageSize := syscall.Getpagesize()
 
+	// Go can return a larger page size than supported by the system
+	// as of go 1.7. This will be fixed in 1.8 and this block can be
+	// removed when building with 1.8.
+	// See https://github.com/golang/go/commit/1b9499b06989d2831e5b156161d6c07642926ee1
+	// See https://github.com/docker/docker/issues/27384
+	if pageSize > 4096 {
+		pageSize = 4096
+	}
+
 	// Use relative paths and mountFrom when the mount data has exceeded
 	// the page size. The mount syscall fails if the mount data cannot
 	// fit within a page and relative links make the mount data much


### PR DESCRIPTION
Go can falsely report a larger page size than supported (such as with arm64), causing overlay2 mount arguments to be truncated. When overlay2 detects the mount arguments have hit the page limit, it will switch to using relative paths. If this limit is smaller than the actual page size there is no behavioral problems, but if it is larger mounts can fail for images with many layers. Since 4096 is a standard page size, don't use reported page size larger than 4096.

Closes #27384

There is a fix for this in go master and we can expect to remove this change once building with the next release of Go, see https://github.com/golang/go/commit/1b9499b06989d2831e5b156161d6c07642926ee1.
