### PR TITLE
Windows: Overhaul Dockerfile.windows and test image name

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,87 +1,162 @@
-# This file describes the standard way to build Docker, using a docker container on Windows
-# Server 2016
+# escape=`
+
+# -----------------------------------------------------------------------------------------
+# This file describes the standard way to build Docker in a container on Windows
+# Server 2016 or Windows 10.
 #
+# Maintainer: @jhowardmsft
+# -----------------------------------------------------------------------------------------
+
+
+# Prerequisites:
+# --------------
+#
+# 1. Windows 10 or Windows Server 2016 with all Windows updates applied. Pre-release
+#    versions of Windows are not supported (eg Windows Server 2016 TP5). The build
+#    number must be at least 14393. This can be confirmed, for example, by running
+#    the following from an elevated PowerShell prompt - this sample output is from a 
+#    fully up to date machine as at late October 2016:
+#
+#    >> PS C:\> $(gin).WindowsBuildLabEx
+#    >> 14393.321.amd64fre.rs1_release_inmarket.161004-2338
+#
+# 2. Git for Windows (or another git client) must be installed. https://git-scm.com/download/win.
+#
+# 3. The machine must be configured to run containers. For example, by following
+#    the quick start guidance at https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start or
+#    https://github.com/docker/labs/blob/master/windows/windows-containers/Setup.md
+
+
+# -----------------------------------------------------------------------------------------
+
+
 # Usage:
+# -----
 #
-# # Assemble the full dev environment. This is slow the first time. Run this from
-# # a directory containing the sources you are validating. For example from
-# # c:\go\src\github.com\docker\docker
+#  The following steps should be run from an (elevated*) Windows PowerShell prompt. 
 #
-# docker build -t docker -f Dockerfile.windows .
+#  (*In a default installation of containers on Windows following the quick-start guidance at
+#    https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start,
+#    the docker.exe client must run elevated to be able to connect to the daemon).
+#
+# 1. Clone the sources from github.com:
+#
+#    >>   git clone https://github.com/docker/docker.git c:\go\src\github.com\docker\docker
+#    >>   Cloning into 'c:\go\src\github.com\docker\docker'...
+#    >>   remote: Counting objects: 186216, done.
+#    >>   remote: Compressing objects: 100% (21/21), done.
+#    >>   remote: Total 186216 (delta 5), reused 0 (delta 0), pack-reused 186195
+#    >>   Receiving objects: 100% (186216/186216), 104.32 MiB | 8.18 MiB/s, done.
+#    >>   Resolving deltas: 100% (123139/123139), done.
+#    >>   Checking connectivity... done.
+#    >>   Checking out files: 100% (3912/3912), done.
+#    >>   PS C:\>
 #
 #
-# # Build docker in a container. Run the following from a Windows cmd command prommpt,
-# # replacing c:\built with the directory you want the binaries to be placed on the
-# # host system.
+# 2. Change directory to the cloned docker sources:
 #
-# docker run --rm -v "c:\built:c:\target" docker sh -c 'cd /c/go/src/github.com/docker/docker; hack/make.sh binary; ec=$?; if [ $ec -eq 0 ]; then robocopy /c/go/src/github.com/docker/docker/bundles/$(cat VERSION)/binary /c/target/binary; fi; exit $ec'
+#    >>   cd c:\go\src\github.com\docker\docker 
 #
