### PR TITLE
Fix install script for multiarch

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -147,15 +147,25 @@ semverParse() {
 }
 
 do_install() {
-	case "$(uname -m)" in
-		*64)
+	architecture=$(uname -m)
+	case $architecture in
+		# officially supported
+		amd64|x86_64)
 			;;
+		# unofficially supported with available repositories
 		armv6l|armv7l)
 			;;
+		# unofficially supported without available repositories
+		aarch64|arm64|ppc64le|s390x)
+			cat 1>&2 <<-EOF
+			Error: Docker doesn't officially support $architecture and no Docker $architecture repository exists.
+			EOF
+			exit 1
+			;;
+		# not supported
 		*)
-			cat >&2 <<-'EOF'
-			Error: you are not using a 64bit platform or a Raspberry Pi (armv6l/armv7l).
-			Docker currently only supports 64bit platforms or a Raspberry Pi (armv6l/armv7l).
+			cat >&2 <<-EOF
+			Error: $architecture is not a recognized platform.
 			EOF
 			exit 1
 			;;


### PR DESCRIPTION
The current check for uname -m just looks for *64 which hits a lot
more cases than it should (mips64 for ex.), and ignores a few that it shouldn't.

This check will run the install script if on a supported architecture
(x86_64 or amd64) or an unofficial one with a docker repository
(armv6l or armv7l) and will give a more accurate error on an unofficial
64-bit architecture that isn't in the docker repository.

For architectures I just referenced the go list here https://golang.org/doc/install/source,
and couldn't think of any more that should hit these cases.

Signed-off-by: Christopher Jones tophj@linux.vnet.ibm.com

![gazelle](http://media.dmnews.com/images/2015/07/13/gazellejumping_800911.jpg)
