### PR TITLE
Fix deadlock on cancelling healthcheck

### DIFF
--- a/container/health.go
+++ b/container/health.go
@@ -42,10 +42,7 @@ func (s *Health) OpenMonitorChannel() chan struct{} {
 func (s *Health) CloseMonitorChannel() {
 	if s.stop != nil {
 		logrus.Debug("CloseMonitorChannel: waiting for probe to stop")
-		// This channel does not buffer. Once the write succeeds, the monitor
-		// has read the stop request and will not make any further updates
-		// to c.State.Health.
-		s.stop <- struct{}{}
+		close(s.stop)
 		s.stop = nil
 		logrus.Debug("CloseMonitorChannel done")
 	}

--- a/daemon/health_test.go
+++ b/daemon/health_test.go
@@ -80,7 +80,7 @@ func TestHealthStates(t *testing.T) {
 			Start:    startTime,
 			End:      startTime,
 			ExitCode: exitCode,
-		})
+		}, nil)
 	}
 
 	// starting -> failed -> success -> failed


### PR DESCRIPTION
fixes #28405

cc @talex5 @jhowardmsft 

Afaics there still remains a possible race with cancelling healthcheck and restarting it, that may cause a wrong status to be reported. That seems like a bigger change that could go in v1.14 milestone.  

`sync.Once` I mentioned in https://github.com/docker/docker/issues/28405#issuecomment-260445221 doesn't seem to be required as all the calls come from `StateChanged` that is called sequentially for a specific ID.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>