### PR TITLE
fix the wrong title with docker swarm

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -212,7 +212,7 @@ environment.
 
 ## service discovery
 
-Swarm mode [service discovery](https://docs.docker.com/engine/swarm/networking/) is a DNS component
+Swarm mode [service discovery](https://docs.docker.com/engine/swarm/networking/#use-swarm-mode-service-discovery) is a DNS component
 internal to the swarm that automatically assigns each service on an overlay
 network in the swarm a VIP and DNS entry. Containers on the network share DNS
 mappings for the service via gossip so any container on the network can access
@@ -226,7 +226,7 @@ automatically distributes requests to the service VIP among the active tasks.
 
 A [swarm](https://docs.docker.com/engine/swarm/) is a cluster of one or more Docker Engines running in [swarm mode](#swarm-mode).
 
-## Swarm
+## Docker Swarm
 
 Do not confuse [Docker Swarm](https://github.com/docker/swarm) with the [swarm mode](#swarm-mode) features in Docker Engine.
 


### PR DESCRIPTION
two modifications:
1. add the location of service discovery in network doc.
2. fix the wrong title with docker swarm, it is not swam but docker swarm because the following description is related to docker swarm.