### PR TITLE
Use sha512 when gpg signing builds

### DIFF
--- a/hack/make/release-deb
+++ b/hack/make/release-deb
@@ -114,7 +114,7 @@ for dir in bundles/$VERSION/build-deb/*/; do
 			# if we have a $GPG_PASSPHRASE we may as well
 			# dpkg-sign before copying the deb into the pool
 			if [ ! -z "$GPG_PASSPHRASE" ]; then
-				dpkg-sig -g "--no-tty --passphrase '$GPG_PASSPHRASE'" \
+				dpkg-sig -g "--no-tty  --digest-algo 'sha512' --passphrase '$GPG_PASSPHRASE'" \
 					-k "$GPG_KEYID" --sign builder "$tempdir/$d"
 			fi
 			mv "$tempdir/$d" "$APTDIR/pool/$component/d/docker-engine/"

--- a/hack/make/release-rpm
+++ b/hack/make/release-rpm
@@ -59,7 +59,7 @@ for dir in bundles/$VERSION/build-rpm/*/; do
 			--define "_gpg_name $GPG_KEYID" \
 			--define "_signature gpg" \
 			--define "__gpg_check_password_cmd /bin/true" \
-			--define "__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --passphrase '$GPG_PASSPHRASE' --no-secmem-warning -u '%{_gpg_name}' --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}" \
+			--define "__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --digest-algo 'sha512' --passphrase '$GPG_PASSPHRASE' --no-secmem-warning -u '%{_gpg_name}' --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}" \
 			--resign "${RPMFILE[@]}"
 	fi
 

--- a/hack/make/sign-repos
+++ b/hack/make/sign-repos
@@ -28,6 +28,7 @@ sign_packages(){
 		for F in $(find $APTDIR -name Release); do
 			if test "$F" -nt "$F.gpg" ; then
 				gpg -u "$GPG_KEYID" --passphrase "$GPG_PASSPHRASE" \
+					--digest-algo "sha512" \
 					--armor --sign --detach-sign \
 					--batch --yes \
 					--output "$F.gpg" "$F"
@@ -35,6 +36,7 @@ sign_packages(){
 			inRelease="$(dirname "$F")/InRelease"
 			if test "$F" -nt "$inRelease" ; then
 				gpg -u "$GPG_KEYID" --passphrase "$GPG_PASSPHRASE" \
+					--digest-algo "sha512" \
 					--clearsign \
 					--batch --yes \
 					--output "$inRelease" "$F"
@@ -51,6 +53,7 @@ sign_packages(){
 		for F in $(find $YUMDIR -name repomd.xml); do
 			if test "$F" -nt "$F.asc" ; then
 				gpg -u "$GPG_KEYID" --passphrase "$GPG_PASSPHRASE" \
+					--digest-algo "sha512" \
 					--armor --sign --detach-sign \
 					--batch --yes \
 					--output "$F.asc" "$F"


### PR DESCRIPTION
This change ensures that all package signing is using sha512, making the digest algorithm used to sign packages less machine dependent. 

ping @andrewhsu 