### PR TITLE
Using distribution reference pkg (pin image by digest)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
 github.com/miekg/dns 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
 # get graph and distribution packages
-github.com/docker/distribution 8016d2d8903e378edacac11e4d809efbc987ad61
+github.com/docker/distribution d22e09a6686c32be8c17b684b639da4b90efe320
 github.com/vbatts/tar-split v0.10.1
 
 # get go-zfs packages

--- a/vendor/github.com/docker/distribution/reference/helpers.go
+++ b/vendor/github.com/docker/distribution/reference/helpers.go
@@ -1,0 +1,12 @@
+package reference
+
+// IsNameOnly returns true if reference only contains a repo name.
+func IsNameOnly(ref Named) bool {
+	if _, ok := ref.(NamedTagged); ok {
+		return false
+	}
+	if _, ok := ref.(Canonical); ok {
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/docker/distribution/reference/normalize.go
+++ b/vendor/github.com/docker/distribution/reference/normalize.go
@@ -1,0 +1,22 @@
+package reference
+
+var (
+	defaultTag = "latest"
+)
+
+// EnsureTagged adds the default tag "latest" to a reference if it only has
+// a repo name.
+func EnsureTagged(ref Named) NamedTagged {
+	namedTagged, ok := ref.(NamedTagged)
+	if !ok {
+		namedTagged, err := WithTag(ref, defaultTag)
+		if err != nil {
+			// Default tag must be valid, to create a NamedTagged
+			// type with non-validated input the WithTag function
+			// should be used instead
+			panic(err)
+		}
+		return namedTagged
+	}
+	return namedTagged
+}


### PR DESCRIPTION
This PR is a follow up to #28173.

- The current code that extracts a digest from the service image in `docker service create` and `docker service update` uses `ParseNamed` from the `docker/docker/reference` package. One problem this causes is that tags are dropped if both tag and digest is provided. For instance , 

```
docker service create alpine:latest@sha256:1354db23ff5478120c980eca1611a51c9f2b88b61f24283ee8200bf9a54f2e5c top
```
will create a service, but the service image will be listed as `alpine@sha256:1354db23ff5478120c980eca1611a51c9f2b88b61f24283ee8200bf9a54f2e5c` instead of `alpine:latest@sha256:1354db23ff5478120c980eca1611a51c9f2b88b61f24283ee8200bf9a54f2e5c`. Using `ParseNamed` from `docker/distribution/reference` package fixes that.

- The second problem this PR fixes is that it gets rid of string manipulation, and uses the `WithDigest` function from `docker/distribution/reference` to cleanly construct the image string.

- This PR also updates the vendored version for `docker/distribution` to include https://github.com/docker/distribution/pull/2062 and https://github.com/docker/distribution/pull/2044