### PR TITLE
Handle NetworkDettach for the case of network-id

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -793,7 +793,10 @@ func (daemon *Daemon) disconnectFromNetwork(container *container.Container, n li
 
 	if daemon.clusterProvider != nil && n.Info().Dynamic() && !container.Managed {
 		if err := daemon.clusterProvider.DetachNetwork(n.Name(), container.ID); err != nil {
-			logrus.Warnf("error detaching from network %s: %v", n, err)
+			logrus.Warnf("error detaching from network %s: %v", n.Name(), err)
+			if err := daemon.clusterProvider.DetachNetwork(n.ID(), container.ID); err != nil {
+				logrus.Warnf("error detaching from network %s: %v", n.ID(), err)
+			}
 		}
 	}
 
@@ -891,6 +894,9 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 		if daemon.clusterProvider != nil && nw.Info().Dynamic() && !container.Managed {
 			if err := daemon.clusterProvider.DetachNetwork(nw.Name(), container.ID); err != nil {
 				logrus.Warnf("error detaching from network %s: %v", nw.Name(), err)
+				if err := daemon.clusterProvider.DetachNetwork(nw.ID(), container.ID); err != nil {
+					logrus.Warnf("error detaching from network %s: %v", nw.ID(), err)
+				}
 			}
 		}
 


### PR DESCRIPTION
When a container is attached to an "--attachable" network, it strictly
forms the attacherKey using either the network-id or network-name
because at the time of attachment, the daemon may not have the network
downloaded locally from the manager. Hence, when the NetworkDettach is
called, it should use either network-name or network-id. This fix
addresses the missing network-id based dettachment case.

Fixes #28051

Signed-off-by: Madhu Venugopal <madhu@docker.com>