### PR TITLE
context.Context should be the first parameter of a function

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -118,7 +118,7 @@ func runAttach(dockerCli *command.DockerCli, opts *attachOptions) error {
 		return errAttach
 	}
 
-	_, status, err := getExitCode(dockerCli, ctx, opts.container)
+	_, status, err := getExitCode(ctx, dockerCli, opts.container)
 	if err != nil {
 		return err
 	}

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -211,7 +211,7 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 		})
 	}
 
-	statusChan := waitExitOrRemoved(dockerCli, ctx, createResponse.ID, hostConfig.AutoRemove)
+	statusChan := waitExitOrRemoved(ctx, dockerCli, createResponse.ID, hostConfig.AutoRemove)
 
 	//start the container
 	if err := client.ContainerStart(ctx, createResponse.ID, types.ContainerStartOptions{}); err != nil {

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -111,7 +111,7 @@ func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 
 		// 3. We should open a channel for receiving status code of the container
 		// no matter it's detached, removed on daemon side(--rm) or exit normally.
-		statusChan := waitExitOrRemoved(dockerCli, ctx, c.ID, c.HostConfig.AutoRemove)
+		statusChan := waitExitOrRemoved(ctx, dockerCli, c.ID, c.HostConfig.AutoRemove)
 		startOptions := types.ContainerStartOptions{
 			CheckpointID:  opts.checkpoint,
 			CheckpointDir: opts.checkpointDir,

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -108,7 +108,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 			s := formatter.NewContainerStats(container.ID[:12], daemonOSType)
 			if cStats.add(s) {
 				waitFirst.Add(1)
-				go collect(s, ctx, dockerCli.Client(), !opts.noStream, waitFirst)
+				go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
 			}
 		}
 	}
@@ -125,7 +125,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 				s := formatter.NewContainerStats(e.ID[:12], daemonOSType)
 				if cStats.add(s) {
 					waitFirst.Add(1)
-					go collect(s, ctx, dockerCli.Client(), !opts.noStream, waitFirst)
+					go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
 				}
 			}
 		})
@@ -134,7 +134,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 			s := formatter.NewContainerStats(e.ID[:12], daemonOSType)
 			if cStats.add(s) {
 				waitFirst.Add(1)
-				go collect(s, ctx, dockerCli.Client(), !opts.noStream, waitFirst)
+				go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
 			}
 		})
 
@@ -160,7 +160,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 			s := formatter.NewContainerStats(name, daemonOSType)
 			if cStats.add(s) {
 				waitFirst.Add(1)
-				go collect(s, ctx, dockerCli.Client(), !opts.noStream, waitFirst)
+				go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
 			}
 		}
 

--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -53,7 +53,7 @@ func (s *stats) isKnownContainer(cid string) (int, bool) {
 	return -1, false
 }
 
-func collect(s *formatter.ContainerStats, ctx context.Context, cli client.APIClient, streamStats bool, waitFirst *sync.WaitGroup) {
+func collect(ctx context.Context, s *formatter.ContainerStats, cli client.APIClient, streamStats bool, waitFirst *sync.WaitGroup) {
 	logrus.Debugf("collecting stats for %s", s.Container)
 	var (
 		getFirst       bool

--- a/cli/command/container/utils.go
+++ b/cli/command/container/utils.go
@@ -13,7 +13,7 @@ import (
 	clientapi "github.com/docker/docker/client"
 )
 
-func waitExitOrRemoved(dockerCli *command.DockerCli, ctx context.Context, containerID string, waitRemove bool) chan int {
+func waitExitOrRemoved(ctx context.Context, dockerCli *command.DockerCli, containerID string, waitRemove bool) chan int {
 	if len(containerID) == 0 {
 		// containerID can never be empty
 		panic("Internal Error: waitExitOrRemoved needs a containerID as parameter")
@@ -87,7 +87,7 @@ func waitExitOrRemoved(dockerCli *command.DockerCli, ctx context.Context, contai
 
 // getExitCode performs an inspect on the container. It returns
 // the running state and the exit code.
-func getExitCode(dockerCli *command.DockerCli, ctx context.Context, containerID string) (bool, int, error) {
+func getExitCode(ctx context.Context, dockerCli *command.DockerCli, containerID string) (bool, int, error) {
 	c, err := dockerCli.Client().ContainerInspect(ctx, containerID)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -34,7 +34,7 @@ func runSecretInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	ctx := context.Background()
 
 	// attempt to lookup secret by name
-	secrets, err := getSecretsByName(client, ctx, []string{opts.name})
+	secrets, err := getSecretsByName(ctx, client, []string{opts.name})
 	if err != nil {
 		return err
 	}

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -32,7 +32,7 @@ func runSecretRemove(dockerCli *command.DockerCli, opts removeOptions) error {
 	ctx := context.Background()
 
 	// attempt to lookup secret by name
-	secrets, err := getSecretsByName(client, ctx, opts.ids)
+	secrets, err := getSecretsByName(ctx, client, opts.ids)
 	if err != nil {
 		return err
 	}

--- a/cli/command/secret/utils.go
+++ b/cli/command/secret/utils.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func getSecretsByName(client client.APIClient, ctx context.Context, names []string) ([]swarm.Secret, error) {
+func getSecretsByName(ctx context.Context, client client.APIClient, names []string) ([]swarm.Secret, error) {
 	args := filters.NewArgs()
 	for _, n := range names {
 		args.Add("names", n)


### PR DESCRIPTION
**- What I did**
Change the place of the context.Context parameter.
**- How I did it**
Move the context.Context parameter to the first place.
**- How to verify it**
golint
**- Description for the changelog**
	\github.com\docker\docker\cli\command\container\stats_helpers.go:56:1: context.Context should be the first parameter of a function
	\github.com\docker\docker\cli\command\container\utils.go:16:1: context.Context should be the first parameter of a function
	\github.com\docker\docker\cli\command\container\utils.go:90:1: context.Context should be the first parameter of a function
	\github.com\docker\docker\cli\command\secret\utils.go:11:1: context.Context should be the first parameter of a function

Signed-off-by: yupeng <yu.peng36@zte.com.cn>