### PR TITLE
Disable v1 protocol for the default registry

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -36,19 +36,15 @@ var (
 	// that carries Registry version info
 	DefaultRegistryVersionHeader = "Docker-Distribution-Api-Version"
 
-	// IndexServer is the v1 registry server used for user auth + account creation
-	IndexServer = DefaultV1Registry.String() + "/v1/"
+	// IndexHostname is the index hostname
+	IndexHostname = "index.docker.io"
+	// IndexServer is used for user auth and image search
+	IndexServer = "https://" + IndexHostname + "/v1/"
 	// IndexName is the name of the index
 	IndexName = "docker.io"
 
 	// NotaryServer is the endpoint serving the Notary trust server
 	NotaryServer = "https://notary.docker.io"
-
-	// DefaultV1Registry is the URI of the default v1 registry
-	DefaultV1Registry = &url.URL{
-		Scheme: "https",
-		Host:   "index.docker.io",
-	}
 
 	// DefaultV2Registry is the URI of the default v2 registry
 	DefaultV2Registry = &url.URL{

--- a/registry/service_v1.go
+++ b/registry/service_v1.go
@@ -1,25 +1,13 @@
 package registry
 
-import (
-	"net/url"
-
-	"github.com/docker/go-connections/tlsconfig"
-)
+import "net/url"
 
 func (s *DefaultService) lookupV1Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
-	tlsConfig := tlsconfig.ServerDefault()
-	if hostname == DefaultNamespace {
-		endpoints = append(endpoints, APIEndpoint{
-			URL:          DefaultV1Registry,
-			Version:      APIVersion1,
-			Official:     true,
-			TrimHostname: true,
-			TLSConfig:    tlsConfig,
-		})
-		return endpoints, nil
+	if hostname == DefaultNamespace || hostname == DefaultV2Registry.Host || hostname == IndexHostname {
+		return []APIEndpoint{}, nil
 	}
 
-	tlsConfig, err = s.tlsConfig(hostname)
+	tlsConfig, err := s.tlsConfig(hostname)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/service_v1_test.go
+++ b/registry/service_v1_test.go
@@ -1,0 +1,23 @@
+package registry
+
+import "testing"
+
+func TestLookupV1Endpoints(t *testing.T) {
+	s := NewService(ServiceOptions{})
+
+	cases := []struct {
+		hostname    string
+		expectedLen int
+	}{
+		{"example.com", 1},
+		{DefaultNamespace, 0},
+		{DefaultV2Registry.Host, 0},
+		{IndexHostname, 0},
+	}
+
+	for _, c := range cases {
+		if ret, err := s.lookupV1Endpoints(c.hostname); err != nil || len(ret) != c.expectedLen {
+			t.Errorf("lookupV1Endpoints(`"+c.hostname+"`) returned %+v and %+v", ret, err)
+		}
+	}
+}

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -9,7 +9,7 @@ import (
 
 func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
-	if hostname == DefaultNamespace || hostname == DefaultV1Registry.Host {
+	if hostname == DefaultNamespace || hostname == IndexHostname {
 		// v2 mirrors
 		for _, mirror := range s.config.Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {


### PR DESCRIPTION
**- What I did**

I disabled the v1 protocol for the default registry.

All images in the default registry (AKA docker.io, index.docker.io, and registry-1.docker.io) are available via the v2 protocol, so there's no reason to use the v1 protocol.  Disabling it prevents useless fallbacks.

**- How I did it**

I modified `registry.DefaultService.lookupV1Endpoints` to return no endpoints for default registry hostnames.

**- How to verify it**

Pull a nonexistent tag from a repository that exists on the default registry (e.g., `docker pull debian:shmebian`). No v1 registry activity should appear in the engine log. 

**- Description for the changelog**

Disable v1 protocol for the default registry

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://cloud.githubusercontent.com/assets/2574448/20034038/e5c00cae-a36d-11e6-97f4-6ffbad4051f9.png)
