### PR TITLE
Split container runtime state from config

### DIFF
--- a/container/monitor.go
+++ b/container/monitor.go
@@ -1,46 +1,100 @@
 package container
 
 import (
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/container/stream"
+	"github.com/docker/docker/daemon/logger"
+	"github.com/docker/docker/restartmanager"
+	"golang.org/x/net/context"
 )
 
 const (
 	loggerCloseTimeout = 10 * time.Second
 )
 
-// Reset puts a container into a state where it can be restarted again.
-func (container *Container) Reset(lock bool) {
-	if lock {
-		container.Lock()
-		defer container.Unlock()
+func newRunState() *runState {
+	return &runState{
+		streams:       stream.NewConfig(),
+		attachContext: &attachContext{},
+	}
+}
+
+type runState struct {
+	mu             sync.Mutex
+	attachContext  *attachContext
+	healthMonitor  chan struct{}
+	logDriver      logger.Logger
+	logCopier      *logger.Copier
+	restartManager restartmanager.RestartManager
+	streams        *stream.Config
+}
+
+func (s *runState) openHealthMonitor() chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.healthMonitor == nil {
+		s.healthMonitor = make(chan struct{})
+		return s.healthMonitor
+	}
+	return nil
+}
+
+func (s *runState) closeHealthMonitor() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.healthMonitor != nil {
+		close(s.healthMonitor)
+		s.healthMonitor = nil
+	}
+}
+
+func (s *runState) resetLogging() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.logDriver != nil {
+		if s.logCopier != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), loggerCloseTimeout)
+			go func() {
+				s.logCopier.Wait()
+				cancel()
+			}()
+			<-ctx.Done()
+		}
+		s.logDriver.Close()
 	}
 
