### PR TITLE
Add bash completion for new `docker container` subcommands

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1629,7 +1629,17 @@ _docker_container_stop() {
 }
 
 _docker_container_top() {
-	_docker_top
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_running
+			fi
+			;;
+	esac
 }
 
 _docker_container_unpause() {
@@ -3022,17 +3032,7 @@ _docker_update() {
 }
 
 _docker_top() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_running
-			fi
-			;;
-	esac
+	_docker_container_top
 }
 
 _docker_version() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1027,7 +1027,7 @@ _docker_container_cp() {
 }
 
 _docker_container_create() {
-	_docker_create
+	_docker_container_run
 }
 
 _docker_container_diff() {
@@ -1133,7 +1133,7 @@ _docker_cp() {
 }
 
 _docker_create() {
-	_docker_run
+	_docker_container_run
 }
 
 _docker_daemon() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1045,7 +1045,23 @@ _docker_container_diff() {
 }
 
 _docker_container_exec() {
-	_docker_exec
+	__docker_complete_detach-keys && return
+
+	case "$prev" in
+		--user|-u)
+			__docker_complete_user_group
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--detach -d --detach-keys -e --env --help --interactive -i --privileged -t --tty -u --user" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_running
+			;;
+	esac
 }
 
 _docker_container_export() {
@@ -1421,23 +1437,7 @@ _docker_events() {
 }
 
 _docker_exec() {
-	__docker_complete_detach-keys && return
-
-	case "$prev" in
-		--user|-u)
-			__docker_complete_user_group
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--detach -d --detach-keys -e --env --help --interactive -i --privileged -t --tty -u --user" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_running
-			;;
-	esac
+	_docker_container_exec
 }
 
 _docker_export() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1065,7 +1065,17 @@ _docker_container_exec() {
 }
 
 _docker_container_export() {
-	_docker_export
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_all
+			fi
+			;;
+	esac
 }
 
 _docker_container_inspect() {
@@ -1441,17 +1451,7 @@ _docker_exec() {
 }
 
 _docker_export() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_all
-			fi
-			;;
-	esac
+	_docker_container_export
 }
 
 _docker_help() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -954,7 +954,31 @@ _docker_container_attach() {
 }
 
 _docker_container_commit() {
-	_docker_commit
+	case "$prev" in
+		--author|-a|--change|-c|--message|-m)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--author -a --change -c --help --message -m --pause=false -p=false" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--author|-a|--change|-c|--message|-m')
+
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_all
+				return
+			fi
+			(( counter++ ))
+
+			if [ $cword -eq $counter ]; then
+				__docker_complete_image_repos_and_tags
+				return
+			fi
+			;;
+	esac
 }
 
 _docker_container_cp() {
@@ -1060,31 +1084,7 @@ _docker_container_wait() {
 
 
 _docker_commit() {
-	case "$prev" in
-		--author|-a|--change|-c|--message|-m)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--author -a --change -c --help --message -m --pause=false -p=false" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag '--author|-a|--change|-c|--message|-m')
-
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_all
-				return
-			fi
-			(( counter++ ))
-
-			if [ $cword -eq $counter ]; then
-				__docker_complete_image_repos_and_tags
-				return
-			fi
-			;;
-	esac
+	_docker_container_commit
 }
 
 _docker_cp() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1249,7 +1249,17 @@ _docker_container_ps() {
 }
 
 _docker_container_rename() {
-	_docker_rename
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_all
+			fi
+			;;
+	esac
 }
 
 _docker_container_restart() {
@@ -2507,17 +2517,7 @@ _docker_push() {
 }
 
 _docker_rename() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_all
-			fi
-			;;
-	esac
+	_docker_container_rename
 }
 
 _docker_restart() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1280,7 +1280,22 @@ _docker_container_restart() {
 }
 
 _docker_container_rm() {
-	_docker_rm
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--force -f --help --link -l --volumes -v" -- "$cur" ) )
+			;;
+		*)
+			for arg in "${COMP_WORDS[@]}"; do
+				case "$arg" in
+					--force|-f)
+						__docker_complete_containers_all
+						return
+						;;
+				esac
+			done
+			__docker_complete_containers_stopped
+			;;
+	esac
 }
 
 _docker_container_run() {
@@ -2538,22 +2553,7 @@ _docker_restart() {
 }
 
 _docker_rm() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--force -f --help --link -l --volumes -v" -- "$cur" ) )
-			;;
-		*)
-			for arg in "${COMP_WORDS[@]}"; do
-				case "$arg" in
-					--force|-f)
-						__docker_complete_containers_all
-						return
-						;;
-				esac
-			done
-			__docker_complete_containers_stopped
-			;;
-	esac
+	_docker_container_rm
 }
 
 _docker_rmi() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1657,7 +1657,42 @@ _docker_container_unpause() {
 }
 
 _docker_container_update() {
-	_docker_update
+	local options_with_args="
+		--blkio-weight
+		--cpu-period
+		--cpu-quota
+		--cpuset-cpus
+		--cpuset-mems
+		--cpu-shares -c
+		--kernel-memory
+		--memory -m
+		--memory-reservation
+		--memory-swap
+		--restart
+	"
+
+	local boolean_options="
+		--help
+	"
+
+	local all_options="$options_with_args $boolean_options"
+
+	__docker_complete_restart && return
+
+	case "$prev" in
+		$(__docker_to_extglob "$options_with_args") )
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_all
+			;;
+	esac
 }
 
 _docker_container_wait() {
@@ -2993,42 +3028,7 @@ _docker_unpause() {
 }
 
 _docker_update() {
-	local options_with_args="
-		--blkio-weight
-		--cpu-period
-		--cpu-quota
-		--cpuset-cpus
-		--cpuset-mems
-		--cpu-shares -c
-		--kernel-memory
-		--memory -m
-		--memory-reservation
-		--memory-swap
-		--restart
-	"
-
-	local boolean_options="
-		--help
-	"
-
-	local all_options="$options_with_args $boolean_options"
-
-	__docker_complete_restart && return
-
-	case "$prev" in
-		$(__docker_to_extglob "$options_with_args") )
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_all
-			;;
-	esac
+	_docker_container_update
 }
 
 _docker_top() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1212,7 +1212,17 @@ _docker_container_ls() {
 }
 
 _docker_container_pause() {
-	_docker_pause
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_running
+			fi
+			;;
+	esac
 }
 
 _docker_container_port() {
@@ -2439,17 +2449,7 @@ _docker_node_update() {
 }
 
 _docker_pause() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_running
-			fi
-			;;
-	esac
+	_docker_container_pause
 }
 
 _docker_port() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1110,7 +1110,21 @@ _docker_container_inspect() {
 }
 
 _docker_container_kill() {
-	_docker_kill
+	case "$prev" in
+		--signal|-s)
+			__docker_complete_signals
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --signal -s" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_running
+			;;
+	esac
 }
 
 _docker_container_logs() {
@@ -1593,21 +1607,7 @@ _docker_inspect() {
 }
 
 _docker_kill() {
-	case "$prev" in
-		--signal|-s)
-			__docker_complete_signals
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help --signal -s" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_running
-			;;
-	esac
+	_docker_container_kill
 }
 
 _docker_load() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1582,7 +1582,16 @@ _docker_container_run() {
 }
 
 _docker_container_start() {
-	_docker_start
+	__docker_complete_detach-keys && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--attach -a --detach-keys --help --interactive -i" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_stopped
+			;;
+	esac
 }
 
 _docker_container_stats() {
@@ -2900,16 +2909,7 @@ _docker_search() {
 }
 
 _docker_start() {
-	__docker_complete_detach-keys && return
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--attach -a --detach-keys --help --interactive -i" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_stopped
-			;;
-	esac
+	_docker_container_start
 }
 
 _docker_stats() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1152,7 +1152,63 @@ _docker_container_list() {
 }
 
 _docker_container_ls() {
-	_docker_ps
+	local key=$(__docker_map_key_of_current_option '--filter|-f')
+	case "$key" in
+		ancestor)
+			cur="${cur##*=}"
+			__docker_complete_images
+			return
+			;;
+		before)
+			__docker_complete_containers_all --cur "${cur##*=}"
+			return
+			;;
+		id)
+			__docker_complete_containers_all --cur "${cur##*=}" --id
+			return
+			;;
+		is-task)
+			COMPREPLY=( $( compgen -W "true false" -- "${cur##*=}" ) )
+			return
+			;;
+		name)
+			__docker_complete_containers_all --cur "${cur##*=}" --name
+			return
+			;;
+		network)
+			__docker_complete_networks --cur "${cur##*=}"
+			return
+			;;
+		since)
+			__docker_complete_containers_all --cur "${cur##*=}"
+			return
+			;;
+		status)
+			COMPREPLY=( $( compgen -W "created dead exited paused restarting running removing" -- "${cur##*=}" ) )
+			return
+			;;
+		volume)
+			__docker_complete_volumes --cur "${cur##*=}"
+			return
+			;;
+	esac
+
+	case "$prev" in
+		--filter|-f)
+			COMPREPLY=( $( compgen -S = -W "ancestor before exited id label name network since status volume" -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+		--format|--last|-n)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--all -a --filter -f --format --help --last -n --latest -l --no-trunc --quiet -q --size -s" -- "$cur" ) )
+			;;
+	esac
 }
 
 _docker_container_pause() {
@@ -2411,63 +2467,7 @@ _docker_port() {
 }
 
 _docker_ps() {
-	local key=$(__docker_map_key_of_current_option '--filter|-f')
-	case "$key" in
-		ancestor)
-			cur="${cur##*=}"
-			__docker_complete_images
-			return
-			;;
-		before)
-			__docker_complete_containers_all --cur "${cur##*=}"
-			return
-			;;
-		id)
-			__docker_complete_containers_all --cur "${cur##*=}" --id
-			return
-			;;
-		is-task)
-			COMPREPLY=( $( compgen -W "true false" -- "${cur##*=}" ) )
-			return
-			;;
-		name)
-			__docker_complete_containers_all --cur "${cur##*=}" --name
-			return
-			;;
-		network)
-			__docker_complete_networks --cur "${cur##*=}"
-			return
-			;;
-		since)
-			__docker_complete_containers_all --cur "${cur##*=}"
-			return
-			;;
-		status)
-			COMPREPLY=( $( compgen -W "created dead exited paused restarting running removing" -- "${cur##*=}" ) )
-			return
-			;;
-		volume)
-			__docker_complete_volumes --cur "${cur##*=}"
-			return
-			;;
-	esac
-
-	case "$prev" in
-		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "ancestor before exited id label name network since status volume" -- "$cur" ) )
-			__docker_nospace
-			return
-			;;
-		--format|--last|-n)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--all -a --filter -f --format --help --last -n --latest -l --no-trunc --quiet -q --size -s" -- "$cur" ) )
-			;;
-	esac
+	_docker_container_ls
 }
 
 _docker_pull() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1031,7 +1031,17 @@ _docker_container_create() {
 }
 
 _docker_container_diff() {
-	_docker_diff
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_all
+			fi
+			;;
+	esac
 }
 
 _docker_container_exec() {
@@ -1317,17 +1327,7 @@ _docker_daemon() {
 }
 
 _docker_diff() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_all
-			fi
-			;;
-	esac
+	_docker_container_diff
 }
 
 _docker_events() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1643,7 +1643,17 @@ _docker_container_top() {
 }
 
 _docker_container_unpause() {
-	_docker_unpause
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_unpauseable
+			fi
+			;;
+	esac
 }
 
 _docker_container_update() {
@@ -2979,17 +2989,7 @@ _docker_tag() {
 }
 
 _docker_unpause() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_unpauseable
-			fi
-			;;
-	esac
+	_docker_container_unpause
 }
 
 _docker_update() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1696,7 +1696,14 @@ _docker_container_update() {
 }
 
 _docker_container_wait() {
-	_docker_wait
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_all
+			;;
+	esac
 }
 
 
