### PR TITLE
Cleanup invalid code in overlay2 and layer store

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -412,7 +412,7 @@ func (d *Driver) getLowerDirs(id string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			lowersArray = append(lowersArray, path.Clean(path.Join(d.home, "link", lp)))
+			lowersArray = append(lowersArray, path.Clean(path.Join(d.home, linkDir, lp)))
 		}
 	} else if !os.IsNotExist(err) {
 		return nil, err

--- a/layer/empty.go
+++ b/layer/empty.go
@@ -24,7 +24,10 @@ func (el *emptyLayer) TarStream() (io.ReadCloser, error) {
 	return ioutil.NopCloser(buf), nil
 }
 
-func (el *emptyLayer) TarStreamFrom(ChainID) (io.ReadCloser, error) {
+func (el *emptyLayer) TarStreamFrom(p ChainID) (io.ReadCloser, error) {
+	if p == "" {
+		return el.TarStream()
+	}
 	return nil, fmt.Errorf("can't get parent tar stream of an empty layer")
 }
 


### PR DESCRIPTION
The overlay2 change ensures that the correct path is used to resolve the symlink. The current code will not fail since the symlinks are always given a value of `../<id>/diff` which ends up ignoring the incorrect `"link"` value. Fix this code so it doesn't cause unexpected errors in the future if the symlink changes or confuse readers of this code.

The layerstore cleanup ensures that the empty layer returns a tar stream if the provided parent is empty. Any value other than empty still returns an error since the empty layer has no parent. Currently empty layer is not used anywhere that TarStreamFrom is used but could break in the future if this function is called.

ping @cpuguy83 the overlay2 code I discovered while reviewing your squash change. For the empty layer even though we aren't currently squashing to `""`, there is no technical reason to error out and not just return the empty tar. Updated so this error is not unnecessarily seen in the future.