### PR TITLE
Update docs for the output of `docker build` (Step 1/...)

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1204,7 +1204,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1246,7 +1246,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1377,7 +1377,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1458,7 +1458,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1636,7 +1636,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -1669,7 +1669,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -1668,7 +1668,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1756,7 +1756,7 @@ Build an image from a Dockerfile
     HTTP/1.1 200 OK
     Content-Type: application/json
 
-    {"stream": "Step 1..."}
+    {"stream": "Step 1/5..."}
     {"stream": "..."}
     {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -97,15 +97,15 @@ the `Using cache` message in the console output.
 
     $ docker build -t svendowideit/ambassador .
     Sending build context to Docker daemon 15.36 kB
-    Step 1 : FROM alpine:3.2
+    Step 1/4 : FROM alpine:3.2
      ---> 31f630c65071
-    Step 2 : MAINTAINER SvenDowideit@home.org.au
+    Step 2/4 : MAINTAINER SvenDowideit@home.org.au
      ---> Using cache
      ---> 2a1c91448f5f
-    Step 3 : RUN apk update &&      apk add socat &&        rm -r /var/cache/
+    Step 3/4 : RUN apk update &&      apk add socat &&        rm -r /var/cache/
      ---> Using cache
      ---> 21ed6e7fbb73
-    Step 4 : CMD env | grep _TCP= | (sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/' && echo wait) | sh
+    Step 4/4 : CMD env | grep _TCP= | (sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -t 100000000 TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/' && echo wait) | sh
      ---> Using cache
      ---> 7ea8aef582cc
     Successfully built 7ea8aef582cc

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -174,9 +174,9 @@ $ docker build -t fail .
 
 Sending build context to Docker daemon 2.048 kB
 Sending build context to Docker daemon
-Step 1 : FROM busybox
+Step 1/3 : FROM busybox
  ---> 4986bf8c1536
-Step 2 : RUN exit 13
+Step 2/3 : RUN exit 13
  ---> Running in e26670ec7a0a
 INFO[0000] The command [/bin/sh -c exit 13] returned a non-zero code: 13
 $ echo $?
@@ -195,10 +195,10 @@ See also:
 $ docker build .
 
 Uploading context 10240 bytes
-Step 1 : FROM busybox
+Step 1/3 : FROM busybox
 Pulling repository busybox
  ---> e9aa60c60128MB/2.284 MB (100%) endpoint: https://cdn-registry-1.docker.io/v1/
-Step 2 : RUN ls -lh /
+Step 2/3 : RUN ls -lh /
  ---> Running in 9c9e81692ae9
 total 24
 drwxr-xr-x    2 root     root        4.0K Mar 12  2013 bin
@@ -212,7 +212,7 @@ dr-xr-xr-x   13 root     root           0 Nov 15 23:34 sys
 drwxr-xr-x    2 root     root        4.0K Mar 12  2013 tmp
 drwxr-xr-x    2 root     root        4.0K Nov 15 23:34 usr
  ---> b35f4035db3f
-Step 3 : CMD echo Hello world
+Step 3/3 : CMD echo Hello world
  ---> Running in 02071fceb21b
  ---> f52f38b7823e
 Successfully built f52f38b7823e
@@ -248,12 +248,12 @@ specify an arbitrary Git repository by using the `git://` or `git@` scheme.
 $ docker build -f ctx/Dockerfile http://server/ctx.tar.gz
 
 Downloading context: http://server/ctx.tar.gz [===================>]    240 B/240 B
-Step 1 : FROM busybox
+Step 1/3 : FROM busybox
  ---> 8c2e06607696
-Step 2 : ADD ctx/container.cfg /
+Step 2/3 : ADD ctx/container.cfg /
  ---> e7829950cee3
 Removing intermediate container b35224abf821
-Step 3 : CMD /bin/ls
+Step 3/3 : CMD /bin/ls
  ---> Running in fbc63d321d73
  ---> 3286931702ad
 Removing intermediate container fbc63d321d73
@@ -293,9 +293,9 @@ $ docker build .
 
 Uploading context 18.829 MB
 Uploading context
-Step 1 : FROM busybox
+Step 1/2 : FROM busybox
  ---> 769b9341d937
-Step 2 : CMD echo Hello world
+Step 2/2 : CMD echo Hello world
  ---> Using cache
  ---> 99cc1ad10469
 Successfully built 99cc1ad10469
@@ -303,9 +303,9 @@ $ echo ".git" > .dockerignore
 $ docker build .
 Uploading context  6.76 MB
 Uploading context
-Step 1 : FROM busybox
+Step 1/2 : FROM busybox
  ---> 769b9341d937
-Step 2 : CMD echo Hello world
+Step 2/2 : CMD echo Hello world
  ---> Using cache
  ---> 99cc1ad10469
 Successfully built 99cc1ad10469


### PR DESCRIPTION
PR #24978 adds hint of of progress to the output of `docker build` for 1.13, in the format of
```
Step 1/5 ...
Step 2/5 ...
...
```

Though some of the docs hasn't been updated.

This fix did a grep in docs and updated the related places.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>