### PR TITLE
Add information for `Manager Addresses` in the output of `docker info`

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -131,6 +132,17 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			}
 		}
 		fmt.Fprintf(dockerCli.Out(), " Node Address: %s\n", info.Swarm.NodeAddr)
+		managers := []string{}
+		for _, entry := range info.Swarm.RemoteManagers {
+			managers = append(managers, entry.Addr)
+		}
+		if len(managers) > 0 {
+			sort.Strings(managers)
+			fmt.Fprintf(dockerCli.Out(), " Manager Addresses:\n")
+			for _, entry := range managers {
+				fmt.Fprintf(dockerCli.Out(), "  %s\n", entry)
+			}
+		}
 	}
 
 	if len(info.Runtimes) > 0 {

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1051,3 +1051,24 @@ func (s *DockerSwarmSuite) TestExtraHosts(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, expectedOutput, check.Commentf("Expected '%s', but got %q", expectedOutput, out))
 }
+
+func (s *DockerSwarmSuite) TestSwarmManagerAddress(c *check.C) {
+	d1 := s.AddDaemon(c, true, true)
+	d2 := s.AddDaemon(c, true, false)
+	d3 := s.AddDaemon(c, true, false)
+
+	// Manager Addresses will always show Node 1's address
+	expectedOutput := fmt.Sprintf("Manager Addresses:\n  127.0.0.1:%d\n", d1.port)
+
+	out, err := d1.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+
+	out, err = d2.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+
+	out, err = d3.Cmd("info")
+	c.Assert(err, checker.IsNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+}


### PR DESCRIPTION
**- What I did**
As is specified in #28018, it would be useful to know the manager's addresses even in a worker node. This is especially useful when there are many worker nodes in a big cluster.

The information is available in `info.Swarm.RemoteManagers`.

This fix add the information of `Manager Addresses` to the output of `docker info`, to explicitly show it.

**- How I did it**

**- How to verify it**

A test has been added for this fix.

Also the new output:
```
$ docker info
...
Cgroup Driver: cgroupfs
Plugins: 
 Volume: local
 Network: bridge host macvlan null overlay
Swarm: active
 NodeID: bu6m8b45fxu8ac4w4wx26iw19
 Is Manager: false
 Node Address: 127.0.0.1
 Manager Addresses: 127.0.0.1:2477
Runtimes: runc
Default Runtime: runc
...
```

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![cute_funny_animals_21](https://cloud.githubusercontent.com/assets/6932348/19980178/4fe2a7aa-a1ba-11e6-830b-94db6787b2d5.jpg)


This fix fixes #28018.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>