### PR TITLE
Splunk logger env regex

### DIFF
--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -14,11 +14,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
-	"strings"
-	"regexp"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"strings"
+	"regexp"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
@@ -38,6 +40,7 @@ const (
 	splunkVerifyConnectionKey     = "splunk-verify-connection"
 	splunkGzipCompressionKey      = "splunk-gzip"
 	splunkGzipCompressionLevelKey = "splunk-gzip-level"
+	splunkEnvRegexKey             = "splunk-env-regex"
 	envKey                        = "env"
 	labelsKey                     = "labels"
 	tagKey                        = "tag"
@@ -236,6 +239,13 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	}
 
 	attrs := ctx.ExtraAttributes(nil)
+	moreAttrs, err := envByRegex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range moreAttrs {
+		attrs[k] = v
+	}
 
 	var (
 		postMessagesFrequency = getAdvancedOptionDuration(envVarPostMessagesFrequency, defaultPostMessagesFrequency)
@@ -537,6 +547,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case splunkVerifyConnectionKey:
 		case splunkGzipCompressionKey:
 		case splunkGzipCompressionLevelKey:
+		case splunkEnvRegexKey:
 		case envKey:
 		case labelsKey:
 		case tagKey:
@@ -545,6 +556,26 @@ func ValidateLogOpt(cfg map[string]string) error {
 		}
 	}
 	return nil
+}
+
+func envByRegex(ctx logger.Context) (map[string]string, error) {
+	theRegex, ok := ctx.Config[splunkEnvRegexKey]
+	if !ok { // Option not set. Nothing to do.
+		return nil, nil
+	}
+	re, err := regexp.Compile(theRegex)
+	if err != nil {
+		return nil, err
+	}
+	matchedEnvVars := make(map[string]string)
+	for _, e := range ctx.ContainerEnv {
+		if kv := strings.SplitN(e, "=", 2); len(kv) == 2 {
+			if re.MatchString(kv[0]) {
+				matchedEnvVars[kv[0]] = kv[1]
+			}
+		}
+	}
+	return matchedEnvVars, nil
 }
 
 func parseURL(ctx logger.Context) (*url.URL, error) {

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -25,6 +25,7 @@ func TestValidateLogOpt(t *testing.T) {
 		splunkVerifyConnectionKey:     "true",
 		splunkGzipCompressionKey:      "true",
 		splunkGzipCompressionLevelKey: "1",
+		splunkEnvRegexKey: "findme",
 		envKey:    "a",
 		labelsKey: "b",
 		tagKey:    "c",
@@ -38,6 +39,22 @@ func TestValidateLogOpt(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Expecting error on unsupported options")
+	}
+}
+
+func TestEnvByRegex(t *testing.T) {
+	ctx := logger.Context{
+		Config: map[string]string{
+		splunkEnvRegexKey:	"^FIND_",
+		},
+		ContainerEnv:       []string{"FIND_ME=HERE"},
+	}
+	attrs,err := envByRegex(ctx)
+	if err != nil {
+		t.Fatal("Failed with error", err)
+	}
+	if attrs["FIND_ME"] != "HERE" {
+		t.Fatal("Failed to find an environment variable when we should have done so.")
 	}
 }
 

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -25,10 +25,10 @@ func TestValidateLogOpt(t *testing.T) {
 		splunkVerifyConnectionKey:     "true",
 		splunkGzipCompressionKey:      "true",
 		splunkGzipCompressionLevelKey: "1",
-		splunkEnvRegexKey: "findme",
-		envKey:    "a",
-		labelsKey: "b",
-		tagKey:    "c",
+		splunkEnvRegexKey:             "findme",
+		envKey:                        "a",
+		labelsKey:                     "b",
+		tagKey:                        "c",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -45,11 +45,11 @@ func TestValidateLogOpt(t *testing.T) {
 func TestEnvByRegex(t *testing.T) {
 	ctx := logger.Context{
 		Config: map[string]string{
-		splunkEnvRegexKey:	"^FIND_",
+			splunkEnvRegexKey: "^FIND_",
 		},
-		ContainerEnv:       []string{"FIND_ME=HERE"},
+		ContainerEnv: []string{"FIND_ME=HERE"},
 	}
-	attrs,err := envByRegex(ctx)
+	attrs, err := envByRegex(ctx)
 	if err != nil {
 		t.Fatal("Failed with error", err)
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Addressing #27561, I added an option to the splunk log driver to include as attributes the environment variables that match a regex.
**\- How I did it**
I added the <code>--splunk-env-regex</code> option to the splunk logging driver (splunk.go).
I added code to scan and match container environment variables against the regex supplied in the above option. I add these matching variables to the 'attrs' map in the log driver.
**\- How to verify it**
In splunk_test.go I added <code>TestEnvByRegex()</code> and updated the <code>TestValidateLogOpt()</code> to check for this new option.
**\- Description for the changelog**
Allow the splunk log driver to pick up environment variables that match a supplied regular expression.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
