### PR TITLE
Add bash completion for new `docker image` command family

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2075,7 +2075,29 @@ _docker_image_images() {
 }
 
 _docker_image_import() {
-	_docker_import
+	case "$prev" in
+		--change|-c|--message|-m)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--change -c --help --message -m" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--change|-c|--message|-m')
+			if [ $cword -eq $counter ]; then
+				return
+			fi
+			(( counter++ ))
+
+			if [ $cword -eq $counter ]; then
+				__docker_complete_image_repos_and_tags
+				return
+			fi
+			;;
+	esac
 }
 
 _docker_image_inspect() {
@@ -2175,29 +2197,7 @@ _docker_images() {
 }
 
 _docker_import() {
-	case "$prev" in
-		--change|-c|--message|-m)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--change -c --help --message -m" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag '--change|-c|--message|-m')
-			if [ $cword -eq $counter ]; then
-				return
-			fi
-			(( counter++ ))
-
-			if [ $cword -eq $counter ]; then
-				__docker_complete_image_repos_and_tags
-				return
-			fi
-			;;
-	esac
+	_docker_image_import
 }
 
 _docker_info() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2203,7 +2203,21 @@ _docker_image_rmi() {
 }
 
 _docker_image_save() {
-	_docker_save
+	case "$prev" in
+		--output|-o)
+			_filedir
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --output -o" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_images
+			;;
+	esac
 }
 
 _docker_image_tag() {
@@ -3068,21 +3082,7 @@ _docker_run() {
 }
 
 _docker_save() {
-	case "$prev" in
-		--output|-o)
-			_filedir
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help --output -o" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_images
-			;;
-	esac
+	_docker_image_save
 }
 
 _docker_search() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2170,7 +2170,17 @@ _docker_image_pull() {
 }
 
 _docker_image_push() {
-	_docker_push
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--disable-content-trust=false --help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_image_repos_and_tags
+			fi
+			;;
+	esac
 }
 
 _docker_image_remove() {
@@ -3027,17 +3037,7 @@ _docker_pull() {
 }
 
 _docker_push() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--disable-content-trust=false --help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_image_repos_and_tags
-			fi
-			;;
-	esac
+	_docker_image_push
 }
 
 _docker_rename() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1951,17 +1951,7 @@ _docker_help() {
 }
 
 _docker_history() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help --human=false -H=false --no-trunc --quiet -q" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_images
-			fi
-			;;
-	esac
+	_docker_image_history
 }
 
 
@@ -2067,7 +2057,17 @@ _docker_image_build() {
 }
 
 _docker_image_history() {
-	_docker_history
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --human=false -H=false --no-trunc --quiet -q" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				__docker_complete_images
+			fi
+			;;
+	esac
 }
 
 _docker_image_images() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2078,7 +2078,18 @@ _docker_image_inspect() {
 }
 
 _docker_image_load() {
-	_docker_load
+	case "$prev" in
+		--input|-i)
+			_filedir
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --input -i --quiet -q" -- "$cur" ) )
+			;;
+	esac
 }
 
 _docker_image_list() {
@@ -2236,18 +2247,7 @@ _docker_kill() {
 }
 
 _docker_load() {
-	case "$prev" in
-		--input|-i)
-			_filedir
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help --input -i --quiet -q" -- "$cur" ) )
-			;;
-	esac
+	_docker_image_load
 }
 
 _docker_login() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1021,34 +1021,7 @@ _docker_container_export() {
 }
 
 _docker_container_inspect() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-		--type)
-                     COMPREPLY=( $( compgen -W "image container" -- "$cur" ) )
-                     return
-                        ;;
-
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help --size -s --type" -- "$cur" ) )
-			;;
-		*)
-			case $(__docker_value_of_option --type) in
-				'')
-					__docker_complete_containers_and_images
-					;;
-				container)
-					__docker_complete_containers_all
-					;;
-				image)
-					__docker_complete_images
-					;;
-			esac
-	esac
+	_docker_inspect --type container
 }
 
 _docker_container_kill() {
@@ -2101,7 +2074,7 @@ _docker_image_import() {
 }
 
 _docker_image_inspect() {
-	_docker_inspect
+	_docker_inspect --type image
 }
 
 _docker_image_load() {
@@ -2215,7 +2188,47 @@ _docker_info() {
 }
 
 _docker_inspect() {
-	_docker_container_inspect
+	local type
+
+	if [ "$1" = "--type" ] ; then
+		type="$2"
+	else
+		type=$(__docker_value_of_option --type)
+	fi
+
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+		--type)
+			if [ -z "$type" ] ; then
+				COMPREPLY=( $( compgen -W "image container" -- "$cur" ) )
+			fi
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			local options="--format -f --help --size -s"
+			if [ -z "$type" ] ; then
+				options+=" --type"
+			fi
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			;;
+		*)
+			case "$type" in
+				'')
+					__docker_complete_containers_and_images
+					;;
+				container)
+					__docker_complete_containers_all
+					;;
+				image)
+					__docker_complete_images
+					;;
+			esac
+	esac
 }
 
 _docker_kill() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2028,6 +2028,106 @@ _docker_history() {
 	esac
 }
 