+#
+# 3. Build a docker image with the components required to build the docker binaries from source:
+#
+#    >>   docker build -t nativebuildimage -f Dockerfile.windows .
+#
+#
+# 4. Build the docker executable binaries in a container:
+#
+#    >>   docker run --name binaries nativebuildimage sh -c 'cd /c/go/src/github.com/docker/docker; hack/make.sh binary'
+#
+#
+# 5. Copy the binaries out of the above container, replacing HostPath with an appropriate destination 
+#    folder on the host system where you want the binaries to be located.
+#
+#    >>   $v=$(Get-Content ".\VERSION" -raw).ToString().Replace("`n","").Trim()
+#    >>   docker cp binaries:c:\go\src\github.com\docker\docker\bundles\$v\binary-client\docker-$v.exe c:\HostPath\docker.exe
+#    >>   docker cp binaries:c:\go\src\github.com\docker\docker\bundles\$v\binary-daemon\dockerd.exe c:\HostPath\dockerd.exe
+#    >>   docker cp binaries:c:\go\src\github.com\docker\docker\bundles\$v\binary-daemon\docker-proxy-$v.exe c:\HostPath\docker-proxy.exe
+#
+#
+# 6. (Optional) Remove the interim container holding the built executable binaries:
+#
+#    >>    docker rm binaries
+#
+#
+# 7. (Optional) Remove the image used for the container in which the executable
+#    binaries are build. Tip - it may be useful to keep this image around if you need to
+#    build multiple times. Then you can take advantage of the builder cache to have an
+#    image which has all the components required to build the binaries already installed.
+#
+#    >>    docker rmi nativebuildimage
+
+
+# -----------------------------------------------------------------------------------------
+
+
 # Important notes:
 # ---------------
 #
-# The posix utilities from GIT aren't usable interactively as at January 2016. This
+# The posix utilities from git aren't usable interactively as at October 2016. This
 # is because they require a console window which isn't present in a container in Windows.
-# See the example at the top of this file. Do NOT use -it in that docker run!!!
+# See the example at the top of this file. Do NOT use -it in that docker run. It will not work.
 #
-# Don't try to use a volume for passing the source through. The posix utilities will
-# balk at reparse points. Again, see the example at the top of this file on how use a volume
-# to get the built binary out of the container.
+# Don't attempt to use a volume for passing the source through to the container. The posix utilities will
+# balk at reparse points. 
 #
-# The steps are minimised dramatically to improve performance
+# The downloaded files are not cleared from the image. go.zip is used by the Windows
+# CI servers to ensure the host and image are running consistent versions of go.
+#
 
-FROM windowsservercore
+# -----------------------------------------------------------------------------------------
+
+# The number of build steps below are explicitly minimised to improve performance.
+FROM microsoft/windowsservercore
 
 # Environment variable notes:
 #  - GO_VERSION must consistent with 'Dockerfile' used by Linux'.
 #  - FROM_DOCKERFILE is used for detection of building within a container.
