### PR TITLE
Windows: Fix builder cache bug

### DIFF
--- a/builder/tarsum.go
+++ b/builder/tarsum.go
@@ -63,7 +63,7 @@ func (c *tarSumContext) Stat(path string) (string, FileInfo, error) {
 	sum := path
 	// Use the checksum of the followed path(not the possible symlink) because
 	// this is the file that is actually copied.
-	if tsInfo := c.sums.GetFile(rel); tsInfo != nil {
+	if tsInfo := c.sums.GetFile(filepath.ToSlash(rel)); tsInfo != nil {
 		sum = tsInfo.Sum()
 	}
 	fi := &HashedFileInfo{PathFileInfo{st, fullpath, filepath.Base(cleanpath)}, sum}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -578,21 +578,21 @@ func (f *FakeContext) Add(file, content string) error {
 }
 
 func (f *FakeContext) addFile(file string, content []byte) error {
-	filepath := path.Join(f.Dir, file)
-	dirpath := path.Dir(filepath)
+	fp := filepath.Join(f.Dir, filepath.FromSlash(file))
+	dirpath := filepath.Dir(fp)
 	if dirpath != "." {
 		if err := os.MkdirAll(dirpath, 0755); err != nil {
 			return err
 		}
 	}
-	return ioutil.WriteFile(filepath, content, 0644)
+	return ioutil.WriteFile(fp, content, 0644)
 
 }
 
 // Delete a file at a path
 func (f *FakeContext) Delete(file string) error {
-	filepath := path.Join(f.Dir, file)
-	return os.RemoveAll(filepath)
+	fp := filepath.Join(f.Dir, filepath.FromSlash(file))
+	return os.RemoveAll(fp)
 }
 
 // Close deletes the context


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes https://github.com/docker/docker/issues/27755.

@duglin. @thaJeztah Honestly astonished this hasn't been found before. The short story is that on Windows, if you do a docker build, then modify the contents of a single file in a folder below the context root (so the path has a slash in it), and build again, the builder will incorrectly see the cached image of the first build.

Many hours of debugging later, I found that since day 1 when I ported the builder to Windows, if you inspect the image created by a build step, it has (incorrectly) `#nop ADD file:filename in c:\path\file.cmd`. So when the builder cache compares the configs, they match just fine when they shouldn't.

What should have been in that `#nop` is `#nop ADD file:tarsum in c:\path\file.cmd`. That way, when the runconfigs are compared, if the file hash has changed, the build cache will be (correctly) broken if the file contents change.

Tracked it down as to where the hash is generated - it's in the tarsum package. The problem is that the code is comparing apples to oranges (linux style paths to windows style paths) in its map so never triggers a match. Hence the sum never actually gets set at https://github.com/docker/docker/blob/master/builder/tarsum.go#L67

@vbatts FYI :smile: 

@friism If there is another cherry-pick, this really has to make it in.
