### PR TITLE
Update the link for sharing images via repositories

### DIFF
--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -29,7 +29,7 @@ periods and dashes. A tag name may not start with a period or a dash and may
 contain a maximum of 128 characters.
 
 You can group your images together using names and tags, and then upload them
-to [*Share Images via Repositories*](https://docs.docker.com/docker-hub/repos/).
+to [*Share Images via Repositories*](https://docs.docker.com/engine/tutorials/dockerrepos/#/contributing-to-docker-hub).
 
 # Examples
 


### PR DESCRIPTION
**\- What I did**
Update the link for sharing images via repositories

**\- How I did it**
**\- How to verify it**
**\- Description for the changelog**
According to @thaJeztah' suggestion,  it is a appropriate  link  as follows:
https://docs.docker.com/engine/tutorials/dockerrepos/#/contributing-to-docker-hub

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
