### PR TITLE
Build docker incrementally by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 # set the graph driver as the current graphdriver if not set
 DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info 2>&1 | grep "Storage Driver" | sed 's/.*: //'))
+export DOCKER_GRAPHDRIVER
+DOCKER_INCREMENTAL_BINARY := $(if $(DOCKER_INCREMENTAL_BINARY),$(DOCKER_INCREMENTAL_BINARY),1)
+export DOCKER_INCREMENTAL_BINARY
 
 # get OS/Arch of docker engine
 DOCKER_OSARCH := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKER_ENGINE_OSARCH:-$$DOCKER_CLIENT_OSARCH}')
@@ -20,7 +23,7 @@ DOCKER_ENVS := \
 	-e DOCKER_DEBUG \
 	-e DOCKER_EXPERIMENTAL \
 	-e DOCKER_GITCOMMIT \
-	-e DOCKER_GRAPHDRIVER=$(DOCKER_GRAPHDRIVER) \
+	-e DOCKER_GRAPHDRIVER \
 	-e DOCKER_INCREMENTAL_BINARY \
 	-e DOCKER_PORT \
 	-e DOCKER_REMAP_ROOT \

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -159,7 +159,7 @@ ORIG_BUILDFLAGS=( -tags "autogen netgo static_build sqlite_omit_load_extension $
 # When $DOCKER_INCREMENTAL_BINARY is set in the environment, enable incremental
 # builds by installing dependent packages to the GOPATH.
 REBUILD_FLAG="-a"
-if [ "$DOCKER_INCREMENTAL_BINARY" ]; then
+if [ "$DOCKER_INCREMENTAL_BINARY" == "1" ] || [ "$DOCKER_INCREMENTAL_BINARY" == "true" ]; then
 	REBUILD_FLAG="-i"
 fi
 ORIG_BUILDFLAGS+=( $REBUILD_FLAG )


### PR DESCRIPTION
This speeds up docker build time drastically. It still possible to disable this by setting `DOCKER_INCREMENTAL_BUILD` to `0` (and this is what should be done on the CI).

/cc @icecrime @tianon @cpuguy83 @aaronlehmann 

This PR doesn't change anything for the CI, i.e. the CI still builds it using `-a`, a.k.a `force rebuilding of packages that are already up-to-date.`.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>