### PR TITLE
support show numbers of global service in service ls command

### DIFF
--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -45,14 +45,13 @@ You can verify that the services were correctly created:
 
 ```bash
 $ docker service ls
-ID            NAME                                     REPLICAS  IMAGE
-COMMAND
-29bv0vnlm903  vossibility-stack_lookupd                1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqlookupd
-4awt47624qwh  vossibility-stack_nsqd                   1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqd --data-path=/data --lookupd-tcp-address=lookupd:4160
-4tjx9biia6fs  vossibility-stack_elasticsearch          1 elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
-7563uuzr9eys  vossibility-stack_kibana                 1 kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
-9gc5m4met4he  vossibility-stack_logstash               1 logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe logstash -f /etc/logstash/conf.d/logstash.conf
-axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba --config /config/config.toml --debug
+ID            NAME                                     MODE         REPLICAS    IMAGE
+29bv0vnlm903  vossibility-stack_lookupd                replicated   1/1         nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility-stack_nsqd                   replicated   1/1         nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility-stack_elasticsearch          replicated   1/1         elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility-stack_kibana                 replicated   1/1         kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility-stack_logstash               replicated   1/1         logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility-stack_vossibility-collector  replicated   1/1         icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
 ```
 
 ## Related information

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -74,9 +74,13 @@ command on a manager node.
 $ docker service create --name redis redis:3.0.6
 dmu1ept4cxcfe8k8lhtux3ro3
 
+$ docker service create --mode global --name redis2 redis:3.0.6
+a8q9dasaafudfs8q8w32udass
+
 $ docker service ls
-ID            NAME   REPLICAS  IMAGE
-dmu1ept4cxcf  redis  1/1       redis:3.0.6
+ID            NAME    MODE        REPLICAS  IMAGE
+dmu1ept4cxcf  redis   replicated  1/1       redis:3.0.6
+a8q9dasaafud  redis2  global      1/1       redis:3.0.6
 ```
 
 ### Create a service with 5 replica tasks (--replicas)
@@ -99,8 +103,8 @@ number of `RUNNING` tasks is `3`:
 
 ```bash
 $ docker service ls
-ID            NAME    REPLICAS  IMAGE
-4cdgfyky7ozw  redis   3/5       redis:3.0.7
+ID            NAME   MODE        REPLICAS  IMAGE
+4cdgfyky7ozw  redis  replicated  3/5       redis:3.0.7
 ```
 
 Once all the tasks are created and `RUNNING`, the actual number of tasks is
@@ -108,8 +112,8 @@ equal to the desired number:
 
 ```bash
 $ docker service ls
-ID            NAME    REPLICAS  IMAGE
-4cdgfyky7ozw  redis   5/5       redis:3.0.7
+ID            NAME   MODE        REPLICAS  IMAGE
+4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
 ```
 
 ### Create a service with a rolling update policy

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -46,8 +46,8 @@ For example, given the following service;
 
 ```bash
 $ docker service ls
-ID            NAME      REPLICAS  IMAGE
-dmu1ept4cxcf  redis     3/3       redis:3.0.6
+ID            NAME   MODE        REPLICAS  IMAGE
+dmu1ept4cxcf  redis  replicated  3/3       redis:3.0.6
 ```
 
 Both `docker service inspect redis`, and `docker service inspect dmu1ept4cxcf`

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -34,14 +34,15 @@ swarm.
 
 On a manager node:
 ```bash
-ID            NAME      REPLICAS  IMAGE
-c8wgl7q4ndfd  frontend  5/5       nginx:alpine
-dmu1ept4cxcf  redis     3/3       redis:3.0.6
+$ docker service ls
+ID            NAME      MODE        REPLICAS    IMAGE
+c8wgl7q4ndfd  frontend  replicated  5/5         nginx:alpine
+dmu1ept4cxcf  redis     replicated  3/3         redis:3.0.6
+iwe3278osahj  mongo     global      7/7         mongo:3.3
 ```
 
 The `REPLICAS` column shows both the *actual* and *desired* number of tasks for
 the service.
-
 
 ## Filtering
 
@@ -60,8 +61,8 @@ The `id` filter matches all or part of a service's id.
 
 ```bash
 $ docker service ls -f "id=0bcjw"
