### PR TITLE
Sync docker/docker refs with files mistakenly edited in docker.github.io repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,14 @@
 # The non-reference docs have been moved!
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 The documentation for Docker Engine has been merged into
 [the general documentation repo](https://github.com/docker/docker.github.io).
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -5,6 +5,15 @@ description: "Deprecated Features."
 keywords: ["docker, documentation, about, technology, deprecate"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Deprecated Engine Features
 
 The following list of features are deprecated in Engine.

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -8,6 +8,15 @@ keywords: ["API, Usage, plugins, documentation, developer"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Engine managed plugin system
 
 This document describes the plugin system available today in the **experimental

--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -5,6 +5,15 @@ description: "How to add additional functionality to Docker with plugins extensi
 keywords: ["Examples, Usage, plugins, docker, documentation, user guide"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Use Docker Engine plugins
 
 This document describes the Docker Engine plugins generally available in Docker

--- a/docs/extend/manifest.md
+++ b/docs/extend/manifest.md
@@ -8,6 +8,15 @@ keywords: ["API, Usage, plugins, documentation, developer"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Plugin Manifest Version 0 of Plugin V2
 
 This document outlines the format of the V0 plugin manifest. The plugin

--- a/docs/extend/menu.md
+++ b/docs/extend/menu.md
@@ -6,5 +6,13 @@ type: "menu"
 identifier: "engine_extend"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 <!--menu page not rendered-->

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -4,6 +4,15 @@ description: "How to write Docker plugins extensions "
 keywords: ["API, Usage, plugins, documentation, developer"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Plugin API
 
 Docker plugins are out-of-process extensions which add capabilities to the

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -5,6 +5,14 @@ keywords: ["security, authorization, authentication, docker, documentation, plug
 aliases: ["/engine/extend/authorization/"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 # Create an authorization plugin
 

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -4,6 +4,15 @@ description: "Network driver plugins."
 keywords: ["Examples, Usage, plugins, docker, documentation, user guide"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Engine network driver plugins
 
 This document describes Docker Engine network driver plugins generally

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -4,6 +4,15 @@ description: "How to manage data with external volume plugins"
 keywords: ["Examples, Usage, volume, docker, data, volumes, plugin, api"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Write a volume plugin
 
 Docker Engine volume plugins enable Engine deployments to be integrated with

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -2,6 +2,15 @@
 published: false
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 This directory holds the authoritative specifications of APIs defined and implemented by Docker. Currently this includes:
 
  * The remote API by which a docker node can be queried over HTTP

--- a/docs/reference/api/docker-io_api.md
+++ b/docs/reference/api/docker-io_api.md
@@ -5,6 +5,15 @@ description: "API Documentation for the Docker Hub API"
 keywords: ["API, Docker, index, REST, documentation, Docker Hub,  registry"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Hub API
 
 This API is deprecated as of 1.7. To view the old version, see the [Docker Hub

--- a/docs/reference/api/docker_io_accounts_api.md
+++ b/docs/reference/api/docker_io_accounts_api.md
@@ -4,6 +4,15 @@ description: "API Documentation for docker.io accounts."
 keywords: ["API, Docker, accounts, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # docker.io accounts API
 
 ## Get a single user

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API
 
 Docker's Remote API uses an open schema model.  In this model, unknown

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.18
 
 ## 1. Brief introduction
@@ -518,7 +527,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -593,7 +604,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -897,7 +910,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -977,7 +992,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1070,7 +1087,9 @@ Copy files or folders of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1176,7 +1195,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1941,7 +1962,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.19
 
 ## 1. Brief introduction
@@ -532,7 +541,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -609,7 +620,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -934,7 +947,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1014,7 +1029,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1107,7 +1124,9 @@ Copy files or folders of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1218,7 +1237,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -2022,7 +2043,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.20
 
 ## 1. Brief introduction
@@ -541,7 +550,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -618,7 +629,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -943,7 +956,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1023,7 +1038,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1118,7 +1135,9 @@ Copy files or folders of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1164,7 +1183,9 @@ Get a tar archive of a resource in the filesystem of container `id`.
     Content-Type: application/x-tar
     X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
@@ -1219,7 +1240,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1345,7 +1368,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -2175,7 +2200,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.21
 
 ## 1. Brief introduction
@@ -610,7 +619,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -687,7 +698,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1024,7 +1037,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1104,7 +1119,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1199,7 +1216,9 @@ Copy files or folders of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1245,7 +1264,9 @@ Get a tar archive of a resource in the filesystem of container `id`.
     Content-Type: application/x-tar
     X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
@@ -1300,7 +1321,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1426,7 +1449,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -2333,7 +2358,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.22
 
 ## 1. Brief introduction
@@ -735,7 +744,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -812,7 +823,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1195,7 +1208,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1279,7 +1294,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1377,7 +1394,9 @@ Copy files or folders of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1423,7 +1442,9 @@ Get a tar archive of a resource in the filesystem of container `id`.
     Content-Type: application/x-tar
     X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
@@ -1478,7 +1499,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1604,7 +1627,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -2727,7 +2752,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.23
 
 ## 1. Brief introduction
@@ -761,7 +770,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -838,7 +849,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1228,7 +1241,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1312,7 +1327,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1410,7 +1427,9 @@ Copy files or folders of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1456,7 +1475,9 @@ Get a tar archive of a resource in the filesystem of container `id`.
     Content-Type: application/x-tar
     X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
@@ -1511,7 +1532,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1637,7 +1660,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -2801,7 +2826,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.24
 
 # 1. Brief introduction
@@ -793,7 +802,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -871,7 +882,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1257,7 +1270,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1341,7 +1356,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1455,7 +1472,9 @@ Get a tar archive of a resource in the filesystem of container `id`.
     Content-Type: application/x-tar
     X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
@@ -1510,7 +1529,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1638,7 +1659,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -2815,7 +2838,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4,6 +4,15 @@ description: "API Documentation for Docker"
 keywords: ["API, Docker, rcli, REST,  documentation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API v1.25
 
 # 1. Brief introduction
@@ -825,7 +834,9 @@ Get `stdout` and `stderr` logs from the container ``id``
      Connection: Upgrade
      Upgrade: tcp
 
+     {% raw %}
      {{ STREAM }}
+     {% endraw %}
 
 **Query parameters**:
 
@@ -903,7 +914,9 @@ Export the contents of container `id`
     HTTP/1.1 200 OK
     Content-Type: application/octet-stream
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Status codes**:
 
@@ -1289,7 +1302,9 @@ Attach to the container `id`
     Connection: Upgrade
     Upgrade: tcp
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1373,7 +1388,9 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example response**
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **Query parameters**:
 
@@ -1487,7 +1504,9 @@ Get a tar archive of a resource in the filesystem of container `id`.
     Content-Type: application/x-tar
     X-Docker-Container-Path-Stat: eyJuYW1lIjoicm9vdCIsInNpemUiOjQwOTYsIm1vZGUiOjIxNDc0ODQwOTYsIm10aW1lIjoiMjAxNC0wMi0yN1QyMDo1MToyM1oiLCJsaW5rVGFyZ2V0IjoiIn0=
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 On success, a response header `X-Docker-Container-Path-Stat` will be set to a
 base64-encoded JSON object containing some filesystem header information about
@@ -1542,7 +1561,9 @@ Upload a tar archive to be extracted to a path in the filesystem of container
     PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -1702,7 +1723,9 @@ Build an image from a Dockerfile
 
     POST /build HTTP/1.1
 
+    {% raw %}
     {{ TAR STREAM }}
+    {% endraw %}
 
 **Example response**:
 
@@ -3217,7 +3240,9 @@ interactive session with the `exec` command.
     HTTP/1.1 200 OK
     Content-Type: application/vnd.docker.raw-stream
 
+    {% raw %}
     {{ STREAM }}
+    {% endraw %}
 
 **JSON parameters**:
 

--- a/docs/reference/api/hub_registry_spec.md
+++ b/docs/reference/api/hub_registry_spec.md
@@ -5,6 +5,15 @@ description: "Documentation for docker Registry and Registry API"
 keywords: ["docker, registry, api,  hub"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # The Docker Hub and the Registry v1
 
 This API is deprecated as of 1.7. To view the old version, see the [go

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -5,6 +5,14 @@ keywords: ["Engine"]
 identifier: "engine_remoteapi"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 # API Reference
 

--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -4,6 +4,15 @@ description: "Various client libraries available to use with the Docker remote A
 keywords: ["API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust,  Scala"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker Remote API client libraries
 
 These libraries make it easier to build applications on top of the Docker
@@ -44,6 +53,11 @@ with the library maintainers.
       <td>Dart</td>
       <td>bwu_docker</td>
       <td><a class="reference external" href="https://github.com/bwu-dart/bwu_docker">https://github.com/bwu-dart/bwu_docker</a></td>
+    </tr>
+    <tr>
+      <td>Go</td>
+      <td>Docker Go client</td>
+      <td><a class="reference external" href="https://godoc.org/github.com/docker/docker/client">https://godoc.org/github.com/docker/docker/client</a></td>
     </tr>
     <tr>
       <td>Gradle</td>

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -4,6 +4,15 @@ description: "Dockerfiles use a simple DSL which allows you to automate the step
 keywords: ["builder, docker, Dockerfile, automation,  image creation"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Dockerfile reference
 
 Docker can build images automatically by reading the instructions from a
@@ -129,7 +138,7 @@ instruction must be \`FROM\`** in order to specify the [*Base
 Image*](glossary.md#base-image) from which you are building.
 
 Docker treats lines that *begin* with `#` as a comment, unless the line is
-a valid [parser directive](builder.md#parser-directives). A `#` marker anywhere
+a valid [parser directive](#parser-directives). A `#` marker anywhere
 else in a line is treated as an argument. This allows statements like:
 
 ```Dockerfile
@@ -1265,9 +1274,9 @@ The output of the final `pwd` command in this `Dockerfile` would be
     ARG <name>[=<default value>]
 
 The `ARG` instruction defines a variable that users can pass at build-time to
-the builder with the `docker build` command using the `--build-arg
-<varname>=<value>` flag. If a user specifies a build argument that was not
-defined in the Dockerfile, the build outputs an error.
+the builder with the `docker build` command using the
+`--build-arg <varname>=<value>` flag. If a user specifies a build argument
+that was not defined in the Dockerfile, the build outputs an error.
 
 ```
 One or more build-args were not consumed, failing build.
@@ -1380,8 +1389,11 @@ corresponding `ARG` instruction in the Dockerfile.
 * `NO_PROXY`
 * `no_proxy`
 
-To use these, simply pass them on the command line using the `--build-arg
-<varname>=<value>` flag.
+To use these, simply pass them on the command line using the flag:
+
+```
+--build-arg <varname>=<value>
+```
 
 ### Impact on build caching
 

--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -4,6 +4,15 @@ description: "The attach command description and usage"
 keywords: ["attach, running, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # attach
 
 ```markdown
@@ -38,13 +47,13 @@ the container. You can detach from a container and leave it running using the
 It is forbidden to redirect the standard input of a `docker attach` command
 while attaching to a tty-enabled container (i.e.: launched with `-t`).
 
-While a client is connected to container's stdio using `docker attach`, Docker 
-uses a ~1MB memory buffer to maximize the throughput of the application. If 
-this buffer is filled, the speed of the API connection will start to have an 
-effect on the process output writing speed. This is similar to other 
-applications like SSH. Because of this, it is not recommended to run 
-performance critical applications that generate a lot of output in the 
-foreground over a slow client connection. Instead, users should use the 
+While a client is connected to container's stdio using `docker attach`, Docker
+uses a ~1MB memory buffer to maximize the throughput of the application. If
+this buffer is filled, the speed of the API connection will start to have an
+effect on the process output writing speed. This is similar to other
+applications like SSH. Because of this, it is not recommended to run
+performance critical applications that generate a lot of output in the
+foreground over a slow client connection. Instead, users should use the
 `docker logs` command to get access to the logs.
 
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -4,6 +4,15 @@ description: "The build command description and usage"
 keywords: ["build, docker, image"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # build
 
 ```markdown
@@ -397,9 +406,9 @@ For detailed information on using `ARG` and `ENV` instructions, see the
 
 ### Optional security options (--security-opt)
 
-This flag is only supported on a daemon running on Windows, and only supports 
+This flag is only supported on a daemon running on Windows, and only supports
 the `credentialspec` option. The `credentialspec` must be in the format
-`file://spec.txt` or `registry://keyname`. 
+`file://spec.txt` or `registry://keyname`.
 
 ### Specify isolation technology for container (--isolation)
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -4,6 +4,15 @@ description: "Docker's CLI command description and usage"
 keywords: ["Docker, Docker documentation, CLI,  command line"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Use the Docker command line
 
 To list available commands, either run `docker` with no parameters
@@ -147,6 +156,7 @@ list of supported formatting directives, see the
 
 Following is a sample `config.json` file:
 
+    {% raw %}
     {
       "HttpHeaders": {
         "MyHeader": "MyValue"
@@ -156,6 +166,7 @@ Following is a sample `config.json` file:
       "serviceInspectFormat": "pretty",
       "detachKeys": "ctrl-e,e"
     }
+    {% endraw %}
 
 ### Notary
 

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -4,6 +4,15 @@ description: "The commit command description and usage"
 keywords: ["commit, file, changes"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # commit
 
 ```markdown
@@ -51,6 +60,7 @@ created.  Supported `Dockerfile` instructions:
 
 ## Commit a container with new configurations
 
+    {% raw %}
     $ docker ps
     ID                  IMAGE               COMMAND             CREATED             STATUS              PORTS
     c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
@@ -61,8 +71,9 @@ created.  Supported `Dockerfile` instructions:
     f5283438590d
     $ docker inspect -f "{{ .Config.Env }}" f5283438590d
     [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true]
+    {% endraw %}
 
-## Commit a container with new `CMD` and `EXPOSE` instructions 
+## Commit a container with new `CMD` and `EXPOSE` instructions
 
     $ docker ps
     ID                  IMAGE               COMMAND             CREATED             STATUS              PORTS
@@ -71,7 +82,7 @@ created.  Supported `Dockerfile` instructions:
 
     $ docker commit --change='CMD ["apachectl", "-DFOREGROUND"]' -c "EXPOSE 80" c3f279d17e0a  svendowideit/testimage:version4
     f5283438590d
-    
+
     $ docker run -d svendowideit/testimage:version4
     89373736e2e7f00bc149bd783073ac43d0507da250e999f3f1036e0db60817c0
 

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -4,6 +4,15 @@ description: "Remove all stopped containers"
 keywords: [container, prune, delete, remove]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # container prune
 
 ```markdown

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -4,6 +4,15 @@ description: "The cp command description and usage"
 keywords: ["copy, container, files, folders"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # cp
 
 ```markdown
@@ -29,7 +38,7 @@ either the `SRC_PATH` or `DEST_PATH`, you can also stream a tar archive from
 `STDIN` or to `STDOUT`. The `CONTAINER` can be a running or stopped container.
 The `SRC_PATH` or `DEST_PATH` can be a file or directory.
 
-The `docker cp` command assumes container paths are relative to the container's 
+The `docker cp` command assumes container paths are relative to the container's
 `/` (root) directory. This means supplying the initial forward slash is optional;
 The command sees `compassionate_darwin:/tmp/foo/myfile.txt` and
 `compassionate_darwin:tmp/foo/myfile.txt` as identical. Local machine paths can
@@ -74,7 +83,7 @@ argument of `DEST_PATH`, the behavior is as follows:
 
 The command requires `SRC_PATH` and `DEST_PATH` to exist according to the above
 rules. If `SRC_PATH` is local and is a symbolic link, the symbolic link, not
-the target, is copied by default. To copy the link target and not the link, specify 
+the target, is copied by default. To copy the link target and not the link, specify
 the `-L` option.
 
 A colon (`:`) is used as a delimiter between `CONTAINER` and its path. You can

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -4,6 +4,15 @@ description: "The create command description and usage"
 keywords: ["docker, create, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # create
 
 Creates a new container.
@@ -167,7 +176,7 @@ Set storage driver options per container.
 
     $ docker create -it --storage-opt size=120G fedora /bin/bash
 
-This (size) will allow to set the container rootfs size to 120G at creation time. 
+This (size) will allow to set the container rootfs size to 120G at creation time.
 This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
 `windowsfilter` and `zfs` graph drivers.
 For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -5,6 +5,15 @@ keywords: ["stack, deploy"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stack deploy (experimental)
 
 ```markdown

--- a/docs/reference/commandline/diff.md
+++ b/docs/reference/commandline/diff.md
@@ -4,6 +4,15 @@ description: "The diff command description and usage"
 keywords: ["list, changed, files, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # diff
 
 ```markdown

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -5,6 +5,15 @@ description: "The daemon command description and usage"
 keywords: ["container, daemon, runtime"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # daemon
 
 ```markdown
@@ -279,7 +288,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
 
 #### Devicemapper options
 
-*  `dm.thinpooldev`
+*   `dm.thinpooldev`
 
     Specifies a custom block storage device to use for the thin pool.
 
@@ -306,7 +315,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.thinpooldev=/dev/mapper/thin-pool
     ```
 
-*  `dm.basesize`
+*   `dm.basesize`
 
     Specifies the size to use when creating the base device, which limits the
     size of images and containers. The default value is 10G. Note, thin devices
@@ -323,7 +332,6 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     ```bash
     $ sudo dockerd --storage-opt dm.basesize=50G
     ```
-
 
     This will increase the base device size to 50G. The Docker daemon will throw an
     error if existing base device size is larger than 50G. A user can use
@@ -345,7 +353,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.basesize=20G
     ```
 
-*  `dm.loopdatasize`
+*   `dm.loopdatasize`
 
     > **Note**:
     > This option configures devicemapper loopback, which should not
@@ -362,7 +370,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.loopdatasize=200G
     ```
 
-*  `dm.loopmetadatasize`
+*   `dm.loopmetadatasize`
 
     > **Note**:
     > This option configures devicemapper loopback, which should not
@@ -379,7 +387,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.loopmetadatasize=4G
     ```
 
-*  `dm.fs`
+*   `dm.fs`
 
     Specifies the filesystem type to use for the base device. The supported
     options are "ext4" and "xfs". The default is "xfs"
@@ -390,7 +398,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.fs=ext4
     ```
 
-*  `dm.mkfsarg`
+*   `dm.mkfsarg`
 
     Specifies extra mkfs arguments to be used when creating the base device.
 
@@ -400,7 +408,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt "dm.mkfsarg=-O ^has_journal"
     ```
 
-*  `dm.mountopt`
+*   `dm.mountopt`
 
     Specifies extra mount options used when mounting the thin devices.
 
@@ -410,7 +418,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.mountopt=nodiscard
     ```
 
-*  `dm.datadev`
+*   `dm.datadev`
 
     (Deprecated, use `dm.thinpooldev`)
 
@@ -428,7 +436,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
           --storage-opt dm.metadatadev=/dev/sdc1
     ```
 
-*  `dm.metadatadev`
+*   `dm.metadatadev`
 
     (Deprecated, use `dm.thinpooldev`)
 
@@ -452,7 +460,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
           --storage-opt dm.metadatadev=/dev/sdc1
     ```
 
-*  `dm.blocksize`
+*   `dm.blocksize`
 
     Specifies a custom blocksize to use for the thin pool. The default
     blocksize is 64K.
@@ -463,7 +471,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.blocksize=512K
     ```
 
-*  `dm.blkdiscard`
+*   `dm.blkdiscard`
 
     Enables or disables the use of blkdiscard when removing devicemapper
     devices. This is enabled by default (only) if using loopback devices and is
@@ -479,7 +487,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.blkdiscard=false
     ```
 
-*  `dm.override_udev_sync_check`
+*   `dm.override_udev_sync_check`
 
     Overrides the `udev` synchronization checks between `devicemapper` and `udev`.
     `udev` is the device manager for the Linux kernel.
@@ -519,7 +527,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     > Otherwise, set this flag for migrating existing Docker daemons to
     > a daemon with a supported environment.
 
-*  `dm.use_deferred_removal`
+*   `dm.use_deferred_removal`
 
     Enables use of deferred device removal if `libdm` and the kernel driver
     support the mechanism.
@@ -541,7 +549,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     $ sudo dockerd --storage-opt dm.use_deferred_removal=true
     ```
 
-*  `dm.use_deferred_deletion`
+*   `dm.use_deferred_deletion`
 
     Enables use of deferred device deletion for thin pool devices. By default,
     thin pool device deletion is synchronous. Before a container is deleted,
@@ -567,7 +575,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
     when unintentional leaking of mount point happens across multiple mount
     namespaces.
 
-*  `dm.min_free_space`
+*   `dm.min_free_space`
 
     Specifies the min free space percent in a thin pool require for new device
     creation to succeed. This check applies to both free data space as well
@@ -615,7 +623,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
 
 #### ZFS options
 
-* `zfs.fsname`
+*   `zfs.fsname`
 
     Set zfs filesystem under which docker will create its own datasets.
     By default docker will pick up the zfs filesystem where docker graph
@@ -629,9 +637,9 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
 
 #### Btrfs options
 
-* `btrfs.min_space`
+*   `btrfs.min_space`
 
-    Specifies the mininum size to use when creating the subvolume which is used
+    Specifies the minimum size to use when creating the subvolume which is used
     for containers. If user uses disk quota for btrfs when creating or running
     a container with **--storage-opt size** option, docker should ensure the
     **size** cannot be smaller than **btrfs.min_space**.
@@ -644,7 +652,7 @@ options for `zfs` start with `zfs` and options for `btrfs` start with `btrfs`.
 
 #### Overlay2 options
 
-* `overlay2.override_kernel_check`
+*   `overlay2.override_kernel_check`
 
     Overrides the Linux kernel version check allowing overlay2. Support for
     specifying multiple lower directories needed by overlay2 was added to the
@@ -672,19 +680,20 @@ Runtimes can be registered with the daemon either via the
 configuration file or using the `--add-runtime` command line argument.
 
 The following is an example adding 2 runtimes via the configuration:
+
 ```json
-	"default-runtime": "runc",
-	"runtimes": {
-		"runc": {
-			"path": "runc"
-		},
-		"custom": {
-			"path": "/usr/local/bin/my-runc-replacement",
-			"runtimeArgs": [
-				"--debug"
-			]
-		}
+"default-runtime": "runc",
+"runtimes": {
+	"runc": {
+		"path": "runc"
+	},
+	"custom": {
+		"path": "/usr/local/bin/my-runc-replacement",
+		"runtimeArgs": [
+			"--debug"
+		]
 	}
+}
 ```
 
 This is the same example via the command line:
@@ -844,35 +853,35 @@ $ sudo dockerd \
 
 The currently supported cluster store options are:
 
-*  `discovery.heartbeat`
+*   `discovery.heartbeat`
 
     Specifies the heartbeat timer in seconds which is used by the daemon as a
     keepalive mechanism to make sure discovery module treats the node as alive
     in the cluster. If not configured, the default value is 20 seconds.
 
-*  `discovery.ttl`
+*   `discovery.ttl`
 
     Specifies the ttl (time-to-live) in seconds which is used by the discovery
     module to timeout a node if a valid heartbeat is not received within the
     configured ttl value. If not configured, the default value is 60 seconds.
 
-*  `kv.cacertfile`
+*   `kv.cacertfile`
 
     Specifies the path to a local file with PEM encoded CA certificates to trust
 
-*  `kv.certfile`
+*   `kv.certfile`
 
     Specifies the path to a local file with a PEM encoded certificate.  This
     certificate is used as the client cert for communication with the
     Key/Value store.
 
-*  `kv.keyfile`
+*   `kv.keyfile`
 
     Specifies the path to a local file with a PEM encoded private key.  This
     private key is used as the client key for communication with the
     Key/Value store.
 
-*  `kv.path`
+*   `kv.path`
 
     Specifies the path in the Key/Value store. If not configured, the default value is 'docker/nodes'.
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -4,6 +4,15 @@ description: "The events command description and usage"
 keywords: ["events, container, report"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # events
 
 ```markdown

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -4,6 +4,15 @@ description: "The exec command description and usage"
 keywords: ["command, container, run, execute"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # exec
 
 ```markdown

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -4,6 +4,15 @@ description: "The export command description and usage"
 keywords: ["export, file, system, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # export
 
 ```markdown

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -4,6 +4,15 @@ description: "The history command description and usage"
 keywords: ["docker, image, history"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # history
 
 ```markdown

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -4,6 +4,15 @@ description: "Remove all stopped images"
 keywords: [image, prune, delete, remove]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # image prune
 
 ```markdown

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -4,6 +4,15 @@ description: "The images command description and usage"
 keywords: ["list, docker, images"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # images
 
 ```markdown
@@ -245,6 +254,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID` and `Repository` entries separated by a colon for all images:
 
+    {% raw %}
     $ docker images --format "{{.ID}}: {{.Repository}}"
     77af4d6b9913: <none>
     b6fa739cedf5: committ
@@ -255,10 +265,12 @@ The following example uses a template without headers and outputs the
     746b819f315e: postgres
     746b819f315e: postgres
     746b819f315e: postgres
+    {% endraw %}
 
 To list all images with their repository and tag in a table format you
 can use:
 
+    {% raw %}
     $ docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}"
     IMAGE ID            REPOSITORY                TAG
     77af4d6b9913        <none>                    <none>
@@ -270,3 +282,4 @@ can use:
     746b819f315e        postgres                  9.3
     746b819f315e        postgres                  9.3.5
     746b819f315e        postgres                  latest
+    {% endraw %}

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -4,6 +4,15 @@ description: "The import command description and usage"
 keywords: ["import, file, system, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # import
 
 ```markdown

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -5,7 +5,14 @@ keywords: ["Docker, Docker documentation, CLI,  command line"]
 identifier: "smn_cli_guide"
 ---
 
-
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 # The Docker commands
 

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -4,6 +4,15 @@ description: "The info command description and usage"
 keywords: ["display, docker, information"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # info
 
 ```markdown
@@ -55,7 +64,7 @@ storage driver and a node that is part of a 2-node swarm:
     Plugins:
      Volume: local
      Network: bridge null host overlay
-    Swarm: 
+    Swarm:
      NodeID: 0gac67oclbxq7
      Is Manager: true
      Managers: 2

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -4,6 +4,15 @@ description: "The inspect command description and usage"
 keywords: ["inspect, container, json"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # inspect
 
 ```markdown
@@ -34,29 +43,39 @@ describes all the details of the format.
 For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
 
+    {% raw %}
     $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $INSTANCE_ID
+    {% endraw %}
 
 **Get an instance's MAC address:**
 
 For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
 
+    {% raw %}
     $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.MacAddress}}{{end}}' $INSTANCE_ID
+    {% endraw %}
 
 **Get an instance's log path:**
 
+    {% raw %}
     $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID
+    {% endraw %}
 
 **Get a Task's image name:**
 
+    {% raw %}
     $ docker inspect --format='{{.Container.Spec.Image}}' $INSTANCE_ID
+    {% endraw %}
 
 **List all port bindings:**
 
 One can loop over arrays and maps in the results to produce simple text
 output:
 
+    {% raw %}
     $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
+    {% endraw %}
 
 **Find a specific port mapping:**
 
@@ -68,7 +87,9 @@ numeric public port, you use `index` to find the specific port map, and
 then `index` 0 contains the first object inside of that. Then we ask for
 the `HostPort` field to get the public address.
 
+    {% raw %}
     $ docker inspect --format='{{(index (index .NetworkSettings.Ports "8787/tcp") 0).HostPort}}' $INSTANCE_ID
+    {% endraw %}
 
 **Get a subsection in JSON format:**
 
@@ -77,4 +98,6 @@ fields, by default you get a Go-style dump of the inner values.
 Docker adds a template function, `json`, which can be applied to get
 results in JSON format.
 
+    {% raw %}
     $ docker inspect --format='{{json .Config}}' $INSTANCE_ID
+    {% endraw %}

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -4,6 +4,15 @@ description: "The kill command description and usage"
 keywords: ["container, kill, signal"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # kill
 
 ```markdown

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -4,6 +4,15 @@ description: "The load command description and usage"
 keywords: ["stdin, tarred, repository"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # load
 
 ```markdown

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -4,6 +4,15 @@ description: "The login command description and usage"
 keywords: ["registry, login, image"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # login
 
 ```markdown
@@ -48,12 +57,12 @@ This is the list of currently available credentials helpers and where
 you can download them from:
 
 - D-Bus Secret Service: https://github.com/docker/docker-credential-helpers/releases
-- Apple OS X keychain: https://github.com/docker/docker-credential-helpers/releases
+- Apple macOS keychain: https://github.com/docker/docker-credential-helpers/releases
 - Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases
 
 ### Usage
 
-You need to speficy the credentials store in `$HOME/.docker/config.json`
+You need to specify the credentials store in `$HOME/.docker/config.json`
 to tell the docker engine to use it:
 
 ```json

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -4,6 +4,15 @@ description: "The logout command description and usage"
 keywords: ["logout, docker, registry"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # logout
 
 ```markdown

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -4,6 +4,15 @@ description: "The logs command description and usage"
 keywords: ["logs, retrieve, docker"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # logs
 
 ```markdown

--- a/docs/reference/commandline/menu.md
+++ b/docs/reference/commandline/menu.md
@@ -5,7 +5,14 @@ keywords: ["Docker, Docker documentation, CLI,  command line"]
 identifier:  "smn_cli"
 ---
 
-
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 # The Docker commands
 

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -4,6 +4,15 @@ description: "The network connect command description and usage"
 keywords: ["network, connect, user-defined"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # network connect
 
 ```markdown

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -4,6 +4,15 @@ description: "The network create command description and usage"
 keywords: ["network, create"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # network create
 
 ```markdown
@@ -129,7 +138,7 @@ support it you can create multiple subnetworks.
 $ docker network create -d overlay \
   --subnet=192.168.0.0/16 \
   --subnet=192.170.0.0/16 \
-  --gateway=192.168.0.100 \ 
+  --gateway=192.168.0.100 \
   --gateway=192.170.0.100 \
   --ip-range=192.168.1.0/24 \
   --aux-address="my-router=192.168.1.5" --aux-address="my-switch=192.168.1.6" \

--- a/docs/reference/commandline/network_disconnect.md
+++ b/docs/reference/commandline/network_disconnect.md
@@ -4,6 +4,15 @@ description: "The network disconnect command description and usage"
 keywords: ["network, disconnect, user-defined"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # network disconnect
 
 ```markdown

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -4,6 +4,15 @@ description: "The network inspect command description and usage"
 keywords: ["network, inspect, user-defined"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # network inspect
 
 ```markdown

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -4,6 +4,15 @@ description: "The network ls command description and usage"
 keywords: ["network, list, user-defined"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # docker network ls
 
 ```markdown
@@ -175,7 +184,7 @@ Valid placeholders for the Go template are listed below:
 
 Placeholder | Description
 ------------|------------------------------------------------------------------------------------------
-`.ID`       | Network ID 
+`.ID`       | Network ID
 `.Name`     | Network name
 `.Driver`   | Network driver
 `.Scope`    | Network scope (local, global)

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -4,6 +4,15 @@ description: "the network rm command description and usage"
 keywords: ["network, rm, user-defined"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # network rm
 
 ```markdown

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -4,6 +4,15 @@ description: "The node demote command description and usage"
 keywords: ["node, demote"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # node demote
 
 ```markdown

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -4,6 +4,15 @@ description: "The node inspect command description and usage"
 keywords: ["node, inspect"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # node inspect
 
 ```markdown
@@ -89,8 +98,10 @@ Example output:
     }
     ]
 
+    {% raw %}
     $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self
     false
+    {% endraw %}
 
     $ docker node inspect --pretty self
     ID:                     e216jshn25ckzbvmwlnh5jr3g

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -4,6 +4,15 @@ description: "The node ls command description and usage"
 keywords: ["node, list"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # node ls
 
 ```markdown

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -4,6 +4,15 @@ description: "The node promote command description and usage"
 keywords: ["node, promote"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # node promote
 
 ```markdown

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -5,6 +5,15 @@ keywords: ["node, tasks", "ps"]
 aliases: ["/engine/reference/commandline/node_tasks/"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # node ps
 
 ```markdown

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -4,6 +4,15 @@ description: "The node rm command description and usage"
 keywords: ["node, remove"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # node rm
 
 ```markdown

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -4,6 +4,15 @@ description: "The node update command description and usage"
 keywords: ["resources, update, dynamically"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 ## update
 
 ```markdown

--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -4,6 +4,15 @@ description: "The pause command description and usage"
 keywords: ["cgroups, container, suspend, SIGSTOP"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # pause
 
 ```markdown

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -5,6 +5,15 @@ keywords: ["plugin, disable"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # plugin disable (experimental)
 
 ```markdown

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -5,6 +5,15 @@ keywords: ["plugin, enable"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # plugin enable (experimental)
 
 ```markdown

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -5,6 +5,15 @@ keywords: ["plugin, inspect"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # plugin inspect (experimental)
 
 ```markdown

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -5,6 +5,15 @@ keywords: ["plugin, install"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # plugin install (experimental)
 
 ```markdown

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -5,6 +5,15 @@ keywords: ["plugin, list"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # plugin ls (experimental)
 
 ```markdown

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -5,6 +5,15 @@ keywords: ["plugin, rm"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # plugin rm (experimental)
 
 ```markdown

--- a/docs/reference/commandline/port.md
+++ b/docs/reference/commandline/port.md
@@ -4,6 +4,15 @@ description: "The port command description and usage"
 keywords: ["port, mapping, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # port
 
 ```markdown

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -4,6 +4,15 @@ description: "The ps command description and usage"
 keywords: ["container, running, list"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # ps
 
 ```markdown
@@ -145,6 +154,7 @@ $ docker ps -a --filter 'exited=137'
 CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES
 b3e1c0ed5bfe        ubuntu:latest       "sleep 1000"           12 seconds ago      Exited (137) 5 seconds ago                       grave_kowalevski
 a2eb5558d669        redis:latest        "/entrypoint.sh redi   2 hours ago         Exited (137) 2 hours ago                         sharp_lalande
+```
 
 Any of these events result in a `137` status:
 
@@ -271,7 +281,7 @@ CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS        
 The `volume` filter shows only containers that mount a specific volume or have
 a volume mounted in a specific path:
 
-```bash
+```bash{% raw %}
 $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
 CONTAINER ID        MOUNTS
 9c3527ed70ce        remote-volume
@@ -279,7 +289,7 @@ CONTAINER ID        MOUNTS
 $ docker ps --filter volume=/data --format "table {{.ID}}\t{{.Mounts}}"
 CONTAINER ID        MOUNTS
 9c3527ed70ce        remote-volume
-```
+{% endraw %}```
 
 #### Network
 
@@ -304,7 +314,9 @@ example shows all containers that are attached to the `net1` network, using
 the network id as a filter;
 
 ```bash
+{% raw %}
 $ docker network inspect --format "{{.ID}}" net1
+{% endraw %}
 
 8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
 
@@ -333,7 +345,7 @@ Placeholder   | Description
 `.Size`       | Container disk size.
 `.Names`      | Container names.
 `.Labels`     | All labels assigned to the container.
-`.Label`      | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'`
+`.Label`      | Value of a specific label for this container. For example `'{% raw %}{{.Label "com.docker.swarm.cpu"}}{% endraw %}'`
 `.Mounts`     | Names of the volumes mounted in this container.
 
 When using the `--format` option, the `ps` command will either output the data
@@ -344,7 +356,9 @@ The following example uses a template without headers and outputs the `ID` and
 `Command` entries separated by a colon for all running containers:
 
 ```bash
+{% raw %}
 $ docker ps --format "{{.ID}}: {{.Command}}"
+{% endraw %}
 
 a87ecb4f327c: /bin/sh -c #(nop) MA
 01946d9d34d8: /bin/sh -c #(nop) MA
@@ -355,7 +369,9 @@ c1d3b0166030: /bin/sh -c yum -y up
 To list all running containers with their labels in a table format you can use:
 
 ```bash
+{% raw %}
 $ docker ps --format "table {{.ID}}\t{{.Labels}}"
+{% endraw %}
 
 CONTAINER ID        LABELS
 a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -4,6 +4,15 @@ description: "The pull command description and usage"
 keywords: ["pull, image, hub, docker"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # pull
 
 ```markdown
@@ -131,7 +140,7 @@ above, the digest of the image is:
 Docker also prints the digest of an image when *pushing* to a registry. This
 may be useful if you want to pin to a version of the image you just pushed.
 
-A digest takes the place of the tag when pulling an image, for example, to 
+A digest takes the place of the tag when pulling an image, for example, to
 pull the above image by digest, run the following command:
 
 ```bash
@@ -154,7 +163,7 @@ MAINTAINER some maintainer <maintainer@example.com>
 ```
 
 > **Note**: Using this feature "pins" an image to a specific version in time.
-> Docker will therefore not pull updated versions of an image, which may include 
+> Docker will therefore not pull updated versions of an image, which may include
 > security updates. If you want to pull an updated image, you need to change the
 > digest accordingly.
 

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -4,6 +4,15 @@ description: "The push command description and usage"
 keywords: ["share, push, image"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # push
 
 ```markdown

--- a/docs/reference/commandline/rename.md
+++ b/docs/reference/commandline/rename.md
@@ -4,6 +4,15 @@ description: "The rename command description and usage"
 keywords: ["rename, docker, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # rename
 
 ```markdown

--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -4,6 +4,15 @@ description: "The restart command description and usage"
 keywords: ["restart, container, Docker"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # restart
 
 ```markdown

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -4,6 +4,15 @@ description: "The rm command description and usage"
 keywords: ["remove, Docker, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # rm
 
 ```markdown

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -4,6 +4,15 @@ description: "The rmi command description and usage"
 keywords: ["remove, image, Docker"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # rmi
 
 ```markdown

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -4,6 +4,15 @@ description: "The run command description and usage"
 keywords: ["run, command, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # run
 
 ```markdown
@@ -618,8 +627,8 @@ or a signal name in the format SIGNAME, for instance SIGKILL.
 
 ### Optional security options (--security-opt)
 
-On Windows, this flag can be used to specify the `credentialspec` option. 
-The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`. 
+On Windows, this flag can be used to specify the `credentialspec` option.
+The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`.
 
 ### Stop container with timeout (--stop-timeout)
 
@@ -673,7 +682,7 @@ network namespace, run this command:
 
 
 > **Note**: Not all sysctls are namespaced. Docker does not support changing sysctls
-> inside of a container that also modify the host system. As the kernel 
+> inside of a container that also modify the host system. As the kernel
 > evolves we expect to see more sysctls become namespaced.
 
 #### Currently supported sysctls

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -4,6 +4,15 @@ description: "The save command description and usage"
 keywords: ["tarred, repository, backup"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # save
 
 ```markdown

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -4,6 +4,15 @@ description: "The search command description and usage"
 keywords: ["search, hub, images"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # search
 
 ```markdown
@@ -76,7 +85,7 @@ at least 3 stars and the description isn't truncated in the output:
 
 ## Limit search results (--limit)
 
-The flag `--limit` is the maximium number of results returned by a search. This value could
+The flag `--limit` is the maximum number of results returned by a search. This value could
 be in the range between 1 and 100. The default value of `--limit` is 25.
 
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -4,6 +4,15 @@ description: "The service create command description and usage"
 keywords: ["service, create"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service create
 
 ```Markdown

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -4,6 +4,15 @@ description: "The service inspect command description and usage"
 keywords: ["service, inspect"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service inspect
 
 ```Markdown
@@ -136,10 +145,10 @@ The `--format` option can be used to obtain specific information about a
 service. For example, the following command outputs the number of replicas
 of the "redis" service.
 
-```bash
+```bash{% raw %}
 $ docker service inspect --format='{{.Spec.Mode.Replicated.Replicas}}' redis
 10
-```
+{% endraw %}```
 
 
 ## Related information

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -4,6 +4,15 @@ description: "The service ls command description and usage"
 keywords: ["service, ls"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service ls
 
 ```Markdown

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -5,6 +5,15 @@ keywords: ["service, tasks", "ps"]
 aliases: ["/engine/reference/commandline/service_tasks/"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service ps
 
 ```Markdown

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -4,6 +4,15 @@ description: "The service rm command description and usage"
 keywords: ["service, rm"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service rm
 
 ```Markdown

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -4,6 +4,15 @@ description: "The service scale command description and usage"
 keywords: ["service, scale"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service scale
 
 ```markdown
@@ -19,8 +28,10 @@ Options:
 
 ### Scale a service
 
-If you scale a service, you set the *desired* number of replicas. Even though
-the command returns directly, actual scaling of the service may take some time.
+The scale command enables you to scale one or more services either up or down to
+the desired number of replicas. The command will return immediately, but the
+actual scaling of the service may take some time. To stop all replicas of a
+service while keeping the service active in the swarm you can set the scale to 0.
 
 For example, the following command scales the "frontend" service to 50 tasks.
 
@@ -30,7 +41,7 @@ frontend scaled to 50
 ```
 
 Directly afterwards, run `docker service ls`, to see the actual number of
-replicas
+replicas.
 
 ```bash
 $ docker service ls --filter name=frontend
@@ -40,7 +51,7 @@ ID            NAME      REPLICAS  IMAGE         COMMAND
 ```
 
 You can also scale a service using the [`docker service update`](service_update.md)
-command. The following commands are therefore equivalent:
+command. The following commands are equivalent:
 
 ```bash
 $ docker service scale frontend=50

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -4,6 +4,15 @@ description: "The service update command description and usage"
 keywords: ["service, update"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # service update
 
 ```Markdown

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -5,6 +5,15 @@ keywords: ["stack, config"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stack config (experimental)
 
 ```markdown

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -5,6 +5,15 @@ keywords: ["stack, deploy, up"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stack deploy (experimental)
 
 ```markdown

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -5,6 +5,15 @@ keywords: ["stack, ls"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stack ls (experimental)
 
 ```markdown

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -5,6 +5,15 @@ keywords: ["stack, ps"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stack ps (experimental)
 
 ```markdown

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -3,9 +3,16 @@ title: "stack rm"
 description: "The stack rm command description and usage"
 keywords: ["stack, rm, remove, down"]
 advisory: "experimental"
-
-
 ---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 # stack rm (experimental)
 

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -5,6 +5,15 @@ keywords: ["stack, services"]
 advisory: "experimental"
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stack services (experimental)
 
 ```markdown

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -4,6 +4,15 @@ description: "The start command description and usage"
 keywords: ["Start, container, stopped"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # start
 
 ```markdown

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -4,6 +4,15 @@ description: "The stats command description and usage"
 keywords: ["container, resource, statistics"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stats
 
 ```markdown

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -4,6 +4,15 @@ description: "The stop command description and usage"
 keywords: ["stop, SIGKILL, SIGTERM"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # stop
 
 ```markdown

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -4,6 +4,15 @@ description: "The swarm init command description and usage"
 keywords: ["swarm, init"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # swarm init
 
 ```markdown

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -4,6 +4,15 @@ description: "The swarm join command description and usage"
 keywords: ["swarm, join"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # swarm join
 
 ```markdown

--- a/docs/reference/commandline/swarm_join_token.md
+++ b/docs/reference/commandline/swarm_join_token.md
@@ -4,6 +4,15 @@ description: "The swarm join-token command description and usage"
 keywords: ["swarm, join-token"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # swarm join-token
 
 ```markdown

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -4,6 +4,15 @@ description: "The swarm leave command description and usage"
 keywords: ["swarm, leave"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # swarm leave
 
 ```markdown

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -4,6 +4,15 @@ description: "The swarm update command description and usage"
 keywords: ["swarm, update"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # swarm update
 
 ```markdown

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -4,6 +4,15 @@ description: "The system df command description and usage"
 keywords: [system, data, usage, disk]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # system df
 
 ```markdown

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -4,6 +4,15 @@ description: "Remove unused data"
 keywords: [system, prune, delete, remove]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # system prune
 
 ```markdown

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -4,6 +4,15 @@ description: "The tag command description and usage"
 keywords: ["tag, name, image"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # tag
 
 ```markdown

--- a/docs/reference/commandline/top.md
+++ b/docs/reference/commandline/top.md
@@ -4,6 +4,15 @@ description: "The top command description and usage"
 keywords: ["container, running, processes"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # top
 
 ```markdown

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -4,6 +4,15 @@ description: "The unpause command description and usage"
 keywords: ["cgroups, suspend, container"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # unpause
 
 ```markdown

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -4,6 +4,15 @@ description: "The update command description and usage"
 keywords: ["resources, update, dynamically"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 ## update
 
 ```markdown

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -4,6 +4,15 @@ description: "The version command description and usage"
 keywords: ["version, architecture, api"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # version
 
 ```markdown
@@ -45,10 +54,14 @@ describes all the details of the format.
 
 **Get server version:**
 
+    {% raw %}
     $ docker version --format '{{.Server.Version}}'
 	1.8.0
+    {% endraw %}
 
 **Dump raw data:**
 
+    {% raw %}
     $ docker version --format '{{json .}}'
     {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
+    {% endraw %}

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -4,6 +4,15 @@ description: "The volume create command description and usage"
 keywords: ["volume, create"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # volume create
 
 ```markdown

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -4,6 +4,15 @@ description: "The volume inspect command description and usage"
 keywords: ["volume, inspect"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # volume inspect
 
 ```markdown
@@ -36,8 +45,10 @@ Example output:
       }
     ]
 
+    {% raw %}
     $ docker volume inspect --format '{{ .Mountpoint }}' 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
     /var/lib/docker/volumes/85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d/_data
+    {% endraw %}
 
 ## Related information
 

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -4,6 +4,15 @@ description: "The volume ls command description and usage"
 keywords: ["volume, list"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # volume ls
 
 ```markdown

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -4,6 +4,15 @@ description: "Remove unused volumes"
 keywords: [volume, prune, delete]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # volume prune
 
 ```markdown

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -4,6 +4,14 @@ description: "the volume rm command description and usage"
 keywords: ["volume, rm"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
 
 # volume rm
 

--- a/docs/reference/commandline/wait.md
+++ b/docs/reference/commandline/wait.md
@@ -4,6 +4,15 @@ description: "The wait command description and usage"
 keywords: ["container, stop, wait"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # wait
 
 ```markdown

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -4,6 +4,15 @@ description: "Glossary of terms used around Docker"
 keywords: ["glossary, docker, terms,  definitions"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Glossary
 
 A list of terms used around the Docker project.
@@ -110,7 +119,7 @@ Examples :
 
 - Linux : ext4, aufs, btrfs, zfs
 - Windows : NTFS
-- OS X : HFS+
+- macOS : HFS+
 
 ## image
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,6 +4,15 @@ description: "Docker Engine reference"
 keywords: ["Engine"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Engine reference
 
 * [Dockerfile reference](builder.md)

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -4,6 +4,15 @@ description: "Configure containers at runtime"
 keywords: ["docker, run, configure,  runtime"]
 ---
 
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
 # Docker run reference
 
 Docker runs processes in isolated containers. A container is a process
@@ -415,7 +424,7 @@ running the `redis-cli` command and connecting to the Redis server over the
 You can create a network using a Docker network driver or an external network
 driver plugin. You can connect multiple containers to the same network. Once
 connected to a user-defined network, the containers can communicate easily using
-only another container's IP address or name.  
+only another container's IP address or name.
 
 For `overlay` networks or custom plugins that support multi-host connectivity,
 containers connected to the same multi-host network but launched from different
@@ -532,13 +541,17 @@ will try forever to restart the container. The number of (attempted) restarts
 for a container can be obtained via [`docker inspect`](commandline/inspect.md). For example, to get the number of restarts
 for container "my-container";
 
+    {% raw %}
     $ docker inspect -f "{{ .RestartCount }}" my-container
     # 2
+    {% endraw %}
 
 Or, to get the last time the container was (re)started;
 
+    {% raw %}
     $ docker inspect -f "{{ .State.StartedAt }}" my-container
     # 2015-03-04T23:47:07.691840179Z
+    {% endraw %}
 
 
 Combining `--restart` (restart policy) with the `--rm` (clean up) flag results
@@ -1369,34 +1382,12 @@ it will provide a named alias for the container being linked to.
 When a new container is created, Docker will set the following environment
 variables automatically:
 
-<table>
- <tr>
-  <th>Variable</th>
-  <th>Value</th>
- </tr>
- <tr>
-  <td><code>HOME</code></td>
-  <td>
-    Set based on the value of <code>USER</code>
-  </td>
- </tr>
- <tr>
-  <td><code>HOSTNAME</code></td>
-  <td>
-    The hostname associated with the container
-  </td>
- </tr>
- <tr>
-  <td><code>PATH</code></td>
-  <td>
-    Includes popular directories, such as :<br>
-    <code>/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</code>
-  </td>
- <tr>
-  <td><code>TERM</code></td>
-  <td><code>xterm</code> if the container is allocated a pseudo-TTY</td>
- </tr>
-</table>
+| Variable | Value |
+| -------- | ----- |
+| `HOME` | Set based on the value of `USER` |
+| `HOSTNAME` | The hostname associated with the container |
+| `PATH` | Includes popular directories, such as `:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` |
+| `TERM` | `xterm` if the container is allocated a pseudo-TTY |
 
 Additionally, the operator can **set any environment variable** in the
 container by using one or more `-e` flags, even overriding those mentioned
@@ -1425,6 +1416,7 @@ Similarly the operator can set the **hostname** with `-h`.
 
 Example:
 
+    {% raw %}
     $ docker run --name=test -d \
         --health-cmd='stat /etc/passwd || exit 1' \
         --health-interval=2s \
@@ -1469,6 +1461,7 @@ Example:
         }
       ]
     }
+    {% endraw %}
 
 The health status is also displayed in the `docker ps` output.
 


### PR DESCRIPTION
**\- What I did**

Synced improvements to docs/reference/\* that were accidentally applied in docker/docker.github.io to docker/docker since it is supposed to be the source of truth for references

**\- How I did it**

docker/docker.github.io branch `master` actually represents the `1.12.x` branch of docker/docker. #27518 represents an attempt to sync those changes with the v1.12.x branch of docker/docker, but we realized that changing the TOML to YAML would break the `make docs` target which still exists in the `1.12.x` branch. So this PR is simply the same patch as in #27518 but applied to docker/docker `master` instead.

The implication of only applying these changes to docker/docker `master` is that we can't improve the reference docs on docs.docker.com until Docker 1.13 is released. because we can't refresh the 1.12.x reference docs anymore (because of TOML / YAML incompatibility). Not sure what the answer is here.

Thoughts appreciated @thaJeztah @dnephin @johndmulhausen 
