### PR TITLE
change join node role judge

### DIFF
--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -2,7 +2,6 @@ package swarm
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli"
@@ -61,15 +60,10 @@ func runJoin(dockerCli *command.DockerCli, opts joinOptions) error {
 		return err
 	}
 
-	_, _, err = client.NodeInspectWithRaw(ctx, info.Swarm.NodeID)
-	if err != nil {
-		// TODO(aaronl): is there a better way to do this?
-		if strings.Contains(err.Error(), "This node is not a swarm manager.") {
-			fmt.Fprintln(dockerCli.Out(), "This node joined a swarm as a worker.")
-		}
-	} else {
+	if info.Swarm.ControlAvailable {
 		fmt.Fprintln(dockerCli.Out(), "This node joined a swarm as a manager.")
+	} else {
+		fmt.Fprintln(dockerCli.Out(), "This node joined a swarm as a worker.")
 	}
-
 	return nil
 }


### PR DESCRIPTION
When a node has joined a swarm cluster, cli will judge whether this a manager or worker.

This PR change the judge way that just using info API response field to finish this.

ping @aaronlehmann 

Signed-off-by: allencloud allen.sun@daocloud.io
