### PR TITLE
error out if checkpoint specified on non-experimental

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -20,6 +20,10 @@ import (
 
 // ContainerStart starts a container.
 func (daemon *Daemon) ContainerStart(name string, hostConfig *containertypes.HostConfig, validateHostname bool, checkpoint string) error {
+	if checkpoint != "" && !daemon.HasExperimental() {
+		return errors.NewBadRequestError(fmt.Errorf("checkpoint is only supported in experimental mode"))
+	}
+
 	container, err := daemon.GetContainer(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds checks on the daemon side for use of `checkpoint` from the API on container start.
