### PR TITLE
add short flag for force

### DIFF
--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -29,7 +29,7 @@ func newRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
 		},
 	}
 	flags := cmd.Flags()
-	flags.BoolVar(&opts.force, "force", false, "Force remove a node from the swarm")
+	flags.BoolVarP(&opts.force, "force", "f", false, "Force remove a node from the swarm")
 	return cmd
 }
 

--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -27,7 +27,7 @@ func newLeaveCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVar(&opts.force, "force", false, "Force this node to leave the swarm, ignoring warnings")
+	flags.BoolVarP(&opts.force, "force", "f", false, "Force this node to leave the swarm, ignoring warnings")
 	return cmd
 }
 

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -16,7 +16,7 @@ keywords: "node, remove"
 # node rm
 
 ```markdown
-Usage:  docker node rm [OPTIONS] NODE [NODE...]
+Usage:	docker node rm [OPTIONS] NODE [NODE...]
 
 Remove one or more nodes from the swarm
 
@@ -24,8 +24,8 @@ Aliases:
   rm, remove
 
 Options:
-      --force  Force remove a node from the swarm
-      --help   Print usage
+  -f, --force   Force remove a node from the swarm
+      --help    Print usage
 ```
 
 When run from a manager node, removes the specified nodes from a swarm.

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -16,12 +16,12 @@ keywords: "swarm, leave"
 # swarm leave
 
 ```markdown
-Usage:  docker swarm leave [OPTIONS]
+Usage:	docker swarm leave [OPTIONS]
 
-Leave the swarm (workers only).
+Leave the swarm (workers only)
 
 Options:
-      --force   Force this node to leave the swarm, ignoring warnings
+  -f, --force   Force this node to leave the swarm, ignoring warnings
       --help    Print usage
 ```
 


### PR DESCRIPTION
Add short flag force for command `docker node rm` and `docker swarm leave`.
As I think all other force flag has a short one for itself.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>