### PR TITLE
Add `--tty` to `docker service create/update`

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -294,6 +294,7 @@ type serviceOptions struct {
 	workdir         string
 	user            string
 	groups          []string
+	tty             bool
 	mounts          opts.MountOpt
 
 	resources resourceOptions
@@ -365,6 +366,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 				Dir:             opts.workdir,
 				User:            opts.user,
 				Groups:          opts.groups,
+				TTY:             opts.tty,
 				Mounts:          opts.mounts.Value(),
 				StopGracePeriod: opts.stopGrace.Value(),
 			},
@@ -450,6 +452,8 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.healthcheck.timeout, flagHealthTimeout, "Maximum time to allow one check to run")
 	flags.IntVar(&opts.healthcheck.retries, flagHealthRetries, 0, "Consecutive failures needed to report unhealthy")
 	flags.BoolVar(&opts.healthcheck.noHealthcheck, flagNoHealthcheck, false, "Disable any container-specified HEALTHCHECK")
+
+	flags.BoolVarP(&opts.tty, flagTTY, "t", false, "Allocate a pseudo-TTY")
 }
 
 const (
@@ -490,6 +494,7 @@ const (
 	flagRestartMaxAttempts    = "restart-max-attempts"
 	flagRestartWindow         = "restart-window"
 	flagStopGracePeriod       = "stop-grace-period"
+	flagTTY                   = "tty"
 	flagUpdateDelay           = "update-delay"
 	flagUpdateFailureAction   = "update-failure-action"
 	flagUpdateMaxFailureRatio = "update-max-failure-ratio"

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -274,6 +274,14 @@ func updateService(flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 		return err
 	}
 
+	if flags.Changed(flagTTY) {
+		tty, err := flags.GetBool(flagTTY)
+		if err != nil {
+			return err
+		}
+		cspec.TTY = tty
+	}
+
 	return nil
 }
 

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -22,6 +22,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 		Dir:      c.Dir,
 		User:     c.User,
 		Groups:   c.Groups,
+		TTY:      c.TTY,
 	}
 
 	// Mounts
@@ -77,6 +78,7 @@ func containerToGRPC(c types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		Dir:      c.Dir,
 		User:     c.User,
 		Groups:   c.Groups,
+		TTY:      c.TTY,
 	}
 
 	if c.StopGracePeriod != nil {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -127,6 +127,7 @@ func (c *containerConfig) image() string {
 func (c *containerConfig) config() *enginecontainer.Config {
 	config := &enginecontainer.Config{
 		Labels:      c.labels(),
+		Tty:         c.spec().TTY,
 		User:        c.spec().User,
 		Hostname:    c.spec().Hostname,
 		Env:         c.spec().Env,

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -167,6 +167,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * The `HostConfig` field now includes `NanoCPUs` that represents CPU quota in units of 10<sup>-9</sup> CPUs.
 * `GET /info` now returns more structured information about security options.
 * The `HostConfig` field now includes `CpuCount` that represents the number of CPUs available for execution by the container. Windows daemon only.
+* `POST /services/create` and `POST /services/(id or name)/update` now accept the `TTY` parameter, which allocate a pseudo-TTY in container.
 
 ### v1.24 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -5102,7 +5102,8 @@ image](#create-an-image) section for more details.
               }
             }
           ],
-          "User": "33"
+          "User": "33",
+          "TTY": false
         },
         "LogDriver": {
           "Name": "json-file",
@@ -5179,6 +5180,7 @@ image](#create-an-image) section for more details.
         - **User** – A string value specifying the user inside the container.
         - **Labels** – A map of labels to associate with the service (e.g.,
           `{"key":"value", "key2":"value2"}`).
+        - **TTY** – A boolean indicating whether a pseudo-TTY should be allocated.
         - **Mounts** – Specification for mounts to be added to containers
           created as part of the service.
             - **Target** – Container path.
@@ -5380,7 +5382,8 @@ image](#create-an-image) section for more details.
           "Image": "busybox",
           "Args": [
             "top"
-          ]
+          ],
+          "TTY": true
         },
         "Resources": {
           "Limits": {},
@@ -5428,6 +5431,7 @@ image](#create-an-image) section for more details.
         - **User** – A string value specifying the user inside the container.
         - **Labels** – A map of labels to associate with the service (e.g.,
           `{"key":"value", "key2":"value2"}`).
+        - **TTY** – A boolean indicating whether a pseudo-TTY should be allocated.
         - **Mounts** – Specification for mounts to be added to containers created as part of the new
           service.
             - **Target** – Container path.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -52,6 +52,7 @@ Options:
       --restart-max-attempts value       Maximum number of restarts before giving up (default none)
       --restart-window value             Window used to evaluate the restart policy (default none)
       --stop-grace-period value          Time to wait before force killing a container (default none)
+  -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")
       --update-max-failure-ratio value   Failure rate to tolerate during an update

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -58,6 +58,7 @@ Options:
       --restart-window value             Window used to evaluate the restart policy (default none)
       --rollback                         Rollback to previous specification
       --stop-grace-period value          Time to wait before force killing a container (default none)
+  -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")
       --update-max-failure-ratio value   Failure rate to tolerate during an update


### PR DESCRIPTION
**- What I did**

This fix tries to add `--tty` to `docker service create/update`. As was specified in #25644, `TTY` flag has been added to SwarmKit and is already vendored.

**- How I did it**

This fix add `--tty` to `docker service create/update`.

Related document has been updated.

**- How to verify it**

Additional integration tests has been added.

**- Description for the changelog**

Add `--tty` flag to `docker service create/update`.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute_kitten-wide](https://cloud.githubusercontent.com/assets/6932348/20018981/653bd31a-a287-11e6-8d9d-df661acfc6b9.jpg)


This fix fixes #25644.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>