### PR TITLE
promote overlay(2) graphdriver

### DIFF
--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -56,8 +56,9 @@ var (
 		"aufs",
 		"btrfs",
 		"zfs",
-		"devicemapper",
+		"overlay2",
 		"overlay",
+		"devicemapper",
 		"vfs",
 	}
 


### PR DESCRIPTION
Now that overlay has matured, using overlay is a better choice than devicemapper on loopback devices.

This change promotes overlay in the priority list. It also adds the overlay2 graphdriver to the list because overlay2 (if supported) should be preferred over overlay.

ping @docker/core-engine-maintainers, @dmcgowan PTAL.