### PR TITLE
Fix issue with cp to container volume dir

### DIFF
--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -30,9 +30,11 @@ func chroot(path string) (err error) {
 	if err := mount.MakeRPrivate("/"); err != nil {
 		return err
 	}
-	// ensure path is a mountpoint
-	if err := mount.MakePrivate(path); err != nil {
-		return err
+
+	if mounted, _ := mount.Mounted(path); !mounted {
+		if err := mount.Mount(path, path, "bind", "rbind,rw"); err != nil {
+			return realChroot(path)
+		}
 	}
 
 	// setup oldRoot for pivot_root


### PR DESCRIPTION
In some cases, attempting to `docker cp` to a container's volume dir
would fail due to the volume mounts not existing after performing a
bind-mount on the container path prior to doing a pivot_root.

This does not seem to be effecting all systems, but was found to be a
problem on centos.
The solution is to use an `rbind` rather than `bind` so that any
existing mounts are carried over.

The `MakePrivate` on `path` is no longer neccessary since we are already
doing `MakeRPrivate` on `/`.

Fixes #27773