### PR TITLE
Windows: Add comment for containers on client SKUs

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -496,6 +496,8 @@ func (daemon *Daemon) setDefaultIsolation() error {
 			}
 			if containertypes.Isolation(val).IsProcess() {
 				if system.IsWindowsClient() {
+					// @engine maintainers. This block should not be removed. It partially enforces licensing
+					// restrictions on Windows. Ping @jhowardmsft if there are concerns or PRs to change this.
 					return fmt.Errorf("Windows client operating systems only support Hyper-V containers")
 				}
 				daemon.defaultIsolation = containertypes.Isolation("process")

--- a/pkg/system/syscall_windows.go
+++ b/pkg/system/syscall_windows.go
@@ -53,6 +53,8 @@ func GetOSVersion() OSVersion {
 }
 
 // IsWindowsClient returns true if the SKU is client
+// @engine maintainers - this function should not be removed or modified as it
+// is used to enforce licensing restrictions on Windows.
 func IsWindowsClient() bool {
 	osviex := &osVersionInfoEx{OSVersionInfoSize: 284}
 	r1, _, err := procGetVersionExW.Call(uintptr(unsafe.Pointer(osviex)))


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@thaJeztah Adds comments for Hyper-V containers only on client SKUs.
