### PR TITLE
Fix failure to get containers when deleting a layer

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm 388960b655244e76e24c75f48631564eaefade62
-github.com/Microsoft/hcsshim v0.5.7
+github.com/Microsoft/hcsshim v0.5.8
 github.com/Microsoft/go-winio v0.3.6
 github.com/Sirupsen/logrus f76d643702a30fbffecdfe50831e11881c96ceb3 https://github.com/aaronlehmann/logrus
 github.com/davecgh/go-spew 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/vendor/github.com/Microsoft/hcsshim/container.go
+++ b/vendor/github.com/Microsoft/hcsshim/container.go
@@ -192,6 +192,10 @@ func GetContainers(q ComputeSystemQuery) ([]ContainerProperties, error) {
 	)
 	err = hcsEnumerateComputeSystems(query, &computeSystemsp, &resultp)
 	err = processHcsResult(err, resultp)
+	if err != nil {
+		return nil, err
+	}
+
 	if computeSystemsp == nil {
 		return nil, ErrUnexpectedValue
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix errors like:
```
01:05:33 
01:05:33 Command: d:\CI\CI-78bcec9\binary\docker.exe rm -fv 7f7995ecef82 3550b04634cf
01:05:33 ExitCode: 1, Error: exit status 1
01:05:33 Stdout: 7f7995ecef82
01:05:33 
01:05:33 Stderr: Error response from daemon: Driver windowsfilter failed to remove root filesystem 3550b04634cf62135f44071b1a0cb727c406fd6557e76f38d27711cfed8a4e0f: unexpected value returned from hcs
01:05:33 
01:05:33 
01:05:33 Failures:
01:05:33 ExitCode was 1 expected 0
01:05:33 Expected no error
```
when deleting layers. Introduced in https://github.com/docker/docker/pull/28141

**- How I did it**

Keep retrying the GetContainers on the known error, just go ahead and delete if it happens more than 5 times though.

**- How to verify it**

Hope it doesn't show up in CI logs. Edit: Looks like it's fixed!

~~Needs a vendor.~~

Signed-off-by: Darren Stahl <darst@microsoft.com>