### PR TITLE
do not require custom build of tini

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -593,7 +593,7 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 	if c.HostConfig.PidMode.IsPrivate() {
 		if (c.HostConfig.Init != nil && *c.HostConfig.Init) ||
 			(c.HostConfig.Init == nil && daemon.configStore.Init) {
-			s.Process.Args = append([]string{"/dev/init", c.Path}, c.Args...)
+			s.Process.Args = append([]string{"/dev/init", "--", c.Path}, c.Args...)
 			var path string
 			if daemon.configStore.InitPath == "" && c.HostConfig.InitPath == "" {
 				path, err = exec.LookPath(DefaultInitBinary)

--- a/hack/dockerfile/install-binaries.sh
+++ b/hack/dockerfile/install-binaries.sh
@@ -77,7 +77,7 @@ do
 			git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 			cd "$GOPATH/tini"
 			git checkout -q "$TINI_COMMIT"
-			cmake -DMINIMAL=ON .
+			cmake .
 			make tini-static
 			cp tini-static /usr/local/bin/docker-init
 			;;


### PR DESCRIPTION
**- What I did**

the original implementation #28037 by @crosbymichael required custom build of `tini` that does not have option parser (requested in krallin/tini#55)
but it can be accomplished without need for such custom build by just using `--` to stop argument parsing.

**- How I did it**

adds `--` argument when calling init reaper allowing flags from `CMD` not to interfere with init own commandline arguments

https://github.com/krallin/tini/issues/55#issuecomment-260507562
https://github.com/krallin/tini/issues/55#issuecomment-260538243
https://github.com/docker/docker/pull/28037

**- How to verify it**

```
# docker run --init --rm -it ubuntu echo 123
```

**- Description for the changelog**

Do not require custom build of tini.

**- A picture of a cute animal (not mandatory but encouraged)**

![14721688_1137226096331677_3024758630935413975_n](https://cloud.githubusercontent.com/assets/199095/20327179/b43452f6-ab94-11e6-8e29-8b1d3e6afaa7.jpg)

