### PR TITLE
Updated daemon documentation to clarify that live-restore is not supp…

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -62,7 +62,7 @@ Options:
       --iptables                              Enable addition of iptables rules (default true)
       --ipv6                                  Enable IPv6 networking
       --label value                           Set key=value labels to the daemon (default [])
-      --live-restore                          Enable live restore of docker when containers are still running
+      --live-restore                          Enable live restore of docker when containers are still running (Linux only)
       --log-driver string                     Default driver for container logs (default "json-file")
   -l, --log-level string                      Set the logging level ("debug", "info", "warn", "error", "fatal") (default "info")
       --log-opt value                         Default log driver options for containers (default map[])
@@ -1234,7 +1234,6 @@ This is a full example of the allowed configuration options on Windows:
     "storage-driver": "",
     "storage-opts": [],
     "labels": [],
-    "live-restore": true,
     "log-driver": "",
     "mtu": 0,
     "pidfile": "",

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -217,7 +217,7 @@ is `hyperv`. Linux only supports `default`.
   Set key=value labels to the daemon (displayed in `docker info`)
 
 **--live-restore**=*false*
-  Enable live restore of running containers when the daemon starts so that they are not restarted.
+  Enable live restore of running containers when the daemon starts so that they are not restarted. This option is applicable only for docker daemon running on Linux host.
 
 **--log-driver**="*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*awslogs*|*splunk*|*etwlogs*|*gcplogs*|*none*"
   Default driver for container logs. Default is `json-file`.


### PR DESCRIPTION
"fixes #28295 "

**- What I did**
Updated docker daemon.md to clarify that this option is  not supported on windows. Also raised https://github.com/docker/docker.github.io/pull/564

**- Description for the changelog**
Updated docker daemon help to clarify --live-restore option is not supported on Windows


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: bbayani <bhumikabayani@gmail.com>