### PR TITLE
sed replace apt mirror with default deb.debian.org for debian distros

### DIFF
--- a/contrib/builder/deb/amd64/debian-jessie/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-jessie/Dockerfile
@@ -4,9 +4,9 @@
 
 FROM debian:jessie
 
-# allow replacing httpredir mirror
-ARG APT_MIRROR=httpredir.debian.org
-RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/contrib/builder/deb/amd64/debian-stretch/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-stretch/Dockerfile
@@ -4,9 +4,9 @@
 
 FROM debian:stretch
 
-# allow replacing httpredir mirror
-ARG APT_MIRROR=httpredir.debian.org
-RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev pkg-config libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
+++ b/contrib/builder/deb/amd64/debian-wheezy/Dockerfile
@@ -4,10 +4,10 @@
 
 FROM debian:wheezy-backports
 
-# allow replacing httpredir mirror
-ARG APT_MIRROR=httpredir.debian.org
-RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
-RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list.d/backports.list
+# allow replacing httpredir or deb mirror
+ARG APT_MIRROR=deb.debian.org
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
+RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  libsqlite3-dev pkg-config --no-install-recommends && rm -rf /var/lib/apt/lists/*

--- a/contrib/builder/deb/amd64/generate.sh
+++ b/contrib/builder/deb/amd64/generate.sh
@@ -43,14 +43,14 @@ for version in "${versions[@]}"; do
 
 	if [ "$distro" = "debian" ]; then
 		cat >> "$version/Dockerfile" <<-'EOF'
-			# allow replacing httpredir mirror
-			ARG APT_MIRROR=httpredir.debian.org
-			RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list
+			# allow replacing httpredir or deb mirror
+			ARG APT_MIRROR=deb.debian.org
+			RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 		EOF
 
 		if [ "$suite" = "wheezy" ]; then
 			cat >> "$version/Dockerfile" <<-'EOF'
-				RUN sed -i s/httpredir.debian.org/$APT_MIRROR/g /etc/apt/sources.list.d/backports.list
+				RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d/backports.list
 			EOF
 		fi
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Change `APT_MIRROR` build arg of the `Dockerfile` used in building the docker debian packages for debian distros to use `deb.debian.org` as default mirror. Also, sed replace existing mirror for patterns of `httpredir.debian.org` or `deb.debian.org`.

```
$ docker run --rm -i -t --entrypoint=/bin/cat debian:stretch /etc/apt/sources.list
deb http://deb.debian.org/debian stretch main
deb http://deb.debian.org/debian stretch-updates main
deb http://security.debian.org stretch/updates main
```

**\- How I did it**

By modifying the `generate.sh` file that creates the `Dockerfile` and then executing `generate.sh` to regenerate the `Dockerfile` for debian package building.

**\- How to verify it**

When this PR is merged, this would be the expected correct output with a build argument passed in to override the apt mirror:

```
$ make DOCKER_BUILD_PKGS=debian-stretch DOCKER_BUILD_ARGS=--build-arg=APT_MIRROR=ftp.us.debian.org deb
...
Get:1 http://ftp.us.debian.org/debian stretch InRelease [251 kB]
Get:2 http://security.debian.org stretch/updates InRelease [68.2 kB]
Get:3 http://ftp.us.debian.org/debian stretch-updates InRelease [124 kB]
Get:4 http://ftp.us.debian.org/debian stretch/main amd64 Packages [10.5 MB]
...
```

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

(nothing needed for changelog, this only affects choosing the mirror to use to download the deb packages for building the docker deb package for stretch, no golang code changes)

**\- A picture of a cute animal (not mandatory but encouraged)**

🐜 

Signed-off-by: Andrew Hsu andrewhsu@docker.com
