### PR TITLE
revendor go-units to update more accurate duration display

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -63,7 +63,7 @@ clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
-clone git github.com/docker/go-units f2145db703495b2e525c59662db69a7344b00bb8
+clone git github.com/docker/go-units 8a7beacffa3009a9ac66bad506b18ffdd110cf97
 clone git github.com/docker/go-connections 988efe982fdecb46f01d53465878ff1f2ff411ce
 
 clone git github.com/RackSec/srslog 365bf33cd9acc21ae1c355209865f17228ca534e

--- a/vendor/src/github.com/docker/go-units/duration.go
+++ b/vendor/src/github.com/docker/go-units/duration.go
@@ -26,7 +26,7 @@ func HumanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d hours", hours)
 	} else if hours < 24*7*2 {
 		return fmt.Sprintf("%d days", hours/24)
-	} else if hours < 24*30*3 {
+	} else if hours < 24*30*2 {
 		return fmt.Sprintf("%d weeks", hours/24/7)
 	} else if hours < 24*365*2 {
 		return fmt.Sprintf("%d months", hours/24/30)


### PR DESCRIPTION
Related PR: https://github.com/docker/go-units/pull/21

This PR makes duration display more accurate. 
Since the original code will NEVER show 2 months, this pr fixes that.

ping @vdemeester @dnephin

Signed-off-by: allencloud allen.sun@daocloud.io
