### PR TITLE
Fix logrus formatting

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -169,7 +169,7 @@ func New(config Config) (*Cluster, error) {
 
 	select {
 	case <-time.After(swarmConnectTimeout):
-		logrus.Errorf("swarm component could not be started before timeout was reached")
+		logrus.Error("swarm component could not be started before timeout was reached")
 	case <-n.Ready():
 	case <-n.done:
 		return nil, fmt.Errorf("swarm component could not be started: %v", c.err)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -190,7 +190,7 @@ func (daemon *Daemon) restore() error {
 		go func(c *container.Container) {
 			defer wg.Done()
 			if err := backportMountSpec(c); err != nil {
-				logrus.Errorf("Failed to migrate old mounts to use new spec format")
+				logrus.Error("Failed to migrate old mounts to use new spec format")
 			}
 
 			if c.IsRunning() || c.IsPaused() {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -636,7 +636,7 @@ func (daemon *Daemon) initNetworkController(config *Config, activeSandboxes map[
 	}
 
 	if len(activeSandboxes) > 0 {
-		logrus.Infof("There are old running containers, the network config will not take affect")
+		logrus.Info("There are old running containers, the network config will not take affect")
 		return controller, nil
 	}
 

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -344,7 +344,7 @@ func (a *Driver) Remove(id string) error {
 	tmpMntPath := path.Join(a.mntPath(), fmt.Sprintf("%s-removing", id))
 	if err := os.Rename(mountpoint, tmpMntPath); err != nil && !os.IsNotExist(err) {
 		if err == syscall.EBUSY {
-			logrus.Warnf("os.Rename err due to EBUSY")
+			logrus.Warn("os.Rename err due to EBUSY")
 			out, debugErr := debugEBusy(mountpoint)
 			if debugErr == nil {
 				logrus.Warnf("debugEBusy returned %v", out)

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -410,8 +410,8 @@ func (devices *DeviceSet) lookupDeviceWithLock(hash string) (*devInfo, error) {
 // This function relies on that device hash map has been loaded in advance.
 // Should be called with devices.Lock() held.
 func (devices *DeviceSet) constructDeviceIDMap() {
-	logrus.Debugf("devmapper: constructDeviceIDMap()")
-	defer logrus.Debugf("devmapper: constructDeviceIDMap() END")
+	logrus.Debug("devmapper: constructDeviceIDMap()")
+	defer logrus.Debug("devmapper: constructDeviceIDMap() END")
 
 	for _, info := range devices.Devices {
 		devices.markDeviceIDUsed(info.DeviceID)
@@ -459,8 +459,8 @@ func (devices *DeviceSet) deviceFileWalkFunction(path string, finfo os.FileInfo)
 }
 
 func (devices *DeviceSet) loadDeviceFilesOnStart() error {
-	logrus.Debugf("devmapper: loadDeviceFilesOnStart()")
-	defer logrus.Debugf("devmapper: loadDeviceFilesOnStart() END")
+	logrus.Debug("devmapper: loadDeviceFilesOnStart()")
+	defer logrus.Debug("devmapper: loadDeviceFilesOnStart() END")
 
 	var scan = func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -1713,9 +1713,9 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	// https://github.com/docker/docker/issues/4036
 	if supported := devicemapper.UdevSetSyncSupport(true); !supported {
 		if dockerversion.IAmStatic == "true" {
-			logrus.Errorf("devmapper: Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a dynamic binary to use devicemapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/daemon/#daemon-storage-driver-option")
+			logrus.Error("devmapper: Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a dynamic binary to use devicemapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/daemon/#daemon-storage-driver-option")
 		} else {
-			logrus.Errorf("devmapper: Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a more recent version of libdevmapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/daemon/#daemon-storage-driver-option")
+			logrus.Error("devmapper: Udev sync is not supported. This will lead to data loss and unexpected behavior. Install a more recent version of libdevmapper or select a different storage driver. For more information, see https://docs.docker.com/engine/reference/commandline/daemon/#daemon-storage-driver-option")
 		}
 
 		if !devices.overrideUdevSyncCheck {

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -125,7 +125,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		if !opts.overrideKernelCheck {
 			return nil, graphdriver.ErrNotSupported
 		}
-		logrus.Warnf("Using pre-4.0.0 kernel for overlay2, mount failures may require kernel update")
+		logrus.Warn("Using pre-4.0.0 kernel for overlay2, mount failures may require kernel update")
 	}
 
 	fsMagic, err := graphdriver.GetFSMagic(home)

--- a/pkg/discovery/kv/kv.go
+++ b/pkg/discovery/kv/kv.go
@@ -73,7 +73,7 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 
 	var config *store.Config
 	if clusterOpts["kv.cacertfile"] != "" && clusterOpts["kv.certfile"] != "" && clusterOpts["kv.keyfile"] != "" {
-		logrus.Infof("Initializing discovery with TLS")
+		logrus.Info("Initializing discovery with TLS")
 		tlsConfig, err := tlsconfig.Client(tlsconfig.Options{
 			CAFile:   clusterOpts["kv.cacertfile"],
 			CertFile: clusterOpts["kv.certfile"],
@@ -93,7 +93,7 @@ func (s *Discovery) Initialize(uris string, heartbeat time.Duration, ttl time.Du
 			TLS: tlsConfig,
 		}
 	} else {
-		logrus.Infof("Initializing discovery without TLS")
+		logrus.Info("Initializing discovery without TLS")
 	}
 
 	// Creates a new store, will ignore options given

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -62,7 +62,7 @@ func (pm *Manager) Pull(name string, metaHeader http.Header, authConfig *types.A
 	name = ref.String()
 
 	if p, _ := pm.pluginStore.GetByName(name); p != nil {
-		logrus.Debugf("plugin already exists")
+		logrus.Debug("plugin already exists")
 		return nil, fmt.Errorf("%s exists", name)
 	}
 

--- a/plugin/distribution/pull.go
+++ b/plugin/distribution/pull.go
@@ -113,7 +113,7 @@ func Pull(ref reference.Named, rs registry.Service, metaheader http.Header, auth
 			return nil, err
 		}
 		if !confirmedV2 {
-			logrus.Debugf("pull.go: !confirmedV2")
+			logrus.Debug("pull.go: !confirmedV2")
 			return nil, ErrUnsupportedRegistry
 		}
 		logrus.Debugf("Trying to pull %s from %s %s", repoInfo.Name(), endpoint.URL, endpoint.Version)


### PR DESCRIPTION
Another refactoring for logrus formatting. 
Following #23459 repalce w/o f function when format string is not used.

Honestly. I have to confess my mistake. I misunderstood #23459 issue. so instead of removing  'f'  I adding it in my previous commit(#24745). 
But I found other misused 'f' functions in the code. so I refactoring as much as function I can.  Maybe we need automatic code review tool for this issue 

Signed-off-by: Daehyeok Mun <daehyeok@gmail.com>