### PR TITLE
fix frontmatter keywords value type (string, instead of []string) in /docs/reference/

### DIFF
--- a/docs/reference/api/docker-io_api.md
+++ b/docs/reference/api/docker-io_api.md
@@ -2,7 +2,7 @@
 published: false
 title: "Docker Hub API"
 description: "API Documentation for the Docker Hub API"
-keywords: ["API, Docker, index, REST, documentation, Docker Hub,  registry"]
+keywords: "API, Docker, index, REST, documentation, Docker Hub, registry"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_io_accounts_api.md
+++ b/docs/reference/api/docker_io_accounts_api.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.io accounts API"
 description: "API Documentation for docker.io accounts."
-keywords: ["API, Docker, accounts, REST,  documentation"]
+keywords: "API, Docker, accounts, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.18"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.19"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.20"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.21"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.22"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.23"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.24"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API v1.25"
 description: "API Documentation for Docker"
-keywords: ["API, Docker, rcli, REST,  documentation"]
+keywords: "API, Docker, rcli, REST, documentation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/hub_registry_spec.md
+++ b/docs/reference/api/hub_registry_spec.md
@@ -2,7 +2,7 @@
 published: false
 title: "The Docker Hub and the Registry v1"
 description: "Documentation for docker Registry and Registry API"
-keywords: ["docker, registry, api,  hub"]
+keywords: "docker, registry, api, hub"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,7 +1,7 @@
 ---
 title: "API Reference"
 description: "Reference"
-keywords: ["Engine"]
+keywords: "Engine"
 identifier: "engine_remoteapi"
 ---
 

--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -1,7 +1,7 @@
 ---
 title: "Remote API client libraries"
 description: "Various client libraries available to use with the Docker remote API"
-keywords: ["API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust,  Scala"]
+keywords: "API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust, Scala"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1,7 +1,7 @@
 ---
 title: "Dockerfile reference"
 description: "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
-keywords: ["builder, docker, Dockerfile, automation,  image creation"]
+keywords: "builder, docker, Dockerfile, automation, image creation"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -1,7 +1,7 @@
 ---
 title: "attach"
 description: "The attach command description and usage"
-keywords: ["attach, running, container"]
+keywords: "attach, running, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -1,7 +1,7 @@
 ---
 title: "build"
 description: "The build command description and usage"
-keywords: ["build, docker, image"]
+keywords: "build, docker, image"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -1,7 +1,7 @@
 ---
 title: "Use the Docker command line"
 description: "Docker's CLI command description and usage"
-keywords: ["Docker, Docker documentation, CLI,  command line"]
+keywords: "Docker, Docker documentation, CLI, command line"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -1,7 +1,7 @@
 ---
 title: "commit"
 description: "The commit command description and usage"
-keywords: ["commit, file, changes"]
+keywords: "commit, file, changes"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -1,7 +1,7 @@
 ---
 title: "container prune"
 description: "Remove all stopped containers"
-keywords: [container, prune, delete, remove]
+keywords: container, prune, delete, remove
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -1,7 +1,7 @@
 ---
 title: "cp"
 description: "The cp command description and usage"
-keywords: ["copy, container, files, folders"]
+keywords: "copy, container, files, folders"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -1,7 +1,7 @@
 ---
 title: "create"
 description: "The create command description and usage"
-keywords: ["docker, create, container"]
+keywords: "docker, create, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -1,7 +1,7 @@
 ---
 title: "deploy"
 description: "The deploy command description and usage"
-keywords: ["stack, deploy"]
+keywords: "stack, deploy"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/diff.md
+++ b/docs/reference/commandline/diff.md
@@ -1,7 +1,7 @@
 ---
 title: "diff"
 description: "The diff command description and usage"
-keywords: ["list, changed, files, container"]
+keywords: "list, changed, files, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -2,7 +2,7 @@
 title: "dockerd"
 aliases: ["/engine/reference/commandline/daemon/"]
 description: "The daemon command description and usage"