-ENV GO_VERSION=1.7.3 \
-    GIT_LOCATION=https://github.com/git-for-windows/git/releases/download/v2.7.2.windows.1/Git-2.7.2-64-bit.exe \
-    GOPATH=C:/go;C:/go/src/github.com/docker/docker/vendor \
+ENV GO_VERSION=1.7.3 `
+    GIT_LOCATION=https://github.com/git-for-windows/git/releases/download/v2.7.2.windows.1/Git-2.7.2-64-bit.exe `
+    GOPATH=C:/go;C:/go/src/github.com/docker/docker/vendor `
     FROM_DOCKERFILE=1
 
 WORKDIR c:/
 
-# Everything downloaded/installed in one go (better performance, esp on TP4)
-RUN \
- setx /M Path "c:\git\cmd;c:\git\bin;c:\git\usr\bin;%Path%;c:\gcc\bin;c:\go\bin" && \
- setx GOROOT "c:\go" && \
- powershell -command \
-  $ErrorActionPreference = 'Stop'; \
-  Function Download-File([string] $source, [string] $target) { \
-   $wc = New-Object net.webclient; $wc.Downloadfile($source, $target) \
-  } \
-  \
-  Write-Host INFO: Downloading git...; \
-  Download-File %GIT_LOCATION% gitsetup.exe; \
-  \
-  Write-Host INFO: Downloading go...; \
-  Download-File https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.msi go.msi; \
-  \
-  Write-Host INFO: Downloading compiler 1 of 3...; \
-  Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/gcc.zip gcc.zip; \
-  \
-  Write-Host INFO: Downloading compiler 2 of 3...; \
-  Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/runtime.zip runtime.zip; \
-  \
-  Write-Host INFO: Downloading compiler 3 of 3...; \
-  Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/binutils.zip binutils.zip; \
-  \
-  Write-Host INFO: Installing git...; \
-  Start-Process gitsetup.exe -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /CLOSEAPPLICATIONS /DIR=c:\git\' -Wait; \
-  \
-  Write-Host INFO: Installing go..."; \
-  Start-Process msiexec -ArgumentList '-i go.msi -quiet' -Wait; \
-  \
-  Write-Host INFO: Unzipping compiler...; \
-  c:\git\usr\bin\unzip.exe -q -o gcc.zip -d /c/gcc; \
-  c:\git\usr\bin\unzip.exe -q -o runtime.zip -d /c/gcc; \
-  c:\git\usr\bin\unzip.exe -q -o binutils.zip -d /c/gcc"; \
-  \
-  Write-Host INFO: Removing interim files; \
-  Remove-Item *.zip; \
-  Remove-Item go.msi; \
-  Remove-Item gitsetup.exe; \
-  \
+RUN `
+ setx /M Path "c:\git\cmd;c:\git\bin;c:\git\usr\bin;%Path%;c:\gcc\bin;c:\go\bin;" && `
+ setx GOROOT "c:\go" && `
+ powershell -command `
+  $ErrorActionPreference = 'Stop'; `
+  Function Download-File([string] $source, [string] $target) { `
+   $wc = New-Object net.webclient; $wc.Downloadfile($source, $target) `
+  } `
+  `
+  Write-Host INFO: Downloading git...; `
+  Download-File %GIT_LOCATION% gitsetup.exe; `
+  `
+  Write-Host INFO: Downloading go...; `
+  Download-File https://golang.org/dl/go%GO_VERSION%.windows-amd64.zip go.zip; `
+  `
+  Write-Host INFO: Downloading compiler 1 of 3...; `
+  Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/gcc.zip gcc.zip; `
+  `
+  Write-Host INFO: Downloading compiler 2 of 3...; `
+  Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/runtime.zip runtime.zip; `
+  `
+  Write-Host INFO: Downloading compiler 3 of 3...; `
+  Download-File https://raw.githubusercontent.com/jhowardmsft/docker-tdmgcc/master/binutils.zip binutils.zip; `
+  `
+  Write-Host INFO: Installing git...; `
+  Start-Process gitsetup.exe -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /CLOSEAPPLICATIONS /DIR=c:\git\' -Wait; `
+  `
+  Write-Host INFO: Expanding go..."; `
+  Expand-Archive c:\go.zip -DestinationPath c:\; `
+  `
+  Write-Host INFO: Expanding compiler...; `
+  Expand-Archive c:\gcc.zip -DestinationPath c:\gcc -Force; `
+  Expand-Archive c:\runtime.zip -DestinationPath c:\gcc -Force; `
+  Expand-Archive c:\binutils.zip -DestinationPath c:\gcc -Force; `
+  `
   Write-Host INFO: Completed
 
 # Prepare for building

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1769,14 +1769,14 @@ func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 	out = strings.TrimSpace(out)
 	expected := "root"
 	if daemonPlatform == "windows" {
-		if WindowsBaseImage == "windowsservercore" {
+		if strings.Contains(WindowsBaseImage, "windowsservercore") {
 			expected = `user manager\containeradministrator`
 		} else {
 			expected = `ContainerAdministrator` // nanoserver
 		}
 	}
 	if out != expected {
-		c.Fatalf("Expected output %s, got %q", expected, out)
+		c.Fatalf("Expected output %s, got %q. %s", expected, out, WindowsBaseImage)
 	}
 }
 

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -68,7 +68,7 @@ var (
 
 	// WindowsBaseImage is the name of the base image for Windows testing
 	// Environment variable WINDOWS_BASE_IMAGE can override this
-	WindowsBaseImage = "windowsservercore"
+	WindowsBaseImage = "microsoft/windowsservercore"
 
 	// isolation is the isolation mode of the daemon under test
 	isolation container.Isolation


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

(I've now updated the CI servers to temporarily (until this PR is merged) to cope with both microsoft/windowsservercore and windowsservercore as the image name.).

This PR gives a pretty comprehensive and well-needed overhaul in terms of the "how to use" bit of the Windows dockerfile. No functional changes.

@friism
