### PR TITLE
Vendoring libnetwork for 1.12.3

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -65,7 +65,7 @@ clone git github.com/RackSec/srslog 365bf33cd9acc21ae1c355209865f17228ca534e
 clone git github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 7ba98d93bd24a04c4a096bf119e9791257631060
+clone git github.com/docker/libnetwork 66c844678f7d7df33e4f46184e5b4749f0204b5a
 clone git github.com/docker/go-events afb2b9f2c23f33ada1a22b03651775fdc65a5089
 clone git github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/src/github.com/docker/libnetwork/Dockerfile.build
+++ b/vendor/src/github.com/docker/libnetwork/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.5.4
+FROM golang:1.7.1
 RUN apt-get update && apt-get -y install iptables
 
 RUN go get github.com/tools/godep \

--- a/vendor/src/github.com/docker/libnetwork/controller.go
+++ b/vendor/src/github.com/docker/libnetwork/controller.go
@@ -881,8 +881,9 @@ func (c *controller) NewSandbox(containerID string, options ...SandboxOption) (s
 		if s.containerID == containerID {
 			// If not a stub, then we already have a complete sandbox.
 			if !s.isStub {
+				sbID := s.ID()
 				c.Unlock()
-				return nil, types.ForbiddenErrorf("container %s is already present: %v", containerID, s)
+				return nil, types.ForbiddenErrorf("container %s is already present in sandbox %s", containerID, sbID)
 			}
 
 			// We already have a stub sandbox from the

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -1286,6 +1286,12 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 		logrus.Warn(err)
 	}
 
+	endpoint.portMapping = nil
+
+	if err = d.storeUpdate(endpoint); err != nil {
+		return fmt.Errorf("failed to update bridge endpoint %s to store: %v", endpoint.id[0:7], err)
+	}
+
 	return nil
 }
 

--- a/vendor/src/github.com/docker/libnetwork/networkdb/networkdb.go
+++ b/vendor/src/github.com/docker/libnetwork/networkdb/networkdb.go
@@ -496,14 +496,14 @@ func (nDB *NetworkDB) addNetworkNode(nid string, nodeName string) {
 // this
 func (nDB *NetworkDB) deleteNetworkNode(nid string, nodeName string) {
 	nodes := nDB.networkNodes[nid]
-	for i, name := range nodes {
+	newNodes := make([]string, 0, len(nodes)-1)
+	for _, name := range nodes {
 		if name == nodeName {
-			nodes[i] = nodes[len(nodes)-1]
-			nodes = nodes[:len(nodes)-1]
-			break
+			continue
 		}
+		newNodes = append(newNodes, name)
 	}
-	nDB.networkNodes[nid] = nodes
+	nDB.networkNodes[nid] = newNodes
 }
 
 // findCommonnetworks find the networks that both this node and the

--- a/vendor/src/github.com/docker/libnetwork/sandbox.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox.go
@@ -917,8 +917,9 @@ func (sb *sandbox) clearNetworkResources(origEp *endpoint) error {
 		releaseOSSboxResources(osSbox, ep)
 	}
 
-	delete(sb.populatedEndpoints, ep.ID())
 	sb.Lock()
+	delete(sb.populatedEndpoints, ep.ID())
+
 	if len(sb.endpoints) == 0 {
 		// sb.endpoints should never be empty and this is unexpected error condition
 		// We log an error message to note this down for debugging purposes.

--- a/vendor/src/github.com/docker/libnetwork/service_linux.go
+++ b/vendor/src/github.com/docker/libnetwork/service_linux.go
@@ -41,8 +41,15 @@ func newService(name string, id string, ingressPorts []*PortConfig, aliases []st
 
 func (c *controller) cleanupServiceBindings(cleanupNID string) {
 	var cleanupFuncs []func()
+
 	c.Lock()
+	services := make([]*service, 0, len(c.serviceBindings))
 	for _, s := range c.serviceBindings {
+		services = append(services, s)
+	}
+	c.Unlock()
+
+	for _, s := range services {
 		s.Lock()
 		for nid, lb := range s.loadBalancers {
 			if cleanupNID != "" && nid != cleanupNID {
@@ -67,7 +74,6 @@ func (c *controller) cleanupServiceBindings(cleanupNID string) {
 		}
 		s.Unlock()
 	}
-	c.Unlock()
 
 	for _, f := range cleanupFuncs {
 		f()


### PR DESCRIPTION
- It includes few bug fixes which prevent
  a deadlock, a panic, a couple of races,
  and a regression.

The related docker issues are: #27323, #27486
The other libnetwork PR are: https://github.com/docker/libnetwork/pull/1495, https://github.com/docker/libnetwork/pull/1503, https://github.com/docker/libnetwork/pull/1504

Signed-off-by: Alessandro Boch aboch@docker.com
