### PR TITLE
Fix bash completion for `docker inspect --type`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2184,9 +2184,11 @@ _docker_info() {
 }
 
 _docker_inspect() {
+	local preselected_type
 	local type
 
 	if [ "$1" = "--type" ] ; then
+		preselected_type=yes
 		type="$2"
 	else
 		type=$(__docker_value_of_option --type)
@@ -2197,17 +2199,17 @@ _docker_inspect() {
 			return
 			;;
 		--type)
-			if [ -z "$type" ] ; then
+			if [ -z "$preselected_type" ] ; then
 				COMPREPLY=( $( compgen -W "image container" -- "$cur" ) )
+				return
 			fi
-			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
 			local options="--format -f --help --size -s"
-			if [ -z "$type" ] ; then
+			if [ -z "$preselected_type" ] ; then
 				options+=" --type"
 			fi
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )


### PR DESCRIPTION
This resolves two minor problems with bash completion:

```bash
$ docker inspect --type <tab><tab>
container  image
$ docker inspect --type c<tab>
```
expected: the second command should complete `container`.
acutal: no completion.

```bash
docker container inspect --nonsense <tab>
[containers]
docker container inspect --type <tab>
docker container inspect --type anything <tab>
[containers]
```
expected: As `--type` is not allowed here, it should be treated just like `--nonsense`: It should be ignored and containers should be completed.
actual: no containers are completed. A dummy argument has to be added (`anything` in the example) for completion of images to occur.

This problem also exists with `docker image inspect --type`.