### PR TITLE
distribution: Remove misleading comment

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -338,9 +338,6 @@ func (p *v2Puller) pullV2Tag(ctx context.Context, ref reference.Named) (tagUpdat
 		tagOrDigest string // Used for logging/progress only
 	)
 	if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
-		// NOTE: not using TagService.Get, since it uses HEAD requests
-		// against the manifests endpoint, which are not supported by
-		// all registry versions.
 		manifest, err = manSvc.Get(ctx, "", distribution.WithTag(tagged.Tag()))
 		if err != nil {
 			return false, allowV1Fallback(err)


### PR DESCRIPTION
Remove the following comment in `pullV2Tag`:

```
// NOTE: not using TagService.Get, since it uses HEAD requests
// against the manifests endpoint, which are not supported by
// all registry versions.
```

This is actually not an issue, because `TagService.Get` does a fallback to
`GET` if `HEAD` fails. It has done this ever since `TagService` was added to
the distribution API, so this comment was probably based on an early
version of `TagService` before it was merged, or was always a
misunderstanding.

However, we continue to use `ManifestService.Get` instead because it
saves a round trip. The manifest can be retrieved directly instead of
resolving the digest first.

cc @dmcgowan @nishanttotla