### PR TITLE
Deprecate API calls without a version

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -226,3 +226,12 @@ Since 1.9, Docker Content Trust Offline key has been renamed to Root key and the
 **Deprecated In Release: v1.13.0**
 
 `MAINTAINER` was an early very limited form of `LABEL` which should be used instead.
+
+### API calls without a version
+**Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/)**
+
+**Target For Removal In Release: v1.16**
+
+API versions should be supplied to all API calls to ensure compatibility with
+future Engine versions. Instead of just requesting, for example, the URL
+`/containers/json`, you must now request `/v1.25/containers/json`.

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -36,23 +36,34 @@ following:
 When using cUrl 7.50 or later:
 
 ```console
-$ curl --unix-socket /var/run/docker.sock http://localhost/containers/json
+$ curl --unix-socket /var/run/docker.sock http://localhost/v1.25/containers/json
 ```
 
 When using cURL 7.40, `localhost` must be omitted:
 
 ```console
-$ curl --unix-socket /var/run/docker.sock http://containers/json
+$ curl --unix-socket /var/run/docker.sock http://v1.25/containers/json
 ```
 
 If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the
 default.
 
-The current version of the API is v1.25 which means calling `/info` is the same
-as calling `/v1.25/info`. To call an older version of the API use
-`/v1.24/info`. If a newer daemon is installed, new properties may be returned
-even when calling older versions of the API.
+## Versioning
+
+It is required to to supply a version to API calls. This is done by prefixing
+the URL with the version number.
+
+The current version of the API is 1.25, so to call the `/info` endpoint, you
+would send a request to the URL `/v1.25/info`. To call, for example, version
+1.24 of the API instead, you would request `/v1.24/info`.
+
+If a newer daemon is installed, new properties may be returned even when
+calling older versions of the API.
+
+In previous versions of Docker, it was possible to access the API without
+providing a version. This behaviour is now deprecated will be removed in a
+future version of Docker.
 
 Use the table below to find the API version for a Docker version:
 
@@ -97,11 +108,11 @@ API requests, for example:
 curl --insecure \
      --cert $DOCKER_CERT_PATH/cert.pem \
      --key $DOCKER_CERT_PATH/key.pem \
-     https://YOUR_VM_IP:2376/images/json
+     https://YOUR_VM_IP:2376/v1.25/images/json
 
 wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem \
      --private-key=$DOCKER_CERT_PATH/key.pem \