@@ -3144,14 +3151,7 @@ _docker_volume() {
 }
 
 _docker_wait() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_all
-			;;
-	esac
+	_docker_container_wait
 }
 
 _docker() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1595,7 +1595,20 @@ _docker_container_start() {
 }
 
 _docker_container_stats() {
-	_docker_stats
+	case "$prev" in
+		--format)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--all -a --format --help --no-stream" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_running
+			;;
+	esac
 }
 
 _docker_container_stop() {
@@ -2913,20 +2926,7 @@ _docker_start() {
 }
 
 _docker_stats() {
-	case "$prev" in
-		--format)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--all -a --format --help --no-stream" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_running
-			;;
-	esac
+	_docker_container_stats
 }
 
 _docker_stop() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1128,7 +1128,23 @@ _docker_container_kill() {
 }
 
 _docker_container_logs() {
-	_docker_logs
+	case "$prev" in
+		--since|--tail)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--details --follow -f --help --since --tail --timestamps -t" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--since|--tail')
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_all
+			fi
+			;;
+	esac
 }
 
 _docker_container_list() {
@@ -1648,23 +1664,7 @@ _docker_logout() {
 }
 
 _docker_logs() {
-	case "$prev" in
-		--since|--tail)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--details --follow -f --help --since --tail --timestamps -t" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag '--since|--tail')
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_all
-			fi
-			;;
-	esac
+	_docker_container_logs
 }
 
 _docker_network_connect() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -821,19 +821,7 @@ _docker_docker() {
 }
 
 _docker_attach() {
-	__docker_complete_detach-keys && return
-
- 	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--detach-keys --help --no-stdin --sig-proxy=false" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag '--detach-keys')
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_running
-			fi
-			;;
-	esac
+	_docker_container_attach
 }
 
 _docker_build() {
@@ -950,7 +938,19 @@ _docker_container() {
 }
 
 _docker_container_attach() {
-	_docker_attach
+	__docker_complete_detach-keys && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--detach-keys --help --no-stdin --sig-proxy=false" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--detach-keys')
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_running
+			fi
+			;;
+	esac
 }
 
 _docker_container_commit() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1263,7 +1263,20 @@ _docker_container_rename() {
 }
 
 _docker_container_restart() {
-	_docker_restart
+	case "$prev" in
+		--time|-t)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --time -t" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_all
+			;;
+	esac
 }
 
 _docker_container_rm() {
@@ -2521,20 +2534,7 @@ _docker_rename() {
 }
 
 _docker_restart() {
-	case "$prev" in
-		--time|-t)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help --time -t" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_all
-			;;
-	esac
+	_docker_container_restart
 }
 
 _docker_rm() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1226,7 +1226,17 @@ _docker_container_pause() {
 }
 
 _docker_container_port() {
-	_docker_port
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_containers_all
+			fi
+			;;
+	esac
 }
 
 # TODO new command
