### PR TITLE
#28331: docker stop should give a proper error on container in Create…

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import "net/http"
+import "errors"
 
 // apiError is an error wrapper that also
 // holds information about response status codes.
@@ -19,6 +20,9 @@ func (e apiError) HTTPErrorStatusCode() int {
 // The Server will take that code and set
 // it as the response status.
 func NewErrorWithStatusCode(err error, code int) error {
+	if err == nil {
+		return apiError{errors.New(""), code}
+	}
 	return apiError{err, code}
 }
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -22,8 +22,7 @@ func (daemon *Daemon) ContainerStop(name string, seconds *int) error {
 		return err
 	}
 	if !container.IsRunning() {
-		err := fmt.Errorf("Container %s is already stopped", name)
-		return errors.NewErrorWithStatusCode(err, http.StatusNotModified)
+		return errors.NewErrorWithStatusCode(nil, http.StatusNotModified)
 	}
 	if seconds == nil {
 		stopTimeout := container.StopTimeout()

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -953,7 +953,7 @@ func (s *DockerSuite) TestContainerAPIStop(c *check.C) {
 	c.Assert(status, checker.Equals, http.StatusNoContent)
 	c.Assert(waitInspect(name, "{{ .State.Running  }}", "false", 60*time.Second), checker.IsNil)
 
-	// second call to start should give 304
+	// second call to stop should give 304
 	status, _, err = sockRequest("POST", "/containers/"+name+"/stop?t=30", nil)
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusNotModified)


### PR DESCRIPTION
fixes #28331 

- What I did
Implemented code for showing error message for docker stop if container in 'created' state

- How I did it
Added method IsCreated() in container/state.go to get container in Created state.
Added changed in daemon/stop.go to show error message if isCreated() outout is true

- How to verify it
Create a container with 'docker create'
Stop container in #1.
  it should give an error that container <id> is not Running

![image](https://cloud.githubusercontent.com/assets/21226676/20236315/3a20c6f4-a8d6-11e6-8696-870ca43e3544.png)
@