-     https://YOUR_VM_IP:2376/images/json -O - -q
+     https://YOUR_VM_IP:2376/v1.25/images/json -O - -q
 ```
 
 ## Docker Events
@@ -130,6 +141,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
+* The API version is now required in all API calls. Instead of just requesting, for example, the URL `/containers/json`, you must now request `/v1.25/containers/json`.
 * `POST /build` accepts `networkmode` parameter to specify network used during build.
 * `GET /images/(name)/json` now returns `OsVersion` if populated
 * `GET /info` now returns `Isolation`.

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.18/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -131,7 +131,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.18/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -318,7 +318,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.18/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -453,7 +453,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -476,7 +476,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -518,7 +518,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
+     GET /v1.18/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
 
 **Example response**:
 
@@ -555,7 +555,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -597,7 +597,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -622,7 +622,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.18/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -710,7 +710,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.18/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -741,7 +741,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.18/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -762,7 +762,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.18/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -787,7 +787,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.18/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -811,7 +811,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.18/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -836,7 +836,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.18/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -861,7 +861,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.18/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -881,7 +881,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.18/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -901,7 +901,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.18/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -988,7 +988,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.18/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1023,7 +1023,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.18/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1075,7 +1075,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.18/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1105,7 +1105,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.18/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1139,7 +1139,7 @@ Copy files or folders of container `id`
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.18/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1193,7 +1193,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.18/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1264,7 +1264,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.18/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1308,7 +1308,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/json HTTP/1.1
+    GET /v1.18/images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1359,7 +1359,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.18/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1393,7 +1393,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.18/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1411,7 +1411,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.18/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1436,7 +1436,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.18/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1501,7 +1501,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.18/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1552,7 +1552,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.18/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1580,7 +1580,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.18/info HTTP/1.1
 
 **Example response**:
 
@@ -1645,7 +1645,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.18/version HTTP/1.1
 
 **Example response**:
 
@@ -1675,7 +1675,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.18/_ping HTTP/1.1
 
 **Example response**:
 
@@ -1697,7 +1697,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.18/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1904,7 +1904,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.18/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1949,7 +1949,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.18/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1989,7 +1989,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.18/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2015,7 +2015,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.18/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.19/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -131,7 +131,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.19/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -328,7 +328,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.19/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -467,7 +467,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -490,7 +490,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -532,7 +532,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.19/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -571,7 +571,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -613,7 +613,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -638,7 +638,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.19/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -747,7 +747,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.19/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -778,7 +778,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.19/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -799,7 +799,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.19/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -824,7 +824,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.19/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -848,7 +848,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.19/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -873,7 +873,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.19/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -898,7 +898,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.19/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -918,7 +918,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.19/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -938,7 +938,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.19/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1025,7 +1025,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.19/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1060,7 +1060,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.19/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1112,7 +1112,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.19/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1142,7 +1142,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.19/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1180,7 +1180,7 @@ Copy files or folders of container `id`
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.19/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1235,7 +1235,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.19/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1308,7 +1308,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.19/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1352,7 +1352,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/json HTTP/1.1
+    GET /v1.19/images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1403,7 +1403,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.19/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1457,7 +1457,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.19/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1475,7 +1475,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.19/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1500,7 +1500,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.19/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1568,7 +1568,7 @@ be deprecated and replaced by the `is_automated` property.
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.19/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1622,7 +1622,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.19/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1650,7 +1650,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.19/info HTTP/1.1
 
 **Example response**:
 
@@ -1719,7 +1719,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.19/version HTTP/1.1
 
 **Example response**:
 
@@ -1749,7 +1749,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.19/_ping HTTP/1.1
 
 **Example response**:
 
@@ -1771,7 +1771,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.19/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1982,7 +1982,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.19/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2030,7 +2030,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.19/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2070,7 +2070,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.19/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2096,7 +2096,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.19/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.20/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -131,7 +131,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.20/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -332,7 +332,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.20/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -476,7 +476,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -499,7 +499,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -541,7 +541,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.20/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -580,7 +580,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -622,7 +622,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -647,7 +647,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.20/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -756,7 +756,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.20/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -787,7 +787,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.20/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -808,7 +808,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.20/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -833,7 +833,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.20/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -857,7 +857,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.20/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -882,7 +882,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.20/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -907,7 +907,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.20/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -927,7 +927,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.20/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -947,7 +947,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.20/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1034,7 +1034,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.20/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1069,7 +1069,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.20/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1123,7 +1123,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.20/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1175,7 +1175,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.20/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1273,7 +1273,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.20/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1311,7 +1311,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.20/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1366,7 +1366,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.20/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1464,7 +1464,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.20/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1508,7 +1508,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/json HTTP/1.1
+    GET /v1.20/images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1559,7 +1559,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.20/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1613,7 +1613,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.20/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1631,7 +1631,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.20/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1656,7 +1656,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.20/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1721,7 +1721,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.20/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1772,7 +1772,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.20/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1800,7 +1800,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.20/info HTTP/1.1
 
 **Example response**:
 
@@ -1869,7 +1869,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.20/version HTTP/1.1
 
 **Example response**:
 
@@ -1900,7 +1900,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.20/_ping HTTP/1.1
 
 **Example response**:
 
@@ -1922,7 +1922,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.20/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2139,7 +2139,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.20/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2187,7 +2187,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.20/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2227,7 +2227,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.20/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2253,7 +2253,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.20/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.21/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -135,7 +135,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.21/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -353,7 +353,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.21/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -511,7 +511,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -545,7 +545,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -568,7 +568,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -610,7 +610,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.21/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -649,7 +649,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -691,7 +691,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -716,7 +716,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.21/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -837,7 +837,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.21/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -868,7 +868,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.21/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -889,7 +889,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.21/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -914,7 +914,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.21/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -938,7 +938,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.21/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -963,7 +963,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.21/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -988,7 +988,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.21/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1008,7 +1008,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.21/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1028,7 +1028,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.21/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1115,7 +1115,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.21/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1150,7 +1150,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.21/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1204,7 +1204,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.21/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1256,7 +1256,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.21/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1354,7 +1354,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.21/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1392,7 +1392,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.21/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1447,7 +1447,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.21/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1551,7 +1551,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.21/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1599,7 +1599,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.21/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1710,7 +1710,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.21/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1764,7 +1764,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.21/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1782,7 +1782,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.21/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1807,7 +1807,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.21/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1872,7 +1872,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.21/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1923,7 +1923,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.21/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1951,7 +1951,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.21/info HTTP/1.1
 
 **Example response**:
 
@@ -2022,7 +2022,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.21/version HTTP/1.1
 
 **Example response**:
 
@@ -2053,7 +2053,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.21/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2075,7 +2075,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.21/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2293,7 +2293,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.21/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2345,7 +2345,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.21/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2386,7 +2386,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.21/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2412,7 +2412,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.21/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2538,7 +2538,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.21/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2572,7 +2572,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.21/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2658,7 +2658,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks HTTP/1.1
+    GET /v1.21/networks HTTP/1.1
 
 **Example response**:
 
@@ -2739,7 +2739,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566 HTTP/1.1
+    GET /v1.21/networks/f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566 HTTP/1.1
 
 **Example response**:
 
@@ -2793,7 +2793,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.21/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -2846,7 +2846,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.21/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -2877,7 +2877,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.21/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.22/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -220,7 +220,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.22/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -465,7 +465,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.22/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -636,7 +636,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -670,7 +670,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -693,7 +693,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -735,7 +735,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.22/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -774,7 +774,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -816,7 +816,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -841,7 +841,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.22/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -962,7 +962,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.22/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -993,7 +993,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.22/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1020,7 +1020,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.22/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1045,7 +1045,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.22/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1069,7 +1069,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.22/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1094,7 +1094,7 @@ Update resource configs of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.22/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1134,7 +1134,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.22/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1159,7 +1159,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.22/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1179,7 +1179,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.22/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1199,7 +1199,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.22/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1290,7 +1290,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.22/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1328,7 +1328,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.22/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1382,7 +1382,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.22/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1434,7 +1434,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.22/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1532,7 +1532,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.22/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1570,7 +1570,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.22/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1625,7 +1625,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.22/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1730,7 +1730,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.22/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1796,7 +1796,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.22/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1907,7 +1907,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.22/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1961,7 +1961,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.22/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1981,7 +1981,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.22/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2023,7 +2023,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.22/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2088,7 +2088,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.22/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2139,7 +2139,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.22/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2167,7 +2167,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.22/info HTTP/1.1
 
 **Example response**:
 
@@ -2254,7 +2254,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.22/version HTTP/1.1
 
 **Example response**:
 
@@ -2286,7 +2286,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.22/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2308,7 +2308,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.22/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2683,7 +2683,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.22/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2739,7 +2739,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.22/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2780,7 +2780,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.22/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2806,7 +2806,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.22/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2849,7 +2849,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.22/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2884,7 +2884,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.22/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2970,7 +2970,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.22/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3054,7 +3054,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.22/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3113,7 +3113,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.22/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3174,7 +3174,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.22/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3211,7 +3211,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.22/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.23/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -242,7 +242,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.23/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -491,7 +491,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.23/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -662,7 +662,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -696,7 +696,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -719,7 +719,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -761,7 +761,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.23/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -800,7 +800,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -842,7 +842,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -867,7 +867,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.23/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -991,7 +991,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.23/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -1022,7 +1022,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.23/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1049,7 +1049,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.23/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1074,7 +1074,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.23/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1098,7 +1098,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.23/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1123,7 +1123,7 @@ Update configuration of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.23/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1167,7 +1167,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.23/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1192,7 +1192,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.23/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1212,7 +1212,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.23/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1232,7 +1232,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.23/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1323,7 +1323,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.23/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1361,7 +1361,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.23/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1415,7 +1415,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.23/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1467,7 +1467,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.23/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1565,7 +1565,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.23/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1603,7 +1603,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.23/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1658,7 +1658,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.23/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1764,7 +1764,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.23/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1830,7 +1830,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.23/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1948,7 +1948,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.23/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -2002,7 +2002,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.23/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -2022,7 +2022,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.23/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2064,7 +2064,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.23/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2129,7 +2129,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.23/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2181,7 +2181,7 @@ if available, for accessing the registry without password.
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.23/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2213,7 +2213,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.23/info HTTP/1.1
 
 **Example response**:
 
@@ -2302,7 +2302,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.23/version HTTP/1.1
 
 **Example response**:
 
@@ -2334,7 +2334,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.23/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2356,7 +2356,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.23/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2757,7 +2757,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.23/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2813,7 +2813,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.23/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2854,7 +2854,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.23/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2880,7 +2880,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.23/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2923,7 +2923,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.23/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2958,7 +2958,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.23/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3057,7 +3057,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.23/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3147,7 +3147,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.23/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3212,7 +3212,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.23/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3290,7 +3290,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.23/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3327,7 +3327,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.23/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -48,7 +48,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.24/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -253,7 +253,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.24/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -516,7 +516,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.24/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -694,7 +694,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -728,7 +728,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -751,7 +751,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -793,7 +793,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.24/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -833,7 +833,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -875,7 +875,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -900,7 +900,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.24/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -1024,7 +1024,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.24/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -1051,7 +1051,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.24/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1078,7 +1078,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.24/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1103,7 +1103,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.24/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1127,7 +1127,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.24/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1152,7 +1152,7 @@ Update configuration of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.24/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1196,7 +1196,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.24/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1221,7 +1221,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.24/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1241,7 +1241,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.24/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1261,7 +1261,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.24/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1352,7 +1352,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.24/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1390,7 +1390,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.24/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1464,7 +1464,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.24/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1562,7 +1562,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.24/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1600,7 +1600,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.24/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1657,7 +1657,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.24/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1763,7 +1763,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.24/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1829,7 +1829,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.24/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1947,7 +1947,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.24/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -2001,7 +2001,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.24/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -2021,7 +2021,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.24/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2063,7 +2063,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
+    POST /v1.24/images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2127,7 +2127,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.24/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2184,7 +2184,7 @@ if available, for accessing the registry without password.
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.24/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2216,7 +2216,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.24/info HTTP/1.1
 
 **Example response**:
 
@@ -2309,7 +2309,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.24/version HTTP/1.1
 
 **Example response**:
 
@@ -2341,7 +2341,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.24/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2363,7 +2363,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.24/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2769,7 +2769,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.24/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2825,7 +2825,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.24/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2866,7 +2866,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.24/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2892,7 +2892,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.24/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2935,7 +2935,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.24/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2975,7 +2975,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.24/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3105,7 +3105,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.24/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3197,7 +3197,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.24/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3262,7 +3262,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.24/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3340,7 +3340,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.24/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3378,7 +3378,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.24/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3433,7 +3433,7 @@ Returns information about installed plugins.
 
 **Example request**:
 
-    GET /plugins HTTP/1.1
+    GET /v1.24/plugins HTTP/1.1
 
 **Example response**:
 
@@ -3565,7 +3565,7 @@ using the [`POST /plugins/(plugin name)/enable` endpoint](#enable-a-plugin).
 **Example request**:
 
 ```
