### PR TITLE
node rm can be applied on not only active node

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6176,7 +6176,7 @@ paths:
           required: true
         - name: "force"
           in: "query"
-          description: "Force remove an active node"
+          description: "Force remove a node from the swarm"
           default: false
           type: "boolean"
       tags:

--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -29,7 +29,7 @@ func newRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVar(&opts.force, "force", false, "Force remove an active node")
+	flags.BoolVar(&opts.force, "force", false, "Force remove a node from the swarm")
 	return cmd
 }
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -818,7 +818,7 @@ __docker_node_subcommand() {
         (rm|remove)
              _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help)--force[Force remove an active node]" \
+                "($help)--force[Force remove a node from the swarm]" \
                 "($help -)*:node:__docker_complete_pending_nodes" && ret=0
             ;;
         (demote)

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -4064,7 +4064,7 @@ Remove a node [`id`] from the swarm.
 
 **Query parameters**:
 
--   **force** - 1/True/true or 0/False/false, Force remove an active node.
+-   **force** - 1/True/true or 0/False/false, Force remove a node from the swarm.
         Default `false`.
 
 **Status codes**:

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4589,7 +4589,7 @@ Remove a node [`id`] from the swarm.
 
 **Query parameters**:
 
--   **force** - 1/True/true or 0/False/false, Force remove an active node.
+-   **force** - 1/True/true or 0/False/false, Force remove a node from the swarm.
         Default `false`.
 
 **Status codes**:

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -24,7 +24,7 @@ Aliases:
   rm, remove
 
 Options:
-      --force  Force remove an active node
+      --force  Force remove a node from the swarm
       --help   Print usage
 ```
 


### PR DESCRIPTION
In docker's original code, `docker node rm --help` shows that `--force` flag's description is `Force remove an active node`.

While I think `--force` can not only be used for active node, but paused node, and drain node as well.
As a result, I tried to change this flag description.

Here are some examples that removing drain node and pause node without `--force` are not OK.

```
root@ubuntu:~# docker node update --availability=pause 34pn48fgq7bf4gg1zhm8d4pok
34pn48fgq7bf4gg1zhm8d4pok
root@ubuntu:~# docker node ls
ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
34pn48fgq7bf4gg1zhm8d4pok    ubuntu    Ready   Pause
bs7spdbpogrny2oywi5q1nrl0 *  ubuntu    Ready   Active        Leader
root@ubuntu:~# docker node rm 34pn48fgq7bf4gg1zhm8d4pok
Error response from daemon: rpc error: code = 9 desc = node 34pn48fgq7bf4gg1zhm8d4pok is not down and can't be removed
```

And
```
root@ubuntu:~# docker node update --availability=drain 34tisc44r4uj70qbiac5loaoh
34tisc44r4uj70qbiac5loaoh
root@ubuntu:~# docker node ls
ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
34tisc44r4uj70qbiac5loaoh    ubuntu    Ready   Drain
bs7spdbpogrny2oywi5q1nrl0 *  ubuntu    Ready   Active        Leader
root@ubuntu:~# docker node rm 34tisc44r4uj70qbiac5loaoh
Error response from daemon: rpc error: code = 9 desc = node 34tisc44r4uj70qbiac5loaoh is not down and can't be removed
```

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>