### PR TITLE
Fix issue with missing fields for `ps` template

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -62,18 +62,17 @@ func newListCommand(dockerCli *command.DockerCli) *cobra.Command {
 type preProcessor struct {
 	types.Container
 	opts *types.ContainerListOptions
+
+	// Fields that need to exist so the template doesn't error out
+	// These are needed since they are available on the final object but are not
+	// fields in types.Container
+	// TODO(cpuguy83): this seems rather broken
+	Networks, CreatedAt, RunningFor bool
 }
 
 // Size sets the size option when called by a template execution.
 func (p *preProcessor) Size() bool {
 	p.opts.Size = true
-	return true
-}
-
-// Networks does nothing but return true.
-// It is needed to avoid the template check to fail as this field
-// doesn't exist in `types.Container`
-func (p *preProcessor) Networks() bool {
 	return true
 }
 

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -370,3 +370,29 @@ func TestContainerContextWriteJSONField(t *testing.T) {
 		assert.Equal(t, s, containers[i].ID)
 	}
 }
+
+func TestContainerBackCompat(t *testing.T) {
+	containers := []types.Container{types.Container{ID: "brewhaha"}}
+	cases := []string{
+		"ID",
+		"Names",
+		"Image",
+		"Command",
+		"CreatedAt",
+		"RunningFor",
+		"Ports",
+		"Status",
+		"Size",
+		"Labels",
+		"Mounts",
+	}
+	buf := bytes.NewBuffer(nil)
+	for _, c := range cases {
+		ctx := Context{Format: Format(fmt.Sprintf("{{ .%s }}", c)), Output: buf}
+		if err := ContainerWrite(ctx, containers); err != nil {
+			t.Log("could not render template for field '%s': %v", c, err)
+			t.Fail()
+		}
+		buf.Reset()
+	}
+}


### PR DESCRIPTION
Fixes #28337 
Fields exposed in the old formatter did not make it to the new formatter.

In addition, I also have some concerns exposing `types.Container` as a top-level item in the formatter. See #28339