-POST /plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
+POST /v1.24/plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -3626,7 +3626,7 @@ Returns detailed information about an installed plugin.
 **Example request**:
 
 ```
-GET /plugins/tiborvass/no-remove:latest HTTP/1.1
+GET /v1.24/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -3759,7 +3759,7 @@ Enables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/enable HTTP/1.1
+POST /v1.24/plugins/tiborvass/no-remove:latest/enable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -3787,7 +3787,7 @@ Disables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/disable HTTP/1.1
+POST /v1.24/plugins/tiborvass/no-remove:latest/disable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -3838,14 +3838,14 @@ Content-Type: text/plain; charset=utf-8
 
 ### Push a plugin
 
-`POST /plugins/tiborvass/(plugin name)/push HTTP/1.1`
+`POST /v1.24/plugins/tiborvass/(plugin name)/push HTTP/1.1`
 
 Pushes a plugin to the registry.
 
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest HTTP/1.1
+POST /v1.24/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -3875,7 +3875,7 @@ List nodes
 
 **Example request**:
 
-    GET /nodes HTTP/1.1
+    GET /v1.24/nodes HTTP/1.1
 
 **Example response**:
 
@@ -3967,7 +3967,7 @@ Return low-level information on the node `id`
 
 **Example request**:
 
-      GET /nodes/24ifsmvkjbyhk HTTP/1.1
+      GET /v1.24/nodes/24ifsmvkjbyhk HTTP/1.1
 
 **Example response**:
 
@@ -4084,7 +4084,7 @@ an empty value or the default cluster-wide value.
 
 **Example Request**
 
-    POST /nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
+    POST /v1.24/nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4182,7 +4182,7 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
 
 **Example request**:
 
-    POST /swarm/init HTTP/1.1
+    POST /v1.24/swarm/init HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4257,7 +4257,7 @@ Join an existing swarm
 
 **Example request**:
 
-    POST /swarm/join HTTP/1.1
+    POST /v1.24/swarm/join HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4300,7 +4300,7 @@ Leave a swarm
 
 **Example request**:
 
-    POST /swarm/leave HTTP/1.1
+    POST /v1.24/swarm/leave HTTP/1.1
 
 **Example response**:
 
@@ -4326,7 +4326,7 @@ Update a swarm
 
 **Example request**:
 
-    POST /swarm/update HTTP/1.1
+    POST /v1.24/swarm/update HTTP/1.1
 
     {
       "Name": "default",
@@ -4411,7 +4411,7 @@ List services
 
 **Example request**:
 
-    GET /services HTTP/1.1
+    GET /v1.24/services HTTP/1.1
 
 **Example response**:
 
@@ -4517,7 +4517,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/create HTTP/1.1
+    POST /v1.24/services/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4711,7 +4711,7 @@ Return information on the service `id`.
 
 **Example request**:
 
-    GET /services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
+    GET /v1.24/services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
 
 **Example response**:
 
@@ -4803,7 +4803,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
+    POST /v1.24/services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4937,7 +4937,7 @@ List tasks
 
 **Example request**:
 
-    GET /tasks HTTP/1.1
+    GET /v1.24/tasks HTTP/1.1
 
 **Example response**:
 
@@ -5135,7 +5135,7 @@ Get details on a task
 
 **Example request**:
 
-    GET /tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
+    GET /v1.24/tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -48,7 +48,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.25/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -256,7 +256,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.25/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -545,7 +545,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.25/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -726,7 +726,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -760,7 +760,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -783,7 +783,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -825,7 +825,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.25/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -865,7 +865,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -907,7 +907,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -932,7 +932,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.25/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -1056,7 +1056,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.25/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -1083,7 +1083,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.25/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1110,7 +1110,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.25/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1135,7 +1135,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.25/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1159,7 +1159,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.25/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1184,7 +1184,7 @@ Update configuration of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.25/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1228,7 +1228,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.25/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1253,7 +1253,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.25/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1273,7 +1273,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.25/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1293,7 +1293,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.25/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1384,7 +1384,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.25/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1422,7 +1422,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.25/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1496,7 +1496,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.25/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1595,7 +1595,7 @@ Delete stopped containers
 
 **Example request**:
 
-    POST /containers/prune HTTP/1.1
+    POST /v1.25/containers/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1626,7 +1626,7 @@ Delete stopped containers
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.25/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1664,7 +1664,7 @@ Delete stopped containers
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.25/v1.25/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1721,7 +1721,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.25/v1.25/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1833,7 +1833,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.25/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1908,7 +1908,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.25/images/example/json HTTP/1.1
 
 **Example response (Linux daemon)**:
 
@@ -2106,7 +2106,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.25/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -2160,7 +2160,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.25/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -2180,7 +2180,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.25/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2222,7 +2222,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
+    POST /v1.25/images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2286,7 +2286,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.25/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2340,7 +2340,7 @@ Delete unused images
 
 **Example request**:
 
-    POST /images/prune HTTP/1.1
+    POST /v1.25/images/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2391,7 +2391,7 @@ if available, for accessing the registry without password.
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.25/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2423,7 +2423,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.25/info HTTP/1.1
 
 **Example response (Linux)**:
 
@@ -2619,7 +2619,7 @@ Return docker data usage information
 
 **Example request**:
 
-    GET /system/df HTTP/1.1
+    GET /v1.25/system/df HTTP/1.1
 
 **Example response**:
 
@@ -2711,7 +2711,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.25/version HTTP/1.1
 
 **Example response**:
 
@@ -2743,7 +2743,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.25/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2765,7 +2765,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.25/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3171,7 +3171,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.25/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3232,7 +3232,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.25/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3273,7 +3273,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.25/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -3299,7 +3299,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.25/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -3343,7 +3343,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.25/volumes HTTP/1.1
 
 **Example response**:
 
@@ -3391,7 +3391,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.25/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3532,7 +3532,7 @@ Delete unused volumes
 
 **Example request**:
 
-    POST /volumes/prune HTTP/1.1
+    POST /v1.25/volumes/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3564,7 +3564,7 @@ Delete unused volumes
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.25/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3659,7 +3659,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.25/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3725,7 +3725,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.25/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3803,7 +3803,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.25/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3841,7 +3841,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.25/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3894,7 +3894,7 @@ Delete unused networks
 
 **Example request**:
 
-    POST /networks/prune HTTP/1.1
+    POST /v1.25/networks/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3926,7 +3926,7 @@ Returns information about installed plugins.
 
 **Example request**:
 
-    GET /plugins HTTP/1.1
+    GET /v1.25/plugins HTTP/1.1
 
 **Example response**:
 
@@ -4058,7 +4058,7 @@ using the [`POST /plugins/(plugin name)/enable` endpoint](#enable-a-plugin).
 **Example request**:
 
 ```
