### PR TITLE
cache partial downloads from docker pull

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -470,13 +470,23 @@ type Runtime struct {
 	Args []string `json:"runtimeArgs,omitempty"`
 }
 
+// DownloadCacheUsage contains information about the disk usage of the download
+// cache
+type DownloadCacheUsage struct {
+	TotalNumber  int64
+	TotalBytes   int64
+	ActiveNumber int64
+	ActiveBytes  int64
+}
+
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {
-	LayersSize int64
-	Images     []*ImageSummary
-	Containers []*Container
-	Volumes    []*Volume
+	LayersSize         int64
+	Images             []*ImageSummary
+	DownloadCacheUsage DownloadCacheUsage
+	Containers         []*Container
+	Volumes            []*Volume
 }
 
 // ContainersPruneReport contains the response for Engine API:
@@ -496,7 +506,9 @@ type VolumesPruneReport struct {
 // ImagesPruneReport contains the response for Engine API:
 // POST "/images/prune"
 type ImagesPruneReport struct {
-	ImagesDeleted  []ImageDeleteResponseItem
+	ImagesDeleted       []ImageDeleteResponseItem
+	CacheSpaceReclaimed uint64
+	// SpaceReclaimed is a total, including CacheSpaceReclaimed
 	SpaceReclaimed uint64
 }
 

--- a/cli/command/formatter/disk_usage_test.go
+++ b/cli/command/formatter/disk_usage_test.go
@@ -19,13 +19,14 @@ func TestDiskUsageContextFormatWrite(t *testing.T) {
 Images              0                   0                   0B                  0B
 Containers          0                   0                   0B                  0B
 Local Volumes       0                   0                   0B                  0B
+Download Cache      0                   0                   0B                  0B
 `,
 		},
 		{
 			DiskUsageContext{Verbose: true},
 			`Images space usage:
 
-REPOSITORY          TAG                 IMAGE ID            CREATED ago         SIZE                SHARED SIZE         UNIQUE SiZE         CONTAINERS
+REPOSITORY          TAG                 IMAGE ID            CREATED ago         SIZE                SHARED SIZE         UNIQUE SIZE         CONTAINERS
 
 Containers space usage:
 
@@ -34,6 +35,11 @@ CONTAINER ID        IMAGE               COMMAND             LOCAL VOLUMES       
 Local Volumes space usage:
 
 VOLUME NAME         LINKS               SIZE
+
+Download Cache space usage:
+
+TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
+Download Cache      0                   0                   0B                  0B
 `,
 		},
 	}

--- a/cli/command/system/df.go
+++ b/cli/command/system/df.go
@@ -43,11 +43,12 @@ func runDiskUsage(dockerCli *command.DockerCli, opts diskUsageOptions) error {
 		Context: formatter.Context{
 			Output: dockerCli.Out(),
 		},
-		LayersSize: du.LayersSize,
-		Images:     du.Images,
-		Containers: du.Containers,
-		Volumes:    du.Volumes,
-		Verbose:    opts.verbose,
+		LayersSize:         du.LayersSize,
+		Images:             du.Images,
+		DownloadCacheUsage: du.DownloadCacheUsage,
+		Containers:         du.Containers,
+		Volumes:            du.Volumes,
+		Verbose:            opts.verbose,
 	}
 
 	duCtx.Write()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -602,7 +602,7 @@ func NewDaemon(config *config.Config, registryService registry.Service, containe
 	}
 
 	logrus.Debugf("Max Concurrent Downloads: %d", *config.MaxConcurrentDownloads)
-	d.downloadManager = xfer.NewLayerDownloadManager(d.layerStore, *config.MaxConcurrentDownloads)
+	d.downloadManager = xfer.NewLayerDownloadManager(d.layerStore, *config.MaxConcurrentDownloads, func(m *xfer.LayerDownloadManager) { m.SetCacheDirManager(filepath.Join(config.Root, "incomplete")) })
 	logrus.Debugf("Max Concurrent Uploads: %d", *config.MaxConcurrentUploads)
 	d.uploadManager = xfer.NewLayerUploadManager(*config.MaxConcurrentUploads)
 

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -91,10 +91,14 @@ func (daemon *Daemon) SystemDiskUsage() (*types.DiskUsage, error) {
 
 	}
 
+	// Calculate download cache usage
+	downloadCacheUsage := daemon.downloadManager.CacheUsage()
+
 	return &types.DiskUsage{
-		LayersSize: allLayersSize,
-		Containers: allContainers,
-		Volumes:    allVolumes,
-		Images:     allImages,
+		LayersSize:         allLayersSize,
+		Containers:         allContainers,
+		Volumes:            allVolumes,
+		Images:             allImages,
+		DownloadCacheUsage: downloadCacheUsage,
 	}, nil
 }

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -85,18 +85,28 @@ func (daemon *Daemon) VolumesPrune(pruneFilters filters.Args) (*types.VolumesPru
 func (daemon *Daemon) ImagesPrune(pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
 	rep := &types.ImagesPruneReport{}
 
-	danglingOnly := true
-	if pruneFilters.Include("dangling") {
-		if pruneFilters.ExactMatch("dangling", "false") || pruneFilters.ExactMatch("dangling", "0") {
-			danglingOnly = false
-		} else if !pruneFilters.ExactMatch("dangling", "true") && !pruneFilters.ExactMatch("dangling", "1") {
-			return nil, fmt.Errorf("Invalid filter 'dangling=%s'", pruneFilters.Get("dangling"))
-		}
+	danglingOnly, err := getBoolFilterValue(pruneFilters, "dangling", true)
+	if err != nil {
+		return nil, err
 	}
 
 	until, err := getUntilFromPruneFilters(pruneFilters)
 	if err != nil {
 		return nil, err
+	}
+
+	keepDownloadCache, err := getBoolFilterValue(pruneFilters, "keep-download-cache", false)
+	if err != nil {
+		return nil, err
+	}
+
+	if !keepDownloadCache {
+		reclaimed, err := daemon.downloadManager.CollectGarbage()
+		if err != nil {
+			logrus.WithError(err).Warn("failed to clean up cache fully")
+		}
+		rep.CacheSpaceReclaimed = reclaimed
+		rep.SpaceReclaimed += reclaimed
 	}
 
 	var allImages map[image.ID]*image.Image
@@ -291,4 +301,18 @@ func getUntilFromPruneFilters(pruneFilters filters.Args) (time.Time, error) {
 	}
 	until = time.Unix(seconds, nanoseconds)
 	return until, nil
+}
+
+func getBoolFilterValue(pruneFilters filters.Args, name string, defaultValue bool) (bool, error) {
+	value := defaultValue
+	if pruneFilters.Include(name) {
+		if pruneFilters.ExactMatch(name, "false") || pruneFilters.ExactMatch(name, "0") {
+			value = false
+		} else if pruneFilters.ExactMatch(name, "true") || pruneFilters.ExactMatch(name, "1") {
+			value = true
+		} else {
+			return false, fmt.Errorf("invalid filter '%s=%s'", name, pruneFilters.Get(name))
+		}
+	}
+	return value, nil
 }

--- a/distribution/cachedir/manager.go
+++ b/distribution/cachedir/manager.go
@@ -1,0 +1,206 @@
+package cachedir
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// Manager handles the creation and deletion of cache directories and has a
+// very particular way of managing the cache. It was designed to be used by a
+// caller that manages the lifetime of the directories, but delegates the
+// mechanics of how to store and locate the directories to the Manager
+type Manager struct {
+	cacheRoot string
+	mu        sync.Mutex
+	inUse     map[digest.Digest]struct{}
+}
+
+// NewManager creates a new cachedir manager
+func NewManager(path string) *Manager {
+	return &Manager{
+		cacheRoot: path,
+		inUse:     map[digest.Digest]struct{}{},
+	}
+}
+
+func (m *Manager) cachePathForKeyHash(keyHash digest.Digest) string {
+	return filepath.Join(m.cacheRoot, keyHash.Algorithm().String(), keyHash.Hex())
+}
+
+func dirSize(path string) (uint64, error) {
+	var size uint64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if info != nil && !info.IsDir() {
+			size += uint64(info.Size())
+		}
+		return err
+	})
+	return size, err
+}
+
+func (m *Manager) sizeEstimateByKeyHash(keyHash digest.Digest) uint64 {
+	dir := m.cachePathForKeyHash(keyHash)
+	size, err := dirSize(dir)
+	if err != nil {
+		logrus.WithError(err).WithField("cachedir", dir).Warn("failed to determine size of directory")
+		return 0
+	}
+	return size
+}
+
+func (m *Manager) cleanUpByKeyHash(keyHash digest.Digest) error {
+	return os.RemoveAll(m.cachePathForKeyHash(keyHash))
+}
+
+// GetDir creates a new cache dir or returns an existing one if one already
+// exists for this key from a previous download. It also keeps track of how
+// many references were made to the cache dir during
+// ReleaseDir or DeleteDir have to be called exactly once per GetDir call
+// and GetDir shouldn't be called again until one or the other is called.
+func (m *Manager) GetDir(key string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	hashedKey := digest.FromString(key)
+	if _, ok := m.inUse[hashedKey]; ok {
+		panic(fmt.Errorf("tried to get a cachedir key (%s) twice without releasing/deleting", key))
+	}
+	m.inUse[hashedKey] = struct{}{}
+
+	return m.cachePathForKeyHash(hashedKey)
+}
+
+// ReleaseDir lets the Manager know that the dir is no longer in use but
+// should be kept around in case we need it again.
+func (m *Manager) ReleaseDir(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	hashedKey := digest.FromString(key)
+	if _, ok := m.inUse[hashedKey]; !ok {
+		panic(fmt.Errorf("tried to release a cachedir key (%s) without getting it first", key))
+	}
+	delete(m.inUse, hashedKey)
+}
+
+// DeleteDir lets the manager know that the dir is no longer used and can be
+// deleted. If the delete operation fails and returns an error, the key is
+// still considered released.
+func (m *Manager) DeleteDir(key string) error {
+	m.mu.Lock()
+	hashedKey := digest.FromString(key)
+	logrus.WithField("key", key).WithField("hashedKey", hashedKey).Debug("cachedir manager delete")
+	if _, ok := m.inUse[hashedKey]; !ok {
+		m.mu.Unlock()
+		panic(fmt.Errorf("tried to delete a cachedir key (%s) without getting it first", key))
+	}
+	delete(m.inUse, hashedKey)
+	m.mu.Unlock()
+	return m.cleanUpByKeyHash(hashedKey)
+}
+
+func (m *Manager) getAllKeyHashes() map[digest.Digest]struct{} {
+	allKeyHashes := map[digest.Digest]struct{}{}
+	algorithmDirs, err := ioutil.ReadDir(m.cacheRoot)
+	if err != nil {
+		if !strings.Contains(err.Error(), "no such file or directory") {
+			logrus.WithError(err).WithField("cacheRoot", m.cacheRoot).Warn("Failed to list cache root")
+		}
+	}
+	for _, algorithmDir := range algorithmDirs {
+		algorithmDirName := algorithmDir.Name()
+		algorithm := filepath.Base(algorithmDirName)
+		cacheDirs, err := ioutil.ReadDir(filepath.Join(m.cacheRoot, algorithm))
+		if err != nil {
+			logrus.WithError(err).WithField("cacheRoot", m.cacheRoot).WithField("algorithmDir", algorithmDir).Warn("Failed to list cache directory")
+		}
+		for _, cacheDir := range cacheDirs {
+			cacheDirName := cacheDir.Name()
+			keyHash := digest.NewDigestFromHex(algorithm, filepath.Base(cacheDirName))
+
+			// safety check to make sure we don't delete anything that's not a hash
+			// we created
+			err := keyHash.Validate()
+			if err != nil {
+				logrus.WithError(err).WithField("cachedir", cacheDirName).Debug("Ignoring unexpected cache directory")
+				continue
+			}
+
+			allKeyHashes[keyHash] = struct{}{}
+		}
+	}
+	return allKeyHashes
+}
+
+// Usage returns information about how much space the download cache is
+// using. If any directories or files are unreadable, we just log the
+// errors and don't count the files.
+func (m *Manager) Usage() types.DownloadCacheUsage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	allKeyHashes := m.getAllKeyHashes()
+
+	var total uint64
+	var active uint64
+	var totalBytes uint64
+	var activeBytes uint64
+	for keyHash := range allKeyHashes {
+		size := m.sizeEstimateByKeyHash(keyHash)
+		totalBytes += size
+		total++
+		if _, ok := m.inUse[keyHash]; ok {
+			active++
+			activeBytes += size
+		}
+	}
+
+	return types.DownloadCacheUsage{
+		TotalNumber:  int64(total),
+		ActiveNumber: int64(active),
+		TotalBytes:   int64(totalBytes),
+		ActiveBytes:  int64(activeBytes),
+	}
+}
+
+// CollectGarbage deletes all dirs that are not currently in use (ones that
+// don't have a GetDir without a matching ReleaseDir/DeleteDir call) and
+// returns the amount of space saved in bytes.
+func (m *Manager) CollectGarbage() (uint64, error) {
+	// safety check to make sure we don't try to delete files in / or pwd
+	if m.cacheRoot == "" {
+		return 0, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// mark
+	allKeyHashes := m.getAllKeyHashes()
+
+	// set subtraction allKeyHashes = allKeyHashes - c.inUse
+	for keyHash := range m.inUse {
+		delete(allKeyHashes, keyHash)
+	}
+
+	// sweep
+	var total uint64
+	errs := []string{}
+	for keyHash := range allKeyHashes {
+		total += m.sizeEstimateByKeyHash(keyHash)
+		err := m.cleanUpByKeyHash(keyHash)
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return total, fmt.Errorf("failed to delete some files during cachedir manager CollectGarbage: %s", strings.Join(errs, "; "))
+	}
+	return total, nil
+}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -194,7 +194,7 @@ func (d *mockDownloadDescriptor) mockTarStream() io.ReadCloser {
 }
 
 // Download is called to perform the download.
-func (d *mockDownloadDescriptor) Download(ctx context.Context, progressOutput progress.Output) (io.ReadCloser, int64, error) {
+func (d *mockDownloadDescriptor) Download(ctx context.Context, progressOutput progress.Output, cacheDir string) (io.ReadCloser, int64, error) {
 	if d.currentDownloads != nil {
 		defer atomic.AddInt32(d.currentDownloads, -1)
 

--- a/distribution/xfer/transfer.go
+++ b/distribution/xfer/transfer.go
@@ -31,7 +31,14 @@ type Watcher struct {
 	// running remains open as long as the watcher is watching the
 	// transfer. It gets closed if the transfer finishes or the
 	// watcher is detached.
-	running chan struct{}
+	running    chan struct{}
+	isOriginal bool
+}
+
+// IsOriginal is true when the download function will be called and false if the
+// watcher is just following an existing download
+func (w Watcher) IsOriginal() bool {
+	return w.isOriginal
 }
 
 // Transfer represents an in-progress transfer.
@@ -356,6 +363,7 @@ func (tm *transferManager) Transfer(key string, xferFunc DoFunc, progressOutput 
 	masterProgressChan := make(chan progress.Progress)
 	xfer := xferFunc(masterProgressChan, start, inactive)
 	watcher := xfer.Watch(progressOutput)
+	watcher.isOriginal = true
 	go xfer.Broadcast(masterProgressChan)
 	tm.transfers[key] = xfer
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -638,6 +638,9 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	if err := os.RemoveAll(filepath.Join(testEnv.DockerBasePath(), "image", s.d.StorageDriver(), "distribution")); err != nil {
 		c.Fatalf("error clearing distribution cache: %v", err)
 	}
+	if err := os.RemoveAll(filepath.Join(testEnv.DockerBasePath(), "incomplete_downloads")); err != nil {
+		c.Fatalf("error clearing incomplete_downloads: %v", err)
+	}
 
 	// Pull from the registry using the <name>@<digest> reference.
 	imageReference := fmt.Sprintf("%s@%s", repoName, manifestDigest)
@@ -680,6 +683,9 @@ func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	// Remove distribution cache to force a re-pull of the blobs
 	if err := os.RemoveAll(filepath.Join(testEnv.DockerBasePath(), "image", s.d.StorageDriver(), "distribution")); err != nil {
 		c.Fatalf("error clearing distribution cache: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(testEnv.DockerBasePath(), "incomplete_downloads")); err != nil {
+		c.Fatalf("error clearing incomplete_downloads: %v", err)
 	}
 
 	// Pull from the registry using the <name>@<digest> reference.

--- a/pkg/progress/progressreader.go
+++ b/pkg/progress/progressreader.go
@@ -31,6 +31,13 @@ func NewProgressReader(in io.ReadCloser, out Output, size int64, id, action stri
 	}
 }
 
+// SetOffset should be called before using the reader in order to set offset to
+// start displaying progress from. This is useful for showing the progress of
+// resumed operations such as resumed pulls.
+func (p *Reader) SetOffset(offset int64) {
+	p.current = offset
+}
+
 func (p *Reader) Read(buf []byte) (n int, err error) {
 	read, err := p.in.Read(buf)
 	p.current += int64(read)


### PR DESCRIPTION
fixes #26146

I'm much more confident in this PR than the previous one because it's much smaller. It basically worked on the first try since I had all the code and already understood the architecture.

**- What I did**
* [x] keep partial downloads accross daemon carshes, restarts and pull cancellations
* [x] use the cache dir for v1 pulls too even though they are not resumable
* [x] small refactors
* [x] print more progress info
* [x] make progress bars start half way through if they are resuming an operation
* [x] improve prune mechanism, report freed space

**- How I did it**
This is my second attempt. My first attempt in #28106 turned out to be way too complex. Now instead of caching partially downloaded manifests and downloads separately, I'm managing the lifetime of the cache form the layer download manager and giving the descriptors a cache directory to use. I also separated the details of managing the cache directory into a separate package to simplify the logic a bit.

**- How to verify it**
Lots of pulling of big images and ctrl+c-ing, pruning, etc..

**- Description for the changelog**
Keep partial download caches from failed pulls

**- A picture of a cute animal (not mandatory but encouraged)**
![](http://www.thinkcats.com/250-wide-images/cat-opening-door-handle.png)