### PR TITLE
Windows: Allow `USER` in builder

### DIFF
--- a/builder/dockerfile/evaluator_windows.go
+++ b/builder/dockerfile/evaluator_windows.go
@@ -6,7 +6,7 @@ import "fmt"
 // a command not supported on the platform.
 func platformSupports(command string) error {
 	switch command {
-	case "user", "stopsignal":
+	case "stopsignal":
 		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
 	}
 	return nil

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -7287,3 +7287,20 @@ func (s *DockerSuite) TestBuildOpaqueDirectory(c *check.C) {
 	_, err := buildImage("testopaquedirectory", dockerFile, false)
 	c.Assert(err, checker.IsNil)
 }
+
+// Windows test for USER in dockerfile
+func (s *DockerSuite) TestBuildWindowsUser(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	name := "testbuildwindowsuser"
+	_, out, err := buildImageWithOut(name,
+		`FROM `+WindowsBaseImage+`
+		RUN net user user /add
+		USER user
+		RUN set username
+		`,
+		true)
+	if err != nil {
+		c.Fatal(err)
+	}
+	c.Assert(strings.ToLower(out), checker.Contains, "username=user")
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@thaJeztah @vieux Another one which should strongly be considered for 1.13.

Fixes https://github.com/docker/docker/issues/28027. `USER` is supported in Windows now after https://github.com/docker/docker/pull/28184, but the block in the builder was never removed.

This removes the block and adds a CI test for it.

@duglin FYI