### PR TITLE
opts/mount: add tmpfs-specific options

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -264,9 +264,9 @@ Docker daemon.
 
 For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/)
 
-### Add bin-mounts or volumes using the --mounts flag
+### Add bin-mounts or volumes using the --mount flag
 
-The `--mounts` flag allows you to mount volumes, host-directories and `tmpfs`
+The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
 mounts in a container.
 
 The `--mount` flag supports most options that are supported by the `-v` or the

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -172,6 +172,8 @@ or write from files or directories on other containers or the host operating
 system. These types are _data volumes_ (often referred to simply as volumes) and
 _bind-mounts_.
 
+Additionally, Docker also supports tmpfs mounts.
+
 A **bind-mount** makes a file or directory on the host available to the
 container it is mounted within. A bind-mount may be either read-only or
 read-write. For example, a container might share its host's DNS information by
@@ -187,6 +189,8 @@ even when no container is currently using it. Data in named volumes can be
 shared between a container and the host machine, as well as between multiple
 containers. Docker uses a _volume driver_ to create, manage, and mount volumes.
 You can back up or restore volumes using Docker commands.
+
+A **tmpfs** mounts a tmpfs inside a container for volatile data.
 
 Consider a situation where your image starts a lightweight web server. You could
 use that image as a base image, copy in your website's HTML files, and package
@@ -204,8 +208,8 @@ volumes in a service:
 
 | Option                                   | Required                  | Description
 |:-----------------------------------------|:--------------------------|:-----------------------------------------------------------------------------------------
-| **type**                                 |                           | The type of mount, can be either `volume`, or `bind`. Defaults to `volume` if no type is specified.<ul><li>`volume`: mounts a [managed volume](volume_create.md) into the container.</li><li>`bind`: bind-mounts a directory or file from the host into the container.</li></ul>
-| **src** or **source**                    | for `type=bind`&nbsp;only | <ul><li>`type=volume`: `src` is an optional way to specify the name of the volume (for example, `src=my-volume`). If the named volume does not exist, it is automatically created. If no `src` is specified, the volume is assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide. A randomly-named volume has the same lifecycle as its container and is destroyed when the *container* is destroyed (which is upon `service update`, or when scaling or re-balancing the service).</li><li>`type=bind`: `src` is required, and specifies an absolute path to the file or directory to bind-mount (for example, `src=/path/on/host/`).  An error is produced if the file or directory does not exist.</li></ul>
+| **type**                                 |                           | The type of mount, can be either `volume`, `bind`, or `tmpfs`. Defaults to `volume` if no type is specified.<ul><li>`volume`: mounts a [managed volume](volume_create.md) into the container.</li><li>`bind`: bind-mounts a directory or file from the host into the container.</li><li>`tmpfs`: mount a tmpfs in the container</li></ul>
+| **src** or **source**                    | for `type=bind`&nbsp;only | <ul><li>`type=volume`: `src` is an optional way to specify the name of the volume (for example, `src=my-volume`). If the named volume does not exist, it is automatically created. If no `src` is specified, the volume is assigned a random name which is guaranteed to be unique on the host, but may not be unique cluster-wide. A randomly-named volume has the same lifecycle as its container and is destroyed when the *container* is destroyed (which is upon `service update`, or when scaling or re-balancing the service).</li><li>`type=bind`: `src` is required, and specifies an absolute path to the file or directory to bind-mount (for example, `src=/path/on/host/`).  An error is produced if the file or directory does not exist.</li><li>`type=tmpfs`: `src` is not supported.</li></ul>
 | **dst** or **destination** or **target** | yes                       | Mount path inside the container, for example `/some/path/in/container/`. If the path does not exist in the container's filesystem, the Engine creates a directory at the specified location before mounting the volume or bind-mount.
 | **readonly** or **ro**                   |                           | The Engine mounts binds and volumes `read-write` unless `readonly` option is given when mounting the bind or volume.<br /><br /><ul><li>`true` or `1` or no value: Mounts the bind or volume read-only.</li><li>`false` or `0`: Mounts the bind or volume read-write.</li></ul>
 
@@ -255,6 +259,14 @@ The following options can only be used for named volumes (`type=volume`);
 | **volume-label**      | One or more custom metadata ("labels") to apply to the volume upon creation. For example, `volume-label=mylabel=hello-world,my-other-label=hello-mars`. For more information about labels, refer to [apply custom metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
 | **volume-nocopy**     | By default, if you attach an empty volume to a container, and files or directories already existed at the mount-path in the container (`dst`), the Engine copies those files and directories into the volume, allowing the host to access them. Set `volume-nocopy` to disables copying files from the container's filesystem to the volume and mount the empty volume.<br /><br />A value is optional:<ul><li>`true` or `1`: Default if you do not provide a value. Disables copying.</li><li>`false` or `0`: Enables copying.</li></ul>
 | **volume-opt**        | Options specific to a given volume driver, which will be passed to the driver when creating the volume. Options are provided as a comma-separated list of key/value pairs, for example, `volume-opt=some-option=some-value,some-other-option=some-other-value`. For available options for a given driver, refer to that driver's documentation.
+
+#### Options for tmpfs
+The following options can only be used for tmpfs mounts (`type=tmpfs`);
+
+| Option                | Description
+|:----------------------|:--------------------------------------------------------------------------------------------------------------------
+| **tmpfs-size**        | Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+| **tmpfs-mode**        | File mode of the tmpfs in octal. (e.g. `"700"` or `"0700"`.) Defaults to ``"1777"`` in Linux.
 
 #### Differences between "--mount" and "--volume"
 


### PR DESCRIPTION

**- What I did**

added following options for `--mount` (addendum to https://github.com/docker/docker/pull/26837):

 * `tmpfs-size`
 * `tmpfs-mode`

**- How I did it**

Updated opts/mount

**- How to verify it**

```console
$ docker run -it --rm --mount type=tmpfs,target=/foo,tmpfs-size=1m busybox df /foo
Filesystem           1K-blocks      Used Available Use% Mounted on
tmpfs                     1024         0      1024   0% /foo
```

```console
$ docker run -it --rm --mount type=tmpfs,target=/foo,tmpfs-mode=0700 busybox stat /foo
  File: /foo
  Size: 40              Blocks: 0          IO Block: 4096   directory
Device: 31h/49d Inode: 2           Links: 2
Access: (0700/drwx------)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2016-11-08 05:59:58.000000000
Modify: 2016-11-08 05:59:58.000000000
Change: 2016-11-08 05:59:58.000000000
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
opts/mount: add tmpfs-specific options

**- A picture of a cute animal (not mandatory but encouraged)**

![penguin](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Rockhopper_Penguin_Chick_%285582542129%29.jpg/475px-Rockhopper_Penguin_Chick_%285582542129%29.jpg)



Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>