### PR TITLE
tiny improvement for devicemapper

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -2399,15 +2399,14 @@ func (devices *DeviceSet) UnmountDevice(hash, mountPath string) error {
 	info.lock.Lock()
 	defer info.lock.Unlock()
 
-	devices.Lock()
-	defer devices.Unlock()
-
 	logrus.Debugf("devmapper: Unmount(%s)", mountPath)
 	if err := syscall.Unmount(mountPath, syscall.MNT_DETACH); err != nil {
 		return err
 	}
 	logrus.Debug("devmapper: Unmount done")
 
+	devices.Lock()
+	defer devices.Unlock()
 	if err := devices.deactivateDevice(info); err != nil {
 		return err
 	}


### PR DESCRIPTION
 before this change:

```
[root@localhost ~]# time docker run --rm -ti busybox ls /
bin   dev   etc   home  proc  root  sys   tmp   usr   var

real    0m10.770s
user    0m0.019s
sys     0m0.016s
[root@localhost ~]# time docker run --rm -ti busybox ls /
bin   dev   etc   home  proc  root  sys   tmp   usr   var

real    0m9.968s
user    0m0.019s
sys     0m0.015s
[root@localhost ~]# time docker run --rm -ti busybox ls /
bin   dev   etc   home  proc  root  sys   tmp   usr   var

real    0m9.910s
user    0m0.013s
sys     0m0.018s
```

after this change:

```
[root@localhost ~]# time docker run --rm -ti busybox ls /
bin   dev   etc   home  proc  root  sys   tmp   usr   var

real    0m3.547s
user    0m0.016s
sys     0m0.017s
[root@localhost ~]# time docker run --rm -ti busybox ls /
bin   dev   etc   home  proc  root  sys   tmp   usr   var

real    0m3.253s
user    0m0.016s
sys     0m0.021s
[root@localhost ~]# time docker run --rm -ti busybox ls /
bin   dev   etc   home  proc  root  sys   tmp   usr   var

real    0m3.399s
user    0m0.020s
sys     0m0.014s
```

Could docker maintainers help to review ?
