### PR TITLE
Add support for host mode port PublishMode in services

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -31,7 +31,22 @@ type PortConfig struct {
 	TargetPort uint32 `json:",omitempty"`
 	// PublishedPort is the port on the swarm hosts
 	PublishedPort uint32 `json:",omitempty"`
+	// PublishMode is the mode in which port is published
+	PublishMode PortConfigPublishMode `json:",omitempty"`
 }
+
+// PortConfigPublishMode represents the mode in which the port is to
+// be published.
+type PortConfigPublishMode string
+
+const (
+	// PortConfigPublishModeIngress is used for ports published
+	// for ingress load balancing using routing mesh.
+	PortConfigPublishModeIngress PortConfigPublishMode = "ingress"
+	// PortConfigPublishModeHost is used for ports published
+	// for direct host level access on the host where the task is running.
+	PortConfigPublishModeHost PortConfigPublishMode = "host"
+)
 
 // PortConfigProtocol represents the protocol of a port.
 type PortConfigProtocol string

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -111,6 +111,7 @@ type TaskStatus struct {
 	Message         string          `json:",omitempty"`
 	Err             string          `json:",omitempty"`
 	ContainerStatus ContainerStatus `json:",omitempty"`
+	PortStatus      PortStatus      `json:",omitempty"`
 }
 
 // ContainerStatus represents the status of a container.
@@ -118,4 +119,10 @@ type ContainerStatus struct {
 	ContainerID string `json:",omitempty"`
 	PID         int    `json:",omitempty"`
 	ExitCode    int    `json:",omitempty"`
+}
+
+// PortStatus represents the port status of a task's host ports whose
+// service has published host ports
+type PortStatus struct {
+	Ports []PortConfig `json:",omitempty"`
 }

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -40,12 +40,14 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.constraints, flagConstraint, "Placement constraints")
 	flags.Var(&opts.networks, flagNetwork, "Network attachments")
 	flags.Var(&opts.secrets, flagSecret, "Specify secrets to expose to the service")
-	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
+	flags.VarP(&opts.endpoint.publishPorts, flagPublish, "p", "Publish a port as a node port")
+	flags.MarkHidden(flagPublish)
 	flags.Var(&opts.groups, flagGroup, "Set one or more supplementary user groups for the container")
 	flags.Var(&opts.dns, flagDNS, "Set custom DNS servers")
 	flags.Var(&opts.dnsOption, flagDNSOption, "Set DNS options")
 	flags.Var(&opts.dnsSearch, flagDNSSearch, "Set custom DNS search domains")
 	flags.Var(&opts.hosts, flagHost, "Set one or more custom host-to-IP mappings (host:ip)")
+	flags.Var(&opts.endpoint.expandedPorts, flagPort, "Publish a port")
 
 	flags.SetInterspersed(false)
 	return cmd

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -238,7 +238,7 @@ func TestUpdatePortsDuplicateEntries(t *testing.T) {
 func TestUpdatePortsDuplicateKeys(t *testing.T) {
 	// Test case for #25375
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("publish-add", "80:20")
+	flags.Set("publish-add", "80:80")
 
 	portConfigs := []swarm.PortConfig{
 		{TargetPort: 80, PublishedPort: 80},
@@ -247,21 +247,7 @@ func TestUpdatePortsDuplicateKeys(t *testing.T) {
 	err := updatePorts(flags, &portConfigs)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(portConfigs), 1)
-	assert.Equal(t, portConfigs[0].TargetPort, uint32(20))
-}
-
-func TestUpdatePortsConflictingFlags(t *testing.T) {
-	// Test case for #25375
-	flags := newUpdateCommand(nil).Flags()
-	flags.Set("publish-add", "80:80")
-	flags.Set("publish-add", "80:20")
-
-	portConfigs := []swarm.PortConfig{
-		{TargetPort: 80, PublishedPort: 80},
-	}
-
-	err := updatePorts(flags, &portConfigs)
-	assert.Error(t, err, "conflicting port mapping")
+	assert.Equal(t, portConfigs[0].TargetPort, uint32(80))
 }
 
 func TestUpdateHealthcheckTable(t *testing.T) {

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -93,6 +93,7 @@ func endpointSpecFromGRPC(es *swarmapi.EndpointSpec) *types.EndpointSpec {
 			endpointSpec.Ports = append(endpointSpec.Ports, types.PortConfig{
 				Name:          portState.Name,
 				Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(portState.Protocol)])),
+				PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(portState.PublishMode)])),
 				TargetPort:    portState.TargetPort,
 				PublishedPort: portState.PublishedPort,
 			})
@@ -112,6 +113,7 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 			endpoint.Ports = append(endpoint.Ports, types.PortConfig{
 				Name:          portState.Name,
 				Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(portState.Protocol)])),
+				PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(portState.PublishMode)])),
 				TargetPort:    portState.TargetPort,
 				PublishedPort: portState.PublishedPort,
 			})

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -199,6 +199,7 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 			spec.Endpoint.Ports = append(spec.Endpoint.Ports, &swarmapi.PortConfig{
 				Name:          portConfig.Name,
 				Protocol:      swarmapi.PortConfig_Protocol(swarmapi.PortConfig_Protocol_value[strings.ToUpper(string(portConfig.Protocol))]),
+				PublishMode:   swarmapi.PortConfig_PublishMode(swarmapi.PortConfig_PublishMode_value[strings.ToUpper(string(portConfig.PublishMode))]),
 				TargetPort:    portConfig.TargetPort,
 				PublishedPort: portConfig.PublishedPort,
 			})

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -63,5 +63,19 @@ func TaskFromGRPC(t swarmapi.Task) types.Task {
 		task.NetworksAttachments = append(task.NetworksAttachments, networkAttachementFromGRPC(na))
 	}
 
