### PR TITLE
Fixes #27687 docker logs --tails returns less lines than expected

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -117,22 +117,28 @@ func (s *DockerSuite) TestLogsTail(c *check.C) {
 	id := strings.TrimSpace(out)
 	dockerCmd(c, "wait", id)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "5", id)
-
+	out, _ = dockerCmd(c, "logs", "--tail", "0", id)
 	lines := strings.Split(out, "\n")
+	c.Assert(lines, checker.HasLen, 1)
 
+	out, _ = dockerCmd(c, "logs", "--tail", "5", id)
+	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, 6)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "all", id)
-
+	out, _ = dockerCmd(c, "logs", "--tail", "99", id)
 	lines = strings.Split(out, "\n")
+	c.Assert(lines, checker.HasLen, 100)
 
+	out, _ = dockerCmd(c, "logs", "--tail", "all", id)
+	lines = strings.Split(out, "\n")
+	c.Assert(lines, checker.HasLen, testLen+1)
+
+	out, _ = dockerCmd(c, "logs", "--tail", "-1", id)
+	lines = strings.Split(out, "\n")
 	c.Assert(lines, checker.HasLen, testLen+1)
 
 	out, _, _ = dockerCmdWithStdoutStderr(c, "logs", "--tail", "random", id)
-
 	lines = strings.Split(out, "\n")
-
 	c.Assert(lines, checker.HasLen, testLen+1)
 }
 

--- a/pkg/tailfile/tailfile.go
+++ b/pkg/tailfile/tailfile.go
@@ -44,7 +44,7 @@ func TailFile(f io.ReadSeeker, n int) ([][]byte, error) {
 			break
 		} else {
 			b = make([]byte, blockSize)
-			if _, err := f.Seek(step, os.SEEK_END); err != nil {
+			if _, err := f.Seek(left, os.SEEK_SET); err != nil {
 				return nil, err
 			}
 			if _, err := f.Read(b); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed issue when log file is too large and there is constant writing activity, the --tail command returns incorrect number of lines, and if the specified number larger than 100000 then the process hangs.

**- How I did it**
0. if the filesize is smaller than the buffer then load the whole file into memory goto 6
1.Changed the reading the last n lines algorithm to:
2.seek the starting position for a buffer size block from EOF
3.count the number of "\n"'s
4.if number of eol is larger than n then return
5.if not then double the size of the buffer then go back to 1.
6.take the last n line of buffered file and return

**- How to verify it**
docker logs --tail 10000 app | wc -l
should return number equal to the number of lines in a log file, or if the logfile has more lines then it should return 10000

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
for large log files tail now only read part of the file instead of the whole file

**- A picture of a cute animal (not mandatory but encouraged)**
![gp](http://cdn.attackofthecute.com/August-04-2011-04-29-47-twitter.jpeg)

The tailfile reader was loading the whole file into the memory before getting the last n files. It was using up a long of memory and have potential deadlock issue. Also when there is constant writing activity the tail returns wrong number of lines.

The fix uses buffer then let the seeker find the starting position of the buffer, if the buffer is too small then increase the size until the number of line are returned.

Signed-off-by: Shayne Wang <shaynexwang@gmail.com>