### PR TITLE
1.13.x: Re-vendor SwarmKit to 577d6bf89a474d3f459804efc5f160ba9fff2b5d

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -100,7 +100,7 @@ github.com/docker/containerd 8517738ba4b82aff5662c97ca4627e7e4d03b531
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit 3076318ec0327e22c837c2bfdfacea08124dc755
+github.com/docker/swarmkit 577d6bf89a474d3f459804efc5f160ba9fff2b5d
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/gogo/protobuf v0.3
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a

--- a/vendor/github.com/docker/swarmkit/manager/logbroker/subscription.go
+++ b/vendor/github.com/docker/swarmkit/manager/logbroker/subscription.go
@@ -1,0 +1,138 @@
+package logbroker
+
+import (
+	"context"
+	"sync"
+
+	events "github.com/docker/go-events"
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state"
+	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/watch"
+)
+
+type subscription struct {
+	mu sync.RWMutex
+
+	store   *store.MemoryStore
+	message *api.SubscriptionMessage
+	changed *watch.Queue
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	nodes map[string]struct{}
+}
+
+func newSubscription(store *store.MemoryStore, message *api.SubscriptionMessage, changed *watch.Queue) *subscription {
+	return &subscription{
+		store:   store,
+		message: message,
+		changed: changed,
+		nodes:   make(map[string]struct{}),
+	}
+}
+
+func (s *subscription) Contains(nodeID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.nodes[nodeID]
+	return ok
+}
+
+func (s *subscription) Run(ctx context.Context) {
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
+	wq := s.store.WatchQueue()
+	ch, cancel := state.Watch(wq, state.EventCreateTask{}, state.EventUpdateTask{})
+	go func() {
+		defer cancel()
+		s.watch(ch)
+	}()
+
+	s.match()
+}
+
+func (s *subscription) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+func (s *subscription) match() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.View(func(tx store.ReadTx) {
+		for _, nid := range s.message.Selector.NodeIDs {
+			s.nodes[nid] = struct{}{}
+		}
+
+		for _, tid := range s.message.Selector.TaskIDs {
+			if task := store.GetTask(tx, tid); task != nil {
+				s.nodes[task.NodeID] = struct{}{}
+			}
+		}
+
+		for _, sid := range s.message.Selector.ServiceIDs {
+			tasks, err := store.FindTasks(tx, store.ByServiceID(sid))
+			if err != nil {
+				log.L.Warning(err)
+				continue
+			}
+			for _, task := range tasks {
+				s.nodes[task.NodeID] = struct{}{}
+			}
+		}
+	})
+}
+
+func (s *subscription) watch(ch <-chan events.Event) error {
+	matchTasks := map[string]struct{}{}
+	for _, tid := range s.message.Selector.TaskIDs {
+		matchTasks[tid] = struct{}{}
+	}
+
+	matchServices := map[string]struct{}{}
+	for _, sid := range s.message.Selector.ServiceIDs {
+		matchServices[sid] = struct{}{}
+	}
+
+	add := func(nodeID string) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if _, ok := s.nodes[nodeID]; !ok {
+			s.nodes[nodeID] = struct{}{}
+			s.changed.Publish(s)
+		}
+	}
+
+	for {
+		var t *api.Task
+		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		case event := <-ch:
+			switch v := event.(type) {
+			case state.EventCreateTask:
+				t = v.Task
+			case state.EventUpdateTask:
+				t = v.Task
+			}
+		}
+
+		if t == nil {
+			panic("received invalid task from the watch queue")
+		}
+
+		if _, ok := matchTasks[t.ID]; ok {
+			add(t.NodeID)
+		}
+		if _, ok := matchServices[t.ServiceID]; ok {
+			add(t.NodeID)
+		}
+	}
+}

--- a/vendor/github.com/docker/swarmkit/manager/manager.go
+++ b/vendor/github.com/docker/swarmkit/manager/manager.go
@@ -256,7 +256,7 @@ func New(config *Config) (*Manager, error) {
 		listeners:   listeners,
 		caserver:    ca.NewServer(raftNode.MemoryStore(), config.SecurityConfig),
 		dispatcher:  dispatcher.New(raftNode, dispatcherConfig),
-		logbroker:   logbroker.New(),
+		logbroker:   logbroker.New(raftNode.MemoryStore()),
 		server:      grpc.NewServer(opts...),
 		localserver: grpc.NewServer(opts...),
 		raftNode:    raftNode,


### PR DESCRIPTION
The re vendoring includes https://github.com/docker/swarmkit/pull/1746, which is an optimization to make service logs much more efficient.

Since logs are an experimental feature, I'd ask to get this merged.

Without this PR, if a service is running on 2 machines out of 1000, `docker service logs` would send down 1000 messages and have all the machines start a go-routine.

With this PR, only the two affected machines will receive the message. If the service is scaled to a third machine, then it will get the message on demand.

/cc @aaronlehmann @vieux 
