### PR TITLE
Nuke when graphdir is a mount

### DIFF
--- a/contrib/nuke-graph-directory.sh
+++ b/contrib/nuke-graph-directory.sh
@@ -44,7 +44,7 @@ dir_in_dir() {
 #   (like -v /home:... for example - DON'T DELETE MY HOME DIRECTORY BRU!)
 for mount in $(awk '{ print $5 }' /proc/self/mountinfo); do
 	mount="$(readlink -f "$mount" || true)"
-	if dir_in_dir "$mount" "$dir"; then
+	if [ "$dir" != "$mount" ] && dir_in_dir "$mount" "$dir"; then
 		( set -x; umount -f "$mount" )
 	fi
 done
@@ -54,9 +54,11 @@ if command -v btrfs > /dev/null 2>&1; then
 	# Find btrfs subvolumes under $dir checking for inode 256
 	# Source: http://stackoverflow.com/a/32865333
 	for subvol in $(find "$dir" -type d -inum 256 | sort -r); do
-		( set -x; btrfs subvolume delete "$subvol" )
+		if [ "$dir" != "$subvol" ]; then
+			( set -x; btrfs subvolume delete "$subvol" )
+		fi
 	done
 fi
 
 # finally, DESTROY ALL THINGS
-( set -x; rm -rf "$dir" )
+( shopt -s dotglob; set -x; rm -rf "$dir"/* )


### PR DESCRIPTION
Hello there,

I've got into a situation where the ideal would be to nuke the Docker folder and start from scratch.
After using the script on `contrib/nuke-graph-directory.sh`, I've noticed something odd.

```
Nuking /var/lib/docker ...
  (if this is wrong, press Ctrl+C NOW!)

+ sleep 10

+ umount -f /var/lib/docker
+ rm -rf /var/lib/docker
```

The Docker graphdir was being unmounted, so no content was actually being destroyed.

```
/dev/xvdc1 /var/lib/docker btrfs
```

This PR includes the necessary changes to nuke the folder on this scenario.
