### PR TITLE
Stop returns 0 when docker service was not running

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -119,9 +119,13 @@ case "$1" in
 	stop)
 		check_init
 		fail_unless_root
-		log_begin_msg "Stopping $DOCKER_DESC: $BASE"
-		start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE" --retry 10
-		log_end_msg $?
+		if [ -f "$DOCKER_SSD_PIDFILE" ]; then
+			log_begin_msg "Stopping $DOCKER_DESC: $BASE"
+			start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE" --retry 10
+			log_end_msg $?
+		else
+			log_warning_msg "Docker already stopped - file $DOCKER_SSD_PIDFILE not found."
+		fi
 		;;
 
 	restart)


### PR DESCRIPTION
**\- Fixed ubuntu uninstall script**

In case when docker was not running init script stop was returning value <> 0.
Due to this fact it was impossible to uninstall the docker-engine if the docker service was stopped.

Signed-off-by: Cyprian Gracz cyprian.gracz@micro-jumbo.eu
