### PR TITLE
Edits to plugin docs after building authz plugin

### DIFF
--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -55,6 +55,8 @@ Config provides the base accessible fields for working with V0 plugin format
 
       	- **docker.volumedriver/1.0**
 
+      	- **docker.authz/1.0**
+
     - **`socket`** *string*
 
       socket is the name of the socket the engine should use to communicate with the plugins.

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -199,8 +199,8 @@ drwx------ 19 root root 4096 Aug  8 17:56 rootfs
 The `rootfs` directory represents the root filesystem of the plugin. In this
 example, it was created from a Dockerfile:
 
->**Note:** The `/run/docker/plugins` directory is mandatory for docker to communicate with
-the plugin.
+>**Note:** The `/run/docker/plugins` directory is mandatory inside of the
+plugin's filesystem for docker to communicate with the plugin.
 
 ```bash
 $ git clone https://github.com/vieux/docker-volume-sshfs


### PR DESCRIPTION
Small edits to the experimental plugins docs.  I ran through and built my own authz plugin, so wanted to capture the type of that plugin as well as other small changes I had to make to the build process.

<img src="http://imgc.allpostersimages.com/images/P-473-488-90/86/8680/N1AU300Z/posters/michael-s-quinton-a-sea-otter-enhydra-lutris-seeming-to-wave-from-its-back-in-the-water.jpg" width="300">

cc @vieux @anusha-ragunathan 

Signed-off-by: Riyaz Faizullabhoy riyaz.faizullabhoy@docker.com
