### PR TITLE
Windows: Allow API v1.24

### DIFF
--- a/api/common_windows.go
+++ b/api/common_windows.go
@@ -1,4 +1,8 @@
 package api
 
 // MinVersion represents Minimum REST API version supported
-const MinVersion string = "1.25"
+// Technically the first daemon API version released on Windows is v1.25 in
+// engine version 1.13. However, some clients are explicitly using downlevel
+// APIs (eg docker-compose v2.1 file format) and that is just too restrictive.
+// Hence also allowing 1.24 on Windows.
+const MinVersion string = "1.24"


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@patricklang @thajeztah

As per conversations, dropping the minimum API version on Windows to v1.24 to allow docker compose v2.1 to work against the Windows engine.