### PR TITLE
Fix missing versions in example requests of api docs

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1044,7 +1044,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.18/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1462,7 +1462,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.18/images/test HTTP/1.1
 
 **Example response**:
 
@@ -1765,7 +1765,7 @@ Docker images report the following events:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.18/events?since=1374067924
 
 **Example response**:
 
@@ -1807,7 +1807,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.18/images/ubuntu/get
 
 **Example response**:
 
@@ -1836,7 +1836,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.18/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -1859,7 +1859,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.18/images/load
     Content-Type: application/x-tar
 
     Tarball in body

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1083,7 +1083,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.19/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1528,7 +1528,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.19/images/test HTTP/1.1
 
 **Example response**:
 
@@ -1845,7 +1845,7 @@ Docker images report the following events:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.19/events?since=1374067924
 
 **Example response**:
 
@@ -1887,7 +1887,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.19/images/ubuntu/get
 
 **Example response**:
 
@@ -1916,7 +1916,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.19/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -1939,7 +1939,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.19/images/load
     Content-Type: application/x-tar
 
     Tarball in body

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1090,7 +1090,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.20/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1235,7 +1235,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    PUT /v1.20/containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
     {% raw %}
@@ -1682,7 +1682,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.20/images/test HTTP/1.1
 
 **Example response**:
 
@@ -2000,7 +2000,7 @@ Docker images report the following events:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.20/events?since=1374067924
 
 **Example response**:
 
@@ -2042,7 +2042,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.20/images/ubuntu/get
 
 **Example response**:
 
@@ -2071,7 +2071,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.20/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -2094,7 +2094,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.20/images/load
     Content-Type: application/x-tar
 
     Tarball in body

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1173,7 +1173,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.21/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1318,7 +1318,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    PUT /v1.21/containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
     {% raw %}
@@ -1835,7 +1835,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.21/images/test HTTP/1.1
 
 **Example response**:
 
@@ -2155,7 +2155,7 @@ Docker images report the following events:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.21/events?since=1374067924
 
 **Example response**:
 
@@ -2198,7 +2198,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.21/images/ubuntu/get
 
 **Example response**:
 
@@ -2227,7 +2227,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.21/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -2250,7 +2250,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.21/images/load
     Content-Type: application/x-tar
 
     Tarball in body
@@ -2637,7 +2637,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    DELETE /volumes/tardis HTTP/1.1
+    DELETE /v1.21/volumes/tardis HTTP/1.1
 
 **Example response**:
 
@@ -2912,7 +2912,7 @@ Instruct the driver to remove the network (`id`).
 
 **Example request**:
 
-    DELETE /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
+    DELETE /v1.21/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.22.md
+++ b/docs/reference/api/docker_remote_api_v1.22.md
@@ -1349,7 +1349,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.22/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1494,7 +1494,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    PUT /v1.22/containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
     {% raw %}
@@ -2049,7 +2049,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.22/images/test HTTP/1.1
 
 **Example response**:
 
@@ -2394,7 +2394,7 @@ Docker networks report the following events:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.22/events?since=1374067924
 
 **Example response**:
 
@@ -2586,7 +2586,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.22/images/ubuntu/get
 
 **Example response**:
 
@@ -2615,7 +2615,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.22/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -2638,7 +2638,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.22/images/load
     Content-Type: application/x-tar
 
     Tarball in body
@@ -2947,7 +2947,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    DELETE /volumes/tardis HTTP/1.1
+    DELETE /v1.22/volumes/tardis HTTP/1.1
 
 **Example response**:
 
@@ -3247,7 +3247,7 @@ Instruct the driver to remove the network (`id`).
 
 **Example request**:
 
-    DELETE /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
+    DELETE /v1.22/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.23.md
+++ b/docs/reference/api/docker_remote_api_v1.23.md
@@ -1384,7 +1384,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.23/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1529,7 +1529,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    PUT /v1.23/containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
     {% raw %}
@@ -2092,7 +2092,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.23/images/test HTTP/1.1
 
 **Example response**:
 
@@ -2444,7 +2444,7 @@ Docker networks report the following events:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.23/events?since=1374067924
 
 **Example response**:
 
