### PR TITLE
cli: Add valid suffixes for remaining duration options

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -575,14 +575,14 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")
 	flags.Var(&opts.resources.resCPU, flagReserveCPU, "Reserve CPUs")
 	flags.Var(&opts.resources.resMemBytes, flagReserveMemory, "Reserve Memory")
-	flags.Var(&opts.stopGrace, flagStopGracePeriod, "Time to wait before force killing a container")
+	flags.Var(&opts.stopGrace, flagStopGracePeriod, "Time to wait before force killing a container (ns|us|ms|s|m|h)")
 
 	flags.Var(&opts.replicas, flagReplicas, "Number of tasks")
 
 	flags.StringVar(&opts.restartPolicy.condition, flagRestartCondition, "", "Restart when condition is met (none, on-failure, or any)")
-	flags.Var(&opts.restartPolicy.delay, flagRestartDelay, "Delay between restart attempts")
+	flags.Var(&opts.restartPolicy.delay, flagRestartDelay, "Delay between restart attempts (ns|us|ms|s|m|h)")
 	flags.Var(&opts.restartPolicy.maxAttempts, flagRestartMaxAttempts, "Maximum number of restarts before giving up")
-	flags.Var(&opts.restartPolicy.window, flagRestartWindow, "Window used to evaluate the restart policy")
+	flags.Var(&opts.restartPolicy.window, flagRestartWindow, "Window used to evaluate the restart policy (ns|us|ms|s|m|h)")
 
 	flags.Uint64Var(&opts.update.parallelism, flagUpdateParallelism, 1, "Maximum number of tasks updated simultaneously (0 to update all at once)")
 	flags.DurationVar(&opts.update.delay, flagUpdateDelay, time.Duration(0), "Delay between updates (ns|us|ms|s|m|h) (default 0s)")
@@ -598,8 +598,8 @@ func addServiceFlags(cmd *cobra.Command, opts *serviceOptions) {
 	flags.Var(&opts.logDriver.opts, flagLogOpt, "Logging driver options")
 
 	flags.StringVar(&opts.healthcheck.cmd, flagHealthCmd, "", "Command to run to check health")
-	flags.Var(&opts.healthcheck.interval, flagHealthInterval, "Time between running the check")
-	flags.Var(&opts.healthcheck.timeout, flagHealthTimeout, "Maximum time to allow one check to run")
+	flags.Var(&opts.healthcheck.interval, flagHealthInterval, "Time between running the check (ns|us|ms|s|m|h)")
+	flags.Var(&opts.healthcheck.timeout, flagHealthTimeout, "Maximum time to allow one check to run (ns|us|ms|s|m|h)")
 	flags.IntVar(&opts.healthcheck.retries, flagHealthRetries, 0, "Consecutive failures needed to report unhealthy")
 	flags.BoolVar(&opts.healthcheck.noHealthcheck, flagNoHealthcheck, false, "Disable any container-specified HEALTHCHECK")
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -31,9 +31,9 @@ Options:
       --env-file list                    Read in a file of environment variables (default [])
       --group list                       Set one or more supplementary user groups for the container (default [])
       --health-cmd string                Command to run to check health
-      --health-interval duration         Time between running the check (default none)
+      --health-interval duration         Time between running the check (ns|us|ms|s|m|h) (default none)
       --health-retries int               Consecutive failures needed to report unhealthy
-      --health-timeout duration          Maximum time to allow one check to run (default none)
+      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h) (default none)
       --help                             Print usage
       --host list                        Set one or more custom host-to-IP mappings (host:ip) (default [])
       --hostname string                  Container hostname
@@ -52,11 +52,11 @@ Options:
       --reserve-cpu decimal              Reserve CPUs (default 0.000)
       --reserve-memory bytes             Reserve Memory (default 0 B)
       --restart-condition string         Restart when condition is met (none, on-failure, or any)
-      --restart-delay duration           Delay between restart attempts (default none)
+      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h) (default none)
       --restart-max-attempts uint        Maximum number of restarts before giving up (default none)
-      --restart-window duration          Window used to evaluate the restart policy (default none)
+      --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h) (default none)
       --secret value                     Specify secrets to expose to the service (default [])
-      --stop-grace-period duration       Time to wait before force killing a container (default none)
+      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h) (default none)
   -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -39,9 +39,9 @@ Options:
       --group-add list                   Add an additional supplementary user group to the container (default [])
       --group-rm list                    Remove a previously added supplementary user group from the container (default [])
       --health-cmd string                Command to run to check health
-      --health-interval duration         Time between running the check (default none)
+      --health-interval duration         Time between running the check (ns|us|ms|s|m|h) (default none)
       --health-retries int               Consecutive failures needed to report unhealthy
-      --health-timeout duration          Maximum time to allow one check to run (default none)
+      --health-timeout duration          Maximum time to allow one check to run (ns|us|ms|s|m|h) (default none)
       --help                             Print usage
       --host-add list                    Add or update a custom host-to-IP mapping (host:ip) (default [])
       --host-rm list                     Remove a custom host-to-IP mapping (host:ip) (default [])
@@ -61,13 +61,13 @@ Options:
       --reserve-cpu decimal              Reserve CPUs (default 0.000)
       --reserve-memory bytes             Reserve Memory (default 0 B)
       --restart-condition string         Restart when condition is met (none, on-failure, or any)
-      --restart-delay duration           Delay between restart attempts (default none)
+      --restart-delay duration           Delay between restart attempts (ns|us|ms|s|m|h) (default none)
       --restart-max-attempts uint        Maximum number of restarts before giving up (default none)
-      --restart-window duration          Window used to evaluate the restart policy (default none)
+      --restart-window duration          Window used to evaluate the restart policy (ns|us|ms|s|m|h) (default none)
       --rollback                         Rollback to previous specification
       --secret-add list                  Add a secret (default [])
       --secret-rm list                   Remove a secret (default [])
-      --stop-grace-period duration       Time to wait before force killing a container (default none)
+      --stop-grace-period duration       Time to wait before force killing a container (ns|us|ms|s|m|h) (default none)
   -t, --tty                              Allocate a pseudo-TTY
       --update-delay duration            Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string     Action on update failure (pause|continue) (default "pause")


### PR DESCRIPTION
#27733 added `(ns|us|ms|s|m|h)` to the descriptions of some
duration options, but not all. Add it to the remaining options for
consistency.