### PR TITLE
Change `docker volume create` to non-idempotent

### DIFF
--- a/volume/store/store.go
+++ b/volume/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -269,7 +270,8 @@ func (s *VolumeStore) create(name, driverName string, opts, labels map[string]st
 		if v.DriverName() != driverName && driverName != "" && driverName != volume.DefaultDriverName {
 			return nil, errNameConflict
 		}
-		return v, nil
+		// In case a volume has already been created, we will return an error for non-idempotency
+		return nil, fmt.Errorf("volume '%s' has already been created", name)
 	}
 
 	// Since there isn't a specified driver name, let's see if any of the existing drivers have this volume name


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #16068 where non-idempotency is desired for `docker volume create`.

**\- How I did it**

Previously `docker volume create` will silently ignore in case a volume with the same name has already been created with the same driver (idempotency). This fix made the change so that an `already exist` error is returned.

**\- How to verify it**

Tests has been added to cover the chagnes.

**\- Description for the changelog**

Returns error if a volume with the same name has already been created with the same driver in `docker volume create`.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #16068.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