-	if err := container.CloseStreams(); err != nil {
+	s.logCopier = nil
+	s.logDriver = nil
+}
+
+func (s *runState) Streams() *stream.Config {
+	s.mu.Lock()
+	streams := s.streams
+	s.mu.Unlock()
+	return streams
+}
+
+// Reset puts a container into a state where it can be restarted again.
+func (container *Container) Reset() {
+	streams := container.Streams()
+
+	if err := streams.CloseStreams(); err != nil {
 		logrus.Errorf("%s: %s", container.ID, err)
 	}
 
 	// Re-create a brand new stdin pipe once the container exited
 	if container.Config.OpenStdin {
-		container.StreamConfig.NewInputPipes()
+		streams.NewInputPipes()
 	}
 
-	if container.LogDriver != nil {
-		if container.LogCopier != nil {
-			exit := make(chan struct{})
-			go func() {
-				container.LogCopier.Wait()
-				close(exit)
-			}()
-			select {
-			case <-time.After(loggerCloseTimeout):
-				logrus.Warn("Logger didn't exit in time: logs may be truncated")
-			case <-exit:
-			}
-		}
-		container.LogDriver.Close()
-		container.LogCopier = nil
-		container.LogDriver = nil
+	container.runState.resetLogging()
+
+	if container.State.Health != nil {
+		container.State.Health.Status = types.Unhealthy
 	}
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -90,9 +90,9 @@ func (daemon *Daemon) load(id string) (*container.Container, error) {
 func (daemon *Daemon) Register(c *container.Container) error {
 	// Attach to stdout and stderr
 	if c.Config.OpenStdin {
-		c.StreamConfig.NewInputPipes()
+		c.Streams().NewInputPipes()
 	} else {
-		c.StreamConfig.NewNopInputPipe()
+		c.Streams().NewNopInputPipe()
 	}
 
 	daemon.containers.Add(c.ID, c)

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -109,6 +109,7 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 	// indexes even if removal failed.
 	defer func() {
 		if err == nil || forceRemove {
+			container.Reset() // make sure everything is cleaned up
 			daemon.nameIndex.Delete(container.ID)
 			daemon.linkIndex.delete(container)
 			selinuxFreeLxcContexts(container.ProcessLabel)

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -237,11 +237,11 @@ func (d *Daemon) updateHealthMonitor(c *container.Container) {
 	probe := getProbe(c)
 	wantRunning := c.Running && !c.Paused && probe != nil
 	if wantRunning {
-		if stop := h.OpenMonitorChannel(); stop != nil {
+		if stop := c.OpenHealthMonitorChannel(); stop != nil {
 			go monitor(d, c, stop, probe)
 		}
 	} else {
-		h.CloseMonitorChannel()
+		d.stopHealthchecks(c)
 	}
 }
 
@@ -273,10 +273,7 @@ func (d *Daemon) initHealthMonitor(c *container.Container) {
 // Called when the container is being stopped (whether because the health check is
 // failing or for any other reason).
 func (d *Daemon) stopHealthchecks(c *container.Container) {
-	h := c.State.Health
-	if h != nil {
-		h.CloseMonitorChannel()
-	}
+	c.CloseHealthMonitorChannel()
 }
 
 // Buffer up to maxOutputLen bytes. Further data is discarded.

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -87,7 +87,7 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 			if !ok {
 				logrus.Debug("logs: end stream")
 				logs.Close()
-				if cLog != container.LogDriver {
+				if cLog != container.LogDriver() {
 					// Since the logger isn't cached in the container, which occurs if it is running, it
 					// must get explicitly closed here to avoid leaking it and any file handles it has.
 					if err := cLog.Close(); err != nil {
@@ -114,8 +114,8 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 }
 
 func (daemon *Daemon) getLogger(container *container.Container) (logger.Logger, error) {
-	if container.LogDriver != nil && container.IsRunning() {
-		return container.LogDriver, nil
+	if l := container.LogDriver(); l != nil && container.IsRunning() {
+		return l, nil
 	}
 	return container.StartLogger()
 }

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -39,8 +39,8 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		}
 
 		c.Lock()
-		c.StreamConfig.Wait()
-		c.Reset(false)
+		c.Streams().Wait()
+		c.Reset()
 
 		restart, wait, err := c.RestartManager().ShouldRestart(e.ExitCode, false, time.Since(c.StartedAt))
 		if err == nil && restart {
@@ -105,7 +105,7 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		c.HasBeenManuallyStopped = false
 		c.HasBeenStartedBefore = true
 		if err := c.ToDisk(); err != nil {
-			c.Reset(false)
+			c.Reset()
 			return err
 		}
 		daemon.initHealthMonitor(c)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -187,7 +187,7 @@ func (daemon *Daemon) containerStart(container *container.Container, checkpoint 
 			container.SetExitCode(127)
 		}
 
-		container.Reset(false)
+		container.Reset()
 
 		return fmt.Errorf("%s", errDesc)
 	}

--- a/integration-cli/docker_cli_service_health_test.go
+++ b/integration-cli/docker_cli_service_health_test.go
@@ -22,16 +22,16 @@ func (s *DockerSwarmSuite) TestServiceHealthRun(c *check.C) {
 	// build image with health-check
 	// note: use `daemon.buildImageWithOut` to build, do not use `buildImage` to build
 	imageName := "testhealth"
-	_, _, err := d.buildImageWithOut(imageName,
+	out, _, err := d.buildImageWithOut(imageName,
 		`FROM busybox
 		RUN touch /status
 		HEALTHCHECK --interval=1s --timeout=1s --retries=1\
 		  CMD cat /status`,
 		true)
-	c.Check(err, check.IsNil)
+	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	serviceName := "healthServiceRun"
-	out, err := d.Cmd("service", "create", "--name", serviceName, imageName, "top")
+	out, err = d.Cmd("service", "create", "--name", serviceName, imageName, "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	id := strings.TrimSpace(out)
 
@@ -84,15 +84,15 @@ func (s *DockerSwarmSuite) TestServiceHealthStart(c *check.C) {
 
 	// service started from this image won't pass health check
 	imageName := "testhealth"
-	_, _, err := d.buildImageWithOut(imageName,
+	out, _, err := d.buildImageWithOut(imageName,
 		`FROM busybox
 		HEALTHCHECK --interval=1s --timeout=1s --retries=1024\
 		  CMD cat /status`,
 		true)
-	c.Check(err, check.IsNil)
+	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	serviceName := "healthServiceStart"
-	out, err := d.Cmd("service", "create", "--name", serviceName, imageName, "top")
+	out, err = d.Cmd("service", "create", "--name", serviceName, imageName, "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	id := strings.TrimSpace(out)
 
@@ -142,15 +142,15 @@ func (s *DockerSwarmSuite) TestServiceHealthUpdate(c *check.C) {
 
 	// service started from this image won't pass health check
 	imageName := "testhealth"
-	_, _, err := d.buildImageWithOut(imageName,
+	out, _, err := d.buildImageWithOut(imageName,
 		`FROM busybox
 		HEALTHCHECK --interval=1s --timeout=1s --retries=1024\
 		  CMD cat /status`,
 		true)
-	c.Check(err, check.IsNil)
+	c.Assert(err, check.IsNil, check.Commentf(out))
 
 	serviceName := "healthServiceStart"
-	out, err := d.Cmd("service", "create", "--name", serviceName, imageName, "top")
+	out, err = d.Cmd("service", "create", "--name", serviceName, imageName, "top")
 	c.Assert(err, checker.IsNil, check.Commentf(out))
 	id := strings.TrimSpace(out)
 


### PR DESCRIPTION
This is step-1 of implementing a lock-less container object.
This moves the live/runtime state off the container object onto a
separately managed object.

Effectively, these are items on the container struct that cannot (or
should not) be copied, e.g. i/o streams, signal channels, secrets, etc.

The new object is stored in a package level singleton that the container
object is able to get at. The objects are keyed by the container ID,
this means using the singleton should not cause any issues with other
uses (e.g. tests, dep injection, etc) as container ID's are unique.

Replaces some of the work from #26759

Signed-off-by: Brian Goff <cpuguy83@gmail.com>