### PR TITLE
Windows: Fix stats CLI

### DIFF
--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -80,6 +80,16 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		}
 	}
 
+	// Get the daemonOSType if not set already
+	if daemonOSType == "" {
+		svctx := context.Background()
+		sv, err := dockerCli.Client().ServerVersion(svctx)
+		if err != nil {
+			return err
+		}
+		daemonOSType = sv.Os
+	}
+
 	// waitFirst is a WaitGroup to wait first stat data's reach for each container
 	waitFirst := &sync.WaitGroup{}
 
@@ -184,7 +194,6 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		Output: dockerCli.Out(),
 		Format: formatter.NewStatsFormat(f, daemonOSType),
 	}
-
 	cleanScreen := func() {
 		if !opts.noStream {
 			fmt.Fprint(dockerCli.Out(), "\033[2J")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@dnephin @friism @thaJeztah. (Mostly) fixes https://github.com/docker/docker/issues/27671

Definitely a 1.13 one! https://github.com/docker/docker/pull/24987 broke the Windows CLI for docker stats. Admittedly there are no CI tests for the CLI on Windows - that's been on my list for a while, but I need to get something in before the freeze so at least it works again, rather than bombs out as described in https://github.com/docker/docker/issues/27671

Manual verification after this PR:
![image](https://cloud.githubusercontent.com/assets/10522484/19707873/558ed1ac-9acf-11e6-8da0-e76433a7dca9.png)

There were multiple issues with #24987.
- The formatter was attempting to use daemonOSType when it was not set. Previously (and still) the OSType comes back with a stats instance, but is processed after a ContainerList only.
  The ContainerList doesn't have the OS type of the daemon. So I had two alternatives to fix this up. One was to change the API (bad), or added a version call up front to ensure it is set before any processing occurs (which is in this PR).
- The Windows header was incorrect
- Incorrect processing of memory on Windows
- Wasn't doing the "Waiting for statistics" more.

All but the last one are fixed (in fact the string for 'waiting' wasn't actually being used in the codebase), but at this current time (see below), the Linux headers are always displayed if there are no containers, regardless of the daemon OS. The right header is displayed when there are running containers. Couldn't figure that out and need to get something in before the freeze.

Output of `docker stats` using a Windows CLI on master today:
![image](https://cloud.githubusercontent.com/assets/10522484/19708050/aaf78994-9ad0-11e6-87af-661acaff2a56.png)

PS
Yes, I will enable some Windows stats CI tests in a follow-up PR, as well as try to figure out why when there are no containers, the default header remains the linux style headers on Windows at https://github.com/docker/docker/blob/master/cli/command/formatter/formatter.go#L75-L77. This is a relatively minor issue though - at least stats do work in the CLI.