-ID            NAME   REPLICAS  IMAGE
-0bcjwfh8ychr  redis  1/1       redis:3.0.6
+ID            NAME   MODE        REPLICAS  IMAGE
+0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
 ```
 
 #### Label
@@ -74,10 +75,10 @@ its value:
 
 ```bash
 $ docker service ls --filter label=project
-ID            NAME       REPLICAS  IMAGE
-01sl1rp6nj5u  frontend2  1/1       nginx:alpine
-36xvvwwauej0  frontend   5/5       nginx:alpine
-74nzcxxjv6fq  backend    3/3       redis:3.0.6
+ID            NAME       MODE        REPLICAS  IMAGE
+01sl1rp6nj5u  frontend2  replicated  1/1       nginx:alpine
+36xvvwwauej0  frontend   replicated  5/5       nginx:alpine
+74nzcxxjv6fq  backend    replicated  3/3       redis:3.0.6
 ```
 
 The following filter matches only services with the `project` label with the
@@ -85,11 +86,10 @@ The following filter matches only services with the `project` label with the
 
 ```bash
 $ docker service ls --filter label=project=project-a
-ID            NAME      REPLICAS  IMAGE
-36xvvwwauej0  frontend  5/5       nginx:alpine
-74nzcxxjv6fq  backend   3/3       redis:3.0.6
+ID            NAME      MODE        REPLICAS  IMAGE
+36xvvwwauej0  frontend  replicated  5/5       nginx:alpine
+74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
 ```
-
 
 #### Name
 
@@ -99,8 +99,8 @@ The following filter matches services with a name containing `redis`.
 
 ```bash
 $ docker service ls --filter name=redis
-ID            NAME   REPLICAS  IMAGE
-0bcjwfh8ychr  redis  1/1       redis:3.0.6
+ID            NAME   MODE        REPLICAS  IMAGE
+0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
 ```
 
 ## Related information

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -36,7 +36,7 @@ For example, to remove the redis service:
 $ docker service rm redis
 redis
 $ docker service ls
-ID            NAME   SCALE  IMAGE
+ID  NAME  MODE  REPLICAS  IMAGE
 ```
 
 > **Warning**: Unlike `docker rm`, this command does not ask for confirmation

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -56,8 +56,8 @@ replicas.
 ```bash
 $ docker service ls --filter name=frontend
 
-ID            NAME      REPLICAS  IMAGE
-3pr5mlvu3fh9  frontend  15/50     nginx:alpine
+ID            NAME      MODE        REPLICAS  IMAGE
+3pr5mlvu3fh9  frontend  replicated  15/50     nginx:alpine
 ```
 
 You can also scale a service using the [`docker service update`](service_update.md)
@@ -80,9 +80,9 @@ backend scaled to 3
 frontend scaled to 5
 
 $ docker service ls
-ID            NAME      REPLICAS  IMAGE
-3pr5mlvu3fh9  frontend  5/5       nginx:alpine
-74nzcxxjv6fq  backend   3/3       redis:3.0.6
+ID            NAME      MODE        REPLICAS  IMAGE
+3pr5mlvu3fh9  frontend  replicated  5/5       nginx:alpine
+74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
 ```
 
 ## Related information

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -47,14 +47,13 @@ You can verify that the services were correctly created:
 
 ```bash
 $ docker service ls
