### PR TITLE
chroot: remount everything as private in new mntns

### DIFF
--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -62,13 +62,6 @@ func chroot(path string) (err error) {
 				err = errCleanup
 			}
 		}
-
-		if errCleanup := syscall.Unmount("/", syscall.MNT_DETACH); errCleanup != nil {
-			if err == nil {
-				err = fmt.Errorf("error unmounting root: %v", errCleanup)
-			}
-			return
-		}
 	}()
 
 	if err := syscall.PivotRoot(path, pivotDir); err != nil {

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -26,7 +26,12 @@ func chroot(path string) (err error) {
 		return fmt.Errorf("Error creating mount namespace before pivot: %v", err)
 	}
 
-	if err := mount.MakeRPrivate(path); err != nil {
+	// make everything in new ns private
+	if err := mount.MakeRPrivate("/"); err != nil {
+		return err
+	}
+	// ensure path is a mountpoint
+	if err := mount.MakePrivate(path); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If parent of the destination path is shared, this path will be unmounted from the parent ns even if
the path itself is private.

Second commit just removes code that seemed unnecessary as kernel would do this cleanup anyway, doesn't fix any issues.

Likely fixes #25925 although it is unknown what makes the `/var/lib/docker/overlay` shared as daemon always enforces them to be private on every boot.

@crosbymichael @runcom  @mlaventure
