### PR TITLE
Add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ bundles
 .gopath
 vendor/pkg
 .go-pkg-cache
+.git


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

I don't think there's any reason not to have this in there - currently the entire .git folder is being sent in the builder context when doing builds which can be a pretty significant overhead if you have lots of branches (it almost triples the size of the build context on my dev machine). Let's see what CI says though, maybe there's some dependency I'm not aware of....
