### PR TITLE
Add validate/swagger-gen

### DIFF
--- a/hack/validate/default
+++ b/hack/validate/default
@@ -10,6 +10,7 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $SCRIPTDIR/lint
 . $SCRIPTDIR/pkg-imports
 . $SCRIPTDIR/swagger
+. $SCRIPTDIR/swagger-gen
 . $SCRIPTDIR/test-imports
 . $SCRIPTDIR/toml
 . $SCRIPTDIR/vet

--- a/hack/validate/swagger-gen
+++ b/hack/validate/swagger-gen
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- 'api/types/' || true) )
+unset IFS
+
+if [ ${#files[@]} -gt 0 ]; then
+	# We run vndr to and see if we have a diff afterwards
+	${SCRIPTDIR}/../generate-swagger-api.sh 2> /dev/null
+	# Let see if the working directory is clean
+	diffs="$(git status --porcelain -- api/types/ 2>/dev/null)"
+	if [ "$diffs" ]; then
+		{
+			echo 'The result of hack/geneate-swagger-api.sh differs'
+			echo
+			echo "$diffs"
+			echo
+			echo 'Please update api/swagger.yaml with any api changes, then '
+			echo 'run `hack/geneate-swagger-api.sh`.'
+		} >&2
+		false
+	else
+		echo 'Congratulations! All api changes are done the right way.'
+	fi
+else
+    echo 'No api/types/ changes in diff.'
+fi


### PR DESCRIPTION
Add a validation for swagger api type generation which works like `validate/vendor` to ensure that any generated types were created from the spec, and not manually edited.