### PR TITLE
Fixes #24083 : Improving cli help for flags with duration option

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -446,8 +446,8 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.restartPolicy.window, flagRestartWindow, "Window used to evaluate the restart policy")
 
 	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 1, "Maximum number of tasks updated simultaneously (0 to update all at once)")
-	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates")
-	flags.DurationVar(&opts.update.monitor, flagUpdateMonitor, time.Duration(0), "Duration after each task update to monitor for failure")
+	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates (ns|us|ms|s|m|h) (default 0s)")
+	flags.DurationVar(&opts.update.monitor, flagUpdateMonitor, time.Duration(0), "Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)")
 	flags.StringVar(&opts.update.onFailure, flagUpdateFailureAction, "pause", "Action on update failure (pause|continue)")
 	flags.Float32Var(&opts.update.maxFailureRatio, flagUpdateMaxFailureRatio, 0, "Failure rate to tolerate during an update")
 

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -168,8 +168,8 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 
 func addSwarmFlags(flags *pflag.FlagSet, opts *swarmOptions) {
 	flags.Int64Var(&opts.taskHistoryLimit, flagTaskHistoryLimit, 5, "Task history retention limit")
-	flags.DurationVar(&opts.dispatcherHeartbeat, flagDispatcherHeartbeat, time.Duration(5*time.Second), "Dispatcher heartbeat period")
-	flags.DurationVar(&opts.nodeCertExpiry, flagCertExpiry, time.Duration(90*24*time.Hour), "Validity period for node certificates")
+	flags.DurationVar(&opts.dispatcherHeartbeat, flagDispatcherHeartbeat, time.Duration(5*time.Second), "Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)")
+	flags.DurationVar(&opts.nodeCertExpiry, flagCertExpiry, time.Duration(90*24*time.Hour), "Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)")
 	flags.Var(&opts.externalCA, flagExternalCA, "Specifications of one or more certificate signing endpoints")
 	flags.Uint64Var(&opts.maxSnapshots, flagMaxSnapshots, 0, "Number of additional Raft snapshots to retain")
 	flags.Uint64Var(&opts.snapshotInterval, flagSnapshotInterval, 10000, "Number of log entries between Raft snapshots")

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -58,9 +58,9 @@ Options:
       --expose value                Expose a port or a range of ports (default [])
       --group-add value             Add additional groups to join (default [])
       --health-cmd string           Command to run to check health
-      --health-interval duration    Time between running the check
+      --health-interval duration    Time between running the check (ns|us|ms|s|m|h) (default 0s)
       --health-retries int          Consecutive failures needed to report unhealthy
-      --health-timeout duration     Maximum time to allow one check to run
+      --health-timeout duration     Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                        Print usage
   -h, --hostname string             Container host name
   -i, --interactive                 Keep STDIN open even if not attached

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -62,9 +62,9 @@ Options:
       --expose value                Expose a port or a range of ports (default [])
       --group-add value             Add additional groups to join (default [])
       --health-cmd string           Command to run to check health
-      --health-interval duration    Time between running the check
+      --health-interval duration    Time between running the check (ns|us|ms|s|m|h) (default 0s)
       --health-retries int          Consecutive failures needed to report unhealthy
-      --health-timeout duration     Maximum time to allow one check to run
+      --health-timeout duration     Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                        Print usage
   -h, --hostname string             Container host name
   -i, --interactive                 Keep STDIN open even if not attached

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -31,9 +31,9 @@ Options:
       --env-file value                   Read in a file of environment variables (default [])
       --group value                      Set one or more supplementary user groups for the container (default [])
       --health-cmd string                Command to run to check health
-      --health-interval duration         Time between running the check
+      --health-interval duration         Time between running the check (ns|us|ms|s|m|h) (default 0s)
       --health-retries int               Consecutive failures needed to report unhealthy
-      --health-timeout duration          Maximum time to allow one check to run
+      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                             Print usage
       --hostname                         Service containers hostname
   -l, --label value                      Service labels (default [])
@@ -56,10 +56,10 @@ Options:
       --restart-window value             Window used to evaluate the restart policy (default none)
       --stop-grace-period value          Time to wait before force killing a container (default none)
   -t, --tty                              Allocate a pseudo-TTY
-      --update-delay duration            Delay between updates
+      --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")
       --update-max-failure-ratio value   Failure rate to tolerate during an update
-      --update-monitor duration          Duration after each task update to monitor for failure (default 0s)
+      --update-monitor duration          Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
       --update-parallelism uint          Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                      Username or UID (format: <name|uid>[:<group|gid>])
       --with-registry-auth               Send registry authentication details to Swarm agents

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -39,9 +39,9 @@ Options:
       --group-add stringSlice              Add an additional supplementary user group to the container
       --group-rm list                      Remove a previously added supplementary user group from the container (default [])
       --health-cmd string                  Command to run to check health
-      --health-interval duration-ptr       Time between running the check (default none)
+      --health-interval duration           Time between running the check (ns|us|ms|s|m|h) (default 0s)
       --health-retries int                 Consecutive failures needed to report unhealthy
-      --health-timeout duration-ptr        Maximum time to allow one check to run (default none)
+      --health-timeout duration            Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)
       --help                               Print usage
       --image string                       Service image tag
       --label-add list                     Add or update a service label (default [])
