### PR TITLE
replace vim-common with vim for opensuse

### DIFF
--- a/contrib/builder/rpm/amd64/generate.sh
+++ b/contrib/builder/rpm/amd64/generate.sh
@@ -135,6 +135,7 @@ for version in "${versions[@]}"; do
 		opensuse:*)
 			packages=( "${packages[@]/btrfs-progs-devel/libbtrfs-devel}" )
 			packages=( "${packages[@]/pkgconfig/pkg-config}" )
+			packages=( "${packages[@]/vim-common/vim}" )
 			if [[ "$from" == "opensuse:13."* ]]; then
 				packages+=( systemd-rpm-macros )
 			fi

--- a/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/amd64/opensuse-13.2/Dockerfile
@@ -5,7 +5,7 @@
 FROM opensuse:13.2
 
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
-RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim-common systemd-rpm-macros
+RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel pkg-config selinux-policy selinux-policy-devel sqlite-devel systemd-devel tar git cmake vim systemd-rpm-macros
 
 ENV GO_VERSION 1.7.3
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Replace `vim-common` install on opensuse builds with `vim` because there is no `vim-common` package in opensuse. Resolves #28270.

**- How I did it**

Quietly and carefully.

**- How to verify it**

```
$ time docker build -t makeamericagreat contrib/builder/rpm/amd64/opensuse-13.2
...
(63/69) Installing: vim-7.4.461.hg.6253-1.5 [............done]
(64/69) Installing: libtool-2.4.2-15.2.2 [............done]
(65/69) Installing: git-core-2.1.4-19.1 [............done]
(66/69) Installing: policycoreutils-2.3-2.5.1 [...........done]
(67/69) Installing: git-2.1.4-19.1 [....done]  
(68/69) Installing: selinux-policy-20140730-21.1 [.....done]
Additional rpm output:
Updating /etc/sysconfig/selinux-policy...


(69/69) Installing: selinux-policy-devel-20140730-21.1 [............done]
Output of btrfsprogs-4.5.3-13.1.x86_64.rpm %posttrans script:
    Please run mkinitrd as soon as your system is complete.

 ---> 07ef5f66f350
Removing intermediate container 3bcc70df22b7
Step 4 : ENV GO_VERSION 1.7.3
 ---> Running in bc2ff3cddaa7
 ---> 888325c576e4
Removing intermediate container bc2ff3cddaa7
Step 5 : RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ---> Running in 24c1363948c8
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    87  100    87    0     0     15      0  0:00:05  0:00:05 --:--:--    28
100 78.7M  100 78.7M    0     0  5485k      0  0:00:14  0:00:14 --:--:-- 22.4M
 ---> ceeb2066aacb
Removing intermediate container 24c1363948c8
Step 6 : ENV PATH $PATH:/usr/local/go/bin
 ---> Running in ee4f90346fb7
 ---> 12b429d30cc6
Removing intermediate container ee4f90346fb7
Step 7 : ENV AUTO_GOPATH 1
 ---> Running in 4167f6149a95
 ---> f6e5fbbd518a
Removing intermediate container 4167f6149a95
Step 8 : ENV DOCKER_BUILDTAGS pkcs11 selinux
 ---> Running in 20b2f45c289e
 ---> 6e7da1101dd3
Removing intermediate container 20b2f45c289e
Step 9 : ENV RUNC_BUILDTAGS selinux
 ---> Running in 8958758b3ca4
 ---> eebab8238ca8
Removing intermediate container 8958758b3ca4
Successfully built eebab8238ca8

real    2m21.661s
user    0m0.069s
sys     0m0.051s
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐥 
