### PR TITLE
Make the check-config script return success or failure

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+EXITCODE=0
+
 # bits of this were adapted from lxc-checkconfig
 # see also https://github.com/lxc/lxc/blob/lxc-1.0.2/src/lxc/lxc-checkconfig.in
 
@@ -90,12 +92,13 @@ check_flag() {
 		wrap_good "CONFIG_$1" 'enabled (as module)'
 	else
 		wrap_bad "CONFIG_$1" 'missing'
+		EXITCODE=1
 	fi
 }
 
 check_flags() {
 	for flag in "$@"; do
-		echo "- $(check_flag "$flag")"
+		echo -n "- "; check_flag "$flag"
 	done
 }
 
@@ -104,6 +107,7 @@ check_command() {
 		wrap_good "$1 command" 'available'
 	else
 		wrap_bad "$1 command" 'missing'
+		EXITCODE=1
 	fi
 }
 
@@ -112,6 +116,7 @@ check_device() {
 		wrap_good "$1" 'present'
 	else
 		wrap_bad "$1" 'missing'
+		EXITCODE=1
 	fi
 }
 
@@ -122,6 +127,7 @@ check_distro_userns() {
 		grep -q "user_namespace.enable=1" /proc/cmdline || {
 			# no user namespace support enabled
 			wrap_bad "  (RHEL7/CentOS7" "User namespaces disabled; add 'user_namespace.enable=1' to boot command line)"
+			EXITCODE=1
 		}
 	fi
 }
@@ -158,6 +164,7 @@ else
 	else
 		echo "$(wrap_bad 'cgroup hierarchy' 'nonexistent??')"
 	fi
+	EXITCODE=1
 	echo "    $(wrap_color '(see https://github.com/tianon/cgroupfs-mount)' yellow)"
 fi
 
@@ -175,6 +182,7 @@ if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = 'Y' ]; then
 		else
 			echo "$(wrap_color '(look for an "apparmor" package for your distribution)')"
 		fi
+		EXITCODE=1
 	fi
 fi
 
@@ -255,41 +263,56 @@ if ! is_set EXT4_FS || ! is_set EXT4_FS_POSIX_ACL || ! is_set EXT4_FS_SECURITY; 
 fi
 
 echo '- Network Drivers:'
-{
-	echo '- "'$(wrap_color 'overlay' blue)'":'
-	check_flags VXLAN | sed 's/^/  /'
-	echo '    Optional (for encrypted networks):'
-	check_flags CRYPTO CRYPTO_AEAD CRYPTO_GCM CRYPTO_SEQIV CRYPTO_GHASH \
-	            XFRM XFRM_USER XFRM_ALGO INET_ESP INET_XFRM_MODE_TRANSPORT | sed 's/^/    /'
-	echo '- "'$(wrap_color 'ipvlan' blue)'":'
-	check_flags IPVLAN | sed 's/^/  /'
-	echo '- "'$(wrap_color 'macvlan' blue)'":'
-	check_flags MACVLAN DUMMY | sed 's/^/  /'
-} | sed 's/^/  /'
+echo '  - "'$(wrap_color 'overlay' blue)'":'
+check_flags VXLAN | sed 's/^/    /'
+echo '      Optional (for encrypted networks):'
+check_flags CRYPTO CRYPTO_AEAD CRYPTO_GCM CRYPTO_SEQIV CRYPTO_GHASH \
+            XFRM XFRM_USER XFRM_ALGO INET_ESP INET_XFRM_MODE_TRANSPORT | sed 's/^/      /'
+echo '  - "'$(wrap_color 'ipvlan' blue)'":'
+check_flags IPVLAN | sed 's/^/    /'
+echo '  - "'$(wrap_color 'macvlan' blue)'":'
+check_flags MACVLAN DUMMY | sed 's/^/    /'
+
+# only fail if no storage drivers available
+CODE=${EXITCODE}
+EXITCODE=0
+STORAGE=1
 
 echo '- Storage Drivers:'
-{
-	echo '- "'$(wrap_color 'aufs' blue)'":'
-	check_flags AUFS_FS | sed 's/^/  /'
-	if ! is_set AUFS_FS && grep -q aufs /proc/filesystems; then
-		echo "    $(wrap_color '(note that some kernels include AUFS patches but not the AUFS_FS flag)' bold black)"
-	fi
+echo '  - "'$(wrap_color 'aufs' blue)'":'
+check_flags AUFS_FS | sed 's/^/    /'
+if ! is_set AUFS_FS && grep -q aufs /proc/filesystems; then
+	echo "      $(wrap_color '(note that some kernels include AUFS patches but not the AUFS_FS flag)' bold black)"
+fi
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
 
-	echo '- "'$(wrap_color 'btrfs' blue)'":'
-	check_flags BTRFS_FS | sed 's/^/  /'
-	check_flags BTRFS_FS_POSIX_ACL | sed 's/^/  /'
+echo '  - "'$(wrap_color 'btrfs' blue)'":'
+check_flags BTRFS_FS | sed 's/^/    /'
+check_flags BTRFS_FS_POSIX_ACL | sed 's/^/    /'
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
 
-	echo '- "'$(wrap_color 'devicemapper' blue)'":'
-	check_flags BLK_DEV_DM DM_THIN_PROVISIONING | sed 's/^/  /'
+echo '  - "'$(wrap_color 'devicemapper' blue)'":'
+check_flags BLK_DEV_DM DM_THIN_PROVISIONING | sed 's/^/    /'
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
 
-	echo '- "'$(wrap_color 'overlay' blue)'":'
-	check_flags OVERLAY_FS | sed 's/^/  /'
+echo '  - "'$(wrap_color 'overlay' blue)'":'
+check_flags OVERLAY_FS | sed 's/^/    /'
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
 
-	echo '- "'$(wrap_color 'zfs' blue)'":'
-	echo "  - $(check_device /dev/zfs)"
-	echo "  - $(check_command zfs)"
-	echo "  - $(check_command zpool)"
-} | sed 's/^/  /'
+echo '  - "'$(wrap_color 'zfs' blue)'":'
+echo -n "    - "; check_device /dev/zfs
+echo -n "    - "; check_command zfs
+echo -n "    - "; check_command zpool
+[ "$EXITCODE" = 0 ] && STORAGE=0
+EXITCODE=0
+
+EXITCODE=$CODE
+[ "$STORAGE" = 1 ] && EXITCODE=1
+
 echo
 
 check_limit_over()
@@ -297,6 +320,7 @@ check_limit_over()
 	if [ $(cat "$1") -le "$2" ]; then
 		wrap_bad "- $1" "$(cat $1)"
 		wrap_color "    This should be set to at least $2, for example set: sysctl -w kernel/keys/root_maxkeys=1000000" bold black
+		EXITCODE=1
 	else
 		wrap_good "- $1" "$(cat $1)"
 	fi
@@ -305,3 +329,5 @@ check_limit_over()
 echo 'Limits:'
 check_limit_over /proc/sys/kernel/keys/root_maxkeys 10000
 echo
+
+exit $EXITCODE


### PR DESCRIPTION
Although primarily a human readable script, it is quite useful
to return success or failure from this script so it can be used
as a basic test.

Fail if any check fails, including some that are optional,
other than the storage driver tests, where only one needs to
succeed, so the system has at least one workable storage driver.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

![turtle_hatching](https://cloud.githubusercontent.com/assets/482364/19951228/7b947d30-a154-11e6-9d08-0d09c4676205.jpg)
