### PR TITLE
[carry 26348] Update cURL connection example in remote API reference

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -33,7 +33,17 @@ later, as these versions have the `--unix-socket` flag available. To
 run `curl` against the daemon on the default socket, use the
 following:
 
-    curl --unix-socket /var/run/docker.sock http://localhost/containers/json
+When using cUrl 7.50 or later:
+
+```console
+$ curl --unix-socket /var/run/docker.sock http://localhost/containers/json
+```
+
+When using cURL 7.40, `localhost` must be omitted:
+
+```console
+$ curl --unix-socket /var/run/docker.sock http://containers/json
+```
 
 If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -33,7 +33,7 @@ later, as these versions have the `--unix-socket` flag available. To
 run `curl` against the daemon on the default socket, use the
 following:
 
-    curl --unix-socket /var/run/docker.sock http:/containers/json
+    curl --unix-socket /var/run/docker.sock http://localhost/containers/json
 
 If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the


### PR DESCRIPTION
cURL 7.50 changed the validation for URL's
when using socket connections. cURL 7.4x
did not expect a hostname, whereas cURL
7.5x and above _requires_ a hostname.

See https://github.com/curl/curl/issues/936

This updates the example to take both
versions into account, because cURL 7.4x
is still widely used by distros.

carries #26348

closes #26348 
