### PR TITLE
[nit] add missing changes in API v1.25 (prune) to docker_remote_api.md

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -143,6 +143,9 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /containers/(id or name)/exec` now accepts an `Env` field, which holds a list of environment variables to be set in the context of the command execution.
 * `GET /volumes`, `GET /volumes/(name)`, and `POST /volumes/create` now return the `Options` field which holds the driver specific options to use for when creating the volume.
 * `GET /exec/(id)/json` now returns `Pid`, which is the system pid for the exec'd process.
+* `POST /containers/prune` prunes stopped containers.
+* `POST /images/prune` prunes unused images.
+* `POST /volumes/prune` prunes unused volumes.
 
 
 ### v1.24 API changes


### PR DESCRIPTION
Added the changes about `prune` (#26108)

There is also a change that makes `DELETE /networks/(id)` return 204 (#26960), but IMO we don't need to add it, because it is just a change to implementation.

Signed-off-by: Akihiro Suda suda.akihiro@lab.ntt.co.jp
