### PR TITLE
Windows: Honour escape directive fully

### DIFF
--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -169,13 +169,13 @@ func (b *Builder) dispatch(stepN int, stepTotal int, ast *parser.Node) error {
 			var words []string
 
 			if allowWordExpansion[cmd] {
-				words, err = ProcessWords(str, envs)
+				words, err = ProcessWords(str, envs, b.directive.EscapeToken)
 				if err != nil {
 					return err
 				}
 				strList = append(strList, words...)
 			} else {
-				str, err = ProcessWord(str, envs)
+				str, err = ProcessWord(str, envs, b.directive.EscapeToken)
 				if err != nil {
 					return err
 				}

--- a/builder/dockerfile/shell_parser_test.go
+++ b/builder/dockerfile/shell_parser_test.go
@@ -40,7 +40,7 @@ func TestShellParser4EnvVars(t *testing.T) {
 		words[0] = strings.TrimSpace(words[0])
 		words[1] = strings.TrimSpace(words[1])
 
-		newWord, err := ProcessWord(words[0], envs)
+		newWord, err := ProcessWord(words[0], envs, '\\')
 
 		if err != nil {
 			newWord = "error"
@@ -83,7 +83,7 @@ func TestShellParser4Words(t *testing.T) {
 		test := strings.TrimSpace(words[0])
 		expected := strings.Split(strings.TrimLeft(words[1], " "), ",")
 
-		result, err := ProcessWords(test, envs)
+		result, err := ProcessWords(test, envs, '\\')
 
 		if err != nil {
 			result = []string{"error"}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR allows the escape directive token to be applied fully. Currently, you have to be counter-intuitive when building dockerfiles targetted at Windows daemon. So for example, on master here's a couple of examples which don't work as expected.

```
PS E:\docker\build\example1> type .\Dockerfile
# escape=`

FROM nanoserver
SHELL ["powershell.exe"]
WORKDIR c:\foo
RUN pwd
```

```
PS E:\docker\build\example1> docker build -t example1 --no-cache .
Sending build context to Docker daemon 2.048 kB
Step 1/4 : FROM nanoserver
 ---> 22738ff49c6d
Step 2/4 : SHELL powershell.exe
 ---> Running in d973096dff78
 ---> 1c82ab6b2b85
Removing intermediate container d973096dff78
Step 3/4 : WORKDIR c:\foo
the working directory 'C:foo' is invalid, it needs to be an absolute path
PS E:\docker\build\example1>
```

and

```
PS E:\docker\build\example2> type .\Dockerfile
# escape=`

FROM nanoserver
SHELL ["powershell.exe"]
ADD Dockerfile c:\foo\
RUN dir c:\foo\Dockerfile
```

```
PS E:\docker\build\example2> docker build -t example2 --no-cache .
Sending build context to Docker daemon 2.048 kB
Step 1/4 : FROM nanoserver
 ---> 22738ff49c6d
Step 2/4 : SHELL powershell.exe
 ---> Running in 62327c77aac1
 ---> e403b72638d7
Removing intermediate container 62327c77aac1
Step 3/4 : ADD Dockerfile c:\foo\
 ---> 7d56cc23742e
Removing intermediate container 353377c2a36f
Step 4/4 : RUN dir c:\foo\Dockerfile
 ---> Running in 9fd689b2bb57
dir : Cannot find path 'C:\foo\Dockerfile' because it does not exist.
At line:1 char:1
+ dir c:\foo\Dockerfile
+ ~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\foo\Dockerfile:String) [Get-
   ChildItem], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetCh
   ildItemCommand

The command 'powershell.exe dir c:\foo\Dockerfile' returned a non-zero code: 1
PS E:\docker\build\example2>
```

So first, with example 1, let's demonstrate what needs to be done without this PR to make things work. There are essentially two solutions for the WORKDIR command. Either `WORKDIR c:/foo` or `WORKDIR c:\\foo`. These are still ultimately extremely confusing to Windows users - a single forward slash is counter-intuitive as it's not the path separator on Windows, and having to use two-double backslashes is just as confusing to remember to escape it. With this PR, the escape directive is applied to all commands, not just to RUN.

So here's the Dockerfile and build output after this PR for the first example:

```
PS E:\docker\build\example1> type Dockerfile
# escape=`

FROM nanoserver
SHELL ["powershell.exe"]
WORKDIR c:\foo
RUN pwd
PS E:\docker\build\example1> docker build -t example1 --no-cache .
Sending build context to Docker daemon 2.048 kB
Step 1/4 : FROM nanoserver
 ---> 22738ff49c6d
Step 2/4 : SHELL powershell.exe
 ---> Running in ba03bdc12c90
 ---> 7ab7c7b9430a
Removing intermediate container ba03bdc12c90
Step 3/4 : WORKDIR c:\foo
 ---> Running in c77f3970e6a5
 ---> 9fccfe704deb
Removing intermediate container c77f3970e6a5
Step 4/4 : RUN pwd
 ---> Running in 6de8a3fb67f6

Path
----
C:\foo


 ---> 8c8682818474
Removing intermediate container 6de8a3fb67f6
Successfully built 8c8682818474
PS E:\docker\build\example1>
```

And similarly for the second example:

```
PS E:\docker\build\example2> type .\Dockerfile
# escape=`

FROM nanoserver
SHELL ["powershell.exe"]
ADD Dockerfile c:\foo\
RUN dir c:\foo\Dockerfile
PS E:\docker\build\example2> docker build -t example2 --no-cache .
Sending build context to Docker daemon 2.048 kB
Step 1/4 : FROM nanoserver
 ---> 22738ff49c6d
Step 2/4 : SHELL powershell.exe
 ---> Running in 44915f74f41c
 ---> e67761d6589e
Removing intermediate container 44915f74f41c
Step 3/4 : ADD Dockerfile c:\foo\
 ---> d49e0a4309c7
Removing intermediate container f70d145f95db
Step 4/4 : RUN dir c:\foo\Dockerfile
 ---> Running in de904b59d3b7


    Directory: C:\foo


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----       10/21/2016   1:56 PM            106 Dockerfile


 ---> ee517cef111b
Removing intermediate container de904b59d3b7
Successfully built ee517cef111b
PS E:\docker\build\example2>
```

@friism @duglin @thaJeztah 
