### PR TITLE
Carry #27834 — Do not require `.git` in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ bundles
 .gopath
 vendor/pkg
 .go-pkg-cache
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 bundles
+integration-cli/bundles
 .gopath
 vendor/pkg
 .go-pkg-cache

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ export DOCKER_INCREMENTAL_BINARY
 DOCKER_OSARCH := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKER_ENGINE_OSARCH:-$$DOCKER_CLIENT_OSARCH}')
 DOCKERFILE := $(shell bash -c 'source hack/make/.detect-daemon-osarch && echo $${DOCKERFILE}')
 
+DOCKER_GITCOMMIT := $(shell git rev-parse --short HEAD || echo unsupported)
+export DOCKER_GITCOMMIT
+
 # env vars passed through directly to Docker's build scripts
 # to allow things like `make KEEPBUNDLE=1 binary` easily
 # `project/PACKAGERS.md` have some limited documentation of some of these

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -70,7 +70,9 @@ DEFAULT_BUNDLES=(
 
 VERSION=$(< ./VERSION)
 ! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
-if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; then
+if [ "$DOCKER_GITCOMMIT" ]; then
+	GITCOMMIT="$DOCKER_GITCOMMIT"
+elif command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; then
 	GITCOMMIT=$(git rev-parse --short HEAD)
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-unsupported"
@@ -83,8 +85,7 @@ if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; the
 		git status --porcelain --untracked-files=no
 		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	fi
-elif [ "$DOCKER_GITCOMMIT" ]; then
-	GITCOMMIT="$DOCKER_GITCOMMIT"
+	! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/') &> /dev/null
 else
 	echo >&2 'error: .git directory missing and DOCKER_GITCOMMIT not specified'
 	echo >&2 '  Please either build with the .git directory accessible, or specify the'


### PR DESCRIPTION
Carry #27834 and hopefully fixes builds :angel:.

- Add `.git` to `.dockerignore`
- export DOCKER_GITCOMMIT in the Makefile
- prioritize DOCKER_GITCOMMIT against the `git` command in
  `./hack/make.sh`
- Also add `integration-cli/bundles` to gitignore (it's generated when
  using integration-cli shell)

Note that, on my laptop for example, I'm sending `30M` of context with this, and `150M` without :scream_cat:, so I really think this can be a huge win :angel: 

/cc @tianon @jhowardmsft @icecrime @thaJeztah @cpuguy83 

:frog: 