### PR TITLE
Move CreateRWLayer() parameters in a struct

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -210,8 +210,13 @@ func (daemon *Daemon) setRWLayer(container *container.Container) error {
 		layerID = img.RootFS.ChainID()
 	}
 
-	rwLayer, err := daemon.layerStore.CreateRWLayer(container.ID, layerID, container.MountLabel, daemon.getLayerInit(), container.HostConfig.StorageOpt)
+	rwLayerOpts := &layer.CreateRWLayerOpts{
+		MountLabel: container.MountLabel,
+		InitFunc:   daemon.getLayerInit(),
+		StorageOpt: container.HostConfig.StorageOpt,
+	}
 
+	rwLayer, err := daemon.layerStore.CreateRWLayer(container.ID, layerID, rwLayerOpts)
 	if err != nil {
 		return err
 	}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -126,7 +126,7 @@ func (ls *mockLayerStore) Get(chainID layer.ChainID) (layer.Layer, error) {
 func (ls *mockLayerStore) Release(l layer.Layer) ([]layer.Metadata, error) {
 	return []layer.Metadata{}, nil
 }
-func (ls *mockLayerStore) CreateRWLayer(string, layer.ChainID, string, layer.MountInit, map[string]string) (layer.RWLayer, error) {
+func (ls *mockLayerStore) CreateRWLayer(string, layer.ChainID, *layer.CreateRWLayerOpts) (layer.RWLayer, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/layer/layer.go
+++ b/layer/layer.go
@@ -169,6 +169,13 @@ type Metadata struct {
 // RWLayer.
 type MountInit func(root string) error
 
+// CreateRWLayerOpts contains optional arguments to be passed to CreateRWLayer
+type CreateRWLayerOpts struct {
+	MountLabel string
+	InitFunc   MountInit
+	StorageOpt map[string]string
+}
+
 // Store represents a backend for managing both
 // read-only and read-write layers.
 type Store interface {
@@ -177,7 +184,7 @@ type Store interface {
 	Map() map[ChainID]Layer
 	Release(Layer) ([]Metadata, error)
 
-	CreateRWLayer(id string, parent ChainID, mountLabel string, initFunc MountInit, storageOpt map[string]string) (RWLayer, error)
+	CreateRWLayer(id string, parent ChainID, opts *CreateRWLayerOpts) (RWLayer, error)
 	GetRWLayer(id string) (RWLayer, error)
 	GetMountID(id string) (string, error)
 	ReleaseRWLayer(RWLayer) ([]Metadata, error)

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -444,7 +444,19 @@ func (ls *layerStore) Release(l Layer) ([]Metadata, error) {
 	return ls.releaseLayer(layer)
 }
 
-func (ls *layerStore) CreateRWLayer(name string, parent ChainID, mountLabel string, initFunc MountInit, storageOpt map[string]string) (RWLayer, error) {
+func (ls *layerStore) CreateRWLayer(name string, parent ChainID, opts *CreateRWLayerOpts) (RWLayer, error) {
+	var (
+		storageOpt map[string]string
+		initFunc   MountInit
+		mountLabel string
+	)
+
+	if opts != nil {
+		mountLabel = opts.MountLabel
+		storageOpt = opts.StorageOpt
+		initFunc = opts.InitFunc
+	}
+
 	ls.mountL.Lock()
 	defer ls.mountL.Unlock()
 	m, ok := ls.mounts[name]

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -84,7 +84,7 @@ type layerInit func(root string) error
 
 func createLayer(ls Store, parent ChainID, layerFunc layerInit) (Layer, error) {
 	containerID := stringid.GenerateRandomID()
-	mount, err := ls.CreateRWLayer(containerID, parent, "", nil, nil)
+	mount, err := ls.CreateRWLayer(containerID, parent, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func TestMountAndRegister(t *testing.T) {
 	size, _ := layer.Size()
 	t.Logf("Layer size: %d", size)
 
-	mount2, err := ls.CreateRWLayer("new-test-mount", layer.ChainID(), "", nil, nil)
+	mount2, err := ls.CreateRWLayer("new-test-mount", layer.ChainID(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func TestStoreRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := ls.CreateRWLayer("some-mount_name", layer3.ChainID(), "", nil, nil)
+	m, err := ls.CreateRWLayer("some-mount_name", layer3.ChainID(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +415,7 @@ func TestStoreRestore(t *testing.T) {
 	assertLayerEqual(t, layer3b, layer3)
 
 	// Create again with same name, should return error
-	if _, err := ls2.CreateRWLayer("some-mount_name", layer3b.ChainID(), "", nil, nil); err == nil {
+	if _, err := ls2.CreateRWLayer("some-mount_name", layer3b.ChainID(), nil); err == nil {
 		t.Fatal("Expected error creating mount with same name")
 	} else if err != ErrMountNameConflict {
 		t.Fatal(err)

--- a/layer/migration_test.go
+++ b/layer/migration_test.go
@@ -380,7 +380,7 @@ func TestMountMigration(t *testing.T) {
 		Kind: archive.ChangeAdd,
 	})
 
-	if _, err := ls.CreateRWLayer("migration-mount", layer1.ChainID(), "", nil, nil); err == nil {
+	if _, err := ls.CreateRWLayer("migration-mount", layer1.ChainID(), nil); err == nil {
 		t.Fatal("Expected error creating mount with same name")
 	} else if err != ErrMountNameConflict {
 		t.Fatal(err)

--- a/layer/mount_test.go
+++ b/layer/mount_test.go
@@ -32,7 +32,10 @@ func TestMountInit(t *testing.T) {
 		return initfile.ApplyFile(root)
 	}
 
-	m, err := ls.CreateRWLayer("fun-mount", layer.ChainID(), "", mountInit, nil)
+	rwLayerOpts := &CreateRWLayerOpts{
+		InitFunc: mountInit,
+	}
+	m, err := ls.CreateRWLayer("fun-mount", layer.ChainID(), rwLayerOpts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,8 +91,11 @@ func TestMountSize(t *testing.T) {
 	mountInit := func(root string) error {
 		return newTestFile("file-init", contentInit, 0777).ApplyFile(root)
 	}
+	rwLayerOpts := &CreateRWLayerOpts{
+		InitFunc: mountInit,
+	}
 
-	m, err := ls.CreateRWLayer("mount-size", layer.ChainID(), "", mountInit, nil)
+	m, err := ls.CreateRWLayer("mount-size", layer.ChainID(), rwLayerOpts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,8 +143,11 @@ func TestMountChanges(t *testing.T) {
 	mountInit := func(root string) error {
 		return initfile.ApplyFile(root)
 	}
+	rwLayerOpts := &CreateRWLayerOpts{
+		InitFunc: mountInit,
+	}
 
-	m, err := ls.CreateRWLayer("mount-changes", layer.ChainID(), "", mountInit, nil)
+	m, err := ls.CreateRWLayer("mount-changes", layer.ChainID(), rwLayerOpts)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Move some of the optional parameters of CreateRWLayer() in a struct
called CreateRWLayerOpts. This will make it easy to add more options
arguments without having to change signature of CreateRWLayer().

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>