### PR TITLE
Fix the link for plugin documentation

### DIFF
--- a/experimental/plugins_graphdriver.md
+++ b/experimental/plugins_graphdriver.md
@@ -10,7 +10,7 @@ being started.
 
 # Write a graph driver plugin
 
-See the [plugin documentation](/docs/extend/plugins.md) for detailed information
+See the [plugin documentation](/docs/extend/index.md) for detailed information
 on the underlying plugin protocol.
 
 


### PR DESCRIPTION
**- What I did**
Fix the link for plugin documentation

**- How I did it**

**- How to verify it**

**- Description for the changelog**
The link cannot be accessed and update the link from plugins.md  to index.md

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>