### PR TITLE
fix secret create url for consistency

### DIFF
--- a/api/server/router/swarm/cluster.go
+++ b/api/server/router/swarm/cluster.go
@@ -55,7 +55,7 @@ func (sr *swarmRouter) initRoutes() {
 		router.NewGetRoute("/tasks", sr.getTasks),
 		router.NewGetRoute("/tasks/{id}", sr.getTask),
 		router.NewGetRoute("/secrets", sr.getSecrets),
-		router.NewPostRoute("/secrets", sr.createSecret),
+		router.NewPostRoute("/secrets/create", sr.createSecret),
 		router.NewDeleteRoute("/secrets/{id}", sr.removeSecret),
 		router.NewGetRoute("/secrets/{id}", sr.getSecret),
 		router.NewPostRoute("/secrets/{id}/update", sr.updateSecret),

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -13,7 +13,7 @@ func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (t
 	var headers map[string][]string
 
 	var response types.SecretCreateResponse
-	resp, err := cli.post(ctx, "/secrets", nil, secret, headers)
+	resp, err := cli.post(ctx, "/secrets/create", nil, secret, headers)
 	if err != nil {
 		return response, err
 	}

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -25,7 +25,7 @@ func TestSecretCreateError(t *testing.T) {
 }
 
 func TestSecretCreate(t *testing.T) {
-	expectedURL := "/secrets"
+	expectedURL := "/secrets/create"
 	client := &Client{
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
@@ -41,7 +41,7 @@ func TestSecretCreate(t *testing.T) {
 				return nil, err
 			}
 			return &http.Response{
-				StatusCode: http.StatusOK,
+				StatusCode: http.StatusCreated,
 				Body:       ioutil.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),

--- a/integration-cli/daemon_swarm.go
+++ b/integration-cli/daemon_swarm.go
@@ -285,7 +285,7 @@ func (d *SwarmDaemon) listServices(c *check.C) []swarm.Service {
 }
 
 func (d *SwarmDaemon) createSecret(c *check.C, secretSpec swarm.SecretSpec) string {
-	status, out, err := d.SockRequest("POST", "/secrets", secretSpec)
+	status, out, err := d.SockRequest("POST", "/secrets/create", secretSpec)
 
 	c.Assert(err, checker.IsNil, check.Commentf(string(out)))
 	c.Assert(status, checker.Equals, http.StatusCreated, check.Commentf("output: %q", string(out)))


### PR DESCRIPTION
Hi, All,

I found that in the api docs, there is `POST /secrets/create`, while in the implementation of code, it is `POST /secrets`.

I think it is some kinds of inconsistency.

In additional, like first class concept of docker, like volume, container, network... Their create url are all `POST /xxx/create`. So here is another kind of consistency.

**- What I did**
1. make secrets creation url consistent with others; 
2. change request url in client side;
3. change a status code in the client side test.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>