### PR TITLE
WIP: Build Secrets

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -92,6 +92,14 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 		}
 		options.BuildArgs = buildArgs
 	}
+	var buildSecrets = []*types.SecretRequestOption{}
+	buildSecretJSON := r.FormValue("buildsecrets")
+	if buildSecretJSON != "" {
+		if err := json.Unmarshal([]byte(buildSecretJSON), &buildSecrets); err != nil {
+			return nil, err
+		}
+		options.BuildSecrets = buildSecrets
+	}
 	var labels = map[string]string{}
 	labelsJSON := r.FormValue("labels")
 	if labelsJSON != "" {

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -23,4 +23,9 @@ type Backend interface {
 	RemoveNode(string, bool) error
 	GetTasks(basictypes.TaskListOptions) ([]types.Task, error)
 	GetTask(string) (types.Task, error)
+	GetSecrets(opts basictypes.SecretListOptions) ([]types.Secret, error)
+	CreateSecret(s types.SecretSpec) (string, error)
+	RemoveSecret(id string) error
+	GetSecret(id string) (types.Secret, error)
+	UpdateSecret(id string, version uint64, spec types.SecretSpec) error
 }

--- a/api/server/router/swarm/cluster.go
+++ b/api/server/router/swarm/cluster.go
@@ -41,7 +41,7 @@ func (sr *swarmRouter) initRoutes() {
 		router.NewGetRoute("/tasks", sr.getTasks),
 		router.NewGetRoute("/tasks/{id:.*}", sr.getTask),
 		router.NewGetRoute("/secrets", sr.getSecrets),
-		router.NewPostRoute("/secrets/create", sr.createSecret),
+		router.NewPostRoute("/secrets", sr.createSecret),
 		router.NewDeleteRoute("/secrets/{id:.*}", sr.removeSecret),
 		router.NewGetRoute("/secrets/{id:.*}", sr.getSecret),
 		router.NewPostRoute("/secrets/{id:.*}/update", sr.updateSecret),

--- a/api/server/router/swarm/cluster.go
+++ b/api/server/router/swarm/cluster.go
@@ -40,5 +40,10 @@ func (sr *swarmRouter) initRoutes() {
 		router.NewPostRoute("/nodes/{id:.*}/update", sr.updateNode),
 		router.NewGetRoute("/tasks", sr.getTasks),
 		router.NewGetRoute("/tasks/{id:.*}", sr.getTask),
+		router.NewGetRoute("/secrets", sr.getSecrets),
+		router.NewPostRoute("/secrets/create", sr.createSecret),
+		router.NewDeleteRoute("/secrets/{id:.*}", sr.removeSecret),
+		router.NewGetRoute("/secrets/{id:.*}", sr.getSecret),
+		router.NewPostRoute("/secrets/{id:.*}/update", sr.updateSecret),
 	}
 }

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -267,14 +267,13 @@ func (sr *swarmRouter) getSecrets(ctx context.Context, w http.ResponseWriter, r 
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	filter, err := filters.FromParam(r.Form.Get("filters"))
+	filters, err := filters.FromParam(r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
 
-	secrets, err := sr.backend.GetSecrets(basictypes.SecretListOptions{Filter: filter})
+	secrets, err := sr.backend.GetSecrets(basictypes.SecretListOptions{Filters: filters})
 	if err != nil {
-		logrus.Errorf("Error getting secrets: %v", err)
 		return err
 	}
 
@@ -289,7 +288,6 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 
 	id, err := sr.backend.CreateSecret(secret)
 	if err != nil {
-		logrus.Errorf("Error creating secret %s: %v", id, err)
 		return err
 	}
 
@@ -300,7 +298,6 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 
 func (sr *swarmRouter) removeSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := sr.backend.RemoveSecret(vars["id"]); err != nil {
-		logrus.Errorf("Error removing secret %s: %v", vars["id"], err)
 		return err
 	}
 
@@ -310,7 +307,6 @@ func (sr *swarmRouter) removeSecret(ctx context.Context, w http.ResponseWriter, 
 func (sr *swarmRouter) getSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	secret, err := sr.backend.GetSecret(vars["id"])
 	if err != nil {
-		logrus.Errorf("Error getting secret %s: %v", vars["id"], err)
 		return err
 	}
 

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -261,3 +261,77 @@ func (sr *swarmRouter) getTask(ctx context.Context, w http.ResponseWriter, r *ht
 
 	return httputils.WriteJSON(w, http.StatusOK, task)
 }
+
+func (sr *swarmRouter) getSecrets(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+	filter, err := filters.FromParam(r.Form.Get("filters"))
+	if err != nil {
+		return err
+	}
+
+	secrets, err := sr.backend.GetSecrets(basictypes.SecretListOptions{Filter: filter})
+	if err != nil {
+		logrus.Errorf("Error getting secrets: %v", err)
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, secrets)
+}
+
+func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	var secret types.SecretSpec
+	if err := json.NewDecoder(r.Body).Decode(&secret); err != nil {
+		return err
+	}
+
+	id, err := sr.backend.CreateSecret(secret)
+	if err != nil {
+		logrus.Errorf("Error creating secret %s: %v", id, err)
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusCreated, &basictypes.SecretCreateResponse{
+		ID: id,
+	})
+}
+
+func (sr *swarmRouter) removeSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := sr.backend.RemoveSecret(vars["id"]); err != nil {
+		logrus.Errorf("Error removing secret %s: %v", vars["id"], err)
+		return err
+	}
+
+	return nil
+}
+
+func (sr *swarmRouter) getSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	secret, err := sr.backend.GetSecret(vars["id"])
+	if err != nil {
+		logrus.Errorf("Error getting secret %s: %v", vars["id"], err)
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, secret)
+}
+
+func (sr *swarmRouter) updateSecret(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	var secret types.SecretSpec
+	if err := json.NewDecoder(r.Body).Decode(&secret); err != nil {
+		return err
+	}
+
+	rawVersion := r.URL.Query().Get("version")
+	version, err := strconv.ParseUint(rawVersion, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid secret version '%s': %s", rawVersion, err.Error())
+	}
+
+	id := vars["id"]
+	if err := sr.backend.UpdateSecret(id, version, secret); err != nil {
+		return fmt.Errorf("Error updating secret: %s", err)
+	}
+
+	return nil
+}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -161,6 +161,7 @@ type ImageBuildOptions struct {
 	Dockerfile     string
 	Ulimits        []*units.Ulimit
 	BuildArgs      map[string]string
+	BuildSecrets   []*SecretRequestOption
 	AuthConfigs    map[string]AuthConfig
 	Context        io.Reader
 	Labels         map[string]string

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -340,8 +340,8 @@ type PluginInstallOptions struct {
 	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
 }
 
-// SecretRequestOptions is a type for requesting secrets
-type SecretRequestOptions struct {
+// SecretRequestOption is a type for requesting secrets
+type SecretRequestOption struct {
 	Source string
 	Target string
 	UID    string

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -337,4 +338,13 @@ type PluginInstallOptions struct {
 	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
 	PrivilegeFunc         RequestPrivilegeFunc
 	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
+}
+
+// SecretRequestOptions is a type for requesting secrets
+type SecretRequestOptions struct {
+	Source string
+	Target string
+	UID    string
+	GID    string
+	Mode   os.FileMode
 }

--- a/api/types/container/secret.go
+++ b/api/types/container/secret.go
@@ -6,7 +6,7 @@ type ContainerSecret struct {
 	Name   string
 	Target string
 	Data   []byte
-	Uid    int
-	Gid    int
+	UID    int
+	GID    int
 	Mode   os.FileMode
 }

--- a/api/types/container/secret.go
+++ b/api/types/container/secret.go
@@ -2,6 +2,8 @@ package container
 
 import "os"
 
+// ContainerSecret represents a secret in a container.  This gets realized
+// in the container tmpfs
 type ContainerSecret struct {
 	Name   string
 	Target string

--- a/api/types/container/secret.go
+++ b/api/types/container/secret.go
@@ -1,0 +1,12 @@
+package container
+
+import "os"
+
+type ContainerSecret struct {
+	Name   string
+	Target string
+	Data   []byte
+	Uid    int
+	Gid    int
+	Mode   os.FileMode
+}

--- a/api/types/container/secret.go
+++ b/api/types/container/secret.go
@@ -6,7 +6,7 @@ type ContainerSecret struct {
 	Name   string
 	Target string
 	Data   []byte
-	UID    int
-	GID    int
+	UID    string
+	GID    string
 	Mode   os.FileMode
 }

--- a/api/types/swarm/container.go
+++ b/api/types/swarm/container.go
@@ -22,4 +22,5 @@ type ContainerSpec struct {
 	Mounts          []mount.Mount           `json:",omitempty"`
 	StopGracePeriod *time.Duration          `json:",omitempty"`
 	Healthcheck     *container.HealthConfig `json:",omitempty"`
+	Secrets         []*SecretReference      `json:",omitempty"`
 }

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -11,11 +11,13 @@ type Secret struct {
 	SecretSize int64
 }
 
+// SecretSpec represents a secret specification from a secret in swarm
 type SecretSpec struct {
 	Annotations
 	Data []byte
 }
 
+// SecretReferenceFileTarget is a file target in a secret reference
 type SecretReferenceFileTarget struct {
 	Name string
 	UID  string
@@ -23,6 +25,7 @@ type SecretReferenceFileTarget struct {
 	Mode os.FileMode
 }
 
+// SecretReference is a reference to a secret in swarm
 type SecretReference struct {
 	SecretID   string
 	SecretName string

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -28,12 +28,3 @@ type SecretReference struct {
 	SecretName string
 	Target     SecretReferenceFileTarget
 }
-
-// SecretRequestSpec is a type for requesting secrets
-type SecretRequestSpec struct {
-	Source string
-	Target string
-	UID    string
-	GID    string
-	Mode   os.FileMode
-}

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -4,14 +4,14 @@ package swarm
 type Secret struct {
 	ID string
 	Meta
-	Spec       *SecretSpec `json:",omitempty"`
-	Digest     string      `json:",omitempty"`
-	SecretSize int64       `json:",omitempty"`
+	Spec       SecretSpec
+	Digest     string
+	SecretSize int64
 }
 
 type SecretSpec struct {
 	Annotations
-	Data []byte `json:",omitempty"`
+	Data []byte
 }
 
 type SecretReferenceMode int
@@ -23,8 +23,8 @@ const (
 )
 
 type SecretReference struct {
-	SecretID   string              `json:",omitempty"`
-	Mode       SecretReferenceMode `json:",omitempty"`
-	Target     string              `json:",omitempty"`
-	SecretName string              `json:",omitempty"`
+	SecretID   string
+	Mode       SecretReferenceMode
+	Target     string
+	SecretName string
 }

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -26,5 +26,5 @@ type SecretReferenceFileTarget struct {
 type SecretReference struct {
 	SecretID   string
 	SecretName string
-	Target     SecretReferenceFileTarget
+	Target     *SecretReferenceFileTarget
 }

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -1,0 +1,30 @@
+package swarm
+
+// Secret represents a secret.
+type Secret struct {
+	ID string
+	Meta
+	Spec       *SecretSpec `json:",omitempty"`
+	Digest     string      `json:",omitempty"`
+	SecretSize int64       `json:",omitempty"`
+}
+
+type SecretSpec struct {
+	Annotations
+	Data []byte `json",omitempty"`
+}
+
+type SecretReferenceMode int
+
+const (
+	SecretReferenceSystem SecretReferenceMode = 0
+	SecretReferenceFile   SecretReferenceMode = 1
+	SecretReferenceEnv    SecretReferenceMode = 2
+)
+
+type SecretReference struct {
+	SecretID   string              `json:",omitempty"`
+	Mode       SecretReferenceMode `json:",omitempty"`
+	Target     string              `json:",omitempty"`
+	SecretName string              `json:",omitempty"`
+}

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -1,5 +1,7 @@
 package swarm
 
+import "os"
+
 // Secret represents a secret.
 type Secret struct {
 	ID string
@@ -14,17 +16,15 @@ type SecretSpec struct {
 	Data []byte
 }
 
-type SecretReferenceMode int
-
-const (
-	SecretReferenceSystem SecretReferenceMode = 0
-	SecretReferenceFile   SecretReferenceMode = 1
-	SecretReferenceEnv    SecretReferenceMode = 2
-)
+type SecretReferenceFileTarget struct {
+	Name string
+	UID  string
+	GID  string
+	Mode os.FileMode
+}
 
 type SecretReference struct {
 	SecretID   string
-	Mode       SecretReferenceMode
-	Target     string
 	SecretName string
+	Target     SecretReferenceFileTarget
 }

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -28,3 +28,12 @@ type SecretReference struct {
 	SecretName string
 	Target     SecretReferenceFileTarget
 }
+
+// SecretRequestSpec is a type for requesting secrets
+type SecretRequestSpec struct {
+	Source string
+	Target string
+	UID    string
+	GID    string
+	Mode   os.FileMode
+}

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -11,7 +11,7 @@ type Secret struct {
 
 type SecretSpec struct {
 	Annotations
-	Data []byte `json",omitempty"`
+	Data []byte `json:",omitempty"`
 }
 
 type SecretReferenceMode int

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
@@ -489,4 +490,16 @@ type ImagesPruneReport struct {
 // POST "/networks/prune"
 type NetworksPruneReport struct {
 	NetworksDeleted []string
+}
+
+// SecretCreateResponse contains the information returned to a client
+// on the creation of a new secret.
+type SecretCreateResponse struct {
+	// ID is the id of the created secret.
+	ID string
+}
+
+// SecretListOptions holds parameters to list secrets
+type SecretListOptions struct {
+	Filter filters.Args
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -501,5 +501,5 @@ type SecretCreateResponse struct {
 
 // SecretListOptions holds parameters to list secrets
 type SecretListOptions struct {
-	Filter filters.Args
+	Filters filters.Args
 }

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -80,6 +80,7 @@ type Builder struct {
 
 	imageCache builder.ImageCache
 	from       builder.Image
+	bindMounts []string
 }
 
 // BuildManager implements builder.Backend and is shared across all Builder objects.

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/cli/command/node"
 	"github.com/docker/docker/cli/command/plugin"
 	"github.com/docker/docker/cli/command/registry"
+	"github.com/docker/docker/cli/command/secret"
 	"github.com/docker/docker/cli/command/service"
 	"github.com/docker/docker/cli/command/stack"
 	"github.com/docker/docker/cli/command/swarm"
@@ -25,6 +26,7 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		node.NewNodeCommand(dockerCli),
 		service.NewServiceCommand(dockerCli),
 		swarm.NewSwarmCommand(dockerCli),
+		secret.NewSecretCommand(dockerCli),
 		container.NewContainerCommand(dockerCli),
 		image.NewImageCommand(dockerCli),
 		system.NewSystemCommand(dockerCli),

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -1,0 +1,29 @@
+package secret
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+)
+
+// NewSecretCommand returns a cobra command for `secret` subcommands
+func NewSecretCommand(dockerCli *command.DockerCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secret",
+		Short: "Manage Docker secrets",
+		Args:  cli.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
+		},
+	}
+	cmd.AddCommand(
+		newSecretListCommand(dockerCli),
+		newSecretCreateCommand(dockerCli),
+		newSecretInspectCommand(dockerCli),
+		newSecretRemoveCommand(dockerCli),
+	)
+	return cmd
+}

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -1,0 +1,57 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	name string
+}
+
+func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "create [name]",
+		Short: "Create a secret using stdin as content",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := createOptions{
+				name: args[0],
+			}
+
+			return runSecretCreate(dockerCli, opts)
+		},
+	}
+}
+
+func runSecretCreate(dockerCli *command.DockerCli, opts createOptions) error {
+	client := dockerCli.Client()
+	ctx := context.Background()
+
+	secretData, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("Error reading content from STDIN: %v", err)
+	}
+
+	spec := swarm.SecretSpec{
+		Annotations: swarm.Annotations{
+			Name: opts.name,
+		},
+		Data: secretData,
+	}
+
+	r, err := client.SecretCreate(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(dockerCli.Out(), r.ID)
+	return nil
+}

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -35,7 +35,7 @@ func runSecretInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	ctx := context.Background()
 
 	// attempt to lookup secret by name
-	secrets, err := getSecrets(client, ctx, []string{opts.name})
+	secrets, err := getSecretsByName(client, ctx, []string{opts.name})
 	if err != nil {
 		return err
 	}

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -1,0 +1,42 @@
+package secret
+
+import (
+	"context"
+
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/cli/command/inspect"
+	"github.com/spf13/cobra"
+)
+
+type inspectOptions struct {
+	name   string
+	format string
+}
+
+func newSecretInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
+	opts := inspectOptions{}
+	cmd := &cobra.Command{
+		Use:   "inspect [name]",
+		Short: "Inspect a secret",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.name = args[0]
+			return runSecretInspect(dockerCli, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.format, "format", "f", "", "Format the output using the given go template")
+	return cmd
+}
+
+func runSecretInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
+	client := dockerCli.Client()
+	ctx := context.Background()
+
+	getRef := func(name string) (interface{}, []byte, error) {
+		return client.SecretInspectWithRaw(ctx, name)
+	}
+
+	return inspect.Inspect(dockerCli.Out(), []string{opts.name}, opts.format, getRef)
+}

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -1,0 +1,62 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type listOptions struct {
+	quiet bool
+}
+
+func newSecretListCommand(dockerCli *command.DockerCli) *cobra.Command {
+	opts := listOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List secrets",
+		Args:  cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSecretList(dockerCli, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display IDs")
+
+	return cmd
+}
+
+func runSecretList(dockerCli *command.DockerCli, opts listOptions) error {
+	client := dockerCli.Client()
+	ctx := context.Background()
+
+	secrets, err := client.SecretList(ctx, types.SecretListOptions{})
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(dockerCli.Out(), 20, 1, 3, ' ', 0)
+	if opts.quiet {
+		for _, s := range secrets {
+			fmt.Fprintf(w, "%s\n", s.ID)
+		}
+	} else {
+		fmt.Fprintf(w, "ID\tNAME\tCREATED\tUPDATED\tSIZE")
+		fmt.Fprintf(w, "\n")
+
+		for _, s := range secrets {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", s.ID, s.Spec.Annotations.Name, s.Meta.CreatedAt, s.Meta.UpdatedAt, s.SecretSize)
+		}
+	}
+
+	w.Flush()
+
+	return nil
+}

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -32,7 +32,7 @@ func runSecretRemove(dockerCli *command.DockerCli, opts removeOptions) error {
 	ctx := context.Background()
 
 	// attempt to lookup secret by name
-	secrets, err := getSecrets(client, ctx, opts.ids)
+	secrets, err := getSecretsByName(client, ctx, opts.ids)
 	if err != nil {
 		return err
 	}

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -1,0 +1,43 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type removeOptions struct {
+	ids []string
+}
+
+func newSecretRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm [id]",
+		Short: "Remove a secret",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := removeOptions{
+				ids: args,
+			}
+			return runSecretRemove(dockerCli, opts)
+		},
+	}
+}
+
+func runSecretRemove(dockerCli *command.DockerCli, opts removeOptions) error {
+	client := dockerCli.Client()
+	ctx := context.Background()
+
+	for _, id := range opts.ids {
+		if err := client.SecretRemove(ctx, id); err != nil {
+			return err
+		}
+
+		fmt.Fprintln(dockerCli.Out(), id)
+	}
+
+	return nil
+}

--- a/cli/command/secret/utils.go
+++ b/cli/command/secret/utils.go
@@ -9,13 +9,13 @@ import (
 	"github.com/docker/docker/client"
 )
 
-func getSecrets(client client.APIClient, ctx context.Context, names []string) ([]swarm.Secret, error) {
+func getSecretsByName(client client.APIClient, ctx context.Context, names []string) ([]swarm.Secret, error) {
 	args := filters.NewArgs()
 	for _, n := range names {
 		args.Add("names", n)
 	}
 
 	return client.SecretList(ctx, types.SecretListOptions{
-		Filter: args,
+		Filters: args,
 	})
 }

--- a/cli/command/secret/utils.go
+++ b/cli/command/secret/utils.go
@@ -1,0 +1,21 @@
+package secret
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+)
+
+func getSecrets(client client.APIClient, ctx context.Context, names []string) ([]swarm.Secret, error) {
+	args := filters.NewArgs()
+	for _, n := range names {
+		args.Add("names", n)
+	}
+
+	return client.SecretList(ctx, types.SecretListOptions{
+		Filter: args,
+	})
+}

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -37,6 +37,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.VarP(&opts.env, flagEnv, "e", "Set environment variables")
 	flags.Var(&opts.envFile, flagEnvFile, "Read in a file of environment variables")
 	flags.Var(&opts.mounts, flagMount, "Attach a filesystem mount to the service")
+	flags.Var(&opts.secrets, flagSecret, "Specify secrets to expose to the service")
 	flags.StringSliceVar(&opts.constraints, flagConstraint, []string{}, "Placement constraints")
 	flags.StringSliceVar(&opts.networks, flagNetwork, []string{}, "Network attachments")
 	flags.VarP(&opts.endpoint.ports, flagPublish, "p", "Publish a port as a node port")
@@ -56,7 +57,7 @@ func runCreate(dockerCli *command.DockerCli, opts *serviceOptions) error {
 	}
 
 	// parse and validate secrets
-	secrets, err := parseSecrets(apiClient, opts.secrets)
+	secrets, err := parseSecrets(apiClient, opts.secrets.Value())
 	if err != nil {
 		return err
 	}

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -55,6 +55,13 @@ func runCreate(dockerCli *command.DockerCli, opts *serviceOptions) error {
 		return err
 	}
 
+	// parse and validate secrets
+	secrets, err := parseSecrets(apiClient, opts.secrets)
+	if err != nil {
+		return err
+	}
+	service.TaskTemplate.ContainerSpec.Secrets = secrets
+
 	ctx := context.Background()
 
 	// only send auth if flag was set

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -199,19 +199,6 @@ func convertNetworks(networks []string) []swarm.NetworkAttachmentConfig {
 	return nets
 }
 
-func convertSecrets(secrets []string) []*swarm.SecretReference {
-	sec := []*swarm.SecretReference{}
-	for _, s := range secrets {
-		sec = append(sec, &swarm.SecretReference{
-			SecretID: s,
-			Mode:     swarm.SecretReferenceFile,
-			Target:   "",
-		})
-	}
-
-	return sec
-}
-
 type endpointOptions struct {
 	mode  string
 	ports opts.ListOpts
@@ -409,7 +396,7 @@ func (opts *serviceOptions) ToService() (swarm.ServiceSpec, error) {
 				Groups:          opts.groups,
 				Mounts:          opts.mounts.Value(),
 				StopGracePeriod: opts.stopGrace.Value(),
-				Secrets:         convertSecrets(opts.secrets),
+				Secrets:         nil,
 			},
 			Networks:      convertNetworks(opts.networks),
 			Resources:     opts.resources.ToResourceRequirements(),

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -537,4 +537,6 @@ const (
 	flagHealthTimeout         = "health-timeout"
 	flagNoHealthcheck         = "no-healthcheck"
 	flagSecret                = "secret"
+	flagSecretAdd             = "secret-add"
+	flagSecretRemove          = "secret-rm"
 )

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -1,8 +1,11 @@
 package service
 
 import (
+	"encoding/csv"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -145,6 +148,98 @@ func (i *Uint64Opt) String() string {
 // Value returns the uint64
 func (i *Uint64Opt) Value() *uint64 {
 	return i.value
+}
+
+// SecretRequestSpec is a type for requesting secrets
+type SecretRequestSpec struct {
+	source string
+	target string
+	uid    string
+	gid    string
+	mode   os.FileMode
+}
+
+// SecretOpt is a Value type for parsing secrets
+type SecretOpt struct {
+	values []*SecretRequestSpec
+}
+
+// Set a new secret value
+func (o *SecretOpt) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	spec := &SecretRequestSpec{
+		source: "",
+		target: "",
+		uid:    "0",
+		gid:    "0",
+		mode:   0444,
+	}
+
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		key := strings.ToLower(parts[0])
+
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid field '%s' must be a key=value pair", field)
+		}
+
+		value := parts[1]
+		switch key {
+		case "source":
+			spec.source = value
+		case "target":
+			tDir, _ := filepath.Split(value)
+			if tDir != "" {
+				return fmt.Errorf("target must not have a path")
+			}
+			spec.target = value
+		case "uid":
+			spec.uid = value
+		case "gid":
+			spec.gid = value
+		case "mode":
+			m, err := strconv.ParseUint(value, 0, 32)
+			if err != nil {
+				return fmt.Errorf("invalid mode specified: %v", err)
+			}
+
+			spec.mode = os.FileMode(m)
+		default:
+			return fmt.Errorf("invalid field in secret request: %s", key)
+		}
+	}
+
+	if spec.source == "" {
+		return fmt.Errorf("source is required")
+	}
+
+	o.values = append(o.values, spec)
+	return nil
+}
+
+// Type returns the type of this option
+func (o *SecretOpt) Type() string {
+	return "secret"
+}
+
+// String returns a string repr of this option
+func (o *SecretOpt) String() string {
+	secrets := []string{}
+	for _, secret := range o.values {
+		repr := fmt.Sprintf("%s -> %s", secret.source, secret.target)
+		secrets = append(secrets, repr)
+	}
+	return strings.Join(secrets, ", ")
+}
+
+// Value returns the secret requests
+func (o *SecretOpt) Value() []*SecretRequestSpec {
+	return o.values
 }
 
 type updateOptions struct {
@@ -341,7 +436,7 @@ type serviceOptions struct {
 	logDriver logDriverOptions
 
 	healthcheck healthCheckOptions
-	secrets     []string
+	secrets     SecretOpt
 }
 
 func newServiceOptions() *serviceOptions {
@@ -480,7 +575,6 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.healthcheck.timeout, flagHealthTimeout, "Maximum time to allow one check to run")
 	flags.IntVar(&opts.healthcheck.retries, flagHealthRetries, 0, "Consecutive failures needed to report unhealthy")
 	flags.BoolVar(&opts.healthcheck.noHealthcheck, flagNoHealthcheck, false, "Disable any container-specified HEALTHCHECK")
-	flags.StringSliceVar(&opts.secrets, flagSecret, []string{}, "Specify secrets to expose to the service")
 }
 
 const (

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -1,13 +1,11 @@
 package service
 
 import (
-	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/testutil/assert"
 )
 
@@ -105,48 +103,4 @@ func TestHealthCheckOptionsToHealthConfigConflict(t *testing.T) {
 	}
 	_, err := opt.toHealthConfig()
 	assert.Error(t, err, "--no-healthcheck conflicts with --health-* options")
-}
-
-func TestSecretOptionsSimple(t *testing.T) {
-	var opt opts.SecretOpt
-
-	testCase := "source=foo,target=testing"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Equal(t, len(reqs), 1)
-	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
-	assert.Equal(t, req.Target, "testing")
-}
-
-func TestSecretOptionsCustomUidGid(t *testing.T) {
-	var opt opts.SecretOpt
-
-	testCase := "source=foo,target=testing,uid=1000,gid=1001"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Equal(t, len(reqs), 1)
-	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
-	assert.Equal(t, req.Target, "testing")
-	assert.Equal(t, req.UID, "1000")
-	assert.Equal(t, req.GID, "1001")
-}
-
-func TestSecretOptionsCustomMode(t *testing.T) {
-	var opt opts.SecretOpt
-
-	testCase := "source=foo,target=testing,uid=1000,gid=1001,mode=0444"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Equal(t, len(reqs), 1)
-	req := reqs[0]
-	assert.Equal(t, req.Source, "foo")
-	assert.Equal(t, req.Target, "testing")
-	assert.Equal(t, req.UID, "1000")
-	assert.Equal(t, req.GID, "1001")
-	assert.Equal(t, req.Mode, os.FileMode(0444))
 }

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -103,4 +104,48 @@ func TestHealthCheckOptionsToHealthConfigConflict(t *testing.T) {
 	}
 	_, err := opt.toHealthConfig()
 	assert.Error(t, err, "--no-healthcheck conflicts with --health-* options")
+}
+
+func TestSecretOptionsSimple(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "source=/foo,target=testing"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.source, "/foo")
+	assert.Equal(t, req.target, "testing")
+}
+
+func TestSecretOptionsCustomUidGid(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "source=/foo,target=testing,uid=1000,gid=1001"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.source, "/foo")
+	assert.Equal(t, req.target, "testing")
+	assert.Equal(t, req.uid, "1000")
+	assert.Equal(t, req.gid, "1001")
+}
+
+func TestSecretOptionsCustomMode(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "source=/foo,target=testing,uid=1000,gid=1001,mode=0444"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.source, "/foo")
+	assert.Equal(t, req.target, "testing")
+	assert.Equal(t, req.uid, "1000")
+	assert.Equal(t, req.gid, "1001")
+	assert.Equal(t, req.mode, os.FileMode(0444))
 }

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/testutil/assert"
 )
 
