### PR TITLE
Remove use of pkg/integration in pkg/idtools

### DIFF
--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/docker/docker/pkg/integration/cmd"
 	"github.com/docker/docker/pkg/system"
 	"github.com/opencontainers/runc/libcontainer/user"
 )
@@ -187,7 +186,7 @@ func callGetent(args string) (io.Reader, error) {
 	}
 	out, err := execCmd(getentCmd, args)
 	if err != nil {
-		exitCode, errC := cmd.GetExitCode(err)
+		exitCode, errC := system.GetExitCode(err)
 		if errC != nil {
 			return nil, err
 		}

--- a/pkg/integration/cmd/command.go
+++ b/pkg/integration/cmd/command.go
@@ -9,9 +9,9 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
+	"github.com/docker/docker/pkg/system"
 	"github.com/go-check/check"
 )
 
@@ -23,32 +23,6 @@ const (
 	// None is a token to inform Result.Assert that the output should be empty
 	None string = "<NOTHING>"
 )
-
-// GetExitCode returns the ExitStatus of the specified error if its type is
-// exec.ExitError, returns 0 and an error otherwise.
-func GetExitCode(err error) (int, error) {
-	exitCode := 0
-	if exiterr, ok := err.(*exec.ExitError); ok {
-		if procExit, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-			return procExit.ExitStatus(), nil
-		}
-	}
-	return exitCode, fmt.Errorf("failed to get exit code")
-}
-
-// ProcessExitCode process the specified error and returns the exit status code
-// if the error was of type exec.ExitError, returns nothing otherwise.
-func ProcessExitCode(err error) (exitCode int) {
-	if err != nil {
-		var exiterr error
-		if exitCode, exiterr = GetExitCode(err); exiterr != nil {
-			// TODO: Fix this so we check the error's text.
-			// we've failed to retrieve exit code, so we set it to 127
-			exitCode = 127
-		}
-	}
-	return
-}
 
 type lockedBuffer struct {
 	m   sync.RWMutex
@@ -196,7 +170,7 @@ func (r *Result) SetExitError(err error) {
 		return
 	}
 	r.Error = err
-	r.ExitCode = ProcessExitCode(err)
+	r.ExitCode = system.ProcessExitCode(err)
 }
 
 type matches struct{}

--- a/pkg/integration/utils.go
+++ b/pkg/integration/utils.go
@@ -15,6 +15,7 @@ import (
 
 	icmd "github.com/docker/docker/pkg/integration/cmd"
 	"github.com/docker/docker/pkg/stringutils"
+	"github.com/docker/docker/pkg/system"
 )
 
 // IsKilled process the specified error and returns whether the process was killed or not.
@@ -35,7 +36,7 @@ func IsKilled(err error) bool {
 func runCommandWithOutput(cmd *exec.Cmd) (output string, exitCode int, err error) {
 	exitCode = 0
 	out, err := cmd.CombinedOutput()
-	exitCode = icmd.ProcessExitCode(err)
+	exitCode = system.ProcessExitCode(err)
 	output = string(out)
 	return
 }

--- a/pkg/system/exitcode.go
+++ b/pkg/system/exitcode.go
@@ -1,0 +1,33 @@
+package system
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// GetExitCode returns the ExitStatus of the specified error if its type is
+// exec.ExitError, returns 0 and an error otherwise.
+func GetExitCode(err error) (int, error) {
+	exitCode := 0
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if procExit, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return procExit.ExitStatus(), nil
+		}
+	}
+	return exitCode, fmt.Errorf("failed to get exit code")
+}
+
+// ProcessExitCode process the specified error and returns the exit status code
+// if the error was of type exec.ExitError, returns nothing otherwise.
+func ProcessExitCode(err error) (exitCode int) {
+	if err != nil {
+		var exiterr error
+		if exitCode, exiterr = GetExitCode(err); exiterr != nil {
+			// TODO: Fix this so we check the error's text.
+			// we've failed to retrieve exit code, so we set it to 127
+			exitCode = 127
+		}
+	}
+	return
+}


### PR DESCRIPTION
This remove a dependency on `go-check` (and more) when using `pkg/idtools`. `pkg/integration` should never be called from any other package then `integration` 🐮.

This made some dependency like `docker/libcompose` not build :

```
---> Making bundle: binary (in .)
vendor/github.com/docker/docker/pkg/integration/cmd/command.go:15:2: cannot find package "github.com/go-check/check" in any of:
        /go/src/github.com/docker/libcompose/vendor/github.com/go-check/check (vendor tree)
        /usr/local/go/src/github.com/go-check/check (from $GOROOT)
        /go/src/github.com/go-check/check (from $GOPATH)
```

/cc @estesp @justincormack @runcom @thaJeztah 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>