### PR TITLE
Remove old Windows hack in make.sh

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -83,10 +83,6 @@ if command -v git &> /dev/null && [ -d .git ] && git rev-parse &> /dev/null; the
 		echo "#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	fi
 	! BUILDTIME=$(date --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/') &> /dev/null
-	if [ -z $BUILDTIME ]; then
-		# If using bash 3.1 which doesn't support --rfc-3389, eg Windows CI
-		BUILDTIME=$(date -u)
-	fi
 elif [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 else


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@tianon Removes an old hack from way back when the Windows CI machines weren't running bash 4. 