### PR TITLE
check container's cidfile and delete it when removing the container.

### DIFF
--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
+	"os"
 )
 
 // ContainerRemove kills and removes a container from the docker host.
@@ -21,7 +22,21 @@ func (cli *Client) ContainerRemove(ctx context.Context, containerID string, opti
 		query.Set("force", "1")
 	}
 
+	// check and remove cidfile directly
+	removeCidFile(cli, ctx, containerID)
+
 	resp, err := cli.delete(ctx, "/containers/"+containerID, query, nil)
 	ensureReaderClosed(resp)
 	return err
+}
+
+func removeCidFile(cli *Client, ctx context.Context, containerID string) {
+	cj, _ := cli.ContainerInspect(ctx, containerID)
+
+	if cj.ContainerJSONBase != nil && cj.HostConfig != nil {
+		cidfile := cj.HostConfig.ContainerIDFile
+		if len(cidfile) > 0 {
+			os.Remove(cidfile)
+		}
+	}
 }


### PR DESCRIPTION
**- What I did**
When I practise 'docker run' command with it's parameter, I found I can set volume and it's can be deleted when remvoe container, but according to the container's idfile(--cidfile), there is no way to delete it using 'docker rm'. I think the file was created by docker, and it would be deleted by docker also. So, I try to impliment it.

**- How I did it**
Because the cidfile is created in user's client host, so the deletion task would be executed by docker when removing container. So, I find out container_remove.go and add my delete cidfile impliment. 

**- How to verify it**
1. make project

2. copy executable program to /usr/bin

service docker stop
cp -f bundles/1.13.0-dev/binary-daemon/dockerd-1.13.0-dev /usr/bin/dockerd ;
cp -f bundles/1.13.0-dev/binary-daemon/docker-containerd /usr/bin/ ;
cp -f bundles/1.13.0-dev/binary-daemon/docker-containerd-ctr /usr/bin/ ;
cp -f bundles/1.13.0-dev/binary-daemon/docker-containerd-shim /usr/bin/ ;
cp -f bundles/1.13.0-dev/binary-daemon/docker-init /usr/bin/ ;
cp -f bundles/1.13.0-dev/binary-daemon/docker-proxy /usr/bin/ ;
cp -f bundles/1.13.0-dev/binary-daemon/docker-runc /usr/bin/ ;
cp -f bundles/1.13.0-dev/binary-client/docker-1.13.0-dev /usr/bin/docker
service docker start

3. create a container with --cidfile
docker run --name h2 --cidfile=/tmp/h2.pid hello-world

4. remove the container
docker rm h2

5. check the cidfile is not exited.

ps: based on https://github.com/docker/docker/pull/27981

**- Description for the changelog**
Check and delete cidfile if existed when removing container.


Signed-off-by: wefine <wang.xiaoren@zte.com.cn>