### PR TITLE
Windows: Enable fluentd logdriver

### DIFF
--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -5,6 +5,7 @@ import (
 	// therefore they register themselves to the logdriver factory.
 	_ "github.com/docker/docker/daemon/logger/awslogs"
 	_ "github.com/docker/docker/daemon/logger/etwlogs"
+	_ "github.com/docker/docker/daemon/logger/fluentd"
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 	_ "github.com/docker/docker/daemon/logger/logentries"
 	_ "github.com/docker/docker/daemon/logger/splunk"


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/docker/docker/issues/26754. @LK4D4. 

I don't have an easy way of verifying overall functionality. This simply enables it on Windows. @johnstep in case you are able to verify E2E functionality.