### PR TITLE
Add bash completion for `docker daemon --seccomp-profile`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1704,6 +1704,7 @@ _docker_daemon() {
 		--oom-score-adjust
 		--pidfile -p
 		--registry-mirror
+		--seccomp-profile
 		--shutdown-timeout
 		--storage-driver -s
 		--storage-opt
@@ -1814,6 +1815,10 @@ _docker_daemon() {
 			;;
 		--log-opt)
 			__docker_complete_log_options
+			return
+			;;
+		--seccomp-profile)
+			_filedir json
 			return
 			;;
 		--userns-remap)


### PR DESCRIPTION
Ref: #26276

Note: this assumes that profile files have `*.json` filenames as suggested in #26276.