### PR TITLE
add replicated in service scale command description

### DIFF
--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -16,7 +16,7 @@ import (
 func newScaleCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "scale SERVICE=REPLICAS [SERVICE=REPLICAS...]",
-		Short: "Scale one or multiple services",
+		Short: "Scale one or multiple replicated services",
 		Args:  scaleArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScale(dockerCli, args)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1075,7 +1075,7 @@ __docker_service_commands() {
         "inspect:Display detailed information on one or more services"
         "ls:List services"
         "rm:Remove one or more services"
-        "scale:Scale one or multiple services"
+        "scale:Scale one or multiple replicated services"
         "ps:List the tasks of a service"
         "update:Update a service"
     )

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -18,7 +18,7 @@ keywords: ["service, scale"]
 ```markdown
 Usage:  docker service scale SERVICE=REPLICAS [SERVICE=REPLICAS...]
 
-Scale one or multiple services
+Scale one or multiple replicated services
 
 Options:
       --help   Print usage
@@ -28,8 +28,9 @@ Options:
 
 ### Scale a service
 
-The scale command enables you to scale one or more services either up or down to
-the desired number of replicas. The command will return immediately, but the
+The scale command enables you to scale one or more replicated services either up 
+or down to the desired number of replicas. This command cannot be applied on 
+services which are global mode. The command will return immediately, but the
 actual scaling of the service may take some time. To stop all replicas of a
 service while keeping the service active in the swarm you can set the scale to 0.
 
@@ -38,6 +39,15 @@ For example, the following command scales the "frontend" service to 50 tasks.
 ```bash
 $ docker service scale frontend=50
 frontend scaled to 50
+```
+
+The following command tries to scale a global service to 10 tasks and returns an error.
+
+```
+$ docker service create --mode global --name backend backend:latest
+b4g08uwuairexjub6ome6usqh
+$ docker service scale backend=10
+backend: scale can only be used with replicated mode
 ```
 
 Directly afterwards, run `docker service ls`, to see the actual number of


### PR DESCRIPTION
Add replicated description in service scale command to make it more explicit.

As `docker service scale` command can only be applied to replicated services, so maybe more explicit will be better.

**- What I did**
1. add replicated in service scale command in cli
2. add more details in docs.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>