### PR TITLE
Windows: Port a docker diff test

### DIFF
--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
@@ -9,16 +10,27 @@ import (
 
 // ensure that an added file shows up in docker diff
 func (s *DockerSuite) TestDiffFilenameShownInOutput(c *check.C) {
-	testRequires(c, DaemonIsLinux)
-	containerCmd := `echo foo > /root/bar`
+	containerCmd := `mkdir /foo; echo xyzzy > /foo/bar`
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
+
+	// Wait for it to exit as cannot diff a running container on Windows, and
+	// it will take a few seconds to exit. Also there's no way in Windows to
+	// differentiate between an Add or a Modify, and all files are under
+	// a "Files/" prefix.
+	containerID := strings.TrimSpace(out)
+	lookingFor := "A /foo/bar"
+	if daemonPlatform == "windows" {
+		err := waitExited(containerID, 60*time.Second)
+		c.Assert(err, check.IsNil)
+		lookingFor = "C Files/foo/bar"
+	}
 
 	cleanCID := strings.TrimSpace(out)
 	out, _ = dockerCmd(c, "diff", cleanCID)
 
 	found := false
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains("A /root/bar", line) {
+		if strings.Contains(line, lookingFor) {
 			found = true
 			break
 		}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Ports and adds a Windows CI test to ensure `docker diff` doesn't regress again on Windows after it was fixed in https://github.com/docker/docker/pull/27842.
