### PR TITLE
fix t.Errorf to t.Error in serveral _test.go

### DIFF
--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -23,10 +23,10 @@ func TestParseArgs(t *testing.T) {
 		}
 	}
 	if len(args.Get("created")) != 1 {
-		t.Errorf("failed to set this arg")
+		t.Error("failed to set this arg")
 	}
 	if len(args.Get("image.name")) != 2 {
-		t.Errorf("the args should have collapsed")
+		t.Error("the args should have collapsed")
 	}
 }
 
@@ -147,7 +147,7 @@ func TestEmpty(t *testing.T) {
 		t.Errorf("%s", err)
 	}
 	if a.Len() != v1.Len() {
-		t.Errorf("these should both be empty sets")
+		t.Error("these should both be empty sets")
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -102,11 +102,11 @@ func TestNewEnvClient(t *testing.T) {
 			// pedantic checking that this is handled correctly
 			tr := apiclient.client.Transport.(*http.Transport)
 			if tr.TLSClientConfig == nil {
-				t.Errorf("no tls config found when DOCKER_TLS_VERIFY enabled")
+				t.Error("no tls config found when DOCKER_TLS_VERIFY enabled")
 			}
 
 			if tr.TLSClientConfig.InsecureSkipVerify {
-				t.Errorf("tls verification should be enabled")
+				t.Error("tls verification should be enabled")
 			}
 		}
 

--- a/daemon/graphdriver/btrfs/version_test.go
+++ b/daemon/graphdriver/btrfs/version_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestLibVersion(t *testing.T) {
 	if btrfsLibVersion() <= 0 {
-		t.Errorf("expected output from btrfs lib version > 0")
+		t.Error("expected output from btrfs lib version > 0")
 	}
 }

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -35,7 +35,7 @@ func TestNoneHealthcheck(t *testing.T) {
 
 	daemon.initHealthMonitor(c)
 	if c.State.Health != nil {
-		t.Errorf("Expecting Health to be nil, but was not")
+		t.Error("Expecting Health to be nil, but was not")
 	}
 }
 

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -50,7 +50,7 @@ func TestMapOpts(t *testing.T) {
 		t.Errorf("max-size = %s != 1", tmpMap["max-size"])
 	}
 	if o.Set("dummy-val=3") == nil {
-		t.Errorf("validator is not being called")
+		t.Error("validator is not being called")
 	}
 }
 

--- a/pkg/httputils/mimetype_test.go
+++ b/pkg/httputils/mimetype_test.go
@@ -8,6 +8,6 @@ func TestDetectContentType(t *testing.T) {
 	input := []byte("That is just a plain text")
 
 	if contentType, _, err := DetectContentType(input); err != nil || contentType != "text/plain" {
-		t.Errorf("TestDetectContentType failed")
+		t.Error("TestDetectContentType failed")
 	}
 }

--- a/pkg/httputils/resumablerequestreader_test.go
+++ b/pkg/httputils/resumablerequestreader_test.go
@@ -229,7 +229,7 @@ func TestResumableRequestReaderWithZeroTotalSize(t *testing.T) {
 	resstr := strings.TrimSuffix(string(data), "\n")
 
 	if resstr != srvtxt {
-		t.Errorf("resstr != srvtxt")
+		t.Error("resstr != srvtxt")
 	}
 }
 
@@ -263,7 +263,7 @@ func TestResumableRequestReader(t *testing.T) {
 	resstr := strings.TrimSuffix(string(data), "\n")
 
 	if resstr != srvtxt {
-		t.Errorf("resstr != srvtxt")
+		t.Error("resstr != srvtxt")
 	}
 }
 
@@ -302,6 +302,6 @@ func TestResumableRequestReaderWithInitialResponse(t *testing.T) {
 	resstr := strings.TrimSuffix(string(data), "\n")
 
 	if resstr != srvtxt {
-		t.Errorf("resstr != srvtxt")
+		t.Error("resstr != srvtxt")
 	}
 }

--- a/pkg/tarsum/fileinfosums_test.go
+++ b/pkg/tarsum/fileinfosums_test.go
@@ -46,7 +46,7 @@ func TestSortFileInfoSums(t *testing.T) {
 	fis = newFileInfoSums()
 	fis.SortByPos()
 	if fis[0].Pos() != 0 {
-		t.Errorf("sorted fileInfoSums by Pos should order them by position.")
+		t.Error("sorted fileInfoSums by Pos should order them by position.")
 	}
 
 	fis = newFileInfoSums()
@@ -56,7 +56,7 @@ func TestSortFileInfoSums(t *testing.T) {
 		t.Errorf("Expected %q, got %q", expected, gotFileInfoSum)
 	}
 	if fis.GetFile("noPresent") != nil {
-		t.Errorf("Should have return nil if name not found.")
+		t.Error("Should have return nil if name not found.")
 	}
 
 }


### PR DESCRIPTION
**- What I did**
fix t.Errorf to t.Error in serveral _test.go, because of no variables to format.  removed **f** can be more effective.

**- How I did it**
fix t.Errorf to t.Error in serveral _test.go

**- A picture of a cute animal (not mandatory but encouraged)**
before -> after
![image](https://cloud.githubusercontent.com/assets/22292664/20250838/2376ed6a-aa4e-11e6-8648-4f4e8cbfa64c.png)

Signed-off-by: wefine <wang.xiaoren@zte.com.cn>