### PR TITLE
Fix issue in `docker ps --format '{{.CreatedAt}}'`

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -77,6 +77,13 @@ func (p *preProcessor) Networks() bool {
 	return true
 }
 
+// CreatedAt does nothing but return true.
+// It is needed to avoid the template check to fail as this field
+// doesn't exist in `types.Container` (only `Created` in `types.Container`)
+func (p *preProcessor) CreatedAt() bool {
+	return true
+}
+
 func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, error) {
 	options := &types.ContainerListOptions{
 		All:     opts.all,


### PR DESCRIPTION
**- What I did**

This fix fixes the issue raised in #28337 where `docker ps --format '{{.CreatedAt}}'` will return an error.

The issue was caused by `container.preProcessor` does not have a field `CreatedAt` (only `Created`).

**- How I did it**

This fix fixes this issue by adding a `CreatedAt()` in `preProcessor`.

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

![de97a04c8bb56c568b1095e4a014bfb1](https://cloud.githubusercontent.com/assets/6932348/20239084/1d7b6fe6-a8ad-11e6-949e-b695f10abf87.jpg)


This fix fixes #28337.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>