### PR TITLE
Add flag `--host` to `service create` and `--host-add/rm` to `service update`

### DIFF
--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -36,6 +36,10 @@ type ContainerSpec struct {
 	Mounts          []mount.Mount           `json:",omitempty"`
 	StopGracePeriod *time.Duration          `json:",omitempty"`
 	Healthcheck     *container.HealthConfig `json:",omitempty"`
-	DNSConfig       *DNSConfig              `json:",omitempty"`
-	Secrets         []*SecretReference      `json:",omitempty"`
+	// The format of extra hosts on swarmkit is specified in:
+	// http://man7.org/linux/man-pages/man5/hosts.5.html
+	//    IP_address canonical_hostname [aliases...]
+	Hosts     []string           `json:",omitempty"`
+	DNSConfig *DNSConfig         `json:",omitempty"`
+	Secrets   []*SecretReference `json:",omitempty"`
 }

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -45,6 +45,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.dns, flagDNS, "Set custom DNS servers")
 	flags.Var(&opts.dnsOption, flagDNSOption, "Set DNS options")
 	flags.Var(&opts.dnsSearch, flagDNSSearch, "Set custom DNS search domains")
+	flags.Var(&opts.hosts, flagHost, "Set one or more custom host-to-IP mappings (host:ip)")
 
 	flags.SetInterspersed(false)
 	return cmd

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -339,3 +339,23 @@ func TestUpdateHealthcheckTable(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateHosts(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("host-add", "example.net:2.2.2.2")
+	flags.Set("host-add", "ipv6.net:2001:db8:abc8::1")
+	// remove with ipv6 should work
+	flags.Set("host-rm", "example.net:2001:db8:abc8::1")
+	// just hostname should work as well
+	flags.Set("host-rm", "example.net")
+	// bad format error
+	assert.Error(t, flags.Set("host-add", "$example.com$"), "bad format for add-host:")
+
+	hosts := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2001:db8:abc8::1 example.net"}
+
+	updateHosts(flags, &hosts)
+	assert.Equal(t, len(hosts), 3)
+	assert.Equal(t, hosts[0], "1.2.3.4 example.com")
+	assert.Equal(t, hosts[1], "2001:db8:abc8::1 ipv6.net")
+	assert.Equal(t, hosts[2], "4.3.2.1 example.org")
+}

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -24,6 +24,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 		User:     c.User,
 		Groups:   c.Groups,
 		TTY:      c.TTY,
+		Hosts:    c.Hosts,
 		Secrets:  secretReferencesFromGRPC(c.Secrets),
 	}
 
@@ -132,6 +133,7 @@ func containerToGRPC(c types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		User:     c.User,
 		Groups:   c.Groups,
 		TTY:      c.TTY,
+		Hosts:    c.Hosts,
 		Secrets:  secretReferencesToGRPC(c.Secrets),
 	}
 

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -345,6 +345,20 @@ func (c *containerConfig) hostConfig() *enginecontainer.HostConfig {
 		hc.DNSOptions = c.spec().DNSConfig.Options
 	}
 
+	// The format of extra hosts on swarmkit is specified in:
+	// http://man7.org/linux/man-pages/man5/hosts.5.html
+	//    IP_address canonical_hostname [aliases...]
+	// However, the format of ExtraHosts in HostConfig is
+	//    <host>:<ip>
+	// We need to do the conversion here
+	// (Alias is ignored for now)
+	for _, entry := range c.spec().Hosts {
+		parts := strings.Fields(entry)
+		if len(parts) > 1 {
+			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", parts[1], parts[0]))
+		}
+	}
+
 	if c.task.LogDriver != nil {
 		hc.LogConfig = enginecontainer.LogConfig{
 			Type:   c.task.LogDriver.Name,

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -35,6 +35,7 @@ Options:
       --health-retries int               Consecutive failures needed to report unhealthy
       --health-timeout duration          Maximum time to allow one check to run (default none)
       --help                             Print usage
+      --host list                        Set one or more custom host-to-IP mappings (host:ip) (default [])
       --hostname string                  Container hostname
   -l, --label list                       Service labels (default [])
       --limit-cpu decimal                Limit CPUs (default 0.000)

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -43,6 +43,8 @@ Options:
       --health-retries int               Consecutive failures needed to report unhealthy
       --health-timeout duration          Maximum time to allow one check to run (default none)
       --help                             Print usage
+      --host-add list                    Add or update a custom host-to-IP mapping (host:ip) (default [])
+      --host-rm list                     Remove a custom host-to-IP mapping (host:ip) (default [])
       --image string                     Service image tag
       --label-add list                   Add or update a service label (default [])
       --label-rm list                    Remove a label by its key (default [])

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1028,3 +1028,26 @@ func (s *DockerSwarmSuite) TestSwarmRotateUnlockKey(c *check.C) {
 		c.Assert(outs, checker.Not(checker.Contains), "Swarm is encrypted and needs to be unlocked")
 	}
 }
+
+func (s *DockerSwarmSuite) TestExtraHosts(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	// Create a service
+	name := "top"
+	_, err := d.Cmd("service", "create", "--name", name, "--host=example.com:1.2.3.4", "busybox", "top")
+	c.Assert(err, checker.IsNil)
+
+	// Make sure task has been deployed.
+	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 1)
+
+	// We need to get the container id.
+	out, err := d.Cmd("ps", "-a", "-q", "--no-trunc")
+	c.Assert(err, checker.IsNil)
+	id := strings.TrimSpace(out)
+
+	// Compare against expected output.
+	expectedOutput := "1.2.3.4\texample.com"
+	out, err = d.Cmd("exec", id, "cat", "/etc/hosts")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, expectedOutput, check.Commentf("Expected '%s', but got %q", expectedOutput, out))
+}


### PR DESCRIPTION
**- What I did**

This fix tries to address #27902 by adding a flag `--host` to `docker service create` and `--host-add/--host-rm` to `docker service update`, so that it is possible to specify extra `host:ip` settings in `/etc/hosts`.

*NOTE: 
The flag `--add-host` is to conform to `docker run` but other suggestions are welcomed.
No flag has been added to `docker service update` yet, as I am not sure about what flag should be added for `add/rm` case.*

**- How I did it**

This fix adds `Hosts` in swarmkit's `ContainerSpec` so that it is possible to specify extra hosts during service creation.

Related docs has been updated.

**- How to verify it**

An integration test has been added.

**- Description for the changelog**

Add flag `--add-host` to `docker service create` so that extra host to ip mappings could be added to `/etc/hosts`.

**- A picture of a cute animal (not mandatory but encouraged)**

![super-cute-animals-awsomelycute-com-01586](https://cloud.githubusercontent.com/assets/6932348/19972558/acc316d2-a19f-11e6-9799-dddb1ec9f565.jpg)


This fix fixes #27902.