-keywords: ["container, daemon, runtime"]
+keywords: "container, daemon, runtime"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -1,7 +1,7 @@
 ---
 title: "events"
 description: "The events command description and usage"
-keywords: ["events, container, report"]
+keywords: "events, container, report"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -1,7 +1,7 @@
 ---
 title: "exec"
 description: "The exec command description and usage"
-keywords: ["command, container, run, execute"]
+keywords: "command, container, run, execute"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -1,7 +1,7 @@
 ---
 title: "export"
 description: "The export command description and usage"
-keywords: ["export, file, system, container"]
+keywords: "export, file, system, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -1,7 +1,7 @@
 ---
 title: "history"
 description: "The history command description and usage"
-keywords: ["docker, image, history"]
+keywords: "docker, image, history"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -1,7 +1,7 @@
 ---
 title: "image prune"
 description: "Remove all stopped images"
-keywords: [image, prune, delete, remove]
+keywords: "image, prune, delete, remove"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -1,7 +1,7 @@
 ---
 title: "images"
 description: "The images command description and usage"
-keywords: ["list, docker, images"]
+keywords: "list, docker, images"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -1,7 +1,7 @@
 ---
 title: "import"
 description: "The import command description and usage"
-keywords: ["import, file, system, container"]
+keywords: "import, file, system, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker commands"
 description: "Docker's CLI command description and usage"
-keywords: ["Docker, Docker documentation, CLI,  command line"]
+keywords: "Docker, Docker documentation, CLI, command line"
 identifier: "smn_cli_guide"
 ---
 

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -1,7 +1,7 @@
 ---
 title: "info"
 description: "The info command description and usage"
-keywords: ["display, docker, information"]
+keywords: "display, docker, information"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -1,7 +1,7 @@
 ---
 title: "inspect"
 description: "The inspect command description and usage"
-keywords: ["inspect, container, json"]
+keywords: "inspect, container, json"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -1,7 +1,7 @@
 ---
 title: "kill"
 description: "The kill command description and usage"
-keywords: ["container, kill, signal"]
+keywords: "container, kill, signal"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -1,7 +1,7 @@
 ---
 title: "load"
 description: "The load command description and usage"
-keywords: ["stdin, tarred, repository"]
+keywords: "stdin, tarred, repository"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -1,7 +1,7 @@
 ---
 title: "login"
 description: "The login command description and usage"
-keywords: ["registry, login, image"]
+keywords: "registry, login, image"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -1,7 +1,7 @@
 ---
 title: "logout"
 description: "The logout command description and usage"
-keywords: ["logout, docker, registry"]
+keywords: "logout, docker, registry"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -1,7 +1,7 @@
 ---
 title: "logs"
 description: "The logs command description and usage"
-keywords: ["logs, retrieve, docker"]
+keywords: "logs, retrieve, docker"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/menu.md
+++ b/docs/reference/commandline/menu.md
@@ -1,7 +1,7 @@
 ---
 title: "Command line reference"
 description: "Docker's CLI command description and usage"
-keywords: ["Docker, Docker documentation, CLI,  command line"]
+keywords: "Docker, Docker documentation, CLI, command line"
 identifier:  "smn_cli"
 ---
 

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -1,7 +1,7 @@
 ---
 title: "network connect"
 description: "The network connect command description and usage"
-keywords: ["network, connect, user-defined"]
+keywords: "network, connect, user-defined"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -1,7 +1,7 @@
 ---
 title: "network create"
 description: "The network create command description and usage"
-keywords: ["network, create"]
+keywords: "network, create"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/network_disconnect.md
+++ b/docs/reference/commandline/network_disconnect.md
@@ -1,7 +1,7 @@
 ---
 title: "network disconnect"
 description: "The network disconnect command description and usage"
-keywords: ["network, disconnect, user-defined"]
+keywords: "network, disconnect, user-defined"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -1,7 +1,7 @@
 ---
 title: "network inspect"
 description: "The network inspect command description and usage"
-keywords: ["network, inspect, user-defined"]
+keywords: "network, inspect, user-defined"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -1,7 +1,7 @@
 ---
 title: "network ls"
 description: "The network ls command description and usage"
