### PR TITLE
Do not warn in check-config script about ext3 if provided by ext4

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -238,14 +238,20 @@ flags=(
 )
 check_flags "${flags[@]}"
 
-check_flags EXT3_FS EXT3_FS_XATTR EXT3_FS_POSIX_ACL EXT3_FS_SECURITY
-if ! is_set EXT3_FS || ! is_set EXT3_FS_XATTR || ! is_set EXT3_FS_POSIX_ACL || ! is_set EXT3_FS_SECURITY; then
-	echo "    $(wrap_color '(enable these ext3 configs if you are using ext3 as backing filesystem)' bold black)"
+if ! is_set EXT4_USE_FOR_EXT2; then
+	check_flags EXT3_FS EXT3_FS_XATTR EXT3_FS_POSIX_ACL EXT3_FS_SECURITY
+	if ! is_set EXT3_FS || ! is_set EXT3_FS_XATTR || ! is_set EXT3_FS_POSIX_ACL || ! is_set EXT3_FS_SECURITY; then
+		echo "    $(wrap_color '(enable these ext3 configs if you are using ext3 as backing filesystem)' bold black)"
+	fi
 fi
 
 check_flags EXT4_FS EXT4_FS_POSIX_ACL EXT4_FS_SECURITY
 if ! is_set EXT4_FS || ! is_set EXT4_FS_POSIX_ACL || ! is_set EXT4_FS_SECURITY; then
-	echo "    $(wrap_color 'enable these ext4 configs if you are using ext4 as backing filesystem' bold black)"
+	if is_set EXT4_USE_FOR_EXT2; then
+		echo "    $(wrap_color 'enable these ext4 configs if you are using ext3 or ext4 as backing filesystem' bold black)"
+	else
+		echo "    $(wrap_color 'enable these ext4 configs if you are using ext4 as backing filesystem' bold black)"
+	fi
 fi
 
 echo '- Network Drivers:'


### PR DESCRIPTION
Many distributions now use ext4 to provide ext2 and ext3 support,
so do not warn about possibly missing ext3 support if the config
option is used.

Signed-off-by: Justin Cormack justin.cormack@docker.com

![goat-climb](https://cloud.githubusercontent.com/assets/482364/19803370/3fb59c5c-9d00-11e6-97a3-b4a41a53f52c.jpg)
