### PR TITLE
Pin images by digest

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -26,6 +27,7 @@ import (
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
+	"github.com/docker/docker/reference"
 	"github.com/docker/docker/runconfig"
 	swarmapi "github.com/docker/swarmkit/api"
 	swarmnode "github.com/docker/swarmkit/node"
@@ -871,6 +873,46 @@ func (c *Cluster) GetServices(options apitypes.ServiceListOptions) ([]types.Serv
 	return services, nil
 }
 
+// imageWithDigestString takes an image such as name or name:tag
+// and returns the image pinned to a digest, such as name@sha256:34234...
+func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authConfig *apitypes.AuthConfig) (string, error) {
+	ref, err := reference.ParseNamed(image)
+	if err != nil {
+		return "", err
+	}
+	// only query registry if not a canonical reference (i.e. with digest)
+	if _, ok := ref.(reference.Canonical); !ok {
+		ref = reference.WithDefaultTag(ref)
+
+		namedTaggedRef, ok := ref.(reference.NamedTagged)
+		if !ok {
+			return "", fmt.Errorf("unable to cast image to NamedTagged reference object")
+		}
+
+		repo, _, err := c.config.Backend.GetRepository(ctx, namedTaggedRef, authConfig)
+		if err != nil {
+			return "", err
+		}
+		dscrptr, err := repo.Tags(ctx).Get(ctx, namedTaggedRef.Tag())
+		if err != nil {
+			return "", err
+		}
+
+		// TODO(nishanttotla): Currently, the service would lose the tag while calling WithDigest
+		// To prevent this, we create the image string manually, which is a bad idea in general
+		// This will be fixed when https://github.com/docker/distribution/pull/2044 is vendored
+		// namedDigestedRef, err := reference.WithDigest(ref, dscrptr.Digest)
+		// if err != nil {
+		// 	return "", err
+		// }
+		// return namedDigestedRef.String(), nil
+		return image + "@" + dscrptr.Digest.String(), nil
+	} else {
+		// reference already contains a digest, so just return it
+		return ref.String(), nil
+	}
+}
+
 // CreateService creates a new service in a managed swarm cluster.
 func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string) (string, error) {
 	c.RLock()
@@ -893,12 +935,31 @@ func (c *Cluster) CreateService(s types.ServiceSpec, encodedAuth string) (string
 		return "", err
 	}
 
+	ctnr := serviceSpec.Task.GetContainer()
+	if ctnr == nil {
+		return "", fmt.Errorf("service does not use container tasks")
+	}
+
 	if encodedAuth != "" {
-		ctnr := serviceSpec.Task.GetContainer()
-		if ctnr == nil {
-			return "", fmt.Errorf("service does not use container tasks")
-		}
 		ctnr.PullOptions = &swarmapi.ContainerSpec_PullOptions{RegistryAuth: encodedAuth}
+	}
+
+	// retrieve auth config from encoded auth
+	authConfig := &apitypes.AuthConfig{}
+	if encodedAuth != "" {
+		if err := json.NewDecoder(base64.NewDecoder(base64.URLEncoding, strings.NewReader(encodedAuth))).Decode(authConfig); err != nil {
+			logrus.Warnf("invalid authconfig: %v", err)
+		}
+	}
+	// pin image by digest
+	if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" {
+		digestImage, err := c.imageWithDigestString(ctx, ctnr.Image, authConfig)
+		if err != nil {
+			logrus.Warnf("unable to pin image %s to digest: %s", ctnr.Image, err.Error())
+		} else {
+			logrus.Debugf("pinning image %s by digest: %s", ctnr.Image, digestImage)
+			ctnr.Image = digestImage
+		}
 	}
 
 	r, err := c.client.CreateService(ctx, &swarmapi.CreateServiceRequest{Spec: &serviceSpec})
@@ -955,12 +1016,13 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 		return err
 	}
 
