### PR TITLE
Copy only the relevant endpoint configs from Attachable config

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -655,7 +655,9 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName 
 				operIPAM = true
 			}
 
-			endpointConfig = epConfig
+			// copy IPAMConfig and NetworkID from epConfig via AttachNetwork
+			endpointConfig.IPAMConfig = epConfig.IPAMConfig
+			endpointConfig.NetworkID = epConfig.NetworkID
 		}
 	}
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -275,6 +275,26 @@ func (s *DockerSwarmSuite) TestSwarmContainerAutoStart(c *check.C) {
 	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
 }
 
+func (s *DockerSwarmSuite) TestSwarmContainerEndpointOptions(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	out, err := d.Cmd("network", "create", "--attachable", "-d", "overlay", "foo")
+	c.Assert(err, checker.IsNil)
+	c.Assert(strings.TrimSpace(out), checker.Not(checker.Equals), "")
+
+	_, err = d.Cmd("run", "-d", "--net=foo", "--name=first", "--net-alias=first-alias", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+
+	_, err = d.Cmd("run", "-d", "--net=foo", "--name=second", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+
+	// ping first container and its alias
+	_, err = d.Cmd("exec", "second", "ping", "-c", "1", "first")
+	c.Assert(err, check.IsNil)
+	_, err = d.Cmd("exec", "second", "ping", "-c", "1", "first-alias")
+	c.Assert(err, check.IsNil)
+}
+
 func (s *DockerSwarmSuite) TestSwarmRemoveInternalNetwork(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 


### PR DESCRIPTION
When a container is run on a --attachable network, the endpoint
configs passed by the user were incorrectly overwritten.
Copy the relevant configs instead of overwriting the entire configs.

Fixes #27370

Signed-off-by: Madhu Venugopal madhu@docker.com
