### PR TITLE
remove COMMAND column from `service ls` output. closes #27994

### DIFF
--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -3,7 +3,6 @@ package service
 import (
 	"fmt"
 	"io"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/docker/docker/api/types"
@@ -18,7 +17,7 @@ import (
 )
 
 const (
-	listItemFmt = "%s\t%s\t%s\t%s\t%s\n"
+	listItemFmt = "%s\t%s\t%s\t%s\n"
 )
 
 type listOptions struct {
@@ -110,7 +109,7 @@ func printTable(out io.Writer, services []swarm.Service, running map[string]int)
 	// Ignore flushing errors
 	defer writer.Flush()
 
-	fmt.Fprintf(writer, listItemFmt, "ID", "NAME", "REPLICAS", "IMAGE", "COMMAND")
+	fmt.Fprintf(writer, listItemFmt, "ID", "NAME", "REPLICAS", "IMAGE")
 	for _, service := range services {
 		replicas := ""
 		if service.Spec.Mode.Replicated != nil && service.Spec.Mode.Replicated.Replicas != nil {
@@ -124,8 +123,7 @@ func printTable(out io.Writer, services []swarm.Service, running map[string]int)
 			stringid.TruncateID(service.ID),
 			service.Spec.Name,
 			replicas,
-			service.Spec.TaskTemplate.ContainerSpec.Image,
-			strings.Join(service.Spec.TaskTemplate.ContainerSpec.Args, " "))
+			service.Spec.TaskTemplate.ContainerSpec.Image)
 	}
 }
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -73,7 +73,7 @@ $ docker service create --name redis redis:3.0.6
 dmu1ept4cxcfe8k8lhtux3ro3
 
 $ docker service ls
-ID            NAME   REPLICAS  IMAGE        COMMAND
+ID            NAME   REPLICAS  IMAGE
 dmu1ept4cxcf  redis  1/1       redis:3.0.6
 ```
 
@@ -97,7 +97,7 @@ number of `RUNNING` tasks is `3`:
 
 ```bash
 $ docker service ls
-ID            NAME    REPLICAS  IMAGE        COMMAND
+ID            NAME    REPLICAS  IMAGE
 4cdgfyky7ozw  redis   3/5       redis:3.0.7
 ```
 
@@ -106,7 +106,7 @@ equal to the desired number:
 
 ```bash
 $ docker service ls
-ID            NAME    REPLICAS  IMAGE        COMMAND
+ID            NAME    REPLICAS  IMAGE
 4cdgfyky7ozw  redis   5/5       redis:3.0.7
 ```
 

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -46,7 +46,7 @@ For example, given the following service;
 
 ```bash
 $ docker service ls
-ID            NAME      REPLICAS  IMAGE         COMMAND
+ID            NAME      REPLICAS  IMAGE
 dmu1ept4cxcf  redis     3/3       redis:3.0.6
 ```
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -34,7 +34,7 @@ swarm.
 
 On a manager node:
 ```bash
-ID            NAME      REPLICAS  IMAGE         COMMAND
+ID            NAME      REPLICAS  IMAGE
 c8wgl7q4ndfd  frontend  5/5       nginx:alpine
 dmu1ept4cxcf  redis     3/3       redis:3.0.6
 ```
@@ -60,7 +60,7 @@ The `id` filter matches all or part of a service's id.
 
 ```bash
 $ docker service ls -f "id=0bcjw"
-ID            NAME   REPLICAS  IMAGE        COMMAND
+ID            NAME   REPLICAS  IMAGE
 0bcjwfh8ychr  redis  1/1       redis:3.0.6
 ```
 
@@ -74,7 +74,7 @@ its value:
 
 ```bash
 $ docker service ls --filter label=project
-ID            NAME       REPLICAS  IMAGE         COMMAND
+ID            NAME       REPLICAS  IMAGE
 01sl1rp6nj5u  frontend2  1/1       nginx:alpine
 36xvvwwauej0  frontend   5/5       nginx:alpine
 74nzcxxjv6fq  backend    3/3       redis:3.0.6
@@ -85,7 +85,7 @@ The following filter matches only services with the `project` label with the
 
 ```bash
 $ docker service ls --filter label=project=project-a
-ID            NAME      REPLICAS  IMAGE         COMMAND
+ID            NAME      REPLICAS  IMAGE
 36xvvwwauej0  frontend  5/5       nginx:alpine
 74nzcxxjv6fq  backend   3/3       redis:3.0.6
 ```
@@ -99,7 +99,7 @@ The following filter matches services with a name containing `redis`.
 
 ```bash
 $ docker service ls --filter name=redis
-ID            NAME   REPLICAS  IMAGE        COMMAND
+ID            NAME   REPLICAS  IMAGE
 0bcjwfh8ychr  redis  1/1       redis:3.0.6
 ```
 

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -36,7 +36,7 @@ For example, to remove the redis service:
 $ docker service rm redis
 redis
 $ docker service ls
-ID            NAME   SCALE  IMAGE        COMMAND
+ID            NAME   SCALE  IMAGE
 ```
 
 > **Warning**: Unlike `docker rm`, this command does not ask for confirmation

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -28,8 +28,8 @@ Options:
 
 ### Scale a service
 
-The scale command enables you to scale one or more replicated services either up 
-or down to the desired number of replicas. This command cannot be applied on 
+The scale command enables you to scale one or more replicated services either up
+or down to the desired number of replicas. This command cannot be applied on
 services which are global mode. The command will return immediately, but the
 actual scaling of the service may take some time. To stop all replicas of a
 service while keeping the service active in the swarm you can set the scale to 0.
@@ -56,7 +56,7 @@ replicas.
 ```bash
 $ docker service ls --filter name=frontend
 
-ID            NAME      REPLICAS  IMAGE         COMMAND
+ID            NAME      REPLICAS  IMAGE
 3pr5mlvu3fh9  frontend  15/50     nginx:alpine
 ```
 
@@ -80,7 +80,7 @@ backend scaled to 3
 frontend scaled to 5
 
 $ docker service ls
-ID            NAME      REPLICAS  IMAGE         COMMAND
+ID            NAME      REPLICAS  IMAGE
 3pr5mlvu3fh9  frontend  5/5       nginx:alpine
 74nzcxxjv6fq  backend   3/3       redis:3.0.6
 ```


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
removes COMMAND col from `service ls` output

**- How to verify it**
run tests, run `docker service ls`
**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/1327886/19969346/99cf239a-a1ae-11e6-9b3e-05ef8d260527.png)



Signed-off-by: Alicia Lauerman <alicia@eta.im>