### PR TITLE
Fix error messages for `--cpus` from daemon

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -129,8 +129,10 @@ func verifyContainerResources(resources *containertypes.Resources, isHyperv bool
 	if resources.NanoCPUs > 0 && resources.CPUShares > 0 {
 		return warnings, fmt.Errorf("conflicting options: Nano CPUs and CPU Shares cannot both be set")
 	}
+	// The precision we could get is 0.01, because on Windows we have to convert to CPUPercent.
+	// We don't set the lower limit here and it is up to the underlying platform (e.g., Windows) to return an error.
 	if resources.NanoCPUs < 0 || resources.NanoCPUs > int64(sysinfo.NumCPU())*1e9 {
-		return warnings, fmt.Errorf("range of Nano CPUs is from 1 to %d", int64(sysinfo.NumCPU())*1e9)
+		return warnings, fmt.Errorf("range of CPUs is from 0.01 to %d.00, as there are only %d CPUs available", sysinfo.NumCPU(), sysinfo.NumCPU())
 	}
 
 	if len(resources.BlkioDeviceReadBps) > 0 {

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1577,7 +1577,7 @@ func (s *DockerSuite) TestRunWithNanoCPUs(c *check.C) {
 	file1 := "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 	file2 := "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 	out, _ := dockerCmd(c, "run", "--cpus", "0.5", "--name", "test", "busybox", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2))
-	c.Assert(strings.TrimSpace(out), checker.Equals, "50000\n100000")
+	c.Assert(strings.TrimSpace(out), checker.Equals, "500000\n1000000")
 
 	out = inspectField(c, "test", "HostConfig.NanoCpus")
 	c.Assert(out, checker.Equals, "5e+08", check.Commentf("setting the Nano CPUs failed"))


### PR DESCRIPTION
This fix fixes error messages for `--cpus` from daemon.

When `docker run` takes `--cpus`, it will translate into NanoCPUs and pass the value to daemon. The `NanoCPU` is not visible to the user. The error message generated from daemon used 'NanoCPU' which may cause some confusion to the user.

This fix fixes this issue by returning the error in CPUs instead.

This fix fixes #28456.

cc @crosbymichael @mstanleyjones @thaJeztah 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>