### PR TITLE
prevent panic when docker build & volume plugin is disabled

### DIFF
--- a/plugin/store/store.go
+++ b/plugin/store/store.go
@@ -79,8 +79,10 @@ func (ps *Store) getAllByCap(capability string) []plugingetter.CompatPlugin {
 
 	result := make([]plugingetter.CompatPlugin, 0, 1)
 	for _, p := range ps.plugins {
-		if _, err := p.FilterByCap(capability); err == nil {
-			result = append(result, p)
+		if p.IsEnabled() {
+			if _, err := p.FilterByCap(capability); err == nil {
+				result = append(result, p)
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
changed `getAllByCap` to only return enabled plugins, other I get a panic on `docker build`

I'm not sure if it has some side effects, @anusha-ragunathan @tiborvass WDYT ?

```
http: panic serving @: runtime error: invalid memory address or nil pointer dereference
goroutine 263 [running]:
net/http.(*conn).serve.func1(0xc421520080)
	/usr/local/go/src/net/http/server.go:1491 +0x12a
panic(0x16c5200, 0xc420012040)
	/usr/local/go/src/runtime/panic.go:458 +0x243
github.com/docker/docker/pkg/plugins.(*Client).callWithRetry(0x0, 0x18dec35, 0x10, 0x235aba0, 0xc42151c700, 0x41c601, 0xc421267a80, 0x10, 0x10, 0x1707580)
	/go/src/github.com/docker/docker/pkg/plugins/client.go:115 +0x5d
github.com/docker/docker/pkg/plugins.(*Client).Call(0x0, 0x18dec35, 0x10, 0x1707580, 0xc421267a80, 0x15cb1a0, 0xc420feada0, 0x0, 0x0)
	/go/src/github.com/docker/docker/pkg/plugins/client.go:77 +0x13d
github.com/docker/docker/volume/drivers.(*volumeDriverProxy).Get(0xc421267a70, 0xc4211aeec0, 0x40, 0xc4204da030, 0xc4211aeec0, 0x40)
	/go/src/github.com/docker/docker/volume/drivers/proxy.go:203 +0x10c
github.com/docker/docker/volume/drivers.(*volumeDriverAdapter).Get(0xc420fead60, 0xc4211aeec0, 0x40, 0x0, 0x0, 0x235b320, 0xc420411570)
	/go/src/github.com/docker/docker/volume/drivers/adapter.go:59 +0x47
github.com/docker/docker/volume/store.(*VolumeStore).getVolume(0xc420058300, 0xc4211aeec0, 0x40, 0x0, 0x0, 0x415500, 0x1754c80)
	/go/src/github.com/docker/docker/volume/store/store.go:419 +0x343
github.com/docker/docker/volume/store.(*VolumeStore).create(0xc420058300, 0xc4211aeec0, 0x40, 0x0, 0x0, 0x0, 0x0, 0xc420f73860, 0xc42151c460, 0x68, ...)
	/go/src/github.com/docker/docker/volume/store/store.go:277 +0x929
github.com/docker/docker/volume/store.(*VolumeStore).CreateWithRef(0xc420058300, 0xc4211aeec0, 0x40, 0x0, 0x0, 0xc4217ffe00, 0x40, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/docker/docker/volume/store/store.go:239 +0x136
github.com/docker/docker/daemon.(*Daemon).createContainerPlatformSpecificSettings(0xc4201ae380, 0xc420a1c780, 0xc421536a00, 0xc420cab400, 0x0, 0x0)
	/go/src/github.com/docker/docker/daemon/create_unix.go:49 +0x364
github.com/docker/docker/daemon.(*Daemon).create(0xc4201ae380, 0x0, 0x0, 0xc421536a00, 0xc420cab400, 0xc42007ea68, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/docker/docker/daemon/create.go:129 +0x54f
github.com/docker/docker/daemon.(*Daemon).containerCreate(0xc4201ae380, 0x0, 0x0, 0xc421536a00, 0xc420cab400, 0xc42007ea68, 0x0, 0x100, 0x0, 0x0, ...)
	/go/src/github.com/docker/docker/daemon/create.go:58 +0x1cc
github.com/docker/docker/daemon.(*Daemon).ContainerCreate(0xc4201ae380, 0x0, 0x0, 0xc421536a00, 0xc420cab400, 0xc42007ea68, 0x0, 0x1, 0x0, 0x0, ...)
	/go/src/github.com/docker/docker/daemon/create.go:31 +0xad
github.com/docker/docker/api/server/router/container.(*containerRouter).postContainersCreate(0xc4207ae0c0, 0x2373ae0, 0xc4207b27b0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0x18cb6dc, 0x4)
	/go/src/github.com/docker/docker/api/server/router/container/container_routes.go:382 +0x2a7
github.com/docker/docker/api/server/router/container.(*containerRouter).(github.com/docker/docker/api/server/router/container.postContainersCreate)-fm(0x2373ae0, 0xc4207b27b0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0x41ce88, 0x30)
	/go/src/github.com/docker/docker/api/server/router/container/container.go:55 +0x69
github.com/docker/docker/api/server/middleware.ExperimentalMiddleware.WrapHandler.func1(0x2373ae0, 0xc4207b27b0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0x19, 0x235f2e0)
	/go/src/github.com/docker/docker/api/server/middleware/experimental.go:27 +0xd8
github.com/docker/docker/api/server/middleware.VersionMiddleware.WrapHandler.func1(0x2373ae0, 0xc420a91ce0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0x2, 0x19e4888)
	/go/src/github.com/docker/docker/api/server/middleware/version.go:49 +0x754
github.com/docker/docker/api/server/middleware.UserAgentMiddleware.WrapHandler.func1(0x2373a60, 0xc42005aca0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0x0, 0x0)
	/go/src/github.com/docker/docker/api/server/middleware/user_agent.go:45 +0x272
github.com/docker/docker/pkg/authorization.(*Middleware).WrapHandler.func1(0x2373a60, 0xc42005aca0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0x0, 0xc420cd1a10)
	/go/src/github.com/docker/docker/pkg/authorization/middleware.go:44 +0xa14
github.com/docker/docker/api/server/middleware.DebugRequestMiddleware.func1(0x2373a60, 0xc42005aca0, 0x23703e0, 0xc42008c000, 0xc4217082d0, 0xc4207ea870, 0xc420cd1bb0, 0x8)
	/go/src/github.com/docker/docker/api/server/middleware/debug.go:53 +0x5bb
github.com/docker/docker/api/server.(*Server).makeHTTPHandler.func1(0x23703e0, 0xc42008c000, 0xc4217082d0)
	/go/src/github.com/docker/docker/api/server/server.go:139 +0xc5
net/http.HandlerFunc.ServeHTTP(0xc4202562e0, 0x23703e0, 0xc42008c000, 0xc4217082d0)
	/usr/local/go/src/net/http/server.go:1726 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc4207e8f00, 0x23703e0, 0xc42008c000, 0xc4217082d0)
	/go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:103 +0x255
github.com/docker/docker/api/server.(*routerSwapper).ServeHTTP(0xc420cc60d0, 0x23703e0, 0xc42008c000, 0xc4217082d0)
	/go/src/github.com/docker/docker/api/server/router_swapper.go:29 +0x70
net/http.serverHandler.ServeHTTP(0xc420347a00, 0x23703e0, 0xc42008c000, 0xc4217082d0)
	/usr/local/go/src/net/http/server.go:2202 +0x7d
net/http.(*conn).serve(0xc421520080, 0x2371f60, 0xc4217d2940)
	/usr/local/go/src/net/http/server.go:1579 +0x4b7
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2293 +0x44d
```