### PR TITLE
DO NOT MERGE: Testing to find an error being seen on CI runs

### DIFF
--- a/vendor/github.com/Microsoft/hcsshim/container.go
+++ b/vendor/github.com/Microsoft/hcsshim/container.go
@@ -192,6 +192,10 @@ func GetContainers(q ComputeSystemQuery) ([]ContainerProperties, error) {
 	)
 	err = hcsEnumerateComputeSystems(query, &computeSystemsp, &resultp)
 	err = processHcsResult(err, resultp)
+	if err != nil {
+		return nil, err
+	}
+
 	if computeSystemsp == nil {
 		return nil, ErrUnexpectedValue
 	}


### PR DESCRIPTION
Windows CI is seeing the following errors during cleanup:
```
01:05:33 
01:05:33 Command: d:\CI\CI-78bcec9\binary\docker.exe rm -fv 7f7995ecef82 3550b04634cf
01:05:33 ExitCode: 1, Error: exit status 1
01:05:33 Stdout: 7f7995ecef82
01:05:33 
01:05:33 Stderr: Error response from daemon: Driver windowsfilter failed to remove root filesystem 3550b04634cf62135f44071b1a0cb727c406fd6557e76f38d27711cfed8a4e0f: unexpected value returned from hcs
01:05:33 
01:05:33 
01:05:33 Failures:
01:05:33 ExitCode was 1 expected 0
01:05:33 Expected no error
```

This is a bug fix in hcsshim to figure out what the error is, as I can't repro locally. It will need to be vendored in, but for now this is to figure out the real error is so I can fix it.

Signed-off-by: Darren Stahl <darst@microsoft.com>