### PR TITLE
Fix overlay unmount for the root case

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -374,6 +374,10 @@ func (d *Driver) Get(id string, mountLabel string) (s string, err error) {
 
 // Put unmounts the mount path created for the give id.
 func (d *Driver) Put(id string) error {
+	// If id has a root, just return
+	if _, err := os.Stat(path.Join(d.dir(id), "root")); err == nil {
+		return nil
+	}
 	mountpoint := path.Join(d.dir(id), "merged")
 	if count := d.ctr.Decrement(mountpoint); count > 0 {
 		return nil


### PR DESCRIPTION
In root case no mount call or reference count
increment actually happens so don’t try to unmount.

Without the fix every pull that pulls all fresh layers would
show "failed to unmount" in the debug logs.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
