### PR TITLE
Windows: Fix COPY file . after WORKDIR

### DIFF
--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -16,6 +16,14 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 		hostConfig.Isolation = daemon.defaultIsolation
 	}
 
+	if err := daemon.Mount(container); err != nil {
+		return nil
+	}
+	defer daemon.Unmount(container)
+	if err := container.SetupWorkingDirectory(0, 0); err != nil {
+		return err
+	}
+
 	for spec := range config.Volumes {
 
 		mp, err := volume.ParseMountRaw(spec, hostConfig.VolumeDriver)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1865,10 +1865,6 @@ func (s *DockerSuite) TestBuildWindowsWorkdirProcessing(c *check.C) {
 func (s *DockerSuite) TestBuildWindowsAddCopyPathProcessing(c *check.C) {
 	testRequires(c, DaemonIsWindows)
 	name := "testbuildwindowsaddcopypathprocessing"
-	// TODO Windows (@jhowardmsft). Needs a follow-up PR to 22181 to
-	// support backslash such as .\\ being equivalent to ./ and c:\\ being
-	// equivalent to c:/. This is not currently (nor ever has been) supported
-	// by docker on the Windows platform.
 	dockerfile := `
 		FROM busybox
 			# No trailing slash on COPY/ADD
@@ -1878,8 +1874,8 @@ func (s *DockerSuite) TestBuildWindowsAddCopyPathProcessing(c *check.C) {
 			WORKDIR /wc2
 			ADD wc2 c:/wc2
 			WORKDIR c:/
-			RUN sh -c "[ $(cat c:/wc1) = 'hellowc1' ]"
-			RUN sh -c "[ $(cat c:/wc2) = 'worldwc2' ]"
+			RUN sh -c "[ $(cat c:/wc1/wc1) = 'hellowc1' ]"
+			RUN sh -c "[ $(cat c:/wc2/wc2) = 'worldwc2' ]"
 
 			# Trailing slash on COPY/ADD, Windows-style path.
 			WORKDIR /wd1
@@ -7173,4 +7169,29 @@ RUN echo vegeta
 	c.Assert(out, checker.Contains, "Step 1/3 : FROM busybox")
 	c.Assert(out, checker.Contains, "Step 2/3 : RUN echo grafana &&     echo raintank")
 	c.Assert(out, checker.Contains, "Step 3/3 : RUN echo vegeta")
+}
+
+// Verifies if COPY file . when WORKDIR is set to a non-existing directory,
+// the directory is created and the file is copied into the directory,
+// as opposed to the file being copied as a file with the name of the
+// directory. Fix for 27545 (found on Windows, but regression good for Linux too)
+func (s *DockerSuite) TestBuildCopyFileDotWithWorkdir(c *check.C) {
+	name := "testbuildcopyfiledotwithworkdir"
+
+	ctx, err := fakeContext(`FROM busybox
+WORKDIR /foo
+COPY file .
+RUN ["cat", "/foo/file"]
+`,
+		map[string]string{})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+	if err := ctx.Add("file", "content"); err != nil {
+		c.Fatal(err)
+	}
+	if _, err = buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes #27545. @duglin @thaJeztah @friism 

This fixes the last of the problems reported in the above issue, specifically on Windows where `COPY somefile .` after a `WORKDIR` statement where the workdir does not previously exist in the image, copied the contents of `somefile` to a filename of the WORKDIR, rather than a file in the folder of the WORKDIR. This change makes the builder on Windows consistent with Linux. Test case added too. 

(Another fix for the overall issue from @duglin at https://github.com/docker/docker/pull/27873)

@MichaelSimons @StefanScherer FYI
