### PR TITLE
Faster validation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ DOCKER_RUN_DOCKER := $(DOCKER_FLAGS) "$(DOCKER_IMAGE)"
 default: binary
 
 all: build ## validate all checks, build linux binaries, run all tests\ncross build non-linux binaries and generate archives
-	$(DOCKER_RUN_DOCKER) hack/make.sh
+	$(DOCKER_RUN_DOCKER) bash -c 'hack/validate/default && hack/make.sh'
 
 binary: build ## build the linux binaries
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
@@ -133,7 +133,7 @@ tgz: build ## build the archives (.zip on windows and .tgz\notherwise) containin
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary binary cross tgz
 
 validate: build ## validate DCO, Seccomp profile generation, gofmt,\n./pkg/ isolation, golint, tests, tomls, go vet and vendor
-	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-default-seccomp validate-gofmt validate-pkg validate-lint validate-test validate-toml validate-vet validate-vendor
+	$(DOCKER_RUN_DOCKER) hack/validate/all
 
 win: build ## cross build the binary for windows
 	$(DOCKER_RUN_DOCKER) hack/make.sh win

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -56,15 +56,6 @@ echo
 
 # List of bundles to create when no argument is passed
 DEFAULT_BUNDLES=(
-	validate-dco
-	validate-default-seccomp
-	validate-gofmt
-	validate-lint
-	validate-pkg
-	validate-test
-	validate-toml
-	validate-vet
-
 	binary-client
 	binary-daemon
 	dynbinary

--- a/hack/make/validate-dco
+++ b/hack/make/validate-dco
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# This file is a stub. It exists because windowsRS1 calls this script directly 
+# instead of using a proper interface. It should be removed once windows CI is 
+# fixed.
+#
+$SCRIPTDIR/validate/dco

--- a/hack/make/validate-gofmt
+++ b/hack/make/validate-gofmt
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# This file is a stub. It exists because windowsRS1 calls this script directly 
+# instead of using a proper interface. It should be removed once windows CI is 
+# fixed.
+#
+$SCRIPTDIR/validate/gofmt

--- a/hack/make/validate-pkg
+++ b/hack/make/validate-pkg
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# This file is a stub. It exists because windowsRS1 calls this script directly 
+# instead of using a proper interface. It should be removed once windows CI is 
+# fixed.
+#
+$SCRIPTDIR/validate/pkg-imports

--- a/hack/validate/.validate
+++ b/hack/validate/.validate
@@ -1,16 +1,13 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 if [ -z "$VALIDATE_UPSTREAM" ]; then
 	# this is kind of an expensive check, so let's not do this twice if we
 	# are running more than one validate bundlescript
 
 	VALIDATE_REPO='https://github.com/docker/docker.git'
 	VALIDATE_BRANCH='master'
-
-	if [ "$TRAVIS" = 'true' -a "$TRAVIS_PULL_REQUEST" != 'false' ]; then
-		VALIDATE_REPO="https://github.com/${TRAVIS_REPO_SLUG}.git"
-		VALIDATE_BRANCH="${TRAVIS_BRANCH}"
-	fi
 
 	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
 

--- a/hack/validate/all
+++ b/hack/validate/all
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Run all validation
+
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $SCRIPTDIR/default
+. $SCRIPTDIR/vendor

--- a/hack/validate/dco
+++ b/hack/validate/dco
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 adds=$(validate_diff --numstat | awk '{ s += $1 } END { print s }')
 dels=$(validate_diff --numstat | awk '{ s += $2 } END { print s }')

--- a/hack/validate/default
+++ b/hack/validate/default
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Run default validation, exclude vendor because it's slow
+
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $SCRIPTDIR/dco
+. $SCRIPTDIR/default-seccomp
+. $SCRIPTDIR/gofmt
+. $SCRIPTDIR/lint
+. $SCRIPTDIR/pkg-imports
+. $SCRIPTDIR/test-imports
+. $SCRIPTDIR/toml
+. $SCRIPTDIR/vet

--- a/hack/validate/default-seccomp
+++ b/hack/validate/default-seccomp
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- 'profiles/seccomp' || true) )
 unset IFS
 
 if [ ${#files[@]} -gt 0 ]; then
-	# We run vendor.sh to and see if we have a diff afterwards
+	# We run 'go generate' and see if we have a diff afterwards
 	go generate ./profiles/seccomp/ >/dev/null
 	# Let see if the working directory is clean
 	diffs="$(git status --porcelain -- profiles/seccomp 2>/dev/null)"

--- a/hack/validate/gofmt
+++ b/hack/validate/gofmt
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' || true) )

--- a/hack/validate/lint
+++ b/hack/validate/lint
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' | grep -v '^api/types/' || true) )

--- a/hack/validate/pkg-imports
+++ b/hack/validate/pkg-imports
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- 'pkg/*.go' || true) )
@@ -19,7 +20,7 @@ for f in "${files[@]}"; do
 done
 
 if [ ${#badFiles[@]} -eq 0 ]; then
-	echo 'Congratulations! "./pkg/..." is safely isolated from internal code.'
+	echo 'Congratulations!  "./pkg/..." is safely isolated from internal code.'
 else
 	{
 		echo 'These files import internal code: (either directly or indirectly)'

--- a/hack/validate/test-imports
+++ b/hack/validate/test-imports
@@ -1,8 +1,8 @@
 #!/bin/bash
-
 # Make sure we're not using gos' Testing package any more in integration-cli
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- 'integration-cli/*.go' || true) )
@@ -25,7 +25,7 @@ for f in "${files[@]}"; do
 done
 
 if [ ${#badFiles[@]} -eq 0 ]; then
-	echo 'Congratulations! No testing.T found.'
+	echo 'Congratulations!  No testing.T found.'
 else
 	{
 		echo "These files use the wrong testing infrastructure:"

--- a/hack/validate/toml
+++ b/hack/validate/toml
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- 'MAINTAINERS' || true) )

--- a/hack/validate/vendor
+++ b/hack/validate/vendor
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- 'hack/vendor.sh' 'hack/.vendor-helpers.sh' 'vendor/' || true) ) 
@@ -24,4 +25,6 @@ if [ ${#files[@]} -gt 0 ]; then
 	else
 		echo 'Congratulations! All vendoring changes are done the right way.'
 	fi
+else
+    echo 'No vendor changes in diff.'
 fi

--- a/hack/validate/vet
+++ b/hack/validate/vet
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "${MAKEDIR}/.validate"
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
 files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' || true) )


### PR DESCRIPTION
Extracted from #27359 

The `hack/make` framework of creating bundle directories and requiring execution of scripts to be run from a driver (hack/make.sh) is ok for build tasks that produce artifacts, but has little to no benefit for these validation/check scripts. This PR changes them to source all their dependencies directly, so they no longer require the hack/make.sh driver. It also moves them from `hack/make` to `hack/validate` so that it's clear they can be run directly without the driver.

They also run as a single process now, so instead of every one of them having to perform a git fetch, hack/validate/all does a single git fetch, reducing the overall runtime of validation.

