### PR TITLE
Adds `MinAPIVersion` to docker version

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -133,6 +133,7 @@ type ContainerProcessList struct {
 type Version struct {
 	Version       string
 	APIVersion    string `json:"ApiVersion"`
+	MinAPIVersion string `json:"MinAPIVersion,omitempty"`
 	GitCommit     string
 	GoVersion     string
 	Os            string

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -23,13 +23,14 @@ var versionTemplate = `Client:
  OS/Arch:      {{.Client.Os}}/{{.Client.Arch}}{{if .ServerOK}}
 
 Server:
- Version:      {{.Server.Version}}
- API version:  {{.Server.APIVersion}}
- Go version:   {{.Server.GoVersion}}
- Git commit:   {{.Server.GitCommit}}
- Built:        {{.Server.BuildTime}}
- OS/Arch:      {{.Server.Os}}/{{.Server.Arch}}
- Experimental: {{.Server.Experimental}}{{end}}`
+ Version:             {{.Server.Version}}
+ API version:         {{.Server.APIVersion}}
+ Minimum API version: {{.Server.MinAPIVersion}}
+ Go version:          {{.Server.GoVersion}}
+ Git commit:          {{.Server.GitCommit}}
+ Built:               {{.Server.BuildTime}}
+ OS/Arch:             {{.Server.Os}}/{{.Server.Arch}}
+ Experimental:        {{.Server.Experimental}}{{end}}`
 
 type versionOptions struct {
 	format string

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/dockerversion"
@@ -156,13 +157,14 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 // SystemVersion returns version information about the daemon.
 func (daemon *Daemon) SystemVersion() types.Version {
 	v := types.Version{
-		Version:      dockerversion.Version,
-		GitCommit:    dockerversion.GitCommit,
-		GoVersion:    runtime.Version(),
-		Os:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
-		BuildTime:    dockerversion.BuildTime,
-		Experimental: daemon.configStore.Experimental,
+		Version:       dockerversion.Version,
+		GitCommit:     dockerversion.GitCommit,
+		MinAPIVersion: api.MinVersion,
+		GoVersion:     runtime.Version(),
+		Os:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		BuildTime:     dockerversion.BuildTime,
+		Experimental:  daemon.configStore.Experimental,
 	}
 
 	kernelVersion := "<unknown>"

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -130,6 +130,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
+* `GET /version` now returns `MinAPIVersion`.
 * `POST /build` accepts `networkmode` parameter to specify network used during build.
 * `GET /images/(name)/json` now returns `OsVersion` if populated
 * `GET /info` now returns `Isolation`.

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -2741,6 +2741,7 @@ Show the docker version information
          "GitCommit": "deadbee",
          "Arch": "amd64",
          "ApiVersion": "1.25",
+         "MinAPIVersion": "1.12",
          "BuildTime": "2016-06-14T07:09:13.444803460+00:00",
          "Experimental": true
     }

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -14,7 +14,7 @@ func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
 		"Client:":       1,
 		"Server:":       1,
 		" Version:":     2,
-		" API version:": 2,
+		" API version:": 3,
 		" Go version:":  2,
 		" Git commit:":  2,
 		" OS/Arch:":     2,
@@ -40,7 +40,7 @@ func (s *DockerSuite) TestVersionPlatform_l(c *check.C) {
 
 func testVersionPlatform(c *check.C, platform string) {
 	out, _ := dockerCmd(c, "version")
-	expected := "OS/Arch:      " + platform
+	expected := "OS/Arch:             " + platform
 
 	split := strings.Split(out, "\n")
 	c.Assert(len(split) >= 14, checker.Equals, true, check.Commentf("got %d lines from version", len(split)))


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Follow-on to https://github.com/docker/docker/pull/27908. Now that Windows and Linux have different minimum supported API versions, it's useful for docker version to return this information.

@thaJeztah 