### PR TITLE
Rectify Images display information for docker 1.10.3

### DIFF
--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -111,7 +111,7 @@ information about the devicemapper storage driver is shown:
      Running: 3
      Paused: 1
      Stopped: 10
-    Untagged Images: 52
+    Images: 52
     Server Version: 1.10.3
     Storage Driver: devicemapper
      Pool Name: docker-202:2-25583803-pool


### PR DESCRIPTION
In docker version 1.10.3, it should be "Images" not "Untagged Images".