### PR TITLE
Fix stack overflow in ErrInAdequateCapacity.

### DIFF
--- a/plugin/store/store.go
+++ b/plugin/store/store.go
@@ -73,17 +73,6 @@ func (ps *Store) SetAll(plugins map[string]*v2.Plugin) {
 	ps.plugins = plugins
 }
 
-func (ps *Store) getByCap(name string, capability string) (*v2.Plugin, error) {
-	ps.RLock()
-	defer ps.RUnlock()
-
-	p, err := ps.GetByName(name)
-	if err != nil {
-		return nil, err
-	}
-	return p.FilterByCap(capability)
-}
-
 func (ps *Store) getAllByCap(capability string) []plugingetter.CompatPlugin {
 	ps.RLock()
 	defer ps.RUnlock()

--- a/plugin/store/store_test.go
+++ b/plugin/store/store_test.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/plugin/v2"
+)
+
+func TestFilterByCapNeg(t *testing.T) {
+	p := v2.NewPlugin("test", "1234567890", "/run/docker", "latest")
+
+	iType := types.PluginInterfaceType{"volumedriver", "docker", "1.0"}
+	i := types.PluginManifestInterface{"plugins.sock", []types.PluginInterfaceType{iType}}
+	p.PluginObj.Manifest.Interface = i
+
+	_, err := p.FilterByCap("foobar")
+	if err == nil {
+		t.Fatalf("expected inadequate error, got %v", err)
+	}
+}
+
+func TestFilterByCapPos(t *testing.T) {
+	p := v2.NewPlugin("test", "1234567890", "/run/docker", "latest")
+
+	iType := types.PluginInterfaceType{"volumedriver", "docker", "1.0"}
+	i := types.PluginManifestInterface{"plugins.sock", []types.PluginInterfaceType{iType}}
+	p.PluginObj.Manifest.Interface = i
+
+	_, err := p.FilterByCap("volumedriver")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -29,10 +29,12 @@ type Plugin struct {
 const defaultPluginRuntimeDestination = "/run/docker/plugins"
 
 // ErrInadequateCapability indicates that the plugin did not have the requested capability.
-type ErrInadequateCapability string
+type ErrInadequateCapability struct {
+	cap string
+}
 
-func (cap ErrInadequateCapability) Error() string {
-	return fmt.Sprintf("plugin does not provide %q capability", cap)
+func (e ErrInadequateCapability) Error() string {
+	return fmt.Sprintf("plugin does not provide %q capability", e.cap)
 }
 
 func newPluginObj(name, id, tag string) types.Plugin {
@@ -75,7 +77,7 @@ func (p *Plugin) FilterByCap(capability string) (*Plugin, error) {
 			return p, nil
 		}
 	}
-	return nil, ErrInadequateCapability(capability)
+	return nil, ErrInadequateCapability{capability}
 }
 
 // RemoveFromDisk deletes the plugin's runtime files from disk.


### PR DESCRIPTION
fmt package formats an error by calling its Error() method.
This results in recursion. Fix this. Also remove dead code.

Signed-off-by: Anusha Ragunathan anusha@docker.com
