### PR TITLE
Windows: create daemon root with ACL

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -67,10 +68,15 @@ func NewDaemonCli() *DaemonCli {
 	return &DaemonCli{}
 }
 
-func migrateKey() (err error) {
+func migrateKey(config *daemon.Config) (err error) {
+	// No migration necessary on Windows
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
 	// Migrate trust key if exists at ~/.docker/key.json and owned by current user
 	oldPath := filepath.Join(cliconfig.ConfigDir(), cliflags.DefaultTrustKeyFile)
-	newPath := filepath.Join(getDaemonConfDir(), cliflags.DefaultTrustKeyFile)
+	newPath := filepath.Join(getDaemonConfDir(config.Root), cliflags.DefaultTrustKeyFile)
 	if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) && currentUserIsOwner(oldPath) {
 		defer func() {
 			// Ensure old path is removed if no error occurred
@@ -82,7 +88,7 @@ func migrateKey() (err error) {
 			}
 		}()
 
-		if err := system.MkdirAll(getDaemonConfDir(), os.FileMode(0644)); err != nil {
+		if err := system.MkdirAll(getDaemonConfDir(config.Root), os.FileMode(0644)); err != nil {
 			return fmt.Errorf("Unable to create daemon configuration directory: %s", err)
 		}
 
@@ -117,16 +123,17 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 
 	opts.common.SetDefaultOptions(opts.flags)
 
-	if opts.common.TrustKey == "" {
-		opts.common.TrustKey = filepath.Join(
-			getDaemonConfDir(),
-			cliflags.DefaultTrustKeyFile)
-	}
 	if cli.Config, err = loadDaemonCliConfig(opts); err != nil {
 		return err
 	}
 	cli.configFile = &opts.configFile
 	cli.flags = opts.flags
+
+	if opts.common.TrustKey == "" {
+		opts.common.TrustKey = filepath.Join(
+			getDaemonConfDir(cli.Config.Root),
+			cliflags.DefaultTrustKeyFile)
+	}
 
 	if cli.Config.Debug {
 		utils.EnableDebug()
@@ -149,6 +156,12 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		if err := logger.ValidateLogOpts(cli.LogConfig.Type, cli.LogConfig.Config); err != nil {
 			return fmt.Errorf("Failed to set log opts: %v", err)
 		}
+	}
+
+	// Create the daemon root before we create ANY other files (PID, or migrate keys)
+	// to ensure the appropriate ACL is set (particularly relevant on Windows)
+	if err := daemon.CreateDaemonRoot(cli.Config); err != nil {
+		return err
 	}
 
 	if cli.Pidfile != "" {
@@ -230,9 +243,10 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 		api.Accept(addr, ls...)
 	}
 
-	if err := migrateKey(); err != nil {
+	if err := migrateKey(cli.Config); err != nil {
 		return err
 	}
+
 	// FIXME: why is this down here instead of with the other TrustKey logic above?
 	cli.TrustKeyPath = opts.common.TrustKey
 

--- a/cmd/dockerd/daemon_solaris.go
+++ b/cmd/dockerd/daemon_solaris.go
@@ -38,7 +38,7 @@ func setDefaultUmask() error {
 	return nil
 }
 
-func getDaemonConfDir() string {
+func getDaemonConfDir(_ string) string {
 	return "/etc/docker"
 }
 

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -43,7 +43,7 @@ func setDefaultUmask() error {
 	return nil
 }
 
-func getDaemonConfDir() string {
+func getDaemonConfDir(_ string) string {
 	return "/etc/docker"
 }
 

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
@@ -11,7 +12,7 @@ import (
 	"github.com/docker/docker/pkg/system"
 )
 
-var defaultDaemonConfigFile = os.Getenv("programdata") + string(os.PathSeparator) + "docker" + string(os.PathSeparator) + "config" + string(os.PathSeparator) + "daemon.json"
+var defaultDaemonConfigFile = ""
 
 // currentUserIsOwner checks whether the current user is the owner of the given
 // file.
@@ -24,8 +25,8 @@ func setDefaultUmask() error {
 	return nil
 }
 
-func getDaemonConfDir() string {
-	return os.Getenv("PROGRAMDATA") + `\docker\config`
+func getDaemonConfDir(root string) string {
+	return filepath.Join(root, `\config`)
 }
 
 // notifySystem sends a message to the host when the server is ready to be used

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -62,9 +62,14 @@ func runDaemon(opts daemonOptions) error {
 
 	daemonCli := NewDaemonCli()
 
-	// On Windows, if there's no explicit pidfile set, set to under the daemon root
-	if runtime.GOOS == "windows" && opts.daemonConfig.Pidfile == "" {
-		opts.daemonConfig.Pidfile = filepath.Join(opts.daemonConfig.Root, "docker.pid")
+	// Windows specific settings as these are not defaulted.
+	if runtime.GOOS == "windows" {
+		if opts.daemonConfig.Pidfile == "" {
+			opts.daemonConfig.Pidfile = filepath.Join(opts.daemonConfig.Root, "docker.pid")
+		}
+		if opts.configFile == "" {
+			opts.configFile = filepath.Join(opts.daemonConfig.Root, `config\daemon.json`)
+		}
 	}
 
 	// On Windows, this may be launching as a service or with an option to

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -432,7 +432,7 @@ func setupRemappedRoot(config *Config) ([]idtools.IDMap, []idtools.IDMap, error)
 func setupDaemonRoot(config *Config, rootDir string, rootUID, rootGID int) error {
 	config.Root = rootDir
 	// Create the root directory if it doesn't exists
-	if err := system.MkdirAll(config.Root, 0700); err != nil && !os.IsExist(err) {
+	if err := system.MkdirAllWithACL(config.Root, 0); err != nil && !os.IsExist(err) {
 		return err
 	}
 	return nil

--- a/pkg/system/filesys.go
+++ b/pkg/system/filesys.go
@@ -7,6 +7,12 @@ import (
 	"path/filepath"
 )
 
+// MkdirAllWithACL is a wrapper for MkdirAll that creates a directory
+// ACL'd for Builtin Administrators and Local System.
+func MkdirAllWithACL(path string, perm os.FileMode) error {
+	return MkdirAll(path, perm)
+}
+
 // MkdirAll creates a directory named path along with any necessary parents,
 // with permission specified by attribute perm for all dir created.
 func MkdirAll(path string, perm os.FileMode) error {

--- a/pkg/system/filesys_windows.go
+++ b/pkg/system/filesys_windows.go
@@ -8,15 +8,31 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"unsafe"
+
+	winio "github.com/Microsoft/go-winio"
 )
 
+// MkdirAllWithACL is a wrapper for MkdirAll that creates a directory
+// ACL'd for Builtin Administrators and Local System.
+func MkdirAllWithACL(path string, perm os.FileMode) error {
+	return mkdirall(path, true)
+}
+
 // MkdirAll implementation that is volume path aware for Windows.
-func MkdirAll(path string, perm os.FileMode) error {
+func MkdirAll(path string, _ os.FileMode) error {
+	return mkdirall(path, false)
+}
+
+// mkdirall is a custom version of os.MkdirAll modified for use on Windows
+// so that it is both volume path aware, and can create a directory with
+// a DACL.
+func mkdirall(path string, adminAndLocalSystem bool) error {
 	if re := regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`); re.MatchString(path) {
 		return nil
 	}
 
-	// The rest of this method is copied from os.MkdirAll and should be kept
+	// The rest of this method is largely copied from os.MkdirAll and should be kept
 	// as-is to ensure compatibility.
 
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
@@ -45,14 +61,19 @@ func MkdirAll(path string, perm os.FileMode) error {
 
 	if j > 1 {
 		// Create parent
-		err = MkdirAll(path[0:j-1], perm)
+		err = mkdirall(path[0:j-1], false)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Parent now exists; invoke Mkdir and use its result.
-	err = os.Mkdir(path, perm)
+	// Parent now exists; invoke os.Mkdir or mkdirWithACL and use its result.
+	if adminAndLocalSystem {
+		err = mkdirWithACL(path)
+	} else {
+		err = os.Mkdir(path, 0)
+	}
+
 	if err != nil {
 		// Handle arguments like "foo/." by
 		// double-checking that directory doesn't exist.
@@ -61,6 +82,36 @@ func MkdirAll(path string, perm os.FileMode) error {
 			return nil
 		}
 		return err
+	}
+	return nil
+}
+
+// mkdirWithACL creates a new directory. If there is an error, it will be of
+// type *PathError. .
+//
+// This is a modified and combined version of os.Mkdir and syscall.Mkdir
+// in golang to cater for creating a directory am ACL permitting full
+// access, with inheritance, to any subfolder/file for Built-in Administrators
+// and Local System.
+func mkdirWithACL(name string) error {
+	sa := syscall.SecurityAttributes{Length: 0}
+	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	if err != nil {
+		return &os.PathError{"mkdir", name, err}
+	}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return &os.PathError{"mkdir", name, err}
+	}
+
+	e := syscall.CreateDirectory(namep, &sa)
+	if e != nil {
+		return &os.PathError{"mkdir", name, e}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This PR ensures the Windows daemon creates the root with an ACL for Local System and Built-In Administrators. @NathanMcCauley @thaJeztah 