### PR TITLE
cli: Change autolock flag description

### DIFF
--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -40,6 +40,7 @@ func newInitCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address (format: <ip|interface>[:port])")
 	flags.StringVar(&opts.advertiseAddr, flagAdvertiseAddr, "", "Advertised address (format: <ip|interface>[:port])")
 	flags.BoolVar(&opts.forceNewCluster, "force-new-cluster", false, "Force create a new cluster from current state")
+	flags.BoolVar(&opts.autolock, flagAutolock, false, "Enable manager autolocking (requiring an unlock key to start a stopped manager)")
 	addSwarmFlags(flags, &opts.swarmOptions)
 	return cmd
 }

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -176,7 +176,6 @@ func addSwarmFlags(flags *pflag.FlagSet, opts *swarmOptions) {
 	flags.Var(&opts.externalCA, flagExternalCA, "Specifications of one or more certificate signing endpoints")
 	flags.Uint64Var(&opts.maxSnapshots, flagMaxSnapshots, 0, "Number of additional Raft snapshots to retain")
 	flags.Uint64Var(&opts.snapshotInterval, flagSnapshotInterval, 10000, "Number of log entries between Raft snapshots")
-	flags.BoolVar(&opts.autolock, flagAutolock, false, "Enable or disable manager autolocking (requiring an unlock key to start a stopped manager)")
 }
 
 func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet) {

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -25,6 +25,7 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&opts.autolock, flagAutolock, false, "Change manager autolocking setting (true|false)")
 	addSwarmFlags(cmd.Flags(), &opts)
 	return cmd
 }

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -22,7 +22,7 @@ Initialize a swarm
 
 Options:
       --advertise-addr value            Advertised address (format: <ip|interface>[:port])
-      --autolock                        Enable or disable manager autolocking (requiring an unlock key to start a stopped manager)
+      --autolock                        Enable manager autolocking (requiring an unlock key to start a stopped manager)
       --cert-expiry duration            Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
       --dispatcher-heartbeat duration   Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
       --external-ca value               Specifications of one or more certificate signing endpoints

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -21,7 +21,7 @@ Usage:  docker swarm update [OPTIONS]
 Update the swarm
 
 Options:
-      --autolock                        Enable or disable manager autolocking (requiring an unlock key to start a stopped manager)
+      --autolock                        Change manager autolocking setting (true|false)
       --cert-expiry duration            Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
       --dispatcher-heartbeat duration   Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
       --external-ca value               Specifications of one or more certificate signing endpoints


### PR DESCRIPTION
This change incorporates feedback from @thaJeztah in the PR that added
the autolock flag. It changes the descriptions to be different for
"swarm init" and "swarm update" so that the boolean nature so that the
purpose of the flag in both contexts is clearer.