### PR TITLE
Add bash completion for new `docker system` command family

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2171,17 +2171,7 @@ _docker_import() {
 }
 
 _docker_info() {
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
-			;;
-	esac
+	_docker_system_info
 }
 
 _docker_inspect() {
@@ -3181,7 +3171,17 @@ _docker_system_events() {
 }
 
 _docker_system_info() {
-	_docker_info
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
+			;;
+	esac
 }
 
 # TODO new command

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3151,6 +3151,45 @@ _docker_stop() {
 	_docker_container_stop
 }
 
+
+_docker_system() {
+	local subcommands="
+		df
+		events
+		info
+		prune
+	"
+	__docker_subcommands "$subcommands $aliases" && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+# TODO new command
+_docker_system_df() {
+	:
+}
+
+_docker_system_events() {
+	_docker_events
+}
+
+_docker_system_info() {
+	_docker_info
+}
+
+# TODO new command
+_docker_system_prune() {
+	:
+}
+
+
 _docker_tag() {
 	_docker_image_tag
 }
@@ -3325,6 +3364,7 @@ _docker() {
 		stats
 		stop
 		swarm
+		system
 		tag
 		top
 		unpause

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1824,93 +1824,7 @@ _docker_diff() {
 }
 
 _docker_events() {
-	local key=$(__docker_map_key_of_current_option '-f|--filter')
-	case "$key" in
-		container)
-			__docker_complete_containers_all --cur "${cur##*=}"
-			return
-			;;
-		daemon)
-			local name=$(__docker_q info | sed -n 's/^\(ID\|Name\): //p')
-			COMPREPLY=( $( compgen -W "$name" -- "${cur##*=}" ) )
-			return
-			;;
-		event)
-			COMPREPLY=( $( compgen -W "
-				attach
-				commit
-				connect
-				copy
-				create
-				delete
-				destroy
-				detach
-				die
-				disconnect
-				exec_create
-				exec_detach
-				exec_start
-				export
-				health_status
-				import
-				kill
-				load
-				mount
-				oom
-				pause
-				pull
-				push
-				reload
-				rename
-				resize
-				restart
-				save
-				start
-				stop
-				tag
-				top
-				unmount
-				unpause
-				untag
-				update
-			" -- "${cur##*=}" ) )
-			return
-			;;
-		image)
-			cur="${cur##*=}"
-			__docker_complete_images
-			return
-			;;
-		network)
-			__docker_complete_networks --cur "${cur##*=}"
-			return
-			;;
-		type)
-			COMPREPLY=( $( compgen -W "container daemon image network volume" -- "${cur##*=}" ) )
-			return
-			;;
-		volume)
-			__docker_complete_volumes --cur "${cur##*=}"
-			return
-			;;
-	esac
-
-	case "$prev" in
-		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "container daemon event image label network type volume" -- "$cur" ) )
-			__docker_nospace
-			return
-			;;
-		--since|--until)
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--filter -f --help --since --until --format" -- "$cur" ) )
-			;;
-	esac
+	_docker_system_events
 }
 
 _docker_exec() {
@@ -3177,7 +3091,93 @@ _docker_system_df() {
 }
 
 _docker_system_events() {
-	_docker_events
+	local key=$(__docker_map_key_of_current_option '-f|--filter')
+	case "$key" in
+		container)
+			__docker_complete_containers_all --cur "${cur##*=}"
+			return
+			;;
+		daemon)
+			local name=$(__docker_q info | sed -n 's/^\(ID\|Name\): //p')
+			COMPREPLY=( $( compgen -W "$name" -- "${cur##*=}" ) )
+			return
+			;;
+		event)
+			COMPREPLY=( $( compgen -W "
+				attach
+				commit
+				connect
+				copy
+				create
+				delete
+				destroy
+				detach
+				die
+				disconnect
+				exec_create
+				exec_detach
+				exec_start
+				export
+				health_status
+				import
+				kill
+				load
+				mount
+				oom
+				pause
+				pull
+				push
+				reload
+				rename
+				resize
+				restart
+				save
+				start
+				stop
+				tag
+				top
+				unmount
+				unpause
+				untag
+				update
+			" -- "${cur##*=}" ) )
+			return
+			;;
+		image)
+			cur="${cur##*=}"
+			__docker_complete_images
+			return
+			;;
+		network)
+			__docker_complete_networks --cur "${cur##*=}"
+			return
+			;;
+		type)
+			COMPREPLY=( $( compgen -W "container daemon image network volume" -- "${cur##*=}" ) )
+			return
+			;;
+		volume)
+			__docker_complete_volumes --cur "${cur##*=}"
+			return
+			;;
+	esac
+
+	case "$prev" in
+		--filter|-f)
+			COMPREPLY=( $( compgen -S = -W "container daemon event image label network type volume" -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+		--since|--until)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--filter -f --help --since --until --format" -- "$cur" ) )
+			;;
+	esac
 }
 
 _docker_system_info() {


### PR DESCRIPTION
Bash completion for the new `docker system` subcommand family introduced in #26025.

As in #27719 and #27579, I created
- one commit for the basic structure in which the new commands delegate to the old ones
- one commit per command that moves the completion logic to the new homes, reversing sense of delegation

so that the PR is easier to review.
With this PR, all the new command aliases from #26025 are implemented :tada:.

**Notes:**
There are two new commands `docker system df` and `docker system prune`. In order to not mix refactoring/aliasing of existing commands and implementing new commands, I just created stubs. I will add the completions in a follow-up PR.

ping @thaJeztah @mlaventure @tianon
