### PR TITLE
Remove legacy armhf things in aarch64 Dockerfile

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -52,11 +52,6 @@ RUN apt-get update && apt-get install -y \
 	iputils-ping \
 	--no-install-recommends
 
-# Install armhf loader to use armv6 binaries on armv8
-RUN dpkg --add-architecture armhf \
-	&& apt-get update \
-	&& apt-get install -y libc6:armhf
-
 # Get lvm2 source for compiling statically
 ENV LVM2_VERSION 2.02.103
 RUN mkdir -p /usr/local/lvm2 \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**\- What I did**

**\- How I did it**

**\- How to verify it**

**\- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**\- A picture of a cute animal (not mandatory but encouraged)**

It's leftover from #20342 . We used to need this so we
can use armv6 binaries as bootstrap to build golang.
Now it's not needed.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
