### PR TITLE
[carry 27830] Deprecate API calls without a version

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -226,3 +226,12 @@ Since 1.9, Docker Content Trust Offline key has been renamed to Root key and the
 **Deprecated In Release: v1.13.0**
 
 `MAINTAINER` was an early very limited form of `LABEL` which should be used instead.
+
+### API calls without a version
+**Deprecated In Release: [v1.13](https://github.com/docker/docker/releases/)**
+
+**Target For Removal In Release: v1.16**
+
+API versions should be supplied to all API calls to ensure compatibility with
+future Engine versions. Instead of just requesting, for example, the URL
+`/containers/json`, you must now request `/v1.25/containers/json`.

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -36,23 +36,34 @@ following:
 When using cUrl 7.50 or later:
 
 ```console
-$ curl --unix-socket /var/run/docker.sock http://localhost/containers/json
+$ curl --unix-socket /var/run/docker.sock http://localhost/v1.25/containers/json
 ```
 
 When using cURL 7.40, `localhost` must be omitted:
 
 ```console
-$ curl --unix-socket /var/run/docker.sock http://containers/json
+$ curl --unix-socket /var/run/docker.sock http://v1.25/containers/json
 ```
 
 If you have bound the Docker daemon to a different socket path or TCP
 port, you would reference that in your cURL rather than the
 default.
 
-The current version of the API is v1.25 which means calling `/info` is the same
-as calling `/v1.25/info`. To call an older version of the API use
-`/v1.24/info`. If a newer daemon is installed, new properties may be returned
-even when calling older versions of the API.
+## Versioning
+
+It is required to to supply a version to API calls. This is done by prefixing
+the URL with the version number.
+
+The current version of the API is 1.25, so to call the `/info` endpoint, you
+would send a request to the URL `/v1.25/info`. To call, for example, version
+1.24 of the API instead, you would request `/v1.24/info`.
+
+If a newer daemon is installed, new properties may be returned even when
+calling older versions of the API.
+
+In previous versions of Docker, it was possible to access the API without
+providing a version. This behaviour is now deprecated will be removed in a
+future version of Docker.
 
 Use the table below to find the API version for a Docker version:
 
@@ -97,11 +108,11 @@ API requests, for example:
 curl --insecure \
      --cert $DOCKER_CERT_PATH/cert.pem \
      --key $DOCKER_CERT_PATH/key.pem \
-     https://YOUR_VM_IP:2376/images/json
+     https://YOUR_VM_IP:2376/v1.25/images/json
 
 wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem \
      --private-key=$DOCKER_CERT_PATH/key.pem \
-     https://YOUR_VM_IP:2376/images/json -O - -q
+     https://YOUR_VM_IP:2376/v1.25/images/json -O - -q
 ```
 
 ## Docker Events
@@ -130,6 +141,7 @@ This section lists each version from latest to oldest.  Each listing includes a 
 
 [Docker Remote API v1.25](docker_remote_api_v1.25.md) documentation
 
+* The API version is now required in all API calls. Instead of just requesting, for example, the URL `/containers/json`, you must now request `/v1.25/containers/json`.
 * `GET /version` now returns `MinAPIVersion`.
 * `POST /build` accepts `networkmode` parameter to specify network used during build.
 * `GET /images/(name)/json` now returns `OsVersion` if populated

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -36,7 +36,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.18/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -129,7 +129,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.18/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -316,7 +316,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.18/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -451,7 +451,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -474,7 +474,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -516,7 +516,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
+     GET /v1.18/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
 
 **Example response**:
 
@@ -553,7 +553,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -595,7 +595,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.18/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -620,7 +620,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.18/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -708,7 +708,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.18/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -739,7 +739,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.18/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -760,7 +760,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.18/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -785,7 +785,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.18/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -809,7 +809,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.18/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -834,7 +834,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.18/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -859,7 +859,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.18/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -879,7 +879,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.18/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -899,7 +899,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.18/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -986,7 +986,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.18/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1021,7 +1021,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.18/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1073,7 +1073,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.18/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1103,7 +1103,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.18/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1137,7 +1137,7 @@ Copy files or folders of container `id`
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.18/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1191,7 +1191,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.18/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1262,7 +1262,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.18/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1306,7 +1306,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/json HTTP/1.1
+    GET /v1.18/images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1357,7 +1357,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.18/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1391,7 +1391,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.18/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1409,7 +1409,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.18/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1434,7 +1434,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.18/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1499,7 +1499,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.18/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1550,7 +1550,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.18/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1578,7 +1578,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.18/info HTTP/1.1
 
 **Example response**:
 
@@ -1643,7 +1643,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.18/version HTTP/1.1
 
 **Example response**:
 
@@ -1673,7 +1673,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.18/_ping HTTP/1.1
 
 **Example response**:
 
@@ -1695,7 +1695,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.18/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1902,7 +1902,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.18/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1947,7 +1947,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.18/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1987,7 +1987,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.18/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2013,7 +2013,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.18/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.19/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -131,7 +131,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.19/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -328,7 +328,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.19/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -467,7 +467,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -490,7 +490,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -532,7 +532,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.19/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -571,7 +571,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -613,7 +613,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.19/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -638,7 +638,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.19/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -747,7 +747,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.19/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -778,7 +778,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.19/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -799,7 +799,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.19/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -824,7 +824,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.19/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -848,7 +848,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.19/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -873,7 +873,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.19/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -898,7 +898,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.19/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -918,7 +918,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.19/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -938,7 +938,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.19/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1025,7 +1025,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.19/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1060,7 +1060,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.19/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1112,7 +1112,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.19/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1142,7 +1142,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.19/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1180,7 +1180,7 @@ Copy files or folders of container `id`
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.19/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1235,7 +1235,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.19/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1308,7 +1308,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.19/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1352,7 +1352,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/json HTTP/1.1
+    GET /v1.19/images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1403,7 +1403,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.19/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1457,7 +1457,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.19/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1475,7 +1475,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.19/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1500,7 +1500,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.19/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1568,7 +1568,7 @@ be deprecated and replaced by the `is_automated` property.
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.19/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1622,7 +1622,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.19/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1650,7 +1650,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.19/info HTTP/1.1
 
 **Example response**:
 
@@ -1719,7 +1719,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.19/version HTTP/1.1
 
 **Example response**:
 
@@ -1749,7 +1749,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.19/_ping HTTP/1.1
 
 **Example response**:
 
@@ -1771,7 +1771,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.19/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1982,7 +1982,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.19/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2030,7 +2030,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.19/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2070,7 +2070,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.19/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2096,7 +2096,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.19/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -36,7 +36,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.20/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -129,7 +129,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.20/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -330,7 +330,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.20/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -474,7 +474,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -497,7 +497,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -539,7 +539,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.20/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -578,7 +578,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -620,7 +620,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.20/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -645,7 +645,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.20/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -754,7 +754,7 @@ Resize the TTY for container with  `id`. You must restart the container for the 
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.20/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -785,7 +785,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.20/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -806,7 +806,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.20/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -831,7 +831,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.20/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -855,7 +855,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.20/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -880,7 +880,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.20/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -905,7 +905,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.20/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -925,7 +925,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.20/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -945,7 +945,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.20/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1032,7 +1032,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.20/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1067,7 +1067,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.20/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1121,7 +1121,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.20/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1173,7 +1173,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.20/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1271,7 +1271,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.20/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1309,7 +1309,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.20/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1364,7 +1364,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.20/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1462,7 +1462,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.20/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1506,7 +1506,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/json HTTP/1.1
+    GET /v1.20/images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1557,7 +1557,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.20/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1611,7 +1611,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.20/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1629,7 +1629,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.20/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1654,7 +1654,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.20/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1719,7 +1719,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.20/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1770,7 +1770,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.20/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1798,7 +1798,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.20/info HTTP/1.1
 
 **Example response**:
 
@@ -1867,7 +1867,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.20/version HTTP/1.1
 
 **Example response**:
 
@@ -1898,7 +1898,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.20/_ping HTTP/1.1
 
 **Example response**:
 
@@ -1920,7 +1920,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.20/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2137,7 +2137,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.20/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2185,7 +2185,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.20/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2225,7 +2225,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.20/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2251,7 +2251,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.20/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.21/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -135,7 +135,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.21/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -353,7 +353,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.21/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -511,7 +511,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -545,7 +545,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -568,7 +568,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -610,7 +610,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.21/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -649,7 +649,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -691,7 +691,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.21/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -716,7 +716,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.21/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -837,7 +837,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.21/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -868,7 +868,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.21/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -889,7 +889,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.21/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -914,7 +914,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.21/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -938,7 +938,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.21/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -963,7 +963,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.21/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -988,7 +988,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.21/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1008,7 +1008,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.21/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1028,7 +1028,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.21/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1115,7 +1115,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.21/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1150,7 +1150,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.21/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1204,7 +1204,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.21/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1256,7 +1256,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.21/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1354,7 +1354,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.21/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1392,7 +1392,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.21/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1447,7 +1447,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.21/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1551,7 +1551,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.21/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1599,7 +1599,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.21/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1710,7 +1710,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.21/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1764,7 +1764,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.21/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1782,7 +1782,7 @@ then be used in the URL. This duplicates the command line's flow.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.21/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -1807,7 +1807,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.21/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -1872,7 +1872,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.21/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -1923,7 +1923,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.21/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1951,7 +1951,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.21/info HTTP/1.1
 
 **Example response**:
 
@@ -2022,7 +2022,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.21/version HTTP/1.1
 
 **Example response**:
 
@@ -2053,7 +2053,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.21/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2075,7 +2075,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.21/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2293,7 +2293,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.21/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2345,7 +2345,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.21/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2386,7 +2386,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.21/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2412,7 +2412,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.21/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2538,7 +2538,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.21/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2572,7 +2572,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.21/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2658,7 +2658,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks HTTP/1.1
+    GET /v1.21/networks HTTP/1.1
 
 **Example response**:
 
@@ -2739,7 +2739,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566 HTTP/1.1
+    GET /v1.21/networks/f2de39df4171b0dc801e8002d1d999b77256983dfc63041c0f34030aa3977566 HTTP/1.1
 
 **Example response**:
 
@@ -2793,7 +2793,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.21/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -2851,7 +2851,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.21/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -2882,7 +2882,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.21/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -36,7 +36,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.22/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -218,7 +218,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.22/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -463,7 +463,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.22/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -634,7 +634,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -668,7 +668,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -691,7 +691,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -733,7 +733,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.22/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -772,7 +772,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -814,7 +814,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.22/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -839,7 +839,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.22/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -960,7 +960,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.22/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -991,7 +991,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.22/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1018,7 +1018,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.22/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1043,7 +1043,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.22/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1067,7 +1067,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.22/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1092,7 +1092,7 @@ Update resource configs of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.22/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1132,7 +1132,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.22/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1157,7 +1157,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.22/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1177,7 +1177,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.22/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1197,7 +1197,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.22/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1288,7 +1288,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.22/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1326,7 +1326,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.22/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1380,7 +1380,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.22/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1432,7 +1432,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.22/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1530,7 +1530,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.22/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1568,7 +1568,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.22/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1623,7 +1623,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.22/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1728,7 +1728,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.22/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1794,7 +1794,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.22/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1905,7 +1905,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.22/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1959,7 +1959,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.22/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -1979,7 +1979,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.22/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2021,7 +2021,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.22/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2086,7 +2086,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.22/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2137,7 +2137,7 @@ Get the default username and email
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.22/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2165,7 +2165,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.22/info HTTP/1.1
 
 **Example response**:
 
@@ -2252,7 +2252,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.22/version HTTP/1.1
 
 **Example response**:
 
@@ -2284,7 +2284,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.22/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2306,7 +2306,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.22/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2681,7 +2681,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.22/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2737,7 +2737,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.22/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2778,7 +2778,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.22/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2804,7 +2804,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.22/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2847,7 +2847,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.22/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2882,7 +2882,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.22/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2968,7 +2968,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.22/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3052,7 +3052,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.22/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3111,7 +3111,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.22/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3178,7 +3178,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.22/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3215,7 +3215,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.22/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -38,7 +38,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.23/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -242,7 +242,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.23/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -491,7 +491,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.23/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -662,7 +662,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -696,7 +696,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -719,7 +719,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -761,7 +761,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.23/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -800,7 +800,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -842,7 +842,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.23/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -867,7 +867,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.23/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -991,7 +991,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.23/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -1022,7 +1022,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.23/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1049,7 +1049,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.23/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1074,7 +1074,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.23/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1098,7 +1098,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.23/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1123,7 +1123,7 @@ Update configuration of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.23/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1167,7 +1167,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.23/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1192,7 +1192,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.23/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1212,7 +1212,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.23/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1232,7 +1232,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.23/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1323,7 +1323,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.23/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1361,7 +1361,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.23/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1415,7 +1415,7 @@ Copy files or folders of container `id`
 
 **Example request**:
 
-    POST /containers/4fa6e0f0c678/copy HTTP/1.1
+    POST /v1.23/containers/4fa6e0f0c678/copy HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1467,7 +1467,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.23/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1565,7 +1565,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.23/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1603,7 +1603,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.23/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1658,7 +1658,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.23/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1764,7 +1764,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.23/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1830,7 +1830,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.23/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1948,7 +1948,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.23/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -2002,7 +2002,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.23/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -2022,7 +2022,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.23/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2064,7 +2064,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+    POST /v1.23/images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2129,7 +2129,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.23/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2181,7 +2181,7 @@ if available, for accessing the registry without password.
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.23/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2213,7 +2213,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.23/info HTTP/1.1
 
 **Example response**:
 
@@ -2302,7 +2302,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.23/version HTTP/1.1
 
 **Example response**:
 
@@ -2334,7 +2334,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.23/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2356,7 +2356,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.23/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2757,7 +2757,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.23/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2813,7 +2813,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.23/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2854,7 +2854,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.23/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2880,7 +2880,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.23/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2923,7 +2923,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.23/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2958,7 +2958,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.23/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3057,7 +3057,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.23/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3147,7 +3147,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.23/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3212,7 +3212,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.23/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3295,7 +3295,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.23/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3332,7 +3332,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.23/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -46,7 +46,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.24/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -251,7 +251,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.24/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -514,7 +514,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.24/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -692,7 +692,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -726,7 +726,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -749,7 +749,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -791,7 +791,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.24/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -831,7 +831,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -873,7 +873,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.24/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -898,7 +898,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.24/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -1022,7 +1022,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.24/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -1049,7 +1049,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.24/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1076,7 +1076,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.24/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1101,7 +1101,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.24/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1125,7 +1125,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.24/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1150,7 +1150,7 @@ Update configuration of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.24/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1194,7 +1194,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.24/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1219,7 +1219,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.24/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1239,7 +1239,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.24/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1259,7 +1259,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.24/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1350,7 +1350,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.24/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1388,7 +1388,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.24/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1462,7 +1462,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.24/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1560,7 +1560,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.24/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1598,7 +1598,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.24/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1655,7 +1655,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.24/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1761,7 +1761,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.24/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1827,7 +1827,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.24/images/example/json HTTP/1.1
 
 **Example response**:
 
@@ -1945,7 +1945,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.24/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1999,7 +1999,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.24/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -2019,7 +2019,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.24/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2061,7 +2061,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
+    POST /v1.24/images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2125,7 +2125,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.24/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2182,7 +2182,7 @@ if available, for accessing the registry without password.
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.24/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2214,7 +2214,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.24/info HTTP/1.1
 
 **Example response**:
 
@@ -2307,7 +2307,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.24/version HTTP/1.1
 
 **Example response**:
 
@@ -2339,7 +2339,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.24/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2361,7 +2361,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.24/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2767,7 +2767,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.24/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2823,7 +2823,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.24/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2864,7 +2864,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.24/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -2890,7 +2890,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.24/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -2933,7 +2933,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.24/volumes HTTP/1.1
 
 **Example response**:
 
@@ -2973,7 +2973,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.24/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3103,7 +3103,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.24/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3195,7 +3195,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.24/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3260,7 +3260,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.24/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3343,7 +3343,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.24/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3381,7 +3381,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.24/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3436,7 +3436,7 @@ Returns information about installed plugins.
 
 **Example request**:
 
-    GET /plugins HTTP/1.1
+    GET /v1.24/plugins HTTP/1.1
 
 **Example response**:
 
@@ -3568,7 +3568,7 @@ using the [`POST /plugins/(plugin name)/enable` endpoint](#enable-a-plugin).
 **Example request**:
 
 ```
-POST /plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
+POST /v1.24/plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -3629,7 +3629,7 @@ Returns detailed information about an installed plugin.
 **Example request**:
 
 ```
-GET /plugins/tiborvass/no-remove:latest HTTP/1.1
+GET /v1.24/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -3762,7 +3762,7 @@ Enables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/enable HTTP/1.1
+POST /v1.24/plugins/tiborvass/no-remove:latest/enable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -3790,7 +3790,7 @@ Disables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/disable HTTP/1.1
+POST /v1.24/plugins/tiborvass/no-remove:latest/disable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -3841,14 +3841,14 @@ Content-Type: text/plain; charset=utf-8
 
 ### Push a plugin
 
-`POST /plugins/tiborvass/(plugin name)/push HTTP/1.1`
+`POST /v1.24/plugins/tiborvass/(plugin name)/push HTTP/1.1`
 
 Pushes a plugin to the registry.
 
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest HTTP/1.1
+POST /v1.24/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -3878,7 +3878,7 @@ List nodes
 
 **Example request**:
 
-    GET /nodes HTTP/1.1
+    GET /v1.24/nodes HTTP/1.1
 
 **Example response**:
 
@@ -3970,7 +3970,7 @@ Return low-level information on the node `id`
 
 **Example request**:
 
-      GET /nodes/24ifsmvkjbyhk HTTP/1.1
+      GET /v1.24/nodes/24ifsmvkjbyhk HTTP/1.1
 
 **Example response**:
 
@@ -4087,7 +4087,7 @@ an empty value or the default cluster-wide value.
 
 **Example Request**
 
-    POST /nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
+    POST /v1.24/nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4185,7 +4185,7 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
 
 **Example request**:
 
-    POST /swarm/init HTTP/1.1
+    POST /v1.24/swarm/init HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4260,7 +4260,7 @@ Join an existing swarm
 
 **Example request**:
 
-    POST /swarm/join HTTP/1.1
+    POST /v1.24/swarm/join HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4303,7 +4303,7 @@ Leave a swarm
 
 **Example request**:
 
-    POST /swarm/leave HTTP/1.1
+    POST /v1.24/swarm/leave HTTP/1.1
 
 **Example response**:
 
@@ -4329,7 +4329,7 @@ Update a swarm
 
 **Example request**:
 
-    POST /swarm/update HTTP/1.1
+    POST /v1.24/swarm/update HTTP/1.1
 
     {
       "Name": "default",
@@ -4414,7 +4414,7 @@ List services
 
 **Example request**:
 
-    GET /services HTTP/1.1
+    GET /v1.24/services HTTP/1.1
 
 **Example response**:
 
@@ -4520,7 +4520,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/create HTTP/1.1
+    POST /v1.24/services/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4714,7 +4714,7 @@ Return information on the service `id`.
 
 **Example request**:
 
-    GET /services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
+    GET /v1.24/services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
 
 **Example response**:
 
@@ -4806,7 +4806,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
+    POST /v1.24/services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4940,7 +4940,7 @@ List tasks
 
 **Example request**:
 
-    GET /tasks HTTP/1.1
+    GET /v1.24/tasks HTTP/1.1
 
 **Example response**:
 
@@ -5138,7 +5138,7 @@ Get details on a task
 
 **Example request**:
 
-    GET /tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
+    GET /v1.24/tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -46,7 +46,7 @@ List containers
 
 **Example request**:
 
-    GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+    GET /v1.25/containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
 
 **Example response**:
 
@@ -255,7 +255,7 @@ Create a container
 
 **Example request**:
 
-    POST /containers/create HTTP/1.1
+    POST /v1.25/containers/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -562,7 +562,7 @@ Return low-level information on the container `id`
 
 **Example request**:
 
-      GET /containers/4fa6e0f0c678/json HTTP/1.1
+      GET /v1.25/containers/4fa6e0f0c678/json HTTP/1.1
 
 **Example response**:
 
@@ -746,7 +746,7 @@ Return low-level information on the container `id`
 
 **Example request, with size information**:
 
-    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/json?size=1 HTTP/1.1
 
 **Example response, with size information**:
 
@@ -780,7 +780,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/top HTTP/1.1
 
 **Example response**:
 
@@ -803,7 +803,7 @@ supported on Windows.
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/top?ps_args=aux HTTP/1.1
 
 **Example response**:
 
@@ -845,7 +845,7 @@ Get `stdout` and `stderr` logs from the container ``id``
 
 **Example request**:
 
-     GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.25/containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -885,7 +885,7 @@ Inspect changes on container `id`'s filesystem
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/changes HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/changes HTTP/1.1
 
 **Example response**:
 
@@ -927,7 +927,7 @@ Export the contents of container `id`
 
 **Example request**:
 
-    GET /containers/4fa6e0f0c678/export HTTP/1.1
+    GET /v1.25/containers/4fa6e0f0c678/export HTTP/1.1
 
 **Example response**:
 
@@ -952,7 +952,7 @@ This endpoint returns a live stream of a container's resource usage statistics.
 
 **Example request**:
 
-    GET /containers/redis1/stats HTTP/1.1
+    GET /v1.25/containers/redis1/stats HTTP/1.1
 
 **Example response**:
 
@@ -1076,7 +1076,7 @@ Resize the TTY for container with  `id`. The unit is number of characters. You m
 
 **Example request**:
 
-      POST /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+      POST /v1.25/containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
 
 **Example response**:
 
@@ -1103,7 +1103,7 @@ Start the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/start HTTP/1.1
+    POST /v1.25/containers/e90e34656806/start HTTP/1.1
 
 **Example response**:
 
@@ -1130,7 +1130,7 @@ Stop the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+    POST /v1.25/containers/e90e34656806/stop?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1155,7 +1155,7 @@ Restart the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+    POST /v1.25/containers/e90e34656806/restart?t=5 HTTP/1.1
 
 **Example response**:
 
@@ -1179,7 +1179,7 @@ Kill the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/kill HTTP/1.1
+    POST /v1.25/containers/e90e34656806/kill HTTP/1.1
 
 **Example response**:
 
@@ -1204,7 +1204,7 @@ Update configuration of one or more containers.
 
 **Example request**:
 
-       POST /containers/e90e34656806/update HTTP/1.1
+       POST /v1.25/containers/e90e34656806/update HTTP/1.1
        Content-Type: application/json
 
        {
@@ -1250,7 +1250,7 @@ Rename the container `id` to a `new_name`
 
 **Example request**:
 
-    POST /containers/e90e34656806/rename?name=new_name HTTP/1.1
+    POST /v1.25/containers/e90e34656806/rename?name=new_name HTTP/1.1
 
 **Example response**:
 
@@ -1275,7 +1275,7 @@ Pause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/pause HTTP/1.1
+    POST /v1.25/containers/e90e34656806/pause HTTP/1.1
 
 **Example response**:
 
@@ -1295,7 +1295,7 @@ Unpause the container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/unpause HTTP/1.1
+    POST /v1.25/containers/e90e34656806/unpause HTTP/1.1
 
 **Example response**:
 
@@ -1315,7 +1315,7 @@ Attach to the container `id`
 
 **Example request**:
 
-    POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+    POST /v1.25/containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
 
 **Example response**:
 
@@ -1406,7 +1406,7 @@ Implements websocket protocol handshake according to [RFC 6455](http://tools.iet
 
 **Example request**
 
-    GET /containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
+    GET /v1.25/containers/e90e34656806/attach/ws?logs=0&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.1
 
 **Example response**
 
@@ -1444,7 +1444,7 @@ Block until container `id` stops, then returns the exit code
 
 **Example request**:
 
-    POST /containers/16253994b7c4/wait HTTP/1.1
+    POST /v1.25/containers/16253994b7c4/wait HTTP/1.1
 
 **Example response**:
 
@@ -1518,7 +1518,7 @@ Get a tar archive of a resource in the filesystem of container `id`.
 
 **Example request**:
 
-    GET /containers/8cce319429b2/archive?path=/root HTTP/1.1
+    GET /v1.25/containers/8cce319429b2/archive?path=/root HTTP/1.1
 
 **Example response**:
 
@@ -1617,7 +1617,7 @@ Delete stopped containers
 
 **Example request**:
 
-    POST /containers/prune HTTP/1.1
+    POST /v1.25/containers/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -1648,7 +1648,7 @@ Delete stopped containers
 
 **Example request**:
 
-    GET /images/json?all=0 HTTP/1.1
+    GET /v1.25/images/json?all=0 HTTP/1.1
 
 **Example response**:
 
@@ -1686,7 +1686,7 @@ Delete stopped containers
 
 **Example request, with digest information**:
 
-    GET /images/json?digests=1 HTTP/1.1
+    GET /v1.25/v1.25/images/json?digests=1 HTTP/1.1
 
 **Example response, with digest information**:
 
@@ -1743,7 +1743,7 @@ Build an image from a Dockerfile
 
 **Example request**:
 
-    POST /build HTTP/1.1
+    POST /v1.25/v1.25/build HTTP/1.1
 
     {% raw %}
     {{ TAR STREAM }}
@@ -1856,7 +1856,7 @@ Create an image either by pulling it from the registry or by importing it
 
 **Example request**:
 
-    POST /images/create?fromImage=busybox&tag=latest HTTP/1.1
+    POST /v1.25/images/create?fromImage=busybox&tag=latest HTTP/1.1
 
 **Example response**:
 
@@ -1931,7 +1931,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-    GET /images/example/json HTTP/1.1
+    GET /v1.25/images/example/json HTTP/1.1
 
 **Example response (Linux daemon)**:
 
@@ -2129,7 +2129,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-    GET /images/ubuntu/history HTTP/1.1
+    GET /v1.25/images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -2183,7 +2183,7 @@ Push the image `name` on the registry
 
 **Example request**:
 
-    POST /images/test/push HTTP/1.1
+    POST /v1.25/images/test/push HTTP/1.1
 
 **Example response**:
 
@@ -2203,7 +2203,7 @@ The push is cancelled if the HTTP connection is closed.
 
 **Example request**:
 
-    POST /images/registry.acme.com:5000/test/push HTTP/1.1
+    POST /v1.25/images/registry.acme.com:5000/test/push HTTP/1.1
 
 
 **Query parameters**:
@@ -2245,7 +2245,7 @@ Tag the image `name` into a repository
 
 **Example request**:
 
-    POST /images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
+    POST /v1.25/images/test/tag?repo=myrepo&tag=v42 HTTP/1.1
 
 **Example response**:
 
@@ -2309,7 +2309,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
 
 **Example request**:
 
-    GET /images/search?term=sshd HTTP/1.1
+    GET /v1.25/images/search?term=sshd HTTP/1.1
 
 **Example response**:
 
@@ -2363,7 +2363,7 @@ Delete unused images
 
 **Example request**:
 
-    POST /images/prune HTTP/1.1
+    POST /v1.25/images/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2414,7 +2414,7 @@ if available, for accessing the registry without password.
 
 **Example request**:
 
-    POST /auth HTTP/1.1
+    POST /v1.25/auth HTTP/1.1
     Content-Type: application/json
 
     {
@@ -2446,7 +2446,7 @@ Display system-wide information
 
 **Example request**:
 
-    GET /info HTTP/1.1
+    GET /v1.25/info HTTP/1.1
 
 **Example response (Linux)**:
 
@@ -2659,7 +2659,7 @@ Return docker data usage information
 
 **Example request**:
 
-    GET /system/df HTTP/1.1
+    GET /v1.25/system/df HTTP/1.1
 
 **Example response**:
 
@@ -2751,7 +2751,7 @@ Show the docker version information
 
 **Example request**:
 
-    GET /version HTTP/1.1
+    GET /v1.25/version HTTP/1.1
 
 **Example response**:
 
@@ -2784,7 +2784,7 @@ Ping the docker server
 
 **Example request**:
 
-    GET /_ping HTTP/1.1
+    GET /v1.25/_ping HTTP/1.1
 
 **Example response**:
 
@@ -2806,7 +2806,7 @@ Create a new image from a container's changes
 
 **Example request**:
 
-    POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+    POST /v1.25/commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3212,7 +3212,7 @@ Sets up an exec instance in a running container `id`
 
 **Example request**:
 
-    POST /containers/e90e34656806/exec HTTP/1.1
+    POST /v1.25/containers/e90e34656806/exec HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3273,7 +3273,7 @@ interactive session with the `exec` command.
 
 **Example request**:
 
-    POST /exec/e90e34656806/start HTTP/1.1
+    POST /v1.25/exec/e90e34656806/start HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3314,7 +3314,7 @@ This API is valid only if `tty` was specified as part of creating and starting t
 
 **Example request**:
 
-    POST /exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
+    POST /v1.25/exec/e90e34656806/resize?h=40&w=80 HTTP/1.1
     Content-Type: text/plain
 
 **Example response**:
@@ -3340,7 +3340,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
+    GET /v1.25/exec/11fb006128e8ceb3942e7c58d77750f24210e35f879dd204ac975c184b820b39/json HTTP/1.1
 
 **Example response**:
 
@@ -3384,7 +3384,7 @@ Return low-level information about the `exec` command `id`.
 
 **Example request**:
 
-    GET /volumes HTTP/1.1
+    GET /v1.25/volumes HTTP/1.1
 
 **Example response**:
 
@@ -3432,7 +3432,7 @@ Create a volume
 
 **Example request**:
 
-    POST /volumes/create HTTP/1.1
+    POST /v1.25/volumes/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3573,7 +3573,7 @@ Delete unused volumes
 
 **Example request**:
 
-    POST /volumes/prune HTTP/1.1
+    POST /v1.25/volumes/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3605,7 +3605,7 @@ Delete unused volumes
 
 **Example request**:
 
-    GET /networks?filters={"type":{"custom":true}} HTTP/1.1
+    GET /v1.25/networks?filters={"type":{"custom":true}} HTTP/1.1
 
 **Example response**:
 
@@ -3700,7 +3700,7 @@ Content-Type: application/json
 
 **Example request**:
 
-    GET /networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
+    GET /v1.25/networks/7d86d31b1478e7cca9ebed7e73aa0fdeec46c5ca29497431d3007d2d9e15ed99 HTTP/1.1
 
 **Example response**:
 
@@ -3766,7 +3766,7 @@ Create a network
 **Example request**:
 
 ```
-POST /networks/create HTTP/1.1
+POST /v1.25/networks/create HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3849,7 +3849,7 @@ Connect a container to a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
+POST /v1.25/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/connect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3887,7 +3887,7 @@ Disconnect a container from a network
 **Example request**:
 
 ```
-POST /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
+POST /v1.25/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30/disconnect HTTP/1.1
 Content-Type: application/json
 
 {
@@ -3940,7 +3940,7 @@ Delete unused networks
 
 **Example request**:
 
-    POST /networks/prune HTTP/1.1
+    POST /v1.25/networks/prune HTTP/1.1
     Content-Type: application/json
 
     {
@@ -3972,7 +3972,7 @@ Returns information about installed plugins.
 
 **Example request**:
 
-    GET /plugins HTTP/1.1
+    GET /v1.25/plugins HTTP/1.1
 
 **Example response**:
 
@@ -4104,7 +4104,7 @@ using the [`POST /plugins/(plugin name)/enable` endpoint](#enable-a-plugin).
 **Example request**:
 
 ```
-POST /plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
+POST /v1.25/plugins/pull?name=tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -4165,7 +4165,7 @@ Returns detailed information about an installed plugin.
 **Example request**:
 
 ```
-GET /plugins/tiborvass/no-remove:latest HTTP/1.1
+GET /v1.25/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4319,7 +4319,7 @@ Enables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/enable HTTP/1.1
+POST /v1.25/plugins/tiborvass/no-remove:latest/enable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4347,7 +4347,7 @@ Disables a plugin
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest/disable HTTP/1.1
+POST /v1.25/plugins/tiborvass/no-remove:latest/disable HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4404,14 +4404,14 @@ Content-Type: text/plain; charset=utf-8
 
 ### Push a plugin
 
-`POST /plugins/tiborvass/(plugin name)/push HTTP/1.1`
+`POST /v1.25/plugins/tiborvass/(plugin name)/push HTTP/1.1`
 
 Pushes a plugin to the registry.
 
 **Example request**:
 
 ```
-POST /plugins/tiborvass/no-remove:latest HTTP/1.1
+POST /v1.25/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted. When using
@@ -4441,7 +4441,7 @@ List nodes
 
 **Example request**:
 
-    GET /nodes HTTP/1.1
+    GET /v1.25/nodes HTTP/1.1
 
 **Example response**:
 
@@ -4534,7 +4534,7 @@ Return low-level information on the node `id`
 
 **Example request**:
 
-      GET /nodes/24ifsmvkjbyhk HTTP/1.1
+      GET /v1.25/nodes/24ifsmvkjbyhk HTTP/1.1
 
 **Example response**:
 
@@ -4652,7 +4652,7 @@ an empty value or the default cluster-wide value.
 
 **Example Request**
 
-    POST /nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
+    POST /v1.25/nodes/24ifsmvkjbyhk/update?version=8 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4750,7 +4750,7 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
 
 **Example request**:
 
-    POST /swarm/init HTTP/1.1
+    POST /v1.25/swarm/init HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4825,7 +4825,7 @@ Join an existing swarm
 
 **Example request**:
 
-    POST /swarm/join HTTP/1.1
+    POST /v1.25/swarm/join HTTP/1.1
     Content-Type: application/json
 
     {
@@ -4868,7 +4868,7 @@ Leave a swarm
 
 **Example request**:
 
-    POST /swarm/leave HTTP/1.1
+    POST /v1.25/swarm/leave HTTP/1.1
 
 **Example response**:
 
@@ -4894,7 +4894,7 @@ Update a swarm
 
 **Example request**:
 
-    POST /swarm/update HTTP/1.1
+    POST /v1.25/swarm/update HTTP/1.1
 
     {
       "Name": "default",
@@ -4979,7 +4979,7 @@ List services
 
 **Example request**:
 
-    GET /services HTTP/1.1
+    GET /v1.25/services HTTP/1.1
 
 **Example response**:
 
@@ -5088,7 +5088,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/create HTTP/1.1
+    POST /v1.25/services/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -5299,7 +5299,7 @@ Return information on the service `id`.
 
 **Example request**:
 
-    GET /services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
+    GET /v1.25/services/1cb4dnqcyx6m66g2t538x3rxha HTTP/1.1
 
 **Example response**:
 
@@ -5391,7 +5391,7 @@ image](#create-an-image) section for more details.
 
 **Example request**:
 
-    POST /services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
+    POST /v1.25/services/1cb4dnqcyx6m66g2t538x3rxha/update?version=23 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -5550,7 +5550,7 @@ List tasks
 
 **Example request**:
 
-    GET /tasks HTTP/1.1
+    GET /v1.25/tasks HTTP/1.1
 
 **Example response**:
 
@@ -5748,7 +5748,7 @@ Get details on a task
 
 **Example request**:
 
-    GET /tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
+    GET /v1.25/tasks/0kzzo1i0y4jz6027t0k7aezc7 HTTP/1.1
 
 **Example response**:
 


### PR DESCRIPTION
Carries https://github.com/docker/docker/pull/27830
closes https://github.com/docker/docker/pull/27830


See #21157 for more details.

In a future version of Docker, providing a version to API calls
will be mandatory. An implementation of this is in #27801.