+
+_docker_image() {
+	local subcommands="
+		build
+		history
+		import
+		inspect
+		load
+		ls
+		prune
+		pull
+		push
+		rm
+		save
+		tag
+	"
+	local aliases="
+		images
+		list
+		remove
+		rmi
+	"
+	__docker_subcommands "$subcommands $aliases" && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_image_build() {
+	_docker_build
+}
+
+_docker_image_history() {
+	_docker_history
+}
+
+_docker_image_images() {
+	_docker_image_ls
+}
+
+_docker_image_import() {
+	_docker_import
+}
+
+_docker_image_inspect() {
+	_docker_inspect
+}
+
+_docker_image_load() {
+	_docker_load
+}
+
+_docker_image_list() {
+	_docker_image_ls
+}
+
+_docker_image_ls() {
+	_docker_images
+}
+
+# TODO new command
+_docker_image_prune() {
+	:
+}
+
+_docker_image_pull() {
+	_docker_pull
+}
+
+_docker_image_push() {
+	_docker_push
+}
+
+_docker_image_remove() {
+	_docker_image_rm
+}
+
+_docker_image_rm() {
+	_docker_rmi
+}
+
+_docker_image_rmi() {
+	_docker_image_rm
+}
+
+_docker_image_save() {
+	_docker_save
+}
+
+_docker_image_tag() {
+	_docker_tag
+}
+
+
 _docker_images() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
@@ -3178,6 +3278,7 @@ _docker() {
 		exec
 		export
 		history
+		image
 		images
 		import
 		info

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2148,7 +2148,25 @@ _docker_image_prune() {
 }
 
 _docker_image_pull() {
-	_docker_pull
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--all-tags -a --disable-content-trust=false --help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ $cword -eq $counter ]; then
+				for arg in "${COMP_WORDS[@]}"; do
+					case "$arg" in
+						--all-tags|-a)
+							__docker_complete_image_repos
+							return
+							;;
+					esac
+				done
+				__docker_complete_image_repos_and_tags
+			fi
+			;;
+	esac
 }
 
 _docker_image_push() {
@@ -3005,25 +3023,7 @@ _docker_ps() {
 }
 
 _docker_pull() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--all-tags -a --disable-content-trust=false --help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				for arg in "${COMP_WORDS[@]}"; do
-					case "$arg" in
-						--all-tags|-a)
-							__docker_complete_image_repos
-							return
-							;;
-					esac
-				done
-				__docker_complete_image_repos_and_tags
-			fi
-			;;
-	esac
+	_docker_image_pull
 }
 
 _docker_push() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2221,7 +2221,25 @@ _docker_image_save() {
 }
 
 _docker_image_tag() {
-	_docker_tag
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+
+			if [ $cword -eq $counter ]; then
+				__docker_complete_image_repos_and_tags
+				return
+			fi
+			(( counter++ ))
+
+			if [ $cword -eq $counter ]; then
+				__docker_complete_image_repos_and_tags
+				return
+			fi
+			;;
+	esac
 }
 
 
@@ -3129,25 +3147,7 @@ _docker_stop() {
 }
 
 _docker_tag() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-
-			if [ $cword -eq $counter ]; then
-				__docker_complete_image_repos_and_tags
-				return
-			fi
-			(( counter++ ))
-
-			if [ $cword -eq $counter ]; then
-				__docker_complete_image_repos_and_tags
-				return
-			fi
-			;;
-	esac
+	_docker_image_tag
 }
 
 _docker_unpause() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -825,71 +825,7 @@ _docker_attach() {
 }
 
 _docker_build() {
-	local options_with_args="
-		--build-arg
-		--cgroup-parent
-		--cpuset-cpus
-		--cpuset-mems
-		--cpu-shares -c
-		--cpu-period
-		--cpu-quota
-		--file -f
-		--isolation
-		--label
-		--memory -m
-		--memory-swap
-		--shm-size
-		--tag -t
-		--ulimit
-	"
-
-	local boolean_options="
-		--compress
-		--disable-content-trust=false
-		--force-rm
-		--help
-		--no-cache
-		--pull
-		--quiet -q
-		--rm
-	"
-
-	local all_options="$options_with_args $boolean_options"
-
-	case "$prev" in
-		--build-arg)
-			COMPREPLY=( $( compgen -e -- "$cur" ) )
-			__docker_nospace
-			return
-			;;
-		--file|-f)
-			_filedir
-			return
-			;;
-		--isolation)
-			__docker_complete_isolation
-			return
-			;;
-		--tag|-t)
-			__docker_complete_image_repos_and_tags
-			return
-			;;
-		$(__docker_to_extglob "$options_with_args") )
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
-			;;
-		*)
-			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
-			if [ $cword -eq $counter ]; then
-				_filedir -d
-			fi
-			;;
-	esac
+	_docker_image_build
 }
 
 