+	newCtnr := serviceSpec.Task.GetContainer()
+	if newCtnr == nil {
+		return fmt.Errorf("service does not use container tasks")
+	}
+
 	if encodedAuth != "" {
-		ctnr := serviceSpec.Task.GetContainer()
-		if ctnr == nil {
-			return fmt.Errorf("service does not use container tasks")
-		}
-		ctnr.PullOptions = &swarmapi.ContainerSpec_PullOptions{RegistryAuth: encodedAuth}
+		newCtnr.PullOptions = &swarmapi.ContainerSpec_PullOptions{RegistryAuth: encodedAuth}
 	} else {
 		// this is needed because if the encodedAuth isn't being updated then we
 		// shouldn't lose it, and continue to use the one that was already present
@@ -979,7 +1041,29 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec typ
 		if ctnr == nil {
 			return fmt.Errorf("service does not use container tasks")
 		}
-		serviceSpec.Task.GetContainer().PullOptions = ctnr.PullOptions
+		newCtnr.PullOptions = ctnr.PullOptions
+		// update encodedAuth so it can be used to pin image by digest
+		if ctnr.PullOptions != nil {
+			encodedAuth = ctnr.PullOptions.RegistryAuth
+		}
+	}
+
+	// retrieve auth config from encoded auth
+	authConfig := &apitypes.AuthConfig{}
+	if encodedAuth != "" {
+		if err := json.NewDecoder(base64.NewDecoder(base64.URLEncoding, strings.NewReader(encodedAuth))).Decode(authConfig); err != nil {
+			logrus.Warnf("invalid authconfig: %v", err)
+		}
+	}
+	// pin image by digest
+	if os.Getenv("DOCKER_SERVICE_PREFER_OFFLINE_IMAGE") != "1" {
+		digestImage, err := c.imageWithDigestString(ctx, newCtnr.Image, authConfig)
+		if err != nil {
+			logrus.Warnf("unable to pin image %s to digest: %s", newCtnr.Image, err.Error())
+		} else if newCtnr.Image != digestImage {
+			logrus.Debugf("pinning image %s by digest: %s", newCtnr.Image, digestImage)
+			newCtnr.Image = digestImage
+		}
 	}
 
 	_, err = c.client.UpdateService(

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
+	"github.com/docker/docker/reference"
 	"github.com/docker/libnetwork"
 	"github.com/docker/libnetwork/cluster"
 	networktypes "github.com/docker/libnetwork/types"
@@ -44,4 +45,5 @@ type Backend interface {
 	UnsubscribeFromEvents(listener chan interface{})
 	UpdateAttachment(string, string, string, *network.NetworkingConfig) error
 	WaitForDetachment(context.Context, string, string, string, string) error
+	ResolveTagToDigest(context.Context, reference.NamedTagged, *types.AuthConfig) (string, error)
 }

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/docker/distribution"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -45,5 +46,5 @@ type Backend interface {
 	UnsubscribeFromEvents(listener chan interface{})
 	UpdateAttachment(string, string, string, *network.NetworkingConfig) error
 	WaitForDetachment(context.Context, string, string, string, string) error
-	ResolveTagToDigest(context.Context, reference.NamedTagged, *types.AuthConfig) (string, error)
+	GetRepository(context.Context, reference.NamedTagged, *types.AuthConfig) (distribution.Repository, bool, error)
 }


### PR DESCRIPTION
**- What I did**
When a Docker Swarm mode service is created using the image and tag, the agents pull image with the specified tag. This creates an issue for non-static tags like `latest`, which keep updating. This might cause multiple versions of the image running for the same service. The solution to this problem is to pin images by digest.

For example, on `docker service create alpine:latest top`, the manifest for the `alpine:latest` image is retrieved, and the digest is added to the image description before passing on the spec to the SwarmKit manager. In this case, `alpine:latest` is changed to `alpine:latest@sha256:1354db23ff5478120c980eca1611a51c9f2b88b61f24283ee8200bf9a54f2e5c` that specifies an image precisely. If at a future time, the image under `alpine:latest` were to have a different digest, this would be detected at the next `service update`, and all images would be pinned to the new digest.

Related issues: #24066, #27508, https://github.com/docker/swarmkit/issues/1334

**- How I did it**
The change is fairly simple. A new daemon function `ResolveTagToDigest` is used to retrieve a digest for a `reference.NamedTagged` object, by making a request to the registry. This function is used by `docker service create` and `docker service update` to resolve image to digest, if the image used to create the service didn't already have it.

The service spec is modified before passing to the SwarmKit manager to always contain a digest string, thereby ensuring that a service image is always precisely specified. On image update, a digest is retrieved again, and if different from the existing one, will result in a service update.

One thing that remains to be done is to enable pinning by digest for private images (this is a minor addition which I will shortly finish) by passing `AuthConfig` to `ResolveTagToDigest`.

**- How to verify it**
Try the following commands:
```
docker service create --name testsvc alpine:latest top
docker service ls
```
This should show the image as `alpine:latest@sha256:1354db23ff5478120c980eca1611a51c9f2b88b61f24283ee8200bf9a54f2e5c`
```
docker service update --image alpine:edge testsvc
docker service ls
```
This will show the image updated to `alpine:edge@sha256:cd9c03c2d382fcf00c31dc1635445163ec185dfffb51242d9e097892b3b0d5b4`

NOTE: It is by choice that the operation won't fail if the digest retrieval fails for some reason. It will only print a warning and move on. This is to make sure that the use case where a locally built image might be used to create a service still works.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Pin images by digest for docker service create and update

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="743" alt="screen shot 2016-11-08 at 10 07 29 am" src="https://cloud.githubusercontent.com/assets/1872537/20111030/9a1fba9e-a59b-11e6-9eb5-4a167e5e476b.png">

This is Mutsu the kitten. For more of Mutsu, you can check [here](https://www.youtube.com/watch?v=PJpcEuSrEn8)