### PR TITLE
Update deprecation versions for "email" and colon in "security options"

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -39,9 +39,9 @@ func NewLoginCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVarP(&opts.user, "username", "u", "", "Username")
 	flags.StringVarP(&opts.password, "password", "p", "", "Password")
 
-	// Deprecated in 1.11: Should be removed in docker 1.13
+	// Deprecated in 1.11: Should be removed in docker 1.14
 	flags.StringVarP(&opts.email, "email", "e", "", "Email")
-	flags.MarkDeprecated("email", "will be removed in 1.13.")
+	flags.MarkDeprecated("email", "will be removed in 1.14.")
 
 	return cmd
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -168,7 +168,7 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 			con = strings.SplitN(opt, "=", 2)
 		} else if strings.Contains(opt, ":") {
 			con = strings.SplitN(opt, ":", 2)
-			logrus.Warn("Security options with `:` as a separator are deprecated and will be completely unsupported in 1.13, use `=` instead.")
+			logrus.Warn("Security options with `:` as a separator are deprecated and will be completely unsupported in 1.14, use `=` instead.")
 		}
 
 		if len(con) != 2 {


### PR DESCRIPTION
These features were originally scheduled for removal in docker 1.13, but we changed our deprecation policy to keep features for three releases instead of two.

This updates the deprecation version to match the deprecation policy.

Relates to https://github.com/docker/docker/commit/8cbe6541b2229357370e61ce6fb35d131be93cac (https://github.com/docker/docker/pull/24572)

/cc @duglin @kencochrane ptal