@@ -107,45 +108,45 @@ func TestHealthCheckOptionsToHealthConfigConflict(t *testing.T) {
 }
 
 func TestSecretOptionsSimple(t *testing.T) {
-	var opt SecretOpt
+	var opt opts.SecretOpt
 
-	testCase := "source=/foo,target=testing"
+	testCase := "source=foo,target=testing"
 	assert.NilError(t, opt.Set(testCase))
 
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.source, "/foo")
-	assert.Equal(t, req.target, "testing")
+	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.Target, "testing")
 }
 
 func TestSecretOptionsCustomUidGid(t *testing.T) {
-	var opt SecretOpt
+	var opt opts.SecretOpt
 
-	testCase := "source=/foo,target=testing,uid=1000,gid=1001"
+	testCase := "source=foo,target=testing,uid=1000,gid=1001"
 	assert.NilError(t, opt.Set(testCase))
 
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.source, "/foo")
-	assert.Equal(t, req.target, "testing")
-	assert.Equal(t, req.uid, "1000")
-	assert.Equal(t, req.gid, "1001")
+	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.Target, "testing")
+	assert.Equal(t, req.UID, "1000")
+	assert.Equal(t, req.GID, "1001")
 }
 
 func TestSecretOptionsCustomMode(t *testing.T) {
-	var opt SecretOpt
+	var opt opts.SecretOpt
 
-	testCase := "source=/foo,target=testing,uid=1000,gid=1001,mode=0444"
+	testCase := "source=foo,target=testing,uid=1000,gid=1001,mode=0444"
 	assert.NilError(t, opt.Set(testCase))
 
 	reqs := opt.Value()
 	assert.Equal(t, len(reqs), 1)
 	req := reqs[0]
-	assert.Equal(t, req.source, "/foo")
-	assert.Equal(t, req.target, "testing")
-	assert.Equal(t, req.uid, "1000")
-	assert.Equal(t, req.gid, "1001")
-	assert.Equal(t, req.mode, os.FileMode(0444))
+	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.Target, "testing")
+	assert.Equal(t, req.UID, "1000")
+	assert.Equal(t, req.GID, "1001")
+	assert.Equal(t, req.Mode, os.FileMode(0444))
 }

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -104,48 +103,4 @@ func TestHealthCheckOptionsToHealthConfigConflict(t *testing.T) {
 	}
 	_, err := opt.toHealthConfig()
 	assert.Error(t, err, "--no-healthcheck conflicts with --health-* options")
