### PR TITLE
judge manager before getting secret

### DIFF
--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -9,6 +9,13 @@ import (
 
 // GetSecret returns a secret from a managed swarm cluster
 func (c *Cluster) GetSecret(id string) (types.Secret, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !c.isActiveManager() {
+		return types.Secret{}, c.errNoManager()
+	}
+
 	ctx, cancel := c.getRequestContext()
 	defer cancel()
 

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -6060,9 +6060,9 @@ Create a secret
 
 ### Inspect a secret
 
-`GET /secrets/(secret id)`
+`GET /secrets/(id)`
 
-Get details on a secret
+Get details on the secret `id`
 
 **Example request**:
 
@@ -6088,6 +6088,7 @@ Get details on a secret
 
 - **200** – no error
 - **404** – unknown secret
+- **406** – node is not part of a swarm
 - **500** – server error
 
 ### Remove a secret


### PR DESCRIPTION
Getting secret needs docker daemon to be a manager.

Then this PR add the daemon role judging (whether this is a manager) before getting secret.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>