@@ -2636,7 +2636,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.23/images/ubuntu/get
 
 **Example response**:
 
@@ -2665,7 +2665,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.23/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -2688,7 +2688,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.23/images/load
     Content-Type: application/x-tar
 
     Tarball in body
@@ -3005,7 +3005,7 @@ Return low-level information on the volume `name`
 
 **Example request**:
 
-    GET /volumes/tardis
+    GET /v1.23/volumes/tardis
 
 **Example response**:
 
@@ -3036,7 +3036,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    DELETE /volumes/tardis HTTP/1.1
+    DELETE /v1.23/volumes/tardis HTTP/1.1
 
 **Example response**:
 
@@ -3364,7 +3364,7 @@ Instruct the driver to remove the network (`id`).
 
 **Example request**:
 
-    DELETE /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
+    DELETE /v1.23/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.24.md
+++ b/docs/reference/api/docker_remote_api_v1.24.md
@@ -1411,7 +1411,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.24/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1524,7 +1524,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    PUT /v1.24/containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
     {% raw %}
@@ -2088,7 +2088,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.24/images/test HTTP/1.1
 
 **Example response**:
 
@@ -2453,7 +2453,7 @@ Docker daemon report the following event:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.24/events?since=1374067924
 
 **Example response**:
 
@@ -2646,7 +2646,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.24/images/ubuntu/get
 
 **Example response**:
 
@@ -2675,7 +2675,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.24/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -2698,7 +2698,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.24/images/load
     Content-Type: application/x-tar
 
     Tarball in body
@@ -3030,7 +3030,7 @@ Return low-level information on the volume `name`
 
 **Example request**:
 
-    GET /volumes/tardis
+    GET /v1.24/volumes/tardis
 
 **Example response**:
 
@@ -3082,7 +3082,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    DELETE /volumes/tardis HTTP/1.1
+    DELETE /v1.24/volumes/tardis HTTP/1.1
 
 **Example response**:
 
@@ -3414,7 +3414,7 @@ Instruct the driver to remove the network (`id`).
 
 **Example request**:
 
-    DELETE /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
+    DELETE /v1.24/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
 
 **Example response**:
 
@@ -3818,7 +3818,7 @@ Removes a plugin
 **Example request**:
 
 ```
-DELETE /plugins/tiborvass/no-remove:latest HTTP/1.1
+DELETE /v1.24/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4053,7 +4053,7 @@ Remove a node [`id`] from the swarm.
 
 **Example request**:
 
-    DELETE /nodes/24ifsmvkjbyhk HTTP/1.1
+    DELETE /v1.24/nodes/24ifsmvkjbyhk HTTP/1.1
 
 **Example response**:
 
@@ -4693,7 +4693,7 @@ Stop and remove the service `id`
 
 **Example request**:
 
-    DELETE /services/16253994b7c4 HTTP/1.1
+    DELETE /v1.24/services/16253994b7c4 HTTP/1.1
 
 **Example response**:
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -1467,7 +1467,7 @@ Remove the container `id` from the filesystem
 
 **Example request**:
 
-    DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+    DELETE /v1.25/containers/16253994b7c4?v=1 HTTP/1.1
 
 **Example response**:
 
@@ -1580,7 +1580,7 @@ Upload a tar archive to be extracted to a path in the filesystem of container
 
 **Example request**:
 
-    PUT /containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
+    PUT /v1.25/containers/8cce319429b2/archive?path=/vol1 HTTP/1.1
     Content-Type: application/x-tar
 
     {% raw %}
@@ -2272,7 +2272,7 @@ Remove the image `name` from the filesystem
 
 **Example request**:
 
-    DELETE /images/test HTTP/1.1
+    DELETE /v1.25/images/test HTTP/1.1
 
 **Example response**:
 
@@ -2898,7 +2898,7 @@ Docker daemon report the following event:
 
 **Example request**:
 
-    GET /events?since=1374067924
+    GET /v1.25/events?since=1374067924
 
 **Example response**:
 
@@ -3091,7 +3091,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/ubuntu/get
+    GET /v1.25/images/ubuntu/get
 
 **Example response**:
 
@@ -3120,7 +3120,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+    GET /v1.25/images/get?names=myname%2Fmyapp%3Alatest&names=busybox
 
 **Example response**:
 
@@ -3143,7 +3143,7 @@ See the [image tarball format](#image-tarball-format) for more details.
 
 **Example request**
 
-    POST /images/load
+    POST /v1.25/images/load
     Content-Type: application/x-tar
 
     Tarball in body
@@ -3490,7 +3490,7 @@ Return low-level information on the volume `name`
 
 **Example request**:
 
-    GET /volumes/tardis
+    GET /v1.25/volumes/tardis
 
 **Example response**:
 
@@ -3547,7 +3547,7 @@ Instruct the driver to remove the volume (`name`).
 
 **Example request**:
 
-    DELETE /volumes/tardis HTTP/1.1
+    DELETE /v1.25/volumes/tardis HTTP/1.1
 
 **Example response**:
 
@@ -3920,7 +3920,7 @@ Instruct the driver to remove the network (`id`).
 
 **Example request**:
 
-    DELETE /networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
+    DELETE /v1.25/networks/22be93d5babb089c5aab8dbc369042fad48ff791584ca2da2100db837a1c7c30 HTTP/1.1
 
 **Example response**:
 
@@ -4296,7 +4296,7 @@ Content-Type: application/json
 **Example request**:
 
 
-    POST /plugins/tiborvass/no-remove/set
+    POST /v1.25/plugins/tiborvass/no-remove/set
     Content-Type: application/json
 
     ["DEBUG=1"]
@@ -4375,7 +4375,7 @@ Removes a plugin
 **Example request**:
 
 ```