-ID            NAME                                     REPLICAS  IMAGE
-COMMAND
-29bv0vnlm903  vossibility-stack_lookupd                1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqlookupd
-4awt47624qwh  vossibility-stack_nsqd                   1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqd --data-path=/data --lookupd-tcp-address=lookupd:4160
-4tjx9biia6fs  vossibility-stack_elasticsearch          1 elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
-7563uuzr9eys  vossibility-stack_kibana                 1 kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
-9gc5m4met4he  vossibility-stack_logstash               1 logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe logstash -f /etc/logstash/conf.d/logstash.conf
-axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba --config /config/config.toml --debug
+ID            NAME                                     MODE        REPLICAS  IMAGE
+29bv0vnlm903  vossibility-stack_lookupd                replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility-stack_nsqd                   replicated  1/1       nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility-stack_elasticsearch          replicated  1/1       elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility-stack_kibana                 replicated  1/1       kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility-stack_logstash               replicated  1/1       logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility-stack_vossibility-collector  replicated  1/1       icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
 ```
 
 ## Related information

--- a/experimental/docker-stacks-and-bundles.md
+++ b/experimental/docker-stacks-and-bundles.md
@@ -65,15 +65,14 @@ Creating service vossibility-stack_vossibility-collector
 We can verify that services were correctly created:
 
 ```bash
-# docker service ls
-ID            NAME                                     REPLICAS  IMAGE
-COMMAND
-29bv0vnlm903  vossibility-stack_lookupd                1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqlookupd
-4awt47624qwh  vossibility-stack_nsqd                   1 nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662 /nsqd --data-path=/data --lookupd-tcp-address=lookupd:4160
-4tjx9biia6fs  vossibility-stack_elasticsearch          1 elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
-7563uuzr9eys  vossibility-stack_kibana                 1 kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
-9gc5m4met4he  vossibility-stack_logstash               1 logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe logstash -f /etc/logstash/conf.d/logstash.conf
-axqh55ipl40h  vossibility-stack_vossibility-collector  1 icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba --config /config/config.toml --debug
+$ docker service ls
+ID            NAME                                     MODE         REPLICAS    IMAGE
+29bv0vnlm903  vossibility-stack_lookupd                replicated   1/1         nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4awt47624qwh  vossibility-stack_nsqd                   replicated   1/1         nsqio/nsq@sha256:eeba05599f31eba418e96e71e0984c3dc96963ceb66924dd37a47bf7ce18a662
+4tjx9biia6fs  vossibility-stack_elasticsearch          replicated   1/1         elasticsearch@sha256:12ac7c6af55d001f71800b83ba91a04f716e58d82e748fa6e5a7359eed2301aa
+7563uuzr9eys  vossibility-stack_kibana                 replicated   1/1         kibana@sha256:6995a2d25709a62694a937b8a529ff36da92ebee74bafd7bf00e6caf6db2eb03
+9gc5m4met4he  vossibility-stack_logstash               replicated   1/1         logstash@sha256:2dc8bddd1bb4a5a34e8ebaf73749f6413c101b2edef6617f2f7713926d2141fe
+axqh55ipl40h  vossibility-stack_vossibility-collector  replicated   1/1         icecrime/vossibility-collector@sha256:f03f2977203ba6253988c18d04061c5ec7aab46bca9dfd89a9a1fa4500989fba
 ```
 
 ## Managing stacks


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/27670

make command `docker service ls` show numbers for global services, like : 

```
ID            NAME              MODE        REPLICAS  IMAGE         COMMAND
50va1ha64xhi  nauseous_beaver   replicated  1/1       nginx
a430fxzr07iq  nauseous_hodgkin  global      1/1       ubuntu:14.04  sleep 1000
```

if a sevice's mode is global, actually we can not get the total number of task in this service. Here what I did is that we collect all the tasks, and classify via task.ServiceID. Then we can know that in a service how many tasks are in this service. In addition, we can not simply get the number of nodes to make it the total number of tasks in a service, since user can use constraints in creating global service, then task number in a service may not equal to the number of nodes.

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
