### PR TITLE
project: unify way of installing runc and containerd

### DIFF
--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -9,6 +9,28 @@ GRIMES_COMMIT=15ecf9414859b16a8a19ac6748a622a5498d57e3
 
 export GOPATH="$(mktemp -d)"
 
+RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp apparmor selinux"}"
+
+install_runc() {
+	echo "Install runc version $RUNC_COMMIT"
+	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
+	cd "$GOPATH/src/github.com/opencontainers/runc"
+	git checkout -q "$RUNC_COMMIT"
+	make BUILDTAGS="$RUNC_BUILDTAGS" $1
+	cp runc /usr/local/bin/docker-runc
+}
+
+install_containerd() {
+	echo "Install containerd version $CONTAINERD_COMMIT"
+	git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd"
+	cd "$GOPATH/src/github.com/docker/containerd"
+	git checkout -q "$CONTAINERD_COMMIT"
+	make $1
+	cp bin/containerd /usr/local/bin/docker-containerd
+	cp bin/containerd-shim /usr/local/bin/docker-containerd-shim
+	cp bin/ctr /usr/local/bin/docker-containerd-ctr
+}
+
 for prog in "$@"
 do
 	case $prog in
@@ -20,23 +42,19 @@ do
 			;;
 
 		runc)
-			echo "Install runc version $RUNC_COMMIT"
-			git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
-			cd "$GOPATH/src/github.com/opencontainers/runc"
-			git checkout -q "$RUNC_COMMIT"
-			make static BUILDTAGS="seccomp apparmor selinux"
-			cp runc /usr/local/bin/docker-runc
+			install_runc static
+			;;
+
+		runc-dynamic)
+			install_runc
 			;;
 
 		containerd)
-			echo "Install containerd version $CONTAINERD_COMMIT"
-			git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd"
-			cd "$GOPATH/src/github.com/docker/containerd"
-			git checkout -q "$CONTAINERD_COMMIT"
-			make static
-			cp bin/containerd /usr/local/bin/docker-containerd
-			cp bin/containerd-shim /usr/local/bin/docker-containerd-shim
-			cp bin/ctr /usr/local/bin/docker-containerd-ctr
+			install_containerd static
+			;;
+
+		containerd-dynamic)
+			install_containerd
 			;;
 
 		grimes)

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -25,10 +25,10 @@ override_dh_auto_install:
 	cp -aT "$$(readlink -f bundles/$(VERSION)/dynbinary-client/docker)" debian/docker-engine/usr/bin/docker
 	cp -aT "$$(readlink -f bundles/$(VERSION)/dynbinary-daemon/dockerd)" debian/docker-engine/usr/bin/dockerd
 	cp -aT "$$(readlink -f bundles/$(VERSION)/dynbinary-daemon/docker-proxy)" debian/docker-engine/usr/bin/docker-proxy
