### PR TITLE
Replace grimes with tini for default init shipped in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y \
 	btrfs-tools \
 	build-essential \
 	clang \
+	cmake \
 	createrepo \
 	curl \
 	dpkg-sig \
@@ -74,6 +75,7 @@ RUN apt-get update && apt-get install -y \
 	python-websocket \
 	ubuntu-zfs \
 	xfsprogs \
+	vim-common \
 	libzfs-dev \
 	tar \
 	zip \
@@ -232,10 +234,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	hello-world:latest@sha256:8be990ef2aeb16dbcb9271ddfe2610fa6658d13f6dfb8bc72074cc1ca36966a7
 # See also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Install tomlv, vndr, runc, containerd, grimes, docker-proxy
+# Install tomlv, vndr, runc, containerd, tini, docker-proxy
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd grimes proxy
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
 	bash-completion \
 	btrfs-tools \
 	build-essential \
+	cmake \
 	createrepo \
 	curl \
 	dpkg-sig \
@@ -50,6 +51,7 @@ RUN apt-get update && apt-get install -y \
 	gccgo \
 	iproute2 \
 	iputils-ping \
+	vim-common \
 	--no-install-recommends
 
 # Get lvm2 source for compiling statically
@@ -160,10 +162,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	aarch64/hello-world:latest@sha256:65a4a158587b307bb02db4de41b836addb0c35175bdc801367b1ac1ddeb9afda
 # See also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Install tomlv, vndr, runc, containerd, grimes, docker-proxy
+# Install tomlv, vndr, runc, containerd, tini, docker-proxy
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd grimes proxy
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y \
 	build-essential \
 	createrepo \
 	curl \
+	cmake \
 	dpkg-sig \
 	git \
 	iptables \
@@ -46,6 +47,7 @@ RUN apt-get update && apt-get install -y \
 	python-websocket \
 	xfsprogs \
 	tar \
+	vim-common \
 	--no-install-recommends \
 	&& pip install awscli==1.10.15
 
@@ -164,10 +166,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	armhf/hello-world:latest@sha256:161dcecea0225975b2ad5f768058212c1e0d39e8211098666ffa1ac74cfb7791
 # See also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Install tomlv, vndr, runc, containerd, grimes, docker-proxy
+# Install tomlv, vndr, runc, containerd, tini, docker-proxy
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd grimes proxy
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy
 
 ENTRYPOINT ["hack/dind"]
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
 	bash-completion \
 	btrfs-tools \
 	build-essential \
+	cmake \
 	createrepo \
 	curl \
 	dpkg-sig \
@@ -47,6 +48,7 @@ RUN apt-get update && apt-get install -y \
 	python-websocket \
 	xfsprogs \
 	tar \
+	vim-common \
 	--no-install-recommends
 
 # Get lvm2 source for compiling statically
@@ -183,10 +185,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	ppc64le/hello-world:latest@sha256:186a40a9a02ca26df0b6c8acdfb8ac2f3ae6678996a838f977e57fac9d963974
 # See also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Install tomlv, vndr, runc, containerd, grimes, docker-proxy
+# Install tomlv, vndr, runc, containerd, tini, docker-proxy
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd grimes proxy
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
 	bash-completion \
 	btrfs-tools \
 	build-essential \
+	cmake \
 	createrepo \
 	curl \
 	dpkg-sig \
@@ -46,6 +47,7 @@ RUN apt-get update && apt-get install -y \
 	python-websocket \
 	xfsprogs \
 	tar \
+	vim-common \
 	--no-install-recommends
 
 # glibc in Debian has a bug specific to s390x that won't be fixed until Debian 8.6 is released
@@ -175,10 +177,10 @@ RUN ./contrib/download-frozen-image-v2.sh /docker-frozen-images \
 	s390x/hello-world:latest@sha256:780d80b3a7677c3788c0d5cd9168281320c8d4a6d9183892d8ee5cdd610f5699
 # See also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
-# Install tomlv, vndr, runc, containerd, grimes, docker-proxy
+# Install tomlv, vndr, runc, containerd, tini, docker-proxy
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh tomlv vndr runc containerd grimes proxy
+RUN /tmp/install-binaries.sh tomlv vndr runc containerd tini proxy
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["hack/dind"]

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		btrfs-tools \
 		build-essential \
 		curl \
+		cmake \
 		gcc \
 		git \
 		libapparmor-dev \
@@ -28,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		xz-utils \
 		\
 		aufs-tools \
+		vim-common \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install seccomp: the version shipped in trusty is too old
@@ -56,10 +58,10 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 ENV CGO_LDFLAGS -L/lib
 
-# Install runc, containerd, grimes and docker-proxy
+# Install runc, containerd, tini and docker-proxy
 # Please edit hack/dockerfile/install-binaries.sh to update them.
 COPY hack/dockerfile/install-binaries.sh /tmp/install-binaries.sh
-RUN /tmp/install-binaries.sh runc containerd grimes proxy
+RUN /tmp/install-binaries.sh runc containerd tini proxy
 
 ENV AUTO_GOPATH 1
 WORKDIR /usr/src/docker

--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -5,7 +5,7 @@ set -x
 TOMLV_COMMIT=9baf8a8a9f2ed20a8e54160840c492f937eeaf9a
 RUNC_COMMIT=ac031b5bf1cc92239461125f4c1ffb760522bbf2
 CONTAINERD_COMMIT=8517738ba4b82aff5662c97ca4627e7e4d03b531
-GRIMES_COMMIT=fe069a03affd2547fdb05e5b8b07202d2e41735b
+TINI_COMMIT=v0.13.0
 LIBNETWORK_COMMIT=0f534354b813003a754606689722fe253101bc4e
 VNDR_COMMIT=f56bd4504b4fad07a357913687fb652ee54bb3b0
 