@@ -65,10 +65,10 @@ Options:
       --rollback                           Rollback to previous specification
       --stop-grace-period duration-ptr     Time to wait before force killing a container (default none)
   -t, --tty                                Allocate a pseudo-TTY
-      --update-delay duration              Delay between updates
+      --update-delay duration              Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string       Action on update failure (pause|continue) (default "pause")
       --update-max-failure-ratio float32   Failure rate to tolerate during an update
-      --update-monitor duration            Duration after each task update to monitor for failure
+      --update-monitor duration            Duration after each task update to monitor for failure (ns|us|ms|s|m|h) (default 0s)
       --update-parallelism uint            Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
   -u, --user string                        Username or UID (format: <name|uid>[:<group|gid>])
       --with-registry-auth                 Send registry authentication details to swarm agents

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -22,8 +22,8 @@ Initialize a swarm
 
 Options:
       --advertise-addr value            Advertised address (format: <ip|interface>[:port])
-      --cert-expiry duration            Validity period for node certificates (default 2160h0m0s)
-      --dispatcher-heartbeat duration   Dispatcher heartbeat period (default 5s)
+      --cert-expiry duration            Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
+      --dispatcher-heartbeat duration   Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
       --external-ca value               Specifications of one or more certificate signing endpoints
       --force-new-cluster               Force create a new cluster from current state
       --help                            Print usage

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -21,8 +21,8 @@ Usage:  docker swarm update [OPTIONS]
 Update the swarm
 
 Options:
-      --cert-expiry duration            Validity period for node certificates (default 2160h0m0s)
-      --dispatcher-heartbeat duration   Dispatcher heartbeat period (default 5s)
+      --cert-expiry duration            Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
+      --dispatcher-heartbeat duration   Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
       --external-ca value               Specifications of one or more certificate signing endpoints
       --help                            Print usage
       --max-snapshots int               Number of additional Raft snapshots to retain

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -218,9 +218,9 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 
 	// Health-checking
 	flags.StringVar(&copts.healthCmd, "health-cmd", "", "Command to run to check health")
-	flags.DurationVar(&copts.healthInterval, "health-interval", 0, "Time between running the check")
+	flags.DurationVar(&copts.healthInterval, "health-interval", 0, "Time between running the check (ns|us|ms|s|m|h) (default 0s)")
 	flags.IntVar(&copts.healthRetries, "health-retries", 0, "Consecutive failures needed to report unhealthy")
-	flags.DurationVar(&copts.healthTimeout, "health-timeout", 0, "Maximum time to allow one check to run")
+	flags.DurationVar(&copts.healthTimeout, "health-timeout", 0, "Maximum time to allow one check to run (ns|us|ms|s|m|h) (default 0s)")
 	flags.BoolVar(&copts.noHealthcheck, "no-healthcheck", false, "Disable any container-specified HEALTHCHECK")
 
 	// Resource management


### PR DESCRIPTION
Fixes #24083

Improving cli help for --update-delay flag

**\- A picture of a cute animal (not mandatory but encouraged)**
