### PR TITLE
Add `publish` and `expose` filter for `docker ps --filter`

### DIFF
--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -32,6 +32,8 @@ Options:
                         - since=(<container-name>|<container-id>)
                         - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>)
                           containers created from an image or a descendant.
+                        - publish=(<port>[/<proto>]|<startport-endport>/[<proto>])
+                        - expose=(<port>[/<proto>]|<startport-endport>/[<proto>])
                         - is-task=(true|false)
                         - health=(starting|healthy|unhealthy|none)
       --format string   Pretty-print containers using a Go template
@@ -83,6 +85,8 @@ The currently supported filters are:
 * volume (volume name or mount point) - filters containers that mount volumes.
 * network (network id or name) - filters containers connected to the provided network
 * health (starting|healthy|unhealthy|none) - filters containers based on healthcheck status
+* publish=(container's published port) - filters published ports by containers
+* expose=(container's exposed port) - filters exposed ports by containers
 
 #### Label
 
@@ -326,6 +330,44 @@ $ docker ps --filter network=8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32
 
 CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
 9d4893ed80fe        ubuntu      "top"         10 minutes ago      Up 10 minutes                           test1
+```
+
+#### Publish and Expose
+
+The `publish` and `expose` filters show only containers that have published or exposed port with a given port
+number, port range, and/or protocol. The default protocol is `tcp` when not specified.
+
+The following filter matches all containers that have published port of 80:
+
+```bash
+$ docker run -d --publish=80 busybox top
+$ docker run -d --expose=8080 busybox top
+
+$ docker ps -a
+
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                   NAMES
+9833437217a5        busybox             "top"               5 seconds ago       Up 4 seconds        8080/tcp                dreamy_mccarthy
+fc7e477723b7        busybox             "top"               50 seconds ago      Up 50 seconds       0.0.0.0:32768->80/tcp   admiring_roentgen
+
+$ docker ps --filter publish=80
+
+CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS                   NAMES
+fc7e477723b7        busybox             "top"               About a minute ago   Up About a minute   0.0.0.0:32768->80/tcp   admiring_roentgen
+```
+
+The following filter matches all containers that have exposed TCP port in the range of `8000-8080`:
+```bash
+$ docker ps --filter expose=8000-8080/tcp
+
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+9833437217a5        busybox             "top"               21 seconds ago      Up 19 seconds       8080/tcp            dreamy_mccarthy
+```
+
+The following filter matches all containers that have exposed UDP port `80`:
+```bash
+$ docker ps --filter publish=80/udp
+
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
 ## Formatting

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -924,3 +924,37 @@ func (s *DockerSuite) TestPsFormatTemplateWithArg(c *check.C) {
 	out, _ := dockerCmd(c, "ps", "--format", `{{.Names}} {{.Label "some.label"}}`)
 	c.Assert(strings.TrimSpace(out), checker.Equals, "top label.foo-bar")
 }
+
+func (s *DockerSuite) TestPsListContainersFilterPorts(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	out, _ := dockerCmd(c, "run", "-d", "--publish=80", "busybox", "top")
+	id1 := strings.TrimSpace(out)
+
+	out, _ = dockerCmd(c, "run", "-d", "--expose=8080", "busybox", "top")
+	id2 := strings.TrimSpace(out)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q")
+	c.Assert(strings.TrimSpace(out), checker.Contains, id1)
+	c.Assert(strings.TrimSpace(out), checker.Contains, id2)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "publish=80-8080/udp")
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id1)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id2)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "expose=8081")
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id1)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id2)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "publish=80-81")
+	c.Assert(strings.TrimSpace(out), checker.Equals, id1)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id2)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "expose=80/tcp")
+	c.Assert(strings.TrimSpace(out), checker.Equals, id1)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id2)
+
+	out, _ = dockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "expose=8080/tcp")
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), id1)
+	c.Assert(strings.TrimSpace(out), checker.Equals, id2)
+}


### PR DESCRIPTION
**\- What I did**

This fix tries to address the enhancement proposal raised in #27178 for filtering based on published or exposed ports of `docker ps --filter`.

Note: this PR didn't implement the wildcard match initially, as protocol (`tcp/udp`) has to be taken into consideration. But is open to suggestions.

**\- How I did it**

In this fix, two filter options, `publish` and `expose` have been added to take either `<port>[/<protocol>]` or `<from>-<to>[/<protocol>]` and filtering on containers.

**\- How to verify it**

An integration test has been added to cover the changes.

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #27178.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
