### PR TITLE
fix manpages

### DIFF
--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -1,7 +1,6 @@
 package secret
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/docker/opts"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type createOptions struct {

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -1,12 +1,11 @@
 package secret
 
 import (
-	"context"
-
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/inspect"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -1,7 +1,6 @@
 package secret
 
 import (
-	"context"
 	"fmt"
 	"text/tabwriter"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type listOptions struct {

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -1,12 +1,12 @@
 package secret
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type removeOptions struct {

--- a/cli/command/secret/utils.go
+++ b/cli/command/secret/utils.go
@@ -1,12 +1,11 @@
 package secret
 
 import (
-	"context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
 )
 
 func getSecretsByName(client client.APIClient, ctx context.Context, names []string) ([]swarm.Secret, error) {


### PR DESCRIPTION
related to https://github.com/docker/docker/pull/28222

fixes `make manpages`

---

The secrets PR added the `context` dependency in the `client` package
`context` is only available in go 1.7
The `client` package is compiled when we generate the man pages.
This process uses a different Dockerfile (in `man/Dockerile*`) 
Those Dockerfile currently use go 1.6

I think the long term solution is to update those Dockerfiles to use go1.7, 
but for the time begin (code freeze tomorrow) I think we should simply use `golang.org/x/net/context` like we do in other packages.

ping @andrewhsu @ehazlett @dnephin 