-keywords: ["network, list, user-defined"]
+keywords: "network, list, user-defined"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -1,7 +1,7 @@
 ---
 title: "network prune"
 description: "Remove unused networks"
-keywords: [network, prune, delete]
+keywords: "network, prune, delete"
 ---
 
 # network prune

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -1,7 +1,7 @@
 ---
 title: "network rm"
 description: "the network rm command description and usage"
-keywords: ["network, rm, user-defined"]
+keywords: "network, rm, user-defined"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -1,7 +1,7 @@
 ---
 title: "node demote"
 description: "The node demote command description and usage"
-keywords: ["node, demote"]
+keywords: "node, demote"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -1,7 +1,7 @@
 ---
 title: "node inspect"
 description: "The node inspect command description and usage"
-keywords: ["node, inspect"]
+keywords: "node, inspect"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -1,7 +1,7 @@
 ---
 title: "node ls"
 description: "The node ls command description and usage"
-keywords: ["node, list"]
+keywords: "node, list"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -1,7 +1,7 @@
 ---
 title: "node promote"
 description: "The node promote command description and usage"
-keywords: ["node, promote"]
+keywords: "node, promote"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -1,7 +1,7 @@
 ---
 title: "node rm"
 description: "The node rm command description and usage"
-keywords: ["node, remove"]
+keywords: "node, remove"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -1,7 +1,7 @@
 ---
 title: "node update"
 description: "The node update command description and usage"
-keywords: ["resources, update, dynamically"]
+keywords: "resources, update, dynamically"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -1,7 +1,7 @@
 ---
 title: "pause"
 description: "The pause command description and usage"
-keywords: ["cgroups, container, suspend, SIGSTOP"]
+keywords: "cgroups, container, suspend, SIGSTOP"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin disable"
 description: "the plugin disable command description and usage"
-keywords: ["plugin, disable"]
+keywords: "plugin, disable"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin enable"
 description: "the plugin enable command description and usage"
-keywords: ["plugin, enable"]
+keywords: "plugin, enable"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin inspect"
 description: "The plugin inspect command description and usage"
-keywords: ["plugin, inspect"]
+keywords: "plugin, inspect"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin install"
 description: "the plugin install command description and usage"
-keywords: ["plugin, install"]
+keywords: "plugin, install"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin ls"
 description: "The plugin ls command description and usage"
-keywords: ["plugin, list"]
+keywords: "plugin, list"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin rm"
 description: "the plugin rm command description and usage"
-keywords: ["plugin, rm"]
+keywords: "plugin, rm"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/port.md
+++ b/docs/reference/commandline/port.md
@@ -1,7 +1,7 @@
 ---
 title: "port"
 description: "The port command description and usage"
-keywords: ["port, mapping, container"]
+keywords: "port, mapping, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -1,7 +1,7 @@
 ---
 title: "ps"
 description: "The ps command description and usage"
-keywords: ["container, running, list"]
+keywords: "container, running, list"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -1,7 +1,7 @@
 ---
 title: "pull"
 description: "The pull command description and usage"
-keywords: ["pull, image, hub, docker"]
+keywords: "pull, image, hub, docker"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -1,7 +1,7 @@
 ---
 title: "push"
 description: "The push command description and usage"
-keywords: ["share, push, image"]
+keywords: "share, push, image"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/rename.md
+++ b/docs/reference/commandline/rename.md
@@ -1,7 +1,7 @@
 ---
 title: "rename"
 description: "The rename command description and usage"
-keywords: ["rename, docker, container"]
+keywords: "rename, docker, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -1,7 +1,7 @@
 ---
 title: "restart"
 description: "The restart command description and usage"
-keywords: ["restart, container, Docker"]
+keywords: "restart, container, Docker"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -1,7 +1,7 @@
 ---
 title: "rm"
 description: "The rm command description and usage"
-keywords: ["remove, Docker, container"]
+keywords: "remove, Docker, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -1,7 +1,7 @@
 ---
 title: "rmi"
 description: "The rmi command description and usage"
