### PR TITLE
add detail information when removeTasksFromNode batch failed

### DIFF
--- a/vendor/src/github.com/docker/swarmkit/manager/orchestrator/global.go
+++ b/vendor/src/github.com/docker/swarmkit/manager/orchestrator/global.go
@@ -202,7 +202,7 @@ func (g *GlobalOrchestrator) removeTasksFromNode(ctx context.Context, node *api.
 		return nil
 	})
 	if err != nil {
-		log.G(ctx).WithError(err).Errorf("global orchestrator: removeTasksFromNode failed")
+		log.G(ctx).WithError(err).Errorf("global orchestrator: removeTasksFromNode failed batching tasks")
 	}
 }
 


### PR DESCRIPTION
add detail information when removeTasksFromNode batch failed, so as to differ from other exception.
