### PR TITLE
Display loglevel panic when docker --help

### DIFF
--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -53,7 +53,7 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	}
 
 	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "Enable debug mode")
-	flags.StringVarP(&commonOpts.LogLevel, "log-level", "l", "info", "Set the logging level (\"debug\", \"info\", \"warn\", \"error\", \"fatal\")")
+	flags.StringVarP(&commonOpts.LogLevel, "log-level", "l", "info", "Set the logging level (\"debug\", \"info\", \"warn\", \"error\", \"fatal\", \"panic\")")
 	flags.BoolVar(&commonOpts.TLS, "tls", false, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&commonOpts.TLSVerify, FlagTLSVerify, dockerTLSVerify, "Use TLS and verify the remote")
 


### PR DESCRIPTION

**- What I did**
There is no `panic` loglevel displayed when `docker --help ` excuted.

>   -l, --log-level string   Set the logging level ("debug", "info", "warn", "error", "fatal") (default "info")

**- How I did it**
to add panic level

> eg:
> flags.StringVarP(&commonOpts.LogLevel, "log-level", "l", "info", "Set the logging level (\"debug\", \"info\", \"warn\", \"error\", \"fatal\", \"panic\")")

**- How to verify it**

> #docker --help
>   -l, --log-level string   Set the logging level ("debug", "info", "warn", "error", "fatal", "panic") (default "info")


Signed-off-by: chchliang <chen.chuanliang@zte.com.cn>