-keywords: ["remove, image, Docker"]
+keywords: "remove, image, Docker"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -1,7 +1,7 @@
 ---
 title: "run"
 description: "The run command description and usage"
-keywords: ["run, command, container"]
+keywords: "run, command, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -1,7 +1,7 @@
 ---
 title: "save"
 description: "The save command description and usage"
-keywords: ["tarred, repository, backup"]
+keywords: "tarred, repository, backup"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -1,7 +1,7 @@
 ---
 title: "search"
 description: "The search command description and usage"
-keywords: ["search, hub, images"]
+keywords: "search, hub, images"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -1,7 +1,7 @@
 ---
 title: "service create"
 description: "The service create command description and usage"
-keywords: ["service, create"]
+keywords: "service, create"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -1,7 +1,7 @@
 ---
 title: "service inspect"
 description: "The service inspect command description and usage"
-keywords: ["service, inspect"]
+keywords: "service, inspect"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -1,7 +1,7 @@
 ---
 title: "service ls"
 description: "The service ls command description and usage"
-keywords: ["service, ls"]
+keywords: "service, ls"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -1,7 +1,7 @@
 ---
 title: "service ps"
 description: "The service ps command description and usage"
-keywords: service, tasks, ps
+keywords: "service, tasks, ps"
 aliases: ["/engine/reference/commandline/service_tasks/"]
 ---
 

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -1,7 +1,7 @@
 ---
 title: "service rm"
 description: "The service rm command description and usage"
-keywords: ["service, rm"]
+keywords: "service, rm"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -1,7 +1,7 @@
 ---
 title: "service scale"
 description: "The service scale command description and usage"
-keywords: ["service, scale"]
+keywords: "service, scale"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -1,7 +1,7 @@
 ---
 title: "service update"
 description: "The service update command description and usage"
-keywords: ["service, update"]
+keywords: "service, update"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -1,7 +1,7 @@
 ---
 title: "stack config"
 description: "The stack config command description and usage"
-keywords: ["stack, config"]
+keywords: "stack, config"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -1,7 +1,7 @@
 ---
 title: "stack deploy"
 description: "The stack deploy command description and usage"
-keywords: ["stack, deploy, up"]
+keywords: "stack, deploy, up"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -1,7 +1,7 @@
 ---
 title: "stack ls"
 description: "The stack ls command description and usage"
-keywords: ["stack, ls"]
+keywords: "stack, ls"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -1,7 +1,7 @@
 ---
 title: "stack ps"
 description: "The stack ps command description and usage"
-keywords: ["stack, ps"]
+keywords: "stack, ps"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -1,7 +1,7 @@
 ---
 title: "stack rm"
 description: "The stack rm command description and usage"
-keywords: ["stack, rm, remove, down"]
+keywords: "stack, rm, remove, down"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -1,7 +1,7 @@
 ---
 title: "stack services"
 description: "The stack services command description and usage"
-keywords: ["stack, services"]
+keywords: "stack, services"
 advisory: "experimental"
 ---
 

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -1,7 +1,7 @@
 ---
 title: "start"
 description: "The start command description and usage"
-keywords: ["Start, container, stopped"]
+keywords: "Start, container, stopped"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -1,7 +1,7 @@
 ---
 title: "stats"
 description: "The stats command description and usage"
-keywords: ["container, resource, statistics"]
+keywords: "container, resource, statistics"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -1,7 +1,7 @@
 ---
 title: "stop"
 description: "The stop command description and usage"
-keywords: ["stop, SIGKILL, SIGTERM"]
+keywords: "stop, SIGKILL, SIGTERM"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -1,7 +1,7 @@
 ---
 title: "swarm init"
 description: "The swarm init command description and usage"
-keywords: ["swarm, init"]
+keywords: "swarm, init"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -1,7 +1,7 @@
 ---
 title: "swarm join"
 description: "The swarm join command description and usage"
