### PR TITLE
Change `docker volume create` to non-idempotent

### DIFF
--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/versions"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	volumestore "github.com/docker/docker/volume/store"
 	"golang.org/x/net/context"
 )
 
@@ -49,6 +51,13 @@ func (v *volumeRouter) postVolumesCreate(ctx context.Context, w http.ResponseWri
 	}
 
 	volume, err := v.backend.VolumeCreate(req.Name, req.Driver, req.DriverOpts, req.Labels)
+	if volumestore.IsAlreadyExists(err) {
+		version := httputils.VersionFromContext(ctx)
+		if versions.GreaterThanOrEqualTo(version, "1.29") {
+			return httputils.WriteJSON(w, http.StatusNotModified, volume)
+		}
+		return httputils.WriteJSON(w, http.StatusCreated, volume)
+	}
 	if err != nil {
 		return err
 	}

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -53,8 +53,9 @@ func (v *volumeRouter) postVolumesCreate(ctx context.Context, w http.ResponseWri
 	volume, err := v.backend.VolumeCreate(req.Name, req.Driver, req.DriverOpts, req.Labels)
 	if volumestore.IsAlreadyExists(err) {
 		version := httputils.VersionFromContext(ctx)
-		if versions.GreaterThanOrEqualTo(version, "1.29") {
-			return httputils.WriteJSON(w, http.StatusNotModified, volume)
+		if versions.GreaterThanOrEqualTo(version, "1.31") {
+			w.WriteHeader(http.StatusNotModified)
+			return nil
 		}
 		return httputils.WriteJSON(w, http.StatusCreated, volume)
 	}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6215,6 +6215,8 @@ paths:
           description: "The volume was created successfully"
           schema:
             $ref: "#/definitions/Volume"
+        304:
+          description: "The volume has already been created"
         500:
           description: "Server error"
           schema:

--- a/client/volume_create.go
+++ b/client/volume_create.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
@@ -12,6 +14,9 @@ import (
 func (cli *Client) VolumeCreate(ctx context.Context, options volumetypes.VolumesCreateBody) (types.Volume, error) {
 	var volume types.Volume
 	resp, err := cli.post(ctx, "/volumes/create", nil, options, nil)
+	if resp.statusCode == http.StatusNotModified {
+		return volume, fmt.Errorf("A volume named %s has already been created.", options.Name)
+	}
 	if err != nil {
 		return volume, err
 	}

--- a/client/volume_create.go
+++ b/client/volume_create.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/docker/docker/api/types"
@@ -15,7 +14,11 @@ func (cli *Client) VolumeCreate(ctx context.Context, options volumetypes.Volumes
 	var volume types.Volume
 	resp, err := cli.post(ctx, "/volumes/create", nil, options, nil)
 	if resp.statusCode == http.StatusNotModified {
-		return volume, fmt.Errorf("A volume named %s has already been created.", options.Name)
+		// StatusNotModified does not carry a body. We assign the name
+		// to the returned types.Volume so that it could be outputed correctly.
+		volume.Name = options.Name
+		ensureReaderClosed(resp)
+		return volume, nil
 	}
 	if err != nil {
 		return volume, err

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -271,9 +271,6 @@ func (daemon *Daemon) VolumeCreate(name, driverName string, opts, labels map[str
 
 	v, err := daemon.volumes.Create(name, driverName, opts, labels)
 	if err != nil {
-		if volumestore.IsNameConflict(err) {
-			return nil, fmt.Errorf("A volume named %s already exists. Choose a different volume name.", name)
-		}
 		// An error will be returned immediately if it is not errAlreadyExists
 		if !volumestore.IsAlreadyExists(err) {
 			return nil, err

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -26,6 +26,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   the daemon. This endpoint is experimental and only available if the daemon is started with experimental features
   enabled.
 * `GET /images/(name)/get` now includes an `ImageMetadata` field which contains image metadata that is local to the engine and not part of the image config.
+* `POST /volumes/create` now returns an error if a volume with the same name has already been created with the same driver for API version >= v1.31. For API version < v1.31, the API will still return success for backward-compatibility.
+>>>>>>> Change `docker volume create` to non-idempotent
 
 ## v1.30 API changes
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -26,8 +26,7 @@ keywords: "API, Docker, rcli, REST, documentation"
   the daemon. This endpoint is experimental and only available if the daemon is started with experimental features
   enabled.
 * `GET /images/(name)/get` now includes an `ImageMetadata` field which contains image metadata that is local to the engine and not part of the image config.
-* `POST /volumes/create` now returns an error if a volume with the same name has already been created with the same driver for API version >= v1.31. For API version < v1.31, the API will still return success for backward-compatibility.
->>>>>>> Change `docker volume create` to non-idempotent
+* `POST /volumes/create` now returns `StatusNotModified` if a volume with the same name has already been created with the same driver and same options for API version >= v1.31. An error is returned if a volume with the same name has already been created with the different driver or different options for API version >= v1.31. For API version < v1.31, the API will still return success for backward-compatibility.
 
 ## v1.30 API changes
 

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -291,8 +291,7 @@ func (s *DockerExternalVolumeSuite) TestVolumeCLICreateOptionConflict(c *check.C
 
 	out, _ = dockerCmd(c, "volume", "inspect", "--format={{ .Driver }}", "test")
 	_, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), checker.Contains, "A volume named test has already been created")
+	c.Assert(err, check.IsNil)
 
 	// make sure hidden --name option conflicts with positional arg name
 	out, _, err = dockerCmdWithError("volume", "create", "--name", "test2", "test2")

--- a/integration-cli/docker_cli_external_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_unix_test.go
@@ -291,7 +291,13 @@ func (s *DockerExternalVolumeSuite) TestVolumeCLICreateOptionConflict(c *check.C
 
 	out, _ = dockerCmd(c, "volume", "inspect", "--format={{ .Driver }}", "test")
 	_, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(out))
-	c.Assert(err, check.IsNil)
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), checker.Contains, "A volume named test has already been created")
+
+	// make sure hidden --name option conflicts with positional arg name
+	out, _, err = dockerCmdWithError("volume", "create", "--name", "test2", "test2")
+	c.Assert(err, check.NotNil)
+	c.Assert(strings.TrimSpace(out), checker.Equals, "Conflicting options: either specify --name or provide positional arg, not both")
 }
 
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamed(c *check.C) {

--- a/volume/store/errors.go
+++ b/volume/store/errors.go
@@ -15,6 +15,8 @@ var (
 	errInvalidName = errors.New("volume name is not valid on this platform")
 	// errNameConflict is a typed error returned on create when a volume exists with the given name, but for a different driver
 	errNameConflict = errors.New("volume name must be unique")
+	// errAlreadyExists is a typed error returned on create when a volume already exists with the same name and same driver
+	errAlreadyExists = errors.New("volume already exists")
 )
 
 // OpErr is the error type returned by functions in the store package. It describes
@@ -62,6 +64,12 @@ func IsNotExist(err error) bool {
 // volume name is already taken
 func IsNameConflict(err error) bool {
 	return isErr(err, errNameConflict)
+}
+
+// IsAlreadyExists returns a boolean indicating whether the error indicates that a
+// volume already exists
+func IsAlreadyExists(err error) bool {
+	return isErr(err, errAlreadyExists)
 }
 
 func isErr(err error, expected error) bool {


### PR DESCRIPTION
**\- What I did**

This fix tries to address the issue raised in #16068 where non-idempotency is desired for `docker volume create`.

**\- How I did it**

Previously `docker volume create` will silently ignore in case a volume with the same name has already been created with the same driver (idempotency). This fix made the change so that an `already exist` error is returned together with the already created volume `v` in `Create/CreateWithRef` func. 

(So a check of return error type is needed if the caller wants idempotency instead)

**\- How to verify it**

Tests has been added to cover the chagnes.

**\- Description for the changelog**

An error will be returned for `docker volume create` in case a volume with the same name has been created by the same driver.

**\- A picture of a cute animal (not mandatory but encouraged)**

This fix fixes #16068.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
