### PR TITLE
Add "--network-opt" option as a way to pass arbitrary options to network drivers

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -23,9 +23,10 @@ type IPAMConfig struct {
 
 // EndpointIPAMConfig represents IPAM configurations for the endpoint
 type EndpointIPAMConfig struct {
-	IPv4Address  string   `json:",omitempty"`
-	IPv6Address  string   `json:",omitempty"`
-	LinkLocalIPs []string `json:",omitempty"`
+	IPv4Address  string            `json:",omitempty"`
+	IPv6Address  string            `json:",omitempty"`
+	LinkLocalIPs []string          `json:",omitempty"`
+	Options      map[string]string `json:"Options,omitempty"`
 }
 
 // Copy makes a copy of the endpoint ipam config
@@ -58,6 +59,7 @@ type EndpointSettings struct {
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
 	MacAddress          string
+	NetworkOpts         map[string]string
 }
 
 // Copy makes a deep copy of `EndpointSettings`

--- a/container/container.go
+++ b/container/container.go
@@ -675,11 +675,18 @@ func (container *Container) BuildCreateEndpointOptions(n libnetwork.Network, epC
 				}
 			}
 			createOptions = append(createOptions,
-				libnetwork.CreateOptionIpam(net.ParseIP(ipam.IPv4Address), net.ParseIP(ipam.IPv6Address), ipList, nil))
+				libnetwork.CreateOptionIpam(net.ParseIP(ipam.IPv4Address), net.ParseIP(ipam.IPv6Address), ipList, epConfig.IPAMConfig.Options))
 		}
 
 		for _, alias := range epConfig.Aliases {
 			createOptions = append(createOptions, libnetwork.CreateOptionMyAlias(alias))
+		}
+
+		// Passing network options to driver on EndpointCreate
+		for key, val := range epConfig.NetworkOpts {
+			genericOption := options.Generic{}
+			genericOption[key] = val
+			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(genericOption))
 		}
 	}
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1477,7 +1477,7 @@ _docker_container_run_and_create() {
 		--init-path
 		--ip
 		--ip6
-		--ipam-opt
+		--ipam
 		--ipc
 		--kernel-memory
 		--label-file
@@ -1494,7 +1494,6 @@ _docker_container_run_and_create() {
 		--name
 		--network
 		--network-alias
-		--network-opt
 		--oom-score-adj
 		--pid
 		--pids-limit

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1477,6 +1477,7 @@ _docker_container_run_and_create() {
 		--init-path
 		--ip
 		--ip6
+		--ipam-opt
 		--ipc
 		--kernel-memory
 		--label-file
@@ -1493,6 +1494,7 @@ _docker_container_run_and_create() {
 		--name
 		--network
 		--network-alias
+		--network-opt
 		--oom-score-adj
 		--pid
 		--pids-limit
@@ -2595,8 +2597,10 @@ _docker_network_connect() {
 		--alias
 		--ip
 		--ip6
+		--ipam-opt
 		--link
 		--link-local-ip
+		--network-opt
 	"
 
 	local boolean_options="

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -621,6 +621,7 @@ __docker_container_subcommand() {
         "($help)--init[Run an init inside the container that forwards signals and reaps processes]"
         "($help)--ip=[IPv4 address]:IPv4: "
         "($help)--ip6=[IPv6 address]:IPv6: "
+        "($help)*--ipam-opt=[Custom IPAM driver options]:opt=value: "
         "($help)--ipc=[IPC namespace to use]:IPC namespace: "
         "($help)--isolation=[Container isolation technology]:isolation:(default hyperv process)"
         "($help)*--link=[Add link to another container]:link:->link"
@@ -632,6 +633,7 @@ __docker_container_subcommand() {
         "($help)--name=[Container name]:name: "
         "($help)--network=[Connect a container to a network]:network mode:(bridge none container host)"
         "($help)*--network-alias=[Add network-scoped alias for the container]:alias: "
+	"($help)*--network-opt=[Custom network driver options]:opt=value: "
         "($help)--oom-kill-disable[Disable OOM Killer]"
         "($help)--oom-score-adj[Tune the host's OOM preferences for containers (accepts -1000 to 1000)]"
         "($help)--pids-limit[Tune container pids limit (set -1 for unlimited)]"
@@ -1225,8 +1227,10 @@ __docker_network_subcommand() {
                 "($help)*--alias=[Add network-scoped alias for the container]:alias: " \
                 "($help)--ip=[IPv4 address]:IPv4: " \
                 "($help)--ip6=[IPv6 address]:IPv6: " \
+                "($help)*--ipam-opt=[Custom IPAM driver options]:opt=value:  "\
                 "($help)*--link=[Add a link to another container]:link:->link" \
                 "($help)*--link-local-ip=[Add a link-local address for the container]:IPv4/IPv6: " \
+                "($help)*--network-opt=[Custom network driver options]:opt=value: "\
                 "($help -)1:network:__docker_complete_networks" \
                 "($help -)2:containers:__docker_complete_containers" && ret=0
 
@@ -1253,6 +1257,7 @@ __docker_network_subcommand() {
                 "($help)*--ipam-opt=[Custom IPAM plugin options]:opt=value: " \
                 "($help)--ipv6[Enable IPv6 networking]" \
                 "($help)*--label=[Set metadata on a network]:label=value: " \
+                "($help)*--network-opt=[Custom network driver options]:opt=value: "\
                 "($help)*"{-o=,--opt=}"[Driver specific options]:opt=value: " \
                 "($help)*--subnet=[Subnet in CIDR format that represents a network segment]:IP/mask: " \
                 "($help -)1:Network Name: " && ret=0

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -621,7 +621,7 @@ __docker_container_subcommand() {
         "($help)--init[Run an init inside the container that forwards signals and reaps processes]"
         "($help)--ip=[IPv4 address]:IPv4: "
         "($help)--ip6=[IPv6 address]:IPv6: "
-        "($help)*--ipam-opt=[Custom IPAM driver options]:opt=value: "
+        "($help)*--ipam=[Custom IPAM driver options]:ipam: "
         "($help)--ipc=[IPC namespace to use]:IPC namespace: "
         "($help)--isolation=[Container isolation technology]:isolation:(default hyperv process)"
         "($help)*--link=[Add link to another container]:link:->link"
@@ -631,9 +631,8 @@ __docker_container_subcommand() {
         "($help)*--log-opt=[Log driver specific options]:log driver options:__docker_complete_log_options"
         "($help)--mac-address=[Container MAC address]:MAC address: "
         "($help)--name=[Container name]:name: "
-        "($help)--network=[Connect a container to a network]:network mode:(bridge none container host)"
+        "($help)--network=[Connect a container to a network, optionally passing a map of options]:network:(bridge none container host)"
         "($help)*--network-alias=[Add network-scoped alias for the container]:alias: "
-	"($help)*--network-opt=[Custom network driver options]:opt=value: "
         "($help)--oom-kill-disable[Disable OOM Killer]"
         "($help)--oom-score-adj[Tune the host's OOM preferences for containers (accepts -1000 to 1000)]"
         "($help)--pids-limit[Tune container pids limit (set -1 for unlimited)]"
@@ -1257,7 +1256,6 @@ __docker_network_subcommand() {
                 "($help)*--ipam-opt=[Custom IPAM plugin options]:opt=value: " \
                 "($help)--ipv6[Enable IPv6 networking]" \
                 "($help)*--label=[Set metadata on a network]:label=value: " \
-                "($help)*--network-opt=[Custom network driver options]:opt=value: "\
                 "($help)*"{-o=,--opt=}"[Driver specific options]:opt=value: " \
                 "($help)*--subnet=[Subnet in CIDR format that represents a network segment]:IP/mask: " \
                 "($help -)1:Network Name: " && ret=0

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -29,6 +29,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 * `POST /plugins/(plugin name)/upgrade` upgrade a plugin.
 
+* `POST /containers/create` now accepts a `NetworkOpts` object in NetworkSettings with options to pass to the network driver on endpoint creation.
+* `GET /containers/(id or name)/json` now returns the `NetworkOpts` object given on `POST /containers/create`.
+* `POST /containers/create` now accepts a `IPAMOpts` object in IPAMConfig with options to pass to the IPAM driver on address request for endpoint creation.
+* `GET /containers/(id or name)/json` now returns the `IPAMOpts` object given on `POST /containers/create`.
+
 ## v1.25 API changes
 
 [Docker Engine API v1.25](https://docs.docker.com/engine/api/v1.25/) documentation

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -25,8 +25,10 @@ Options:
       --help                  Print usage
       --ip string             IPv4 address (e.g., 172.30.100.104)
       --ip6 string            IPv6 address (e.g., 2001:db8::33)
+      --ipam-opt value        IPAM driver options (default [])
       --link value            Add link to another container (default [])
       --link-local-ip value   Add a link-local address for the container (default [])
+      --network-opt value     Network driver options (default [])
 ```
 
 ## Description
@@ -49,6 +51,20 @@ You can also use the `docker run --network=<network-name>` option to start a con
 
 ```bash
 $ docker run -itd --network=multi-host-network busybox
+```
+
+### Specify options for network and ipam driver
+
+`--ipam-opt` option can be used to configure IPAM driver specific options when the container is attached to the network.
+
+```bash
+$ docker network connect --ipam-opt "com.example.ipam.option"="foo" multi-host-network container2
+```
+
+`--network-opt` option can be used to configure network driver specific options when the container is attached to the network.
+
+```bash
+$ docker network connect --network-opt "com.example.net.option"="foo" multi-host-network container2
 ```
 
 ### Specify the IP address a container will use on a given network

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -81,6 +81,7 @@ Options:
       --io-maxiops uint             Maximum IOps limit for the system drive (Windows only)
       --ip string                   IPv4 address (e.g., 172.30.100.104)
       --ip6 string                  IPv6 address (e.g., 2001:db8::33)
+      --ipam-opt value              IPAM driver options (default [])
       --ipc string                  IPC namespace to use
       --isolation string            Container isolation technology
       --kernel-memory string        Kernel memory limit
@@ -97,6 +98,7 @@ Options:
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1)
       --name string                 Assign a name to the container
       --network-alias value         Add network-scoped alias for the container (default [])
+      --network-opt value           Network driver options (default [])
       --network string              Connect a container to a network
                                     'bridge': create a network stack on the default Docker bridge
                                     'none': no networking

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -81,7 +81,7 @@ Options:
       --io-maxiops uint             Maximum IOps limit for the system drive (Windows only)
       --ip string                   IPv4 address (e.g., 172.30.100.104)
       --ip6 string                  IPv6 address (e.g., 2001:db8::33)
-      --ipam-opt value              IPAM driver options (default [])
+      --ipam value                  IPAM driver options (default [])
       --ipc string                  IPC namespace to use
       --isolation string            Container isolation technology
       --kernel-memory string        Kernel memory limit
@@ -98,8 +98,7 @@ Options:
       --memory-swappiness int       Tune container memory swappiness (0 to 100) (default -1)
       --name string                 Assign a name to the container
       --network-alias value         Add network-scoped alias for the container (default [])
-      --network-opt value           Network driver options (default [])
-      --network string              Connect a container to a network
+      --network string              Connect a container to a network, with optional network driver options
                                     'bridge': create a network stack on the default Docker bridge
                                     'none': no networking
                                     'container:<name|id>': reuse another container's network stack

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -295,7 +295,9 @@ of the containers.
     --mac-address=""   : Sets the container's Ethernet device's MAC address
     --ip=""            : Sets the container's Ethernet device's IPv4 address
     --ip6=""           : Sets the container's Ethernet device's IPv6 address
+    --ipam-opt=[]      : Sets one or more option for the IPAM driver
     --link-local-ip=[] : Sets one or more container's Ethernet device's link local IPv4/IPv6 addresses
+    --network-opt=[]   : Sets one or more option for the network driver
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -284,20 +284,20 @@ of the containers.
 ## Network settings
 
     --dns=[]           : Set custom dns servers for the container
-    --network="bridge" : Connect a container to a network
+    --network="bridge" : Connect a container to a network, passing optional network options
                           'bridge': create a network stack on the default Docker bridge
                           'none': no networking
                           'container:<name|id>': reuse another container's network stack
                           'host': use the Docker host network stack
                           '<network-name>|<network-id>': connect to a user-defined network
+			  'name=<bridge|host|name>,key1=val1,key2=val2..': connect to network with driver options 
     --network-alias=[] : Add network-scoped alias for the container
     --add-host=""      : Add a line to /etc/hosts (host:IP)
     --mac-address=""   : Sets the container's Ethernet device's MAC address
     --ip=""            : Sets the container's Ethernet device's IPv4 address
     --ip6=""           : Sets the container's Ethernet device's IPv6 address
-    --ipam-opt=[]      : Sets one or more option for the IPAM driver
+    --ipam="" 	       : Sets one or more options for the IPAM driver as 'name=<bridge|host|name>,key1=val1,key2=val2..'
     --link-local-ip=[] : Sets one or more container's Ethernet device's link local IPv4/IPv6 addresses
-    --network-opt=[]   : Sets one or more option for the network driver
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -48,6 +48,7 @@ docker-run - Run a command in a new container
 [**--ip**[=*IPv4-ADDRESS*]]
 [**--ip6**[=*IPv6-ADDRESS*]]
 [**--ipc**[=*IPC*]]
+[**--ipam-opt**[=*[]*]]
 [**--isolation**[=*default*]]
 [**--kernel-memory**[=*KERNEL-MEMORY*]]
 [**-l**|**--label**[=*[]*]]
@@ -64,6 +65,7 @@ docker-run - Run a command in a new container
 [**--name**[=*NAME*]]
 [**--network-alias**[=*[]*]]
 [**--network**[=*"bridge"*]]
+[**--network-opt**[=*[]*]]
 [**--oom-kill-disable**]
 [**--oom-score-adj**[=*0*]]
 [**-P**|**--publish-all**]
@@ -345,6 +347,9 @@ redirection on the host system.
 
    It can only be used in conjunction with **--network** for user-defined networks
 
+**--ipam-opt**=[]
+      Add IPAM driver specific options.
+
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues
@@ -450,6 +455,9 @@ and foreground Docker containers.
 
 **--network-alias**=[]
    Add network-scoped alias for the container
+
+**--network-opt**=[]
+   Add network driver specific options.
 
 **--oom-kill-disable**=*true*|*false*
    Whether to disable OOM Killer for the container or not.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -48,7 +48,7 @@ docker-run - Run a command in a new container
 [**--ip**[=*IPv4-ADDRESS*]]
 [**--ip6**[=*IPv6-ADDRESS*]]
 [**--ipc**[=*IPC*]]
-[**--ipam-opt**[=*[]*]]
+[**--ipam**[=*""*]]
 [**--isolation**[=*default*]]
 [**--kernel-memory**[=*KERNEL-MEMORY*]]
 [**-l**|**--label**[=*[]*]]
@@ -65,7 +65,6 @@ docker-run - Run a command in a new container
 [**--name**[=*NAME*]]
 [**--network-alias**[=*[]*]]
 [**--network**[=*"bridge"*]]
-[**--network-opt**[=*[]*]]
 [**--oom-kill-disable**]
 [**--oom-score-adj**[=*0*]]
 [**-P**|**--publish-all**]
@@ -347,7 +346,7 @@ redirection on the host system.
 
    It can only be used in conjunction with **--network** for user-defined networks
 
-**--ipam-opt**=[]
+**--ipam**=""
       Add IPAM driver specific options.
 
 **--ipc**=""
@@ -446,7 +445,7 @@ other place you need to identify a container). This works for both background
 and foreground Docker containers.
 
 **--network**="*bridge*"
-   Set the Network mode for the container
+   Set the Network mode for the container, optionally passing driver options
                                'bridge': create a network stack on the default Docker bridge
                                'none': no networking
                                'container:<name|id>': reuse another container's network stack
@@ -455,9 +454,6 @@ and foreground Docker containers.
 
 **--network-alias**=[]
    Add network-scoped alias for the container
-
-**--network-opt**=[]
-   Add network driver specific options.
 
 **--oom-kill-disable**=*true*|*false*
    Whether to disable OOM Killer for the container or not.

--- a/opts/ipam.go
+++ b/opts/ipam.go
@@ -1,0 +1,16 @@
+package opts
+
+// IPAMOpts groups options for IPAM driver
+type IPAMOpts struct {
+	GroupMapOptions
+}
+
+// NewIPAMOpts creates a new IPAMOpts
+func NewIPAMOpts(validator ValidatorFctType) IPAMOpts {
+	return IPAMOpts{NewGroupMapOptions(validator)}
+}
+
+// Type returns the type of IPAM option
+func (n *IPAMOpts) Type() string {
+	return "ipam"
+}

--- a/opts/network.go
+++ b/opts/network.go
@@ -1,0 +1,16 @@
+package opts
+
+// NetworkOpts groups options for network drivers
+type NetworkOpts struct {
+	GroupMapOptions
+}
+
+// NewNetworkOpts creates a new NetworOpts
+func NewNetworkOpts(validator ValidatorFctType) NetworkOpts {
+	return NetworkOpts{NewGroupMapOptions(validator)}
+}
+
+// Type returns the type of network option
+func (n *NetworkOpts) Type() string {
+	return "network"
+}


### PR DESCRIPTION
- Fixes https://github.com/docker/libnetwork/issues/910
  The docker plugin model has made it easier to extend docker with custom
  drivers that can be maintained independently by third parties. However,
  as reported by issue https://github.com/docker/libnetwork/issues/910
  a way of passing arbitrary parameters from docker client to remote
  driver is needed.
  Many use cases require passing network configuration to a network driver
  that might vary from container to container and might only be known at
  container creation time. Examples are configuring the MTU or queue
  length of a network interface or passing ip aliases, routes or iptables
  rules for containers. This patch proposes adding a new --net-opt option
  to docker to allow passing arbitrary information to network drivers.
  net-opt options are used with docker run command and are directly copied
  to the container's NetworkSettings and then passed to the network driver
  on endpoint create.

Signed-off-by: Alina Quereilhac alina@medallia.com
