### PR TITLE
Remove invalid installation content because there is no corresponding files

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -41,7 +41,7 @@ each `docker` command with `sudo`. To avoid having to use `sudo` with the
 `docker` and add users to it.
 
 For more information about installing Docker or `sudo` configuration, refer to
-the [installation](../../installation/index.md) instructions for your operating system.
+the [installation](https://docs.docker.com/engine/installation/) instructions for your operating system.
 
 ## Environment variables
 


### PR DESCRIPTION
Remove invalid installstion content because there is no corresponding files.
