### PR TITLE
fix frontmatter keywords value type (string, instead of []string)

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -2,7 +2,7 @@
 aliases: ["/engine/misc/deprecated/"]
 title: "Deprecated Engine Features"
 description: "Deprecated Features."
-keywords: ["docker, documentation, about, technology, deprecate"]
+keywords: "docker, documentation, about, technology, deprecate"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -3,8 +3,7 @@ advisory: experimental
 aliases:
 - /engine/extend/
 description: Develop and use a plugin with the managed plugin system
-keywords:
-- API, Usage, plugins, documentation, developer
+keywords: "API, Usage, plugins, documentation, developer"
 title: Managed plugin system
 ---
 

--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -2,7 +2,7 @@
 aliases: "/engine/extend/plugins/"
 title: "Use Docker Engine plugins"
 description: "How to add additional functionality to Docker with plugins extensions"
-keywords: ["Examples, Usage, plugins, docker, documentation, user guide"]
+keywords: "Examples, Usage, plugins, docker, documentation, user guide"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/extend/manifest.md
+++ b/docs/extend/manifest.md
@@ -4,7 +4,7 @@ aliases: [
 ]
 title: "Plugin manifest"
 description: "How develop and use a plugin with the managed plugin system"
-keywords: ["API, Usage, plugins, documentation, developer"]
+keywords: "API, Usage, plugins, documentation, developer"
 advisory: "experimental"
 ---
 

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -1,7 +1,7 @@
 ---
 title: "Plugins API"
 description: "How to write Docker plugins extensions "
-keywords: ["API, Usage, plugins, documentation, developer"]
+keywords: "API, Usage, plugins, documentation, developer"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -1,7 +1,7 @@
 ---
 title: "Access authorization plugin"
 description: "How to create authorization plugins to manage access control to your Docker daemon."
-keywords: ["security, authorization, authentication, docker, documentation, plugin, extend"]
+keywords: "security, authorization, authentication, docker, documentation, plugin, extend"
 aliases: ["/engine/extend/authorization/"]
 ---
 

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker network driver plugins"
 description: "Network driver plugins."
-keywords: ["Examples, Usage, plugins, docker, documentation, user guide"]
+keywords: "Examples, Usage, plugins, docker, documentation, user guide"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -1,7 +1,7 @@
 ---
 title: "Volume plugins"
 description: "How to manage data with external volume plugins"
-keywords: ["Examples, Usage, volume, docker, data, volumes, plugin, api"]
+keywords: "Examples, Usage, volume, docker, data, volumes, plugin, api"
 ---
 
 <!-- This file is maintained within the docker/docker Github


### PR DESCRIPTION
contributes to https://github.com/docker/docker.github.io/issues/435

I fixed the type of the `keywords` value in the frontmatter header of some documentation files.

Thanks. 🐨

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>