### PR TITLE
Add "userns" to `docker info` security options output

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -78,6 +78,10 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	if selinuxEnabled() {
 		securityOptions = append(securityOptions, "selinux")
 	}
+	uid, gid := daemon.GetRemappedUIDGID()
+	if uid != 0 || gid != 0 {
+		securityOptions = append(securityOptions, "userns")
+	}
 
 	v := &types.Info{
 		ID:                 daemon.ID,

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -161,7 +161,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * `POST /networks/prune` prunes unused networks.
 * Every API response now includes a `Docker-Experimental` header specifying if experimental features are enabled (value can be `true` or `false`).
 * The `hostConfig` option now accepts the fields `CpuRealtimePeriod` and `CpuRtRuntime` to allocate cpu runtime to rt tasks when `CONFIG_RT_GROUP_SCHED` is enabled in the kernel.
-
+* The `SecurityOptions` field within the `GET /info` response now includes `userns` if user namespaces are enabled in the daemon.
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -2503,7 +2503,8 @@ Display system-wide information
         "SecurityOptions": [
             "apparmor",
             "seccomp",
-            "selinux"
+            "selinux",
+            "userns"
         ],
         "ServerVersion": "1.9.0",
         "SwapLimit": false,

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -986,6 +986,11 @@ If you have a group that doesn't match the username, you may provide the `gid`
 or group name as well; otherwise the username will be used as the group name
 when querying the system for the subordinate group ID range.
 
+The output of `docker info` can be used to determine if the daemon is running
+with user namespaces enabled or not. If the daemon is configured with user
+namespaces, the Security Options entry in the response will list "userns" as
+one of the enabled security features.
+
 ### Detailed information on `subuid`/`subgid` ranges
 
 Given potential advanced use of the subordinate ID ranges by power users, the


### PR DESCRIPTION
Fixes: #27740 

If user namespaces is enabled on the daemon, reveal that via docker info
by adding "userns" to the list of security options reported by the
info endpoint.

Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com
