### PR TITLE
use "golang.org/x/net/context" instead of "context"

### DIFF
--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -2,7 +2,6 @@ package swarm
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cli/command"
+	"golang.org/x/net/context"
 )
 
 func newUnlockCommand(dockerCli *command.DockerCli) *cobra.Command {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Following on #28224 looks like a file slipped into `master` branch from 0f9fc54 with go import "context". This PR will change go to import "golang.org/x/net/context" instead of "context".

**- How I did it**

One character at a time.

**- How to verify it**

```
$ time make manpages # upon merge of PR, manpages will build
...
Step 13 : ENTRYPOINT man/generate.sh
 ---> Using cache
 ---> 1a10ea51a51f
Successfully built 1a10ea51a51f
docker run --rm \
                -v /Users/andrewhsu/src/thaJeztah-docker:/go/src/github.com/docker/docker/ \
                docker-manpage-dev
Generating man pages into ./man/man1

real    0m32.956s
user    0m0.070s
sys     0m0.082s
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐘 

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>