### PR TITLE
Complemented "SCOPE" column towards  "docker network ls " command-line

### DIFF
--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -36,23 +36,23 @@ networks that span across multiple hosts in a cluster, for example:
 
 ```bash
     $ sudo docker network ls
-    NETWORK ID          NAME                DRIVER
-    7fca4eb8c647        bridge              bridge
-    9f904ee27bf5        none                null
-    cf03ee007fb4        host                host
-    78b03ee04fc4        multi-host          overlay
+    NETWORK ID          NAME                DRIVER          SCOPE
+    7fca4eb8c647        bridge              bridge          local
+    9f904ee27bf5        none                null            local
+    cf03ee007fb4        host                host            local
+    78b03ee04fc4        multi-host          overlay         local
 ```
 
 Use the `--no-trunc` option to display the full network id:
 
 ```bash
 docker network ls --no-trunc
-NETWORK ID                                                         NAME                DRIVER
-18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null
-c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host                host
-7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185   bridge              bridge
-95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd   foo                 bridge
-63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge
+NETWORK ID                                                         NAME                DRIVER           SCOPE
+18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null             local
+c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host                host             local
+7b369448dccbf865d397c8d2be0cda7cf7edc6b0945f77d2529912ae917a0185   bridge              bridge           local
+95e74588f40db048e86320c6526440c504650a1ff3e9f7d60a497c4d2163e5bd   foo                 bridge           local
+63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge           local
 ```
 
 ## Filtering
@@ -78,9 +78,9 @@ The following example matches networks with the `bridge` driver:
 
 ```bash
 $ docker network ls --filter driver=bridge
-NETWORK ID          NAME                DRIVER
-db9db329f835        test1               bridge
-f6e212da9dfd        test2               bridge
+NETWORK ID          NAME                DRIVER            SCOPE
+db9db329f835        test1               bridge            local
+f6e212da9dfd        test2               bridge            local
 ```
 
 #### ID
@@ -92,20 +92,20 @@ The following filter matches all networks with an ID containing the
 
 ```bash
 $ docker network ls --filter id=63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161
-NETWORK ID          NAME                DRIVER
-63d1ff1f77b0        dev                 bridge
+NETWORK ID          NAME                DRIVER           SCOPE
+63d1ff1f77b0        dev                 bridge           local
 ```
 
 You can also filter for a substring in an ID as this shows:
 
 ```bash
 $ docker network ls --filter id=95e74588f40d
-NETWORK ID          NAME                DRIVER
-95e74588f40d        foo                 bridge
+NETWORK ID          NAME                DRIVER          SCOPE
+95e74588f40d        foo                 bridge          local
 
 $ docker network ls --filter id=95e
-NETWORK ID          NAME                DRIVER
-95e74588f40d        foo                 bridge
+NETWORK ID          NAME                DRIVER          SCOPE
+95e74588f40d        foo                 bridge          local
 ```
 
 #### Label
@@ -117,17 +117,17 @@ The following filter matches networks with the `usage` label regardless of its v
 
 ```bash
 $ docker network ls -f "label=usage"
-NETWORK ID          NAME                DRIVER
-db9db329f835        test1               bridge
-f6e212da9dfd        test2               bridge
+NETWORK ID          NAME                DRIVER         SCOPE
+db9db329f835        test1               bridge         local
+f6e212da9dfd        test2               bridge         local
 ```
 
 The following filter matches networks with the `usage` label with the `prod` value.
 
 ```bash
 $ docker network ls -f "label=usage=prod"
-NETWORK ID          NAME                DRIVER
-f6e212da9dfd        test2               bridge
+NETWORK ID          NAME                DRIVER        SCOPE
+f6e212da9dfd        test2               bridge        local
 ```
 
 #### Name
@@ -138,17 +138,17 @@ The following filter matches all networks with a name containing the `foobar` st
 
 ```bash
 $ docker network ls --filter name=foobar
-NETWORK ID          NAME                DRIVER
-06e7eef0a170        foobar              bridge
+NETWORK ID          NAME                DRIVER       SCOPE
+06e7eef0a170        foobar              bridge       local
 ```
 
 You can also filter for a substring in a name as this shows:
 
 ```bash
 $ docker network ls --filter name=foo
-NETWORK ID          NAME                DRIVER
-95e74588f40d        foo                 bridge
-06e7eef0a170        foobar              bridge
+NETWORK ID          NAME                DRIVER       SCOPE
+95e74588f40d        foo                 bridge       local
+06e7eef0a170        foobar              bridge       local
 ```
 
 #### Type
@@ -160,9 +160,9 @@ The following filter matches all user defined networks:
 
 ```bash
 $ docker network ls --filter type=custom
-NETWORK ID          NAME                DRIVER
-95e74588f40d        foo                 bridge
-63d1ff1f77b0        dev                 bridge
+NETWORK ID          NAME                DRIVER       SCOPE
+95e74588f40d        foo                 bridge       local	
+63d1ff1f77b0        dev                 bridge       local
 ```
 
 By having this flag it allows for batch cleanup. For example, use this filter

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -35,18 +35,18 @@ Lists all the networks the Engine `daemon` knows about. This includes the
 networks that span across multiple hosts in a cluster, for example:
 
 ```bash
-    $ sudo docker network ls
-    NETWORK ID          NAME                DRIVER          SCOPE
-    7fca4eb8c647        bridge              bridge          local
-    9f904ee27bf5        none                null            local
-    cf03ee007fb4        host                host            local
-    78b03ee04fc4        multi-host          overlay         local
+$ sudo docker network ls
+NETWORK ID          NAME                DRIVER          SCOPE
+7fca4eb8c647        bridge              bridge          local
+9f904ee27bf5        none                null            local
+cf03ee007fb4        host                host            local
+78b03ee04fc4        multi-host          overlay         local
 ```
 
 Use the `--no-trunc` option to display the full network id:
 
 ```bash
-docker network ls --no-trunc
+$ docker network ls --no-trunc
 NETWORK ID                                                         NAME                DRIVER           SCOPE
 18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null             local
 c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host                host             local


### PR DESCRIPTION
When I check network_ls.md for further study , I found the document description about "docker network ls" does not match with the terminal "docker network ls" , due to the document missed the "SCOPE" column.

So I complemented the missing part of  "SCOPE" column.

My docker version is 1.12.3


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


