### PR TITLE
Show peer nodes in network inspect for swarm overlay networks

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -28,6 +28,12 @@ type EndpointIPAMConfig struct {
 	LinkLocalIPs []string `json:",omitempty"`
 }
 
+// PeerInfo represents one peer of a overlay network
+type PeerInfo struct {
+	Name string
+	IP   string
+}
+
 // EndpointSettings stores the network endpoint details
 type EndpointSettings struct {
 	// Configurations

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -395,6 +395,7 @@ type NetworkResource struct {
 	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
 	Options    map[string]string           // Options holds the network specific options to use for when creating the network
 	Labels     map[string]string           // Labels holds metadata specific to the network being created
+	Peers      []network.PeerInfo          `json:",omitempty"` // List of peer nodes for an overlay network
 }
 
 // EndpointResource contains network resources allocated and used for a container in a network

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -171,6 +171,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 * The `HostConfig` field now includes `CpuCount` that represents the number of CPUs available for execution by the container. Windows daemon only.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept the `TTY` parameter, which allocate a pseudo-TTY in container.
 * `POST /services/create` and `POST /services/(id or name)/update` now accept the `DNSConfig` parameter, which specifies DNS related configurations in resolver configuration file (resolv.conf) through `Nameservers`, `Search`, and `Options`.
+* `GET /networks/(id or name)` now includes IP and name of all peers nodes for swarm mode overlay networks.
 
 ### v1.24 API changes
 

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -124,6 +124,63 @@ $ docker network inspect simple-network
 ]
 ```
 
+For swarm mode overlay networks `network inspect` also shows the IP address and node name 
+of the peers. Peers are the nodes in the swarm cluster which have at least one task attached 
+to the network. Node name is of the format `<hostname>-<unique ID>`.
+
+```bash
+$ docker network inspect ingress
+[
+    {
+        "Name": "ingress",
+        "Id": "j0izitrut30h975vk4m1u5kk3",
+        "Created": "2016-11-08T06:49:59.803387552Z",
+        "Scope": "swarm",
+        "Driver": "overlay",
+        "EnableIPv6": false,
+        "IPAM": {
+            "Driver": "default",
+            "Options": null,
+            "Config": [
+                {
+                    "Subnet": "10.255.0.0/16",
+                    "Gateway": "10.255.0.1"
+                }
+            ]
+        },
+        "Internal": false,
+        "Attachable": false,
+        "Containers": {
+            "ingress-sbox": {
+                "Name": "ingress-endpoint",
+                "EndpointID": "40e002d27b7e5d75f60bc72199d8cae3344e1896abec5eddae9743755fe09115",
+                "MacAddress": "02:42:0a:ff:00:03",
+                "IPv4Address": "10.255.0.3/16",
+                "IPv6Address": ""
+            }
+        },
+        "Options": {
+            "com.docker.network.driver.overlay.vxlanid_list": "256"
+        },
+        "Labels": {},
+        "Peers": [
+            {
+                "Name": "net-1-1d22adfe4d5c",
+                "IP": "192.168.33.11"
+            },
+            {
+                "Name": "net-2-d55d838b34af",
+                "IP": "192.168.33.12"
+            },
+            {
+                "Name": "net-3-8473f8140bd9",
+                "IP": "192.168.33.13"
+            }
+        ]
+    }
+]
+```
+
 ## Related information
 
 * [network disconnect ](network_disconnect.md)


### PR DESCRIPTION
swarm mode overlay networks rely on a functional gossip cluster across all nodes. If there is a firewall blocking the gossip ports or underlay network issue it can lead to inconsistent routing information across nodes leading to hard to debug connectivity issues. 

To improve the debug-ability this fix shows the peer nodes in the network inspect. In healthy state network inspect on all nodes should be consistent.

for ex: in a three node cluster, output from the lead manager..

```
vagrant@net-1:~$ docker network inspect ingress
[
    {
        "Name": "ingress",
....
....
        "Peers": [
            {
                "Name": "net-1-c1ce0cae5ec9",
                "IP": "192.168.33.11"
            },
            {
                "Name": "net-2-dfddfc3f9d91",
                "IP": "192.168.33.12"
            },
            {
                "Name": "net-3-3c4c1a195855",
                "IP": "192.168.33.13"
            }
        ]
    }
] 

Signed-off-by: Santhosh Manohar <santhosh@docker.com>