### PR TITLE
Terminate template containers before delting a layer

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -244,6 +244,32 @@ func (d *Driver) Remove(id string) error {
 		return err
 	}
 
+	// Get and terminate any template VMs that are currently using the layer
+	computeSystems, err := hcsshim.GetContainers(hcsshim.ComputeSystemQuery{})
+	if err != nil {
+		return err
+	}
+
+	for _, computeSystem := range computeSystems {
+		if strings.Contains(computeSystem.RuntimeImagePath, id) && computeSystem.IsRuntimeTemplate {
+			container, err := hcsshim.OpenContainer(computeSystem.ID)
+			if err != nil {
+				return err
+			}
+			defer container.Close()
+			err = container.Terminate()
+			if hcsshim.IsPending(err) {
+				err = container.Wait()
+			} else if hcsshim.IsAlreadyStopped(err) {
+				err = nil
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	layerPath := filepath.Join(d.info.HomeDir, rID)
 	tmpID := fmt.Sprintf("%s-removing", rID)
 	tmpLayerPath := filepath.Join(d.info.HomeDir, tmpID)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes https://github.com/docker/docker/issues/28087

**- What I did**

When deleting a layer, make sure to terminate any template VMs that are using the layer.

**- How I did it**

Add GetContainers to hcsshim, used to check if the layer is in use by any containers on the system. Terminate all template VMs that are using the layer being deleted.

**- How to verify it**

See repro steps for https://github.com/docker/docker/issues/28087. Will add a test to this PR soon.

NOTE: This needs a vendor update to hcsshim after https://github.com/Microsoft/hcsshim/pull/86 and https://github.com/Microsoft/hcsshim/pull/85 are merged.


Signed-off-by: Darren Stahl <darst@microsoft.com>

/cc @jhowardmsft @jstarks 