### PR TITLE
vendor libnetwork @1861587

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -23,7 +23,7 @@ github.com/RackSec/srslog 365bf33cd9acc21ae1c355209865f17228ca534e
 github.com/imdario/mergo 0.2.1
 
 #get libnetwork packages
-github.com/docker/libnetwork 3ab699ea36573d98f481d233c30c742ade737565
+github.com/docker/libnetwork 1861587d0fe7cdf85b89160ed36f20b81e96528d
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -2,6 +2,8 @@ package bridge
 
 import (
 	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libnetwork/iptables"
 	"io/ioutil"
 )
 
@@ -10,7 +12,15 @@ const (
 	ipv4ForwardConfPerm = 0644
 )
 
-func setupIPForwarding() error {
+func configureIPForwarding(enable bool) error {
+	var val byte
+	if enable {
+		val = '1'
+	}
+	return ioutil.WriteFile(ipv4ForwardConf, []byte{val, '\n'}, ipv4ForwardConfPerm)
+}
+
+func setupIPForwarding(enableIPTables bool) error {
 	// Get current IPv4 forward setup
 	ipv4ForwardData, err := ioutil.ReadFile(ipv4ForwardConf)
 	if err != nil {
@@ -20,10 +30,26 @@ func setupIPForwarding() error {
 	// Enable IPv4 forwarding only if it is not already enabled
 	if ipv4ForwardData[0] != '1' {
 		// Enable IPv4 forwarding
-		if err := ioutil.WriteFile(ipv4ForwardConf, []byte{'1', '\n'}, ipv4ForwardConfPerm); err != nil {
-			return fmt.Errorf("Setup IP forwarding failed: %v", err)
+		if err := configureIPForwarding(true); err != nil {
+			return fmt.Errorf("Enabling IP forwarding failed: %v", err)
 		}
+		// When enabling ip_forward set the default policy on forward chain to
+		// drop only if the daemon option iptables is not set to false.
+		if !enableIPTables {
+			return nil
+		}
+		if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+			if err := configureIPForwarding(false); err != nil {
+				log.Errorf("Disabling IP forwarding failed, %v", err)
+			}
+			return err
+		}
+		iptables.OnReloaded(func() {
+			log.Debugf("Setting the default DROP policy on firewall reload")
+			if err := iptables.SetDefaultPolicy(iptables.Filter, "FORWARD", iptables.Drop); err != nil {
+				log.Warnf("Settig the default DROP policy on firewall reload failed, %v", err)
+			}
+		})
 	}
-
 	return nil
 }

--- a/vendor/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/github.com/docker/libnetwork/iptables/iptables.go
@@ -16,6 +16,9 @@ import (
 // Action signifies the iptable action.
 type Action string
 
+// Policy is the default iptable policies
+type Policy string
+
 // Table refers to Nat, Filter or Mangle.
 type Table string
 
@@ -32,6 +35,10 @@ const (
 	Filter Table = "filter"
 	// Mangle table is used for mangling the packet.
 	Mangle Table = "mangle"
+	// Drop is the default iptables DROP policy
+	Drop Policy = "DROP"
+	// Accept is the default iptables ACCEPT policy
+	Accept Policy = "ACCEPT"
 )
 
 var (
@@ -435,6 +442,14 @@ func GetVersion() (major, minor, micro int, err error) {
 		major, minor, micro = parseVersionNumbers(string(out))
 	}
 	return
+}
+
+// SetDefaultPolicy sets the passed default policy for the table/chain
+func SetDefaultPolicy(table Table, chain string, policy Policy) error {
+	if err := RawCombinedOutput("-t", string(table), "-P", chain, string(policy)); err != nil {
+		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
+	}
+	return nil
 }
 
 func parseVersionNumbers(input string) (major, minor, micro int) {


### PR DESCRIPTION
Fixes #14041 

With this change if  `ip_forward` is enabled by docker daemon then the iptables FORWARD policy will be set to DROP.  On a docker upgrade if `ip_forward` is already enabled this change will not take effect, because in that case the user might have intended to have the default policy ACCEPT. Changing it to DROP will break such setups. Current users of docker can avoid this issue by either
1) setting the FORWARD policy to DROP manually
2) reload the host before upgrading to 1.13. If docker daemon enabled `ip_forward` its not persistent. So after a reload the fix will take effect and the policy will be set to DROP.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>