### PR TITLE
change network route url

### DIFF
--- a/api/server/router/network/network.go
+++ b/api/server/router/network/network.go
@@ -31,8 +31,7 @@ func (r *networkRouter) initRoutes() {
 	r.routes = []router.Route{
 		// GET
 		router.NewGetRoute("/networks", r.getNetworksList),
-		router.NewGetRoute("/networks/", r.getNetworksList),
-		router.NewGetRoute("/networks/{id:.+}", r.getNetwork),
+		router.NewGetRoute("/networks/{id:.*}", r.getNetwork),
 		// POST
 		router.NewPostRoute("/networks/create", r.postNetworkCreate),
 		router.NewPostRoute("/networks/{id:.*}/connect", r.postNetworkConnect),


### PR DESCRIPTION
I am not sure whether the original code is out of some legacy concern.

While I think the new style is enough. However this PR makes `GET /networks/` behave different.  Maybe a little bit back compatibility has been broken.

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Signed-off-by: allencloud allen.sun@daocloud.io
