### PR TITLE
Fix use of cap in MultiReadSeeker; possible data corruption bug.

### DIFF
--- a/pkg/ioutils/multireader.go
+++ b/pkg/ioutils/multireader.go
@@ -155,18 +155,18 @@ func (r *multiReadSeeker) Read(b []byte) (int, error) {
 		r.pos = &pos{0, 0}
 	}
 
-	bCap := int64(len(b))
+	bLen := int64(len(b))
 	buf := bytes.NewBuffer(nil)
 	var rdr io.ReadSeeker
 
 	for _, rdr = range r.readers[r.pos.idx:] {
-		readBytes, err := io.CopyN(buf, rdr, bCap)
+		readBytes, err := io.CopyN(buf, rdr, bLen)
 		if err != nil && err != io.EOF {
 			return -1, err
 		}
-		bCap -= readBytes
+		bLen -= readBytes
 
-		if bCap == 0 {
+		if bLen == 0 {
 			break
 		}
 	}

--- a/pkg/ioutils/multireader.go
+++ b/pkg/ioutils/multireader.go
@@ -155,7 +155,7 @@ func (r *multiReadSeeker) Read(b []byte) (int, error) {
 		r.pos = &pos{0, 0}
 	}
 
-	bCap := int64(cap(b))
+	bCap := int64(len(b))
 	buf := bytes.NewBuffer(nil)
 	var rdr io.ReadSeeker
 

--- a/pkg/ioutils/multireader_test.go
+++ b/pkg/ioutils/multireader_test.go
@@ -2,6 +2,7 @@ package ioutils
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -186,5 +187,25 @@ func TestMultiReadSeekerCurAfterSet(t *testing.T) {
 	}
 	if size != mid+18 {
 		t.Fatalf("reader size does not match, got %d, expected %d", size, mid+18)
+	}
+}
+
+func TestMultiReadSeekerSmallReads(t *testing.T) {
+	readers := []io.ReadSeeker{}
+	for i := 0; i < 10; i++ {
+		integer := make([]byte, 4, 4)
+		binary.BigEndian.PutUint32(integer, uint32(i))
+		readers = append(readers, bytes.NewReader(integer))
+	}
+
+	reader := MultiReadSeeker(readers...)
+	for i := 0; i < 10; i++ {
+		var integer uint32
+		if err := binary.Read(reader, binary.BigEndian, &integer); err != nil {
+			t.Fatalf("Read from NewMultiReadSeeker failed: %v", err)
+		}
+		if uint32(i) != integer {
+			t.Fatalf("Read wrong value from NewMultiReadSeeker: %d != %d", i, integer)
+		}
 	}
 }


### PR DESCRIPTION
**- What I did**

Tried to use MultiReadSeeker; hit a possible data corruption bug.

**- How I did it**

See my usage here: https://github.com/weaveworks/cortex/pull/142/files#diff-e179054c3d912cc0aaa6f11efb991521R72

Was building a reader out of multiple smaller readers; noticed that results from reading this reader were invalid.

This is due to MultiReadSeeker.Read using the passed in buffers capacity and not length, in violation of the [Read contract](https://golang.org/pkg/io/#Reader):

> Read reads up to **len(p)** bytes into p.

**- How to verify it**

I've added a test (`TestMultiReadSeekerSmallReads`) which fails without this change.
