### PR TITLE
Rename docker run "--cpus" to "--limit-cpu"

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1239,7 +1239,6 @@ _docker_container_run() {
 		--cpu-rt-period
 		--cpu-rt-runtime
 		--cpuset-cpus
-		--cpus
 		--cpuset-mems
 		--cpu-shares -c
 		--device
@@ -1263,6 +1262,7 @@ _docker_container_run() {
 		--kernel-memory
 		--label-file
 		--label -l
+		--limit-cpu
 		--link
 		--link-local-ip
 		--log-driver

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -38,7 +38,6 @@ Options:
       --cpu-period int              Limit CPU CFS (Completely Fair Scheduler) period
       --cpu-quota int               Limit CPU CFS (Completely Fair Scheduler) quota
   -c, --cpu-shares int              CPU shares (relative weight)
-      --cpus NanoCPUs               Number of CPUs (default 0.000)
       --cpu-rt-period int           Limit the CPU real-time period in microseconds
       --cpu-rt-runtime int          Limit the CPU real-time runtime in microseconds
       --cpuset-cpus string          CPUs in which to allow execution (0-3, 0,1)
@@ -73,6 +72,7 @@ Options:
       --kernel-memory string        Kernel memory limit
   -l, --label value                 Set meta data on a container (default [])
       --label-file value            Read in a line delimited file of labels (default [])
+      --limit-cpu NanoCPUs          Limit number (fractional) of CPUs used by the container (default 0.000)
       --link value                  Add link to another container (default [])
       --link-local-ip value         Container IPv4/IPv6 link-local addresses (default [])
       --log-driver string           Logging driver for the container

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -40,7 +40,6 @@ Options:
       --cpu-period int              Limit CPU CFS (Completely Fair Scheduler) period
       --cpu-quota int               Limit CPU CFS (Completely Fair Scheduler) quota
   -c, --cpu-shares int              CPU shares (relative weight)
-      --cpus NanoCPUs               Number of CPUs (default 0.000)
       --cpu-rt-period int           Limit the CPU real-time period in microseconds
       --cpu-rt-runtime int          Limit the CPU real-time runtime in microseconds
       --cpuset-cpus string          CPUs in which to allow execution (0-3, 0,1)
@@ -83,6 +82,7 @@ Options:
       --kernel-memory string        Kernel memory limit
   -l, --label value                 Set meta data on a container (default [])
       --label-file value            Read in a line delimited file of labels (default [])
+      --limit-cpu NanoCPUs          Limit number (fractional) of CPUs used by the container (default 0.000)
       --link value                  Add link to another container (default [])
       --link-local-ip value         Container IPv4/IPv6 link-local addresses (default [])
       --log-driver string           Logging driver for the container

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -681,12 +681,12 @@ container:
 
 | Option                     |  Description                                                                                                                                    |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--limit-cpu=0.000`        | Limit number (fractional) of CPUs used by the container. 0.000 means no limit.                                                                  |
 | `-m`, `--memory=""`        | Memory limit (format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`. Minimum is 4M.               |
 | `--memory-swap=""`         | Total memory limit (memory + swap, format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`.         |
 | `--memory-reservation=""`  | Memory soft limit (format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`.                         |
 | `--kernel-memory=""`       | Kernel memory limit (format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`. Minimum is 4M.        |
 | `-c`, `--cpu-shares=0`     | CPU shares (relative weight)                                                                                                                    |
-| `--cpus=0.000`             | Number of CPUs. Number is a fractional number. 0.000 means no limit.                                                                            |
 | `--cpu-period=0`           | Limit the CPU CFS (Completely Fair Scheduler) period                                                                                            |
 | `--cpuset-cpus=""`         | CPUs in which to allow execution (0-3, 0,1)                                                                                                     |
 | `--cpuset-mems=""`         | Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.                                                     |

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1576,7 +1576,7 @@ func (s *DockerSuite) TestRunWithNanoCPUs(c *check.C) {
 
 	file1 := "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 	file2 := "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-	out, _ := dockerCmd(c, "run", "--cpus", "0.5", "--name", "test", "busybox", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2))
+	out, _ := dockerCmd(c, "run", "--limit-cpu", "0.5", "--name", "test", "busybox", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2))
 	c.Assert(strings.TrimSpace(out), checker.Equals, "50000\n100000")
 
 	out = inspectField(c, "test", "HostConfig.NanoCpus")
@@ -1586,7 +1586,7 @@ func (s *DockerSuite) TestRunWithNanoCPUs(c *check.C) {
 	out = inspectField(c, "test", "HostConfig.CpuPeriod")
 	c.Assert(out, checker.Equals, "0", check.Commentf("CPU CFS period should be 0"))
 
-	out, _, err := dockerCmdWithError("run", "--cpus", "0.5", "--cpu-quota", "50000", "--cpu-period", "100000", "busybox", "sh")
+	out, _, err := dockerCmdWithError("run", "--limit-cpu", "0.5", "--cpu-quota", "50000", "--cpu-period", "100000", "busybox", "sh")
 	c.Assert(err, check.NotNil)
 	c.Assert(out, checker.Contains, "Conflicting options: Nano CPUs and CPU Period cannot both be set")
 }

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -21,7 +21,6 @@ docker-create - Create a new container
 [**--cpu-quota**[=*0*]]
 [**--cpu-rt-period**[=*0*]]
 [**--cpu-rt-runtime**[=*0*]]
-[**--cpus**[=*0.0*]]
 [**--cpuset-cpus**[=*CPUSET-CPUS*]]
 [**--cpuset-mems**[=*CPUSET-MEMS*]]
 [**--device**[=*[]*]]
@@ -47,6 +46,7 @@ docker-create - Create a new container
 [**--kernel-memory**[=*KERNEL-MEMORY*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
+[**--limit-cpu**[=*0.000*]]
 [**--link**[=*[]*]]
 [**--link-local-ip**[=*[]*]]
 [**--log-driver**[=*[]*]]
@@ -169,9 +169,6 @@ two memory nodes.
 
    The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
 
-**--cpus**=0.0
-   Number of CPUs. The default is *0.0*.
-
 **--device**=[]
    Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
 
@@ -254,6 +251,9 @@ millions of trillions.
 
 **--label-file**=[]
    Read labels from a file. Delimit each label with an EOL.
+
+**--limit-cpu**=0.000
+   Limit number (fractional) of CPUs used by the container. The default is *0.000* which means no limit.
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias or just

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -21,7 +21,6 @@ docker-run - Run a command in a new container
 [**--cpu-quota**[=*0*]]
 [**--cpu-rt-period**[=*0*]]
 [**--cpu-rt-runtime**[=*0*]]
-[**--cpus**[=*0.0*]]
 [**--cpuset-cpus**[=*CPUSET-CPUS*]]
 [**--cpuset-mems**[=*CPUSET-MEMS*]]
 [**-d**|**--detach**]
@@ -49,6 +48,7 @@ docker-run - Run a command in a new container
 [**--kernel-memory**[=*KERNEL-MEMORY*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
+[**--limit-cpu**[=*0.000*]]
 [**--link**[=*[]*]]
 [**--link-local-ip**[=*[]*]]
 [**--log-driver**[=*[]*]]
@@ -223,9 +223,6 @@ to the quota you specify.
 
    The sum of all runtimes across containers cannot exceed the amount allotted to the parent cgroup.
 
-**--cpus**=0.0
-   Number of CPUs. The default is *0.0* which means no limit.
-
 **-d**, **--detach**=*true*|*false*
    Detached mode: run the container in the background and print the new container ID. The default is *false*.
 
@@ -351,6 +348,9 @@ millions of trillions.
 
 **--label-file**=[]
    Read in a line delimited file of labels
+
+**--limit-cpu**=0.000
+   Limit number (fractional) of CPUs used by the container. The default is *0.000* which means no limit.
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias or just <name or id>

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -80,7 +80,7 @@ type ContainerOptions struct {
 	cpuRealtimePeriod  int64
 	cpuRealtimeRuntime int64
 	cpuQuota           int64
-	cpus               opts.NanoCPUs
+	limitCPU           opts.NanoCPUs
 	cpusetCpus         string
 	cpusetMems         string
 	blkioWeight        uint16
@@ -235,7 +235,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.Int64Var(&copts.cpuRealtimePeriod, "cpu-rt-period", 0, "Limit CPU real-time period in microseconds")
 	flags.Int64Var(&copts.cpuRealtimeRuntime, "cpu-rt-runtime", 0, "Limit CPU real-time runtime in microseconds")
 	flags.Int64VarP(&copts.cpuShares, "cpu-shares", "c", 0, "CPU shares (relative weight)")
-	flags.Var(&copts.cpus, "cpus", "Number of CPUs")
+	flags.Var(&copts.limitCPU, "limit-cpu", "Limit number (fractional) of CPUs used by the container")
 	flags.Var(&copts.deviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
 	flags.Var(&copts.deviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
 	flags.Var(&copts.deviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) to a device")
@@ -530,7 +530,7 @@ func Parse(flags *pflag.FlagSet, copts *ContainerOptions) (*container.Config, *c
 		MemorySwappiness:     &copts.swappiness,
 		KernelMemory:         kernelMemory,
 		OomKillDisable:       &copts.oomKillDisable,
-		NanoCPUs:             copts.cpus.Value(),
+		NanoCPUs:             copts.limitCPU.Value(),
 		CPUCount:             copts.cpuCount,
 		CPUPercent:           copts.cpuPercent,
 		CPUShares:            copts.cpuShares,


### PR DESCRIPTION
This fix renames docker run "--cpus" to "--limit-cpu", based on related discussion in #28095. Related docs and tests have been updated accordingly

*(Feel free to close it if there are concerns, and feel free for any suggestions).*


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>