### PR TITLE
Return an empty stats if the container is restarting

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -27,8 +27,8 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 		return err
 	}
 
-	// If the container is not running and requires no stream, return an empty stats.
-	if !container.IsRunning() && !config.Stream {
+	// If the container is either not running or restarting and requires no stream, return an empty stats.
+	if (!container.IsRunning() || container.IsRestarting()) && !config.Stream {
 		return json.NewEncoder(config.OutStream).Encode(&types.Stats{})
 	}
 


### PR DESCRIPTION
**- What I did**
Send an empty stats if a container is restarting to avoid suspended docker-stats.
Closes #27772

**- How I did it**
In case `stream` is `0` and the given container is restarting the daemon returns an empty stats.

**- How to verify it**
```shell
$ docker run --restart always ubuntu true
$ docker stats --no-stream
CONTAINER           CPU %               MEM USAGE / LIMIT   MEM %               NET I/O             BLOCK I/O           PIDS
61d2e2e3fbb3        0.00%               0 B / 0 B           0.00%               0 B / 0 B           0 B / 0 B           0
```
