### PR TITLE
api: fix ReadOnly support for tmpfs

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -414,7 +414,7 @@ func (container *Container) TmpfsMounts() ([]Mount, error) {
 	}
 	for dest, mnt := range container.MountPoints {
 		if mnt.Type == mounttypes.TypeTmpfs {
-			data, err := volume.ConvertTmpfsOptions(mnt.Spec.TmpfsOptions)
+			data, err := volume.ConvertTmpfsOptions(mnt.Spec.TmpfsOptions, mnt.Spec.ReadOnly)
 			if err != nil {
 				return nil, err
 			}

--- a/volume/validate.go
+++ b/volume/validate.go
@@ -91,7 +91,7 @@ func validateMountConfig(mnt *mount.Mount, options ...func(*validateOpts)) error
 		if len(mnt.Source) != 0 {
 			return &errMountConfig{mnt, errExtraField("Source")}
 		}
-		if _, err := ConvertTmpfsOptions(mnt.TmpfsOptions); err != nil {
+		if _, err := ConvertTmpfsOptions(mnt.TmpfsOptions, mnt.ReadOnly); err != nil {
 			return &errMountConfig{mnt, err}
 		}
 	default:

--- a/volume/volume_linux.go
+++ b/volume/volume_linux.go
@@ -13,16 +13,17 @@ import (
 // for mount(2).
 // The logic is copy-pasted from daemon/cluster/executer/container.getMountMask.
 // It will be deduplicated when we migrated the cluster to the new mount scheme.
-func ConvertTmpfsOptions(opt *mounttypes.TmpfsOptions) (string, error) {
-	if opt == nil {
-		return "", nil
-	}
+func ConvertTmpfsOptions(opt *mounttypes.TmpfsOptions, readOnly bool) (string, error) {
 	var rawOpts []string
-	if opt.Mode != 0 {
+	if readOnly {
+		rawOpts = append(rawOpts, "ro")
+	}
+
+	if opt != nil && opt.Mode != 0 {
 		rawOpts = append(rawOpts, fmt.Sprintf("mode=%o", opt.Mode))
 	}
 
-	if opt.SizeBytes != 0 {
+	if opt != nil && opt.SizeBytes != 0 {
 		// calculate suffix here, making this linux specific, but that is
 		// okay, since API is that way anyways.
 

--- a/volume/volume_unsupported.go
+++ b/volume/volume_unsupported.go
@@ -11,6 +11,6 @@ import (
 
 // ConvertTmpfsOptions converts *mounttypes.TmpfsOptions to the raw option string
 // for mount(2).
-func ConvertTmpfsOptions(opt *mounttypes.TmpfsOptions) (string, error) {
+func ConvertTmpfsOptions(opt *mounttypes.TmpfsOptions, readOnly bool) (string, error) {
 	return "", fmt.Errorf("%s does not support tmpfs", runtime.GOOS)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**



For `--mount type=tmpfs,target=/foo,readonly`, the `readonly` flag was just ignored.

This PR fix that issue.

**- How I did it**
Please refer to the code

**- How to verify it**

```console
$ docker run -it --rm --mount type=tmpfs,target=/foo,readonly busybox touch /foo/bar
touch: /foo/bar: Read-only file system
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>