### PR TITLE
daemon: cleanup containers as early as possible

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -77,6 +77,22 @@ func (daemon *Daemon) rmLink(container *container.Container, name string) error 
 // cleanupContainer unregisters a container from the daemon, stops stats
 // collection and cleanly removes contents and metadata from the filesystem.
 func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemove, removeVolume bool) (err error) {
+	// If force removal is required, delete container from various
+	// indexes even if removal failed.
+	defer func() {
+		if err == nil || forceRemove {
+			daemon.nameIndex.Delete(container.ID)
+			daemon.linkIndex.delete(container)
+			selinuxFreeLxcContexts(container.ProcessLabel)
+			daemon.idIndex.Delete(container.ID)
+			daemon.containers.Delete(container.ID)
+			if e := daemon.removeMountPoints(container, removeVolume); e != nil {
+				logrus.Error(e)
+			}
+			daemon.LogContainerEvent(container, "destroy")
+		}
+	}()
+
 	if container.IsRunning() {
 		if !forceRemove {
 			err := fmt.Errorf("You cannot remove a running container %s. Stop the container before attempting removal or use -f", container.ID)
@@ -104,22 +120,6 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	if err := container.ToDiskLocking(); err != nil && !os.IsNotExist(err) {
 		logrus.Errorf("Error saving dying container to disk: %v", err)
 	}
-
-	// If force removal is required, delete container from various
-	// indexes even if removal failed.
-	defer func() {
-		if err == nil || forceRemove {
-			daemon.nameIndex.Delete(container.ID)
-			daemon.linkIndex.delete(container)
-			selinuxFreeLxcContexts(container.ProcessLabel)
-			daemon.idIndex.Delete(container.ID)
-			daemon.containers.Delete(container.ID)
-			if e := daemon.removeMountPoints(container, removeVolume); e != nil {
-				logrus.Error(e)
-			}
-			daemon.LogContainerEvent(container, "destroy")
-		}
-	}()
 
 	if err = os.RemoveAll(container.Root); err != nil {
 		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)


### PR DESCRIPTION
**- What I did**

I fixed a race condition in `docker.newContainer()` that can lead to an inconsistent state of docker's in-memory structures.

**- How I did it**

`cleanupContainer` can fail to delete a container name from nameIndex if for example `container.ToDiskLocking()` fails. This is a problem because users of this function rely on it always cleaning up to ensure the in-memory data structures are consistent.

One user is Daemon.newContainer() which first updates the nameIndex, and then registers the container, calling `cleanupContainer` whenever anything fails inbetween.

I fixed the problem by moving the deferred invocation at the beginning of the cleanup function so that it always cleans up the in-memory structures.

**- How to verify it**
Reproducing this bug with a normal build is difficult since the filesystem has to fail while container creation is happening. The way I tested it was by uncondintionally returning an error [here](https://github.com/docker/docker/blob/bad849fc826b410/daemon/create.go#L110).

**- Description for the changelog**
Fix race condition in container creation

**- A picture of a cute animal (not mandatory but encouraged)**

![85120553](https://cloud.githubusercontent.com/assets/939420/19900273/2636c5f8-a020-11e6-921b-356f745034aa.jpg)


Partial solution for #23371 