### PR TITLE
remove field Name from NodeSpec

### DIFF
--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -19,9 +19,9 @@ type Node struct {
 
 // NodeSpec represents the spec of a node.
 type NodeSpec struct {
-	Annotations
-	Role         NodeRole         `json:",omitempty"`
-	Availability NodeAvailability `json:",omitempty"`
+	Role         NodeRole          `json:",omitempty"`
+	Availability NodeAvailability  `json:",omitempty"`
+	Labels       map[string]string `json:",omitempty"`
 }
 
 // NodeRole represents the role of a node.

--- a/cli/command/idresolver/idresolver.go
+++ b/cli/command/idresolver/idresolver.go
@@ -33,9 +33,6 @@ func (r *IDResolver) get(ctx context.Context, t interface{}, id string) (string,
 		if err != nil {
 			return id, nil
 		}
-		if node.Spec.Annotations.Name != "" {
-			return node.Spec.Annotations.Name, nil
-		}
 		if node.Description.Hostname != "" {
 			return node.Description.Hostname, nil
 		}

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -81,7 +81,6 @@ func printHumanFriendly(out io.Writer, refs []string, getRef inspect.GetRefFunc)
 // TODO: use a template
 func printNode(out io.Writer, node swarm.Node) {
 	fmt.Fprintf(out, "ID:\t\t\t%s\n", node.ID)
-	ioutils.FprintfIfNotEmpty(out, "Name:\t\t\t%s\n", node.Spec.Name)
 	if node.Spec.Labels != nil {
 		fmt.Fprintln(out, "Labels:")
 		for k, v := range node.Spec.Labels {

--- a/cli/command/node/opts.go
+++ b/cli/command/node/opts.go
@@ -10,29 +10,21 @@ import (
 )
 
 type nodeOptions struct {
-	annotations
+	labels       opts.ListOpts
 	role         string
 	availability string
 }
 
-type annotations struct {
-	name   string
-	labels opts.ListOpts
-}
-
 func newNodeOptions() *nodeOptions {
 	return &nodeOptions{
-		annotations: annotations{
-			labels: opts.NewListOpts(nil),
-		},
+		labels: opts.NewListOpts(nil),
 	}
 }
 
 func (opts *nodeOptions) ToNodeSpec() (swarm.NodeSpec, error) {
 	var spec swarm.NodeSpec
 
-	spec.Annotations.Name = opts.annotations.name
-	spec.Annotations.Labels = runconfigopts.ConvertKVStringsToMap(opts.annotations.labels.GetAll())
+	spec.Labels = runconfigopts.ConvertKVStringsToMap(opts.labels.GetAll())
 
 	switch swarm.NodeRole(strings.ToLower(opts.role)) {
 	case swarm.NodeRoleWorker:

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -33,7 +33,7 @@ func newUpdateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&nodeOpts.role, flagRole, "", "Role of the node (worker/manager)")
 	flags.StringVar(&nodeOpts.availability, flagAvailability, "", "Availability of the node (active/pause/drain)")
-	flags.Var(&nodeOpts.annotations.labels, flagLabelAdd, "Add or update a node label (key=value)")
+	flags.Var(&nodeOpts.labels, flagLabelAdd, "Add or update a node label (key=value)")
 	labelKeys := opts.NewListOpts(nil)
 	flags.Var(&labelKeys, flagLabelRemove, "Remove a node label if exists")
 	return cmd
@@ -90,23 +90,23 @@ func mergeNodeUpdate(flags *pflag.FlagSet) func(*swarm.Node) error {
 			}
 			spec.Availability = swarm.NodeAvailability(str)
 		}
-		if spec.Annotations.Labels == nil {
-			spec.Annotations.Labels = make(map[string]string)
+		if spec.Labels == nil {
+			spec.Labels = make(map[string]string)
 		}
 		if flags.Changed(flagLabelAdd) {
 			labels := flags.Lookup(flagLabelAdd).Value.(*opts.ListOpts).GetAll()
 			for k, v := range runconfigopts.ConvertKVStringsToMap(labels) {
-				spec.Annotations.Labels[k] = v
+				spec.Labels[k] = v
 			}
 		}
 		if flags.Changed(flagLabelRemove) {
 			keys := flags.Lookup(flagLabelRemove).Value.(*opts.ListOpts).GetAll()
 			for _, k := range keys {
 				// if a key doesn't exist, fail the command explicitly
-				if _, exists := spec.Annotations.Labels[k]; !exists {
+				if _, exists := spec.Labels[k]; !exists {
 					return fmt.Errorf("key %s doesn't exist in node's labels", k)
 				}
-				delete(spec.Annotations.Labels, k)
+				delete(spec.Labels, k)
 			}
 		}
 		return nil

--- a/daemon/cluster/convert/node.go
+++ b/daemon/cluster/convert/node.go
@@ -29,8 +29,6 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 	node.CreatedAt, _ = ptypes.Timestamp(n.Meta.CreatedAt)
 	node.UpdatedAt, _ = ptypes.Timestamp(n.Meta.UpdatedAt)
 
-	//Annotations
-	node.Spec.Name = n.Spec.Annotations.Name
 	node.Spec.Labels = n.Spec.Annotations.Labels
 
 	//Description
@@ -69,7 +67,6 @@ func NodeFromGRPC(n swarmapi.Node) types.Node {
 func NodeSpecToGRPC(s types.NodeSpec) (swarmapi.NodeSpec, error) {
 	spec := swarmapi.NodeSpec{
 		Annotations: swarmapi.Annotations{
-			Name:   s.Name,
 			Labels: s.Labels,
 		},
 	}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -434,13 +434,13 @@ func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintLabel(c *check.C) {
 
 	// add labels to nodes
 	daemons[0].updateNode(c, nodes[0].ID, func(n *swarm.Node) {
-		n.Spec.Annotations.Labels = map[string]string{
+		n.Spec.Labels = map[string]string{
 			"security": "high",
 		}
 	})
 	for i := 1; i < nodeCount; i++ {
 		daemons[0].updateNode(c, nodes[i].ID, func(n *swarm.Node) {
-			n.Spec.Annotations.Labels = map[string]string{
+			n.Spec.Labels = map[string]string{
 				"security": "low",
 			}
 		})
@@ -504,7 +504,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServiceConstraintLabel(c *check.C) {
 	}
 	// make nodes[1] fulfills the constraints
 	daemons[0].updateNode(c, nodes[1].ID, func(n *swarm.Node) {
-		n.Spec.Annotations.Labels = map[string]string{
+		n.Spec.Labels = map[string]string{
 			"security": "high",
 		}
 	})


### PR DESCRIPTION
fixes #28351 

I think field `Name` in `NodeSpec` is not used. Then I try to remove this part.

If the design is OK, I am afraid we still need to remove that from swarmkit side.

**- What I did**
1. remove field `Name` from `NodeSpec`;
2. changed some typos in API doc 1.24;
3. remove node name update part from API doc 1.25.


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>