### PR TITLE
fix experimental detection client side

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -19,7 +19,6 @@ import (
 	dopts "github.com/docker/docker/opts"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
-	"golang.org/x/net/context"
 )
 
 // Streams is an interface which exposes the standard input and output streams
@@ -32,27 +31,12 @@ type Streams interface {
 // DockerCli represents the docker command line client.
 // Instances of the client can be returned from NewDockerCli.
 type DockerCli struct {
-	configFile      *configfile.ConfigFile
-	in              *InStream
-	out             *OutStream
-	err             io.Writer
-	keyFile         string
-	client          client.APIClient
-	hasExperimental *bool
-}
-
-// HasExperimental returns true if experimental features are accessible
-func (cli *DockerCli) HasExperimental() bool {
-	if cli.hasExperimental == nil {
-		if cli.client == nil {
-			cli.Initialize(cliflags.NewClientOptions())
-		}
-		enabled := false
-		cli.hasExperimental = &enabled
-		enabled, _ = cli.client.Ping(context.Background())
-	}
-
-	return *cli.hasExperimental
+	configFile *configfile.ConfigFile
+	in         *InStream
+	out        *OutStream
+	err        io.Writer
+	keyFile    string
+	client     client.APIClient
 }
 
 // Client returns the APIClient

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -45,10 +45,8 @@ func NewStartCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.BoolVarP(&opts.openStdin, "interactive", "i", false, "Attach container's STDIN")
 	flags.StringVar(&opts.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
 
-	if dockerCli.HasExperimental() {
-		flags.StringVar(&opts.checkpoint, "checkpoint", "", "Restore from this checkpoint")
-		flags.StringVar(&opts.checkpointDir, "checkpoint-dir", "", "Use a custom checkpoint storage directory")
-	}
+	flags.StringVar(&opts.checkpoint, "checkpoint", "", command.PrependExperimental("Restore from this checkpoint"))
+	flags.StringVar(&opts.checkpointDir, "checkpoint-dir", "", command.PrependExperimental("Use a custom checkpoint storage directory"))
 
 	return cmd
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -111,9 +111,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	command.AddTrustedFlags(flags, true)
 
-	if dockerCli.HasExperimental() {
-		flags.BoolVar(&options.squash, "squash", false, "Squash newly built layers into a single new layer")
-	}
+	flags.BoolVar(&options.squash, "squash", false, command.PrependExperimental("Squash newly built layers into a single new layer"))
 
 	return cmd
 }

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -79,3 +79,12 @@ func PromptForConfirmation(ins *InStream, outs *OutStream, message string) bool 
 
 	return true
 }
+
+// PrependExperimental prepends [experimental] to the string if
+// DOCKER_EXPERIMENTAL != 1
+func PrependExperimental(usage string) string {
+	if os.Getenv("DOCKER_EXPERIMENTAL") == "1" {
+		return usage
+	}
+	return "[experimental] " + usage
+}


### PR DESCRIPTION
Let's assume **local daemon is stable** and **remote daemon is experimental**:

```bash
# help on local daemon shouldn't display experimental commands
$ docker --help
[...]
Management Commands:
  container   Manage containers
  image       Manage images
  network     Manage networks
  node        Manage Swarm nodes
  service     Manage services
[...]
# OK

# help on remote daemon should display experimental commands
$ DOCKER_HOST=<remote_addr> docker --help
[...]
Management Commands:
  checkpoint  Manage checkpoints
  container   Manage containers
  image       Manage images
  network     Manage networks
  node        Manage Swarm nodes
  plugin      Manage plugins
  service     Manage services
  stack       Manage Docker stacks
[...]
# OK

# help on remote daemon should display experimental commands
$ docker -H <remote_addr> --help
[...]
Management Commands:
  container   Manage containers
  image       Manage images
  network     Manage networks
  node        Manage Swarm nodes
  service     Manage services
[...]
# KO
```

It doesn't work with `-H` because we detect if the daemon is experimental before parsing the flags, and I don't see any way around it.

---

Here what I propose (inspired by @dnephin comments) :
* Remove the ping
* Always display experimental commands and flags.
* Prepended with `[experimental]` to the usage unless `DOCKER_EXPERIMENTAL=1`

Example:

```bash
$ docker --help
[...]
Management Commands:
  checkpoint  [experimental] Manage checkpoints
  container   Manage containers
  image       Manage images
  network     Manage networks
  node        Manage Swarm nodes
  plugin      [experimental] Manage plugins
  service     Manage services
  stack       [experimental] Manage Docker stacks
[...]

$ docker -H <remote_addr> --help
[...]
Management Commands:
  checkpoint  [experimental] Manage checkpoints
  container   Manage containers
  image       Manage images
  network     Manage networks
  node        Manage Swarm nodes
  plugin      [experimental] Manage plugins
  service     Manage services
  stack       [experimental] Manage Docker stacks
[...]

$ DOCKER_EXPERIMENTAL=1 docker -H <remote_addr> --help
[...]
Management Commands:
  checkpoint  Manage checkpoints
  container   Manage containers
  image       Manage images
  network     Manage networks
  node        Manage Swarm nodes
  plugin      Manage plugins
  service     Manage services
  stack       Manage Docker stacks
[...]
```

And it works the same way with flags.

ping @mlaventure @dnephin @icecrime 
