### PR TITLE
Add bash completion for `dockerd --shutdown-timeout`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1031,6 +1031,7 @@ _docker_daemon() {
 		--oom-score-adjust
 		--pidfile -p
 		--registry-mirror
+		--shutdown-timeout
 		--storage-driver -s
 		--storage-opt
 		--userns-remap


### PR DESCRIPTION
Ref: #23036
