### PR TITLE
Service create --group param

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -39,6 +39,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringSliceVar(&opts.constraints, flagConstraint, []string{}, "Placement constraints")
 	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")
 	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
+	flags.StringSliceVar(&opts.groups, flagGroup, []string{}, "Set one or more supplementary user groups for the container")
 
 	flags.SetInterspersed(false)
 	return cmd

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -583,7 +583,6 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 
 	flags.StringVarP(&opts.workdir, flagWorkdir, "w", "", "Working directory inside the container")
 	flags.StringVarP(&opts.user, flagUser, "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
-	flags.StringSliceVar(&opts.groups, flagGroupAdd, []string{}, "Add additional user groups to the container")
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")
@@ -630,6 +629,7 @@ const (
 	flagEnvFile               = "env-file"
 	flagEnvRemove             = "env-rm"
 	flagEnvAdd                = "env-add"
+	flagGroup                 = "group"
 	flagGroupAdd              = "group-add"
 	flagGroupRemove           = "group-rm"
 	flagLabel                 = "label"

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -42,7 +42,7 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	addServiceFlags(cmd, opts)
 
 	flags.Var(newListOptsVar(), flagEnvRemove, "Remove an environment variable")
-	flags.Var(newListOptsVar(), flagGroupRemove, "Remove previously added user groups from the container")
+	flags.Var(newListOptsVar(), flagGroupRemove, "Remove previously added supplementary user groups from the container")
 	flags.Var(newListOptsVar(), flagLabelRemove, "Remove a label by its key")
 	flags.Var(newListOptsVar(), flagContainerLabelRemove, "Remove a container label by its key")
 	flags.Var(newListOptsVar(), flagMountRemove, "Remove a mount by its target path")
@@ -54,6 +54,7 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.mounts, flagMountAdd, "Add or update a mount on a service")
 	flags.StringSliceVar(&opts.constraints, flagConstraintAdd, []string{}, "Add or update placement constraints")
 	flags.Var(&opts.endpoint.ports, flagPublishAdd, "Add or update a published port")
+	flags.StringSliceVar(&opts.groups, flagGroupAdd, []string{}, "Add additional supplementary user groups to the container")
 	return cmd
 }
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2573,7 +2573,6 @@ _docker_service_update() {
 		--endpoint-mode
 		--env -e
 		--force
-		--group-add
 		--health-cmd
 		--health-interval
 		--health-retries
@@ -2616,6 +2615,7 @@ _docker_service_update() {
 		options_with_args="$options_with_args
 			--container-label
 			--env-file
+			--group
 			--mode
 			--name
 		"
@@ -2629,6 +2629,10 @@ _docker_service_update() {
 				COMPREPLY=( $( compgen -W "global replicated" -- "$cur" ) )
 				return
 				;;
+			--group)
+			COMPREPLY=( $(compgen -g -- "$cur") )
+			return
+			;;
 		esac
 	fi
 	if [ "$subcommand" = "update" ] ; then
@@ -2636,11 +2640,16 @@ _docker_service_update() {
 			--arg
 			--container-label-add
 			--container-label-rm
+			--group-add
 			--group-rm
 			--image
 		"
 
 		case "$prev" in
+			--group-add)
+				COMPREPLY=( $(compgen -g -- "$cur") )
+				return
+				;;
 			--group-rm)
 				COMPREPLY=( $(compgen -g -- "$cur") )
 				return
@@ -2661,10 +2670,6 @@ _docker_service_update() {
 			# we do not append a "=" here because "-e VARNAME" is legal systax, too
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			__docker_nospace
-			return
-			;;
-		--group-add)
-			COMPREPLY=( $(compgen -g -- "$cur") )
 			return
 			;;
 		--log-driver)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1088,7 +1088,6 @@ __docker_service_subcommand() {
         "($help)*--constraint=[Placement constraints]:constraint: "
         "($help)--endpoint-mode=[Placement constraints]:mode:(dnsrr vip)"
         "($help)*"{-e=,--env=}"[Set environment variables]:env: "
-        "($help)*--group-add=[Add additional user groups to the container]:group:_groups"
         "($help)--health-cmd=[Command to run to check health]:command: "
         "($help)--health-interval=[Time between running the check]:time: "
         "($help)--health-retries=[Consecutive failures needed to report unhealthy]:retries:(1 2 3 4 5)"
@@ -1192,7 +1191,8 @@ __docker_service_subcommand() {
                 "($help)*--container-label-add=[Add or update container labels]:label: " \
                 "($help)*--container-label-rm=[Remove a container label by its key]:label: " \
                 "($help)--force[Force update]" \
-                "($help)*--group-rm=[Remove previously added user groups from the container]:group:_groups" \
+                "($help)*--group-add=[Add additional supplementary user groups to the container]:group:_groups" \
+                "($help)*--group-rm=[Remove previously added supplementary user groups from the container]:group:_groups" \
                 "($help)--image=[Service image tag]:image:__docker_repositories" \
                 "($help)--rollback[Rollback to previous specification]" \
                 "($help -)1:service:__docker_complete_services" && ret=0
@@ -1465,7 +1465,7 @@ __docker_subcommand() {
         "($help)--entrypoint=[Overwrite the default entrypoint of the image]:entry point: "
         "($help)*--env-file=[Read environment variables from a file]:environment file:_files"
         "($help)*--expose=[Expose a port from the container without publishing it]: "
-        "($help)*--group-add=[Add additional groups to run as]:group:_groups"
+        "($help)*--group=[Set one or more supplementary user groups for the container]:group:_groups"
         "($help -h --hostname)"{-h=,--hostname=}"[Container host name]:hostname:_hosts"
         "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]"
         "($help)--ip=[Container IPv4 address]:IPv4: "

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -26,7 +26,7 @@ Options:
       --endpoint-mode string             Endpoint mode (vip or dnsrr)
   -e, --env value                        Set environment variables (default [])
       --env-file value                   Read in a file of environment variables (default [])
-      --group-add value                  Add additional user groups to the container (default [])
+      --group value                      Set one or more supplementary user groups for the container (default [])
       --health-cmd string                Command to run to check health
       --health-interval duration         Time between running the check
       --health-retries int               Consecutive failures needed to report unhealthy

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -30,8 +30,8 @@ Options:
       --env-add value                    Add or update environment variables (default [])
       --env-rm value                     Remove an environment variable (default [])
       --force                            Force update even if no changes require it
-      --group-add value                  Add additional user groups to the container (default [])
-      --group-rm value                   Remove previously added user groups from the container (default [])
+      --group-add value                  Add additional supplementary user groups to the container (default [])
+      --group-rm value                   Remove previously added supplementary user groups from the container (default [])
       --health-cmd string                Command to run to check health
       --health-interval duration         Time between running the check
       --health-retries int               Consecutive failures needed to report unhealthy

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -235,7 +235,7 @@ func (s *DockerSwarmSuite) TestSwarmServiceWithGroup(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	name := "top"
-	out, err := d.Cmd("service", "create", "--name", name, "--user", "root:root", "--group-add", "wheel", "--group-add", "audio", "--group-add", "staff", "--group-add", "777", "busybox", "top")
+	out, err := d.Cmd("service", "create", "--name", name, "--user", "root:root", "--group", "wheel", "--group", "audio", "--group", "staff", "--group", "777", "busybox", "top")
 	c.Assert(err, checker.IsNil)
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 


### PR DESCRIPTION
--group-add was used for specifying groups for both service create
and service update. For create it was confusing since we don't have
an existing set of groups. Instead I added --group to create, and
moved --group-add to service update only, like --group-rm
This deals with issue https://github.com/docker/docker/issues/27646

Signed-off-by: Lily Guo lily.guo@docker.com