-POST /plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
+POST /v1.25/plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -4119,7 +4119,7 @@ Returns detailed information about an installed plugin.
 **Example request**:
 
 ```
-GET /plugins/tiborvass/no-remove:latest HTTP/1.1
+GET /v1.25/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4263,7 +4263,7 @@ Enables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/enable HTTP/1.1
+POST /v1.25/plugins/tiborvass/no-remove:latest/enable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4291,7 +4291,7 @@ Disables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/disable HTTP/1.1
+POST /v1.25/plugins/tiborvass/no-remove:latest/disable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4348,14 +4348,14 @@ Content-Type: text/plain; charset=utf-8
 
 ### Push a plugin
 
-`POST /plugins/tiborvass/(plugin name)/push HTTP/1.1`
+`POST /v1.25/plugins/tiborvass/(plugin name)/push HTTP/1.1`
 
 Pushes a plugin to the registry.
 
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest HTTP/1.1
+POST /v1.25/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -4385,7 +4385,7 @@ List nodes
 
 **Example request**:
 
-    GET /nodes HTTP/1.1
+    GET /v1.25/nodes HTTP/1.1
 
 **Example response**:
 
@@ -4477,7 +4477,7 @@ Return low-level information on the node `id`
 
 **Example request**:
 
-      GET /nodes/24ifsmvkjbyhk HTTP/1.1
+      GET /v1.25/nodes/24ifsmvkjbyhk HTTP/1.1
 
 **Example response**:
 
@@ -4594,7 +4594,7 @@ an empty value or the default cluster-wide value.
 
 **Example Request**
 
-    POST /nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
+    POST /v1.25/nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4692,7 +4692,7 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
 
 **Example request**:
 
-    POST /swarm/init HTTP/1.1
+    POST /v1.25/swarm/init HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4767,7 +4767,7 @@ Join an existing swarm
 
 **Example request**:
 
-    POST /swarm/join HTTP/1.1
+    POST /v1.25/swarm/join HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4810,7 +4810,7 @@ Leave a swarm
 
 **Example request**:
 
-    POST /swarm/leave HTTP/1.1
+    POST /v1.25/swarm/leave HTTP/1.1
 
 **Example response**:
 
@@ -4836,7 +4836,7 @@ Update a swarm
 
 **Example request**:
 
-    POST /swarm/update HTTP/1.1
+    POST /v1.25/swarm/update HTTP/1.1
 
     {
       "Name": "default",
@@ -4921,7 +4921,7 @@ List services
 
 **Example request**:
 
-    GET /services HTTP/1.1
+    GET /v1.25/services HTTP/1.1
 
 **Example response**:
 
@@ -5030,7 +5030,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/create HTTP/1.1
+    POST /v1.25/services/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -5229,7 +5229,7 @@ Return information on the service `id`.
 
 **Example request**:
 
-    GET /services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
+    GET /v1.25/services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
 
 **Example response**:
 
@@ -5321,7 +5321,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
+    POST /v1.25/services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -5468,7 +5468,7 @@ List tasks
 
 **Example request**:
 
-    GET /tasks HTTP/1.1
+    GET /v1.25/tasks HTTP/1.1
 
 **Example response**:
 
@@ -5666,7 +5666,7 @@ Get details on a task
 
 **Example request**:
 
-    GET /tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
+    GET /v1.25/tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
 
 **Example response**:
 


### PR DESCRIPTION
**\- What I did**

At some point it would be good to make providing a version to API calls mandatory. See #21157 for more information.

However, this will break clients, so we should mark it as deprecated before making the change. See #27801 for the proposed actual change and discussion around deprecation.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Not providing an API version in API calls is now deprecated, and those endpoints will be removed in a future version of Docker. Instead of just requesting, for example, the URL /containers/json, you must now request /v1.25/containers/json.
