### PR TITLE
Add support for extra_hosts in compose to swarm

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -498,6 +498,7 @@ func convertService(
 				Command:         service.Entrypoint,
 				Args:            service.Command,
 				Hostname:        service.Hostname,
+				Hosts:           convertExtraHosts(service.ExtraHosts),
 				Env:             convertEnvironment(service.Environment),
 				Labels:          getStackLabels(namespace.name, service.Labels),
 				Dir:             service.WorkingDir,
@@ -519,6 +520,14 @@ func convertService(
 	}
 
 	return serviceSpec, nil
+}
+
+func convertExtraHosts(extraHosts map[string]string) []string {
+	hosts := []string{}
+	for host, ip := range extraHosts {
+		hosts = append(hosts, fmt.Sprintf("%s %s", host, ip))
+	}
+	return hosts
 }
 
 func convertRestartPolicy(restart string, source *composetypes.RestartPolicy) (*swarm.RestartPolicy, error) {


### PR DESCRIPTION
Adds support for `extra_hosts` in the composefile v3 format, used it `docker stack deploy --compose-file` 🐮.

/cc @dnephin @aanand @icecrime @stevvooe @aaronlehmann @aluzzardi 

This bumps [compose-file](https://github.com/aanand/compose-file) to 8cff34df885ef07824138236bc4d27d359888b17.

🐸