### PR TITLE
Update docs for `docker info` for most recent changes.

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -2459,7 +2459,7 @@ Docker daemon report the following event:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
-    Server: Docker/1.11.0 (linux)
+    Server: Docker/1.12.0 (linux)
     Date: Fri, 29 Apr 2016 15:18:06 GMT
     Transfer-Encoding: chunked
 
@@ -3912,7 +3912,7 @@ List nodes
             "MemoryBytes": 8272408576
           },
           "Engine": {
-            "EngineVersion": "1.12.0-dev",
+            "EngineVersion": "1.12.0",
             "Labels": {
                 "foo": "bar",
             }
@@ -4004,7 +4004,7 @@ Return low-level information on the node `id`
           "MemoryBytes": 8272408576
         },
         "Engine": {
-          "EngineVersion": "1.12.0-dev",
+          "EngineVersion": "1.12.0",
           "Labels": {
               "foo": "bar",
           }

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -2610,7 +2610,7 @@ Display system-wide information
         "Name": "WIN-V0V70C0LU5P",
         "Labels": null,
         "ExperimentalBuild": false,
-        "ServerVersion": "1.13.0-dev",
+        "ServerVersion": "1.13.0",
         "ClusterStore": "",
         "ClusterAdvertise": "",
         "SecurityOptions": null,
@@ -2904,7 +2904,7 @@ Docker daemon report the following event:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
-    Server: Docker/1.11.0 (linux)
+    Server: Docker/1.13.0 (linux)
     Date: Fri, 29 Apr 2016 15:18:06 GMT
     Transfer-Encoding: chunked
 
@@ -4510,7 +4510,7 @@ List nodes
             "MemoryBytes": 8272408576
           },
           "Engine": {
-            "EngineVersion": "1.12.0-dev",
+            "EngineVersion": "1.13.0",
             "Labels": {
                 "foo": "bar",
             }
@@ -4603,7 +4603,7 @@ Return low-level information on the node `id`
           "MemoryBytes": 8272408576
         },
         "Engine": {
-          "EngineVersion": "1.12.0-dev",
+          "EngineVersion": "1.13.0",
           "Labels": {
               "foo": "bar",
           }
@@ -4813,7 +4813,7 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
     Content-Length: 28
     Content-Type: application/json
     Date: Thu, 01 Sep 2016 21:49:13 GMT
-    Server: Docker/1.12.0 (linux)
+    Server: Docker/1.13.0 (linux)
 
     "7v2t30z9blmxuhnyo6s4cpenp"
 

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -47,7 +47,7 @@ available on the volume where `/var/lib/docker` is mounted.
 
 ## Display Docker system information
 
-Here is a sample output for a daemon running on Ubuntu, using the overlay
+Here is a sample output for a daemon running on Ubuntu, using the overlay2
 storage driver and a node that is part of a 2-node swarm:
 
     $ docker -D info
@@ -56,49 +56,72 @@ storage driver and a node that is part of a 2-node swarm:
      Paused: 1
      Stopped: 10
     Images: 52
-    Server Version: 1.12.0-dev
-    Storage Driver: overlay
+    Server Version: 1.13.0
+    Storage Driver: overlay2
      Backing Filesystem: extfs
+     Supports d_type: true
+     Native Overlay Diff: false
     Logging Driver: json-file
     Cgroup Driver: cgroupfs
     Plugins:
      Volume: local
-     Network: bridge null host overlay
-    Swarm:
-     NodeID: 0gac67oclbxq7
+     Network: bridge host macvlan null overlay
+    Swarm: active
+     NodeID: rdjq45w1op418waxlairloqbm
      Is Manager: true
-     Managers: 2
+     ClusterID: te8kdyw33n36fqiz74bfjeixd
+     Managers: 1
      Nodes: 2
-    Runtimes: default
-    Default Runtime: default
-    Security Options: apparmor seccomp
-    Kernel Version: 4.4.0-21-generic
-    Operating System: Ubuntu 16.04 LTS
+     Orchestration:
+      Task History Retention Limit: 5
+     Raft:
+      Snapshot Interval: 10000
+      Number of Old Snapshots to Retain: 0
+      Heartbeat Tick: 1
+      Election Tick: 3
+     Dispatcher:
+      Heartbeat Period: 5 seconds
+     CA Configuration:
+      Expiry Duration: 3 months
+     Node Address: 172.16.66.128 172.16.66.129
+     Manager Addresses:
+      172.16.66.128:2477
+    Runtimes: runc
+    Default Runtime: runc
+    Init Binary: docker-init
+    containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
+    runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
+    init version: N/A (expected: v0.13.0)
+    Security Options:
+     apparmor
+     seccomp
+      Profile: default
+    Kernel Version: 4.4.0-31-generic
+    Operating System: Ubuntu 16.04.1 LTS
     OSType: linux
     Architecture: x86_64
-    CPUs: 24
-    Total Memory: 62.86 GiB
-    Name: docker
-    ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    CPUs: 2
+    Total Memory: 1.937 GiB
+    Name: ubuntu
+    ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
     Docker Root Dir: /var/lib/docker
-    Debug mode (client): true
-    Debug mode (server): true
-     File Descriptors: 59
-     Goroutines: 159
-     System Time: 2016-04-26T10:04:06.14689342-04:00
+    Debug Mode (client): true
+    Debug Mode (server): true
+     File Descriptors: 30
+     Goroutines: 123
+     System Time: 2016-11-12T17:24:37.955404361-08:00
      EventsListeners: 0
-    Http Proxy: http://test:test@localhost:8080
-    Https Proxy: https://test:test@localhost:8080
+    Http Proxy: http://proxy.example.com:80/
     No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
-    Username: svendowideit
     Registry: https://index.docker.io/v1/
     WARNING: No swap limit support
     Labels:
      storage=ssd
      staging=true
-    Insecure registries:
-     myinsecurehost:5000
+    Experimental: false
+    Insecure Registries:
      127.0.0.0/8
+    Live Restore Enabled: false
 
 The global `-D` option tells all `docker` commands to output debug information.
 
@@ -168,7 +191,7 @@ Here is a sample output for a daemon running on Windows Server 2016:
      Paused: 0
      Stopped: 1
     Images: 17
-    Server Version: 1.13.0-dev
+    Server Version: 1.13.0
     Storage Driver: windowsfilter
      Windows:
     Logging Driver: json-file

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -39,7 +39,7 @@ available on the volume where `/var/lib/docker` is mounted.
 
 ## Display Docker system information
 
-Here is a sample output for a daemon running on Ubuntu, using the overlay
+Here is a sample output for a daemon running on Ubuntu, using the overlay2
 storage driver:
 
     $ docker -D info
@@ -48,49 +48,74 @@ storage driver:
      Paused: 1
      Stopped: 10
     Images: 52
-    Server Version: 1.12.0-dev
-    Storage Driver: overlay
+    Server Version: 1.13.0
+    Storage Driver: overlay2
      Backing Filesystem: extfs
+     Supports d_type: true
+     Native Overlay Diff: false
     Logging Driver: json-file
     Cgroup Driver: cgroupfs
     Plugins:
      Volume: local
-     Network: bridge null host overlay
-    Swarm: 
-     NodeID: 0gac67oclbxq7
-     IsManager: YES
-     Managers: 2
+     Network: bridge host macvlan null overlay
+    Swarm: active
+     NodeID: rdjq45w1op418waxlairloqbm
+     Is Manager: true
+     ClusterID: te8kdyw33n36fqiz74bfjeixd
+     Managers: 1
      Nodes: 2
-    Runtimes: default
-    Default Runtime: default
-    Security Options: apparmor seccomp
-    Kernel Version: 4.4.0-21-generic
-    Operating System: Ubuntu 16.04 LTS
+     Orchestration:
+      Task History Retention Limit: 5
+     Raft:
+      Snapshot Interval: 10000
+      Number of Old Snapshots to Retain: 0
+      Heartbeat Tick: 1
+      Election Tick: 3
+     Dispatcher:
+      Heartbeat Period: 5 seconds
+     CA Configuration:
+      Expiry Duration: 3 months
+     Node Address: 172.16.66.128 172.16.66.129
+     Manager Addresses:
+      172.16.66.128:2477
+    Runtimes: runc
+    Default Runtime: runc
+    Init Binary: docker-init
+    containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
+    runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
+    init version: N/A (expected: v0.13.0)
+    Security Options:
+     apparmor
+     seccomp
+      Profile: default
+    Kernel Version: 4.4.0-31-generic
+    Operating System: Ubuntu 16.04.1 LTS
     OSType: linux
     Architecture: x86_64
-    CPUs: 24
-    Total Memory: 62.86 GiB
-    Name: docker
-    ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+    CPUs: 2
+    Total Memory: 1.937 GiB
+    Name: ubuntu
+    ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
     Docker Root Dir: /var/lib/docker
-    Debug mode (client): true
-    Debug mode (server): true
-     File Descriptors: 59
-     Goroutines: 159
-     System Time: 2016-04-26T10:04:06.14689342-04:00
+    Debug Mode (client): true
+    Debug Mode (server): true
+     File Descriptors: 30
+     Goroutines: 123
+     System Time: 2016-11-12T17:24:37.955404361-08:00
      EventsListeners: 0
-    Http Proxy: http://test:test@localhost:8080
-    Https Proxy: https://test:test@localhost:8080
+    Http Proxy: http://proxy.example.com:80/
     No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
-    Username: svendowideit
     Registry: https://index.docker.io/v1/
     WARNING: No swap limit support
     Labels:
      storage=ssd
      staging=true
-    Insecure registries:
-     myinsecurehost:5000
+    Experimental: false
+    Insecure Registries:
      127.0.0.0/8
+    Live Restore Enabled: false
+
+
 
 The global `-D` option tells all `docker` commands to output debug information.
 


### PR DESCRIPTION
This is a follow up to #28042:
https://github.com/docker/docker/pull/28042#issuecomment-259989631

The output of `docker info` in docs has been way out of sync.
This fix updates docs for `docker info` for most recent changes.

This fix also made several changes:
1. Replace 0.12.0-dev to 0.13.0 for api docs v1.24.
2. Replace 0.13.0-dev to 0.13.0 for api docs v1.25

cc @vieux @thaJeztah

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>