### PR TITLE
Fixing broken img link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,8 @@
 # Contributing to Docker
 
-Want to hack on Docker? Awesome!  We have a contributor's guide that explains
+Want to hack on Docker? Awesome!  We have a [contributor's guide](https://docs.docker.com/opensource/project/who-written-for/) that explains
 [setting up a Docker development environment and the contribution
 process](https://docs.docker.com/opensource/project/who-written-for/). 
-
-[![Contributors guide](docs/static_files/contributors.png)](https://docs.docker.com/opensource/project/who-written-for/)
 
 This page contains information about reporting issues as well as some tips and
 guidelines useful to experienced open source contributors. Finally, make sure


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**
Fix the broken image link in  CONTRIBUTING.md

**\- How I did it**
Removed the reference to the missing image

**\- How to verify it**
Check the CONTRIBUTING.md after merge, should not have a broken image rendered in browser.

**\- Description for the changelog**

<!--
Fix broken image reference in CONTRIBUTING.md
-->

**\- A picture of a cute animal (not mandatory but encouraged)**
https://i.ytimg.com/vi/44Ehu8D8znQ/maxresdefault.jpg

 The image file it's referring to is missing. So I moved the link in paragraph itself.
