### PR TITLE
Fix crash caused by `docker service inspect --pretty`

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -263,6 +263,9 @@ func (ctx *serviceInspectContext) HasResources() bool {
 }
 
 func (ctx *serviceInspectContext) HasResourceReservations() bool {
+	if ctx.Service.Spec.TaskTemplate.Resources == nil || ctx.Service.Spec.TaskTemplate.Resources.Reservations == nil {
+		return false
+	}
 	return ctx.Service.Spec.TaskTemplate.Resources.Reservations.NanoCPUs > 0 || ctx.Service.Spec.TaskTemplate.Resources.Reservations.MemoryBytes > 0
 }
 
@@ -281,6 +284,9 @@ func (ctx *serviceInspectContext) ResourceReservationMemory() string {
 }
 
 func (ctx *serviceInspectContext) HasResourceLimits() bool {
+	if ctx.Service.Spec.TaskTemplate.Resources == nil || ctx.Service.Spec.TaskTemplate.Resources.Limits == nil {
+		return false
+	}
 	return ctx.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs > 0 || ctx.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes > 0
 }
 

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1072,3 +1072,19 @@ func (s *DockerSwarmSuite) TestSwarmManagerAddress(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(out, checker.Contains, expectedOutput)
 }
+
+func (s *DockerSwarmSuite) TestSwarmServiceInspectPretty(c *check.C) {
+	d := s.AddDaemon(c, true, true)
+
+	name := "top"
+	out, err := d.Cmd("service", "create", "--name", name, "--limit-cpu=0.5", "busybox", "top")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+
+	expectedOutput := `
+Resources:
+ Limits:
+  CPU:		0.5`
+	out, err = d.Cmd("service", "inspect", "--pretty", name)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Contains, expectedOutput, check.Commentf(out))
+}


### PR DESCRIPTION
This fix tries to fix the crash caused by `docker service inspect --pretty`, by performing necessary nil pointer check.

This fix fixes #28519.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>