### PR TITLE
Windows: Plumb through user

### DIFF
--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -9,5 +9,6 @@ import (
 func execSetPlatformOpt(c *container.Container, ec *exec.Config, p *libcontainerd.Process) error {
 	// Process arguments need to be escaped before sending to OCI.
 	p.Args = escapeArgs(p.Args)
+	p.User.Username = ec.User
 	return nil
 }

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -301,6 +301,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(procToAdd.Env)
 	createProcessParms.CommandLine = strings.Join(procToAdd.Args, " ")
+	createProcessParms.User = procToAdd.User.Username
 
 	logrus.Debugf("libcontainerd: commandLine: %s", createProcessParms.CommandLine)
 

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -81,6 +81,7 @@ func (ctr *container) start(attachStdio StdioCallback) error {
 	// Configure the environment for the process
 	createProcessParms.Environment = setupEnvironmentVariables(ctr.ociSpec.Process.Env)
 	createProcessParms.CommandLine = strings.Join(ctr.ociSpec.Process.Args, " ")
+	createProcessParms.User = ctr.ociSpec.Process.User.Username
 
 	// Start the command running in the container.
 	newProcess, err := ctr.hcsContainer.CreateProcess(createProcessParms)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Plumbs through the user into HCS. @thaJeztah Needed for 1.13.

(Yes, I need to think how to test this on Windows, particularly a nanoserver container. Once I have that thought through, I'll submit a follow up integration test PR). 