### PR TITLE
Fixes #27798 : Update help for --blkio-weight parameter

### DIFF
--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -50,7 +50,7 @@ func NewUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.Uint16Var(&opts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000")
+	flags.Uint16Var(&opts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)")
 	flags.Int64Var(&opts.cpuPeriod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period")
 	flags.Int64Var(&opts.cpuQuota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 	flags.Int64Var(&opts.cpuRealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds")

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -219,7 +219,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.BoolVar(&copts.noHealthcheck, "no-healthcheck", false, "Disable any container-specified HEALTHCHECK")
 
 	// Resource management
-	flags.Uint16Var(&copts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000")
+	flags.Uint16Var(&copts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)")
 	flags.Var(&copts.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flags.StringVar(&copts.containerIDFile, "cidfile", "", "Write the container ID to the file")
 	flags.StringVar(&copts.cpusetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")


### PR DESCRIPTION
Fixes #27798

**- What I did**
Updated the help message for --blkio-weight parameter. 

**- How to verify it**
1. docker run --blkio-weight (any value out of 10-1000 range) busybox
2. docker run --blkio-weight (any value between 10-1000 range) busybox
3. docker run --blkio-weight 0 busybox (Must run successfully since default is 0 means none)


Signed-off-by: milindchawre <milindchawre@gmail.com>