### PR TITLE
Add bash completion for `docker build --network`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1912,6 +1912,7 @@ _docker_image_build() {
 		--label
 		--memory -m
 		--memory-swap
+		--network
 		--shm-size
 		--tag -t
 		--ulimit
@@ -1942,6 +1943,20 @@ _docker_image_build() {
 			;;
 		--isolation)
 			__docker_complete_isolation
+			return
+			;;
+		--network)
+			case "$cur" in
+				container:*)
+					__docker_complete_containers_all --cur "${cur#*:}"
+					;;
+				*)
+					COMPREPLY=( $( compgen -W "$(__docker_plugins --type Network) $(__docker_networks) container:" -- "$cur") )
+					if [ "${COMPREPLY[*]}" = "container:" ] ; then
+						__docker_nospace
+					fi
+					;;
+			esac
 			return
 			;;
 		--tag|-t)


### PR DESCRIPTION
Ref: #27702

Completion is the same as for `docker run --network`. Is that correct?

Please schedule for 1.13.0
Ping @sdurrheimer for zsh completion