### PR TITLE
Windows: Allow a no-reexec option for importLayer

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
 github.com/Microsoft/hcsshim v0.5.7
-github.com/Microsoft/go-winio v0.3.5
+github.com/Microsoft/go-winio v0.3.6
 github.com/Sirupsen/logrus f76d643702a30fbffecdfe50831e11881c96ceb3 https://github.com/aaronlehmann/logrus
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/vendor/github.com/Microsoft/go-winio/privilege.go
+++ b/vendor/github.com/Microsoft/go-winio/privilege.go
@@ -83,7 +83,7 @@ func RunWithPrivileges(names []string, fn func() error) error {
 		return err
 	}
 	defer releaseThreadToken(token)
-	err = adjustPrivileges(token, privileges)
+	err = adjustPrivileges(token, privileges, SE_PRIVILEGE_ENABLED)
 	if err != nil {
 		return err
 	}
@@ -110,6 +110,15 @@ func mapPrivileges(names []string) ([]uint64, error) {
 
 // EnableProcessPrivileges enables privileges globally for the process.
 func EnableProcessPrivileges(names []string) error {
+	return enableDisableProcessPrivilege(names, SE_PRIVILEGE_ENABLED)
+}
+
+// DisableProcessPrivileges disables privileges globally for the process.
+func DisableProcessPrivileges(names []string) error {
+	return enableDisableProcessPrivilege(names, 0)
+}
+
+func enableDisableProcessPrivilege(names []string, action uint32) error {
 	privileges, err := mapPrivileges(names)
 	if err != nil {
 		return err
@@ -123,15 +132,15 @@ func EnableProcessPrivileges(names []string) error {
 	}
 
 	defer token.Close()
-	return adjustPrivileges(token, privileges)
+	return adjustPrivileges(token, privileges, action)
 }
 
-func adjustPrivileges(token windows.Token, privileges []uint64) error {
+func adjustPrivileges(token windows.Token, privileges []uint64, action uint32) error {
 	var b bytes.Buffer
 	binary.Write(&b, binary.LittleEndian, uint32(len(privileges)))
 	for _, p := range privileges {
 		binary.Write(&b, binary.LittleEndian, p)
-		binary.Write(&b, binary.LittleEndian, uint32(SE_PRIVILEGE_ENABLED))
+		binary.Write(&b, binary.LittleEndian, action)
 	}
 	prevState := make([]byte, b.Len())
 	reqSize := uint32(0)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jstarks This PR allows an environment variable to control whether the Windows graphdriver performs the importLayer operation through a re-exec call (default), or in-process. This is to aide debugging only. If the environment variable is set, the daemon logs a warning during startup

