### PR TITLE
Windows: support docker diff

### DIFF
--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"errors"
+	"runtime"
 	"time"
 
 	"github.com/docker/docker/pkg/archive"
@@ -12,6 +14,10 @@ func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err
+	}
+
+	if runtime.GOOS == "windows" && container.IsRunning() {
+		return nil, errors.New("Windows does not support diff of a running container")
 	}
 
 	container.Lock()


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jstarks @darrenstahlmsft PTAL

Fixes https://github.com/docker/docker/issues/27672. `docker diff` has been broken on Windows for many months. This fixes it.

```
PS E:\go\src\github.com\docker\docker> docker run --name diff nanoserver powershell echo hello
hello
PS E:\go\src\github.com\docker\docker> docker diff diff
C Files
C Files/ProgramData
C Files/ProgramData/Microsoft
C Files/ProgramData/Microsoft/Windows
C Files/ProgramData/Microsoft/Windows/AppRepository
C Files/ProgramData/Microsoft/Windows/AppRepository/StateRepository-Deployment.srd
C Files/ProgramData/Microsoft/Windows/AppRepository/StateRepository-Deployment.srd-shm
C Files/ProgramData/Microsoft/Windows/AppRepository/StateRepository-Deployment.srd-wal
C Files/ProgramData/Microsoft/Windows/AppRepository/StateRepository-Machine.srd
C Files/ProgramData/Microsoft/Windows/AppRepository/StateRepository-Machine.srd-shm
C Files/ProgramData/Microsoft/Windows/AppRepository/StateRepository-Machine.srd-wal
C Files/Users
C Files/Users/ContainerAdministrator
C Files/Users/ContainerAdministrator/AppData
C Files/Users/ContainerAdministrator/AppData/Local
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft/Windows
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/PowerShell
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/PowerShell/StartupProfileData-NonInteractive
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/UsrClass.dat
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/UsrClass.dat.LOG1
C Files/Users/ContainerAdministrator/AppData/Local/Microsoft/Windows/UsrClass.dat.LOG2
C Files/Users/ContainerAdministrator/AppData/Local/Temp
C Files/Users/ContainerAdministrator/AppData/LocalLow
C Files/Users/ContainerAdministrator/Documents
C Files/Users/ContainerAdministrator/NTUSER.DAT
C Files/Users/ContainerAdministrator/NTUSER.DAT.LOG1
C Files/Users/ContainerAdministrator/NTUSER.DAT.LOG2
C Files/Users/ContainerAdministrator/ntuser.ini
C Files/Windows
C Files/Windows/Panther
C Files/Windows/Panther/UnattendGC
C Files/Windows/Panther/UnattendGC/diagerr.xml
C Files/Windows/Panther/UnattendGC/diagwrn.xml
C Files/Windows/Panther/UnattendGC/setupact.log
C Files/Windows/Panther/UnattendGC/setuperr.log
C Files/Windows/Panther/diagerr.xml
C Files/Windows/Panther/diagwrn.xml
C Files/Windows/Panther/setupact.log
C Files/Windows/Panther/setuperr.log
C Files/Windows/ServiceProfiles
C Files/Windows/ServiceProfiles/LocalService
C Files/Windows/ServiceProfiles/LocalService/AppData
C Files/Windows/ServiceProfiles/LocalService/AppData/Local
C Files/Windows/ServiceProfiles/LocalService/AppData/Local/Microsoft
C Files/Windows/ServiceProfiles/LocalService/AppData/Local/Microsoft/WindowsApps
C Files/Windows/ServiceProfiles/LocalService/AppData/Local/Temp
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft/Windows
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft/Windows/Start Menu
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/System Tools
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/System Tools/Command Prompt.lnk
C Files/Windows/ServiceProfiles/LocalService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/System Tools/desktop.ini
C Files/Windows/ServiceProfiles/LocalService/NTUSER.DAT
C Files/Windows/ServiceProfiles/LocalService/NTUSER.DAT.LOG1
C Files/Windows/ServiceProfiles/LocalService/NTUSER.DAT.LOG2
C Files/Windows/ServiceProfiles/LocalService/NTUSER.DAT{bb6a8fd1-8b3f-11e6-80ce-e41d2d0d3bd0}.TM.blf
C Files/Windows/ServiceProfiles/LocalService/NTUSER.DAT{bb6a8fd1-8b3f-11e6-80ce-e41d2d0d3bd0}.TMContainer00000000000000000001.regtrans-ms
C Files/Windows/ServiceProfiles/LocalService/NTUSER.DAT{bb6a8fd1-8b3f-11e6-80ce-e41d2d0d3bd0}.TMContainer00000000000000000002.regtrans-ms
C Files/Windows/ServiceProfiles/LocalService/winhttp
C Files/Windows/ServiceProfiles/LocalService/winhttp/cachev3.dat
C Files/Windows/ServiceProfiles/NetworkService
C Files/Windows/ServiceProfiles/NetworkService/AppData
C Files/Windows/ServiceProfiles/NetworkService/AppData/Local
C Files/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft
C Files/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/WindowsApps
C Files/Windows/ServiceProfiles/NetworkService/AppData/Local/Temp
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft/Windows
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft/Windows/Start Menu
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/System Tools
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/System Tools/Command Prompt.lnk
C Files/Windows/ServiceProfiles/NetworkService/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/System Tools/desktop.ini
C Files/Windows/ServiceProfiles/NetworkService/NTUSER.DAT
C Files/Windows/ServiceProfiles/NetworkService/NTUSER.DAT.LOG1
C Files/Windows/ServiceProfiles/NetworkService/NTUSER.DAT.LOG2
C Files/Windows/ServiceProfiles/NetworkService/NTUSER.DAT{bb6a8fd1-8b3f-11e6-80ce-e41d2d0d3bd0}.TM.blf
C Files/Windows/ServiceProfiles/NetworkService/NTUSER.DAT{bb6a8fd1-8b3f-11e6-80ce-e41d2d0d3bd0}.TMContainer00000000000000000001.regtrans-ms
C Files/Windows/ServiceProfiles/NetworkService/NTUSER.DAT{bb6a8fd1-8b3f-11e6-80ce-e41d2d0d3bd0}.TMContainer00000000000000000002.regtrans-ms
C Files/Windows/Setup
C Files/Windows/Setup/State
C Files/Windows/Setup/State/State.ini
C Files/Windows/System32
C Files/Windows/System32/LogFiles
C Files/Windows/System32/LogFiles/Scm
C Files/Windows/System32/LogFiles/Scm/SCM.EVM
C Files/Windows/System32/LogFiles/WMI
C Files/Windows/System32/LogFiles/WMI/RtBackup
C Files/Windows/System32/LogFiles/WMI/RtBackup/EtwRTEventLog-Application.etl
C Files/Windows/System32/LogFiles/WMI/RtBackup/EtwRTEventlog-Security.etl
C Files/Windows/System32/Microsoft
C Files/Windows/System32/Microsoft/Protect
C Files/Windows/System32/Microsoft/Protect/S-1-5-18
C Files/Windows/System32/Microsoft/Protect/S-1-5-18/User
C Files/Windows/System32/Microsoft/Protect/S-1-5-18/User/Preferred
C Files/Windows/System32/Microsoft/Protect/S-1-5-18/User/f075795d-458d-47cd-9f05-27797ff8b8d0
C Files/Windows/System32/UserMgrLog.etl
C Files/Windows/System32/catroot2
C Files/Windows/System32/catroot2/edb.chk
C Files/Windows/System32/catroot2/edb.log
C Files/Windows/System32/catroot2/edbres00001.jrs
C Files/Windows/System32/catroot2/edbres00002.jrs
C Files/Windows/System32/catroot2/edbtmp.log
C Files/Windows/System32/catroot2/{127D0A1D-4EF2-11D1-8608-00C04FC295EE}
C Files/Windows/System32/catroot2/{127D0A1D-4EF2-11D1-8608-00C04FC295EE}/catdb
C Files/Windows/System32/catroot2/{127D0A1D-4EF2-11D1-8608-00C04FC295EE}/catdb.jfm
C Files/Windows/System32/catroot2/{F750E6C3-38EE-11D1-85E5-00C04FC295EE}
C Files/Windows/System32/catroot2/{F750E6C3-38EE-11D1-85E5-00C04FC295EE}/catdb
C Files/Windows/System32/catroot2/{F750E6C3-38EE-11D1-85E5-00C04FC295EE}/catdb.jfm
C Files/Windows/System32/config
C Files/Windows/System32/config/systemprofile
C Files/Windows/System32/config/systemprofile/AppData
C Files/Windows/System32/config/systemprofile/AppData/LocalLow
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/Content
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/Content/57C8EDB95DF3F0AD4EE2DC2B8CFD4157
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/Content/77EC63BDA74BD0D0E0426DC8F8008506
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/Content/FB0D848F74F70BB2EAA93746D24D9749
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/MetaData
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/MetaData/57C8EDB95DF3F0AD4EE2DC2B8CFD4157
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/MetaData/77EC63BDA74BD0D0E0426DC8F8008506
C Files/Windows/System32/config/systemprofile/AppData/LocalLow/Microsoft/CryptnetUrlCache/MetaData/FB0D848F74F70BB2EAA93746D24D9749
C Files/Windows/System32/license.rtf
C Files/Windows/System32/umstartup.etl
C Files/Windows/System32/wbem
C Files/Windows/System32/wbem/MOF
C Files/Windows/System32/wbem/MOF/bad
C Files/Windows/System32/wbem/MOF/good
C Files/Windows/System32/winevt
C Files/Windows/System32/winevt/Logs
C Files/Windows/System32/winevt/Logs/Application.evtx
C Files/Windows/System32/winevt/Logs/Internet Explorer.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-PowerShell%4Admin.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-PowerShell%4Operational.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-StateRepository%4Operational.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-StateRepository%4Restricted.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-TaskScheduler%4Maintenance.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-UniversalTelemetryClient%4Operational.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-User Profile Service%4Operational.evtx
C Files/Windows/System32/winevt/Logs/Microsoft-Windows-WinRM%4Operational.evtx
C Files/Windows/System32/winevt/Logs/Security.evtx
C Files/Windows/System32/winevt/Logs/System.evtx
C Hives
C Hives/DefaultUser_Delta
C Hives/Sam_Delta
C Hives/Security_Delta
C Hives/Software_Delta
C Hives/System_Delta
PS E:\go\src\github.com\docker\docker> docker rm diff
diff
PS E:\go\src\github.com\docker\docker>
```

Yes, on my list is to port the diff CI tests to Windows. 
