### PR TITLE
Add --chown flag to Dockerfile ADD and COPY

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -139,7 +139,7 @@ type Backend interface {
 	// with Context.Walk
 	// ContainerCopy(name string, res string) (io.ReadCloser, error)
 	// TODO: use copyBackend api
-	CopyOnBuild(containerID string, destPath string, src FileInfo, decompress bool) error
+	CopyOnBuild(containerID string, destPath string, src FileInfo, decompress bool, usergrp string) error
 
 	// HasExperimental checks if the backend supports experimental features
 	HasExperimental() bool

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -166,11 +166,13 @@ func add(b *Builder, args []string, attributes map[string]bool, original string)
 		return errAtLeastTwoArguments("ADD")
 	}
 
+	userStr := b.flags.AddString("user", "")
+
 	if err := b.flags.Parse(); err != nil {
 		return err
 	}
 
-	return b.runContextCommand(args, true, true, "ADD")
+	return b.runContextCommand(args, true, true, "ADD", userStr.Value)
 }
 
 // COPY foo /path
@@ -182,11 +184,13 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, origina
 		return errAtLeastTwoArguments("COPY")
 	}
 
+	userStr := b.flags.AddString("user", "")
+
 	if err := b.flags.Parse(); err != nil {
 		return err
 	}
 
-	return b.runContextCommand(args, false, false, "COPY")
+	return b.runContextCommand(args, false, false, "COPY", userStr.Value)
 }
 
 // FROM imagename

--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -166,13 +166,13 @@ func add(b *Builder, args []string, attributes map[string]bool, original string)
 		return errAtLeastTwoArguments("ADD")
 	}
 
-	userStr := b.flags.AddString("user", "")
+	chownStr := b.flags.AddString("chown", "")
 
 	if err := b.flags.Parse(); err != nil {
 		return err
 	}
 
-	return b.runContextCommand(args, true, true, "ADD", userStr.Value)
+	return b.runContextCommand(args, true, true, "ADD", chownStr.Value)
 }
 
 // COPY foo /path
@@ -184,13 +184,13 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, origina
 		return errAtLeastTwoArguments("COPY")
 	}
 
-	userStr := b.flags.AddString("user", "")
+	chownStr := b.flags.AddString("chown", "")
 
 	if err := b.flags.Parse(); err != nil {
 		return err
 	}
 
-	return b.runContextCommand(args, false, false, "COPY", userStr.Value)
+	return b.runContextCommand(args, false, false, "COPY", chownStr.Value)
 }
 
 // FROM imagename

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -172,7 +172,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 
 	cmd := b.runConfig.Cmd
 	if usergrp != "" {
-		b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s --user=%s %s in %s ", cmdName, usergrp, srcHash, dest)))
+		b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s --chown=%s %s in %s ", cmdName, usergrp, srcHash, dest)))
 	} else {
 		b.runConfig.Cmd = strslice.StrSlice(append(getShell(b.runConfig), fmt.Sprintf("#(nop) %s %s in %s ", cmdName, srcHash, dest)))
 	}
