### PR TITLE
build debian package for armhf ubuntu-xenial

### DIFF
--- a/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/armhf/ubuntu-xenial/Dockerfile
@@ -1,0 +1,12 @@
+FROM armhf/ubuntu:xenial
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev libsqlite3-dev libsystemd-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.7.3
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV PATH $PATH:/usr/local/go/bin
+
+ENV AUTO_GOPATH 1
+
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux


### PR DESCRIPTION
**\- What I did**
Add a Dockerfile to build armhf deb package for Ubuntu Xenial (16.04)

**\- How to verify it**
Build deb, install, enjoy...

**\- Description for the changelog**
Build armhf debian package for Ubuntu 16.04

Signed-off-by: Felix Ruess felix.ruess@gmail.com
