### PR TITLE
api: Remove omitempty tag on Parallelism

### DIFF
--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -74,7 +74,7 @@ const (
 type UpdateConfig struct {
 	// Maximum number of tasks to be updated in one iteration.
 	// 0 means unlimited parallelism.
-	Parallelism uint64 `json:",omitempty"`
+	Parallelism uint64
 
 	// Amount of time between updates.
 	Delay time.Duration `json:",omitempty"`


### PR DESCRIPTION
It doesn't make sense to use omitempty here. 0 is a meaningful value and it's different from the default. If someone sets Parallelism to 0, we want to show that Parallelism is 0, not hide the field.