-DELETE /plugins/tiborvass/no-remove:latest HTTP/1.1
+DELETE /v1.25/plugins/tiborvass/no-remove:latest HTTP/1.1
 ```
 
 The `:latest` tag is optional, and is used as default if omitted.
@@ -4653,7 +4653,7 @@ Remove a node [`id`] from the swarm.
 
 **Example request**:
 
-    DELETE /nodes/24ifsmvkjbyhk HTTP/1.1
+    DELETE /v1.25/nodes/24ifsmvkjbyhk HTTP/1.1
 
 **Example response**:
 
@@ -5367,7 +5367,7 @@ Stop and remove the service `id`
 
 **Example request**:
 
-    DELETE /services/16253994b7c4 HTTP/1.1
+    DELETE /v1.25/services/16253994b7c4 HTTP/1.1
 
 **Example response**:
 
@@ -5639,7 +5639,7 @@ Get `stdout` and `stderr` logs from the service ``id``
 
 **Example request**:
 
-     GET /services/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
+     GET /v1.25/services/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=1428990821 HTTP/1.1
 
 **Example response**:
 
@@ -5988,7 +5988,7 @@ List secrets
 
 **Example request**:
 
-    GET /secrets HTTP/1.1
+    GET /v1.25/secrets HTTP/1.1
 
 **Example response**:
 
@@ -6026,7 +6026,7 @@ Create a secret
 
 **Example request**:
 
-    POST /secrets/create HTTP/1.1
+    POST /v1.25/secrets/create HTTP/1.1
     Content-Type: application/json
 
     {
@@ -6066,7 +6066,7 @@ Get details on a secret
 
 **Example request**:
 
-    GET /secrets/ktnbjxoalbkvbvedmg1urrz8h HTTP/1.1
+    GET /v1.25/secrets/ktnbjxoalbkvbvedmg1urrz8h HTTP/1.1
 
 **Example response**:
 
@@ -6098,7 +6098,7 @@ Remove the secret `id` from the secret store
 
 **Example request**:
 
-    DELETE /secrets/ktnbjxoalbkvbvedmg1urrz8h HTTP/1.1
+    DELETE /v1.25/secrets/ktnbjxoalbkvbvedmg1urrz8h HTTP/1.1
 
 **Example response**:
 


### PR DESCRIPTION
It is now required to have version prefix for all the remote APIs. Though there are still quite a few example requests in api docs that does not have the version prefix.

This fix update the remote api docs to address this issue.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>