### PR TITLE
Add support for multiple containers to bash completion for `docker pause`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1223,10 +1223,7 @@ _docker_container_pause() {
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ $cword -eq $counter ]; then
-				__docker_complete_containers_running
-			fi
+			__docker_complete_containers_running
 			;;
 	esac
 }


### PR DESCRIPTION
`docker [container] pause` used to only work on one container but now supports multple containers:

```
Usage:  docker container pause CONTAINER [CONTAINER...]
```
