### PR TITLE
Change the docker-tag usage text to be clearer

### DIFF
--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -18,8 +18,8 @@ func NewTagCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts tagOptions
 
 	cmd := &cobra.Command{
-		Use:   "tag IMAGE[:TAG] IMAGE[:TAG]",
-		Short: "Tag an image into a repository",
+		Use:   "tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
+		Short: "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.image = args[0]

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -16,9 +16,9 @@ keywords: "tag, name, image"
 # tag
 
 ```markdown
-Usage:  docker tag IMAGE[:TAG] IMAGE[:TAG]
+Usage:  docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]
 
-Tag an image into a repository
+Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
 
 Options:
       --help   Print usage

--- a/man/docker-tag.1.md
+++ b/man/docker-tag.1.md
@@ -2,12 +2,12 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-tag - Tag an image into a repository
+docker-tag - Create a tag `TARGET_IMAGE` that refers to `SOURCE_IMAGE`
 
 # SYNOPSIS
 **docker tag**
 [**--help**]
-NAME[:TAG] NAME[:TAG]
+SOURCE_NAME[:TAG] TARGET_NAME[:TAG]
 
 # DESCRIPTION
 Assigns a new alias to an image in a registry. An alias refers to the


### PR DESCRIPTION
**- What I did**
Changed the tag command usage text to be clearer regarding the order of the images.
Closes #28204

**- How I did it**
Changed the `Use` field at `cobra.Command` in cli/command/image/tag.go

**- How to verify it**
Run
```shell
$ docker tag --help
```

and expect to get:

```shell
Usage:  docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]

Create a tag in the TARGET_IMAGE repository that refers to SOURCE_IMAGE

Options:
      --help   Print usage
```