### PR TITLE
Support Windows Named Pipe for Swarm Mode

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -277,13 +278,20 @@ func (c *Cluster) startNewNode(conf nodeStartConfig) (*node, error) {
 		}
 	}
 
+	var control string
+	if runtime.GOOS == "windows" {
+		control = `\\.\pipe\` + controlSocket
+	} else {
+		control = filepath.Join(c.runtimeRoot, controlSocket)
+	}
+
 	c.node = nil
 	c.cancelDelay = nil
 	c.stop = false
 	n, err := swarmnode.New(&swarmnode.Config{
 		Hostname:           c.config.Name,
 		ForceNewCluster:    conf.forceNewCluster,
-		ListenControlAPI:   filepath.Join(c.runtimeRoot, controlSocket),
+		ListenControlAPI:   control,
 		ListenRemoteAPI:    conf.ListenAddr,
 		AdvertiseRemoteAPI: conf.AdvertiseAddr,
 		JoinAddr:           conf.joinAddr,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

As of docker/swarmkit#1654, the swarmkit manager can now be communicated with over windows named pipe on a windows system. This alters the docker daemon to take advantage of this capability. This change is one small step toward supporting Windows with Docker Swarm mode.

**\- How I did it**

This PR introduces a small change to the manager init process to pass in a windows-specific named pipe name instead of a unix socket directory. It also vendors in the latest swarmkit commit with this named pipe functionality. Again, note, _this change includes vendoring of docker/swarmkit_

**\- How to verify it**

Build Docker on Windows. Do `docker swarm init`. Note how instead of failing to even get started, the manage gets all the way to NetworkAllocator before panicking. The fact that we get this far means the change works. With some out-of-scope patches applied, this crash is averted and  swarmkit manager accepts commands over the named pipe.

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Docker daemon now communicates with Swarmkit over Named Pipe on Windows.

**\- A picture of a cute animal (not mandatory but encouraged)**

This is the world's oldest manatee. His name is Snooty and he is 68 years old. He will be in the Guinness Book of World Records. 

![image](https://cloud.githubusercontent.com/assets/2367858/19787621/8181c820-9c58-11e6-8b83-599d4a88d3be.png)
