### PR TITLE
Move stack dump dir to exec root

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -693,7 +693,11 @@ func NewDaemon(config *Config, registryService registry.Service, containerdRemot
 
 	// set up SIGUSR1 handler on Unix-like systems, or a Win32 global event
 	// on Windows to dump Go routine stacks
-	d.setupDumpStackTrap(config.Root)
+	stackDumpDir := config.Root
+	if execRoot := config.GetExecRoot(); execRoot != "" {
+		stackDumpDir = execRoot
+	}
+	d.setupDumpStackTrap(stackDumpDir)
 
 	return d, nil
 }


### PR DESCRIPTION
Dump stack dumps to exec root instead of daemon root.
When no path is provided to the stack dumper, such is the case with
SIGQUIT, dump to stderr.

This also makes it possible to collect stack dumps when integration tests timeout once again.