### PR TITLE
whether there is a error or not, to close response is necessary, can …

### DIFF
--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -73,10 +73,11 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 		Details:    opts.details,
 	}
 	responseBody, err := dockerCli.Client().ContainerLogs(ctx, opts.container, options)
+	defer responseBody.Close()
+
 	if err != nil {
 		return err
 	}
-	defer responseBody.Close()
 
 	if c.Config.Tty {
 		_, err = io.Copy(dockerCli.Out(), responseBody)


### PR DESCRIPTION
**- What I did**

I exchange the order of `defer responseBody.Close()` and error detected, whether there is a error or not, to close response is necessary, can not skipped by error.

**- How I did it**
exchange the order


**- A picture of a cute animal (not mandatory but encouraged)**
before --> after
![image](https://cloud.githubusercontent.com/assets/22292664/20291650/a3487ac0-ab22-11e6-8524-e6f1ecb61b77.png)


Signed-off-by: wefine <wang.xiaoren@zte.com.cn>