-	cp -aT /usr/local/bin/containerd debian/docker-engine/usr/bin/docker-containerd
-	cp -aT /usr/local/bin/containerd-shim debian/docker-engine/usr/bin/docker-containerd-shim
-	cp -aT /usr/local/bin/ctr debian/docker-engine/usr/bin/docker-containerd-ctr
-	cp -aT /usr/local/sbin/runc debian/docker-engine/usr/bin/docker-runc
+	cp -aT /usr/local/bin/docker-containerd debian/docker-engine/usr/bin/docker-containerd
+	cp -aT /usr/local/bin/docker-containerd-shim debian/docker-engine/usr/bin/docker-containerd-shim
+	cp -aT /usr/local/bin/docker-containerd-ctr debian/docker-engine/usr/bin/docker-containerd-ctr
+	cp -aT /usr/local/bin/docker-runc debian/docker-engine/usr/bin/docker-runc
 	mkdir -p debian/docker-engine/usr/lib/docker
 
 override_dh_installinit:

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -129,12 +129,12 @@ install -p -m 755 bundles/%{_origversion}/dynbinary-daemon/dockerd-%{_origversio
 install -p -m 755 bundles/%{_origversion}/dynbinary-daemon/docker-proxy-%{_origversion} $RPM_BUILD_ROOT/%{_bindir}/docker-proxy
 
 # install containerd
-install -p -m 755 /usr/local/bin/containerd $RPM_BUILD_ROOT/%{_bindir}/docker-containerd
-install -p -m 755 /usr/local/bin/containerd-shim $RPM_BUILD_ROOT/%{_bindir}/docker-containerd-shim
-install -p -m 755 /usr/local/bin/ctr $RPM_BUILD_ROOT/%{_bindir}/docker-containerd-ctr
+install -p -m 755 /usr/local/bin/docker-containerd $RPM_BUILD_ROOT/%{_bindir}/docker-containerd
+install -p -m 755 /usr/local/bin/docker-containerd-shim $RPM_BUILD_ROOT/%{_bindir}/docker-containerd-shim
+install -p -m 755 /usr/local/bin/docker-containerd-ctr $RPM_BUILD_ROOT/%{_bindir}/docker-containerd-ctr
 
 # install runc
-install -p -m 755 /usr/local/sbin/runc $RPM_BUILD_ROOT/%{_bindir}/docker-runc
+install -p -m 755 /usr/local/bin/docker-runc $RPM_BUILD_ROOT/%{_bindir}/docker-runc
 
 # install udev rules
 install -d $RPM_BUILD_ROOT/%{_sysconfdir}/udev/rules.d

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -72,23 +72,11 @@ set -e
 				&& ln -snf /usr/src/docker /go/src/github.com/docker/docker
 		EOF
 
-		echo "ENV RUNC_COMMIT $(grep "^RUNC_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
-		echo "ENV CONTAINERD_COMMIT $(grep "^CONTAINERD_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
-
-		# add runc and containerd compile and install
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			# Install runc
-			RUN git clone https://github.com/opencontainers/runc.git "/go/src/github.com/opencontainers/runc" \
-					&& cd "/go/src/github.com/opencontainers/runc" \
-					&& git checkout -q "\$RUNC_COMMIT"
-			RUN set -x && export GOPATH="/go" && cd "/go/src/github.com/opencontainers/runc" \
-					&& make BUILDTAGS="\$RUNC_BUILDTAGS" && make install
-			# Install containerd
-			RUN git clone https://github.com/docker/containerd.git "/go/src/github.com/docker/containerd" \
-					&& cd "/go/src/github.com/docker/containerd" \
-					&& git checkout -q "\$CONTAINERD_COMMIT"
-			RUN set -x && export GOPATH="/go" && cd "/go/src/github.com/docker/containerd" && make && make install
+			# Install runc and containerd
+			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic
 		EOF
+
 		if [ "$DOCKER_EXPERIMENTAL" ]; then
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
 		fi

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -92,23 +92,11 @@ set -e
 			RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 		EOF
 
-		echo "ENV RUNC_COMMIT $(grep "^RUNC_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
-		echo "ENV CONTAINERD_COMMIT $(grep "^CONTAINERD_COMMIT" hack/dockerfile/install-binaries.sh | cut -d"=" -f 2)" >> "$DEST/$version/Dockerfile.build"
-
-		# add runc and containerd compile and install
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			# Install runc
-			RUN git clone https://github.com/opencontainers/runc.git "/go/src/github.com/opencontainers/runc" \
-					&& cd "/go/src/github.com/opencontainers/runc" \
-					&& git checkout -q "\$RUNC_COMMIT"
-			RUN set -x && export GOPATH="/go" && cd "/go/src/github.com/opencontainers/runc" \
-					&& make BUILDTAGS="\$RUNC_BUILDTAGS" && make install
-			# Install containerd
-			RUN git clone https://github.com/docker/containerd.git "/go/src/github.com/docker/containerd" \
-					&& cd "/go/src/github.com/docker/containerd" \
-					&& git checkout -q "\$CONTAINERD_COMMIT"
-			RUN set -x && export GOPATH="/go" && cd "/go/src/github.com/docker/containerd" && make && make install
+			# Install runc and containerd
+			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic
 		EOF
+
 		if [ "$DOCKER_EXPERIMENTAL" ]; then
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
 		fi


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Unified way of installing runc and containerd in Dockerfiles and generated Dockerfiles for make deb and make rpm
**\- How I did it**
Used hack/dockerfile/install-binaries.sh script where I added options to install dynamically linked runc and containerd. This is part of epic quest of moving to "new" vendor layout.
**\- How to verify it**
make deb rpm
**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
![cat](https://scontent-iad3-1.cdninstagram.com/l/t51.2885-15/e35/14350447_507875182740250_112165811124174848_n.jpg)
