### PR TITLE
Add bash completion for `docker export --output`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1071,9 +1071,16 @@ _docker_container_exec() {
 }
 
 _docker_container_export() {
+	case "$prev" in
+		--output|-o)
+			_filedir
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --output -o" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)


### PR DESCRIPTION
Fixed a missing option in bash completion: `docker [container] export --output|-o`.
