### PR TITLE
integration-cli: Fix style of swarm test name

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -329,7 +329,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *check.C) {
 		map[string]int{image1: instances})
 }
 
-func (s *DockerSwarmSuite) TestApiSwarmServicesFailedUpdate(c *check.C) {
+func (s *DockerSwarmSuite) TestAPISwarmServicesFailedUpdate(c *check.C) {
 	const nodeCount = 3
 	var daemons [nodeCount]*SwarmDaemon
 	for i := 0; i < nodeCount; i++ {


### PR DESCRIPTION
A recent change fixed integration tests to use "API" in test names
instead of "Api". A new test was added in a PR opened before this
change, and didn't benefit from the cleanup. Fix its name.

Signed-off-by: Aaron Lehmann aaron.lehmann@docker.com
