### PR TITLE
Auto-detect node IP address 

### DIFF
--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -77,6 +77,7 @@ type PluginDescription struct {
 type NodeStatus struct {
 	State   NodeState `json:",omitempty"`
 	Message string    `json:",omitempty"`
+	Addr    string    `json:",omitempty"`
 }
 
 // Reachability represents the reachability of a node.

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -95,6 +95,7 @@ func printNode(out io.Writer, node swarm.Node) {
 	fmt.Fprintf(out, " State:\t\t\t%s\n", command.PrettyPrint(node.Status.State))
 	ioutils.FprintfIfNotEmpty(out, " Message:\t\t%s\n", command.PrettyPrint(node.Status.Message))
 	fmt.Fprintf(out, " Availability:\t\t%s\n", command.PrettyPrint(node.Spec.Availability))
+	ioutils.FprintfIfNotEmpty(out, " Address:\t\t%s\n", command.PrettyPrint(node.Status.Addr))
 
 	if node.ManagerStatus != nil {
 		fmt.Fprintln(out, "Manager Status:")

--- a/daemon/cluster/convert/node.go
+++ b/daemon/cluster/convert/node.go
@@ -20,6 +20,7 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 		Status: types.NodeStatus{
 			State:   types.NodeState(strings.ToLower(n.Status.State.String())),
 			Message: n.Status.Message,
+			Addr:    n.Status.Addr,
 		},
 	}
 

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -163,6 +163,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * Every API response now includes a `Docker-Experimental` header specifying if experimental features are enabled (value can be `true` or `false`).
 * The `hostConfig` option now accepts the fields `CpuRealtimePeriod` and `CpuRtRuntime` to allocate cpu runtime to rt tasks when `CONFIG_RT_GROUP_SCHED` is enabled in the kernel.
 * The `SecurityOptions` field within the `GET /info` response now includes `userns` if user namespaces are enabled in the daemon.
+* `GET /nodes` and `GET /node/(id or name)` now return `Addr` as part of a node's `Status`, which is the address that that node connects to the manager from.
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4464,7 +4464,8 @@ List nodes
           }
         },
         "Status": {
-          "State": "ready"
+          "State": "ready",
+          "Addr": "172.17.0.2"
         },
         "ManagerStatus": {
           "Leader": true,
@@ -4555,7 +4556,8 @@ Return low-level information on the node `id`
         }
       },
       "Status": {
-        "State": "ready"
+        "State": "ready",
+        "Addr": "172.17.0.2"
       },
       "ManagerStatus": {
         "Leader": true,

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -88,7 +88,8 @@ Example output:
             }
         },
         "Status": {
-            "State": "ready"
+            "State": "ready",
+            "Addr": "168.0.32.137"
         },
         "ManagerStatus": {
             "Leader": true,
@@ -110,6 +111,7 @@ Example output:
     Status:
      State:                 Ready
      Availability:          Active
+     Address:               172.17.0.2
     Manager Status:
      Address:               172.17.0.2:2377
      Raft Status:           Reachable


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The IP address that an agent connects to the manager from is recorded, stored, and exposed through the API. This is useful for many kinds of internal cluster management tools. The field is `Node.Status.Addr`. 

**- How I did it**
Change in swarmkit to support this behavior, then update docker to expose this in its api

**- How to verify it**
`docker node inspect` now shows node address under `Status`, both with and without `--pretty`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Autodetect, store, and expose node IP address as seen by the manager.

**- A picture of a cute animal (not mandatory but encouraged)**
This bird, the violet-backed starling, is purple.
![image](https://cloud.githubusercontent.com/assets/2367858/19864690/8d640904-9f56-11e6-83ec-11f1de20bedc.png)
