### PR TITLE
add Akihiro to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -27,6 +27,7 @@
 
 		people = [
 			"aaronlehmann",
+			"akihirosuda",
 			"aluzzardi",
 			"anusha",
 			"coolljt0725",
@@ -166,6 +167,11 @@
 	Name = "Aaron Lehmann"
 	Email = "aaron.lehmann@docker.com"
 	GitHub = "aaronlehmann"
+
+	[people.akihirosuda]
+	Name = "Akihiro Suda"
+	Email = "suda.akihiro@lab.ntt.co.jp"
+	GitHub = "AkihiroSuda"
 
 	[people.aluzzardi]
 	Name = "Andrea Luzzardi"


### PR DESCRIPTION
**- What I did**

Added Akihiro to the maintainers file

**- How I did it**

By [following our procedures](https://github.com/docker/opensource/blob/4d07402732876f347ebb7adfdb3af37f00786492/MAINTAINERS#L36-L67)

**- A picture of a cute animal (not mandatory but encouraged)**

![japanese-cat-maneki-neko-lucky-ceramic-7418](https://cloud.githubusercontent.com/assets/1804568/19881083/fd78d080-9fbf-11e6-9446-884a373779f9.jpg)


This adds Akihiro as a maintainer for
docker/docker, as was proposed and
voted on the maintainers mailinglist.

ping @docker/core-engine-maintainers 