### PR TITLE
cherry-picks 1.12.3

### DIFF
--- a/api/client/node/inspect.go
+++ b/api/client/node/inspect.go
@@ -137,8 +137,7 @@ func printNode(out io.Writer, node swarm.Node) {
 	if len(node.Description.Engine.Labels) != 0 {
 		fmt.Fprintln(out, "Engine Labels:")
 		for k, v := range node.Description.Engine.Labels {
-			fmt.Fprintf(out, " - %s = %s", k, v)
+			fmt.Fprintf(out, " - %s = %s\n", k, v)
 		}
 	}
-
 }

--- a/contrib/builder/deb/armhf/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/debian-jessie/Dockerfile
@@ -12,3 +12,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS apparmor selinux
+ENV RUNC_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
+++ b/contrib/builder/deb/armhf/raspbian-jessie/Dockerfile
@@ -13,3 +13,4 @@ ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS apparmor selinux
+ENV RUNC_BUILDTAGS apparmor selinux

--- a/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-trusty/Dockerfile
@@ -1,10 +1,12 @@
 FROM armhf/ubuntu:trusty
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.6.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS apparmor selinux
+
+ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
+ENV RUNC_BUILDTAGS apparmor selinux

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -606,6 +606,7 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 		return nil, err
 	}
 
+	// Plugin system initialization should happen before restore. Do not change order.
 	if err := pluginInit(d, config, containerdRemote); err != nil {
 		return nil, err
 	}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -251,7 +251,10 @@ func (d *Daemon) initHealthMonitor(c *container.Container) {
 	// This is needed in case we're auto-restarting
 	d.stopHealthchecks(c)
 
-	if c.State.Health == nil {
+	if h := c.State.Health; h != nil {
+		h.Status = types.Starting
+		h.FailingStreak = 0
+	} else {
 		h := &container.Health{}
 		h.Status = types.Starting
 		c.State.Health = h

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -114,7 +114,7 @@ clone git github.com/golang/protobuf 3c84672111d91bb5ac31719e112f9f7126a0e26e
 # gelf logging driver deps
 clone git github.com/Graylog2/go-gelf aab2f594e4585d43468ac57287b0dece9d806883
 
-clone git github.com/fluent/fluent-logger-golang v1.2.0
+clone git github.com/fluent/fluent-logger-golang v1.2.1
 # fluent-logger-golang deps
 clone git github.com/philhofer/fwd 899e4efba8eaa1fea74175308f3fae18ff3319fa
 clone git github.com/tinylib/msgp 75ee40d2601edf122ef667e2a07d600d4c44490c

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -255,6 +255,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 
 	// Tell the engine to attach streams back to the client
 	if err := clnt.backend.AttachStreams(processFriendlyName, *iopipe); err != nil {
+		clnt.lock(containerID)
 		return err
 	}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1040,7 +1040,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 		return nil
 	})
 	defer func() {
-		if er := <-errC; err != nil {
+		if er := <-errC; err == nil && er != nil {
 			err = er
 		}
 	}()

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -21,7 +21,12 @@ func chroot(path string) (err error) {
 		return fmt.Errorf("Error creating mount namespace before pivot: %v", err)
 	}
 
-	if err := mount.MakeRPrivate(path); err != nil {
+	// make everything in new ns private
+	if err := mount.MakeRPrivate("/"); err != nil {
+		return err
+	}
+	// ensure path is a mountpoint
+	if err := mount.MakePrivate(path); err != nil {
 		return err
 	}
 

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -52,13 +52,6 @@ func chroot(path string) (err error) {
 				err = errCleanup
 			}
 		}
-
-		if errCleanup := syscall.Unmount("/", syscall.MNT_DETACH); errCleanup != nil {
-			if err == nil {
-				err = fmt.Errorf("error unmounting root: %v", errCleanup)
-			}
-			return
-		}
 	}()
 
 	if err := syscall.PivotRoot(path, pivotDir); err != nil {

--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
@@ -78,7 +78,7 @@ func New(config Config) (f *Fluent, err error) {
 	}
 	if config.AsyncConnect {
 		f = &Fluent{Config: config, reconnecting: true}
-		f.reconnect()
+		go f.reconnect()
 	} else {
 		f = &Fluent{Config: config, reconnecting: false}
 		err = f.connect()
@@ -254,7 +254,7 @@ func (f *Fluent) connect() (err error) {
 		err = net.UnknownNetworkError(f.Config.FluentNetwork)
 	}
 
-	if err != nil {
+	if err == nil {
 		f.reconnecting = false
 	}
 	return

--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/version.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/version.go
@@ -1,3 +1,3 @@
 package fluent
 
-const Version = "1.1.0"
+const Version = "1.2.1"


### PR DESCRIPTION
- [#27474](https://github.com/docker/docker/pull/27474)
  - 53ed17449e990f49e8eecdf71ec3704ce7118660 Update fluent-logger-golang to v1.2.1
- [#27421](https://github.com/docker/docker/pull/27421)
  - e0c7300e3b2abea3d32d591fb01ee798ff59e0d4 Add AppArmor to runc buildtags for armhf
- [#27387](https://github.com/docker/docker/pull/27387)
  - b8793cff48fc4c1b702917ebc528ca0c60fb3397 Reset health status to starting when a container is restarted
- [#27327](https://github.com/docker/docker/pull/27327)
  - 63515bc59e5be4cebaa475ec4c8fe992a6c1107d debian package: update buildtags for armhf ubuntu-trusty
- [#27136](https://github.com/docker/docker/pull/27136)
  - 5143be0ccf70c7cb2acc2aa39fd7ec47450e5daa add lock in libcontainerd client AddProcess of Windows
- [#27075](https://github.com/docker/docker/pull/27075)
  - 57e12037ac8f8eb48cc05979c3030853d011dfea Fix error reporting in `CopyFileWithTar` 
- [#27007](https://github.com/docker/docker/pull/27007)
  - ddec4c3ee4e51cb62060f752777bdd32e86607e3 add \n in engine labels display in docker node inspect xxx --pretty
- [#27062](https://github.com/docker/docker/pull/27062)
  - bc32fcabebb5f3a83d47c00d85317ce82c963edf Fix conversion of restart-policy from GRPC 
- [#27609](https://github.com/docker/docker/pull/27609)
  - 70dfea63ba2a8a6d8b367420039aeb6a1759c240 chroot: let root be cleaned up by kernel 
  - b511d1f0cabd32ca30c87fa1bbc7ecac283dab39 chroot: remount everything as private in new mntns
