### PR TITLE
pkg/jsonmessage: Avoid undefined ANSI escape codes.

### DIFF
--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -189,13 +189,9 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 				if isTerminal {
 					fmt.Fprintf(out, "\n")
 				}
-			} else {
-				diff = len(ids) - line
 			}
-			if isTerminal {
-				// NOTE: this appears to be necessary even if
-				// diff == 0.
-				// <ESC>[{diff}A = move cursor up diff rows
+			diff = len(ids) - line
+			if isTerminal && diff > 0 {
 				fmt.Fprintf(out, "%c[%dA", 27, diff)
 			}
 		} else {
@@ -207,10 +203,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 			ids = make(map[string]int)
 		}
 		err := jm.Display(out, isTerminal)
-		if jm.ID != "" && isTerminal {
-			// NOTE: this appears to be necessary even if
-			// diff == 0.
-			// <ESC>[{diff}B = move cursor down diff rows
+		if jm.ID != "" && isTerminal && diff > 0 {
 			fmt.Fprintf(out, "%c[%dB", 27, diff)
 		}
 		if err != nil {

--- a/pkg/jsonmessage/jsonmessage_test.go
+++ b/pkg/jsonmessage/jsonmessage_test.go
@@ -205,17 +205,17 @@ func TestDisplayJSONMessagesStream(t *testing.T) {
 		// Without progress, with ID
 		"{ \"id\": \"ID\",\"status\": \"status\" }": {
 			"ID: status\n",
-			fmt.Sprintf("ID: status\n%c[%dB", 27, 0),
+			fmt.Sprintf("ID: status\n"),
 		},
 		// With progress
 		"{ \"id\": \"ID\", \"status\": \"status\", \"progress\": \"ProgressMessage\" }": {
 			"ID: status ProgressMessage",
-			fmt.Sprintf("\n%c[%dAID: status ProgressMessage%c[%dB", 27, 0, 27, 0),
+			fmt.Sprintf("\n%c[%dAID: status ProgressMessage%c[%dB", 27, 1, 27, 1),
 		},
 		// With progressDetail
 		"{ \"id\": \"ID\", \"status\": \"status\", \"progressDetail\": { \"Current\": 1} }": {
 			"", // progressbar is disabled in non-terminal
-			fmt.Sprintf("\n%c[%dA%c[2K\rID: status      1 B\r%c[%dB", 27, 0, 27, 27, 0),
+			fmt.Sprintf("\n%c[%dA%c[2K\rID: status      1 B\r%c[%dB", 27, 1, 27, 27, 1),
 		},
 	}
 	for jsonMessage, expectedMessages := range messages {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Corrected line diff calculation for newly added lines to avoid emitting 0 line cursor movement ANSI escape codes.

**- How I did it**

The ANSI escape codes \e[0A (cursor up 0 lines) and \e[0B (cursor down 0 lines) are not well defined and are treated differently by different terminals. In particular xterm treats 0 as a missing parameter and therefore defaults to 1, whereas rxvt-unicode treats these escapes as a request to move 0 lines.
    
However the use of these codes is unnecessary and were really just hiding the fact that we were not correctly computing diff when adding a new line. Having added the new line to the ids map and output the corresponding \n we need to then calculate a correct diff of 1 rather than leaving it as the default 0 (which xterm then interprets as 1). The fix is to pull the diff calculation out of the else case and to always do it.

With this in place we can then avoid outputting escapes for moving 0 lines. Actually diff should never be 0 to start with any more, but check to be safe.

This fixes corruption of `docker pull` seen with rxvt-unicode (and likely other terminals in that family) seen in #28111. Tested with rxvt-unicode ($TERM=rxvt-unicode), xterm ($TERM=xterm), mlterm ($TERM=mlterm) and aterm ($TERM=kterm).


Note that the discussion on #28111  also recommends a switch to using termcap rather than raw ANSI codes which is something I will tackle in a separate PR.

**- How to verify it**

Run a `docker pull` under a variety of terminals (I used rxvt-unicode, xterm, mlterm and aterm) and observe that the corruption described in #28111 no longer appears with any of them.

**- Description for the changelog**

Avoid undefined ANSI escape codes causing corruption during docker pull et al.

**- A picture of a cute animal (not mandatory but encouraged)**
Does this count?
![Eric Burdon, The Animals](https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Eric-Burdon_1973.jpg/440px-Eric-Burdon_1973.jpg)
