### PR TITLE
Add local address autodetection on swarm init

### DIFF
--- a/daemon/cluster/listen_addr.go
+++ b/daemon/cluster/listen_addr.go
@@ -9,7 +9,7 @@ import (
 var (
 	errNoSuchInterface         = errors.New("no such interface")
 	errNoIP                    = errors.New("could not find the system's IP address")
-	errMustSpecifyListenAddr   = errors.New("must specify a listening address because the address to advertise is not recognized as a system address")
+	errMustSpecifyListenAddr   = errors.New("must specify a listening address because the address to advertise is not recognized as a system address, and a system's IP address to use could not be uniquely identified")
 	errBadListenAddr           = errors.New("listen address must be an IP address or network interface (with optional port number)")
 	errBadAdvertiseAddr        = errors.New("advertise address must be an IP address or network interface (with optional port number)")
 	errBadDefaultAdvertiseAddr = errors.New("default advertise address must be an IP address or network interface (without a port number)")


### PR DESCRIPTION
**- What I did**
Added local address auto detection during `swarm init` when `--advertise-addr` is a non local address.
It is the same best-effort auto detection logic which is being used when advertise address is not specified.

**- How to verify it**
Form a cluster on AWS with 
`swarm init --advertise-addr <this VM public IP>` and
`swarm join ... --advertise-addr <this VM public IP>`

Create a service over an encrypted overlay network and make sure tasks can talk to other nodes' tasks. Run a container on the attachable network and make sure it can access the service.

Fixes #27647 

**- A picture of a cute animal (not mandatory but encouraged)**
![840756455839-cute-wallpapers-animals-nature-cat-animal-pictures-garden](https://cloud.githubusercontent.com/assets/10080882/20158559/cd6a4794-a68f-11e6-81ca-b58ccfea7e75.jpg)
