### PR TITLE
executor: Don't repull image if pinned by digest

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -48,4 +48,5 @@ type Backend interface {
 	UpdateAttachment(string, string, string, *network.NetworkingConfig) error
 	WaitForDetachment(context.Context, string, string, string, string) error
 	GetRepository(context.Context, reference.NamedTagged, *types.AuthConfig) (distribution.Repository, bool, error)
+	LookupImage(name string) (*types.ImageInspect, error)
 }


### PR DESCRIPTION
If the image reference in the spec uses a digest, and an image with that
digest already exists locally, avoid an unnecessary repull.

cc @nishanttotla @stevvooe @aluzzardi @tonistiigi