### PR TITLE
Update go-connections vendoring

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -64,7 +64,7 @@ clone git github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 clone git golang.org/x/net 2beffdc2e92c8a3027590f898fe88f69af48a3f8 https://github.com/tonistiigi/net.git
 clone git golang.org/x/sys eb2c74142fd19a79b3f237334c7384d5167b1b46 https://github.com/golang/sys.git
 clone git github.com/docker/go-units 8a7beacffa3009a9ac66bad506b18ffdd110cf97
-clone git github.com/docker/go-connections 988efe982fdecb46f01d53465878ff1f2ff411ce
+clone git github.com/docker/go-connections 1494b6df4050e60923d68cd8cc6a19e7af9f1c01
 
 clone git github.com/RackSec/srslog 365bf33cd9acc21ae1c355209865f17228ca534e
 clone git github.com/imdario/mergo 0.2.1

--- a/vendor/src/github.com/docker/go-connections/nat/parse.go
+++ b/vendor/src/github.com/docker/go-connections/nat/parse.go
@@ -8,6 +8,7 @@ import (
 
 // PartParser parses and validates the specified string (data) using the specified template
 // e.g. ip:public:private -> 192.168.0.1:80:8000
+// DEPRECATED: do not use, this function may be removed in a future version
 func PartParser(template, data string) (map[string]string, error) {
 	// ip:public:private
 	var (

--- a/vendor/src/github.com/docker/go-connections/sockets/tcp_socket.go
+++ b/vendor/src/github.com/docker/go-connections/sockets/tcp_socket.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewTCPSocket creates a TCP socket listener with the specified address and
-// and the specified tls configuration. If TLSConfig is set, will encapsulate the
+// the specified tls configuration. If TLSConfig is set, will encapsulate the
 // TCP listener inside a TLS one.
 func NewTCPSocket(addr string, tlsConfig *tls.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", addr)


### PR DESCRIPTION
This makes possible to use IPv6 addresses in the `--publish` flag of docker (`run`, …).

Closes #11518 (once again :joy:).

/cc @dnephin @mavenugo @mrjana @aboch 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
