### PR TITLE
Remove TarStreamFrom from RWLayer interface

### DIFF
--- a/layer/layer.go
+++ b/layer/layer.go
@@ -78,14 +78,15 @@ type TarStreamer interface {
 	// TarStream returns a tar archive stream
 	// for the contents of a layer.
 	TarStream() (io.ReadCloser, error)
-	// TarStreamFrom returns a tar archive stream for all the layer chain with
-	// arbitrary depth.
-	TarStreamFrom(ChainID) (io.ReadCloser, error)
 }
 
 // Layer represents a read-only layer
 type Layer interface {
 	TarStreamer
+
+	// TarStreamFrom returns a tar archive stream for all the layer chain with
+	// arbitrary depth.
+	TarStreamFrom(ChainID) (io.ReadCloser, error)
 
 	// ChainID returns the content hash of the entire layer chain. The hash
 	// chain is made up of DiffID of top layer and all of its parents.

--- a/layer/mounted_layer.go
+++ b/layer/mounted_layer.go
@@ -1,7 +1,6 @@
 package layer
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/docker/docker/pkg/archive"
@@ -30,13 +29,6 @@ func (ml *mountedLayer) cacheParent() string {
 
 func (ml *mountedLayer) TarStream() (io.ReadCloser, error) {
 	return ml.layerStore.driver.Diff(ml.mountID, ml.cacheParent())
-}
-
-func (ml *mountedLayer) TarStreamFrom(parent ChainID) (io.ReadCloser, error) {
-	// Not supported since this will include the init layer as well
-	// This can already be acheived with mount + tar.
-	// Should probably never reach this point, but error out here.
-	return nil, fmt.Errorf("getting a layer diff from an arbitrary parent is not supported on mounted layer")
 }
 
 func (ml *mountedLayer) Name() string {


### PR DESCRIPTION
`RWLayer` does not implement `TarStreamFrom`, moved the definition to `Layer` instead of `TarStreamer`

From feedback I didn't get in before the merge of #22641

Ping @cpuguy83 I kind of flip flopped on this one but after seeing it shouldn't be implemented by the `RWLayer`,  I think we should keep in `Layer`. 