+	if t.Status.PortStatus == nil {
+		return task
+	}
+
+	for _, p := range t.Status.PortStatus.Ports {
+		task.Status.PortStatus.Ports = append(task.Status.PortStatus.Ports, types.PortConfig{
+			Name:          p.Name,
+			Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(p.Protocol)])),
+			PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(p.PublishMode)])),
+			TargetPort:    p.TargetPort,
+			PublishedPort: p.PublishedPort,
+		})
+	}
+
 	return task
 }

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -32,6 +32,7 @@ func (s *DockerSwarmSuite) TestServiceUpdatePort(c *check.C) {
 			Protocol:      "tcp",
 			PublishedPort: 8082,
 			TargetPort:    8083,
+			PublishMode:   "ingress",
 		},
 	}
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -321,12 +321,9 @@ func (s *DockerSwarmSuite) TestSwarmPublishAdd(c *check.C) {
 	out, err = d.cmdRetryOutOfSequence("service", "update", "--publish-add", "80:80", "--publish-add", "80:20", name)
 	c.Assert(err, checker.NotNil)
 
-	out, err = d.cmdRetryOutOfSequence("service", "update", "--publish-add", "80:20", name)
-	c.Assert(err, checker.IsNil)
-
 	out, err = d.Cmd("service", "inspect", "--format", "{{ .Spec.EndpointSpec.Ports }}", name)
 	c.Assert(err, checker.IsNil)
-	c.Assert(strings.TrimSpace(out), checker.Equals, "[{ tcp 20 80}]")
+	c.Assert(strings.TrimSpace(out), checker.Equals, "[{ tcp 80 80 ingress}]")
 }
 
 func (s *DockerSwarmSuite) TestSwarmServiceWithGroup(c *check.C) {

--- a/opts/port.go
+++ b/opts/port.go
@@ -1,0 +1,99 @@
+package opts
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+const (
+	portOptTargetPort    = "target"
+	portOptPublishedPort = "published"
+	portOptProtocol      = "protocol"
+	portOptMode          = "mode"
+)
+
+type PortOpt struct {
+	ports []swarm.PortConfig
+}
+
+// Set a new port value
+func (p *PortOpt) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	pConfig := swarm.PortConfig{}
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid field %s", field)
+		}
+
+		key := strings.ToLower(parts[0])
+		value := strings.ToLower(parts[1])
+
+		switch key {
+		case portOptProtocol:
+			if value != string(swarm.PortConfigProtocolTCP) && value != string(swarm.PortConfigProtocolUDP) {
+				return fmt.Errorf("invalid protocol value %s", value)
+			}
+
+			pConfig.Protocol = swarm.PortConfigProtocol(value)
+		case portOptMode:
+			if value != string(swarm.PortConfigPublishModeIngress) && value != string(swarm.PortConfigPublishModeHost) {
+				return fmt.Errorf("invalid publish mode value %s", value)
+			}
+
+			pConfig.PublishMode = swarm.PortConfigPublishMode(value)
+		case portOptTargetPort:
+			tPort, err := strconv.ParseUint(value, 10, 16)
+			if err != nil {
+				return err
+			}
+
+			pConfig.TargetPort = uint32(tPort)
+		case portOptPublishedPort:
+			pPort, err := strconv.ParseUint(value, 10, 16)
+			if err != nil {
+				return err
+			}
+
+			pConfig.PublishedPort = uint32(pPort)
+		default:
+			return fmt.Errorf("invalid field key %s", key)
+		}
+	}
+
+	if pConfig.TargetPort == 0 {
+		return fmt.Errorf("missing mandatory field %q", portOptTargetPort)
+	}
+
+	p.ports = append(p.ports, pConfig)
+	return nil
+}
+
+// Type returns the type of this option
+func (p *PortOpt) Type() string {
+	return "port"
+}
+
+// String returns a string repr of this option
+func (p *PortOpt) String() string {
+	ports := []string{}
+	for _, port := range p.ports {
+		repr := fmt.Sprintf("%v:%v/%s/%s", port.PublishedPort, port.TargetPort, port.Protocol, port.PublishMode)
+		ports = append(ports, repr)
+	}
+	return strings.Join(ports, ", ")
+}
+
+// Value returns the ports
+func (p *PortOpt) Value() []swarm.PortConfig {
+	return p.ports
+}


### PR DESCRIPTION
Add api/cli support for adding host port PublishMode in services.

```
mrjana@dev-1:~/docker/scripts$ docker service create --name ss2 --publish-host 5000 --publish-ingress 5000 --network foo mrjana/simpleweb simpleweb

mrjana@dev-1:~/docker/scripts$ docker service ps ss2
NAME                             IMAGE             NODE     DESIRED STATE  CURRENT STATE          ERROR  PORTS
ss2.1.xlgwmnomhp609divvy8xdqh5w  mrjana/simpleweb  worker1  Running        Running 9 seconds ago         *:32768->5000/tcp
```
Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>