### PR TITLE
remove duplicated error judgement in cluster.go

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -632,10 +632,6 @@ func (c *Cluster) Inspect() (types.Swarm, error) {
 		return types.Swarm{}, err
 	}
 
-	if err != nil {
-		return types.Swarm{}, err
-	}
-
 	return convert.SwarmFromGRPC(*swarm), nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

I found the duplicate error judgement in cluster.go    

```
if err != nil {
       return types.Swarm{}, err
}   
```

so I removed the duplicate error judgement.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
