### PR TITLE
Revert "Update authz plugin list on failure."

### DIFF
--- a/pkg/authorization/middleware.go
+++ b/pkg/authorization/middleware.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -60,11 +59,6 @@ func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.Respon
 
 		if err := authCtx.AuthZRequest(w, r); err != nil {
 			logrus.Errorf("AuthZRequest for %s %s returned error: %s", r.Method, r.RequestURI, err)
-			if strings.Contains(err.Error(), ErrInvalidPlugin.Error()) {
-				m.mu.Lock()
-				m.plugins = authCtx.plugins
-				m.mu.Unlock()
-			}
 			return err
 		}
 
@@ -78,11 +72,6 @@ func (m *Middleware) WrapHandler(handler func(ctx context.Context, w http.Respon
 
 		if err := authCtx.AuthZResponse(rw, r); errD == nil && err != nil {
 			logrus.Errorf("AuthZResponse for %s %s returned error: %s", r.Method, r.RequestURI, err)
-			if strings.Contains(err.Error(), ErrInvalidPlugin.Error()) {
-				m.mu.Lock()
-				m.plugins = authCtx.plugins
-				m.mu.Unlock()
-			}
 			return err
 		}
 

--- a/pkg/authorization/plugin.go
+++ b/pkg/authorization/plugin.go
@@ -1,18 +1,10 @@
 package authorization
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/plugins"
-)
-
-var (
-	// ErrInvalidPlugin indicates that the plugin cannot be used. This is
-	// because the plugin was not found or does not implement necessary
-	// functionality
-	ErrInvalidPlugin = errors.New("invalid plugin")
 )
 
 // Plugin allows third party plugins to authorize requests and responses
@@ -110,7 +102,7 @@ func (a *authorizationPlugin) initPlugin() error {
 				plugin, e = plugins.Get(a.name, AuthZApiImplements)
 			}
 			if e != nil {
-				err = ErrInvalidPlugin
+				err = e
 				return
 			}
 			a.plugin = plugin.Client()


### PR DESCRIPTION
This reverts commit fae904af02a184833d2cd5ce9fdd61a4083707c7 (#27804), tracked from https://github.com/docker/docker/issues/27909 since the daemon will just fail to start if the authz plugin is invalid or not present.

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>