### PR TITLE
delete reduntant description in run.md

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -143,7 +143,7 @@ previous changes intact using `docker start`. See `docker ps -a` to view a list
 of all containers.
 
 The `docker run` command can be used in combination with `docker commit` to
-[*change the command that a container runs*](commit.md). There is additional detailed information about `docker run` in the [Docker run reference](../run.md).
+[*change the command that a container runs*](commit.md). 
 
 For information on connecting a container to a network, see the ["*Docker network overview*"](https://docs.docker.com/engine/userguide/networking/).
 


### PR DESCRIPTION
this md doc is run.md, so the description is reduntant, better to remove it, or else it will cause misunderstand.