### PR TITLE
Remove duplicate `nat`, `null` in `docker info` for Windows

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -364,6 +364,9 @@ func (daemon *Daemon) GetNetworkDriverList() []string {
 
 	pluginList := daemon.netController.BuiltinDrivers()
 	pluginMap := make(map[string]bool)
+	for _, plugin := range pluginList {
+		pluginMap[plugin] = true
+	}
 
 	networks := daemon.netController.Networks()
 


### PR DESCRIPTION
This fix tries to address the issue raised in https://github.com/docker/docker/issues/27695 where duplicate `nat` and `null` has been listed in `docker info` for Windows.

Signed-off-by: Yong Tang yong.tang.github@outlook.com
