### PR TITLE
Add a comment about how we don't mkdir during WORKDIR directly

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -278,6 +278,11 @@ func workdir(b *Builder, args []string, attributes map[string]bool, original str
 		return err
 	}
 
+	// NOTE: You won't find the "mkdir" for the directory in here. Rather we
+	// just set the value in the image's runConfig.WorkingDir property
+	// and container.SetupWorkingDirectory() will create it automatically
+	// for us the next time the image is used to create a container.
+
 	return b.commit("", b.runConfig.Cmd, fmt.Sprintf("WORKDIR %v", b.runConfig.WorkingDir))
 }
 


### PR DESCRIPTION
Just to help the next time someone goes looking for it while debugging.
Like @jhowardmsft and I did while looking at #27545.

Signed-off-by: Doug Davis dug@us.ibm.com
