### PR TITLE
Tidy GetDockerOS() function

### DIFF
--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -21,6 +21,6 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 		return types.ContainerStats{}, err
 	}
 
-	osType := GetDockerOS(resp.header.Get("Server"))
+	osType := getDockerOS(resp.header.Get("Server"))
 	return types.ContainerStats{Body: resp.body, OSType: osType}, err
 }

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 
 	"golang.org/x/net/context"
@@ -14,8 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 )
-
-var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)
 
 // ImageBuild sends request to the daemon to build images.
 // The Body in the response implement an io.ReadCloser and it's up to the caller to
@@ -39,7 +36,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 		return types.ImageBuildResponse{}, err
 	}
 
-	osType := GetDockerOS(serverResp.header.Get("Server"))
+	osType := getDockerOS(serverResp.header.Get("Server"))
 
 	return types.ImageBuildResponse{
 		Body:   serverResp.body,
@@ -123,14 +120,4 @@ func (cli *Client) imageBuildOptionsToQuery(options types.ImageBuildOptions) (ur
 	query.Set("cachefrom", string(cacheFromJSON))
 
 	return query, nil
-}
-
-// GetDockerOS returns the operating system based on the server header from the daemon.
-func GetDockerOS(serverHeader string) string {
-	var osType string
-	matches := headerRegexp.FindStringSubmatch(serverHeader)
-	if len(matches) > 0 {
-		osType = matches[1]
-	}
-	return osType
 }

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -222,7 +222,7 @@ func TestGetDockerOS(t *testing.T) {
 		"Foo/v1.22 (bar)":        "",
 	}
 	for header, os := range cases {
-		g := GetDockerOS(header)
+		g := getDockerOS(header)
 		if g != os {
 			t.Fatalf("Expected %s, got %s", os, g)
 		}

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,0 +1,15 @@
+package client
+
+import "regexp"
+
+var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)
+
+// getDockerOS returns the operating system based on the server header from the daemon.
+func getDockerOS(serverHeader string) string {
+	var osType string
+	matches := headerRegexp.FindStringSubmatch(serverHeader)
+	if len(matches) > 0 {
+		osType = matches[1]
+	}
+	return osType
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Ticks off the comment by @vdemeester in https://github.com/docker/engine-api/pull/373, when the Docker stats implementation PR https://github.com/docker/docker/pull/25737 was split between engine-api and docker/docker. By the time the PR actually went in, engine-api was back in the docker/docker repo.

Just moves the GetDockerOS() function to a utils.go file, and doesn't externalise it as that's not required.