### PR TITLE
support env for docker plugin set

### DIFF
--- a/api/server/router/plugin/plugin_routes.go
+++ b/api/server/router/plugin/plugin_routes.go
@@ -89,7 +89,11 @@ func (pr *pluginRouter) setPlugin(ctx context.Context, w http.ResponseWriter, r 
 	if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
 		return err
 	}
-	return pr.backend.Set(vars["name"], args)
+	if err := pr.backend.Set(vars["name"], args); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 func (pr *pluginRouter) listPlugins(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4290,16 +4290,26 @@ Content-Type: application/json
 -   **200** - no error
 -   **404** - plugin not installed
 
-<!-- TODO Document "docker plugin set" endpoint once implemented
 ### Configure a plugin
 
-`POST /plugins/(plugin name)/set`
+POST /plugins/(plugin name)/set`
+
+**Example request**:
+
+
+    POST /plugins/tiborvass/no-remove/set
+    Content-Type: application/json
+
+    ["DEBUG=1"]
+
+**Example response**:
+
+    HTTP/1.1 204 No Content
 
 **Status codes**:
 
--   **500** - not implemented
-
--->
+-   **204** - no error
+-   **404** - plugin not installed
 
 ### Enable a plugin
 

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -59,3 +59,4 @@ tiborvass/no-remove   latest              A test plugin for Docker   false
 * [plugin inspect](plugin_inspect.md)
 * [plugin install](plugin_install.md)
 * [plugin rm](plugin_rm.md)
+* [plugin set](plugin_set.md)

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -59,3 +59,4 @@ tiborvass/no-remove   latest              A test plugin for Docker   true
 * [plugin inspect](plugin_inspect.md)
 * [plugin install](plugin_install.md)
 * [plugin rm](plugin_rm.md)
+* [plugin set](plugin_set.md)

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -159,3 +159,4 @@ $ docker plugin inspect -f '{{.Id}}' tiborvass/no-remove:latest
 * [plugin disable](plugin_disable.md)
 * [plugin install](plugin_install.md)
 * [plugin rm](plugin_rm.md)
+* [plugin set](plugin_set.md)

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -64,3 +64,4 @@ tiborvass/no-remove   latest              A test plugin for Docker   true
 * [plugin disable](plugin_disable.md)
 * [plugin inspect](plugin_inspect.md)
 * [plugin rm](plugin_rm.md)
+* [plugin set](plugin_set.md)

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -51,3 +51,4 @@ tiborvass/no-remove
 * [plugin disable](plugin_disable.md)
 * [plugin inspect](plugin_inspect.md)
 * [plugin install](plugin_install.md)
+* [plugin set](plugin_set.md)

--- a/docs/reference/commandline/plugin_set.md
+++ b/docs/reference/commandline/plugin_set.md
@@ -1,7 +1,7 @@
 ---
-title: "plugin ls"
-description: "The plugin ls command description and usage"
-keywords: "plugin, list"
+title: "plugin set"
+description: "the plugin set command description and usage"
+keywords: "plugin, set"
 advisory: "experimental"
 ---
 
@@ -14,38 +14,38 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# plugin ls (experimental)
+# plugin set (experimental)
 
 ```markdown
-Usage:  docker plugin ls [OPTIONS]
+Usage:  docker plugin set PLUGIN key1=value1 [key2=value2...]
 
-List plugins
-
-Aliases:
-  ls, list
+Change settings for a plugin
 
 Options:
-      --help	   Print usage
-      --no-trunc   Don't truncate output
+      --help                    Print usage
 ```
 
-Lists all the plugins that are currently installed. You can install plugins
-using the [`docker plugin install`](plugin_install.md) command.
+Change settings for a plugin. The plugin must be disabled.
 
-Example output:
+
+The following example installs change the env variable `DEBUG` of the
+`no-remove` plugin.
 
 ```bash
-$ docker plugin ls
+$ docker plugin inspect -f {{.Config.Env}} tiborvass/no-remove
+[DEBUG=0]
 
-NAME                  TAG                 DESCRIPTION                ENABLED
-tiborvass/no-remove   latest              A test plugin for Docker   true
+$ docker plugin set DEBUG=1 tiborvass/no-remove
+
+$ docker plugin inspect -f {{.Config.Env}} tiborvass/no-remove
+[DEBUG=1]
 ```
 
 ## Related information
 
+* [plugin ls](plugin_ls.md)
 * [plugin enable](plugin_enable.md)
 * [plugin disable](plugin_disable.md)
 * [plugin inspect](plugin_inspect.md)
 * [plugin install](plugin_install.md)
 * [plugin rm](plugin_rm.md)
-* [plugin set](plugin_set.md)

--- a/integration-cli/docker_cli_plugins_test.go
+++ b/integration-cli/docker_cli_plugins_test.go
@@ -117,6 +117,20 @@ func (s *DockerSuite) TestPluginInstallDisableVolumeLs(c *check.C) {
 	dockerCmd(c, "volume", "ls")
 }
 
+func (s *DockerSuite) TestPluginSet(c *check.C) {
+	testRequires(c, DaemonIsLinux, ExperimentalDaemon, Network)
+	out, _ := dockerCmd(c, "plugin", "install", "--grant-all-permissions", "--disable", pName)
+	c.Assert(strings.TrimSpace(out), checker.Contains, pName)
+
+	env, _ := dockerCmd(c, "plugin", "inspect", "-f", "{{.Config.Env}}", pName)
+	c.Assert(strings.TrimSpace(env), checker.Equals, "[DEBUG=0]")
+
+	dockerCmd(c, "plugin", "set", pName, "DEBUG=1")
+
+	env, _ = dockerCmd(c, "plugin", "inspect", "-f", "{{.Config.Env}}", pName)
+	c.Assert(strings.TrimSpace(env), checker.Equals, "[DEBUG=1]")
+}
+
 func (s *DockerSuite) TestPluginInstallImage(c *check.C) {
 	testRequires(c, DaemonIsLinux, ExperimentalDaemon)
 	out, _, err := dockerCmdWithError("plugin", "install", "redis")

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -85,8 +85,8 @@ func (pm *Manager) Pull(name string, metaHeader http.Header, authConfig *types.A
 	}
 
 	tag := distribution.GetTag(ref)
-	p := v2.NewPlugin(ref.Name(), pluginID, pm.runRoot, tag)
-	if err := p.InitPlugin(pm.libRoot); err != nil {
+	p := v2.NewPlugin(ref.Name(), pluginID, pm.runRoot, pm.libRoot, tag)
+	if err := p.InitPlugin(); err != nil {
 		return nil, err
 	}
 	pm.pluginStore.Add(p)

--- a/plugin/store/store_test.go
+++ b/plugin/store/store_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestFilterByCapNeg(t *testing.T) {
-	p := v2.NewPlugin("test", "1234567890", "/run/docker", "latest")
+	p := v2.NewPlugin("test", "1234567890", "/run/docker", "/var/lib/docker/plugins", "latest")
 
 	iType := types.PluginInterfaceType{"volumedriver", "docker", "1.0"}
 	i := types.PluginManifestInterface{"plugins.sock", []types.PluginInterfaceType{iType}}
@@ -21,7 +21,7 @@ func TestFilterByCapNeg(t *testing.T) {
 }
 
 func TestFilterByCapPos(t *testing.T) {
-	p := v2.NewPlugin("test", "1234567890", "/run/docker", "latest")
+	p := v2.NewPlugin("test", "1234567890", "/run/docker", "/var/lib/docker/plugins", "latest")
 
 	iType := types.PluginInterfaceType{"volumedriver", "docker", "1.0"}
 	i := types.PluginManifestInterface{"plugins.sock", []types.PluginInterfaceType{iType}}

--- a/plugin/v2/settable.go
+++ b/plugin/v2/settable.go
@@ -1,0 +1,102 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type settable struct {
+	name  string
+	field string
+	value string
+}
+
+var (
+	allowedSettableFieldsEnv     = []string{"value"}
+	allowedSettableFieldsArgs    = []string{"value"}
+	allowedSettableFieldsDevices = []string{"path"}
+	allowedSettableFieldsMounts  = []string{"source"}
+
+	errMultipleFields = errors.New("multiple fields are settable, one must be specified")
+	errInvalidFormat  = errors.New("invalid format, must be <name>[.<field>][=<value>]")
+)
+
+func newSettables(args []string) ([]settable, error) {
+	sets := make([]settable, 0, len(args))
+	for _, arg := range args {
+		set, err := newSettable(arg)
+		if err != nil {
+			return nil, err
+		}
+		sets = append(sets, set)
+	}
+	return sets, nil
+}
+
+func newSettable(arg string) (settable, error) {
+	var set settable
+	if i := strings.Index(arg, "="); i == 0 {
+		return set, errInvalidFormat
+	} else if i < 0 {
+		set.name = arg
+	} else {
+		set.name = arg[:i]
+		set.value = arg[i+1:]
+	}
+
+	if i := strings.LastIndex(set.name, "."); i > 0 {
+		set.field = set.name[i+1:]
+		set.name = arg[:i]
+	}
+
+	return set, nil
+}
+
+// prettyName return name.field if there is a field, otherwise name.
+func (set *settable) prettyName() string {
+	if set.field != "" {
+		return fmt.Sprintf("%s.%s", set.name, set.field)
+	}
+	return set.name
+}
+
+func (set *settable) isSettable(allowedSettableFields []string, settable []string) (bool, error) {
+	if set.field == "" {
+		if len(settable) == 1 {
+			// if field is not specified and there only one settable, default to it.
+			set.field = settable[0]
+		} else if len(settable) > 1 {
+			return false, errMultipleFields
+		}
+	}
+
+	isAllowed := false
+	for _, allowedSettableField := range allowedSettableFields {
+		if set.field == allowedSettableField {
+			isAllowed = true
+			break
+		}
+	}
+
+	if isAllowed {
+		for _, settableField := range settable {
+			if set.field == settableField {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func updateConfigEnv(env *[]string, set *settable) {
+	for i, e := range *env {
+		if parts := strings.SplitN(e, "=", 2); parts[0] == set.name {
+			(*env)[i] = fmt.Sprintf("%s=%s", set.name, set.value)
+			return
+		}
+	}
+
+	*env = append(*env, fmt.Sprintf("%s=%s", set.name, set.value))
+}

--- a/plugin/v2/settable_test.go
+++ b/plugin/v2/settable_test.go
@@ -1,0 +1,91 @@
+package v2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewSettable(t *testing.T) {
+	contexts := []struct {
+		arg   string
+		name  string
+		field string
+		value string
+		err   error
+	}{
+		{"name=value", "name", "", "value", nil},
+		{"name", "name", "", "", nil},
+		{"name.field=value", "name", "field", "value", nil},
+		{"name.field", "name", "field", "", nil},
+		{"=value", "", "", "", errInvalidFormat},
+		{"=", "", "", "", errInvalidFormat},
+	}
+
+	for _, c := range contexts {
+		s, err := newSettable(c.arg)
+		if err != c.err {
+			t.Fatalf("expected error to be %v, got %v", c.err, err)
+		}
+
+		if s.name != c.name {
+			t.Fatalf("expected name to be %q, got %q", c.name, s.name)
+		}
+
+		if s.field != c.field {
+			t.Fatalf("expected field to be %q, got %q", c.field, s.field)
+		}
+
+		if s.value != c.value {
+			t.Fatalf("expected value to be %q, got %q", c.value, s.value)
+		}
+
+	}
+}
+
+func TestIsSettable(t *testing.T) {
+	contexts := []struct {
+		allowedSettableFields []string
+		set                   settable
+		settable              []string
+		result                bool
+		err                   error
+	}{
+		{allowedSettableFieldsEnv, settable{}, []string{}, false, nil},
+		{allowedSettableFieldsEnv, settable{field: "value"}, []string{}, false, nil},
+		{allowedSettableFieldsEnv, settable{}, []string{"value"}, true, nil},
+		{allowedSettableFieldsEnv, settable{field: "value"}, []string{"value"}, true, nil},
+		{allowedSettableFieldsEnv, settable{field: "foo"}, []string{"value"}, false, nil},
+		{allowedSettableFieldsEnv, settable{field: "foo"}, []string{"foo"}, false, nil},
+		{allowedSettableFieldsEnv, settable{}, []string{"value1", "value2"}, false, errMultipleFields},
+	}
+
+	for _, c := range contexts {
+		if res, err := c.set.isSettable(c.allowedSettableFields, c.settable); res != c.result {
+			t.Fatalf("expected result to be %t, got %t", c.result, res)
+		} else if err != c.err {
+			t.Fatalf("expected error to be %v, got %v", c.err, err)
+		}
+	}
+}
+
+func TestUpdateConfigEnv(t *testing.T) {
+	contexts := []struct {
+		env    []string
+		set    settable
+		newEnv []string
+	}{
+		{[]string{}, settable{name: "DEBUG", value: "1"}, []string{"DEBUG=1"}},
+		{[]string{"DEBUG=0"}, settable{name: "DEBUG", value: "1"}, []string{"DEBUG=1"}},
+		{[]string{"FOO=0"}, settable{name: "DEBUG", value: "1"}, []string{"FOO=0", "DEBUG=1"}},
+		{[]string{"FOO=0", "DEBUG=0"}, settable{name: "DEBUG", value: "1"}, []string{"FOO=0", "DEBUG=1"}},
+		{[]string{"FOO=0", "DEBUG=0", "BAR=1"}, settable{name: "DEBUG", value: "1"}, []string{"FOO=0", "DEBUG=1", "BAR=1"}},
+	}
+
+	for _, c := range contexts {
+		updateConfigEnv(&c.env, &c.set)
+
+		if !reflect.DeepEqual(c.env, c.newEnv) {
+			t.Fatalf("expected env to be %q, got %q", c.newEnv, c.env)
+		}
+	}
+}


### PR DESCRIPTION
The plugin `vieux/sshfs` was updated to support the evironment variable `DEBUG` to be set

```json
	"env": [
	    {
		"name":"DEBUG",
		"settable":["value"],
		"value":"0"
	    }
	]
```


---

This PR adds support for `docker plugin set vieux/sshfs DEBUG=1`

ping @anusha-ragunathan @tiborvass 

I'm not a big fan of the code I produced :/, feel free to comment! I added unit test.
The biggest ugliness is the code is how to update the env. It requires parsing it back from string array to key/value to detect if we should append to the env and update an existing variable.