### PR TITLE
Making docker local volume driver support most of FS mount type

### DIFF
--- a/pkg/mount/mounter_linux.go
+++ b/pkg/mount/mounter_linux.go
@@ -6,6 +6,18 @@ import (
 
 func mount(device, target, mType string, flag uintptr, data string) error {
 	if err := syscall.Mount(device, target, mType, flag, data); err != nil {
+		// If traditional mount failed, give one more chance for fuse-based/glusterfs/ceph/.. requests to mount via standard mount command
+		// * SSHFS Example: docker service create .. --mount type=volume,volume-opt=type=fuse.sshfs,volume-opt=device=ssh-node-1:/home/user1,volume-opt=o=workaround=all:o=reconnect:o=IdentityFile=/ssh_keys/user1.key,source=user1.home,target=/mount ..
+		// * GlusterFS Example: docker service create .. --mount type=volume,volume-opt=type=glusterfs,volume-opt=device=gfs-node-1:/shared,source=gfs-shared-1,target=/mount ..
+		// * CephFS Example: docker service create .. --mount type=volume,volume-opt=type=ceph,volume-opt=device=ceph-node-1:/shared,source=ceph-shared-1,target=/mount ..
+		cmd := []string{"-t", mType, device, target}
+		if data != "" {
+			opts := strings.Split(data, ":o=")
+			for i := 0; i < len(opts); i++ {
+				cmd = append(cmd, []string{"-o", opts[i]}...)
+			}
+		}
+		err := exec.Command("mount", cmd...).Run()
 		return err
 	}
 


### PR DESCRIPTION
Making docker local volume driver support most of remote FS mount type, such as glusterfs, cephfs, fused-based fs (sshfs/curlftpfs/..) and so on.

Options for each kind of fs-type are configurable via '--volume-opt'.
This fix is essential for docker-swarm cluster whose services run on different machines at different time.
Besides, to build a swarm cluster with persistent and secure volume storage, most of unstable 3rd-party plugin drivers are no longer needed.

Signed-off-by: CUI Wei <ghostplant@qq.com>