### PR TITLE
Change to plural forms for help output of `docker service update`

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -42,19 +42,19 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	addServiceFlags(cmd, opts)
 
 	flags.Var(newListOptsVar(), flagEnvRemove, "Remove an environment variable")
-	flags.Var(newListOptsVar(), flagGroupRemove, "Remove previously added supplementary user groups from the container")
+	flags.Var(newListOptsVar(), flagGroupRemove, "Remove a previously added supplementary user group from the container")
 	flags.Var(newListOptsVar(), flagLabelRemove, "Remove a label by its key")
 	flags.Var(newListOptsVar(), flagContainerLabelRemove, "Remove a container label by its key")
 	flags.Var(newListOptsVar(), flagMountRemove, "Remove a mount by its target path")
 	flags.Var(newListOptsVar(), flagPublishRemove, "Remove a published port by its target port")
 	flags.Var(newListOptsVar(), flagConstraintRemove, "Remove a constraint")
-	flags.Var(&opts.labels, flagLabelAdd, "Add or update service labels")
-	flags.Var(&opts.containerLabels, flagContainerLabelAdd, "Add or update container labels")
-	flags.Var(&opts.env, flagEnvAdd, "Add or update environment variables")
+	flags.Var(&opts.labels, flagLabelAdd, "Add or update a service label")
+	flags.Var(&opts.containerLabels, flagContainerLabelAdd, "Add or update a container label")
+	flags.Var(&opts.env, flagEnvAdd, "Add or update an environment variable")
 	flags.Var(&opts.mounts, flagMountAdd, "Add or update a mount on a service")
-	flags.StringSliceVar(&opts.constraints, flagConstraintAdd, []string{}, "Add or update placement constraints")
+	flags.StringSliceVar(&opts.constraints, flagConstraintAdd, []string{}, "Add or update a placement constraint")
 	flags.Var(&opts.endpoint.ports, flagPublishAdd, "Add or update a published port")
-	flags.StringSliceVar(&opts.groups, flagGroupAdd, []string{}, "Add additional supplementary user groups to the container")
+	flags.StringSliceVar(&opts.groups, flagGroupAdd, []string{}, "Add an additional supplementary user group to the container")
 	return cmd
 }
 

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -21,52 +21,52 @@ Usage:  docker service update [OPTIONS] SERVICE
 Update a service
 
 Options:
