### PR TITLE
rectify several places using wrong variables in container inspect file

### DIFF
--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -67,10 +67,10 @@ func TestContainerInspect(t *testing.T) {
 		t.Fatalf("expected `container_id`, got %s", r.ID)
 	}
 	if r.Image != "image" {
-		t.Fatalf("expected `image`, got %s", r.ID)
+		t.Fatalf("expected `image`, got %s", r.Image)
 	}
 	if r.Name != "name" {
-		t.Fatalf("expected `name`, got %s", r.ID)
+		t.Fatalf("expected `name`, got %s", r.Name)
 	}
 }
 
@@ -107,10 +107,10 @@ func TestContainerInspectNode(t *testing.T) {
 		t.Fatalf("expected `container_id`, got %s", r.ID)
 	}
 	if r.Image != "image" {
-		t.Fatalf("expected `image`, got %s", r.ID)
+		t.Fatalf("expected `image`, got %s", r.Image)
 	}
 	if r.Name != "name" {
-		t.Fatalf("expected `name`, got %s", r.ID)
+		t.Fatalf("expected `name`, got %s", r.Name)
 	}
 	if r.Node.ID != "container_node_id" {
 		t.Fatalf("expected `container_node_id`, got %s", r.Node.ID)


### PR DESCRIPTION
rectify several places using wrong variables in container inspect file.