### PR TITLE
Add bash completion for managing ports in services

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2648,6 +2648,7 @@ _docker_service_update() {
 			--hostname
 			--mode
 			--name
+			--port
 		"
 
 		case "$prev" in
@@ -2673,6 +2674,8 @@ _docker_service_update() {
 			--group-add
 			--group-rm
 			--image
+			--port-add
+			--port-rm
 		"
 
 		case "$prev" in


### PR DESCRIPTION
Ref: #27917

Bash completion for

- `docker service create --port`
- `docker service update --port-{add,rm}`

Please schedule for 1.13.0
@thaJeztah This is still missing in the docs,
ping @sdurrheimer for zsh completion