### PR TITLE
Skip cli initialization for daemon command

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -39,6 +39,10 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 			return nil
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// daemon command is special, we redirect directly to another binary
+			if cmd.Name() == "daemon" {
+				return nil
+			}
 			// flags must be the top-level command flags, not cmd.Flags()
 			opts.Common.SetDefaultOptions(flags)
 			dockerPreRun(opts)


### PR DESCRIPTION
fixes #28368

Cli initialization pings back to remote API and
creates a deadlock if socket is already being
listened by systemd.

cc @dnephin 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>