@@ -2063,7 +1999,71 @@ _docker_image() {
 }
 
 _docker_image_build() {
-	_docker_build
+	local options_with_args="
+		--build-arg
+		--cgroup-parent
+		--cpuset-cpus
+		--cpuset-mems
+		--cpu-shares -c
+		--cpu-period
+		--cpu-quota
+		--file -f
+		--isolation
+		--label
+		--memory -m
+		--memory-swap
+		--shm-size
+		--tag -t
+		--ulimit
+	"
+
+	local boolean_options="
+		--compress
+		--disable-content-trust=false
+		--force-rm
+		--help
+		--no-cache
+		--pull
+		--quiet -q
+		--rm
+	"
+
+	local all_options="$options_with_args $boolean_options"
+
+	case "$prev" in
+		--build-arg)
+			COMPREPLY=( $( compgen -e -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+		--file|-f)
+			_filedir
+			return
+			;;
+		--isolation)
+			__docker_complete_isolation
+			return
+			;;
+		--tag|-t)
+			__docker_complete_image_repos_and_tags
+			return
+			;;
+		$(__docker_to_extglob "$options_with_args") )
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
+			;;
+		*)
+			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
+			if [ $cword -eq $counter ]; then
+				_filedir -d
+			fi
+			;;
+	esac
 }
 
 _docker_image_history() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2097,44 +2097,6 @@ _docker_image_list() {
 }
 
 _docker_image_ls() {
-	_docker_images
-}
-
-# TODO new command
-_docker_image_prune() {
-	:
-}
-
-_docker_image_pull() {
-	_docker_pull
-}
-
-_docker_image_push() {
-	_docker_push
-}
-
-_docker_image_remove() {
-	_docker_image_rm
-}
-
-_docker_image_rm() {
-	_docker_rmi
-}
-
-_docker_image_rmi() {
-	_docker_image_rm
-}
-
-_docker_image_save() {
-	_docker_save
-}
-
-_docker_image_tag() {
-	_docker_tag
-}
-
-
-_docker_images() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		before)
@@ -2178,6 +2140,44 @@ _docker_images() {
 			__docker_complete_image_repos
 			;;
 	esac
+}
+
+# TODO new command
+_docker_image_prune() {
+	:
+}
+
+_docker_image_pull() {
+	_docker_pull
+}
+
+_docker_image_push() {
+	_docker_push
+}
+
+_docker_image_remove() {
+	_docker_image_rm
+}
+
+_docker_image_rm() {
+	_docker_rmi
+}
+
+_docker_image_rmi() {
+	_docker_image_rm
+}
+
+_docker_image_save() {
+	_docker_save
+}
+
+_docker_image_tag() {
+	_docker_tag
+}
+
+
+_docker_images() {
+	_docker_image_ls
 }
 
 _docker_import() {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2188,7 +2188,14 @@ _docker_image_remove() {
 }
 
 _docker_image_rm() {
-	_docker_rmi
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--force -f --help --no-prune" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_images
+			;;
+	esac
 }
 
 _docker_image_rmi() {
@@ -3053,14 +3060,7 @@ _docker_rm() {
 }
 
 _docker_rmi() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--force -f --help --no-prune" -- "$cur" ) )
-			;;
-		*)
-			__docker_complete_images
-			;;
-	esac
+	_docker_image_rm
 }
 
 _docker_run() {


### PR DESCRIPTION
This is the second part of adding bash completion for #26025 (#27579 being the first one): `docker image *`.

Like in #27579, I created one commit for the pricipal flow of logic and subsequent ones that move the completion logic to the new homes. This was done so that the changes can be easily reviewed (as all the changes were applied to the same file, the overall diff is not very helpful).

One of the commits is special. From the commit message:

> In #23614 `docker inspect` was semantically enhanced to inspect "everything".
> Therefore moving its logic to `_docker_container_inspect` in #27579 was not correct.
> 
> This commit moves it back to its original top-level location (`_docker_inspect`) so that it can be called by `_docker_{container,image}_inspect` and others (will be added in follow-up PRs).
> Parameterization was added in order to get caller-specific behavior.

For the new command `docker image prune` I just added a stub. I'll implement it in a follow-up PR.

ping @thaJeztah @mlaventure @tianon