@@ -77,13 +77,14 @@ do
 			install_containerd
 			;;
 
-		grimes)
-			echo "Install grimes version $GRIMES_COMMIT"
-			git clone https://github.com/crosbymichael/grimes.git "$GOPATH/grimes"
-			cd "$GOPATH/grimes"
-			git checkout -q "$GRIMES_COMMIT"
-			make
-			cp init /usr/local/bin/docker-init
+		tini)
+			echo "Install tini version $TINI_COMMIT"
+			git clone https://github.com/krallin/tini.git "$GOPATH/tini"
+			cd "$GOPATH/tini"
+			git checkout -q "$TINI_COMMIT"
+			cmake -DMINIMAL=ON .
+			make tini-static
+			cp tini-static /usr/local/bin/docker-init
 			;;
 
 		proxy)
@@ -104,7 +105,7 @@ do
 			;;
 
 		*)
-			echo echo "Usage: $0 [tomlv|runc|containerd|grimes|proxy]"
+			echo echo "Usage: $0 [tomlv|runc|containerd|tini|proxy]"
 			exit 1
 
 	esac

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -138,7 +138,7 @@ install -p -m 755 /usr/local/bin/docker-containerd-ctr $RPM_BUILD_ROOT/%{_bindir
 # install runc
 install -p -m 755 /usr/local/bin/docker-runc $RPM_BUILD_ROOT/%{_bindir}/docker-runc
 
-# install grimes
+# install tini
 install -p -m 755 /usr/local/bin/docker-init $RPM_BUILD_ROOT/%{_bindir}/docker-init
 
 # install udev rules

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -73,8 +73,8 @@ set -e
 		EOF
 
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			# Install runc, containerd, proxy and grimes
-			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic grimes
+			# Install runc, containerd, proxy and tini
+			RUN ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 		EOF
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN cp -aL hack/make/.build-deb debian

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -94,8 +94,8 @@ set -e
 		EOF
 
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
-			# Install runc, containerd, proxy and grimes
-			RUN TMP_GOPATH="/go" ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic grimes
+			# Install runc, containerd, proxy and tini
+			RUN TMP_GOPATH="/go" ./hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 		EOF
 		if [[ "$VERSION" == *-dev ]] || [ -n "$(git status --porcelain)" ]; then
 			echo 'ENV DOCKER_EXPERIMENTAL 1' >> "$DEST/$version/Dockerfile.build"
@@ -110,7 +110,7 @@ set -e
 			RUN tar --exclude .git -r -C /go/src/github.com/docker -f /root/rpmbuild/SOURCES/${rpmName}.tar containerd
 			RUN tar --exclude .git -r -C /go/src/github.com/docker/libnetwork/cmd -f /root/rpmbuild/SOURCES/${rpmName}.tar proxy
 			RUN tar --exclude .git -r -C /go/src/github.com/opencontainers -f /root/rpmbuild/SOURCES/${rpmName}.tar runc
-			RUN tar --exclude .git -r -C /go/ -f /root/rpmbuild/SOURCES/${rpmName}.tar grimes
+			RUN tar --exclude .git -r -C /go/ -f /root/rpmbuild/SOURCES/${rpmName}.tar tini
 			RUN gzip /root/rpmbuild/SOURCES/${rpmName}.tar
 			RUN { cat /usr/src/${rpmName}/contrib/builder/rpm/${PACKAGE_ARCH}/changelog; } >> ${rpmName}.spec && tail >&2 ${rpmName}.spec
 			RUN rpmbuild -ba \

--- a/integration-cli/daemon.go
+++ b/integration-cli/daemon.go
@@ -154,7 +154,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		fmt.Sprintf("--userland-proxy=%t", d.userlandProxy),
 	)
 	if experimentalDaemon {
-		args = append(args, "--experimental")
+		args = append(args, "--experimental", "--init")
 	}
 	if !(d.useDefaultHost || d.useDefaultTLSHost) {
 		args = append(args, []string{"--host", d.sock()}...)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2735,11 +2735,9 @@ func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *check.C) {
 	c.Assert(err, checker.IsNil)
 
 	containerName := "error-values"
-	runError := `exec: \"toto\": executable file not found in $PATH`
 	// Make a container with both a non 0 exit code and an error message
 	out, err := s.d.Cmd("run", "--name", containerName, "busybox", "toto")
 	c.Assert(err, checker.NotNil)
-	c.Assert(out, checker.Contains, runError)
 
 	// Check that those values were saved on disk
 	out, err = s.d.Cmd("inspect", "-f", "{{.State.ExitCode}}", containerName)
@@ -2750,7 +2748,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *check.C) {
 	out, err = s.d.Cmd("inspect", "-f", "{{.State.Error}}", containerName)
 	out = strings.TrimSpace(out)
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, runError)
 
 	// now restart daemon
 	err = s.d.Restart()
@@ -2765,7 +2762,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *check.C) {
 	out, err = s.d.Cmd("inspect", "-f", "{{.State.Error}}", containerName)
 	out = strings.TrimSpace(out)
 	c.Assert(err, checker.IsNil)
-	c.Assert(out, checker.Contains, runError)
 }
 
 func (s *DockerDaemonSuite) TestDaemonBackcompatPre17Volumes(c *check.C) {


### PR DESCRIPTION
There is no reason to duplicate efforts and tini is well built and
better than grimes.  It is a much stronger option for the default init
and @krallin has done a great job maintaining it and helping make
changes so that it will work with Docker using it as the default.

The only build change required is that we add `cmake` to the dockerfile and `vim-common` because it has tools for embedding the licence in tini that is part of its build process.

You can see the tini repo here:

https://github.com/krallin/tini

The init change has not be released so changing from grimes to tini does not impact anyone out of master. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>