### PR TITLE
Fixes #26009 : Trim double/single quotes in env-file variables

### DIFF
--- a/runconfig/opts/envfile.go
+++ b/runconfig/opts/envfile.go
@@ -58,6 +58,9 @@ func ParseEnvFile(filename string) ([]string, error) {
 
 			if len(data) > 1 {
 
+				// Trim any leading or trailing double or single quotes in variable
+				data[1] = strings.Trim(data[1], "\"\\'")
+
 				// pass the value through, no trimming
 				lines = append(lines, fmt.Sprintf("%s=%s", variable, data[1]))
 			} else {


### PR DESCRIPTION
Fixes #26009

**- What I did**
Trim leading/trailing double/single quotes in env-file variables

**- How to verify it**
1. Create myvars.env file with following contents
```
var1="something else"
var2="another thing"
var3='value3'
var4='value4'
var5=value5
var6=yet another thing
```

2. docker run --env-file myvars.env alpine sh -c "env"
It should print env variables without any trailing/leading quotes
```
var1=something else
var2=another thing
var3=value3
var4=value4
var5=value5
var6=yet another thing
```

Signed-off-by: milindchawre <milindchawre@gmail.com>