### PR TITLE
The type of 'ExportdPorts' should be 'nat.PortSet'

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	AttachStdin     bool                  // Attach the standard input, makes possible user interaction
 	AttachStdout    bool                  // Attach the standard output
 	AttachStderr    bool                  // Attach the standard error
-	ExposedPorts    map[nat.Port]struct{} `json:",omitempty"` // List of exposed ports
+	ExposedPorts    nat.PortSet           `json:",omitempty"` // List of exposed ports
 	Tty             bool                  // Attach standard streams to a tty, including stdin if it is not closed.
 	OpenStdin       bool                  // Open stdin
 	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.


### PR DESCRIPTION
`nat.PortSet` has been defined in `github.com\docker\go-connections\nat\nat.go`, so we should use `nat.PortSet` as the type of  'ExportdPorts'.

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>