### PR TITLE
`dont` spell error

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -793,7 +793,7 @@ func (daemon *Daemon) Shutdown() error {
 		})
 	}
 
-	// Shutdown plugins after containers. Dont change the order.
+	// Shutdown plugins after containers. Don't change the order.
 	daemon.pluginShutdown()
 
 	// trigger libnetwork Stop only if it's initialized


### PR DESCRIPTION
**- What I did**
In daemon/daemon.go,line 796 ` Shutdown plugins after containers. Dont change the order.`
`Dont `  spell error ,should Don't
**- How I did it**
modify  `Dont `  -> Don't
**- How to verify it**
In daemon/daemon.go,line 796 ,you can see `Shutdown plugins after containers. Don't change the order.`

Signed-off-by: chchliang <chen.chuanliang@zte.com.cn>