### PR TITLE
Don't include PowerShell completions in tgz

### DIFF
--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -58,7 +58,7 @@ for d in "$CROSS/"*/*; do
 	copy_binaries $TAR_PATH
 
 	# add completions
-	for s in bash fish powershell zsh; do
+	for s in bash fish zsh; do
 		mkdir -p $TAR_PATH/completion/$s
 		cp -L contrib/completion/$s/*docker* $TAR_PATH/completion/$s/
 	done


### PR DESCRIPTION
Alternative to https://github.com/docker/docker/pull/28015

The PowerShell completion script was outdated,
and removed from this repository in
65fdbf0210e8faa1598515a7fd7ef4ed33d68d43.

A more up to date implementation can be found
here; https://github.com/samneirinck/posh-docker

Removing this script from the tgz

ping @jhowardmsft @icecrime PTAL