### PR TITLE
dockerversion: add other binaries to _lib.go

### DIFF
--- a/dockerversion/version_lib.go
+++ b/dockerversion/version_lib.go
@@ -6,8 +6,11 @@ package dockerversion
 // Default build-time variable for library-import.
 // This file is overridden on build with build-time informations.
 const (
-	GitCommit string = "library-import"
-	Version   string = "library-import"
-	BuildTime string = "library-import"
-	IAmStatic string = "library-import"
+	GitCommit          string = "library-import"
+	Version            string = "library-import"
+	BuildTime          string = "library-import"
+	IAmStatic          string = "library-import"
+	ContainerdCommitID string = "library-import"
+	RuncCommitID       string = "library-import"
+	InitCommitID       string = "library-import"
 )


### PR DESCRIPTION
Otherwise it's impossible to build without autogen tag

Btw I think that storing versions that way is really fragile way to know versions.