### PR TITLE
function TestCreateSuccess uses a wrong variable LogGroupName

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs_test.go
+++ b/daemon/logger/awslogs/cloudwatchlogs_test.go
@@ -99,7 +99,7 @@ func TestCreateSuccess(t *testing.T) {
 		t.Errorf("Expected LogGroupName to be %s", groupName)
 	}
 	if argument.LogStreamName == nil {
-		t.Fatal("Expected non-nil LogGroupName")
+		t.Fatal("Expected non-nil LogStreamName")
 	}
 	if *argument.LogStreamName != streamName {
 		t.Errorf("Expected LogStreamName to be %s", streamName)


### PR DESCRIPTION
LogGroupName should be LogStreamName