### PR TITLE
Update bash completion `dns-options-add/rm` -> `dns-option-add/rm`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2679,8 +2679,8 @@ _docker_service_update() {
 			--container-label-add
 			--container-label-rm
 			--dns-add
-			--dns-options-add
-			--dns-options-rm
+			--dns-option-add
+			--dns-option-rm
 			--dns-rm
 			--dns-search-add
 			--dns-search-rm


### PR DESCRIPTION
In #28186, `dns-options-add/rm` has been changed to `dns-option-add/rm` in `docker service create/update`, for the purpose of consistency.

This fix updates bash completion to remove extra `s`.

cc @albers

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>