### PR TITLE
Add --format to man and fix some typos

### DIFF
--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -134,8 +134,8 @@ The currently supported filters are:
 
 * dangling (boolean - true or false)
 * label (`label=<key>` or `label=<key>=<value>`)
-* before (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters images created before given id or references
-* since (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters images created since given id or references
+* before (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created before given id or references
+* since (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created since given id or references
 
 ##### Untagged images (dangling)
 
@@ -243,9 +243,9 @@ Placeholder | Description
 `.Repository` | Image repository
 `.Tag` | Image tag
 `.Digest` | Image digest
-`.CreatedSince` | Elapsed time since the image was created.
-`.CreatedAt` | Time when the image was created.
-`.Size` | Image disk size.
+`.CreatedSince` | Elapsed time since the image was created
+`.CreatedAt` | Time when the image was created
+`.Size` | Image disk size
 
 When using the `--format` option, the `image` command will either
 output the data exactly as the template declares or, when using the

--- a/man/docker-images.1.md
+++ b/man/docker-images.1.md
@@ -10,6 +10,7 @@ docker-images - List images
 [**-a**|**--all**]
 [**--digests**]
 [**-f**|**--filter**[=*[]*]]
+[**--format**=*"TEMPLATE"*]
 [**--no-trunc**]
 [**-q**|**--quiet**]
 [REPOSITORY[:TAG]]
@@ -39,7 +40,7 @@ versions.
 
 **-f**, **--filter**=[]
    Filters the output based on these conditions:
-   - dangling=(true|false) - finds unused images.
+   - dangling=(true|false) - find unused images
    - label=<key> or label=<key>=<value>
    - before=(<image-name>[:tag]|<image-id>|<image@digest>)
    - since=(<image-name>[:tag]|<image-id>|<image@digest>)
@@ -51,9 +52,9 @@ versions.
       .Repository - Image repository
       .Tag - Image tag
       .Digest - Image digest
-      .CreatedSince - Elapsed time since the image was created.
-      .CreatedAt - Time when the image was created..
-      .Size - Image disk size.
+      .CreatedSince - Elapsed time since the image was created
+      .CreatedAt - Time when the image was created
+      .Size - Image disk size
 
 **--help**
   Print usage statement


### PR DESCRIPTION
**\- What I did**
Add --format and fix some typos for docker images in man

**\- How I did it**
**\- How to verify it**

**\- Description for the changelog**
1.  Add --format into the option for docker images
2.  Fix some typos

Signed-off-by: yuexiao-wang wang.yuexiao@zte.com.cn