-      --args string                      Service command args
-      --constraint-add value             Add or update placement constraints (default [])
-      --constraint-rm value              Remove a constraint (default [])
-      --container-label-add value        Add or update container labels (default [])
-      --container-label-rm value         Remove a container label by its key (default [])
-      --endpoint-mode string             Endpoint mode (vip or dnsrr)
-      --env-add value                    Add or update environment variables (default [])
-      --env-rm value                     Remove an environment variable (default [])
-      --force                            Force update even if no changes require it
-      --group-add value                  Add additional supplementary user groups to the container (default [])
-      --group-rm value                   Remove previously added supplementary user groups from the container (default [])
-      --health-cmd string                Command to run to check health
-      --health-interval duration         Time between running the check
-      --health-retries int               Consecutive failures needed to report unhealthy
-      --health-timeout duration          Maximum time to allow one check to run
-      --help                             Print usage
-      --image string                     Service image tag
-      --label-add value                  Add or update service labels (default [])
-      --label-rm value                   Remove a label by its key (default [])
-      --limit-cpu value                  Limit CPUs (default 0.000)
-      --limit-memory value               Limit Memory (default 0 B)
-      --log-driver string                Logging driver for service
-      --log-opt value                    Logging driver options (default [])
-      --mount-add value                  Add or update a mount on a service
-      --mount-rm value                   Remove a mount by its target path (default [])
-      --no-healthcheck                   Disable any container-specified HEALTHCHECK
-      --publish-add value                Add or update a published port (default [])
-      --publish-rm value                 Remove a published port by its target port (default [])
-      --replicas value                   Number of tasks (default none)
-      --reserve-cpu value                Reserve CPUs (default 0.000)
-      --reserve-memory value             Reserve Memory (default 0 B)
-      --restart-condition string         Restart when condition is met (none, on-failure, or any)
-      --restart-delay value              Delay between restart attempts (default none)
-      --restart-max-attempts value       Maximum number of restarts before giving up (default none)
-      --restart-window value             Window used to evaluate the restart policy (default none)
-      --rollback                         Rollback to previous specification
-      --stop-grace-period value          Time to wait before force killing a container (default none)
-  -t, --tty                              Allocate a pseudo-TTY
-      --update-delay duration            Delay between updates
-      --update-failure-action string     Action on update failure (pause|continue) (default "pause")
-      --update-max-failure-ratio value   Failure rate to tolerate during an update
-      --update-monitor duration          Duration after each task update to monitor for failure (default 0s)
-      --update-parallelism uint          Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
-  -u, --user string                      Username or UID (format: <name|uid>[:<group|gid>])
-      --with-registry-auth               Send registry authentication details to Swarm agents
-  -w, --workdir string                   Working directory inside the container
+      --args string                        Service command args
+      --constraint-add stringSlice         Add or update a placement constraint
+      --constraint-rm list                 Remove a constraint (default [])
+      --container-label-add list           Add or update a container label (default [])
+      --container-label-rm list            Remove a container label by its key (default [])
+      --endpoint-mode string               Endpoint mode (vip or dnsrr)
+      --env-add list                       Add or update an environment variable (default [])
+      --env-rm list                        Remove an environment variable (default [])
+      --force                              Force update even if no changes require it
+      --group-add stringSlice              Add an additional supplementary user group to the container
+      --group-rm list                      Remove a previously added supplementary user group from the container (default [])
+      --health-cmd string                  Command to run to check health
+      --health-interval duration-ptr       Time between running the check (default none)
+      --health-retries int                 Consecutive failures needed to report unhealthy
+      --health-timeout duration-ptr        Maximum time to allow one check to run (default none)
+      --help                               Print usage
+      --image string                       Service image tag
+      --label-add list                     Add or update a service label (default [])
+      --label-rm list                      Remove a label by its key (default [])
+      --limit-cpu NanoCPUs                 Limit CPUs (default 0.000)
+      --limit-memory MemoryBytes           Limit Memory (default 0 B)
+      --log-driver string                  Logging driver for service
+      --log-opt list                       Logging driver options (default [])
+      --mount-add mount                    Add or update a mount on a service
+      --mount-rm list                      Remove a mount by its target path (default [])
+      --no-healthcheck                     Disable any container-specified HEALTHCHECK
+      --publish-add list                   Add or update a published port (default [])
+      --publish-rm list                    Remove a published port by its target port (default [])
+      --replicas uint64-ptr                Number of tasks (default none)
+      --reserve-cpu NanoCPUs               Reserve CPUs (default 0.000)
+      --reserve-memory MemoryBytes         Reserve Memory (default 0 B)
+      --restart-condition string           Restart when condition is met (none, on-failure, or any)
+      --restart-delay duration-ptr         Delay between restart attempts (default none)
+      --restart-max-attempts uint64-ptr    Maximum number of restarts before giving up (default none)
+      --restart-window duration-ptr        Window used to evaluate the restart policy (default none)
+      --rollback                           Rollback to previous specification
+      --stop-grace-period duration-ptr     Time to wait before force killing a container (default none)
+  -t, --tty                                Allocate a pseudo-TTY
+      --update-delay duration              Delay between updates
+      --update-failure-action string       Action on update failure (pause|continue) (default "pause")
+      --update-max-failure-ratio float32   Failure rate to tolerate during an update
+      --update-monitor duration            Duration after each task update to monitor for failure
+      --update-parallelism uint            Maximum number of tasks updated simultaneously (0 to update all at once) (default 1)
+  -u, --user string                        Username or UID (format: <name|uid>[:<group|gid>])
+      --with-registry-auth                 Send registry authentication details to swarm agents
+  -w, --workdir string                     Working directory inside the container
 ```
 
 Updates a service as described by the specified parameters. This command has to be run targeting a manager node.


### PR DESCRIPTION
This fix is based on the comment in
https://github.com/docker/docker/pull/27567#discussion_r86910604

Basically, in the help output of `docker service update`, the `--xxx-add` flags typically have plural forms while `--xxx-rm` flags have singular forms.

This fix updates the help output for consistency.

This fix also updates the related docs in `service_update.md`.

The help output in `service_update.md` has been quite out-of-sync with the actual output, so this fix replaces the output with the most up-to-date output.

This fix is related to #27567.

cc @aaronlehmann 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>