### PR TITLE
Add bash completion for `docker {run,create} --cpus`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1236,6 +1236,7 @@ _docker_container_run() {
 		--cpu-rt-period
 		--cpu-rt-runtime
 		--cpuset-cpus
+		--cpus
 		--cpuset-mems
 		--cpu-shares -c
 		--device


### PR DESCRIPTION
Ref: #27958