-}
-
-func TestSecretOptionsSimple(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=/foo,target=testing"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Equal(t, len(reqs), 1)
-	req := reqs[0]
-	assert.Equal(t, req.source, "/foo")
-	assert.Equal(t, req.target, "testing")
-}
-
-func TestSecretOptionsCustomUidGid(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=/foo,target=testing,uid=1000,gid=1001"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Equal(t, len(reqs), 1)
-	req := reqs[0]
-	assert.Equal(t, req.source, "/foo")
-	assert.Equal(t, req.target, "testing")
-	assert.Equal(t, req.uid, "1000")
-	assert.Equal(t, req.gid, "1001")
-}
-
-func TestSecretOptionsCustomMode(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=/foo,target=testing,uid=1000,gid=1001,mode=0444"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Equal(t, len(reqs), 1)
-	req := reqs[0]
-	assert.Equal(t, req.source, "/foo")
-	assert.Equal(t, req.target, "testing")
-	assert.Equal(t, req.uid, "1000")
-	assert.Equal(t, req.gid, "1001")
-	assert.Equal(t, req.mode, os.FileMode(0444))
 }

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -54,8 +54,13 @@ func parseSecrets(client client.APIClient, requestedSecrets []string) ([]*swarmt
 
 		secretRef := &swarmtypes.SecretReference{
 			SecretName: n,
-			Mode:       swarmtypes.SecretReferenceFile,
-			Target:     t,
+			// TODO (ehazlett): parse these from cli request
+			Target: swarmtypes.SecretReferenceFileTarget{
+				Name: t,
+				UID:  "0",
+				GID:  "0",
+				Mode: 0444,
+			},
 		}
 
 		if _, exists := secretRefs[t]; exists {

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -19,7 +19,7 @@ func parseSecrets(client client.APIClient, requestedSecrets []*types.SecretReque
 	for _, secret := range requestedSecrets {
 		secretRef := &swarmtypes.SecretReference{
 			SecretName: secret.Source,
-			Target: swarmtypes.SecretReferenceFileTarget{
+			Target: &swarmtypes.SecretReferenceFileTarget{
 				Name: secret.Target,
 				UID:  secret.UID,
 				GID:  secret.GID,

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -12,7 +12,7 @@ import (
 
 // parseSecrets retrieves the secrets from the requested names and converts
 // them to secret references to use with the spec
-func parseSecrets(client client.APIClient, requestedSecrets []*types.SecretRequestOptions) ([]*swarmtypes.SecretReference, error) {
+func parseSecrets(client client.APIClient, requestedSecrets []*types.SecretRequestOption) ([]*swarmtypes.SecretReference, error) {
 	secretRefs := make(map[string]*swarmtypes.SecretReference)
 	ctx := context.Background()
 

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -31,6 +32,13 @@ func parseSecretString(secretString string) (string, string, error) {
 	} else {
 		targetName = secretName
 	}
+
+	// ensure target is a filename only; no paths allowed
+	tDir, _ := filepath.Split(targetName)
+	if tDir != "" {
+		return "", "", fmt.Errorf("target must not have a path")
+	}
+
 	return secretName, targetName, nil
 }
 

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -1,13 +1,13 @@
 package service
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
 )
 
 // parseSecrets retrieves the secrets from the requested names and converts
@@ -39,7 +39,7 @@ func parseSecrets(client client.APIClient, requestedSecrets []*types.SecretReque
 	}
 
 	secrets, err := client.SecretList(ctx, types.SecretListOptions{
-		Filter: args,
+		Filters: args,
 	})
 	if err != nil {
 		return nil, err

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -12,25 +12,25 @@ import (
 
 // parseSecrets retrieves the secrets from the requested names and converts
 // them to secret references to use with the spec
-func parseSecrets(client client.APIClient, requestedSecrets []*SecretRequestSpec) ([]*swarmtypes.SecretReference, error) {
+func parseSecrets(client client.APIClient, requestedSecrets []*types.SecretRequestOptions) ([]*swarmtypes.SecretReference, error) {
 	secretRefs := make(map[string]*swarmtypes.SecretReference)
 	ctx := context.Background()
 
 	for _, secret := range requestedSecrets {
 		secretRef := &swarmtypes.SecretReference{
-			SecretName: secret.source,
+			SecretName: secret.Source,
 			Target: swarmtypes.SecretReferenceFileTarget{
-				Name: secret.target,
-				UID:  secret.uid,
-				GID:  secret.gid,
-				Mode: secret.mode,
+				Name: secret.Target,
+				UID:  secret.UID,
+				GID:  secret.GID,
+				Mode: secret.Mode,
 			},
 		}
 
-		if _, exists := secretRefs[secret.target]; exists {
-			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secret.source)
+		if _, exists := secretRefs[secret.Target]; exists {
+			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secret.Source)
 		}
-		secretRefs[secret.target] = secretRef
+		secretRefs[secret.Target] = secretRef
 	}
 
 	args := filters.NewArgs()

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	swarmtypes "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+)
+
+// parseSecretString parses the requested secret and returns the secret name
+// and target.  Expects format SECRET_NAME:TARGET
+func parseSecretString(secretString string) (string, string, error) {
+	tokens := strings.Split(secretString, ":")
+
+	secretName := strings.TrimSpace(tokens[0])
+	targetName := ""
+
+	if secretName == "" {
+		return "", "", fmt.Errorf("invalid secret name provided")
+	}
+
+	if len(tokens) > 1 {
+		targetName = strings.TrimSpace(tokens[1])
+		if targetName == "" {
+			return "", "", fmt.Errorf("invalid presentation name provided")
+		}
+	} else {
+		targetName = secretName
+	}
+	return secretName, targetName, nil
+}
+
+// parseSecrets retrieves the secrets from the requested names and converts
+// them to secret references to use with the spec
+func parseSecrets(client client.APIClient, requestedSecrets []string) ([]*swarmtypes.SecretReference, error) {
+	lookupSecretNames := []string{}
+	needSecrets := make(map[string]*swarmtypes.SecretReference)
+	ctx := context.Background()
+
+	for _, secret := range requestedSecrets {
+		n, t, err := parseSecretString(secret)
+		if err != nil {
+			return nil, err
+		}
+
+		secretRef := &swarmtypes.SecretReference{
+			SecretName: n,
+			Mode:       swarmtypes.SecretReferenceFile,
+			Target:     t,
+		}
+
+		lookupSecretNames = append(lookupSecretNames, n)
+		needSecrets[n] = secretRef
+	}
+
+	args := filters.NewArgs()
+	for _, s := range lookupSecretNames {
+		args.Add("names", s)
+	}
+
+	secrets, err := client.SecretList(ctx, types.SecretListOptions{
+		Filter: args,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	foundSecrets := make(map[string]*swarmtypes.Secret)
+	for _, secret := range secrets {
+		foundSecrets[secret.Spec.Annotations.Name] = &secret
+	}
+
+	addedSecrets := []*swarmtypes.SecretReference{}
+
+	for secretName, secretRef := range needSecrets {
+		s, ok := foundSecrets[secretName]
+		if !ok {
+			return nil, fmt.Errorf("secret not found: %s", secretName)
+		}
+
+		// set the id for the ref to properly assign in swarm
+		// since swarm needs the ID instead of the name
+		secretRef.SecretID = s.ID
+		addedSecrets = append(addedSecrets, secretRef)
+	}
+
+	return addedSecrets, nil
+}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -50,11 +50,11 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(newListOptsVar(), flagPublishRemove, "Remove a published port by its target port")
 	flags.Var(newListOptsVar(), flagConstraintRemove, "Remove a constraint")
 	flags.Var(newListOptsVar(), flagSecretRemove, "Remove a secret")
-	flags.StringSliceVar(&opts.secrets, flagSecretAdd, []string{}, "Add a secret")
 	flags.Var(&opts.labels, flagLabelAdd, "Add or update service labels")
 	flags.Var(&opts.containerLabels, flagContainerLabelAdd, "Add or update container labels")
 	flags.Var(&opts.env, flagEnvAdd, "Add or update environment variables")
 	flags.Var(&opts.mounts, flagMountAdd, "Add or update a mount on a service")
+	flags.Var(&opts.secrets, flagSecretAdd, "Add or update a secret on a service")
 	flags.StringSliceVar(&opts.constraints, flagConstraintAdd, []string{}, "Add or update placement constraints")
 	flags.Var(&opts.endpoint.ports, flagPublishAdd, "Add or update a published port")
 	flags.StringSliceVar(&opts.groups, flagGroupAdd, []string{}, "Add additional supplementary user groups to the container")
@@ -376,10 +376,7 @@ func updateEnvironment(flags *pflag.FlagSet, field *[]string) {
 
 func getUpdatedSecrets(apiClient client.APIClient, flags *pflag.FlagSet, secrets []*swarm.SecretReference) ([]*swarm.SecretReference, error) {
 	if flags.Changed(flagSecretAdd) {
-		values, err := flags.GetStringSlice(flagSecretAdd)
-		if err != nil {
-			return nil, err
-		}
+		values := flags.Lookup(flagSecretAdd).Value.(*SecretOpt).Value()
 
 		addSecrets, err := parseSecrets(apiClient, values)
 		if err != nil {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -376,7 +376,7 @@ func updateEnvironment(flags *pflag.FlagSet, field *[]string) {
 
 func getUpdatedSecrets(apiClient client.APIClient, flags *pflag.FlagSet, secrets []*swarm.SecretReference) ([]*swarm.SecretReference, error) {
 	if flags.Changed(flagSecretAdd) {
-		values := flags.Lookup(flagSecretAdd).Value.(*SecretOpt).Value()
+		values := flags.Lookup(flagSecretAdd).Value.(*opts.SecretOpt).Value()
 
 		addSecrets, err := parseSecrets(apiClient, values)
 		if err != nil {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/opts"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/docker/go-connections/nat"
@@ -48,6 +49,8 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(newListOptsVar(), flagMountRemove, "Remove a mount by its target path")
 	flags.Var(newListOptsVar(), flagPublishRemove, "Remove a published port by its target port")
 	flags.Var(newListOptsVar(), flagConstraintRemove, "Remove a constraint")
+	flags.Var(newListOptsVar(), flagSecretRemove, "Remove a secret")
+	flags.StringSliceVar(&opts.secrets, flagSecretAdd, []string{}, "Add a secret")
 	flags.Var(&opts.labels, flagLabelAdd, "Add or update service labels")
 	flags.Var(&opts.containerLabels, flagContainerLabelAdd, "Add or update container labels")
 	flags.Var(&opts.env, flagEnvAdd, "Add or update environment variables")
@@ -89,6 +92,13 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, serviceID str
 	if err != nil {
 		return err
 	}
+
+	updatedSecrets, err := getUpdatedSecrets(apiClient, flags, spec.TaskTemplate.ContainerSpec.Secrets)
+	if err != nil {
+		return err
+	}
+
+	spec.TaskTemplate.ContainerSpec.Secrets = updatedSecrets
 
 	// only send auth if flag was set
 	sendAuth, err := flags.GetBool(flagRegistryAuth)
@@ -362,6 +372,30 @@ func updateEnvironment(flags *pflag.FlagSet, field *[]string) {
 
 	toRemove := buildToRemoveSet(flags, flagEnvRemove)
 	*field = removeItems(*field, toRemove, envKey)
+}
+
+func getUpdatedSecrets(apiClient client.APIClient, flags *pflag.FlagSet, secrets []*swarm.SecretReference) ([]*swarm.SecretReference, error) {
+	if flags.Changed(flagSecretAdd) {
+		values, err := flags.GetStringSlice(flagSecretAdd)
+		if err != nil {
+			return nil, err
+		}
+
+		addSecrets, err := parseSecrets(apiClient, values)
+		if err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, addSecrets...)
+	}
+	toRemove := buildToRemoveSet(flags, flagSecretRemove)
+	newSecrets := []*swarm.SecretReference{}
+	for _, secret := range secrets {
+		if _, exists := toRemove[secret.SecretName]; !exists {
+			newSecrets = append(newSecrets, secret)
+		}
+	}
+
+	return newSecrets, nil
 }
 
 func envKey(value string) string {

--- a/client/errors.go
+++ b/client/errors.go
@@ -206,3 +206,25 @@ func IsErrPluginPermissionDenied(err error) bool {
 	_, ok := err.(pluginPermissionDenied)
 	return ok
 }
+
+// secretNotFoundError implements an error returned when a secret is not found.
+type secretNotFoundError struct {
+	name string
+}
+
+// Error returns a string representation of a secretNotFoundError
+func (e secretNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such secret: %s", e.name)
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e secretNotFoundError) NotFound() bool {
+	return true
+}
+
+// IsErrSecretNotFound returns true if the error is caused
+// when a secret is not found.
+func IsErrSecretNotFound(err error) bool {
+	_, ok := err.(secretNotFoundError)
+	return ok
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -214,7 +214,7 @@ type secretNotFoundError struct {
 
 // Error returns a string representation of a secretNotFoundError
 func (e secretNotFoundError) Error() string {
-	return fmt.Sprintf("Error: No such secret: %s", e.name)
+	return fmt.Sprintf("Error: no such secret: %s", e.name)
 }
 
 // NoFound indicates that this error type is of NotFound

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -107,10 +107,16 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	}
 	query.Set("buildargs", string(buildArgsJSON))
 
+	buildSecretsJSON, err := json.Marshal(options.BuildSecrets)
+	if err != nil {
+		return query, err
+	}
+	query.Set("buildsecrets", string(buildSecretsJSON))
 	labelsJSON, err := json.Marshal(options.Labels)
 	if err != nil {
 		return query, err
 	}
+
 	query.Set("labels", string(labelsJSON))
 
 	cacheFromJSON, err := json.Marshal(options.CacheFrom)

--- a/client/interface.go
+++ b/client/interface.go
@@ -23,6 +23,7 @@ type CommonAPIClient interface {
 	NetworkAPIClient
 	ServiceAPIClient
 	SwarmAPIClient
+	SecretAPIClient
 	SystemAPIClient
 	VolumeAPIClient
 	ClientVersion() string
@@ -140,4 +141,12 @@ type VolumeAPIClient interface {
 	VolumeList(ctx context.Context, filter filters.Args) (volumetypes.VolumesListOKBody, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	VolumesPrune(ctx context.Context, cfg types.VolumesPruneConfig) (types.VolumesPruneReport, error)
+}
+
+// SecretAPIClient defines API client methods for secrets
+type SecretAPIClient interface {
+	SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error)
+	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error)
+	SecretRemove(ctx context.Context, id string) error
+	SecretInspectWithRaw(ctx context.Context, name string) (swarm.Secret, []byte, error)
 }

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SecretCreate creates a new Secret.
+func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error) {
+	var headers map[string][]string
+
+	var response types.SecretCreateResponse
+	resp, err := cli.post(ctx, "/secrets/create", nil, secret, headers)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
+	return response, err
+}

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -13,7 +13,7 @@ func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (t
 	var headers map[string][]string
 
 	var response types.SecretCreateResponse
-	resp, err := cli.post(ctx, "/secrets/create", nil, secret, headers)
+	resp, err := cli.post(ctx, "/secrets", nil, secret, headers)
 	if err != nil {
 		return response, err
 	}

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+func TestSecretCreateError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestSecretCreate(t *testing.T) {
+	expectedURL := "/secrets/create"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			if req.Method != "POST" {
+				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			}
+			b, err := json.Marshal(types.SecretCreateResponse{
+				ID: "test_secret",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	r, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != "test_secret" {
+		t.Fatalf("expected `test_secret`, got %s", r.ID)
+	}
+}

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -25,7 +25,7 @@ func TestSecretCreateError(t *testing.T) {
 }
 
 func TestSecretCreate(t *testing.T) {
-	expectedURL := "/secrets/create"
+	expectedURL := "/secrets"
 	client := &Client{
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SecretInspectWithRaw returns the secret information with raw data
+func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.Secret, []byte, error) {
+	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
+	if err != nil {
+		if resp.statusCode == http.StatusNotFound {
+			return swarm.Secret{}, nil, secretNotFoundError{id}
+		}
+		return swarm.Secret{}, nil, err
+	}
+	defer ensureReaderClosed(resp)
+
+	body, err := ioutil.ReadAll(resp.body)
+	if err != nil {
+		return swarm.Secret{}, nil, err
+	}
+
+	var secret swarm.Secret
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&secret)
+
+	return secret, body, err
+}

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+func TestSecretInspectError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	_, _, err := client.SecretInspectWithRaw(context.Background(), "nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestSecretInspectSecretNotFound(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
+	}
+
+	_, _, err := client.SecretInspectWithRaw(context.Background(), "unknown")
+	if err == nil || !IsErrSecretNotFound(err) {
+		t.Fatalf("expected an secretNotFoundError error, got %v", err)
+	}
+}
+
+func TestSecretInspect(t *testing.T) {
+	expectedURL := "/secrets/secret_id"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			content, err := json.Marshal(swarm.Secret{
+				ID: "secret_id",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+
+	secretInspect, _, err := client.SecretInspectWithRaw(context.Background(), "secret_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secretInspect.ID != "secret_id" {
+		t.Fatalf("expected `secret_id`, got %s", secretInspect.ID)
+	}
+}

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SecretList returns the list of secrets.
+func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/secrets", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var secrets []swarm.Secret
+	err = json.NewDecoder(resp.body).Decode(&secrets)
+	ensureReaderClosed(resp)
+	return secrets, err
+}

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -14,8 +14,8 @@ import (
 func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
 	query := url.Values{}
 
-	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filter)
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+func TestSecretListError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestSecretList(t *testing.T) {
+	expectedURL := "/secrets"
+
+	filters := filters.NewArgs()
+	filters.Add("label", "label1")
+	filters.Add("label", "label2")
+
+	listCases := []struct {
+		options             types.SecretListOptions
+		expectedQueryParams map[string]string
+	}{
+		{
+			options: types.SecretListOptions{},
+			expectedQueryParams: map[string]string{
+				"filters": "",
+			},
+		},
+		{
+			options: types.SecretListOptions{
+				Filter: filters,
+			},
+			expectedQueryParams: map[string]string{
+				"filters": `{"label":{"label1":true,"label2":true}}`,
+			},
+		},
+	}
+	for _, listCase := range listCases {
+		client := &Client{
+			client: newMockClient(func(req *http.Request) (*http.Response, error) {
+				if !strings.HasPrefix(req.URL.Path, expectedURL) {
+					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+				}
+				query := req.URL.Query()
+				for key, expected := range listCase.expectedQueryParams {
+					actual := query.Get(key)
+					if actual != expected {
+						return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
+					}
+				}
+				content, err := json.Marshal([]swarm.Secret{
+					{
+						ID: "secret_id1",
+					},
+					{
+						ID: "secret_id2",
+					},
+				})
+				if err != nil {
+					return nil, err
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader(content)),
+				}, nil
+			}),
+		}
+
+		secrets, err := client.SecretList(context.Background(), listCase.options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(secrets) != 2 {
+			t.Fatalf("expected 2 secrets, got %v", secrets)
+		}
+	}
+}

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -45,7 +45,7 @@ func TestSecretList(t *testing.T) {
 		},
 		{
 			options: types.SecretListOptions{
-				Filter: filters,
+				Filters: filters,
 			},
 			expectedQueryParams: map[string]string{
 				"filters": `{"label":{"label1":true,"label2":true}}`,

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -1,0 +1,10 @@
+package client
+
+import "golang.org/x/net/context"
+
+// SecretRemove removes a Secret.
+func (cli *Client) SecretRemove(ctx context.Context, id string) error {
+	resp, err := cli.delete(ctx, "/secrets/"+id, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestSecretRemoveError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	err := client.SecretRemove(context.Background(), "secret_id")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestSecretRemove(t *testing.T) {
+	expectedURL := "/secrets/secret_id"
+
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			if req.Method != "DELETE" {
+				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte("body"))),
+			}, nil
+		}),
+	}
+
+	err := client.SecretRemove(context.Background(), "secret_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/container/container.go
+++ b/container/container.go
@@ -89,8 +89,9 @@ type CommonContainer struct {
 	HasBeenStartedBefore   bool
 	HasBeenManuallyStopped bool // used for unless-stopped restart policy
 	MountPoints            map[string]*volume.MountPoint
-	HostConfig             *containertypes.HostConfig `json:"-"` // do not serialize the host config in the json, otherwise we'll make the container unportable
-	ExecCommands           *exec.Store                `json:"-"`
+	HostConfig             *containertypes.HostConfig        `json:"-"` // do not serialize the host config in the json, otherwise we'll make the container unportable
+	ExecCommands           *exec.Store                       `json:"-"`
+	Secrets                []*containertypes.ContainerSecret `json:"-"` // do not serialize
 	// logDriver for closing
 	LogDriver      logger.Logger  `json:"-"`
 	LogCopier      *logger.Copier `json:"-"`

--- a/container/container_solaris.go
+++ b/container/container_solaris.go
@@ -62,6 +62,16 @@ func (container *Container) IpcMounts() []Mount {
 	return nil
 }
 
+// SecretMount returns the mount for the secret path
+func (container *Container) SecretMount() *Mount {
+	return nil
+}
+
+// UnmountSecrets unmounts the fs for secrets
+func (container *Container) UnmountSecrets() error {
+	return nil
+}
+
 // UpdateContainer updates configuration of a container
 func (container *Container) UpdateContainer(hostConfig *container.HostConfig) error {
 	return nil

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -283,6 +283,14 @@ func (container *Container) SecretMount() *Mount {
 
 // UnmountSecrets unmounts the local tmpfs for secrets
 func (container *Container) UnmountSecrets() error {
+	if _, err := os.Stat(container.SecretMountPath()); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
 	return detachMounted(container.SecretMountPath())
 }
 

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -268,7 +268,7 @@ func (container *Container) IpcMounts() []Mount {
 	return mounts
 }
 
-// SecretMount returns the list of Secret mounts
+// SecretMount returns the mount for the secret path
 func (container *Container) SecretMount() *Mount {
 	if len(container.Secrets) > 0 {
 		return &Mount{

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -286,9 +286,8 @@ func (container *Container) UnmountSecrets() error {
 	if _, err := os.Stat(container.SecretMountPath()); err != nil {
 		if os.IsNotExist(err) {
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 
 	return detachMounted(container.SecretMountPath())

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -269,18 +269,16 @@ func (container *Container) IpcMounts() []Mount {
 }
 
 // SecretMount returns the list of Secret mounts
-func (container *Container) SecretMount() Mount {
-	var mount Mount
-
+func (container *Container) SecretMount() *Mount {
 	if len(container.Secrets) > 0 {
-		mount = Mount{
+		return &Mount{
 			Source:      container.SecretMountPath(),
 			Destination: containerSecretMountPath,
 			Writable:    false,
 		}
 	}
 
-	return mount
+	return nil
 }
 
 // UnmountSecrets unmounts the local tmpfs for secrets

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -22,8 +22,8 @@ import (
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
-// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
 const (
+	// DefaultSHMSize is the default size (64MB) of the SHM which will be mounted in the container
 	DefaultSHMSize           int64 = 67108864
 	containerSecretMountPath       = "/run/secrets"
 )
@@ -178,6 +178,7 @@ func (container *Container) NetworkMounts() []Mount {
 	return mounts
 }
 
+// SecretMountPath returns the path of the secret mount for the container
 func (container *Container) SecretMountPath() string {
 	return filepath.Join(container.Root, "secrets")
 }
@@ -267,19 +268,19 @@ func (container *Container) IpcMounts() []Mount {
 	return mounts
 }
 
-// SecretMounts returns the list of Secret mounts
-func (container *Container) SecretMounts() []Mount {
-	var mounts []Mount
+// SecretMount returns the list of Secret mounts
+func (container *Container) SecretMount() Mount {
+	var mount Mount
 
 	if len(container.Secrets) > 0 {
-		mounts = append(mounts, Mount{
+		mount = Mount{
 			Source:      container.SecretMountPath(),
 			Destination: containerSecretMountPath,
 			Writable:    false,
-		})
+		}
 	}
 
-	return mounts
+	return mount
 }
 
 // UnmountSecrets unmounts the local tmpfs for secrets

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -44,6 +44,16 @@ func (container *Container) IpcMounts() []Mount {
 	return nil
 }
 
+// SecretMount returns the mount for the secret path
+func (container *Container) SecretMount() *Mount {
+	return nil
+}
+
+// UnmountSecrets unmounts the fs for secrets
+func (container *Container) UnmountSecrets() error {
+	return nil
+}
+
 // UnmountVolumes explicitly unmounts volumes from the container.
 func (container *Container) UnmountVolumes(forceSyscall bool, volumeEventLog func(name, action string, attributes map[string]string)) error {
 	var (

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -22,6 +22,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 		Dir:      c.Dir,
 		User:     c.User,
 		Groups:   c.Groups,
+		Secrets:  secretReferencesFromGRPC(c.Secrets),
 	}
 
 	// Mounts
@@ -66,6 +67,47 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 	return containerSpec
 }
 
+func secretReferencesToGRPC(sr []*types.SecretReference) []*swarmapi.SecretReference {
+	refs := []*swarmapi.SecretReference{}
+	for _, s := range sr {
+		var mode swarmapi.SecretReference_Mode
+		switch s.Mode {
+		case types.SecretReferenceSystem:
+			mode = swarmapi.SecretReference_SYSTEM
+		default:
+			mode = swarmapi.SecretReference_FILE
+		}
+		refs = append(refs, &swarmapi.SecretReference{
+			SecretID:   s.SecretID,
+			SecretName: s.SecretName,
+			Target:     s.Target,
+			Mode:       mode,
+		})
+	}
+
+	return refs
+}
+func secretReferencesFromGRPC(sr []*swarmapi.SecretReference) []*types.SecretReference {
+	refs := []*types.SecretReference{}
+	for _, s := range sr {
+		var mode types.SecretReferenceMode
+		switch s.Mode {
+		case swarmapi.SecretReference_SYSTEM:
+			mode = types.SecretReferenceSystem
+		default:
+			mode = types.SecretReferenceFile
+		}
+		refs = append(refs, &types.SecretReference{
+			SecretID:   s.SecretID,
+			SecretName: s.SecretName,
+			Target:     s.Target,
+			Mode:       mode,
+		})
+	}
+
+	return refs
+}
+
 func containerToGRPC(c types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 	containerSpec := &swarmapi.ContainerSpec{
 		Image:    c.Image,
@@ -77,6 +119,7 @@ func containerToGRPC(c types.ContainerSpec) (*swarmapi.ContainerSpec, error) {
 		Dir:      c.Dir,
 		User:     c.User,
 		Groups:   c.Groups,
+		Secrets:  secretReferencesToGRPC(c.Secrets),
 	}
 
 	if c.StopGracePeriod != nil {

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -70,12 +70,9 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 func secretReferencesToGRPC(sr []*types.SecretReference) []*swarmapi.SecretReference {
 	refs := []*swarmapi.SecretReference{}
 	for _, s := range sr {
-		var mode swarmapi.SecretReference_Mode
-		switch s.Mode {
-		case types.SecretReferenceSystem:
+		mode := swarmapi.SecretReference_FILE
+		if s.Mode == types.SecretReferenceSystem {
 			mode = swarmapi.SecretReference_SYSTEM
-		default:
-			mode = swarmapi.SecretReference_FILE
 		}
 		refs = append(refs, &swarmapi.SecretReference{
 			SecretID:   s.SecretID,

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -69,7 +69,7 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 }
 
 func secretReferencesToGRPC(sr []*types.SecretReference) []*swarmapi.SecretReference {
-	refs := []*swarmapi.SecretReference{}
+	refs := make([]*swarmapi.SecretReference, 0, len(sr))
 	for _, s := range sr {
 		refs = append(refs, &swarmapi.SecretReference{
 			SecretID:   s.SecretID,
@@ -88,7 +88,7 @@ func secretReferencesToGRPC(sr []*types.SecretReference) []*swarmapi.SecretRefer
 	return refs
 }
 func secretReferencesFromGRPC(sr []*swarmapi.SecretReference) []*types.SecretReference {
-	refs := []*types.SecretReference{}
+	refs := make([]*types.SecretReference, 0, len(sr))
 	for _, s := range sr {
 		target := s.GetFile()
 		if target == nil {

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -99,7 +99,7 @@ func secretReferencesFromGRPC(sr []*swarmapi.SecretReference) []*types.SecretRef
 		refs = append(refs, &types.SecretReference{
 			SecretID:   s.SecretID,
 			SecretName: s.SecretName,
-			Target: types.SecretReferenceFileTarget{
+			Target: &types.SecretReferenceFileTarget{
 				Name: target.Name,
 				UID:  target.UID,
 				GID:  target.GID,

--- a/daemon/cluster/convert/container.go
+++ b/daemon/cluster/convert/container.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	container "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	types "github.com/docker/docker/api/types/swarm"
@@ -70,15 +71,17 @@ func containerSpecFromGRPC(c *swarmapi.ContainerSpec) types.ContainerSpec {
 func secretReferencesToGRPC(sr []*types.SecretReference) []*swarmapi.SecretReference {
 	refs := []*swarmapi.SecretReference{}
 	for _, s := range sr {
-		mode := swarmapi.SecretReference_FILE
-		if s.Mode == types.SecretReferenceSystem {
-			mode = swarmapi.SecretReference_SYSTEM
-		}
 		refs = append(refs, &swarmapi.SecretReference{
 			SecretID:   s.SecretID,
 			SecretName: s.SecretName,
-			Target:     s.Target,
-			Mode:       mode,
+			Target: &swarmapi.SecretReference_File{
+				File: &swarmapi.SecretReference_FileTarget{
+					Name: s.Target.Name,
+					UID:  s.Target.UID,
+					GID:  s.Target.GID,
+					Mode: s.Target.Mode,
+				},
+			},
 		})
 	}
 
@@ -87,18 +90,21 @@ func secretReferencesToGRPC(sr []*types.SecretReference) []*swarmapi.SecretRefer
 func secretReferencesFromGRPC(sr []*swarmapi.SecretReference) []*types.SecretReference {
 	refs := []*types.SecretReference{}
 	for _, s := range sr {
-		var mode types.SecretReferenceMode
-		switch s.Mode {
-		case swarmapi.SecretReference_SYSTEM:
-			mode = types.SecretReferenceSystem
-		default:
-			mode = types.SecretReferenceFile
+		target := s.GetFile()
+		if target == nil {
+			// not a file target
+			logrus.Warnf("secret target not a file: secret=%s", s.SecretID)
+			continue
 		}
 		refs = append(refs, &types.SecretReference{
 			SecretID:   s.SecretID,
 			SecretName: s.SecretName,
-			Target:     s.Target,
-			Mode:       mode,
+			Target: types.SecretReferenceFileTarget{
+				Name: target.Name,
+				UID:  target.UID,
+				GID:  target.GID,
+				Mode: target.Mode,
+			},
 		})
 	}
 

--- a/daemon/cluster/convert/secret.go
+++ b/daemon/cluster/convert/secret.go
@@ -1,7 +1,6 @@
 package convert
 
 import (
-	"github.com/Sirupsen/logrus"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	swarmapi "github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/protobuf/ptypes"
@@ -9,7 +8,6 @@ import (
 
 // SecretFromGRPC converts a grpc Secret to a Secret.
 func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
-	logrus.Debugf("%+v", s)
 	secret := swarmtypes.Secret{
 		ID:         s.ID,
 		Digest:     s.Digest,
@@ -33,14 +31,12 @@ func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
 }
 
 // SecretSpecToGRPC converts Secret to a grpc Secret.
-func SecretSpecToGRPC(s swarmtypes.SecretSpec) (swarmapi.SecretSpec, error) {
-	spec := swarmapi.SecretSpec{
+func SecretSpecToGRPC(s swarmtypes.SecretSpec) swarmapi.SecretSpec {
+	return swarmapi.SecretSpec{
 		Annotations: swarmapi.Annotations{
 			Name:   s.Name,
 			Labels: s.Labels,
 		},
 		Data: s.Data,
 	}
-
-	return spec, nil
 }

--- a/daemon/cluster/convert/secret.go
+++ b/daemon/cluster/convert/secret.go
@@ -19,7 +19,7 @@ func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
 	secret.CreatedAt, _ = ptypes.Timestamp(s.Meta.CreatedAt)
 	secret.UpdatedAt, _ = ptypes.Timestamp(s.Meta.UpdatedAt)
 
-	secret.Spec = &swarmtypes.SecretSpec{
+	secret.Spec = swarmtypes.SecretSpec{
 		Annotations: swarmtypes.Annotations{
 			Name:   s.Spec.Annotations.Name,
 			Labels: s.Spec.Annotations.Labels,

--- a/daemon/cluster/convert/secret.go
+++ b/daemon/cluster/convert/secret.go
@@ -1,0 +1,46 @@
+package convert
+
+import (
+	"github.com/Sirupsen/logrus"
+	swarmtypes "github.com/docker/docker/api/types/swarm"
+	swarmapi "github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/protobuf/ptypes"
+)
+
+// SecretFromGRPC converts a grpc Secret to a Secret.
+func SecretFromGRPC(s *swarmapi.Secret) swarmtypes.Secret {
+	logrus.Debugf("%+v", s)
+	secret := swarmtypes.Secret{
+		ID:         s.ID,
+		Digest:     s.Digest,
+		SecretSize: s.SecretSize,
+	}
+
+	// Meta
+	secret.Version.Index = s.Meta.Version.Index
+	secret.CreatedAt, _ = ptypes.Timestamp(s.Meta.CreatedAt)
+	secret.UpdatedAt, _ = ptypes.Timestamp(s.Meta.UpdatedAt)
+
+	secret.Spec = &swarmtypes.SecretSpec{
+		Annotations: swarmtypes.Annotations{
+			Name:   s.Spec.Annotations.Name,
+			Labels: s.Spec.Annotations.Labels,
+		},
+		Data: s.Spec.Data,
+	}
+
+	return secret
+}
+
+// SecretSpecToGRPC converts Secret to a grpc Secret.
+func SecretSpecToGRPC(s swarmtypes.SecretSpec) (swarmapi.SecretSpec, error) {
+	spec := swarmapi.SecretSpec{
+		Annotations: swarmapi.Annotations{
+			Name:   s.Name,
+			Labels: s.Labels,
+		},
+		Data: s.Data,
+	}
+
+	return spec, nil
+}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -32,6 +32,7 @@ type Backend interface {
 	ContainerWaitWithContext(ctx context.Context, name string) error
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerKill(name string, sig uint64) error
+	SetContainerSecrets(name string, secrets []*container.ContainerSecret) error
 	SystemInfo() (*types.Info, error)
 	VolumeCreate(name, driverName string, opts, labels map[string]string) (*types.Volume, error)
 	Containers(config *types.ContainerListOptions) ([]*types.Container, error)

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -30,10 +30,10 @@ import (
 type containerAdapter struct {
 	backend   executorpkg.Backend
 	container *containerConfig
-	secrets   exec.SecretProvider
+	secrets   exec.SecretGetter
 }
 
-func newContainerAdapter(b executorpkg.Backend, task *api.Task, secrets exec.SecretProvider) (*containerAdapter, error) {
+func newContainerAdapter(b executorpkg.Backend, task *api.Task, secrets exec.SecretGetter) (*containerAdapter, error) {
 	ctnr, err := newContainerConfig(task)
 	if err != nil {
 		return nil, err

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -223,7 +223,7 @@ func (c *containerAdapter) create(ctx context.Context) error {
 		return fmt.Errorf("unable to get container from task spec")
 	}
 	secrets := make([]*containertypes.ContainerSecret, 0, len(container.Secrets))
-	for _, s := range c.container.task.Spec.GetContainer().Secrets {
+	for _, s := range container.Secrets {
 		sec := c.secrets.Get(s.SecretID)
 		if sec == nil {
 			logrus.Warnf("unable to get secret %s from provider", s.SecretID)

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/libnetwork"
+	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"golang.org/x/net/context"
@@ -29,9 +30,10 @@ import (
 type containerAdapter struct {
 	backend   executorpkg.Backend
 	container *containerConfig
+	secrets   exec.SecretProvider
 }
 
-func newContainerAdapter(b executorpkg.Backend, task *api.Task) (*containerAdapter, error) {
+func newContainerAdapter(b executorpkg.Backend, task *api.Task, secrets exec.SecretProvider) (*containerAdapter, error) {
 	ctnr, err := newContainerConfig(task)
 	if err != nil {
 		return nil, err
@@ -40,6 +42,7 @@ func newContainerAdapter(b executorpkg.Backend, task *api.Task) (*containerAdapt
 	return &containerAdapter{
 		container: ctnr,
 		backend:   b,
+		secrets:   secrets,
 	}, nil
 }
 
@@ -213,6 +216,35 @@ func (c *containerAdapter) create(ctx context.Context) error {
 				return err
 			}
 		}
+	}
+
+	secrets := []*containertypes.ContainerSecret{}
+	for _, s := range c.container.task.Spec.GetContainer().Secrets {
+		sec := c.secrets.Get(s.SecretID)
+		if sec == nil {
+			logrus.Warnf("unable to get secret %s from provider", s.SecretID)
+			continue
+		}
+
+		name := sec.Spec.Annotations.Name
+		target := s.Target
+		if target == "" {
+			target = name
+		}
+		secrets = append(secrets, &containertypes.ContainerSecret{
+			Name:   name,
+			Target: target,
+			Data:   sec.Spec.Data,
+			// TODO (ehazlett): enable configurable uid, gid, mode
+			Uid:  0,
+			Gid:  0,
+			Mode: 0444,
+		})
+	}
+
+	// configure secrets
+	if err := c.backend.SetContainerSecrets(cr.ID, secrets); err != nil {
+		return err
 	}
 
 	if err := c.backend.UpdateContainerServiceConfig(cr.ID, c.container.serviceConfig()); err != nil {

--- a/daemon/cluster/executor/container/attachment.go
+++ b/daemon/cluster/executor/container/attachment.go
@@ -4,6 +4,7 @@ import (
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/swarmkit/api"
 	"golang.org/x/net/context"
+	"src/github.com/docker/swarmkit/agent/exec"
 )
 
 // networkAttacherController implements agent.Controller against docker's API.
@@ -19,8 +20,8 @@ type networkAttacherController struct {
 	closed  chan struct{}
 }
 
-func newNetworkAttacherController(b executorpkg.Backend, task *api.Task) (*networkAttacherController, error) {
-	adapter, err := newContainerAdapter(b, task)
+func newNetworkAttacherController(b executorpkg.Backend, task *api.Task, secrets exec.SecretProvider) (*networkAttacherController, error) {
+	adapter, err := newContainerAdapter(b, task, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/cluster/executor/container/attachment.go
+++ b/daemon/cluster/executor/container/attachment.go
@@ -20,7 +20,7 @@ type networkAttacherController struct {
 	closed  chan struct{}
 }
 
-func newNetworkAttacherController(b executorpkg.Backend, task *api.Task, secrets exec.SecretProvider) (*networkAttacherController, error) {
+func newNetworkAttacherController(b executorpkg.Backend, task *api.Task, secrets exec.SecretGetter) (*networkAttacherController, error) {
 	adapter, err := newContainerAdapter(b, task, secrets)
 	if err != nil {
 		return nil, err

--- a/daemon/cluster/executor/container/attachment.go
+++ b/daemon/cluster/executor/container/attachment.go
@@ -2,9 +2,9 @@ package container
 
 import (
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
+	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
 	"golang.org/x/net/context"
-	"src/github.com/docker/swarmkit/agent/exec"
 )
 
 // networkAttacherController implements agent.Controller against docker's API.

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -33,8 +33,8 @@ type controller struct {
 var _ exec.Controller = &controller{}
 
 // NewController returns a docker exec runner for the provided task.
-func newController(b executorpkg.Backend, task *api.Task) (*controller, error) {
-	adapter, err := newContainerAdapter(b, task)
+func newController(b executorpkg.Backend, task *api.Task, secrets exec.SecretProvider) (*controller, error) {
+	adapter, err := newContainerAdapter(b, task, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -33,7 +33,7 @@ type controller struct {
 var _ exec.Controller = &controller{}
 
 // NewController returns a docker exec runner for the provided task.
-func newController(b executorpkg.Backend, task *api.Task, secrets exec.SecretProvider) (*controller, error) {
+func newController(b executorpkg.Backend, task *api.Task, secrets exec.SecretGetter) (*controller, error) {
 	adapter, err := newContainerAdapter(b, task, secrets)
 	if err != nil {
 		return nil, err

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -18,6 +18,10 @@ type executor struct {
 	backend executorpkg.Backend
 }
 
+type secretProvider interface {
+	Get(secretID string) *api.Secret
+}
+
 // NewExecutor returns an executor from the docker client.
 func NewExecutor(b executorpkg.Backend) exec.Executor {
 	return &executor{
@@ -120,12 +124,12 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 }
 
 // Controller returns a docker container runner.
-func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
+func (e *executor) Controller(t *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
 	if t.Spec.GetAttachment() != nil {
-		return newNetworkAttacherController(e.backend, t)
+		return newNetworkAttacherController(e.backend, t, secrets)
 	}
 
-	ctlr, err := newController(e.backend, t)
+	ctlr, err := newController(e.backend, t, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -18,10 +18,6 @@ type executor struct {
 	backend executorpkg.Backend
 }
 
-type secretProvider interface {
-	Get(secretID string) *api.Secret
-}
-
 // NewExecutor returns an executor from the docker client.
 func NewExecutor(b executorpkg.Backend) exec.Executor {
 	return &executor{

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -54,7 +54,7 @@ func TestHealthStates(t *testing.T) {
 		EventsService: e,
 	}
 
-	controller, err := newController(daemon, task)
+	controller, err := newController(daemon, task, nil)
 	if err != nil {
 		t.Fatalf("create controller fail %v", err)
 	}

--- a/daemon/cluster/executor/container/validate_test.go
+++ b/daemon/cluster/executor/container/validate_test.go
@@ -26,7 +26,7 @@ func newTestControllerWithMount(m api.Mount) (*controller, error) {
 				},
 			},
 		},
-	})
+	}, nil)
 }
 
 func TestControllerValidateMountBind(t *testing.T) {

--- a/daemon/cluster/filters.go
+++ b/daemon/cluster/filters.go
@@ -96,3 +96,21 @@ func newListTasksFilters(filter filters.Args, transformFunc func(filters.Args) e
 
 	return f, nil
 }
+
+func newListSecretsFilters(filter filters.Args) (*swarmapi.ListSecretsRequest_Filters, error) {
+	accepted := map[string]bool{
+		"names": true,
+		"name":  true,
+		"id":    true,
+		"label": true,
+	}
+	if err := filter.Validate(accepted); err != nil {
+		return nil, err
+	}
+	return &swarmapi.ListSecretsRequest_Filters{
+		Names:        filter.Get("names"),
+		NamePrefixes: filter.Get("name"),
+		IDPrefixes:   filter.Get("id"),
+		Labels:       runconfigopts.ConvertKVStringsToMap(filter.Get("label")),
+	}, nil
+}

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -29,7 +29,7 @@ func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret
 		return nil, c.errNoManager()
 	}
 
-	filters, err := newListSecretsFilters(options.Filter)
+	filters, err := newListSecretsFilters(options.Filters)
 	if err != nil {
 		return nil, err
 	}
@@ -97,6 +97,7 @@ func (c *Cluster) RemoveSecret(id string) error {
 }
 
 // UpdateSecret updates a secret in a managed swarm cluster.
+// Note: this is not exposed to the CLI but is available from the API only
 func (c *Cluster) UpdateSecret(id string, version uint64, spec types.SecretSpec) error {
 	c.RLock()
 	defer c.RUnlock()

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -1,0 +1,131 @@
+package cluster
+
+import (
+	apitypes "github.com/docker/docker/api/types"
+	types "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/daemon/cluster/convert"
+	swarmapi "github.com/docker/swarmkit/api"
+)
+
+// GetSecret returns a secret from a managed swarm cluster
+func (c *Cluster) GetSecret(id string) (types.Secret, error) {
+	ctx, cancel := c.getRequestContext()
+	defer cancel()
+
+	r, err := c.node.client.GetSecret(ctx, &swarmapi.GetSecretRequest{SecretID: id})
+	if err != nil {
+		return types.Secret{}, err
+	}
+
+	return convert.SecretFromGRPC(r.Secret), nil
+}
+
+// GetSecrets returns all secrets of a managed swarm cluster.
+func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !c.isActiveManager() {
+		return nil, c.errNoManager()
+	}
+
+	filters, err := newListSecretsFilters(options.Filter)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := c.getRequestContext()
+	defer cancel()
+
+	r, err := c.node.client.ListSecrets(ctx,
+		&swarmapi.ListSecretsRequest{Filters: filters})
+	if err != nil {
+		return nil, err
+	}
+
+	secrets := []types.Secret{}
+
+	for _, secret := range r.Secrets {
+		secrets = append(secrets, convert.SecretFromGRPC(secret))
+	}
+
+	return secrets, nil
+}
+
+// CreateSecret creates a new secret in a managed swarm cluster.
+func (c *Cluster) CreateSecret(s types.SecretSpec) (string, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !c.isActiveManager() {
+		return "", c.errNoManager()
+	}
+
+	ctx, cancel := c.getRequestContext()
+	defer cancel()
+
+	secretSpec, err := convert.SecretSpecToGRPC(s)
+	if err != nil {
+		return "", err
+	}
+
+	r, err := c.node.client.CreateSecret(ctx,
+		&swarmapi.CreateSecretRequest{Spec: &secretSpec})
+	if err != nil {
+		return "", err
+	}
+
+	return r.Secret.ID, nil
+}
+
+// RemoveSecret removes a secret from a managed swarm cluster.
+func (c *Cluster) RemoveSecret(id string) error {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !c.isActiveManager() {
+		return c.errNoManager()
+	}
+
+	ctx, cancel := c.getRequestContext()
+	defer cancel()
+
+	req := &swarmapi.RemoveSecretRequest{
+		SecretID: id,
+	}
+
+	if _, err := c.node.client.RemoveSecret(ctx, req); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateSecret updates a secret in a managed swarm cluster.
+func (c *Cluster) UpdateSecret(id string, version uint64, spec types.SecretSpec) error {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !c.isActiveManager() {
+		return c.errNoManager()
+	}
+
+	ctx, cancel := c.getRequestContext()
+	defer cancel()
+
+	secretSpec, err := convert.SecretSpecToGRPC(spec)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.client.UpdateSecret(ctx,
+		&swarmapi.UpdateSecretRequest{
+			SecretID: id,
+			SecretVersion: &swarmapi.Version{
+				Index: version,
+			},
+			Spec: &secretSpec,
+		}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -63,10 +63,7 @@ func (c *Cluster) CreateSecret(s types.SecretSpec) (string, error) {
 	ctx, cancel := c.getRequestContext()
 	defer cancel()
 
-	secretSpec, err := convert.SecretSpecToGRPC(s)
-	if err != nil {
-		return "", err
-	}
+	secretSpec := convert.SecretSpecToGRPC(s)
 
 	r, err := c.node.client.CreateSecret(ctx,
 		&swarmapi.CreateSecretRequest{Spec: &secretSpec})
@@ -111,10 +108,7 @@ func (c *Cluster) UpdateSecret(id string, version uint64, spec types.SecretSpec)
 	ctx, cancel := c.getRequestContext()
 	defer cancel()
 
-	secretSpec, err := convert.SecretSpecToGRPC(spec)
-	if err != nil {
-		return err
-	}
+	secretSpec := convert.SecretSpecToGRPC(spec)
 
 	if _, err := c.client.UpdateSecret(ctx,
 		&swarmapi.UpdateSecretRequest{

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -225,7 +225,7 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 			return errors.Wrap(err, "error injecting secret")
 		}
 
-		if err := os.Chown(fPath, s.Uid, s.Gid); err != nil {
+		if err := os.Chown(fPath, s.UID, s.GID); err != nil {
 			return errors.Wrap(err, "error setting ownership for secret")
 		}
 	}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -225,7 +225,16 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 			return errors.Wrap(err, "error injecting secret")
 		}
 
-		if err := os.Chown(fPath, s.UID, s.GID); err != nil {
+		uid, err := strconv.Atoi(s.UID)
+		if err != nil {
+			return err
+		}
+		gid, err := strconv.Atoi(s.GID)
+		if err != nil {
+			return err
+		}
+
+		if err := os.Chown(fPath, uid, gid); err != nil {
 			return errors.Wrap(err, "error setting ownership for secret")
 		}
 	}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -206,13 +206,13 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 	}
 
 	for _, s := range c.Secrets {
+		targetPath := filepath.Clean(s.Target)
 		// ensure that the target is a filename only; no paths allowed
-		tDir, tPath := filepath.Split(s.Target)
-		if tDir != "" {
-			return fmt.Errorf("error creating secret: secret must not have a path")
+		if targetPath != filepath.Base(targetPath) {
+			return fmt.Errorf("error creating secret: secret must not be a path")
 		}
 
-		fPath := filepath.Join(localMountPath, tPath)
+		fPath := filepath.Join(localMountPath, targetPath)
 		if err := os.MkdirAll(filepath.Dir(fPath), 0700); err != nil {
 			return errors.Wrap(err, "error creating secret mount path")
 		}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -182,8 +182,8 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 	localMountPath := c.SecretMountPath()
 	logrus.Debugf("secrets: setting up secret dir: %s", localMountPath)
 
-	defer func(err error) {
-		if err != nil {
+	defer func() {
+		if setupErr != nil {
 			// cleanup
 			_ = detachMounted(localMountPath)
 
@@ -191,13 +191,13 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 				log.Errorf("error cleaning up secret mount: %s", err)
 			}
 		}
-	}(setupErr)
+	}()
 
 	// create tmpfs
 	if err := os.MkdirAll(localMountPath, 0700); err != nil {
 		return errors.Wrap(err, "error creating secret local mount path")
 	}
-	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "nodev"); err != nil {
+	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "nodev,nosuid,noexec"); err != nil {
 		return errors.Wrap(err, "unable to setup secret mount")
 	}
 

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -178,11 +178,9 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 	return nil
 }
 
-func (daemon *Daemon) setupSecretDir(c *container.Container) error {
+func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 	localMountPath := c.SecretMountPath()
 	logrus.Debugf("secrets: setting up secret dir: %s", localMountPath)
-
-	var setupErr error
 
 	defer func(err error) {
 		if err != nil {
@@ -197,22 +195,22 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) error {
 
 	// create tmpfs
 	if err := os.MkdirAll(localMountPath, 0700); err != nil {
-		setupErr = errors.Wrap(err, "error creating secret local mount path")
+		return errors.Wrap(err, "error creating secret local mount path")
 	}
 	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "nodev"); err != nil {
-		setupErr = errors.Wrap(err, "unable to setup secret mount")
+		return errors.Wrap(err, "unable to setup secret mount")
 	}
 
 	for _, s := range c.Secrets {
 		// ensure that the target is a filename only; no paths allowed
 		tDir, tPath := filepath.Split(s.Target)
 		if tDir != "" {
-			setupErr = fmt.Errorf("error creating secret: secret must not have a path")
+			return fmt.Errorf("error creating secret: secret must not have a path")
 		}
 
 		fPath := filepath.Join(localMountPath, tPath)
 		if err := os.MkdirAll(filepath.Dir(fPath), 0700); err != nil {
-			setupErr = errors.Wrap(err, "error creating secret mount path")
+			return errors.Wrap(err, "error creating secret mount path")
 		}
 
 		logrus.WithFields(logrus.Fields{
@@ -220,20 +218,20 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) error {
 			"path": fPath,
 		}).Debug("injecting secret")
 		if err := ioutil.WriteFile(fPath, s.Data, s.Mode); err != nil {
-			setupErr = errors.Wrap(err, "error injecting secret")
+			return errors.Wrap(err, "error injecting secret")
 		}
 
 		if err := os.Chown(fPath, s.Uid, s.Gid); err != nil {
-			setupErr = errors.Wrap(err, "error setting ownership for secret")
+			return errors.Wrap(err, "error setting ownership for secret")
 		}
 	}
 
 	// remount secrets ro
 	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "remount,ro"); err != nil {
-		setupErr = errors.Wrap(err, "unable to remount secret dir as readonly")
+		return errors.Wrap(err, "unable to remount secret dir as readonly")
 	}
 
-	return setupErr
+	return nil
 }
 
 func (daemon *Daemon) mountVolumes(container *container.Container) error {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/cloudflare/cfssl/log"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/links"
@@ -26,6 +27,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/devices"
 	"github.com/opencontainers/runc/libcontainer/label"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 func u32Ptr(i int64) *uint32     { u := uint32(i); return &u }
@@ -180,37 +182,60 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) error {
 	localMountPath := c.SecretMountPath()
 	logrus.Debugf("secrets: setting up secret dir: %s", localMountPath)
 
+	var setupErr error
+
+	defer func(err error) {
+		if err != nil {
+			// cleanup
+			_ = detachMounted(localMountPath)
+
+			if err := os.RemoveAll(localMountPath); err != nil {
+				log.Errorf("error cleaning up secret mount: %s", err)
+			}
+		}
+	}(setupErr)
+
 	// create tmpfs
 	if err := os.MkdirAll(localMountPath, 0700); err != nil {
-		return fmt.Errorf("error creating secret local mount path: %s", err)
+		setupErr = errors.Wrap(err, "error creating secret local mount path")
 	}
 	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "nodev"); err != nil {
-		return fmt.Errorf("unable to setup secret mount: %s", err)
+		setupErr = errors.Wrap(err, "unable to setup secret mount")
 	}
 
 	for _, s := range c.Secrets {
-		fPath := filepath.Join(localMountPath, s.Target)
-		if err := os.MkdirAll(filepath.Dir(fPath), 0700); err != nil {
-			return fmt.Errorf("error creating secret mount path: %s", err)
+		// ensure that the target is a filename only; no paths allowed
+		tDir, tPath := filepath.Split(s.Target)
+		if tDir != "" {
+			setupErr = fmt.Errorf("error creating secret: secret must not have a path")
 		}
 
-		logrus.Debugf("injecting secret: name=%s path=%s", s.Name, fPath)
+		fPath := filepath.Join(localMountPath, tPath)
+		if err := os.MkdirAll(filepath.Dir(fPath), 0700); err != nil {
+			setupErr = errors.Wrap(err, "error creating secret mount path")
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"name": s.Name,
+			"path": fPath,
+		}).Debug("injecting secret")
 		if err := ioutil.WriteFile(fPath, s.Data, s.Mode); err != nil {
-			return fmt.Errorf("error injecting secret: %s", err)
+			setupErr = errors.Wrap(err, "error injecting secret")
 		}
 
 		if err := os.Chown(fPath, s.Uid, s.Gid); err != nil {
-			return fmt.Errorf("error setting ownership for secret: %s", err)
+			setupErr = errors.Wrap(err, "error setting ownership for secret")
 		}
 	}
 
 	// remount secrets ro
 	if err := mount.Mount("tmpfs", localMountPath, "tmpfs", "remount,ro"); err != nil {
-		return fmt.Errorf("unable to remount secret dir as readonly: %s", err)
+		setupErr = errors.Wrap(err, "unable to remount secret dir as readonly")
 	}
 
-	return nil
+	return setupErr
 }
+
 func (daemon *Daemon) mountVolumes(container *container.Container) error {
 	mounts, err := daemon.setupMounts(container)
 	if err != nil {

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -179,6 +179,10 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 }
 
 func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
+	if len(c.Secrets) == 0 {
+		return nil
+	}
+
 	localMountPath := c.SecretMountPath()
 	logrus.Debugf("secrets: setting up secret dir: %s", localMountPath)
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -847,6 +847,7 @@ func (daemon *Daemon) Unmount(container *container.Container) error {
 		logrus.Errorf("Error unmounting container %s: %s", container.ID, err)
 		return err
 	}
+
 	return nil
 }
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -718,7 +718,8 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	}
 	ms = append(ms, tmpfsMounts...)
 
-	ms = append(ms, c.SecretMounts()...)
+	ms = append(ms, c.SecretMount())
+
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {
 		return nil, fmt.Errorf("linux mounts: %v", err)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -702,16 +702,23 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		return nil, err
 	}
 
+	if err := daemon.setupSecretDir(c); err != nil {
+		return nil, err
+	}
+
 	ms, err := daemon.setupMounts(c)
 	if err != nil {
 		return nil, err
 	}
 	ms = append(ms, c.IpcMounts()...)
+
 	tmpfsMounts, err := c.TmpfsMounts()
 	if err != nil {
 		return nil, err
 	}
 	ms = append(ms, tmpfsMounts...)
+
+	ms = append(ms, c.SecretMounts()...)
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {
 		return nil, fmt.Errorf("linux mounts: %v", err)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -710,6 +710,7 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	ms = append(ms, c.IpcMounts()...)
 
 	tmpfsMounts, err := c.TmpfsMounts()
@@ -718,7 +719,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	}
 	ms = append(ms, tmpfsMounts...)
 
-	ms = append(ms, c.SecretMount())
+	if m := c.SecretMount(); m != nil {
+		ms = append(ms, *m)
+	}
 
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {

--- a/daemon/secrets.go
+++ b/daemon/secrets.go
@@ -1,0 +1,22 @@
+package daemon
+
+import (
+	"github.com/Sirupsen/logrus"
+	containertypes "github.com/docker/docker/api/types/container"
+)
+
+func (daemon *Daemon) SetContainerSecrets(name string, secrets []*containertypes.ContainerSecret) error {
+	if !secretsSupported() {
+		logrus.Warn("secrets are not supported on this platform")
+		return nil
+	}
+
+	c, err := daemon.GetContainer(name)
+	if err != nil {
+		return err
+	}
+
+	c.Secrets = secrets
+
+	return nil
+}

--- a/daemon/secrets.go
+++ b/daemon/secrets.go
@@ -5,8 +5,9 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 )
 
+// SetContainerSecrets sets the container secrets needed
 func (daemon *Daemon) SetContainerSecrets(name string, secrets []*containertypes.ContainerSecret) error {
-	if !secretsSupported() {
+	if !secretsSupported() && len(secrets) > 0 {
 		logrus.Warn("secrets are not supported on this platform")
 		return nil
 	}

--- a/daemon/secrets_linux.go
+++ b/daemon/secrets_linux.go
@@ -1,0 +1,7 @@
+// +build linux
+
+package daemon
+
+func secretsSupported() bool {
+	return true
+}

--- a/daemon/secrets_unsupported.go
+++ b/daemon/secrets_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package daemon
+
+func secretsSupported() bool {
+	return false
+}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -209,6 +209,10 @@ func (daemon *Daemon) Cleanup(container *container.Container) {
 		}
 	}
 
+	if err := container.UnmountSecrets(); err != nil {
+		logrus.Warnf("%s cleanup: failed to unmount secrets: %s", container.ID, err)
+	}
+
 	for _, eConfig := range container.ExecCommands.Commands() {
 		daemon.unregisterExecCommand(container, eConfig)
 	}

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -22,6 +22,7 @@ Build an image from a Dockerfile
 
 Options:
       --build-arg value         Set build-time variables (default [])
+      --build-secret secret     Set build secrets
       --cache-from value        Images to consider as cache sources (default [])
       --cgroup-parent string    Optional parent cgroup for the container
       --compress                Compress the build context using gzip
@@ -54,7 +55,7 @@ Options:
                                 The format is `<number><unit>`. `number` must be greater than `0`.
                                 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                 or `g` (gigabytes). If you omit the unit, the system uses bytes.
-  --squash                      Squash newly built layers into a single new layer (**Experimental Only**) 
+  --squash                      Squash newly built layers into a single new layer (**Experimental Only**)
   -t, --tag value               Name and optionally a tag in the 'name:tag' format (default [])
       --ulimit value            Ulimit options (default [])
 ```
@@ -373,6 +374,21 @@ the command line.
 > directory (and its children) for security reasons, and to ensure
 > repeatable builds on remote Docker hosts. This is also the reason why
 > `ADD ../file` will not work.
+
+### Build with Secrets
+
+Build Secrets can be specified to provide private data such as keys or
+passwords.
+
+Build an image using secrets:
+
+```bash
+docker build -t app \
+    --secret source=/path/to/github-key,target=git.key .
+```
+
+This will expose the contents of `github-key` in the container during build
+as `/run/secrets/git.key`.
 
 ### Optional parent cgroup (--cgroup-parent)
 

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -19,6 +19,9 @@ keywords: ["secret, create"]
 Usage:  docker secret create [NAME]
 
 Create a secret using stdin as content
+Options:
+      --help         Print usage
+  -l, --label list   Secret labels (default [])
 ```
 
 Creates a secret using standard input for the secret content. You must run this
@@ -29,13 +32,44 @@ command on a manager node.
 ### Create a secret
 
 ```bash
-$ cat ssh-dev | docker secret create ssh-dev
+$ cat secret.json | docker secret create secret.json
 mhv17xfe3gh6xc4rij5orpfds
 
 $ docker secret ls
-ID                          NAME                CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   ssh-dev             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+ID                          NAME                    CREATED                                   UPDATED                                   SIZE
+mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
 ```
+
+### Create a secret with labels
+
+```bash
+$ cat secret.json | docker secret create secret.json --label env=dev --label rev=20161102
+jtn7g6aukl5ky7nr9gvwafoxh
+
+$ docker secret inspect secret.json
+[
+    {
+        "ID": "jtn7g6aukl5ky7nr9gvwafoxh",
+        "Version": {
+            "Index": 541
+        },
+        "CreatedAt": "2016-11-03T20:54:12.924766548Z",
+        "UpdatedAt": "2016-11-03T20:54:12.924766548Z",
+        "Spec": {
+            "Name": "secret.json",
+            "Labels": {
+                "env": "dev",
+                "rev": "20161102"
+            },
+            "Data": null
+        },
+        "Digest": "sha256:4212a44b14e94154359569333d3fc6a80f6b9959dfdaff26412f4b2796b1f387",
+        "SecretSize": 1679
+    }
+]
+
+```
+
 
 ## Related information
 

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -1,0 +1,46 @@
+---
+title: "secret create"
+description: "The secret create command description and usage"
+keywords: ["secret, create"]
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# secret create
+
+```Markdown
+Usage:  docker secret create [NAME]
+
+Create a secret using stdin as content
+```
+
+Creates a secret using standard input for the secret content. You must run this
+command on a manager node.
+
+## Examples
+
+### Create a secret
+
+```bash
+$ cat ssh-dev | docker secret create ssh-dev
+mhv17xfe3gh6xc4rij5orpfds
+
+$ docker secret ls
+ID                          NAME                CREATED                                   UPDATED                                   SIZE
+mhv17xfe3gh6xc4rij5orpfds   ssh-dev             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+```
+
+## Related information
+
+* [secret inspect](secret_inspect.md)
+* [secret ls](secret_ls.md)
+* [secret rm](secret_rm.md)
+
+<style>table tr > td:first-child { white-space: nowrap;}</style>

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -1,0 +1,88 @@
+---
+title: "secret inspect"
+description: "The secret inspect command description and usage"
+keywords: ["secret, inspect"]
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# secret inspect
+
+```Markdown
+Usage:  docker secret inspect [OPTIONS] SECRET [SECRET...]
+
+Display detailed information on one or more secrets
+
+Options:
+  -f, --format string   Format the output using the given Go template
+      --help            Print usage
+```
+
+
+Inspects the specified secret. This command has to be run targeting a manager
+node.
+
+By default, this renders all results in a JSON array. If a format is specified,
+the given template will be executed for each result.
+
+Go's [text/template](http://golang.org/pkg/text/template/) package
+describes all the details of the format.
+
+## Examples
+
+### Inspecting a secret  by name or ID
+
+You can inspect a secret, either by its *name*, or *ID*
+
+For example, given the following secret:
+
+```bash
+$ docker secret ls
+ID                          NAME                CREATED                                   UPDATED                                   SIZE
+mhv17xfe3gh6xc4rij5orpfds   ssh-dev             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+```
+
+```bash
+$ docker secret inspect mhv17xfe3gh6xc4rij5orpfds
+[
+    {
+        "ID": "mhv17xfe3gh6xc4rij5orpfds",
+            "Version": {
+            "Index": 1198
+        },
+        "CreatedAt": "2016-10-27T23:25:43.909181089Z",
+        "UpdatedAt": "2016-10-27T23:25:43.909181089Z",
+        "Spec": {
+            "Name": "ssh-dev",
+            "Data": null
+        },
+        "Digest": "sha256:8281c6d924520986e3c6af23ed8926710a611c90339db582c2a9ac480ba622b7",
+        "SecretSize": 1679
+    }
+]
+```
+
+### Formatting secret output
+
+The `--format` option can be used to obtain specific information about a
+secret. For example, the following command outputs the digest of the
+secret.
+
+```bash{% raw %}
+$ docker secret inspect --format='{{.Digest}}' mhv17xfe3gh6xc4rij5orpfds
+sha256:8281c6d924520986e3c6af23ed8926710a611c90339db582c2a9ac480ba622b7
+{% endraw %}```
+
+
+## Related information
+
+* [secret create](secret_create.md)
+* [secret ls](secret_ls.md)
+* [secret rm](secret_rm.md)

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -71,8 +71,8 @@ $ docker secret inspect mhv17xfe3gh6xc4rij5orpfds
 
 ### Formatting secret output
 
-The `--format` option can be used to obtain specific information about a
-secret. For example, the following command outputs the digest of the
+You can use the --format option to obtain specific information about a
+secret. The following example command outputs the digest of the
 secret.
 
 ```bash{% raw %}

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -37,7 +37,7 @@ describes all the details of the format.
 
 ## Examples
 
-### Inspecting a secret  by name or ID
+### Inspecting a secret by name or ID
 
 You can inspect a secret, either by its *name*, or *ID*
 
@@ -45,12 +45,12 @@ For example, given the following secret:
 
 ```bash
 $ docker secret ls
-ID                          NAME                CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   ssh-dev             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+ID                          NAME                    CREATED                                   UPDATED                                   SIZE
+mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
 ```
 
 ```bash
-$ docker secret inspect mhv17xfe3gh6xc4rij5orpfds
+$ docker secret inspect secret.json
 [
     {
         "ID": "mhv17xfe3gh6xc4rij5orpfds",
@@ -60,7 +60,7 @@ $ docker secret inspect mhv17xfe3gh6xc4rij5orpfds
         "CreatedAt": "2016-10-27T23:25:43.909181089Z",
         "UpdatedAt": "2016-10-27T23:25:43.909181089Z",
         "Spec": {
-            "Name": "ssh-dev",
+            "Name": "secret.json",
             "Data": null
         },
         "Digest": "sha256:8281c6d924520986e3c6af23ed8926710a611c90339db582c2a9ac480ba622b7",

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -1,0 +1,44 @@
+---
+title: "secret ls"
+description: "The secret ls command description and usage"
+keywords: ["secret, ls"]
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# secret ls
+
+```Markdown
+Usage:	docker secret ls [OPTIONS]
+
+List secrets
+
+Aliases:
+  ls, list
+
+Options:
+  -q, --quiet          Only display IDs
+```
+
+This command when run targeting a manager, lists secrets in the
+swarm.
+
+On a manager node:
+
+```bash
+$ docker secret ls
+ID                          NAME                CREATED                                   UPDATED                                   SIZE
+mhv17xfe3gh6xc4rij5orpfds   ssh-dev             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+```
+## Related information
+
+* [secret create](secret_create.md)
+* [secret inspect](secret_inspect.md)
+* [secret rm](secret_rm.md)

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -33,8 +33,8 @@ On a manager node:
 
 ```bash
 $ docker secret ls
-ID                          NAME                CREATED                                   UPDATED                                   SIZE
-mhv17xfe3gh6xc4rij5orpfds   ssh-dev             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
+ID                          NAME                    CREATED                                   UPDATED                                   SIZE
+mhv17xfe3gh6xc4rij5orpfds   secret.json             2016-10-27 23:25:43.909181089 +0000 UTC   2016-10-27 23:25:43.909181089 +0000 UTC   1679
 ```
 ## Related information
 

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -27,8 +27,7 @@ Options:
   -q, --quiet          Only display IDs
 ```
 
-This command when run targeting a manager, lists secrets in the
-swarm.
+Run this command from a manager to list the secrets in the Swarm.
 
 On a manager node:
 

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -30,7 +30,7 @@ Options:
 Removes the specified secrets from the swarm. This command has to be run
 targeting a manager node.
 
-For example, to remove secret:
+This example removes a secret:
 
 ```bash
 $ docker secret rm sapth4csdo5b6wz2p5uimh5xg

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -1,0 +1,48 @@
+---
+title: "secret rm"
+description: "The secret rm command description and usage"
+keywords: ["secret, rm"]
+---
+
+<!-- This file is maintained within the docker/docker Github
+     repository at https://github.com/docker/docker/. Make all
+     pull requests against that repo. If you see this file in
+     another repository, consider it read-only there, as it will
+     periodically be overwritten by the definitive file. Pull
+     requests which include edits to this file in other repositories
+     will be rejected.
+-->
+
+# secret rm
+
+```Markdown
+Usage:	docker secret rm SECRET [SECRET...]
+
+Remove one or more secrets
+
+Aliases:
+  rm, remove
+
+Options:
+      --help   Print usage
+```
+
+Removes the specified secrets from the swarm. This command has to be run
+targeting a manager node.
+
+For example, to remove secret:
+
+```bash
+$ docker secret rm sapth4csdo5b6wz2p5uimh5xg
+sapth4csdo5b6wz2p5uimh5xg
+```
+
+> **Warning**: Unlike `docker rm`, this command does not ask for confirmation
+> before removing a secret.
+
+
+## Related information
+
+* [secret create](secret_create.md)
+* [secret inspect](secret_inspect.md)
+* [secret ls](secret_ls.md)

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -33,7 +33,7 @@ targeting a manager node.
 This example removes a secret:
 
 ```bash
-$ docker secret rm sapth4csdo5b6wz2p5uimh5xg
+$ docker secret rm secret.json
 sapth4csdo5b6wz2p5uimh5xg
 ```
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -118,7 +118,7 @@ Use the `--secret` flag to give a container access to a
 with two secrets named `ssh-key` and `app-key`:
 
 ```bash
-$ docker service create --name redis --secret ssh-key:ssh --secret app-key:app redis:3.0.6
+$ docker service create --name redis --secret source=ssh-key,target=ssh --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 redis:3.0.6
 4cdgfyky7ozwh3htjfw0d12qv
 ```
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -114,11 +114,22 @@ ID            NAME    REPLICAS  IMAGE        COMMAND
 
 ### Create a service with secrets
 Use the `--secret` flag to give a container access to a
-[secret](secret_create.md).  The following command will create a service
-with two secrets named `ssh-key` and `app-key`:
+[secret](secret_create.md).
+
+Create a service specifying a secret:
 
 ```bash
-$ docker service create --name redis --secret source=ssh-key,target=ssh --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 redis:3.0.6
+$ docker service create --name redis --secret secret.json redis:3.0.6
+4cdgfyky7ozwh3htjfw0d12qv
+```
+
+Create a service specifying the secret, target, user/group ID and mode:
+
+```bash
+$ docker service create --name redis \
+    --secret source=ssh-key,target=ssh \
+    --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \
+    redis:3.0.6
 4cdgfyky7ozwh3htjfw0d12qv
 ```
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -113,8 +113,9 @@ ID            NAME    REPLICAS  IMAGE        COMMAND
 ```
 
 ### Create a service with secrets
-Use the `--secret` flag to use a [secret](secret_create.md).  The following
-command will create a service with two secrets named `ssh-key` and `app-key`:
+Use the `--secret` flag to give a container access to a
+[secret](secret_create.md).  The following command will create a service
+with two secrets named `ssh-key` and `app-key`:
 
 ```bash
 $ docker service create --name redis --secret ssh-key:ssh --secret app-key:app redis:3.0.6

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -51,6 +51,7 @@ Options:
       --restart-delay value              Delay between restart attempts (default none)
       --restart-max-attempts value       Maximum number of restarts before giving up (default none)
       --restart-window value             Window used to evaluate the restart policy (default none)
+      --secret value                     Specify secrets to expose to the service (default [])
       --stop-grace-period value          Time to wait before force killing a container (default none)
       --update-delay duration            Delay between updates
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")
@@ -110,6 +111,21 @@ $ docker service ls
 ID            NAME    REPLICAS  IMAGE        COMMAND
 4cdgfyky7ozw  redis   5/5       redis:3.0.7
 ```
+
+### Create a service with secrets
+Use the `--secret` flag to use a [secret](secret_create.md).  The following
+command will create a service with two secrets named `ssh-key` and `app-key`:
+
+```bash
+$ docker service create --name redis --secret ssh-key:ssh --secret app-key:app redis:3.0.6
+4cdgfyky7ozwh3htjfw0d12qv
+```
+
+Secrets are located in `/run/secrets` in the container.  If no target is
+specified, the name of the secret will be used as the in memory file in the
+container.  If a target is specified, that will be the filename.  In the
+example above, two files will be created: `/run/secrets/ssh` and
+`/run/secrets/app` for each of the secret targets specified.
 
 ### Create a service with a rolling update policy
 

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -150,7 +150,7 @@ The following example adds a secret named `ssh-2` and removes `ssh-1`:
 
 ```bash
 $ docker service update \
-    --secret-add ssh-2 \
+    --secret-add source=ssh-2,target=ssh-2 \
     --secret-rm ssh-1 \
     myservice
 ```

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -57,6 +57,8 @@ Options:
       --restart-max-attempts value       Maximum number of restarts before giving up (default none)
       --restart-window value             Window used to evaluate the restart policy (default none)
       --rollback                         Rollback to previous specification
+      --secret-add list                  Add a secret (default [])
+      --secret-rm list                   Remove a secret (default [])
       --stop-grace-period value          Time to wait before force killing a container (default none)
       --update-delay duration            Delay between updates
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")
@@ -137,6 +139,20 @@ myservice
 $ docker service update --mount-rm /somewhere myservice
 
 myservice
+```
+
+### Adding and removing secrets
+
+Use the `--secret-add` or `--secret-rm` options add or remove a service's
+secrets.
+
+The following example adds a secret named `ssh-2` and removes `ssh-1`:
+
+```bash
+$ docker service update \
+    --secret-add ssh-2 \
+    --secret-rm ssh-1 \
+    myservice
 ```
 
 ## Related information

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -284,14 +284,14 @@ func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 	return services
 }
 
-func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Service {
+func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Secret {
 	status, out, err := d.SockRequest("GET", "/secrets", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 
 	secrets := []swarm.Secret{}
 	c.Assert(json.Unmarshal(out, &secrets), checker.IsNil)
-	return services
+	return secrets
 }
 
 func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -284,6 +284,17 @@ func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 	return services
 }
 
+func (d *SwarmDaemon) createSecret(c *check.C, secretSpec swarm.SecretSpec) string {
+	status, out, err := d.SockRequest("POST", "/secrets", secretSpec)
+
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusCreated, check.Commentf("output: %q", string(out)))
+
+	var scr types.SecretCreateResponse
+	c.Assert(json.Unmarshal(out, &scr), checker.IsNil)
+	return scr.ID
+}
+
 func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Secret {
 	status, out, err := d.SockRequest("GET", "/secrets", nil)
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
@@ -292,6 +303,21 @@ func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Secret {
 	secrets := []swarm.Secret{}
 	c.Assert(json.Unmarshal(out, &secrets), checker.IsNil)
 	return secrets
+}
+
+func (d *SwarmDaemon) getSecret(c *check.C, id string) *swarm.Secret {
+	var secret swarm.Secret
+	status, out, err := d.SockRequest("GET", "/secrets/"+id, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+	c.Assert(json.Unmarshal(out, &secret), checker.IsNil)
+	return &secret
+}
+
+func (d *SwarmDaemon) deleteSecret(c *check.C, id string) {
+	status, out, err := d.SockRequest("DELETE", "/secrets/"+id, nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 }
 
 func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -284,6 +284,16 @@ func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 	return services
 }
 
+func (d *SwarmDaemon) listSecrets(c *check.C) []swarm.Service {
+	status, out, err := d.SockRequest("GET", "/secrets", nil)
+	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
+	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
+
+	secrets := []swarm.Secret{}
+	c.Assert(json.Unmarshal(out, &secrets), checker.IsNil)
+	return services
+}
+
 func (d *SwarmDaemon) getSwarm(c *check.C) swarm.Swarm {
 	var sw swarm.Swarm
 	status, out, err := d.SockRequest("GET", "/swarm", nil)

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -1271,3 +1271,42 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsEmptyList(c *check.C) {
 	c.Assert(secrets, checker.NotNil)
 	c.Assert(len(secrets), checker.Equals, 0, check.Commentf("secrets: %#v", secrets))
 }
+
+func (s *DockerSwarmSuite) TestAPISwarmSecretsCreate(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	secrets := d.listSecrets(c)
+	c.Assert(len(secrets), checker.Equals, 1, check.Commentf("secrets: %#v", secrets))
+	name := secrets[0].Spec.Annotations.Name
+	c.Assert(name, checker.Equals, testName, check.Commentf("secret: %s", name))
+}
+
+func (s *DockerSwarmSuite) TestAPISwarmSecretsDelete(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	secret := d.getSecret(c, id)
+	c.Assert(secret.ID, checker.Equals, id, check.Commentf("secret: %v", secret))
+
+	d.deleteSecret(c, secret.ID)
+	status, out, err := d.SockRequest("GET", "/secrets/"+id, nil)
+	c.Assert(err, checker.IsNil)
+	c.Assert(status, checker.Equals, http.StatusNotFound, check.Commentf("secret delete: %s", string(out)))
+}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -1271,19 +1271,3 @@ func (s *DockerSwarmSuite) TestAPISwarmSecretsEmptyList(c *check.C) {
 	c.Assert(secrets, checker.NotNil)
 	c.Assert(len(secrets), checker.Equals, 0, check.Commentf("secrets: %#v", secrets))
 }
-
-//func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *check.C) {
-//	d := s.AddDaemon(c, true, true)
-//
-//	instances := 2
-//	id := d.createService(c, simpleTestService, setInstances(instances))
-//	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
-//
-//	service := d.getService(c, id)
-//	instances = 5
-//	d.updateService(c, service, setInstances(instances))
-//	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
-//
-//	d.removeService(c, service.ID)
-//	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 0)
-//}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -1263,3 +1263,27 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusOK, check.Commentf("output: %q", string(out)))
 	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
 }
+
+func (s *DockerSwarmSuite) TestAPISwarmSecretsEmptyList(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	secrets := d.listSecrets(c)
+	c.Assert(secrets, checker.NotNil)
+	c.Assert(len(secrets), checker.Equals, 0, check.Commentf("secrets: %#v", secrets))
+}
+
+//func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *check.C) {
+//	d := s.AddDaemon(c, true, true)
+//
+//	instances := 2
+//	id := d.createService(c, simpleTestService, setInstances(instances))
+//	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
+//
+//	service := d.getService(c, id)
+//	instances = 5
+//	d.updateService(c, service, setInstances(instances))
+//	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, instances)
+//
+//	d.removeService(c, service.ID)
+//	waitAndAssert(c, defaultReconciliationTimeout, d.checkActiveContainerCount, checker.Equals, 0)
+//}

--- a/integration-cli/docker_cli_secret_create_test.go
+++ b/integration-cli/docker_cli_secret_create_test.go
@@ -1,0 +1,48 @@
+// +build !windows
+
+package main
+
+import (
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/go-check/check"
+)
+
+func (s *DockerSwarmSuite) TestSecretCreate(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	secret := d.getSecret(c, id)
+	c.Assert(secret.Spec.Name, checker.Equals, testName)
+}
+
+func (s *DockerSwarmSuite) TestSecretCreateWithLabels(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	secret := d.getSecret(c, id)
+	c.Assert(secret.Spec.Name, checker.Equals, testName)
+	c.Assert(len(secret.Spec.Labels), checker.Equals, 2)
+	c.Assert(secret.Spec.Labels["key1"], checker.Equals, "value1")
+	c.Assert(secret.Spec.Labels["key2"], checker.Equals, "value2")
+}

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -70,5 +70,6 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecret(c *check.C) {
 	c.Assert(refs, checker.HasLen, 1)
 
 	c.Assert(refs[0].SecretName, checker.Equals, testName)
-	c.Assert(refs[0].Target, checker.Equals, testTarget)
+	c.Assert(refs[0].Target, checker.Not(checker.IsNil))
+	c.Assert(refs[0].Target.Name, checker.Equals, testTarget)
 }

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -59,7 +59,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecret(c *check.C) {
 	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
 	testTarget := "testing"
 
-	out, err := d.Cmd("service", "create", "--name", serviceName, "--secret", fmt.Sprintf("%s:%s", testName, testTarget), "busybox", "top")
+	out, err := d.Cmd("service", "create", "--name", serviceName, "--secret", fmt.Sprintf("source=%s,target=%s", testName, testTarget), "busybox", "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -45,7 +45,37 @@ func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *check.C) {
 	c.Assert(mounts[0].RW, checker.Equals, true)
 }
 
-func (s *DockerSwarmSuite) TestServiceCreateWithSecret(c *check.C) {
+func (s *DockerSwarmSuite) TestServiceCreateWithSecretSimple(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	serviceName := "test-service-secret"
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+
+	out, err := d.Cmd("service", "create", "--name", serviceName, "--secret", testName, "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)
+	c.Assert(err, checker.IsNil)
+
+	var refs []swarm.SecretReference
+	c.Assert(json.Unmarshal([]byte(out), &refs), checker.IsNil)
+	c.Assert(refs, checker.HasLen, 1)
+
+	c.Assert(refs[0].SecretName, checker.Equals, testName)
+	c.Assert(refs[0].Target, checker.Not(checker.IsNil))
+	c.Assert(refs[0].Target.Name, checker.Equals, testName)
+	c.Assert(refs[0].Target.UID, checker.Equals, "0")
+	c.Assert(refs[0].Target.GID, checker.Equals, "0")
+}
+
+func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTarget(c *check.C) {
 	d := s.AddDaemon(c, true, true)
 
 	serviceName := "test-service-secret"

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -42,4 +43,32 @@ func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *check.C) {
 	c.Assert(mounts[0].Name, checker.Equals, "foo")
 	c.Assert(mounts[0].Destination, checker.Equals, "/foo")
 	c.Assert(mounts[0].RW, checker.Equals, true)
+}
+
+func (s *DockerSwarmSuite) TestServiceCreateWithSecret(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	serviceName := "test-service-secret"
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+	testTarget := "testing"
+
+	out, err := d.Cmd("service", "create", "--name", serviceName, "--secret", fmt.Sprintf("%s:%s", testName, testTarget), "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)
+	c.Assert(err, checker.IsNil)
+
+	var refs []swarm.SecretReference
+	c.Assert(json.Unmarshal([]byte(out), &refs), checker.IsNil)
+	c.Assert(refs, checker.HasLen, 1)
+
+	c.Assert(refs[0].SecretName, checker.Equals, testName)
+	c.Assert(refs[0].Target, checker.Equals, testTarget)
 }

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/integration/checker"
@@ -83,4 +84,45 @@ func (s *DockerSwarmSuite) TestServiceUpdateLabel(c *check.C) {
 	service = d.getService(c, "test")
 	c.Assert(service.Spec.Labels, checker.HasLen, 1)
 	c.Assert(service.Spec.Labels["foo"], checker.Equals, "bar")
+}
+
+func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+	testName := "test_secret"
+	id := d.createSecret(c, swarm.SecretSpec{
+		swarm.Annotations{
+			Name: testName,
+		},
+		[]byte("TESTINGDATA"),
+	})
+	c.Assert(id, checker.Not(checker.Equals), "", check.Commentf("secrets: %s", id))
+	testTarget := "testing"
+	serviceName := "test"
+
+	out, err := d.Cmd("service", "create", "--name", serviceName, "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	// add secret
+	out, err = d.Cmd("service", "update", "test", "--secret-add", fmt.Sprintf("%s:%s", testName, testTarget))
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)
+	c.Assert(err, checker.IsNil)
+
+	var refs []swarm.SecretReference
+	c.Assert(json.Unmarshal([]byte(out), &refs), checker.IsNil)
+	c.Assert(refs, checker.HasLen, 1)
+
+	c.Assert(refs[0].SecretName, checker.Equals, testName)
+	c.Assert(refs[0].Target, checker.Equals, testTarget)
+
+	// remove
+	out, err = d.Cmd("service", "update", "test", "--secret-rm", testName)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)
+	c.Assert(err, checker.IsNil)
+
+	c.Assert(json.Unmarshal([]byte(out), &refs), checker.IsNil)
+	c.Assert(refs, checker.HasLen, 0)
 }

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -103,7 +103,7 @@ func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	// add secret
-	out, err = d.Cmd("service", "update", "test", "--secret-add", fmt.Sprintf("%s:%s", testName, testTarget))
+	out, err = d.Cmd("service", "update", "test", "--secret-add", fmt.Sprintf("source=%s,target=%s", testName, testTarget))
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 
 	out, err = d.Cmd("service", "inspect", "--format", "{{ json .Spec.TaskTemplate.ContainerSpec.Secrets }}", serviceName)

--- a/integration-cli/docker_cli_service_update_test.go
+++ b/integration-cli/docker_cli_service_update_test.go
@@ -114,7 +114,8 @@ func (s *DockerSwarmSuite) TestServiceUpdateSecrets(c *check.C) {
 	c.Assert(refs, checker.HasLen, 1)
 
 	c.Assert(refs[0].SecretName, checker.Equals, testName)
-	c.Assert(refs[0].Target, checker.Equals, testTarget)
+	c.Assert(refs[0].Target, checker.Not(checker.IsNil))
+	c.Assert(refs[0].Target.Name, checker.Equals, testTarget)
 
 	// remove
 	out, err = d.Cmd("service", "update", "test", "--secret-rm", testName)

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -1,0 +1,95 @@
+package opts
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+)
+
+// SecretOpt is a Value type for parsing secrets
+type SecretOpt struct {
+	values []*types.SecretRequestOptions
+}
+
+// Set a new secret value
+func (o *SecretOpt) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	options := &types.SecretRequestOptions{
+		Source: "",
+		Target: "",
+		UID:    "0",
+		GID:    "0",
+		Mode:   0444,
+	}
+
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		key := strings.ToLower(parts[0])
+
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid field '%s' must be a key=value pair", field)
+		}
+
+		value := parts[1]
+		switch key {
+		case "source":
+			options.Source = value
+		case "target":
+			tDir, _ := filepath.Split(value)
+			if tDir != "" {
+				return fmt.Errorf("target must not be a path")
+			}
+			options.Target = value
+		case "uid":
+			options.UID = value
+		case "gid":
+			options.GID = value
+		case "mode":
+			m, err := strconv.ParseUint(value, 0, 32)
+			if err != nil {
+				return fmt.Errorf("invalid mode specified: %v", err)
+			}
+
+			options.Mode = os.FileMode(m)
+		default:
+			return fmt.Errorf("invalid field in secret request: %s", key)
+		}
+	}
+
+	if options.Source == "" {
+		return fmt.Errorf("source is required")
+	}
+
+	o.values = append(o.values, options)
+	return nil
+}
+
+// Type returns the type of this option
+func (o *SecretOpt) Type() string {
+	return "secret"
+}
+
+// String returns a string repr of this option
+func (o *SecretOpt) String() string {
+	secrets := []string{}
+	for _, secret := range o.values {
+		repr := fmt.Sprintf("%s -> %s", secret.Source, secret.Target)
+		secrets = append(secrets, repr)
+	}
+	return strings.Join(secrets, ", ")
+}
+
+// Value returns the secret requests
+func (o *SecretOpt) Value() []*types.SecretRequestOptions {
+	return o.values
+}

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -32,6 +32,14 @@ func (o *SecretOpt) Set(value string) error {
 		Mode:   0444,
 	}
 
+	// support a simple syntax of --secret foo
+	if len(fields) == 1 {
+		options.Source = fields[0]
+		options.Target = fields[0]
+		o.values = append(o.values, options)
+		return nil
+	}
+
 	for _, field := range fields {
 		parts := strings.SplitN(field, "=", 2)
 		key := strings.ToLower(parts[0])
@@ -62,7 +70,11 @@ func (o *SecretOpt) Set(value string) error {
 
 			options.Mode = os.FileMode(m)
 		default:
-			return fmt.Errorf("invalid field in secret request: %s", key)
+			if len(fields) == 1 && value == "" {
+
+			} else {
+				return fmt.Errorf("invalid field in secret request: %s", key)
+			}
 		}
 	}
 

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -13,7 +13,7 @@ import (
 
 // SecretOpt is a Value type for parsing secrets
 type SecretOpt struct {
-	values []*types.SecretRequestOptions
+	values []*types.SecretRequestOption
 }
 
 // Set a new secret value
@@ -24,7 +24,7 @@ func (o *SecretOpt) Set(value string) error {
 		return err
 	}
 
-	options := &types.SecretRequestOptions{
+	options := &types.SecretRequestOption{
 		Source: "",
 		Target: "",
 		UID:    "0",
@@ -102,6 +102,6 @@ func (o *SecretOpt) String() string {
 }
 
 // Value returns the secret requests
-func (o *SecretOpt) Value() []*types.SecretRequestOptions {
+func (o *SecretOpt) Value() []*types.SecretRequestOption {
 	return o.values
 }

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -1,0 +1,67 @@
+package opts
+
+import (
+	"os"
+	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
+)
+
+func TestSecretOptionsSimple(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "app-secret"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.Source, "app-secret")
+	assert.Equal(t, req.Target, "app-secret")
+	assert.Equal(t, req.UID, "0")
+	assert.Equal(t, req.GID, "0")
+}
+
+func TestSecretOptionsSourceTarget(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "source=foo,target=testing"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.Target, "testing")
+}
+
+func TestSecretOptionsCustomUidGid(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "source=foo,target=testing,uid=1000,gid=1001"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.Target, "testing")
+	assert.Equal(t, req.UID, "1000")
+	assert.Equal(t, req.GID, "1001")
+}
+
+func TestSecretOptionsCustomMode(t *testing.T) {
+	var opt SecretOpt
+
+	testCase := "source=foo,target=testing,uid=1000,gid=1001,mode=0444"
+	assert.NilError(t, opt.Set(testCase))
+
+	reqs := opt.Value()
+	assert.Equal(t, len(reqs), 1)
+	req := reqs[0]
+	assert.Equal(t, req.Source, "foo")
+	assert.Equal(t, req.Target, "testing")
+	assert.Equal(t, req.UID, "1000")
+	assert.Equal(t, req.GID, "1001")
+	assert.Equal(t, req.Mode, os.FileMode(0444))
+}

--- a/vendor/github.com/docker/swarmkit/agent/secrets/secrets.go
+++ b/vendor/github.com/docker/swarmkit/agent/secrets/secrets.go
@@ -1,0 +1,87 @@
+package secrets
+
+import (
+	"sync"
+
+	"github.com/docker/swarmkit/agent/exec"
+	"github.com/docker/swarmkit/api"
+)
+
+// secrets is a map that keeps all the currenty available secrets to the agent
+// mapped by secret ID
+type secrets struct {
+	mu sync.RWMutex
+	m  map[string]*api.Secret
+}
+
+// NewManager returns a place to store secrets.
+func NewManager() exec.SecretsManager {
+	return &secrets{
+		m: make(map[string]*api.Secret),
+	}
+}
+
+// Get returns a secret by ID.  If the secret doesn't exist, returns nil.
+func (s *secrets) Get(secretID string) *api.Secret {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s, ok := s.m[secretID]; ok {
+		return s
+	}
+	return nil
+}
+
+// add adds one or more secrets to the secret map
+func (s *secrets) Add(secrets ...api.Secret) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, secret := range secrets {
+		s.m[secret.ID] = secret.Copy()
+	}
+}
+
+// remove removes one or more secrets by ID from the secret map.  Succeeds
+// whether or not the given IDs are in the map.
+func (s *secrets) Remove(secrets []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, secret := range secrets {
+		delete(s.m, secret)
+	}
+}
+
+// reset removes all the secrets
+func (s *secrets) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m = make(map[string]*api.Secret)
+}
+
+// taskRestrictedSecretsProvider restricts the ids to the task.
+type taskRestrictedSecretsProvider struct {
+	secrets   exec.SecretGetter
+	secretIDs map[string]struct{} // allow list of secret ids
+}
+
+func (sp *taskRestrictedSecretsProvider) Get(secretID string) *api.Secret {
+	if _, ok := sp.secretIDs[secretID]; !ok {
+		return nil
+	}
+
+	return sp.secrets.Get(secretID)
+}
+
+// Restrict provides a getter that only allows access to the secrets
+// referenced by the task.
+func Restrict(secrets exec.SecretGetter, t *api.Task) exec.SecretGetter {
+	sids := map[string]struct{}{}
+
+	container := t.Spec.GetContainer()
+	if container != nil {
+		for _, ref := range container.Secrets {
+			sids[ref.SecretID] = struct{}{}
+		}
+	}
+
+	return &taskRestrictedSecretsProvider{secrets: secrets, secretIDs: sids}
+}


### PR DESCRIPTION
RE-OPENED in #30637 

This enables build time secrets using the `--build-secret` flag.

Similar to #27794 this creates a tmpfs during each run of the build and exposes the specified "secrets" into the container.  These are not committed to the image.

Here is an example Dockerfile:

```
FROM busybox:latest
RUN mount | grep tmpfs
RUN find /run
RUN cat /run/secrets/git-key
```

Given the following command:

```
docker build -t test --no-cache --build-secret source=~/git-key,target=git-key .
```

This will expose the key from `~/git-key` as `/run/secrets/git-key`.  This can be used however needed during build by the corresponding `RUN` directives.

Here is the example output:

```
Sending build context to Docker daemon 3.072 kB
Step 1/4 : FROM busybox:latest
 ---> e02e811dd08f
Step 2/4 : RUN mount | grep tmpfs
 ---> Running in 9c7863ab331b
tmpfs on /dev type tmpfs (rw,nosuid,mode=755)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,relatime,mode=755)
tmpfs on /run type tmpfs (rw,nosuid,nodev,noexec,relatime)
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
tmpfs on /proc/kcore type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/timer_list type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/timer_stats type tmpfs (rw,nosuid,mode=755)
tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,mode=755)
tmpfs on /sys/firmware type tmpfs (ro,relatime)
 ---> 60836fd9a783
Removing intermediate container 9c7863ab331b
Step 3/4 : RUN find /run
 ---> Running in 56a46a797034
/run
/run/secrets
/run/secrets/git-key
 ---> 908a73ff32a1
Removing intermediate container 56a46a797034
Step 4/4 : RUN cat /run/secrets/git-key
 ---> Running in e8f6b05e7a81
TESTKEY
 ---> 3c13c956d170
Removing intermediate container e8f6b05e7a81
Successfully built 3c13c956d170
root@dev:~/build# docker run --rm -ti test ls -lah /run/
total 8
drwxr-xr-x    2 root     root        4.0K Nov  4 19:55 .
drwxr-xr-x    1 root     root        4.0K Nov  4 19:56 ..
```

Depends on: https://github.com/docker/docker/pull/27794 I re-used some structs from that PR to reduce duplication.  