### PR TITLE
Cleanup after plugin install.

### DIFF
--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -36,6 +36,7 @@ func (pm *Manager) enable(p *v2.Plugin, force bool) error {
 		p.Lock()
 		p.Restart = false
 		p.Unlock()
+		shutdownPlugin(p, pm.containerdClient)
 		return err
 	}
 


### PR DESCRIPTION
During error cases, we dont cleanup correctly. This commit takes care
of removing the plugin, if there are errors after the pull passed. It
also shuts down the plugin, if there are errors after the plugin in the
enable path.

Signed-off-by: Anusha Ragunathan <anusha@docker.com>