### PR TITLE
[integration-cli] fix race condition in kill tests

### DIFF
--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
@@ -15,6 +16,7 @@ func (s *DockerSuite) TestKillContainer(c *check.C) {
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	dockerCmd(c, "kill", cleanedContainerID)
+	c.Assert(waitExited(cleanedContainerID, 10*time.Second), check.IsNil)
 
 	out, _ = dockerCmd(c, "ps", "-q")
 	c.Assert(out, checker.Not(checker.Contains), cleanedContainerID, check.Commentf("killed container is still running"))
@@ -26,6 +28,7 @@ func (s *DockerSuite) TestKillOffStoppedContainer(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "stop", cleanedContainerID)
+	c.Assert(waitExited(cleanedContainerID, 10*time.Second), check.IsNil)
 
 	_, _, err := dockerCmdWithError("kill", "-s", "30", cleanedContainerID)
 	c.Assert(err, check.Not(check.IsNil), check.Commentf("Container %s is not running", cleanedContainerID))
@@ -39,6 +42,7 @@ func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	dockerCmd(c, "kill", cleanedContainerID)
+	c.Assert(waitExited(cleanedContainerID, 10*time.Second), check.IsNil)
 
 	out, _ = dockerCmd(c, "ps", "-q")
 	c.Assert(out, checker.Not(checker.Contains), cleanedContainerID, check.Commentf("killed container is still running"))
@@ -54,6 +58,7 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 	c.Assert(waitRun(cid), check.IsNil)
 
 	dockerCmd(c, "kill", "-s", "SIGWINCH", cid)
+	time.Sleep(250 * time.Millisecond)
 
 	running := inspectField(c, cid, "State.Running")
 
@@ -67,8 +72,10 @@ func (s *DockerSuite) TestKillWithStopSignalWithSameSignalShouldDisableRestartPo
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
-	// Let's docker send a CONT signal to the container
+	// Let docker send a TERM signal to the container
+	// It will kill the process and disable the restart policy
 	dockerCmd(c, "kill", "-s", "TERM", cid)
+	c.Assert(waitExited(cid, 10*time.Second), check.IsNil)
 
 	out, _ = dockerCmd(c, "ps", "-q")
 	c.Assert(out, checker.Not(checker.Contains), cid, check.Commentf("killed container is still running"))
@@ -81,9 +88,10 @@ func (s *DockerSuite) TestKillWithStopSignalWithDifferentSignalShouldKeepRestart
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
-	// Let's docker send a TERM signal to the container
+	// Let docker send a TERM signal to the container
 	// It will kill the process, but not disable the restart policy
 	dockerCmd(c, "kill", "-s", "TERM", cid)
+	c.Assert(waitRestart(cid, 10*time.Second), check.IsNil)
 
 	// Restart policy should still be in place, so it should be still running
 	c.Assert(waitRun(cid), check.IsNil)

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -68,7 +68,7 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 func (s *DockerSuite) TestKillWithStopSignalWithSameSignalShouldDisableRestartPolicy(c *check.C) {
 	// Cannot port to Windows - does not support signals int the same way as Linux does
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--stop-signal=TERM", "busybox", "top")
+	out, _ := dockerCmd(c, "run", "-d", "--stop-signal=TERM", "--restart=always", "busybox", "top")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
@@ -84,7 +84,7 @@ func (s *DockerSuite) TestKillWithStopSignalWithSameSignalShouldDisableRestartPo
 func (s *DockerSuite) TestKillWithStopSignalWithDifferentSignalShouldKeepRestartPolicy(c *check.C) {
 	// Cannot port to Windows - does not support signals int the same way as Linux does
 	testRequires(c, DaemonIsLinux)
-	out, _ := dockerCmd(c, "run", "-d", "--stop-signal=CONT", "busybox", "top")
+	out, _ := dockerCmd(c, "run", "-d", "--stop-signal=CONT", "--restart=always", "busybox", "top")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1401,6 +1401,11 @@ func waitForContainer(contID string, args ...string) error {
 	return waitRun(contID)
 }
 
+// waitRestart will wait for the specified container to restart once
+func waitRestart(contID string, duration time.Duration) error {
+	return waitInspect(contID, "{{.RestartCount}}", "1", duration)
+}
+
 // waitRun will wait for the specified container to be running, maximum 5 seconds.
 func waitRun(contID string) error {
 	return waitInspect(contID, "{{.State.Running}}", "true", 5*time.Second)


### PR DESCRIPTION
Two commits because both are very closely related and will fail without the other.

The second commit should fix the Z CI, which was failing correctly because a test that tested container restart policy,
didn't have a restart policy. Then the first commit should fix the race condition that was causing the test to succeed on non-Z CI's in the first place.

commit 1.) Fixes a race condition in the kill tests where the container
would be killed but inspected before it's state changed. Fixes
this by waiting for a state change instead.

commit 2.) Fixes two tests that tested containers restart policy without
actually having a restart policy.

Fixes #28033 

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>

![race condition pig](http://hurthawaii.blogs.com/.a/6a00d83451d2fd69e2011571e6e4fb970b-pi)