### PR TITLE
remove some description not consistant for docker load

### DIFF
--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -23,7 +23,6 @@ Load an image from a tar archive or STDIN
 Options:
       --help           Print usage
   -i, --input string   Read from tar archive file, instead of STDIN.
-                       The tarball may be compressed with gzip, bzip, or xz
   -q, --quiet          Suppress the load output but still outputs the imported images
 ```
 

--- a/man/docker-load.1.md
+++ b/man/docker-load.1.md
@@ -21,7 +21,7 @@ standard output stream.
   Print usage statement
 
 **-i**, **--input**=""
-   Read from a tar archive file, instead of STDIN. The tarball may be compressed with gzip, bzip, or xz.
+   Read from a tar archive file, instead of STDIN.
 
 **-q**, **--quiet**
    Suppress the load progress bar but still outputs the imported images.


### PR DESCRIPTION
in load.go:

	flags.StringVarP(&opts.input, "input", "i", "", "Read from tar archive file, instead of STDIN")