### PR TITLE
No variables to format, no fmt.Errorf.

### DIFF
--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"errors"
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -52,7 +53,7 @@ func TestCheckpointCreate(t *testing.T) {
 			}
 
 			if !createOptions.Exit {
-				return nil, fmt.Errorf("expected Exit to be true")
+				return nil, errors.New("expected Exit to be true")
 			}
 
 			return &http.Response{


### PR DESCRIPTION
**- What I did**
Replace `fmt.Errorf` with `errors.New`, because there is no variables to format, using `errors.New` would be more effective.

**- How I did it**
Replace `fmt.Errorf` with `errors.New`


**- A picture of a cute animal (not mandatory but encouraged)**
Before:
![image](https://cloud.githubusercontent.com/assets/22292664/20208337/863aad06-a828-11e6-97ef-85eaa6a4e4e2.png)

After:
![image](https://cloud.githubusercontent.com/assets/22292664/20208348/91584216-a828-11e6-8fcd-d80eb5004174.png)


Signed-off-by: wefine <wang.xiaoren@zte.com.cn>