### PR TITLE
Remove Windows CI stubs from hack/

### DIFF
--- a/hack/make/validate-dco
+++ b/hack/make/validate-dco
@@ -1,7 +1,0 @@
-#!/bin/bash
-#
-# This file is a stub. It exists because windowsRS1 calls this script directly 
-# instead of using a proper interface. It should be removed once windows CI is 
-# fixed.
-#
-$SCRIPTDIR/validate/dco

--- a/hack/make/validate-gofmt
+++ b/hack/make/validate-gofmt
@@ -1,7 +1,0 @@
-#!/bin/bash
-#
-# This file is a stub. It exists because windowsRS1 calls this script directly 
-# instead of using a proper interface. It should be removed once windows CI is 
-# fixed.
-#
-$SCRIPTDIR/validate/gofmt

--- a/hack/make/validate-pkg
+++ b/hack/make/validate-pkg
@@ -1,7 +1,0 @@
-#!/bin/bash
-#
-# This file is a stub. It exists because windowsRS1 calls this script directly 
-# instead of using a proper interface. It should be removed once windows CI is 
-# fixed.
-#
-$SCRIPTDIR/validate/pkg-imports


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Removes the interim hacks introduced by @dnephin in 9a2eb8b162e4df0533aeafc2e8d7bb9bbadb8234 as part of https://github.com/docker/docker/pull/27964.