### PR TITLE
Windows: Avoid concurrent access to sysinfo

### DIFF
--- a/pkg/platform/architecture_windows.go
+++ b/pkg/platform/architecture_windows.go
@@ -34,10 +34,9 @@ const (
 	ProcessorArchitectureArm  = 5 // PROCESSOR_ARCHITECTURE_ARM
 )
 
-var sysinfo systeminfo
-
 // runtimeArchitecture gets the name of the current architecture (x86, x86_64, …)
 func runtimeArchitecture() (string, error) {
+	var sysinfo systeminfo
 	syscall.Syscall(procGetSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(&sysinfo)), 0, 0)
 	switch sysinfo.wProcessorArchitecture {
 	case ProcessorArchitecture64, ProcessorArchitectureIA64:
@@ -53,6 +52,7 @@ func runtimeArchitecture() (string, error) {
 
 // NumProcs returns the number of processors on the system
 func NumProcs() uint32 {
+	var sysinfo systeminfo
 	syscall.Syscall(procGetSystemInfo.Addr(), 1, uintptr(unsafe.Pointer(&sysinfo)), 0, 0)
 	return sysinfo.dwNumberOfProcessors
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

While I don't think there's any active instances ever seen of corruption because of this, there's a concurrent access condition to the `sysinfo` variable in `architecture_windows.go`. It should be function local, not global.

@thaJeztah @cpuguy83 @tiborvass 