### PR TITLE
Correct go-units import in cli/command/formatter/stats.go

### DIFF
--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	units "src/github.com/docker/go-units"
+	units "github.com/docker/go-units"
 )
 
 const (


### PR DESCRIPTION
from src/github.com/docker/go-units -> github.com/docker/go-units

Signed-off-by: Amit Krishnan krish.amit@gmail.com
