### PR TITLE
Update hcsshim to v0.5.2

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -48,7 +48,7 @@ esac
 
 # the following lines are in sorted order, FYI
 clone git github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
-clone git github.com/Microsoft/hcsshim v0.5.1
+clone git github.com/Microsoft/hcsshim v0.5.2
 clone git github.com/Microsoft/go-winio v0.3.5
 clone git github.com/Sirupsen/logrus f76d643702a30fbffecdfe50831e11881c96ceb3 https://github.com/aaronlehmann/logrus
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/vendor/src/github.com/Microsoft/hcsshim/hcsshim.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/hcsshim.go
@@ -1,4 +1,4 @@
-// Shim for the Host Compute Service (HSC) to manage Windows Server
+// Shim for the Host Compute Service (HCS) to manage Windows Server
 // containers and Hyper-V containers.
 
 package hcsshim

--- a/vendor/src/github.com/Microsoft/hcsshim/hnsfuncs.go
+++ b/vendor/src/github.com/Microsoft/hcsshim/hnsfuncs.go
@@ -30,6 +30,11 @@ type VsidPolicy struct {
 	VSID uint
 }
 
+type PaPolicy struct {
+	Type string
+	PA   string
+}
+
 // Subnet is assoicated with a network and represents a list
 // of subnets available to the network
 type Subnet struct {
@@ -58,6 +63,7 @@ type HNSNetwork struct {
 	DNSSuffix            string            `json:",omitempty"`
 	DNSServerList        string            `json:",omitempty"`
 	DNSServerCompartment uint32            `json:",omitempty"`
+	ManagementIP         string            `json:",omitempty"`
 }
 
 // HNSEndpoint represents a network endpoint in HNS
@@ -74,6 +80,7 @@ type HNSEndpoint struct {
 	GatewayAddress     string            `json:",omitempty"`
 	EnableInternalDNS  bool              `json:",omitempty"`
 	PrefixLength       uint8             `json:",omitempty"`
+	IsRemoteEndpoint   bool              `json:",omitempty"`
 }
 
 type hnsNetworkResponse struct {


### PR DESCRIPTION
Update hcsshim to v0.5.2. This version includes a temporary workaround for some cases of the timeouts reported in https://github.com/docker/docker/issues/27588 (unfortunately I don't think it will fix the issue as reported, just a set of similar issues).

@msabansal This also includes some of your changes.

Signed-off-by: Darren Stahl darst@microsoft.com

/cc @jhowardmsft @jstarks 
