### PR TITLE
change node ls and service ls api and docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -3952,9 +3952,10 @@ List nodes
 - **filters** – a JSON encoded value of the filters (a `map[string][]string`) to process on the
   nodes list. Available filters:
   - `id=<node id>`
+  - `label=<engine label>`
+  - `membership=`(`accepted`|`pending`)`
   - `name=<node name>`
-  - `membership=`(`pending`|`accepted`|`rejected`)`
-  - `role=`(`worker`|`manager`)`
+  - `role=`(`manager`|`worker`)`
 
 **Status codes**:
 
@@ -4501,8 +4502,9 @@ List services
 
 - **filters** – a JSON encoded value of the filters (a `map[string][]string`) to process on the
   services list. Available filters:
-  - `id=<node id>`
-  - `name=<node name>`
+  - `id=<service id>`
+  - `label=<service label>`
+  - `name=<service name>`
 
 **Status codes**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4554,9 +4554,10 @@ List nodes
 - **filters** – a JSON encoded value of the filters (a `map[string][]string`) to process on the
   nodes list. Available filters:
   - `id=<node id>`
+  - `label=<engine label>`
+  - `membership=`(`accepted`|`pending`)`
   - `name=<node name>`
-  - `membership=`(`pending`|`accepted`|`rejected`)`
-  - `role=`(`worker`|`manager`)`
+  - `role=`(`manager`|`worker`)`
 
 **Status codes**:
 
@@ -5161,8 +5162,9 @@ List services
 
 - **filters** – a JSON encoded value of the filters (a `map[string][]string`) to process on the
   services list. Available filters:
-  - `id=<node id>`
-  - `name=<node name>`
+  - `id=<service id>`
+  - `label=<service label>`
+  - `name=<service name>`
 
 **Status codes**:
 

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -49,24 +49,13 @@ than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "b
 
 The currently supported filters are:
 
-* name
-* id
-* label
+* [id](node_ls.md#id)
+* [label](node_ls.md#label)
+* [membership](node_ls.md#membership)
+* [name](node_ls.md#name)
+* [role](node_ls.md#role)
 
-### name
-
-The `name` filter matches on all or part of a node name.
-
-The following filter matches the node with a name equal to `swarm-master` string.
-
-```bash
-$ docker node ls -f name=swarm-manager1
-
-ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
-e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
-```
-
-### id
+#### ID
 
 The `id` filter matches all or part of a node's id.
 
@@ -77,12 +66,11 @@ ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
 1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
 ```
 
-#### label
+#### Label
 
-The `label` filter matches tasks based on the presence of a `label` alone or a `label` and a
-value.
+The `label` filter matches nodes based on engine labels and on the presence of a `label` alone or a `label` and a value. Node labels are currently not used for filtering.
 
-The following filter matches nodes with the `usage` label regardless of its value.
+The following filter matches nodes with the `foo` label regardless of its value.
 
 ```bash
 $ docker node ls -f "label=foo"
@@ -91,6 +79,46 @@ ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
 1bcef6utixb0l0ca7gxuivsj0  swarm-worker2  Ready   Active
 ```
 
+#### Membership
+
+The `membership` filter matches nodes based on the presence of a `membership` and a value
+`accepted` or `pending`.
+
+The following filter matches nodes with the `membership` of `accepted`.
+
+```bash
+$ docker node ls -f "membership=accepted"
+
+ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+1bcef6utixb0l0ca7gxuivsj0    swarm-worker2   Ready   Active
+38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
+```
+
+#### Name
+
+The `name` filter matches on all or part of a node hostname.
+
+The following filter matches the nodes with a name equal to `swarm-master` string.
+
+```bash
+$ docker node ls -f name=swarm-manager1
+
+ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+```
+
+#### Role
+
+The `role` filter matches nodes based on the presence of a `role` and a value `worker` or `manager`.
+
+The following filter matches nodes with the `manager` role.
+
+```bash
+$ docker node ls -f "role=manager"
+
+ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
+e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
+```
 
 ## Related information
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -51,9 +51,9 @@ than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "b
 
 The currently supported filters are:
 
-* [id](#id)
-* [label](#label)
-* [name](#name)
+* [id](service_ls.md#id)
+* [label](service_ls.md#label)
+* [name](service_ls.md#name)
 
 #### ID
 
@@ -93,7 +93,7 @@ ID            NAME      MODE        REPLICAS  IMAGE
 
 #### Name
 
-The `name` filter matches on all or part of a tasks's name.
+The `name` filter matches on all or part of a service's name.
 
 The following filter matches services with a name containing `redis`.
 


### PR DESCRIPTION
fixes https://github.com/docker/docker/issues/28165

There are some places in docs that maybe need improvements.

* command `docker node ls`;
* command `docker service ls` description 
* api `GET /services`
* api `GET /nodes`

All about filter description.

Also add more description about label filtering in `docker node ls`. related to https://github.com/docker/docker/issues/27231
Label filtering in `docker node ls` is looking at engine labels rather than node labels.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>