### PR TITLE
Replace all "Filter" field with "Filters" for consistency

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -32,11 +32,11 @@ func (s *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 	}
 
 	config := &types.ContainerListOptions{
-		All:    httputils.BoolValue(r, "all"),
-		Size:   httputils.BoolValue(r, "size"),
-		Since:  r.Form.Get("since"),
-		Before: r.Form.Get("before"),
-		Filter: filter,
+		All:     httputils.BoolValue(r, "all"),
+		Size:    httputils.BoolValue(r, "size"),
+		Since:   r.Form.Get("since"),
+		Before:  r.Form.Get("before"),
+		Filters: filter,
 	}
 
 	if tmpLimit := r.Form.Get("limit"); tmpLimit != "" {

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -102,7 +102,7 @@ func (sr *swarmRouter) getServices(ctx context.Context, w http.ResponseWriter, r
 		return err
 	}
 
-	services, err := sr.backend.GetServices(basictypes.ServiceListOptions{Filter: filter})
+	services, err := sr.backend.GetServices(basictypes.ServiceListOptions{Filters: filter})
 	if err != nil {
 		logrus.Errorf("Error getting services: %v", err)
 		return err
@@ -182,7 +182,7 @@ func (sr *swarmRouter) getNodes(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	nodes, err := sr.backend.GetNodes(basictypes.NodeListOptions{Filter: filter})
+	nodes, err := sr.backend.GetNodes(basictypes.NodeListOptions{Filters: filter})
 	if err != nil {
 		logrus.Errorf("Error getting nodes: %v", err)
 		return err
@@ -243,7 +243,7 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	tasks, err := sr.backend.GetTasks(basictypes.TaskListOptions{Filter: filter})
+	tasks, err := sr.backend.GetTasks(basictypes.TaskListOptions{Filters: filter})
 	if err != nil {
 		logrus.Errorf("Error getting tasks: %v", err)
 		return err

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -59,14 +59,14 @@ type ContainerExecInspect struct {
 
 // ContainerListOptions holds parameters to list containers with.
 type ContainerListOptions struct {
-	Quiet  bool
-	Size   bool
-	All    bool
-	Latest bool
-	Since  string
-	Before string
-	Limit  int
-	Filter filters.Args
+	Quiet   bool
+	Size    bool
+	All     bool
+	Latest  bool
+	Since   string
+	Before  string
+	Limit   int
+	Filters filters.Args
 }
 
 // ContainerLogsOptions holds parameters to filter logs with.
@@ -267,7 +267,7 @@ func (v VersionResponse) ServerOK() bool {
 
 // NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
-	Filter filters.Args
+	Filters filters.Args
 }
 
 // NodeRemoveOptions holds parameters to remove nodes with.
@@ -317,12 +317,12 @@ type ServiceUpdateOptions struct {
 
 // ServiceListOptions holds parameters to list  services with.
 type ServiceListOptions struct {
-	Filter filters.Args
+	Filters filters.Args
 }
 
 // TaskListOptions holds parameters to list  tasks with.
 type TaskListOptions struct {
-	Filter filters.Args
+	Filters filters.Args
 }
 
 // PluginRemoveOptions holds parameters to remove plugins.

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -79,10 +79,10 @@ func (p *preProcessor) Networks() bool {
 
 func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, error) {
 	options := &types.ContainerListOptions{
-		All:    opts.all,
-		Limit:  opts.last,
-		Size:   opts.size,
-		Filter: opts.filter.Value(),
+		All:     opts.all,
+		Limit:   opts.last,
+		Size:    opts.size,
+		Filters: opts.filter.Value(),
 	}
 
 	if opts.nLatest && opts.last == -1 {

--- a/cli/command/container/ps_test.go
+++ b/cli/command/container/ps_test.go
@@ -55,10 +55,10 @@ func TestBuildContainerListOptions(t *testing.T) {
 		assert.Equal(t, c.expectedAll, options.All)
 		assert.Equal(t, c.expectedSize, options.Size)
 		assert.Equal(t, c.expectedLimit, options.Limit)
-		assert.Equal(t, options.Filter.Len(), len(c.expectedFilters))
+		assert.Equal(t, options.Filters.Len(), len(c.expectedFilters))
 
 		for k, v := range c.expectedFilters {
-			f := options.Filter
+			f := options.Filters
 			if !f.ExactMatch(k, v) {
 				t.Fatalf("Expected filter with key %s to be %s but got %s", k, v, f.Get(k))
 			}

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -50,7 +50,7 @@ func runList(dockerCli *command.DockerCli, opts listOptions) error {
 
 	nodes, err := client.NodeList(
 		ctx,
-		types.NodeListOptions{Filter: opts.filter.Value()})
+		types.NodeListOptions{Filters: opts.filter.Value()})
 	if err != nil {
 		return err
 	}

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -72,7 +72,7 @@ func runPs(dockerCli *command.DockerCli, opts psOptions) error {
 		filter := opts.filter.Value()
 		filter.Add("node", node.ID)
 
-		nodeTasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})
+		nodeTasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -51,7 +51,7 @@ func runList(dockerCli *command.DockerCli, opts listOptions) error {
 	client := dockerCli.Client()
 	out := dockerCli.Out()
 
-	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filter: opts.filter.Value()})
+	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: opts.filter.Value()})
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func runList(dockerCli *command.DockerCli, opts listOptions) error {
 			taskFilter.Add("service", service.ID)
 		}
 
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: taskFilter})
+		tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: taskFilter})
 		if err != nil {
 			return err
 		}

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -64,7 +64,7 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 		}
 	}
 
-	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})
+	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 	if err != nil {
 		return err
 	}