@@ -192,7 +192,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowLocalD
 
 	var comment string
 	if usergrp != "" {
-		comment = fmt.Sprintf("%s --user=%s %s in %s", cmdName, usergrp, origPaths, dest)
+		comment = fmt.Sprintf("%s --chown=%s %s in %s", cmdName, usergrp, origPaths, dest)
 	} else {
 		comment = fmt.Sprintf("%s %s in %s", cmdName, origPaths, dest)
 	}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -156,7 +156,7 @@ func (daemon *Daemon) setupSecretDir(c *container.Container) (setupErr error) {
 	}()
 
 	// retrieve possible remapped range start for root UID, GID
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	// create tmpfs
 	if err := idtools.MkdirAllAs(localMountPath, 0700, rootUID, rootGID); err != nil {
 		return errors.Wrap(err, "error creating secret local mount path")

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -107,7 +107,7 @@ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
 		}
 		c.ShmPath = "/dev/shm"
 	} else {
-		rootUID, rootGID := daemon.GetRemappedUIDGID()
+		rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 		if !c.HasMountFor("/dev/shm") {
 			shmPath, err := c.ShmResourcePath()
 			if err != nil {

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -22,7 +22,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 	}
 	defer daemon.Unmount(container)
 
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	if err := container.SetupWorkingDirectory(rootUID, rootGID); err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -950,7 +950,7 @@ func tempDir(rootDir string, rootUID, rootGID int) (string, error) {
 
 func (daemon *Daemon) setupInitLayer(initPath string) error {
 	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
-	return initLayer.Setup(initPath, rootUID, rootGID)
+	return initlayer.Setup(initPath, rootUID, rootGID)
 }
 
 func setDefaultMtu(config *Config) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -923,12 +923,20 @@ func (daemon *Daemon) GetUIDGIDMaps() ([]idtools.IDMap, []idtools.IDMap) {
 	return daemon.uidMaps, daemon.gidMaps
 }
 
-// GetRemappedUIDGID returns the current daemon's uid and gid values
+// GetRemappedRootUIDGID returns the current daemon's uid and gid values
 // if user namespaces are in use for this daemon instance.  If not
 // this function will return "real" root values of 0, 0.
-func (daemon *Daemon) GetRemappedUIDGID() (int, int) {
+func (daemon *Daemon) GetRemappedRootUIDGID() (int, int) {
 	uid, gid, _ := idtools.GetRootUIDGID(daemon.uidMaps, daemon.gidMaps)
 	return uid, gid
+}
+
+// GetRemappedUIDGID returns the current daemon's uid and gid values for
+// the specified user and group, if user namespaces are in use for this
+// daemon instance. If not, this function will return the passed in values.
+func (daemon *Daemon) GetRemappedUIDGID(uid, gid int) (int, int) {
+	mappedUID, mappedGID, _ := idtools.GetUIDGID(uid, gid, daemon.uidMaps, daemon.gidMaps)
+	return mappedUID, mappedGID
 }
 
 // tempDir returns the default directory to use for temporary files.
@@ -941,8 +949,8 @@ func tempDir(rootDir string, rootUID, rootGID int) (string, error) {
 }
 
 func (daemon *Daemon) setupInitLayer(initPath string) error {
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
-	return initlayer.Setup(initPath, rootUID, rootGID)
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
+	return initLayer.Setup(initPath, rootUID, rootGID)
 }
 
 func setDefaultMtu(config *Config) {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -84,7 +84,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	if selinuxEnabled() {
 		securityOptions = append(securityOptions, "name=selinux")
 	}
-	uid, gid := daemon.GetRemappedUIDGID()
+	uid, gid := daemon.GetRemappedRootUIDGID()
 	if uid != 0 || gid != 0 {
 		securityOptions = append(securityOptions, "name=userns")
 	}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -565,7 +565,7 @@ func (daemon *Daemon) populateCommonSpec(s *specs.Spec, c *container.Container) 
 		Path:     c.BaseFS,
 		Readonly: c.HostConfig.ReadonlyRootfs,
 	}
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
 		return err
 	}

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -19,8 +19,11 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 	}
 
 	// TODO Windows - this can be removed. Not used (UID/GID)
-	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
-	if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
+	// When Windows supports remapping 'root' then the code should
+	// probably look like this:
+	//   rootUID, rootGID := daemon.GetRemappedRootUIDGID()
+	//   if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
+	if err := c.SetupWorkingDirectory(0, 0); err != nil {
 		return nil, err
 	}
 

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -18,7 +18,9 @@ func (daemon *Daemon) createSpec(c *container.Container) (*specs.Spec, error) {
 		return nil, err
 	}
 
-	if err := c.SetupWorkingDirectory(0, 0); err != nil {
+	// TODO Windows - this can be removed. Not used (UID/GID)
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
+	if err := c.SetupWorkingDirectory(rootUID, rootGID); err != nil {
 		return nil, err
 	}
 

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -42,7 +42,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		if err := daemon.lazyInitializeVolume(c.ID, m); err != nil {
 			return nil, err
 		}
-		rootUID, rootGID := daemon.GetRemappedUIDGID()
+		rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 		path, err := m.Setup(c.MountLabel, rootUID, rootGID)
 		if err != nil {
 			return nil, err
@@ -73,7 +73,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 	// if we are going to mount any of the network files from container
 	// metadata, the ownership must be set properly for potential container
 	// remapped root (user namespaces)
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	for _, mount := range netMounts {
 		if err := os.Chown(mount.Source, rootUID, rootGID); err != nil {
 			return nil, err

--- a/daemon/workdir.go
+++ b/daemon/workdir.go
@@ -16,6 +16,6 @@ func (daemon *Daemon) ContainerCreateWorkdir(cID string) error {
 		return err
 	}
 	defer daemon.Unmount(container)
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	rootUID, rootGID := daemon.GetRemappedRootUIDGID()
 	return container.SetupWorkingDirectory(rootUID, rootGID)
 }

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -297,9 +297,9 @@ Results in:
      ---> Running in a2c157f842f5
      Volume in drive C has no label.
      Volume Serial Number is 7E6D-E0F7
-    
+
      Directory of c:\
-    
+
     10/05/2016  05:04 PM             1,894 License.txt
     10/05/2016  02:22 PM    <DIR>          Program Files
     10/05/2016  02:14 PM    <DIR>          Program Files (x86)
@@ -801,11 +801,11 @@ the source will be copied inside the destination container.
     ADD test relativeDir/          # adds "test" to `WORKDIR`/relativeDir/
     ADD test /absoluteDir/         # adds "test" to /absoluteDir/
 
-If the `--user` flag is specified (e.g., `ADD --user=john:john`), new files and
-directories will be created with the UID and GID corresponding to the specified
-user and group. Formats allowed are `user`, `uid`, `user:group`,
+If the `--chown` flag is specified (e.g., `ADD --chown=john:john`), new files
+and directories will be created with the UID and GID corresponding to the
+specified user and group. Formats allowed are `user`, `uid`, `user:group`,
 `user:gid`, `uid:group`, and `uid:gid`
-If `--user` is not specified, all new files and directories are created with a
+If `--chown` is not specified, all new files and directories are created with a
 UID and GID of 0.
 
 In the case where `<src>` is a remote file URL, the destination will
@@ -918,11 +918,11 @@ the source will be copied inside the destination container.
     COPY test relativeDir/   # adds "test" to `WORKDIR`/relativeDir/
     COPY test /absoluteDir/  # adds "test" to /absoluteDir/
 
-If the `--user` flag is specified (e.g., `COPY --user=john:john`), new files and
-directories will be created with the UID and GID corresponding to the specified
-user and group. Formats allowed are `user`, `uid`, `user:group`,
+If the `--chown` flag is specified (e.g., `COPY --chown=john:john`), new files
+and directories will be created with the UID and GID corresponding to the
+specified user and group. Formats allowed are `user`, `uid`, `user:group`,
 `user:gid`, `uid:group`, and `uid:gid`
-If `--user` is not specified, all new files and directories are created with a
+If `--chown` is not specified, all new files and directories are created with a
 UID and GID of 0.
 
 > **Note**:
@@ -1282,7 +1282,7 @@ On Windows, `WORKDIR` behaves differently depending on whether using Windows
 Server containers or Hyper-V containers. For Hyper-V containers, the engine
 is, for architectural reasons, unable to create the directory if it does not
 previously exist. For Windows Server containers, the directory is created
-if it does not exist. Hence, for consistency between Windows Server and 
+if it does not exist. Hence, for consistency between Windows Server and
 Hyper-V containers, it is strongly recommended to include an explicit instruction
 to create the directory in the Dockerfile. For example:
 
@@ -1685,16 +1685,16 @@ Resulting in:
     Removing intermediate container 6fcdb6855ae2
     Step 3/5 : RUN New-Item -ItemType Directory C:\Example
      ---> Running in d0eef8386e97
-    
-    
+
+
         Directory: C:\
-    
-    
+
+
     Mode                LastWriteTime         Length Name
     ----                -------------         ------ ----
     d-----       10/28/2016  11:26 AM                Example
-    
-    
+
+
      ---> 3f2fbf1395d9
     Removing intermediate container d0eef8386e97
     Step 4/5 : ADD Execute-MyCmdlet.ps1 c:\example\

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -801,7 +801,12 @@ the source will be copied inside the destination container.
     ADD test relativeDir/          # adds "test" to `WORKDIR`/relativeDir/
     ADD test /absoluteDir/         # adds "test" to /absoluteDir/
 
-All new files and directories are created with a UID and GID of 0.
+If the `--user` flag is specified (e.g., `ADD --user=john:john`), new files and
+directories will be created with the UID and GID corresponding to the specified
+user and group. Formats allowed are `user`, `uid`, `user:group`,
+`user:gid`, `uid:group`, and `uid:gid`
+If `--user` is not specified, all new files and directories are created with a
+UID and GID of 0.
 
 In the case where `<src>` is a remote file URL, the destination will
 have permissions of 600. If the remote file being retrieved has an HTTP
@@ -913,7 +918,12 @@ the source will be copied inside the destination container.
     COPY test relativeDir/   # adds "test" to `WORKDIR`/relativeDir/
     COPY test /absoluteDir/  # adds "test" to /absoluteDir/
 
-All new files and directories are created with a UID and GID of 0.
+If the `--user` flag is specified (e.g., `COPY --user=john:john`), new files and
+directories will be created with the UID and GID corresponding to the specified
+user and group. Formats allowed are `user`, `uid`, `user:group`,
+`user:gid`, `uid:group`, and `uid:gid`
+If `--user` is not specified, all new files and directories are created with a
+UID and GID of 0.
 
 > **Note**:
 > If you build using STDIN (`docker build - < somefile`), there is no

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -804,76 +804,67 @@ RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'root:root' ]`, true);
 	}
 }
 
-func (s *DockerSuite) TestBuildAddUserFlag(c *check.C) {
+func (s *DockerSuite) TestBuildAddChownFlag(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
 	name := "testaddtonewdest"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'test1:x:1001:' >> /etc/group
 RUN echo 'test2:x:1002:' >> /etc/group
-ADD --user=test1:1002 . /new_dir
+ADD --chown=test1:1002 . /new_dir
 RUN ls -l /
 RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
 		map[string]string{
 			"test_dir/test_file": "test file",
 		})
-	if err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
-		c.Fatal(err)
-	}
+	_, err = buildImageFromContext(name, ctx, true)
+	c.Assert(err, check.IsNil)
 }
 
-func (s *DockerDaemonSuite) TestBuildAddUserFlagUserNamespace(c *check.C) {
+func (s *DockerDaemonSuite) TestBuildAddChownFlagUserNamespace(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
 
-	c.Assert(s.d.StartWithBusybox("--userns-remap", "default"), checker.IsNil)
+	s.d.StartWithBusybox(c, "--userns-remap", "default")
 
 	name := "testaddtonewdest"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'test1:x:1001:' >> /etc/group
 RUN echo 'test2:x:1002:' >> /etc/group
-ADD --user=test1:1002 . /new_dir
+ADD --chown=test1:1002 . /new_dir
 RUN ls -l /
 RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
 		map[string]string{
 			"test_dir/test_file": "test file",
 		})
-	if err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
-		c.Fatal(err)
-	}
+	_, err = buildImageFromContext(name, ctx, true)
+	c.Assert(err, check.IsNil)
 }
 
-func (s *DockerSuite) TestBuildCopyUserFlag(c *check.C) {
+func (s *DockerSuite) TestBuildCopyChownFlag(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
 	name := "testaddtonewdest"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'test1:x:1001:' >> /etc/group
 RUN echo 'test2:x:1002:' >> /etc/group
-COPY --user=test1:1002 . /new_dir
+COPY --chown=test1:1002 . /new_dir
 RUN ls -l /
 RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
 		map[string]string{
 			"test_dir/test_file": "test file",
 		})
-	if err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 	defer ctx.Close()
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
-		c.Fatal(err)
-	}
+	_, err = buildImageFromContext(name, ctx, true)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *DockerSuite) TestBuildAddFileWithWhitespace(c *check.C) {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -804,6 +804,78 @@ RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'root:root' ]`, true);
 	}
 }
 
+func (s *DockerSuite) TestBuildAddUserFlag(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Linux specific test
+	name := "testaddtonewdest"
+	ctx, err := fakeContext(`FROM busybox
+RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
+RUN echo 'test1:x:1001:' >> /etc/group
+RUN echo 'test2:x:1002:' >> /etc/group
+ADD --user=test1:1002 . /new_dir
+RUN ls -l /
+RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
+		map[string]string{
+			"test_dir/test_file": "test file",
+		})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerDaemonSuite) TestBuildAddUserFlagUserNamespace(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Linux specific test
+
+	c.Assert(s.d.StartWithBusybox("--userns-remap", "default"), checker.IsNil)
+
+	name := "testaddtonewdest"
+	ctx, err := fakeContext(`FROM busybox
+RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
+RUN echo 'test1:x:1001:' >> /etc/group
+RUN echo 'test2:x:1002:' >> /etc/group
+ADD --user=test1:1002 . /new_dir
+RUN ls -l /
+RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
+		map[string]string{
+			"test_dir/test_file": "test file",
+		})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerSuite) TestBuildCopyUserFlag(c *check.C) {
+	testRequires(c, DaemonIsLinux) // Linux specific test
+	name := "testaddtonewdest"
+	ctx, err := fakeContext(`FROM busybox
+RUN echo 'test1:x:1001:1001::/bin:/bin/false' >> /etc/passwd
+RUN echo 'test1:x:1001:' >> /etc/group
+RUN echo 'test2:x:1002:' >> /etc/group
+COPY --user=test1:1002 . /new_dir
+RUN ls -l /
+RUN [ $(ls -l / | grep new_dir | awk '{print $3":"$4}') = 'test1:test2' ]`,
+		map[string]string{
+			"test_dir/test_file": "test file",
+		})
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}
+
 func (s *DockerSuite) TestBuildAddFileWithWhitespace(c *check.C) {
 	testRequires(c, DaemonIsLinux) // Not currently passing on Windows
 	name := "testaddfilewithwhitespace"

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -54,6 +54,29 @@ func MkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int) error {
 	return mkdirAs(path, mode, ownerUID, ownerGID, false, true)
 }
 
+// GetUIDGID retrieves the remapped uid/gid pair from the set of maps.
+// If the maps are empty, If no map is provided, then the translation
+// assumes a 1-to-1 mapping and returns the passed in uid and gid.
+func GetUIDGID(uid, gid int, uidMap, gidMap []IDMap) (int, int, error) {
+	mappedUID, mappedGID := uid, gid
+
+	if uidMap != nil {
+		xUID, err := ToHost(uid, uidMap)
+		if err != nil {
+			return -1, -1, err
+		}
+		mappedUID = xUID
+	}
+	if gidMap != nil {
+		xGID, err := ToHost(gid, gidMap)
+		if err != nil {
+			return -1, -1, err
+		}
+		mappedGID = xGID
+	}
+	return mappedUID, mappedGID, nil
+}
+
 // GetRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.
 // If the maps are empty, then the root uid/gid will default to "real" 0/0
 func GetRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {


### PR DESCRIPTION
Carrying moby/moby#27303 since Kara is off doing other exciting things.

- What Kara did
Add a --chown flag to Dockerfile ADD and COPY instructions, proposed by moby/moby#13600

- How Kara did it
Added flag to add and disptachCopy of builder/dockerfile/dispatchers.go, and passed the relevant information through to the daemon which looks up the user/group using a new function on the container object.

- How to verify it
Create a Dockerfile that uses the --chown flag on an ADD or COPY instruction, and check that the file is listed as having the appropriate owner

- Description for the changelog
add --chown flag to Dockerfile ADD and COPY instructions

2nd commit is just a rebase.

Signed-off-by: Doug Davis <dug@us.ibm.com>


