### PR TITLE
Basic IT for plugin-v2 network driver

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -768,6 +768,30 @@ func (s *DockerNetworkSuite) TestDockerNetworkDriverOptions(c *check.C) {
 
 }
 
+func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon, Network)
+
+	var (
+		npName        = "mavenugo/test-docker-netplugin"
+		npTag         = "latest"
+		npNameWithTag = npName + ":" + npTag
+	)
+	_, _, err := dockerCmdWithError("plugin", "install", "--grant-all-permissions", npNameWithTag)
+	c.Assert(err, checker.IsNil)
+
+	out, _, err := dockerCmdWithError("plugin", "ls")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, npName)
+	c.Assert(out, checker.Contains, npTag)
+	c.Assert(out, checker.Contains, "true")
+
+	dockerCmd(c, "network", "create", "-d", npNameWithTag, "v2net")
+	assertNwIsAvailable(c, "v2net")
+	dockerCmd(c, "network", "rm", "v2net")
+	assertNwNotAvailable(c, "v2net")
+
+}
+
 func (s *DockerDaemonSuite) TestDockerNetworkNoDiscoveryDefaultBridgeNetwork(c *check.C) {
 	testRequires(c, ExecSupport)
 	// On default bridge network built-in service discovery should not happen


### PR DESCRIPTION

The plugin APIs have not changed between plugin-v1 and v2 for local-scoped network drivers.
Hence a simple test to validate the bootstrapping and network creation APIs would suffice.

Any network driver specific API validations are handled independent of plugin v1 or v2 format.

Using a sample v2 network plugin : https://github.com/mavenugo/test-docker-netplugin/

Signed-off-by: Madhu Venugopal <madhu@docker.com>