--- a/cli/command/stack/common.go
+++ b/cli/command/stack/common.go
@@ -34,7 +34,7 @@ func getServices(
 ) ([]swarm.Service, error) {
 	return apiclient.ServiceList(
 		ctx,
-		types.ServiceListOptions{Filter: getStackFilter(namespace)})
+		types.ServiceListOptions{Filters: getStackFilter(namespace)})
 }
 
 func getNetworks(

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -87,7 +87,7 @@ func getStacks(
 
 	services, err := apiclient.ServiceList(
 		ctx,
-		types.ServiceListOptions{Filter: filter})
+		types.ServiceListOptions{Filters: filter})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -56,7 +56,7 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 		filter.Add("desired-state", string(swarm.TaskStateAccepted))
 	}
 
-	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: filter})
+	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 	if err != nil {
 		return err
 	}

--- a/cli/command/stack/services.go
+++ b/cli/command/stack/services.go
@@ -46,7 +46,7 @@ func runServices(dockerCli *command.DockerCli, opts servicesOptions) error {
 	filter := opts.filter.Value()
 	filter.Add("label", labelNamespace+"="+opts.namespace)
 
-	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filter: filter})
+	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: filter})
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func runServices(dockerCli *command.DockerCli, opts servicesOptions) error {
 			taskFilter.Add("service", service.ID)
 		}
 
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{Filter: taskFilter})
+		tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: taskFilter})
 		if err != nil {
 			return err
 		}

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -34,8 +34,8 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 		query.Set("size", "1")
 	}
 
-	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filter)
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 
 		if err != nil {
 			return nil, err

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -82,10 +82,10 @@ func TestContainerList(t *testing.T) {
 	filters.Add("label", "label2")
 	filters.Add("before", "container")
 	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
-		Size:   true,
-		All:    true,
-		Since:  "container",
-		Filter: filters,
+		Size:    true,
+		All:     true,
+		Since:   "container",
+		Filters: filters,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -14,8 +14,8 @@ import (
 func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
 	query := url.Values{}
 
-	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filter)
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filters)
 
 		if err != nil {
 			return nil, err

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -45,7 +45,7 @@ func TestNodeList(t *testing.T) {
 		},
 		{
 			options: types.NodeListOptions{
-				Filter: filters,
+				Filters: filters,
 			},
 			expectedQueryParams: map[string]string{
 				"filters": `{"label":{"label1":true,"label2":true}}`,

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -14,8 +14,8 @@ import (
 func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
 	query := url.Values{}
 
-	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filter)
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -45,7 +45,7 @@ func TestServiceList(t *testing.T) {
 		},
 		{
 			options: types.ServiceListOptions{
-				Filter: filters,
+				Filters: filters,
 			},
 			expectedQueryParams: map[string]string{
 				"filters": `{"label":{"label1":true,"label2":true}}`,

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -14,8 +14,8 @@ import (
 func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
 	query := url.Values{}
 
-	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filter)
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -45,7 +45,7 @@ func TestTaskList(t *testing.T) {
 		},
 		{
 			options: types.TaskListOptions{
-				Filter: filters,
+				Filters: filters,
 			},
 			expectedQueryParams: map[string]string{
 				"filters": `{"label":{"label1":true,"label2":true}}`,

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -597,7 +597,7 @@ func (c *Cluster) listContainerForNode(nodeID string) ([]string, error) {
 	filters := filters.NewArgs()
 	filters.Add("label", fmt.Sprintf("com.docker.swarm.node.id=%s", nodeID))
 	containers, err := c.config.Backend.Containers(&apitypes.ContainerListOptions{
-		Filter: filters,
+		Filters: filters,
 	})
 	if err != nil {
 		return []string{}, err
@@ -840,7 +840,7 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 		return nil, c.errNoManager()
 	}
 
-	filters, err := newListServicesFilters(options.Filter)
+	filters, err := newListServicesFilters(options.Filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1019,7 +1019,7 @@ func (c *Cluster) GetNodes(options apitypes.NodeListOptions) ([]types.Node, erro
 		return nil, c.errNoManager()
 	}
 
-	filters, err := newListNodesFilters(options.Filter)
+	filters, err := newListNodesFilters(options.Filters)
 	if err != nil {
 		return nil, err
 	}
@@ -1149,7 +1149,7 @@ func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, erro
 		return nil
 	}
 
-	filters, err := newListTasksFilters(options.Filter, byName)
+	filters, err := newListTasksFilters(options.Filters, byName)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -217,7 +217,7 @@ func (daemon *Daemon) reducePsContainer(container *container.Container, ctx *lis
 
 // foldFilter generates the container filter based on the user's filtering options.
 func (daemon *Daemon) foldFilter(config *types.ContainerListOptions) (*listContext, error) {
-	psFilters := config.Filter
+	psFilters := config.Filters
 
 	if err := psFilters.Validate(acceptedPsFilterTags); err != nil {
 		return nil, err


### PR DESCRIPTION
In file `api/types/client.go`, some of the "*Options{}" structs own a
`Filters` field while some else have the name of `Filter`, this commit
will rename all `Filter` to `Filters` for consistency. Also `Filters`
is consistent with API with format `/xxx?filters=xxx`, that's why
`Filters` is the right name.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

*Note*: There's no function change in this commit.