### PR TITLE
Remove duplicated document

### DIFF
--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -14,7 +14,7 @@ advisory: "experimental"
      will be rejected.
 -->
 
-# stack deploy (experimental)
+# deploy (alias for stack deploy) (experimental)
 
 ```markdown
 Usage:  docker deploy [OPTIONS] STACK


### PR DESCRIPTION
**- What I did**
Remove  docs/reference/commandline/deploy.md 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
The docs/reference/commandline/deploy.md is duplicated document for docs/reference/commandline/stack_deploy.md 
which makes me confused

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>