### PR TITLE
Process isolation containers on Windows Client

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -495,9 +495,6 @@ func (daemon *Daemon) setDefaultIsolation() error {
 				daemon.defaultIsolation = containertypes.Isolation("hyperv")
 			}
 			if containertypes.Isolation(val).IsProcess() {
-				if system.IsWindowsClient() {
-					return fmt.Errorf("Windows client operating systems only support Hyper-V containers")
-				}
 				daemon.defaultIsolation = containertypes.Isolation("process")
 			}
 		default:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

Process isolation containers work fine on Windows client these days. This PR enables them to be set as default.