@@ -2453,17 +2463,7 @@ _docker_pause() {
 }
 
 _docker_port() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_all
-			fi
-			;;
-	esac
+	_docker_container_port
 }
 
 _docker_ps() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -982,7 +982,48 @@ _docker_container_commit() {
 }
 
 _docker_container_cp() {
-	_docker_cp
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--follow-link -L --help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				case "$cur" in
+					*:)
+						return
+						;;
+					*)
+						# combined container and filename completion
+						_filedir
+						local files=( ${COMPREPLY[@]} )
+
+						__docker_complete_containers_all
+						COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
+						local containers=( ${COMPREPLY[@]} )
+
+						COMPREPLY=( $( compgen -W "${files[*]} ${containers[*]}" -- "$cur" ) )
+						if [[ "$COMPREPLY" == *: ]]; then
+							__docker_nospace
+						fi
+						return
+						;;
+				esac
+			fi
+			(( counter++ ))
+
+			if [ $cword -eq $counter ]; then
+				if [ -e "$prev" ]; then
+					__docker_complete_containers_all
+					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
+					__docker_nospace
+				else
+					_filedir
+				fi
+				return
+			fi
+			;;
+	esac
 }
 
 _docker_container_create() {
@@ -1088,48 +1129,7 @@ _docker_commit() {
 }
 
 _docker_cp() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--follow-link -L --help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				case "$cur" in
-					*:)
-						return
-						;;
-					*)
-						# combined container and filename completion
-						_filedir
-						local files=( ${COMPREPLY[@]} )
-
-						__docker_complete_containers_all
-						COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
-						local containers=( ${COMPREPLY[@]} )
-
-						COMPREPLY=( $( compgen -W "${files[*]} ${containers[*]}" -- "$cur" ) )
-						if [[ "$COMPREPLY" == *: ]]; then
-							__docker_nospace
-						fi
-						return
-						;;
-				esac
-			fi
-			(( counter++ ))
-
-			if [ $cword -eq $counter ]; then
-				if [ -e "$prev" ]; then
-					__docker_complete_containers_all
-					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
-					__docker_nospace
-				else
-					_filedir
-				fi
-				return
-			fi
-			;;
-	esac
+	_docker_container_cp
 }
 
 _docker_create() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1299,7 +1299,286 @@ _docker_container_rm() {
 }
 
 _docker_container_run() {
-	_docker_run
+	local options_with_args="
+		--add-host
+		--attach -a
+		--blkio-weight
+		--blkio-weight-device
+		--cap-add
+		--cap-drop
+		--cgroup-parent
+		--cidfile
+		--cpu-period
+		--cpu-quota
+		--cpuset-cpus
+		--cpuset-mems
+		--cpu-shares -c
+		--device
+		--device-read-bps
+		--device-read-iops
+		--device-write-bps
+		--device-write-iops
+		--dns
+		--dns-opt
+		--dns-search
+		--entrypoint
+		--env -e
+		--env-file
+		--expose
+		--group-add
+		--hostname -h
+		--ip
+		--ip6
+		--ipc
+		--isolation
+		--kernel-memory
+		--label-file
+		--label -l
+		--link
+		--link-local-ip
+		--log-driver
+		--log-opt
+		--mac-address
+		--memory -m
+		--memory-swap
+		--memory-swappiness
+		--memory-reservation
+		--name
+		--network
+		--network-alias
+		--oom-score-adj
+		--pid
+		--pids-limit
+		--publish -p
+		--restart
+		--runtime
+		--security-opt
+		--shm-size
+		--stop-signal
+		--stop-timeout
+		--storage-opt
+		--tmpfs
+		--sysctl
+		--ulimit
+		--user -u
+		--userns
+		--uts
+		--volume-driver
+		--volumes-from
+		--volume -v
+		--workdir -w
+	"
+
+	local boolean_options="
+		--disable-content-trust=false
+		--help
+		--interactive -i
+		--oom-kill-disable
+		--privileged
+		--publish-all -P
+		--read-only
+		--tty -t
+	"
+
+	if [ "$command" = "run" -o "$subcommand" = "run" ] ; then
+		options_with_args="$options_with_args
+			--detach-keys
+			--health-cmd
+			--health-interval
+			--health-retries
+			--health-timeout
+		"
+		boolean_options="$boolean_options
+			--detach -d
+			--no-healthcheck
+			--rm
+			--sig-proxy=false
+		"
+		__docker_complete_detach-keys && return
+	fi
+
+	local all_options="$options_with_args $boolean_options"
+
+
+	__docker_complete_log_driver_options && return
+	__docker_complete_restart && return
+
+	local key=$(__docker_map_key_of_current_option '--security-opt')
+	case "$key" in
+		label)
+			[[ $cur == *: ]] && return
+			COMPREPLY=( $( compgen -W "user: role: type: level: disable" -- "${cur##*=}") )
+			if [ "${COMPREPLY[*]}" != "disable" ] ; then
+				__docker_nospace
+			fi
+			return
+			;;
+		seccomp)
+			local cur=${cur##*=}
+			_filedir
+			COMPREPLY+=( $( compgen -W "unconfined" -- "$cur" ) )
+			return
+			;;
+	esac
+
+	case "$prev" in
+		--add-host)
+			case "$cur" in
+				*:)
+					__docker_complete_resolved_hostname
+					return
+					;;
+			esac
+			;;
+		--attach|-a)
+			COMPREPLY=( $( compgen -W 'stdin stdout stderr' -- "$cur" ) )
+			return
+			;;
+		--cap-add|--cap-drop)
+			__docker_complete_capabilities
+			return
+			;;
+		--cidfile|--env-file|--label-file)
+			_filedir
+			return
+			;;
+		--device|--tmpfs|--volume|-v)
+			case "$cur" in
+				*:*)
+					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)
+					;;
+				'')
+					COMPREPLY=( $( compgen -W '/' -- "$cur" ) )
+					__docker_nospace
+					;;
+				/*)
+					_filedir
+					__docker_nospace
+					;;
+			esac
+			return
+			;;
+		--env|-e)
+			# we do not append a "=" here because "-e VARNAME" is legal systax, too
+			COMPREPLY=( $( compgen -e -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+		--ipc)
+			case "$cur" in
+				*:*)
+					cur="${cur#*:}"
+					__docker_complete_containers_running
+					;;
+				*)
+					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
+					if [ "$COMPREPLY" = "container:" ]; then
+						__docker_nospace
+					fi
+					;;
+			esac
+			return
+			;;
+		--isolation)
+			__docker_complete_isolation
+			return
+			;;
+		--link)
+			case "$cur" in
+				*:*)
+					;;
+				*)
+					__docker_complete_containers_running
+					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
+					__docker_nospace
+					;;
+			esac
+			return
+			;;
+		--log-driver)
+			__docker_complete_log_drivers
+			return
+			;;
+		--log-opt)
+			__docker_complete_log_options
+			return
+			;;
+		--network)
+			case "$cur" in
+				container:*)
+					__docker_complete_containers_all --cur "${cur#*:}"
+					;;
+				*)
+					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
+					if [ "${COMPREPLY[*]}" = "container:" ] ; then
+						__docker_nospace
+					fi
+					;;
+			esac
+			return
+			;;
+		--pid)
+			case "$cur" in
+				*:*)
+					__docker_complete_containers_running --cur "${cur#*:}"
+					;;
+				*)
+					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
+					if [ "$COMPREPLY" = "container:" ]; then
+						__docker_nospace
+					fi
+					;;
+			esac
+			return
+			;;
+		--runtime)
+			__docker_complete_runtimes
+			return
+			;;
+		--security-opt)
+			COMPREPLY=( $( compgen -W "apparmor= label= no-new-privileges seccomp=" -- "$cur") )
+			if [ "${COMPREPLY[*]}" != "no-new-privileges" ] ; then
+				__docker_nospace
+			fi
+			return
+			;;
+		--storage-opt)
+			COMPREPLY=( $( compgen -W "size" -S = -- "$cur") )
+			__docker_nospace
+			return
+			;;
+		--user|-u)
+			__docker_complete_user_group
+			return
+			;;
+		--userns)
+			COMPREPLY=( $( compgen -W "host" -- "$cur" ) )
+			return
+			;;
+		--volume-driver)
+			__docker_complete_plugins --type Volume
+			return
+			;;
+		--volumes-from)
+			__docker_complete_containers_all
+			return
+			;;
+		$(__docker_to_extglob "$options_with_args") )
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
+			;;
+		*)
+			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
+			if [ $cword -eq $counter ]; then
+				__docker_complete_images
+			fi
+			;;
+	esac
 }
 
 _docker_container_start() {
@@ -2568,286 +2847,7 @@ _docker_rmi() {
 }
 
 _docker_run() {
-	local options_with_args="
-		--add-host
-		--attach -a
-		--blkio-weight
-		--blkio-weight-device
-		--cap-add
-		--cap-drop
-		--cgroup-parent
-		--cidfile
-		--cpu-period
-		--cpu-quota
-		--cpuset-cpus
-		--cpuset-mems
-		--cpu-shares -c
-		--device
-		--device-read-bps
-		--device-read-iops
-		--device-write-bps
-		--device-write-iops
-		--dns
-		--dns-opt
-		--dns-search
-		--entrypoint
-		--env -e
-		--env-file
-		--expose
-		--group-add
-		--hostname -h
-		--ip
-		--ip6
-		--ipc
-		--isolation
-		--kernel-memory
-		--label-file
-		--label -l
-		--link
-		--link-local-ip
-		--log-driver
-		--log-opt
-		--mac-address
-		--memory -m
-		--memory-swap
-		--memory-swappiness
-		--memory-reservation
-		--name
-		--network
-		--network-alias
-		--oom-score-adj
-		--pid
-		--pids-limit
-		--publish -p
-		--restart
-		--runtime
-		--security-opt
-		--shm-size
-		--stop-signal
-		--stop-timeout
-		--storage-opt
-		--tmpfs
-		--sysctl
-		--ulimit
-		--user -u
-		--userns
-		--uts
-		--volume-driver
-		--volumes-from
-		--volume -v
-		--workdir -w
-	"
-
-	local boolean_options="
-		--disable-content-trust=false
-		--help
-		--interactive -i
-		--oom-kill-disable
-		--privileged
-		--publish-all -P
-		--read-only
-		--tty -t
-	"
-
-	if [ "$command" = "run" -o "$subcommand" = "run" ] ; then
-		options_with_args="$options_with_args
-			--detach-keys
-			--health-cmd
-			--health-interval
-			--health-retries
-			--health-timeout
-		"
-		boolean_options="$boolean_options
-			--detach -d
-			--no-healthcheck
-			--rm
-			--sig-proxy=false
-		"
-		__docker_complete_detach-keys && return
-	fi
-
-	local all_options="$options_with_args $boolean_options"
-
-
-	__docker_complete_log_driver_options && return
-	__docker_complete_restart && return
-
-	local key=$(__docker_map_key_of_current_option '--security-opt')
-	case "$key" in
-		label)
-			[[ $cur == *: ]] && return
-			COMPREPLY=( $( compgen -W "user: role: type: level: disable" -- "${cur##*=}") )
-			if [ "${COMPREPLY[*]}" != "disable" ] ; then
-				__docker_nospace
-			fi
-			return
-			;;
-		seccomp)
-			local cur=${cur##*=}
-			_filedir
-			COMPREPLY+=( $( compgen -W "unconfined" -- "$cur" ) )
-			return
-			;;
-	esac
-
-	case "$prev" in
-		--add-host)
-			case "$cur" in
-				*:)
-					__docker_complete_resolved_hostname
-					return
-					;;
-			esac
-			;;
-		--attach|-a)
-			COMPREPLY=( $( compgen -W 'stdin stdout stderr' -- "$cur" ) )
-			return
-			;;
-		--cap-add|--cap-drop)
-			__docker_complete_capabilities
-			return
-			;;
-		--cidfile|--env-file|--label-file)
-			_filedir
-			return
-			;;
-		--device|--tmpfs|--volume|-v)
-			case "$cur" in
-				*:*)
-					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)
-					;;
-				'')
-					COMPREPLY=( $( compgen -W '/' -- "$cur" ) )
-					__docker_nospace
-					;;
-				/*)
-					_filedir
-					__docker_nospace
-					;;
-			esac
-			return
-			;;
-		--env|-e)
-			# we do not append a "=" here because "-e VARNAME" is legal systax, too
-			COMPREPLY=( $( compgen -e -- "$cur" ) )
-			__docker_nospace
-			return
-			;;
-		--ipc)
-			case "$cur" in
-				*:*)
-					cur="${cur#*:}"
-					__docker_complete_containers_running
-					;;
-				*)
-					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
-					if [ "$COMPREPLY" = "container:" ]; then
-						__docker_nospace
-					fi
-					;;
-			esac
-			return
-			;;
-		--isolation)
-			__docker_complete_isolation
-			return
-			;;
-		--link)
-			case "$cur" in
-				*:*)
-					;;
-				*)
-					__docker_complete_containers_running
-					COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
-					__docker_nospace
-					;;
-			esac
-			return
-			;;
-		--log-driver)
-			__docker_complete_log_drivers
-			return
-			;;
-		--log-opt)
-			__docker_complete_log_options
-			return
-			;;
-		--network)
-			case "$cur" in
-				container:*)
-					__docker_complete_containers_all --cur "${cur#*:}"
-					;;
-				*)
-					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
-					if [ "${COMPREPLY[*]}" = "container:" ] ; then
-						__docker_nospace
-					fi
-					;;
-			esac
-			return
-			;;
-		--pid)
-			case "$cur" in
-				*:*)
-					__docker_complete_containers_running --cur "${cur#*:}"
-					;;
-				*)
-					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
-					if [ "$COMPREPLY" = "container:" ]; then
-						__docker_nospace
-					fi
-					;;
-			esac
-			return
-			;;
-		--runtime)
-			__docker_complete_runtimes
-			return
-			;;
-		--security-opt)
-			COMPREPLY=( $( compgen -W "apparmor= label= no-new-privileges seccomp=" -- "$cur") )
-			if [ "${COMPREPLY[*]}" != "no-new-privileges" ] ; then
-				__docker_nospace
-			fi
-			return
-			;;
-		--storage-opt)
-			COMPREPLY=( $( compgen -W "size" -S = -- "$cur") )
-			__docker_nospace
-			return
-			;;
-		--user|-u)
-			__docker_complete_user_group
-			return
-			;;
-		--userns)
-			COMPREPLY=( $( compgen -W "host" -- "$cur" ) )
-			return
-			;;
-		--volume-driver)
-			__docker_complete_plugins --type Volume
-			return
-			;;
-		--volumes-from)
-			__docker_complete_containers_all
-			return
-			;;
-		$(__docker_to_extglob "$options_with_args") )
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
-			;;
-		*)
-			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
-			if [ $cword -eq $counter ]; then
-				__docker_complete_images
-			fi
-			;;
-	esac
+	_docker_container_run
 }
 
 _docker_save() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1079,7 +1079,34 @@ _docker_container_export() {
 }
 
 _docker_container_inspect() {
-	_docker_inspect
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+		--type)
+                     COMPREPLY=( $( compgen -W "image container" -- "$cur" ) )
+                     return
+                        ;;
+
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format -f --help --size -s --type" -- "$cur" ) )
+			;;
+		*)
+			case $(__docker_value_of_option --type) in
+				'')
+					__docker_complete_containers_and_images
+					;;
+				container)
+					__docker_complete_containers_all
+					;;
+				image)
+					__docker_complete_images
+					;;
+			esac
+	esac
 }
 
 _docker_container_kill() {
@@ -1562,34 +1589,7 @@ _docker_info() {
 }
 
 _docker_inspect() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-		--type)
-                     COMPREPLY=( $( compgen -W "image container" -- "$cur" ) )
-                     return
-                        ;;
-
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help --size -s --type" -- "$cur" ) )
-			;;
-		*)
-			case $(__docker_value_of_option --type) in
-				'')
-					__docker_complete_containers_and_images
-					;;
-				container)
-					__docker_complete_containers_all
-					;;
-				image)
-					__docker_complete_images
-					;;
-			esac
-	esac
+	_docker_container_inspect
 }
 
 _docker_kill() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1612,7 +1612,20 @@ _docker_container_stats() {
 }
 
 _docker_container_stop() {
-	_docker_stop
+	case "$prev" in
+		--time|-t)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --time -t" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_containers_running
+			;;
+	esac
 }
 
 _docker_container_top() {
@@ -2930,20 +2943,7 @@ _docker_stats() {
 }
 
 _docker_stop() {
-	case "$prev" in
-		--time|-t)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help --time -t" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_containers_running
-			;;
-	esac
+	_docker_container_stop
 }
 
 _docker_tag() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -904,6 +904,161 @@ _docker_build() {
 	esac
 }
 
+
+_docker_container() {
+	local subcommands="
+		attach
+		commit
+		cp
+		create
+		diff
+		exec
+		export
+		inspect
+		kill
+		logs
+		ls
+		pause
+		port
+		prune
+		rename
+		restart
+		rm
+		run
+		start
+		stats
+		stop
+		top
+		unpause
+		update
+		wait
+	"
+	local aliases="
+		list
+		ps
+	"
+	__docker_subcommands "$subcommands $aliases" && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_container_attach() {
+	_docker_attach
+}
+
+_docker_container_commit() {
+	_docker_commit
+}
+
+_docker_container_cp() {
+	_docker_cp
+}
+
+_docker_container_create() {
+	_docker_create
+}
+
+_docker_container_diff() {
+	_docker_diff
+}
+
+_docker_container_exec() {
+	_docker_exec
+}
+
+_docker_container_export() {
+	_docker_export
+}
+
+_docker_container_inspect() {
+	_docker_inspect
+}
+
+_docker_container_kill() {
+	_docker_kill
+}
+
+_docker_container_logs() {
+	_docker_logs
+}
+
+_docker_container_list() {
+	_docker_container_ls
+}
+
+_docker_container_ls() {
+	_docker_ps
+}
+
+_docker_container_pause() {
+	_docker_pause
+}
+
+_docker_container_port() {
+	_docker_port
+}
+
+# TODO new command
+_docker_container_prune() {
+	:
+}
+
+_docker_container_ps() {
+	_docker_container_ls
+}
+
+_docker_container_rename() {
+	_docker_rename
+}
+
+_docker_container_restart() {
+	_docker_restart
+}
+
+_docker_container_rm() {
+	_docker_rm
+}
+
+_docker_container_run() {
+	_docker_run
+}
+
+_docker_container_start() {
+	_docker_start
+}
+
+_docker_container_stats() {
+	_docker_stats
+}
+
+_docker_container_stop() {
+	_docker_stop
+}
+
+_docker_container_top() {
+	_docker_top
+}
+
+_docker_container_unpause() {
+	_docker_unpause
+}
+
+_docker_container_update() {
+	_docker_update
+}
+
+_docker_container_wait() {
+	_docker_wait
+}
+
+
 _docker_commit() {
 	case "$prev" in
 		--author|-a|--change|-c|--message|-m)
@@ -2494,7 +2649,7 @@ _docker_run() {
 		--tty -t
 	"
 
-	if [ "$command" = "run" ] ; then
+	if [ "$command" = "run" -o "$subcommand" = "run" ] ; then
 		options_with_args="$options_with_args
 			--detach-keys
 			--health-cmd
@@ -3007,6 +3162,7 @@ _docker() {
 		attach
 		build
 		commit
+		container
 		cp
 		create
 		daemon


### PR DESCRIPTION
Bash completion for the new `docker container` subcommand family introduced in #26025.
#26025 completely restructures the commands, So, to keep my changes reviewable, I chose to
- create one PR for each new subcommand. This one is just for `docker container`.
- create individual commits for each step

Notes for reviewers
- The first commit serves to illustrate the new flow of logic. The new commands still delegate to the old ones.
- The subsequent commits move the completion logic to their new homes, reversing the direction of delegation. These commits allow to see what really gets moved where. This is helpful because the overall result looks like a complete mess when diffed.
- The commit for `run` looks bungled because github displays it in a very technical way. This is because the moved code block is very large.
- The aliases `docker container list` and `docker container ps` need special treatment. To be consistent with the output of `docker container --help`, they are not included in the completion for `docker container <tab>`. But completion works after them.
- For one of the new subcommands (`prune`) there is no existing bash completion. I will add this in a subsequent PR. This PR just adds a stub for it.
- Please create a squashed merge commit with the commit message "Add bash completion for `docker container` subcommands" or give me a ping if and when I should squash the PR.
