### PR TITLE
Fix creation of the APT repo directory structure for similar distros

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -78,7 +78,7 @@ set -e
 		EOF
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN cp -aL hack/make/.build-deb debian
-			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
+			RUN { echo '$debSource (${debVersion}-0~${version}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
 			RUN dpkg-buildpackage -uc -us -I.git
 		EOF
 		tempImage="docker-temp/build-deb:$version"

--- a/hack/make/release-deb
+++ b/hack/make/release-deb
@@ -132,6 +132,7 @@ for dir in bundles/$VERSION/build-deb/*/; do
 
 	# update the filelist for this codename/component
 	find "$APTDIR/pool/$component" \
+		-name *~${codename}*.deb -o \
 		-name *~${codename#*-}*.deb > "$APTDIR/dists/$codename/$component/filelist"
 done
 


### PR DESCRIPTION
Right now we do have a problem to store the .debs for `raspbian-jessie` and
`debian-jessie` distro version for `armhf` arch. Both .debs have the same filename
so we have to include the distro version, too.

Signed-off-by: Dieter Reuter dieter.reuter@me.com
