### PR TITLE
Update docs for dockerd.md about `max-concurrent-downloads/max-concurrent-uploads`

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1208,6 +1208,8 @@ This is a full example of the allowed configuration options on Windows:
     "graph": "",
     "cluster-store": "",
     "cluster-advertise": "",
+    "max-concurrent-downloads": 3,
+    "max-concurrent-uploads": 5,
     "shutdown-timeout": 15,
     "debug": true,
     "hosts": [],


### PR DESCRIPTION
It seems that `max-concurrent-downloads` and `max-concurrent-uploads` are supported in Windows for `config.json`. Though that was not mentioned in the docs for dockerd.md.

This fix adds the following to the example `config.json` file for Windows:

```
    "max-concurrent-downloads": 3,
    "max-concurrent-uploads": 5,
```

Signed-off-by: Yong Tang yong.tang.github@outlook.com
