### PR TITLE
Remove redundant parameter and fix typos

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -65,7 +65,7 @@ func NewExecCommand(dockerCli *command.DockerCli) *cobra.Command {
 }
 
 func runExec(dockerCli *command.DockerCli, opts *execOptions, container string, execCmd []string) error {
-	execConfig, err := parseExec(opts, container, execCmd)
+	execConfig, err := parseExec(opts, execCmd)
 	// just in case the ParseExec does not exit
 	if container == "" || err != nil {
 		return cli.StatusError{StatusCode: 1}
@@ -181,14 +181,13 @@ func getExecExitCode(ctx context.Context, client apiclient.ContainerAPIClient, e
 
 // parseExec parses the specified args for the specified command and generates
 // an ExecConfig from it.
-func parseExec(opts *execOptions, container string, execCmd []string) (*types.ExecConfig, error) {
+func parseExec(opts *execOptions, execCmd []string) (*types.ExecConfig, error) {
 	execConfig := &types.ExecConfig{
 		User:       opts.user,
 		Privileged: opts.privileged,
 		Tty:        opts.tty,
 		Cmd:        execCmd,
 		Detach:     opts.detach,
-		// container is not used here
 	}
 
 	// If -d is not set, attach to everything by default

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -7,9 +7,8 @@ import (
 )
 
 type arguments struct {
-	options   execOptions
-	container string
-	execCmd   []string
+	options execOptions
+	execCmd []string
 }
 
 func TestParseExec(t *testing.T) {
@@ -73,7 +72,7 @@ func TestParseExec(t *testing.T) {
 	}
 
 	for valid, expectedExecConfig := range valids {
-		execConfig, err := parseExec(&valid.options, valid.container, valid.execCmd)
+		execConfig, err := parseExec(&valid.options, valid.execCmd)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -72,7 +72,7 @@ func printTable(out io.Writer, stacks []*stack) {
 
 type stack struct {
 	// Name is the name of the stack
-	Name string
+	Name     string
 	// Services is the number of the services
 	Services int
 }

--- a/docs/reference/commandline/diff.md
+++ b/docs/reference/commandline/diff.md
@@ -24,7 +24,7 @@ Options:
       --help   Print usage
 ```
 
-List the changed files and directories in a container᾿s filesystem
+List the changed files and directories in a container᾿s filesystem.
  There are 3 events that are listed in the `diff`:
 
 1. `A` - Add


### PR DESCRIPTION
**- What I did**
Remove redundant parameter and fix typos
**- How I did it**

**- How to verify it**

**- Description for the changelog**
1. Remove redundant parameter 
2. Fix typos


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>