### PR TITLE
Fix `/proc/<pid>/oom_score_adj: invalid argument` error caused by empty env name

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/truncindex"
+	"github.com/docker/docker/runconfig/opts"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -230,6 +231,13 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *containertypes.HostCon
 			matched, _ := regexp.MatchString("^(([[:alnum:]]|[[:alnum:]][[:alnum:]\\-]*[[:alnum:]])\\.)*([[:alnum:]]|[[:alnum:]][[:alnum:]\\-]*[[:alnum:]])$", config.Hostname)
 			if len(config.Hostname) > 63 || !matched {
 				return nil, fmt.Errorf("invalid hostname format: %s", config.Hostname)
+			}
+		}
+
+		// Validate if Env contains empty variable or not (e.g., ``, `=foo`)
+		for _, env := range config.Env {
+			if _, err := opts.ValidateEnv(env); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -42,3 +42,43 @@ func (s *DockerSuite) TestAPICreateWithNotExistImage(c *check.C) {
 	c.Assert(getErrorMessage(c, body), checker.Equals, expected)
 
 }
+
+// Test for #25099
+func (s *DockerSuite) TestAPICreateEmptyEnv(c *check.C) {
+	name := "test1"
+	config := map[string]interface{}{
+		"Image": "busybox",
+		"Env":   []string{"", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		"Cmd":   []string{"true"},
+	}
+
+	status, body, err := sockRequest("POST", "/containers/create?name="+name, config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	expected := "invalid environment variable:"
+	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+
+	name = "test2"
+	config = map[string]interface{}{
+		"Image": "busybox",
+		"Env":   []string{"=", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		"Cmd":   []string{"true"},
+	}
+	status, body, err = sockRequest("POST", "/containers/create?name="+name, config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	expected = "invalid environment variable: ="
+	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+
+	name = "test3"
+	config = map[string]interface{}{
+		"Image": "busybox",
+		"Env":   []string{"=foo", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+		"Cmd":   []string{"true"},
+	}
+	status, body, err = sockRequest("POST", "/containers/create?name="+name, config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	expected = "invalid environment variable: =foo"
+	c.Assert(getErrorMessage(c, body), checker.Contains, expected)
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4830,3 +4830,22 @@ func (s *DockerSuite) TestRunHypervIsolationWithCPUCountCPUSharesAndCPUPercent(c
 	out = inspectField(c, "test", "HostConfig.CPUPercent")
 	c.Assert(out, check.Equals, "80")
 }
+
+// Test for #25099
+func (s *DockerSuite) TestRunEmptyEnv(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	expectedOutput := "invalid environment variable:"
+
+	out, _, err := dockerCmdWithError("run", "-e", "", "busybox", "true")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+
+	out, _, err = dockerCmdWithError("run", "-e", "=", "busybox", "true")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+
+	out, _, err = dockerCmdWithError("run", "-e", "=foo", "busybox", "true")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, expectedOutput)
+}

--- a/runconfig/opts/opts.go
+++ b/runconfig/opts/opts.go
@@ -26,8 +26,13 @@ func ValidateAttach(val string) (string, error) {
 // As on ParseEnvFile and related to #16585, environment variable names
 // are not validate what so ever, it's up to application inside docker
 // to validate them or not.
+//
+// The only validation here is to check if name is empty, per #25099
 func ValidateEnv(val string) (string, error) {
 	arr := strings.Split(val, "=")
+	if arr[0] == "" {
+		return "", fmt.Errorf("invalid environment variable: %s", val)
+	}
 	if len(arr) > 1 {
 		return val, nil
 	}


### PR DESCRIPTION
**- What I did**

This fix is part of the fix for issue #25099. In #25099, if an env has a empty name, then `docker run` will throw out an error:
```
ubuntu@ubuntu:~/docker$ docker run -e =A busybox true
docker: Error response from daemon: invalid header field value "oci runtime error:
container_linux.go:247: starting container process caused \"process_linux.go:295:
setting oom score for ready process caused \\\"write /proc/83582/oom_score_adj:
invalid argument\\\"\"\n".
```

**- How I did it**

This fix validates the Env in the container spec before it is sent to containerd/runc.

**- How to verify it**

Integration tests have been created to cover the changes.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![polar-bear-lodge_by-michelle-valberg-_mv83473](https://cloud.githubusercontent.com/assets/6932348/20032907/783c6cf2-a351-11e6-9d44-7019948b0ba5.jpg)


This fix is part of fix for #25099 (not complete yet, non-utf case may require a fix in `runc`).
This fix is related to #25300.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>