### PR TITLE
Don't set GOROOT in dockerfile.Windows

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -127,7 +127,6 @@ SHELL ["powershell", "-command"]
 ENV GO_VERSION=1.7.3 `
     GIT_LOCATION=https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/Git-2.10.1-64-bit.exe `
     GOPATH=C:\go `
-    GOROOT=C:\go `
     FROM_DOCKERFILE=1
 
 WORKDIR C:\


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Minor fix to dockerfile.Windows. Avoids the needless spew in the current CI output such as shown below:

```
21:03:48 Removing intermediate container 44960108edc9
21:03:48 Successfully built 9ff7396401fd
21:03:49 INFO: Image build ended at 11/06/2016 04:03:49. Duration:00:00:21.7784239
21:03:49 
21:03:49 
21:03:49 INFO: Building the test binaries at 11/06/2016 04:03:49...
21:03:56 warning: GOPATH set to GOROOT (C:\go) has no effect
21:03:56 
21:03:57 warning: GOPATH set to GOROOT (C:\go) has no effect
21:03:58 warning: GOPATH set to GOROOT (C:\go) has no effect
21:03:59 warning: GOPATH set to GOROOT (C:\go) has no effect
21:03:59 ---> Making bundle: binary (in bundles/1.13.0-dev/binary)
21:03:59 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:00 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:00 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:01 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:02 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:02 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:02 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:03 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:03 Building: bundles/1.13.0-dev/binary-client/docker-1.13.0-dev.exe
21:04:03 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:19 Created binary: bundles/1.13.0-dev/binary-client/docker-1.13.0-dev.exe
21:04:20 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:20 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:21 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:22 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:22 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:22 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:23 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:23 warning: GOPATH set to GOROOT (C:\go) has no effect
21:04:23 Building: bundles/1.13.0-dev/binary-daemon/dockerd-1.13.0-dev.exe
21:04:23 warning: GOPATH set to GOROOT (C:\go) has no effect
21:05:26 Created binary: bundles/1.13.0-dev/binary-daemon/dockerd-1.13.0-dev.exe
21:05:27 warning: GOPATH set to GOROOT (C:\go) has no effect
21:05:27 warning: GOPATH set to GOROOT (C:\go) has no effect
21:05:27 warning: GOPATH set to GOROOT (C:\go) has no effect
21:05:28 warning: GOPATH set to GOROOT (C:\go) has no effect
```

@thaJeztah 