### PR TITLE
Run lint on most of api/types

### DIFF
--- a/hack/validate/lint
+++ b/hack/validate/lint
@@ -4,7 +4,7 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/.validate"
 
 IFS=$'\n'
-files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' | grep -v '^api/types/' || true) )
+files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' | grep -v '^api/types/container/' || true) )
 unset IFS
 
 errors=()


### PR DESCRIPTION
The validate-lint script excludes any package names that match
`api/types`. However, the only subpackage that appears to cause issues is
`api/types/container` (due to stuttering names). Tighten the filtering so
that other code inside `api/types` is validated.