### PR TITLE
move func getNetwork into helper.go to keep consistent

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -1748,33 +1748,6 @@ func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.Control
 	return nil
 }
 
-func getNetwork(ctx context.Context, c swarmapi.ControlClient, input string) (*swarmapi.Network, error) {
-	// GetNetwork to match via full ID.
-	rg, err := c.GetNetwork(ctx, &swarmapi.GetNetworkRequest{NetworkID: input})
-	if err != nil {
-		// If any error (including NotFound), ListNetworks to match via ID prefix and full name.
-		rl, err := c.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: &swarmapi.ListNetworksRequest_Filters{Names: []string{input}}})
-		if err != nil || len(rl.Networks) == 0 {
-			rl, err = c.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: &swarmapi.ListNetworksRequest_Filters{IDPrefixes: []string{input}}})
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		if len(rl.Networks) == 0 {
-			return nil, fmt.Errorf("network %s not found", input)
-		}
-
-		if l := len(rl.Networks); l > 1 {
-			return nil, fmt.Errorf("network %s is ambiguous (%d matches found)", input, l)
-		}
-
-		return rl.Networks[0], nil
-	}
-	return rg.Network, nil
-}
-
 // Cleanup stops active swarm node. This is run before daemon shutdown.
 func (c *Cluster) Cleanup() {
 	c.Lock()

--- a/daemon/cluster/helpers.go
+++ b/daemon/cluster/helpers.go
@@ -106,3 +106,30 @@ func getTask(ctx context.Context, c swarmapi.ControlClient, input string) (*swar
 	}
 	return rg.Task, nil
 }
+
+func getNetwork(ctx context.Context, c swarmapi.ControlClient, input string) (*swarmapi.Network, error) {
+	// GetNetwork to match via full ID.
+	rg, err := c.GetNetwork(ctx, &swarmapi.GetNetworkRequest{NetworkID: input})
+	if err != nil {
+		// If any error (including NotFound), ListNetworks to match via ID prefix and full name.
+		rl, err := c.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: &swarmapi.ListNetworksRequest_Filters{Names: []string{input}}})
+		if err != nil || len(rl.Networks) == 0 {
+			rl, err = c.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: &swarmapi.ListNetworksRequest_Filters{IDPrefixes: []string{input}}})
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(rl.Networks) == 0 {
+			return nil, fmt.Errorf("network %s not found", input)
+		}
+
+		if l := len(rl.Networks); l > 1 {
+			return nil, fmt.Errorf("network %s is ambiguous (%d matches found)", input, l)
+		}
+
+		return rl.Networks[0], nil
+	}
+	return rg.Network, nil
+}


### PR DESCRIPTION
I found that when cluster is getting resources like swarm, node, service, task via `getSwarm`, `getNode`, `getService`, and `getTask`, this functions are all in helper.go.

While in swarm cluster, `getNetwork` is also a kind of resource fetching. I think it is better to get all these functions together to keep consistent.

**- What I did**
1.move func getNetwork into helper.go to keep consistent

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>