### PR TITLE
1.13.x: Revendor swarmkit to 3076318ec0327e22c837c2bfdfacea08124dc755

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 8517738ba4b82aff5662c97ca4627e7e4d03b531
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit efd44df04cc0fd828de5947263858c3a5a2729b1
+github.com/docker/swarmkit 3076318ec0327e22c837c2bfdfacea08124dc755
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/manager/controlapi/secret.go
+++ b/vendor/github.com/docker/swarmkit/manager/controlapi/secret.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"crypto/subtle"
 	"regexp"
 	"strings"
 
@@ -71,7 +72,10 @@ func (s *Server) UpdateSecret(ctx context.Context, request *api.UpdateSecretRequ
 			return nil
 		}
 
-		if secret.Spec.Annotations.Name != request.Spec.Annotations.Name || request.Spec.Data != nil {
+		// Check if the Name is different than the current name, or the secret is non-nil and different
+		// than the current secret
+		if secret.Spec.Annotations.Name != request.Spec.Annotations.Name ||
+			(request.Spec.Data != nil && subtle.ConstantTimeCompare(request.Spec.Data, secret.Spec.Data) == 0) {
 			return grpc.Errorf(codes.InvalidArgument, "only updates to Labels are allowed")
 		}
 


### PR DESCRIPTION
This includes:

- https://github.com/docker/swarmkit/pull/1693 (/cc @mavenugo)
- https://github.com/docker/swarmkit/pull/1747 (/cc @diogomonica)

/cc @aaronlehmann @vieux @thaJeztah 