### PR TITLE
added date to version number in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ information on the list of deprecated flags and APIs please have a look at
 https://docs.docker.com/engine/deprecated/ where target removal dates can also
 be found.
 
-## 1.12.3
+## 1.12.3 (2016-10-24)
 
 **IMPORTANT**: Docker 1.12 ships with an updated systemd unit file for rpm
 based installs (which includes RHEL, Fedora, CentOS, and Oracle Linux 7). When


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

Added line to CHANGELOG.md so that RPMs can build properly. They have been failing because the hack script converts CHANGELOG.md to RPM changelog format and the version number line is missing a date:
https://github.com/docker/docker/blob/1.12.x/hack/make/build-rpm#L56

**\- How I did it**

With my fingers.

**\- How to verify it**

See that the version line in the CHANGELOG.md now correctly has the date in parenthesis after the version number so that the RPMs can build.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**\- A picture of a cute animal (not mandatory but encouraged)**

🐩 

Signed-off-by: Andrew Hsu andrewhsu@docker.com
