### PR TITLE
Suppressing digest for docker service ls/ps

### DIFF
--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"text/tabwriter"
 
+	distreference "github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
@@ -127,6 +128,16 @@ func printTable(out io.Writer, services []swarm.Service, running, tasksNoShutdow
 			mode = "global"
 			replicas = fmt.Sprintf("%d/%d", running[service.ID], tasksNoShutdown[service.ID])
 		}
+		image := service.Spec.TaskTemplate.ContainerSpec.Image
+		ref, err := distreference.ParseNamed(image)
+		if err == nil {
+			// update image string for display
+			namedTagged, ok := ref.(distreference.NamedTagged)
+			if ok {
+				image = namedTagged.Name() + ":" + namedTagged.Tag()
+			}
+		}
+
 		fmt.Fprintf(
 			writer,
 			listItemFmt,
@@ -134,7 +145,7 @@ func printTable(out io.Writer, services []swarm.Service, running, tasksNoShutdow
 			service.Spec.Name,
 			mode,
 			replicas,
-			service.Spec.TaskTemplate.ContainerSpec.Image)
+			image)
 	}
 }
 

--- a/cli/command/task/print.go
+++ b/cli/command/task/print.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	distreference "github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/cli/command"
 	"github.com/docker/docker/cli/command/idresolver"
@@ -118,11 +119,23 @@ func print(out io.Writer, ctx context.Context, tasks []swarm.Task, resolver *idr
 			taskErr = fmt.Sprintf("\"%s\"", taskErr)
 		}
 
+		image := task.Spec.ContainerSpec.Image
+		if !noTrunc {
+			ref, err := distreference.ParseNamed(image)
+			if err == nil {
+				// update image string for display
+				namedTagged, ok := ref.(distreference.NamedTagged)
+				if ok {
+					image = namedTagged.Name() + ":" + namedTagged.Tag()
+				}
+			}
+		}
+
 		fmt.Fprintf(
 			out,
 			psTaskItemFmt,
 			indentedName,
-			task.Spec.ContainerSpec.Image,
+			image,
 			nodeValue,
 			command.PrettyPrint(task.DesiredState),
 			command.PrettyPrint(task.Status.State),


### PR DESCRIPTION
This PR simplifies the UI for the changes introduced in #28173 (Pin images by digest).

In particular, this PR suppresses the digest for `docker service ls` and `docker service ps`, showing only `image:tag`. The full digest `image:tag@digest` is still shown as part of `docker service inspect`.

Fix #28502 