### PR TITLE
fix frontmatter in reference md files

### DIFF
--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -1,7 +1,7 @@
 ---
 title: "node ps"
 description: "The node ps command description and usage"
-keywords: ["node, tasks", "ps"]
+keywords: node, tasks, ps
 aliases: ["/engine/reference/commandline/node_tasks/"]
 ---
 

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -1,7 +1,7 @@
 ---
 title: "service ps"
 description: "The service ps command description and usage"
-keywords: ["service, tasks", "ps"]
+keywords: service, tasks, ps
 aliases: ["/engine/reference/commandline/service_tasks/"]
 ---
 


### PR DESCRIPTION
contributes to https://github.com/docker/docker.github.io/issues/435

I changed the value of the `keywords` entry in two markdown files of the CLI reference to fix the html meta tag issue described here https://github.com/docker/docker.github.io/issues/435

Value is expected to be a string, not an array of strings.

Thanks 🐨

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>