### PR TITLE
Windows: Require REST 1.25 or later

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -23,9 +23,6 @@ const (
 	// DefaultVersion of Current REST API
 	DefaultVersion string = "1.25"
 
-	// MinVersion represents Minimum REST API version supported
-	MinVersion string = "1.12"
-
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.
 	NoBaseImageSpecifier string = "scratch"

--- a/api/common_unix.go
+++ b/api/common_unix.go
@@ -1,0 +1,6 @@
+// +build !windows
+
+package api
+
+// MinVersion represents Minimum REST API version supported
+const MinVersion string = "1.12"

--- a/api/common_windows.go
+++ b/api/common_windows.go
@@ -1,0 +1,4 @@
+package api
+
+// MinVersion represents Minimum REST API version supported
+const MinVersion string = "1.25"

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -976,7 +976,7 @@ func (s *DockerSuite) TestContainerAPICopyNotExistsAnyMore(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerAPICopyPre124(c *check.C) {
-
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	name := "test-container-api-copy"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
 
@@ -1006,6 +1006,7 @@ func (s *DockerSuite) TestContainerAPICopyPre124(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerAPICopyResourcePathEmptyPr124(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	name := "test-container-api-copy-resource-empty"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
 
@@ -1020,6 +1021,7 @@ func (s *DockerSuite) TestContainerAPICopyResourcePathEmptyPr124(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerAPICopyResourcePathNotFoundPre124(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	name := "test-container-api-copy-resource-not-found"
 	dockerCmd(c, "run", "--name", name, "busybox")
 
@@ -1034,6 +1036,7 @@ func (s *DockerSuite) TestContainerAPICopyResourcePathNotFoundPre124(c *check.C)
 }
 
 func (s *DockerSuite) TestContainerAPICopyContainerNotFoundPr124(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	postData := types.CopyConfig{
 		Resource: "/something",
 	}
@@ -1245,6 +1248,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCapAddDrop(c *che
 
 // #14915
 func (s *DockerSuite) TestContainerAPICreateNoHostConfig118(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only support 1.25 or later
 	config := struct {
 		Image string
 	}{"busybox"}

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -90,6 +90,7 @@ func (s *DockerSuite) TestExecAPIStart(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecAPIStartBackwardsCompatible(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	runSleepingContainer(c, "-d", "--name", "test")
 	id := createExec(c, "test")
 

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -40,6 +40,7 @@ func (s *DockerSuite) TestInfoAPI(c *check.C) {
 }
 
 func (s *DockerSuite) TestInfoAPIVersioned(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	endpoint := "/v1.20/info"
 
 	status, body, err := sockRequest("GET", endpoint, nil)

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestInspectAPIContainerResponse(c *check.C) {
 
 	if daemonPlatform == "windows" {
 		cases = []acase{
-			{"v1.20", append(keysBase, "Mounts")},
+			{"v1.25", append(keysBase, "Mounts")},
 		}
 
 	} else {
@@ -84,23 +84,23 @@ func (s *DockerSuite) TestInspectAPIContainerVolumeDriver(c *check.C) {
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	body := getInspectBody(c, "v1.21", cleanedContainerID)
+	body := getInspectBody(c, "v1.25", cleanedContainerID)
 
 	var inspectJSON map[string]interface{}
 	err := json.Unmarshal(body, &inspectJSON)
-	c.Assert(err, checker.IsNil, check.Commentf("Unable to unmarshal body for version 1.21"))
+	c.Assert(err, checker.IsNil, check.Commentf("Unable to unmarshal body for version 1.25"))
 
 	config, ok := inspectJSON["Config"]
 	c.Assert(ok, checker.True, check.Commentf("Unable to find 'Config'"))
 	cfg := config.(map[string]interface{})
 	_, ok = cfg["VolumeDriver"]
-	c.Assert(ok, checker.False, check.Commentf("API version 1.21 expected to not include VolumeDriver in 'Config'"))
+	c.Assert(ok, checker.False, check.Commentf("API version 1.25 expected to not include VolumeDriver in 'Config'"))
 
 	config, ok = inspectJSON["HostConfig"]
 	c.Assert(ok, checker.True, check.Commentf("Unable to find 'HostConfig'"))
 	cfg = config.(map[string]interface{})
 	_, ok = cfg["VolumeDriver"]
-	c.Assert(ok, checker.True, check.Commentf("API version 1.21 expected to include VolumeDriver in 'HostConfig'"))
+	c.Assert(ok, checker.True, check.Commentf("API version 1.25 expected to include VolumeDriver in 'HostConfig'"))
 }
 
 func (s *DockerSuite) TestInspectAPIImageResponse(c *check.C) {

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -162,20 +162,15 @@ func (s *DockerSuite) TestAPIStatsNetworkStats(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIStatsNetworkStatsVersioning(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	// Windows doesn't support API versions less than 1.25, so no point testing 1.17 .. 1.21
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := runSleepingContainer(c)
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), checker.IsNil)
 	wg := sync.WaitGroup{}
 
-	// Windows API versions prior to 1.21 doesn't support stats.
-	startAt := 17
-	if daemonPlatform == "windows" {
-		startAt = 21
-	}
-
-	for i := startAt; i <= 21; i++ {
+	for i := 17; i <= 21; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -75,7 +75,7 @@ func (s *DockerSuite) TestAPIClientVersionOldNotSupported(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusBadRequest)
 	expected := fmt.Sprintf("client version %s is too old. Minimum supported API version is %s, please upgrade your client to a newer version", version, api.MinVersion)
-	c.Assert(strings.TrimSpace(string(body)), checker.Equals, expected)
+	c.Assert(strings.TrimSpace(string(body)), checker.Contains, expected)
 }
 
 func (s *DockerSuite) TestAPIDockerAPIVersion(c *check.C) {
@@ -108,6 +108,9 @@ func (s *DockerSuite) TestAPIErrorJSON(c *check.C) {
 }
 
 func (s *DockerSuite) TestAPIErrorPlainText(c *check.C) {
+	// Windows requires API 1.25 or later. This test is validating a behaviour which was present
+	// in v1.23, but changed in 1.24, hence not applicable on Windows. See apiVersionSupportsJSONErrors
+	testRequires(c, DaemonIsLinux)
 	httpResp, body, err := sockRequestRaw("POST", "/v1.23/containers/create", strings.NewReader(`{}`), "application/json")
 	c.Assert(err, checker.IsNil)
 	c.Assert(httpResp.StatusCode, checker.Equals, http.StatusInternalServerError)

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -116,6 +116,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillStoppedContainerAPIPre120(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Windows only supports 1.25 or later
 	runSleepingContainer(c, "--name", "docker-kill-test-api", "-d")
 	dockerCmd(c, "stop", "docker-kill-test-api")
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/docker/docker/issues/27601. 

@thaJeztah Windows support doesn't start until API version 1.25.  