### PR TITLE
add docker port alias for docker container port, like ps.

### DIFF
--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -18,14 +18,15 @@ type portOptions struct {
 	port string
 }
 
-// NewPortCommand creates a new cobra.Command for `docker port`
+// NewPortCommand creates a new cobra.Command for both `docker port` and `docker container port`
 func NewPortCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts portOptions
 
 	cmd := &cobra.Command{
-		Use:   "port CONTAINER [PRIVATE_PORT[/PROTO]]",
-		Short: "List port mappings or a specific mapping for the container",
-		Args:  cli.RequiresRangeArgs(1, 2),
+		Use:     "port CONTAINER [PRIVATE_PORT[/PROTO]]",
+		Short:   "List port mappings or a specific mapping for the container",
+		Aliases: []string{"container port"},
+		Args:    cli.RequiresRangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.container = args[0]
 			if len(args) > 1 {


### PR DESCRIPTION
**- What I did**
Both `docker port` and `docker container port` are using the same 'NewPortCommand' function, so the two commands do the same thing, and so I add alias for them just like `docker container ps|ls|list`.

**- How I did it**
Add 'Aliases: []string{"container port"}' in NewPortCommand, and add comment it.


**- A picture of a cute animal (not mandatory but encouraged)**
Before:
![image](https://cloud.githubusercontent.com/assets/22292664/20054925/de348e58-a519-11e6-923e-2099c2c49b24.png)

After:
![image](https://cloud.githubusercontent.com/assets/22292664/20054938/e6a466c6-a519-11e6-892e-c6d14d969ef2.png)


Signed-off-by: wefine <wang.xiaoren@zte.com.cn>