### PR TITLE
api/server/httputils: service unavailable for disable swarm

### DIFF
--- a/api/server/httputils/errors.go
+++ b/api/server/httputils/errors.go
@@ -62,7 +62,7 @@ func GetHTTPErrorStatusCode(err error) int {
 			{"wrong login/password", http.StatusUnauthorized},
 			{"unauthorized", http.StatusUnauthorized},
 			{"hasn't been activated", http.StatusForbidden},
-			{"this node", http.StatusNotAcceptable},
+			{"this node", http.StatusServiceUnavailable},
 		} {
 			if strings.Contains(errStr, status.keyword) {
 				statusCode = status.code

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6731,12 +6731,12 @@ paths:
           description: "bad parameter"
           schema:
             $ref: "#/definitions/ErrorResponse"
-        406:
-          description: "node is already part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        503:
+          description: "node is already part of a swarm"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:
@@ -6773,12 +6773,12 @@ paths:
       responses:
         200:
           description: "no error"
-        406:
-          description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        503:
+          description: "node is not part of a swarm"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:
@@ -6800,12 +6800,12 @@ paths:
           description: "bad parameter"
           schema:
             $ref: "#/definitions/ErrorResponse"
-        406:
-          description: "node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        503:
+          description: "node is not part of a swarm"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:
@@ -6877,16 +6877,16 @@ paths:
                 type: "string"
             example:
               ID: "ak7w3gjqoa3kuz8xcpnyy0pvl"
-        406:
-          description: "server error or node is not part of a swarm"
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         409:
           description: "name conflicts with an existing service"
           schema:
             $ref: "#/definitions/ErrorResponse"
         500:
           description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        503:
+          description: "server error or node is not part of a swarm"
           schema:
             $ref: "#/definitions/ErrorResponse"
       parameters:

--- a/docs/reference/api/docker_remote_api_v1.25.md
+++ b/docs/reference/api/docker_remote_api_v1.25.md
@@ -4821,7 +4821,7 @@ Initialize a new swarm. The body of the HTTP response includes the node ID.
 
 - **200** – no error
 - **400** – bad parameter
-- **406** – node is already part of a swarm
+- **503** – node is already part of a swarm
 
 JSON Parameters:
 
@@ -4890,7 +4890,7 @@ Join an existing swarm
 
 - **200** – no error
 - **400** – bad parameter
-- **406** – node is already part of a swarm
+- **503** – node is already part of a swarm
 
 JSON Parameters:
 
@@ -4928,7 +4928,7 @@ Leave a swarm
 **Status codes**:
 
 - **200** – no error
-- **406** – node is not part of a swarm
+- **503** – node is not part of a swarm
 
 ### Retrieve the swarm's unlock key
 
@@ -5024,7 +5024,7 @@ Update a swarm
 
 - **200** – no error
 - **400** – bad parameter
-- **406** – node is not part of a swarm
+- **503** – node is not part of a swarm
 
 JSON Parameters:
 
@@ -5268,8 +5268,8 @@ image](#create-an-image) section for more details.
 **Status codes**:
 
 - **201** – no error
-- **406** – server error or node is not part of a swarm
 - **409** – name conflicts with an existing object
+- **503** – server error or node is not part of a swarm
 
 **JSON Parameters**:
 
@@ -6049,8 +6049,8 @@ Create a secret
 **Status codes**:
 
 - **201** – no error
-- **406** – server error or node is not part of a swarm
 - **409** – name conflicts with an existing object
+- **503** – server error or node is not part of a swarm
 
 **JSON Parameters**:
 


### PR DESCRIPTION
When swarm-mode is disabled, we need to return an error indicating this.
406 was chosen for the "Not Acceptable" verbiage, but this code has
specific semantics in relation to the `Accept` header, which aren't
applicable here.

We now use a 503 for this case. While it is not a perfect match, it does
make it clear that the particular "service" (read: API endpoint) is not
available. The body of the message provides the user with enough
information to take action on it by enabling swarm-mode and ensuring the
service is available.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

This PR is likely incomplete. This can be incorporated into #26576 or simply closed if covered elsewhere.