### PR TITLE
project: fix build rpm

### DIFF
--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -8,7 +8,16 @@ CONTAINERD_COMMIT=52ef1ceb4b660c42cf4ea9013180a5663968d4c7
 GRIMES_COMMIT=74341e923bdf06cfb6b70cf54089c4d3ac87ec2d
 LIBNETWORK_COMMIT=0f534354b813003a754606689722fe253101bc4e
 
-export GOPATH="$(mktemp -d)"
+RM_GOPATH=0
+
+TMP_GOPATH=${TMP_GOPATH:-""}
+
+if [ -z "$TMP_GOPATH" ]; then
+	export GOPATH="$(mktemp -d)"
+	RM_GOPATH=1
+else
+	export GOPATH="$TMP_GOPATH"
+fi
 
 RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp apparmor selinux"}"
 
@@ -30,6 +39,14 @@ install_containerd() {
 	cp bin/containerd /usr/local/bin/docker-containerd
 	cp bin/containerd-shim /usr/local/bin/docker-containerd-shim
 	cp bin/ctr /usr/local/bin/docker-containerd-ctr
+}
+
+install_proxy() {
+	echo "Install docker-proxy version $LIBNETWORK_COMMIT"
+	git clone https://github.com/docker/libnetwork.git "$GOPATH/src/github.com/docker/libnetwork"
+	cd "$GOPATH/src/github.com/docker/libnetwork"
+	git checkout -q "$LIBNETWORK_COMMIT"
+	go build -ldflags="$PROXY_LDFLAGS" -o /usr/local/bin/docker-proxy github.com/docker/libnetwork/cmd/proxy
 }
 
 for prog in "$@"
@@ -68,11 +85,12 @@ do
 			;;
 
 		proxy)
-			echo "Install docker-proxy version $LIBNETWORK_COMMIT"
-			git clone https://github.com/docker/libnetwork.git "$GOPATH/src/github.com/docker/libnetwork"
-			cd "$GOPATH/src/github.com/docker/libnetwork"
-			git checkout -q "$LIBNETWORK_COMMIT"
-			CGO_ENABLED=0 go build -v -o /usr/local/bin/docker-proxy github.com/docker/libnetwork/cmd/proxy
+			export CGO_ENABLED=0
+			install_proxy
+			;;
+
+		proxy-dynamic)
+			PROXY_LDFLAGS="-linkmode=external" install_proxy
 			;;
 
 		*)
@@ -82,4 +100,6 @@ do
 	esac
 done
 
-rm -rf "$GOPATH"
+if [ $RM_GOPATH -eq 1 ]; then
+	rm -rf "$GOPATH"
+fi

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -195,6 +195,7 @@ install -p -m 644 contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/shar
 /%{_bindir}/docker-containerd-ctr
 /%{_bindir}/docker-proxy
 /%{_bindir}/docker-runc
+/%{_bindir}/docker-init
 /%{_sysconfdir}/udev/rules.d/80-docker.rules
 %if 0%{?is_systemd}
 /%{_unitdir}/docker.service

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -74,7 +74,7 @@ set -e
 
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			# Install runc, containerd, proxy and grimes
-			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy grimes
+			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic grimes
 		EOF
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN cp -aL hack/make/.build-deb debian

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -89,12 +89,13 @@ set -e
 		cat > "$DEST/$version/Dockerfile.build" <<-EOF
 			FROM $image
 			COPY . /usr/src/${rpmName}
+			WORKDIR /usr/src/${rpmName}
 			RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 		EOF
 
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			# Install runc, containerd, proxy and grimes
-			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy grimes
+			RUN TMP_GOPATH="/go" ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic grimes
 		EOF
 		if [[ "$VERSION" == *-dev ]] || [ -n "$(git status --porcelain)" ]; then
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
@@ -107,7 +108,9 @@ set -e
 			WORKDIR /root/rpmbuild/SPECS
 			RUN tar --exclude .git -r -C /usr/src -f /root/rpmbuild/SOURCES/${rpmName}.tar ${rpmName}
 			RUN tar --exclude .git -r -C /go/src/github.com/docker -f /root/rpmbuild/SOURCES/${rpmName}.tar containerd
+			RUN tar --exclude .git -r -C /go/src/github.com/docker/libnetwork/cmd -f /root/rpmbuild/SOURCES/${rpmName}.tar proxy
 			RUN tar --exclude .git -r -C /go/src/github.com/opencontainers -f /root/rpmbuild/SOURCES/${rpmName}.tar runc
+			RUN tar --exclude .git -r -C /go/ -f /root/rpmbuild/SOURCES/${rpmName}.tar grimes
 			RUN gzip /root/rpmbuild/SOURCES/${rpmName}.tar
 			RUN { cat /usr/src/${rpmName}/contrib/builder/rpm/${PACKAGE_ARCH}/changelog; } >> ${rpmName}.spec && tail >&2 ${rpmName}.spec
 			RUN rpmbuild -ba \


### PR DESCRIPTION
- change workdir for accessing install-binaries.sh
- use other gopath for binaries to preserve sources
- add sources of proxy and grimes to rpc spec
- use dynamic proxy with -linkmode external in deb and rpm

Closes #27858 
