### PR TITLE
poule: add `rebuild/*` to rebuild all at once

### DIFF
--- a/poule.yml
+++ b/poule.yml
@@ -46,6 +46,13 @@
   operations:
       - type:       rebuild
         settings: {
+            # When configurations are empty, the `rebuild` operation rebuilds all the currently
+            # known statuses for that pull request.
+            configurations: [],
+            label:          "rebuild/*",
+        }
+      - type:       rebuild
+        settings: {
             configurations: [ arm ],
             label:          "rebuild/arm",
         }


### PR DESCRIPTION
Add a `rebuild/*` label to trigger rebuilds of all known configurations for a given pull request.

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>