### PR TITLE
Fixes #25363 : Fix hang issue with docker load without parameters

### DIFF
--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -41,6 +42,9 @@ func NewLoadCommand(dockerCli *command.DockerCli) *cobra.Command {
 func runLoad(dockerCli *command.DockerCli, opts loadOptions) error {
 
 	var input io.Reader = dockerCli.In()
+	if opts.input == "" && opts.quiet == false && dockerCli.In().IsTerminal() {
+		return fmt.Errorf("docker load : No stdin")
+	}
 	if opts.input != "" {
 		file, err := os.Open(opts.input)
 		if err != nil {


### PR DESCRIPTION
Fixes #25363 

**- What I did**
Fix hang issue while running docker load without parameters.

**- How to verify it**
Run "docker load" (with and without any parameters)
Withput parameters, it should error out saying No stdin.

Signed-off-by: milindchawre <milindchawre@gmail.com>