### PR TITLE
Add StatsFormat to the config.json file

### DIFF
--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -186,13 +186,17 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 
 	// before print to screen, make sure each container get at least one valid stat data
 	waitFirst.Wait()
-	f := "table"
-	if len(opts.format) > 0 {
-		f = opts.format
+	format := opts.format
+	if len(format) == 0 {
+		if len(dockerCli.ConfigFile().StatsFormat) > 0 {
+			format = dockerCli.ConfigFile().StatsFormat
+		} else {
+			format = formatter.TableFormatKey
+		}
 	}
 	statsCtx := formatter.Context{
 		Output: dockerCli.Out(),
-		Format: formatter.NewStatsFormat(f, daemonOSType),
+		Format: formatter.NewStatsFormat(format, daemonOSType),
 	}
 	cleanScreen := func() {
 		if !opts.noStream {

--- a/cliconfig/configfile/file.go
+++ b/cliconfig/configfile/file.go
@@ -28,6 +28,7 @@ type ConfigFile struct {
 	ImagesFormat         string                      `json:"imagesFormat,omitempty"`
 	NetworksFormat       string                      `json:"networksFormat,omitempty"`
 	VolumesFormat        string                      `json:"volumesFormat,omitempty"`
+	StatsFormat          string                      `json:"statsFormat,omitempty"`
 	DetachKeys           string                      `json:"detachKeys,omitempty"`
 	CredentialsStore     string                      `json:"credsStore,omitempty"`
 	Filename             string                      `json:"-"` // Note: for internal use only

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -123,6 +123,26 @@ falls back to the default table format. For a list of supported formatting
 directives, see the
 [**Formatting** section in the `docker ps` documentation](ps.md)
 
+The property `imagesFormat` specifies the default format for `docker images` output.
+When the `--format` flag is not provided with the `docker images` command,
+Docker's client uses this property. If this property is not set, the client
+falls back to the default table format. For a list of supported formatting
+directives, see the [**Formatting** section in the `docker images` documentation](images.md)
+
+The property `serviceInspectFormat` specifies the default format for `docker
+service inspect` output. When the `--format` flag is not provided with the
+`docker service inspect` command, Docker's client uses this property. If this
+property is not set, the client falls back to the default json format. For a
+list of supported formatting directives, see the
+[**Formatting** section in the `docker service inspect` documentation](service_inspect.md)
+
+The property `statsFormat` specifies the default format for `docker
+stats` output. When the `--format` flag is not provided with the
+`docker stats` command, Docker's client uses this property. If this
+property is not set, the client falls back to the default table
+format. For a list of supported formatting directives, see
+[**Formatting** section in the `docker stats` documentation](stats.md)
+
 Once attached to a container, users detach from it and leave it running using
 the using `CTRL-p CTRL-q` key sequence. This detach key sequence is customizable
 using the `detachKeys` property. Specify a `<sequence>` value for the
@@ -141,19 +161,6 @@ Users can override your custom or the default key sequence on a per-container
 basis. To do this, the user specifies the `--detach-keys` flag with the `docker
 attach`, `docker exec`, `docker run` or `docker start` command.
 
-The property `imagesFormat` specifies the default format for `docker images` output.
-When the `--format` flag is not provided with the `docker images` command,
-Docker's client uses this property. If this property is not set, the client
-falls back to the default table format. For a list of supported formatting
-directives, see the [**Formatting** section in the `docker images` documentation](images.md)
-
-The property `serviceInspectFormat` specifies the default format for `docker
-service inspect` output. When the `--format` flag is not provided with the
-`docker service inspect` command, Docker's client uses this property. If this
-property is not set, the client falls back to the default json format. For a
-list of supported formatting directives, see the
-[**Formatting** section in the `docker service inspect` documentation](service_inspect.md)
-
 Following is a sample `config.json` file:
 
     {% raw %}
@@ -163,6 +170,7 @@ Following is a sample `config.json` file:
       },
       "psFormat": "table {{.ID}}\\t{{.Image}}\\t{{.Command}}\\t{{.Labels}}",
       "imagesFormat": "table {{.ID}}\\t{{.Repository}}\\t{{.Tag}}\\t{{.CreatedAt}}",
+      "statsFormat": "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}",
       "serviceInspectFormat": "pretty",
       "detachKeys": "ctrl-e,e"
     }


### PR DESCRIPTION
As for `ps`, `images`, `network ls` and `volume ls`, this makes it possible to define a custom default format.

```
{
    "HttpHeaders": {
      "MyHeader": "MyValue"
    },
    "psFormat": "table {{.ID}}\\t{{.Image}}\\t{{.Command}}\\t{{.Labels}}",
    "imagesFormat": "table {{.ID}}\\t{{.Repository}}\\t{{.Tag}}\\t{{.CreatedAt}}",
    "statsFormat": "table {{.Container}}\\t{{.CPUPerc}}\\t{{.MemUsage}}",
    "detachKeys": "ctrl-e,e"
}
```

/cc @thaJeztah @dnephin 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