-keywords: ["swarm, join"]
+keywords: "swarm, join"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/swarm_join_token.md
+++ b/docs/reference/commandline/swarm_join_token.md
@@ -1,7 +1,7 @@
 ---
 title: "swarm join-token"
 description: "The swarm join-token command description and usage"
-keywords: ["swarm, join-token"]
+keywords: "swarm, join-token"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -1,7 +1,7 @@
 ---
 title: "swarm leave"
 description: "The swarm leave command description and usage"
-keywords: ["swarm, leave"]
+keywords: "swarm, leave"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -1,7 +1,7 @@
 ---
 title: "swarm update"
 description: "The swarm update command description and usage"
-keywords: ["swarm, update"]
+keywords: "swarm, update"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -1,7 +1,7 @@
 ---
 title: "system df"
 description: "The system df command description and usage"
-keywords: [system, data, usage, disk]
+keywords: "system, data, usage, disk"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -1,7 +1,7 @@
 ---
 title: "system prune"
 description: "Remove unused data"
-keywords: [system, prune, delete, remove]
+keywords: "system, prune, delete, remove"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -1,7 +1,7 @@
 ---
 title: "tag"
 description: "The tag command description and usage"
-keywords: ["tag, name, image"]
+keywords: "tag, name, image"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/top.md
+++ b/docs/reference/commandline/top.md
@@ -1,7 +1,7 @@
 ---
 title: "top"
 description: "The top command description and usage"
-keywords: ["container, running, processes"]
+keywords: "container, running, processes"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -1,7 +1,7 @@
 ---
 title: "unpause"
 description: "The unpause command description and usage"
-keywords: ["cgroups, suspend, container"]
+keywords: "cgroups, suspend, container"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -1,7 +1,7 @@
 ---
 title: "update"
 description: "The update command description and usage"
-keywords: ["resources, update, dynamically"]
+keywords: "resources, update, dynamically"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -1,7 +1,7 @@
 ---
 title: "version"
 description: "The version command description and usage"
-keywords: ["version, architecture, api"]
+keywords: "version, architecture, api"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -1,7 +1,7 @@
 ---
 title: "volume create"
 description: "The volume create command description and usage"
-keywords: ["volume, create"]
+keywords: "volume, create"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -1,7 +1,7 @@
 ---
 title: "volume inspect"
 description: "The volume inspect command description and usage"
-keywords: ["volume, inspect"]
+keywords: "volume, inspect"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -1,7 +1,7 @@
 ---
 title: "volume ls"
 description: "The volume ls command description and usage"
-keywords: ["volume, list"]
+keywords: "volume, list"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -1,7 +1,7 @@
 ---
 title: "volume prune"
 description: "Remove unused volumes"
-keywords: [volume, prune, delete]
+keywords: "volume, prune, delete"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -1,7 +1,7 @@
 ---
 title: "volume rm"
 description: "the volume rm command description and usage"
-keywords: ["volume, rm"]
+keywords: "volume, rm"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/commandline/wait.md
+++ b/docs/reference/commandline/wait.md
@@ -1,7 +1,7 @@
 ---
 title: "wait"
 description: "The wait command description and usage"
-keywords: ["container, stop, wait"]
+keywords: "container, stop, wait"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker Glossary"
 description: "Glossary of terms used around Docker"
-keywords: ["glossary, docker, terms,  definitions"]
+keywords: "glossary, docker, terms, definitions"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Engine reference"
 description: "Docker Engine reference"
-keywords: ["Engine"]
+keywords: "Engine"
 ---
 
 <!-- This file is maintained within the docker/docker Github

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker run reference"
 description: "Configure containers at runtime"
-keywords: ["docker, run, configure,  runtime"]
+keywords: "docker, run, configure, runtime"
 ---
 
 <!-- This file is maintained within the docker/docker Github


### PR DESCRIPTION
contributes to docker/docker.github.io#435

I fixed the type of the keywords value in the frontmatter header of some documentation files.
This PR concerns only files located in `/docs/reference/`.
@thaJeztah I did a separate PR for those files as I wasn't sure if they were generated or not,
but apparently they are not. (not yet)

Thanks. 🐨

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>