### PR TITLE
Refix COPY file . after WORKDIR (now always created)

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -129,6 +129,8 @@ type Backend interface {
 	ContainerWait(containerID string, timeout time.Duration) (int, error)
 	// ContainerUpdateCmdOnBuild updates container.Path and container.Args
 	ContainerUpdateCmdOnBuild(containerID string, cmd []string) error
+	// ContainerCreateWorkdir creates the workdir (currently only used on Windows)
+	ContainerCreateWorkdir(containerID string) error
 
 	// ContainerCopy copies/extracts a source FileInfo to a destination path inside a container
 	// specified by a container object.

--- a/daemon/workdir.go
+++ b/daemon/workdir.go
@@ -1,0 +1,21 @@
+package daemon
+
+// ContainerCreateWorkdir creates the working directory. This is solves the
+// issue arising from https://github.com/docker/docker/issues/27545,
+// which was initially fixed by https://github.com/docker/docker/pull/27884. But that fix
+// was too expensive in terms of performance on Windows. Instead,
+// https://github.com/docker/docker/pull/28514 introduces this new functionality
+// where the builder calls into the backend here to create the working directory.
+func (daemon *Daemon) ContainerCreateWorkdir(cID string) error {
+	container, err := daemon.GetContainer(cID)
+	if err != nil {
+		return err
+	}
+	err = daemon.Mount(container)
+	if err != nil {
+		return err
+	}
+	defer daemon.Unmount(container)
+	rootUID, rootGID := daemon.GetRemappedUIDGID()
+	return container.SetupWorkingDirectory(rootUID, rootGID)
+}

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -104,7 +104,6 @@ func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitChange(c *check.C) {
-	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "test", "busybox", "true")
 
 	imageID, _ := dockerCmd(c, "commit",
@@ -122,12 +121,14 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 		"test", "test-commit")
 	imageID = strings.TrimSpace(imageID)
 
+	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
+	prefix = strings.ToUpper(prefix) // Force C: as that's how WORKDIR is normalised on Windows
 	expected := map[string]string{
 		"Config.ExposedPorts": "map[8080/tcp:{}]",
 		"Config.Env":          "[DEBUG=true test=1 PATH=/foo]",
 		"Config.Labels":       "map[foo:bar]",
 		"Config.Cmd":          "[/bin/sh]",
-		"Config.WorkingDir":   "/opt",
+		"Config.WorkingDir":   prefix + slash + "opt",
 		"Config.Entrypoint":   "[/bin/sh]",
 		"Config.User":         "testuser",
 		"Config.Volumes":      "map[/var/lib/docker:{}]",


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes #27545 (again). @duglin @thaJeztah @vieux @cpuguy83 

The fix for the above issue was in #27884, but reverted in https://github.com/docker/docker/pull/28505 as doing a mount/unmount for each container create is prohibitively expensive in terms of performance (as discovered by our performance team). Instead, this extends the interface from the builder back into the daemon so that the mount/unmount in container creation is done (on Windows) in the WORKDIR processing itself. The overall solution should still be in 1.13.

Edit: From comments below. The Linux behaviour has been updated to mirror the new Windows behaviour - WORKDIR in the builder always calls back into the daemon to create the directory rather than deferring it to the next statement.

@swernli @jstarks FYI.