### PR TITLE
Gitignore dockerversion\version_autogen_unix.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bundles/
 cmd/dockerd/dockerd
 cmd/docker/docker
 dockerversion/version_autogen.go
+dockerversion/version_autogen_unix.go
 docs/AWS_S3_BUCKET
 docs/GITCOMMIT
 docs/GIT_BRANCH


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@mlaventure I should have noticed during the review, but missed this. After https://github.com/docker/docker/pull/28310/files#diff-dbcafc41041b7d81fb0502ef3a81ddf5R25 (which made it into 1.13 RC2), every time on Windows I do a sh hack/make.sh binary (or indirectly run .go-autogen) for a local build, I get a dirty git repository as it creates the _unix.go file.

@thaJeztah @vieux @johnstep On the basis that the commit that 'broke' this is cherry-picked, this one probably ought to be too.

@darrenstahlmsft Fixes what you mentioned. Workaround is to manually delete `.\dockerversion\version_autogen_unix.go`.