### PR TITLE
add missing status code of swarm cluster in api 1.24

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -56,7 +56,7 @@ info:
 
     Docker version  | API version | Changes
     ----------------|-------------|---------
-    1.13.x | [1.25](https://docs.docker.com/engine/api/v1.25/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-24-api-changes)
+    1.13.x | [1.25](https://docs.docker.com/engine/api/v1.25/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-25-api-changes)
     1.12.x | [1.24](https://docs.docker.com/engine/api/v1.24/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-24-api-changes)
     1.11.x | [1.23](https://docs.docker.com/engine/api/v1.23/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-23-api-changes)
     1.10.x | [1.22](https://docs.docker.com/engine/api/v1.22/) | [API changes](https://docs.docker.com/engine/api/version-history/#v1-22-api-changes)

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -3962,8 +3962,9 @@ List nodes
 
 **Status codes**:
 
-- **200** – no error
-- **500** – server error
+-   **200** – no error
+-   **406** - node is not part of a swarm
+-   **500** – server error
 
 #### Inspect a node
 
@@ -4045,6 +4046,7 @@ Return low-level information on the node `id`
 
 -   **200** – no error
 -   **404** – no such node
+-   **406** – node is not part of a swarm
 -   **500** – server error
 
 #### Remove a node
@@ -4073,6 +4075,7 @@ Remove a node from the swarm.
 
 -   **200** – no error
 -   **404** – no such node
+-   **406** – node is not part of a swarm 
 -   **500** – server error
 
 #### Update a node
@@ -4128,6 +4131,7 @@ JSON Parameters:
 
 -   **200** – no error
 -   **404** – no such node
+-   **406** – node is not part of a swarm
 -   **500** – server error
 
 ### 3.8 Swarm
@@ -4178,7 +4182,9 @@ Inspect swarm
 
 **Status codes**:
 
-- **200** - no error
+-   **200** - no error
+-   **406** – node is not part of a swarm
+-   **500** - sever error
 
 #### Initialize a new swarm
 
@@ -4216,9 +4222,10 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
 
 **Status codes**:
 
-- **200** – no error
-- **400** – bad parameter
-- **406** – node is already part of a swarm
+-   **200** – no error
+-   **400** – bad parameter
+-   **406** – node is already part of a swarm
+-   **500** - server error
 
 JSON Parameters:
 
@@ -4282,9 +4289,10 @@ Join an existing swarm
 
 **Status codes**:
 
-- **200** – no error
-- **400** – bad parameter
-- **406** – node is already part of a swarm
+-   **200** – no error
+-   **400** – bad parameter
+-   **406** – node is already part of a swarm
+-   **500** - server error
 
 JSON Parameters:
 
@@ -4321,8 +4329,9 @@ Leave a swarm
 
 **Status codes**:
 
-- **200** – no error
-- **406** – node is not part of a swarm
+-  **200** – no error
+-  **406** – node is not part of a swarm
+-  **500** - server error
 
 #### Update a swarm
 
@@ -4374,9 +4383,10 @@ Update a swarm
 
 **Status codes**:
 
-- **200** – no error
-- **400** – bad parameter
-- **406** – node is not part of a swarm
+-   **200** – no error
+-   **400** – bad parameter
+-   **406** – node is not part of a swarm
+-   **500** - server error
 
 JSON Parameters:
 
@@ -4511,8 +4521,9 @@ List services
 
 **Status codes**:
 
-- **200** – no error
-- **500** – server error
+-   **200** – no error
+-   **406** – node is not part of a swarm
+-   **500** – server error
 
 #### Create a service
 
@@ -4606,9 +4617,10 @@ image](#create-an-image) section for more details.
 
 **Status codes**:
 
-- **201** – no error
-- **406** – server error or node is not part of a swarm
-- **409** – name conflicts with an existing object
+-   **201** – no error
+-   **406** – node is not part of a swarm
+-   **409** – name conflicts with an existing object
+-   **500** - server error
 
 **JSON Parameters**:
 
@@ -4708,6 +4720,7 @@ Stop and remove the service `id`
 
 -   **200** – no error
 -   **404** – no such service
+-   **406** - node is not part of a swarm
 -   **500** – server error
 
 #### Inspect one or more services
@@ -4797,6 +4810,7 @@ Return information on the service `id`.
 
 -   **200** – no error
 -   **404** – no such service
+-   **406** - node is not part of a swarm
 -   **500** – server error
 
 #### Update a service
@@ -4930,6 +4944,7 @@ image](#create-an-image) section for more details.
 
 -   **200** – no error
 -   **404** – no such service
+-   **406** - node is not part of a swarm
 -   **500** – server error
 
 ### 3.10 Tasks
@@ -5131,15 +5146,16 @@ List tasks
 
 **Status codes**:
 
-- **200** – no error
-- **500** – server error
+-   **200** – no error
+-   **406** - node is not part of a swarm
+-   **500** – server error
 
 #### Inspect a task
 
 
-`GET /tasks/(task id)`
+`GET /tasks/(id)`
 
-Get details on a task
+Get details on the task `id`
 
 **Example request**:
 
@@ -5233,9 +5249,10 @@ Get details on a task
 
 **Status codes**:
 
-- **200** – no error
-- **404** – unknown task
-- **500** – server error
+-   **200** – no error
+-   **404** – unknown task
+-   **406** - node is not part of a swarm
+-   **500** – server error
 
 ## 4. Going further
 


### PR DESCRIPTION
In the api docs, I found that some status codes daemon side returns are also very important.
These codes have already been implemented by the daemon, while are missing in the API docs.

Since 1.12 is born, these status codes are already implemented. Now 1.12 has been frozen, api 1.24 doc still has  these missing status codes which needs added.

Although status code 406 may be some kind of improper which needs more discussion, I think 1.13 still bears 406 one of the missing status code. Afterwards, we will go further to discuss more about the more accurate one.

**- What I did**
1. Add missing status codes in the API docs 1.24 in the aspect of swam cluster.

Signed-off-by: allencloud <allen.sun@daocloud.io>