### PR TITLE
return when error happens on listener close

### DIFF
--- a/pkg/listeners/listeners_unix.go
+++ b/pkg/listeners/listeners_unix.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/activation"
 	"github.com/docker/go-connections/sockets"
 )
@@ -86,8 +85,7 @@ func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
 			continue
 		}
 		if err := ls.Close(); err != nil {
-			// TODO: We shouldn't log inside a library. Remove this or error out.
-			logrus.Errorf("failed to close systemd activated file: fd %d: %v", fdOffset+3, err)
+			return nil, fmt.Errorf("failed to close systemd activated file: fd %d: %v", fdOffset+3, err)
 		}
 	}
 	return []net.Listener{listeners[fdOffset]}, nil


### PR DESCRIPTION
**\- What I did**

I am using this fd listener in the lib in my own daemon and encountered this nit. I'd like it return error instead when listener wrongly close (also implies in comment.

But if anyone don't want it, just close it :/

**\- How I did it**

Remove the original logrus log and return error instead

**\- How to verify it**

**\- Description for the changelog**

**\- A picture of a cute animal (not mandatory but encouraged)**
🐱 

Signed-off-by: Harry Zhang harryz@hyper.sh
