### PR TITLE
Validate docker-load receives a tar file

### DIFF
--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -49,6 +50,13 @@ func runLoad(dockerCli *command.DockerCli, opts loadOptions) error {
 		defer file.Close()
 		input = file
 	}
+
+	// To avoid getting stuck, verify that a tar file is given either in
+	// the input flag or through stdin and if not display an error message and exit.
+	if opts.input == "" && dockerCli.In().IsTerminal() {
+		return fmt.Errorf("requested load from stdin, but stdin is empty")
+	}
+
 	if !dockerCli.Out().IsTerminal() {
 		opts.quiet = true
 	}


### PR DESCRIPTION
**- What I did**
Should close #25363 
Print an error message if the tar file isn't specified using either the input argument or stdin.

**- How I did it**
Checking the docker CLI input is not a terminal or the input argument is set.

**- How to verify it**
Run:
```
TESTFLAGS='-check.f DockerSuite.TestLoadNoStdinFail' hack/make.sh test-integration-cli
```
```
TESTFLAGS='-check.f DockerSuite.TestSaveAndLoadWithProgressBar' hack/make.sh test-integration-cli
```

**- Description for the changelog**

To load an image from a tar file, you can specify the tar file in the -i/--input option:
docker load -i image_1.tar

or using stdin:

docker load < image_1.tar
cat image_1.tat | docker load

If the image file isn't given the `docker load` command gets stuck.

To avoid that, the load makes sure the CLI input is not a terminal or the `--input` option was set.
If not then an error message is shown.

**- A picture of a cute animal (not mandatory but encouraged)**