### PR TITLE
Fix zsh completion for 'docker exec --env'

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1680,7 +1680,7 @@ __docker_subcommand() {
                 $opts_help \
                 $opts_attach_exec_run_start \
                 "($help -d --detach)"{-d,--detach}"[Detached mode: leave the container running in the background]" \
-                "($help -e --env)"{-e,--env}"[Set environment variables]" \
+                "($help)*"{-e=,--env=}"[Set environment variables]:environment variable: " \
                 "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]" \
                 "($help)--privileged[Give extended Linux capabilities to the command]" \
                 "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]" \


### PR DESCRIPTION
Fix incorrect zsh completion in #24594.

Signed-off-by: Steve Durrheimer s.durrheimer@gmail.com
