### PR TITLE
Update containerd to b818e749726ba18e430bb825396c85408dfaf2a4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -253,7 +253,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -192,7 +192,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -201,7 +201,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.gccgo
+++ b/Dockerfile.gccgo
@@ -85,7 +85,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -213,7 +213,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -208,7 +208,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -68,7 +68,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Install containerd
-ENV CONTAINERD_COMMIT 0366d7e9693c930cf18c0f50cc16acec064e96c5
+ENV CONTAINERD_COMMIT b818e749726ba18e430bb825396c85408dfaf2a4
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/docker/containerd.git "$GOPATH/src/github.com/docker/containerd" \


### PR DESCRIPTION
This add backward compatibility with the event logs format prior to 1.12.2.

Signed-off-by: Kenfe-Mickael Laventure mickael.laventure@gmail.com
## 

ping @tonistiigi @vieux @thaJeztah 
