### PR TITLE
fix up engine labels conflicting in 'daemon/config.go and cli/command/system/info.go '

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -273,7 +273,7 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			stringSlice := strings.SplitN(label, "=", 2)
 			if len(stringSlice) > 1 {
 				// If there is a conflict we will throw out an warning
-				if v, ok := labelMap[stringSlice[0]]; ok && v != stringSlice[1] {
+				if v, ok := labelMap[stringSlice[0]]; ok && v == stringSlice[1] {
 					fmt.Fprintln(dockerCli.Err(), "WARNING: labels with duplicate keys and conflicting values have been deprecated")
 					break
 				}

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -249,7 +249,7 @@ func GetConflictFreeLabels(labels []string) ([]string, error) {
 		stringSlice := strings.SplitN(label, "=", 2)
 		if len(stringSlice) > 1 {
 			// If there is a conflict we will return an error
-			if v, ok := labelMap[stringSlice[0]]; ok && v != stringSlice[1] {
+			if v, ok := labelMap[stringSlice[0]]; ok && v == stringSlice[1] {
 				return nil, fmt.Errorf("conflict labels for %s=%s and %s=%s", stringSlice[0], stringSlice[1], stringSlice[0], v)
 			}
 			labelMap[stringSlice[0]] = stringSlice[1]


### PR DESCRIPTION
**- What I did**
Fix up engine labels conflicting when running `dockerd` cmd with duplicate key-value pairs(such as --lable x=y --label x=y) and `docker info`.
**- How I did it**
I just modify two files daemon/config.go and cli/command/system/info.go,and change "if v, ok := labelMap[stringSlice[0]]; ok && v != stringSlice[1]" to "if v, ok := labelMap[stringSlice[0]]; ok && v == stringSlice[1]".
**- How to verify it**
Run command `dockerd --label x=y --label x=y --label x=y` and `docker info`,it will print warning information.
**- Description for the changelog**
Fix up engine labels conflicting in 'daemon/config.go and cli/command/system/info.go '
Signed-off-by: zhukj <zhu.kunjia@zte.com.cn>