### PR TITLE
allow node update API to receive node name and id prefix

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1369,7 +1369,7 @@ func (c *Cluster) GetNode(input string) (types.Node, error) {
 }
 
 // UpdateNode updates existing nodes properties.
-func (c *Cluster) UpdateNode(nodeID string, version uint64, spec types.NodeSpec) error {
+func (c *Cluster) UpdateNode(input string, version uint64, spec types.NodeSpec) error {
 	c.RLock()
 	defer c.RUnlock()
 
@@ -1385,10 +1385,15 @@ func (c *Cluster) UpdateNode(nodeID string, version uint64, spec types.NodeSpec)
 	ctx, cancel := c.getRequestContext()
 	defer cancel()
 
+	currentNode, err := getNode(ctx, c.client, input)
+	if err != nil {
+		return err
+	}
+
 	_, err = c.client.UpdateNode(
 		ctx,
 		&swarmapi.UpdateNodeRequest{
-			NodeID: nodeID,
+			NodeID: currentNode.ID,
 			Spec:   &nodeSpec,
 			NodeVersion: &swarmapi.Version{
 				Index: version,

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -193,6 +193,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /plugins/(plugin name)/push` push a plugin.
 * `POST /plugins/create?name=(plugin name)` create a plugin.
 * `DELETE /plugins/(plugin name)` delete a plugin.
+* `POST /node/(id or name)/update` now accepts both `id` or `name` to identify the node to update.
 
 
 ### v1.24 API changes

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3965,7 +3965,7 @@ List nodes
 ### Inspect a node
 
 
-`GET /nodes/<id>`
+`GET /nodes/(id or name)`
 
 Return low-level information on the node `id`
 
@@ -4047,9 +4047,9 @@ Return low-level information on the node `id`
 ### Remove a node
 
 
-`DELETE /nodes/(id)`
+`DELETE /nodes/(id or name)`
 
-Remove a node [`id`] from the swarm.
+Remove a node from the swarm.
 
 **Example request**:
 
@@ -4077,7 +4077,7 @@ Remove a node [`id`] from the swarm.
 
 `POST /nodes/(id)/update`
 
-Update the node `id`.
+Update a node.
 
 The payload of the `POST` request is the new `NodeSpec` and
 overrides the current `NodeSpec` for the specified node.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4564,7 +4564,7 @@ List nodes
 ### Inspect a node
 
 
-`GET /nodes/<id>`
+`GET /nodes/(id or name)`
 
 Return low-level information on the node `id`
 
@@ -4647,9 +4647,9 @@ Return low-level information on the node `id`
 ### Remove a node
 
 
-`DELETE /nodes/(id)`
+`DELETE /nodes/(id or name)`
 
-Remove a node [`id`] from the swarm.
+Remove a node from the swarm.
 
 **Example request**:
 
@@ -4675,9 +4675,9 @@ Remove a node [`id`] from the swarm.
 ### Update a node
 
 
-`POST /nodes/(id)/update`
+`POST /nodes/(id or name)/update`
 
-Update the node `id`.
+Update a node.
 
 The payload of the `POST` request is the new `NodeSpec` and
 overrides the current `NodeSpec` for the specified node.


### PR DESCRIPTION
In docker's api, there are many docker swarm nodes operations supported, such as INSPECT, DELETE, UPDATE.

Currently docker daemon supports node operation `DELETE` and `INSPECT` to receive a parameter of **ID** or **Name**. In the daemon side, maybe we should support operation `UPDATE` to receive both `id` and `name`. This will expand the ability of daemon's API.

Yeah, docker cli will take advantage of Remote API. While now `docker node update` command will trigger two API calls, one for `GET /node/(id)` and the other is `POST /nodes/(id)`. This is the CLI side's logic, while in the daemon side, we could still implement more widely.

Above is only my own thought, I was wondering if I missed something. Then I am afraid we need more discussion here. Please help to check and review my design.

**\- What I did**
1. In the handler of  `UpdateNode`,  make docker engine getNode via `id or name` before updating. This pr makes it consistent with service actions.
2. change docs about node update description to receive `id or name`

Signed-off-by: allencloud allen.sun@daocloud.io

fixes https://github.com/docker/docker/pull/27631
