### PR TITLE
[integration-cli] changes syntax to support older version of jq

### DIFF
--- a/integration-cli/fixtures/auth/docker-credential-shell-test
+++ b/integration-cli/fixtures/auth/docker-credential-shell-test
@@ -38,7 +38,7 @@ case $1 in
 
 		# Remove the server from the list
 		list=$(<$TEMP/$listFile)
-		echo "$list" | jq "del(.\"${in}\")" > $TEMP/$listFile
+		echo "$list" | jq "del(.[\"${in}\"])" > $TEMP/$listFile
 		;;
 	"list")
 		if [[ ! -f $TEMP/$listFile ]]; then


### PR DESCRIPTION
Fixes #27966 

Fixes a bug where a test would fail due to jq syntax
not being supported on versions < 1.5. Changes the syntax
to an equivalent way also supported on older versions.

Related issue in jq reported here https://github.com/stedolan/jq/issues/273

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>