### PR TITLE
Fix several issues with `go vet` and `gofmt -s`

### DIFF
--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -372,7 +372,7 @@ func TestContainerContextWriteJSONField(t *testing.T) {
 }
 
 func TestContainerBackCompat(t *testing.T) {
-	containers := []types.Container{types.Container{ID: "brewhaha"}}
+	containers := []types.Container{{ID: "brewhaha"}}
 	cases := []string{
 		"ID",
 		"Names",
@@ -390,7 +390,7 @@ func TestContainerBackCompat(t *testing.T) {
 	for _, c := range cases {
 		ctx := Context{Format: Format(fmt.Sprintf("{{ .%s }}", c)), Output: buf}
 		if err := ContainerWrite(ctx, containers); err != nil {
-			t.Log("could not render template for field '%s': %v", c, err)
+			t.Logf("could not render template for field '%s': %v", c, err)
 			t.Fail()
 		}
 		buf.Reset()

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -72,7 +72,7 @@ func printTable(out io.Writer, stacks []*stack) {
 
 type stack struct {
 	// Name is the name of the stack
-	Name     string
+	Name string
 	// Services is the number of the services
 	Services int
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -240,8 +240,8 @@ func (daemon *Daemon) Commit(name string, c *backend.ContainerCommitConfig) (str
 	}
 
 	attributes := map[string]string{
-		"comment": c.Comment,
-		"imageID": id.String(),
+		"comment":  c.Comment,
+		"imageID":  id.String(),
 		"imageRef": imageRef,
 	}
 	daemon.LogContainerEventWithAttributes(container, "commit", attributes)

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -254,7 +254,7 @@ func TestParseMountSpec(t *testing.T) {
 			t.Fatalf("Expected mount source to match. Expected: '%s', Actual: '%s'", c.expected.Source, mp.Source)
 		}
 		if c.expected.RW != mp.RW {
-			t.Fatalf("Expected mount writable to match. Expected: '%v', Actual: '%s'", c.expected.RW, mp.RW)
+			t.Fatalf("Expected mount writable to match. Expected: '%v', Actual: '%v'", c.expected.RW, mp.RW)
 		}
 		if c.expected.Propagation != mp.Propagation {
 			t.Fatalf("Expected mount propagation to match. Expected: '%v', Actual: '%s'", c.expected.Propagation, mp.Propagation)


### PR DESCRIPTION
For some reason, `go vet` and `gofmt -s` validate does not capture several issues.

The following was the output of `go vet`:
```
ubuntu@ubuntu:~/docker$ go vet ./... 2>&1 | grep -v ^vendor | grep -v '^exit status 1$'
cli/command/formatter/container_test.go:393: possible formatting directive in Log call
volume/volume_test.go:257: arg mp.RW for printf verb %s of wrong type: bool
```

The following was the output of `go fmt -s`:
```
ubuntu@ubuntu:~/docker$ gofmt -s -l . | grep -v ^vendor
cli/command/stack/list.go
daemon/commit.go
```

Fixed above issues with `go vet` and `go fmt -s`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>