### PR TITLE
Fix swagger-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ win: build ## cross build the binary for windows
 
 .PHONY: swagger-gen
 swagger-gen:
-	docker run --rm -v $(PWD):/work -w /work \
+	docker run --rm -v $(PWD):/go/src/github.com/docker/docker \
+		-w /go/src/github.com/docker/docker \
 		--entrypoint hack/generate-swagger-api.sh \
+		-e GOPATH=/go \
 		quay.io/goswagger/swagger


### PR DESCRIPTION
I guess I was running this locally from a different container, so I didn't notice the makefile target was broken.

#27919 has an item to use this for validation so that it will be checked during CI