### PR TITLE
Update examples in builder.md

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -255,7 +255,7 @@ of this dockerfile is that second and third lines are considered a single
 instruction:
 
 ```Dockerfile
-FROM windowsservercore
+FROM microsoft/nanoserver
 COPY testfile.txt c:\\
 RUN dir c:\
 ```
@@ -264,9 +264,9 @@ Results in:
 
     PS C:\John> docker build -t cmd .
     Sending build context to Docker daemon 3.072 kB
-    Step 1 : FROM windowsservercore
-     ---> dbfee88ee9fd
-    Step 2 : COPY testfile.txt c:RUN dir c:
+    Step 1/2 : FROM microsoft/nanoserver
+     ---> 22738ff49c6d
+    Step 2/2 : COPY testfile.txt c:\RUN dir c:
     GetFileAttributesEx c:RUN: The system cannot find the file specified.
     PS C:\John>
 
@@ -280,7 +280,7 @@ expected with the use of natural platform semantics for file paths on `Windows`:
 
     # escape=`
 
-    FROM windowsservercore
+    FROM microsoft/nanoserver
     COPY testfile.txt c:\
     RUN dir c:\
 
@@ -288,30 +288,29 @@ Results in:
 
     PS C:\John> docker build -t succeeds --no-cache=true .
     Sending build context to Docker daemon 3.072 kB
-    Step 1 : FROM windowsservercore
-     ---> dbfee88ee9fd
-    Step 2 : COPY testfile.txt c:\
-     ---> 99ceb62e90df
-    Removing intermediate container 62afbe726221
-    Step 3 : RUN dir c:\
-     ---> Running in a5ff53ad6323
+    Step 1/3 : FROM microsoft/nanoserver
+     ---> 22738ff49c6d
+    Step 2/3 : COPY testfile.txt c:\
+     ---> 96655de338de
+    Removing intermediate container 4db9acbb1682
+    Step 3/3 : RUN dir c:\
+     ---> Running in a2c157f842f5
      Volume in drive C has no label.
-     Volume Serial Number is 1440-27FA
-
+     Volume Serial Number is 7E6D-E0F7
+    
      Directory of c:\
-
-    03/25/2016  05:28 AM    <DIR>          inetpub
-    03/25/2016  04:22 AM    <DIR>          PerfLogs
-    04/22/2016  10:59 PM    <DIR>          Program Files
-    03/25/2016  04:22 AM    <DIR>          Program Files (x86)
-    04/18/2016  09:26 AM                 4 testfile.txt
-    04/22/2016  10:59 PM    <DIR>          Users
-    04/22/2016  10:59 PM    <DIR>          Windows
-                   1 File(s)              4 bytes
-                   6 Dir(s)  21,252,689,920 bytes free
-     ---> 2569aa19abef
-    Removing intermediate container a5ff53ad6323
-    Successfully built 2569aa19abef
+    
+    10/05/2016  05:04 PM             1,894 License.txt
+    10/05/2016  02:22 PM    <DIR>          Program Files
+    10/05/2016  02:14 PM    <DIR>          Program Files (x86)
+    10/28/2016  11:18 AM                62 testfile.txt
+    10/28/2016  11:20 AM    <DIR>          Users
+    10/28/2016  11:20 AM    <DIR>          Windows
+               2 File(s)          1,956 bytes
+               4 Dir(s)  21,259,096,064 bytes free
+     ---> 01c7f3bef04f
+    Removing intermediate container a2c157f842f5
+    Successfully built 01c7f3bef04f
     PS C:\John>
 
 ## Environment replacement
@@ -1596,7 +1595,7 @@ well as alternate shells available including `sh`.
 The `SHELL` instruction can appear multiple times. Each `SHELL` instruction overrides
 all previous `SHELL` instructions, and affects all subsequent instructions. For example:
 
-    FROM windowsservercore
+    FROM microsoft/windowsservercore
 
     # Executed as cmd /S /C echo default
     RUN echo default
@@ -1645,7 +1644,7 @@ the `escape` parser directive:
 
     # escape=`
 
-    FROM windowsservercore
+    FROM microsoft/nanoserver
     SHELL ["powershell","-command"]
     RUN New-Item -ItemType Directory C:\Example
     ADD Execute-MyCmdlet.ps1 c:\example\
@@ -1654,36 +1653,36 @@ the `escape` parser directive:
 Resulting in:
 
     PS E:\docker\build\shell> docker build -t shell .
-    Sending build context to Docker daemon 3.584 kB
-    Step 1 : FROM windowsservercore
-     ---> 5bc36a335344
-    Step 2 : SHELL powershell -command
-     ---> Running in 87d7a64c9751
-     ---> 4327358436c1
-    Removing intermediate container 87d7a64c9751
-    Step 3 : RUN New-Item -ItemType Directory C:\Example
-     ---> Running in 3e6ba16b8df9
-
-
+    Sending build context to Docker daemon 4.096 kB
+    Step 1/5 : FROM microsoft/nanoserver
+     ---> 22738ff49c6d
+    Step 2/5 : SHELL powershell -command
+     ---> Running in 6fcdb6855ae2
+     ---> 6331462d4300
+    Removing intermediate container 6fcdb6855ae2
+    Step 3/5 : RUN New-Item -ItemType Directory C:\Example
+     ---> Running in d0eef8386e97
+    
+    
         Directory: C:\
-
-
+    
+    
     Mode                LastWriteTime         Length Name
     ----                -------------         ------ ----
-    d-----         6/2/2016   2:59 PM                Example
-
-
-     ---> 1f1dfdcec085
-    Removing intermediate container 3e6ba16b8df9
-    Step 4 : ADD Execute-MyCmdlet.ps1 c:\example\
-     ---> 6770b4c17f29
-    Removing intermediate container b139e34291dc
-    Step 5 : RUN c:\example\Execute-MyCmdlet -sample 'hello world'
-     ---> Running in abdcf50dfd1f
-    Hello from Execute-MyCmdlet.ps1 - passed hello world
-     ---> ba0e25255fda
-    Removing intermediate container abdcf50dfd1f
-    Successfully built ba0e25255fda
+    d-----       10/28/2016  11:26 AM                Example
+    
+    
+     ---> 3f2fbf1395d9
+    Removing intermediate container d0eef8386e97
+    Step 4/5 : ADD Execute-MyCmdlet.ps1 c:\example\
+     ---> a955b2621c31
+    Removing intermediate container b825593d39fc
+    Step 5/5 : RUN c:\example\Execute-MyCmdlet 'hello world'
+     ---> Running in be6d8e63fe75
+    hello world
+     ---> 8e559e9bf424
+    Removing intermediate container be6d8e63fe75
+    Successfully built 8e559e9bf424
     PS E:\docker\build\shell>
 
 The `SHELL` instruction could also be used to modify the way in which


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Refreshes builder.md to use the canonical image names (microsoft/nanoserver rather than just nanoserver or windowsservercore), and refreshes the output examples as the builder has slightly changed since the original introduction of the escape/shell commands. 
