### PR TITLE
cli: shorten description of "inspect" subcommand

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -25,12 +25,9 @@ func NewInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
-		Use: "inspect [OPTIONS] NAME|ID [NAME|ID...]",
-		Short: strings.Join([]string{
-			"Return low-level information on Docker object(s) (e.g. container, image, volume,",
-			"\nnetwork, node, service, or task) identified by name or ID",
-		}, ""),
-		Args: cli.RequiresMinArgs(1),
+		Use:   "inspect [OPTIONS] NAME|ID [NAME|ID...]",
+		Short: "Return low-level information on Docker objects",
+		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ids = args
 			return runInspect(dockerCli, opts)


### PR DESCRIPTION
The short description should be kept short. Spanning on several lines is
a bit ugly. A user can still get more information in the manual or we
can expand the long description instead if we want (there is currently
none).

This reverts a bit of #26683.

Signed-off-by: Vincent Bernat <vincent@bernat.im>