### PR TITLE
[ppc64le] update go download link, and improve comments

### DIFF
--- a/contrib/builder/deb/ppc64le/generate.sh
+++ b/contrib/builder/deb/ppc64le/generate.sh
@@ -99,7 +99,7 @@ for version in "${versions[@]}"; do
 	# ppc64le doesn't have an official downloadable binary as of go 1.6.2. so use the
 	# older packaged go(v1.6.1) to bootstrap latest go, then remove the packaged go
 	echo "# Install Go" >> "$version/Dockerfile"
-	echo "# ppc64le doesn't have official go binaries, so use the version of go installed from the image" >> "$version/Dockerfile"
+	echo "# ppc64le doesn't have official go binaries, so use a distro packaged version of go" >> "$version/Dockerfile"
 	echo "# to build go from source." >> "$version/Dockerfile"
 	echo "# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6" >> "$version/Dockerfile"
 	

--- a/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-trusty/Dockerfile
@@ -6,8 +6,12 @@ FROM ppc64le/ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config golang-1.6 libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
+# Install Go
+# ppc64le doesn't have official go binaries, so use a distro packaged version of go
+# to build go from source.
+# NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.3
-ENV GO_DOWNLOAD_URL https://golang.org/dl/go${GO_VERSION}.src.tar.gz
+ENV GO_DOWNLOAD_URL https://storage.googleapis.com/golang/go${GO_VERSION}.src.tar.gz
 ENV GOROOT_BOOTSTRAP /usr/lib/go-1.6
 
 RUN curl -fsSL "$GO_DOWNLOAD_URL" -o golang.tar.gz \

--- a/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
+++ b/contrib/builder/deb/ppc64le/ubuntu-xenial/Dockerfile
@@ -7,7 +7,7 @@ FROM ppc64le/ubuntu:xenial
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev pkg-config golang-go libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 # Install Go
-# ppc64le doesn't have official go binaries, so use the version of go installed from the image
+# ppc64le doesn't have official go binaries, so use a distro packaged version of go
 # to build go from source.
 # NOTE: ppc64le has compatibility issues with older versions of go, so make sure the version >= 1.6
 ENV GO_VERSION 1.7.3


### PR DESCRIPTION
Updates the ppc64le `make deb` trusty download link to be
consistent with the other Dockerfiles. Also minor clarification
to how we install go.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

![gorilla ipad](http://inagorillacostume.com/wp-content/uploads/2011/04/New-toy-...-intrigued-gorilla-prods-iPad.jpg)