### PR TITLE
--max-concurrent-downloads,--max-concurrent-uploads must great than or equal to 0 

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -276,7 +276,7 @@ func MergeDaemonConfigurations(flagsConfig *Config, flags *pflag.FlagSet, config
 	}
 
 	if err := Validate(fileConfig); err != nil {
-		return nil, fmt.Errorf("file configuration validation failed (%v)", err)
+		return nil, fmt.Errorf("configuration validation from file failed (%v)", err)
 	}
 
 	// merge flags configuration on top of the file configuration
@@ -287,7 +287,7 @@ func MergeDaemonConfigurations(flagsConfig *Config, flags *pflag.FlagSet, config
 	// We need to validate again once both fileConfig and flagsConfig
 	// have been merged
 	if err := Validate(fileConfig); err != nil {
-		return nil, fmt.Errorf("file configuration validation failed (%v)", err)
+		return nil, fmt.Errorf("merged configuration validation from file and command line flags failed (%v)", err)
 	}
 
 	return fileConfig, nil
@@ -459,14 +459,12 @@ func Validate(config *Config) error {
 			return err
 		}
 	}
-
 	// validate MaxConcurrentDownloads
-	if config.IsValueSet("max-concurrent-downloads") && config.MaxConcurrentDownloads != nil && *config.MaxConcurrentDownloads < 0 {
+	if config.MaxConcurrentDownloads != nil && *config.MaxConcurrentDownloads < 0 {
 		return fmt.Errorf("invalid max concurrent downloads: %d", *config.MaxConcurrentDownloads)
 	}
-
 	// validate MaxConcurrentUploads
-	if config.IsValueSet("max-concurrent-uploads") && config.MaxConcurrentUploads != nil && *config.MaxConcurrentUploads < 0 {
+	if config.MaxConcurrentUploads != nil && *config.MaxConcurrentUploads < 0 {
 		return fmt.Errorf("invalid max concurrent uploads: %d", *config.MaxConcurrentUploads)
 	}
 


### PR DESCRIPTION
**- What I did**

I think that  --max-concurrent-downloads,--max-concurrent-uploads must great than or equal to 0 

**- How I did it**
  remove  config.IsValueSet("max-concurrent-downloads") && and config.IsValueSet("max-concurrent-uploads") and modify the error message description.

![image](https://cloud.githubusercontent.com/assets/23158339/21968663/fd1a1b82-dbd1-11e6-8534-1eb83c92598b.png)

	
     
**- How to verify it**

`dockerd   --max-concurrent-downloads=-1 --max-concurrent-uploads=2`

exit and console print：
invalid max concurrent downloads: -1



**- Description for the changelog**



**- A picture of a cute animal (not mandatory but encouraged)**

