### PR TITLE
remove world/group writable perms

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -147,7 +147,7 @@ func (container *Container) ToDisk() error {
 		return err
 	}
 
-	jsonSource, err := ioutils.NewAtomicFileWriter(pth, 0666)
+	jsonSource, err := ioutils.NewAtomicFileWriter(pth, 0644)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func (container *Container) WriteHostConfig() error {
 		return err
 	}
 
-	f, err := ioutils.NewAtomicFileWriter(pth, 0666)
+	f, err := ioutils.NewAtomicFileWriter(pth, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**- What I did**

Fixed files from being written with group and world writable permissions.

Signed-off-by: Eric Peterson epeterson@breakpoint-labs.com