### PR TITLE
error on cli when trying to use experimental feature with non experimental daemon

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -44,17 +45,25 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 			// flags must be the top-level command flags, not cmd.Flags()
 			opts.Common.SetDefaultOptions(flags)
 			dockerPreRun(opts)
-			return dockerCli.Initialize(opts)
+			if err := dockerCli.Initialize(opts); err != nil {
+				return err
+			}
+			return isSupported(cmd, dockerCli.Client().ClientVersion(), dockerCli.HasExperimental())
 		},
 	}
 	cli.SetupRootCommand(cmd)
 
 	cmd.SetHelpFunc(func(ccmd *cobra.Command, args []string) {
-		if dockerCli.Client() == nil {
+		if dockerCli.Client() == nil { // when using --help, PersistenPreRun is not called, so initialization is needed.
 			// flags must be the top-level command flags, not cmd.Flags()
 			opts.Common.SetDefaultOptions(flags)
 			dockerPreRun(opts)
 			dockerCli.Initialize(opts)
+		}
+
+		if err := isSupported(ccmd, dockerCli.Client().ClientVersion(), dockerCli.HasExperimental()); err != nil {
+			ccmd.Println(err)
+			return
 		}
 
 		hideUnsupportedFeatures(ccmd, dockerCli.Client().ClientVersion(), dockerCli.HasExperimental())
@@ -154,4 +163,18 @@ func hideUnsupportedFeatures(cmd *cobra.Command, clientVersion string, hasExperi
 			subcmd.Hidden = true
 		}
 	}
+}
+
+func isSupported(cmd *cobra.Command, clientVersion string, hasExperimental bool) error {
+	if !hasExperimental {
+		if _, ok := cmd.Tags["experimental"]; ok {
+			return errors.New("only supported with experimental daemon")
+		}
+	}
+
+	if cmdVersion, ok := cmd.Tags["version"]; ok && versions.LessThan(clientVersion, cmdVersion) {
+		return fmt.Errorf("only supported with daemon version >= %s", cmdVersion)
+	}
+
+	return nil
 }


### PR DESCRIPTION
```
$ docker stack
only supported with experimental daemon

$ docker service logs --help
only supported with experimental daemon

$ docker service logs foo
only supported with experimental daemon
```

only caveat: since arg validation is done before the rest:

```
 $ docker service logs
"docker service logs" requires exactly 1 argument(s).
See 'docker service logs --help'.

Usage:  docker service logs [OPTIONS] SERVICE

Fetch the logs of a service
```

```
$ docker service logs foo bar
"docker service logs" requires exactly 1 argument(s).
See 'docker service logs --help'.

Usage:  docker service logs [OPTIONS] SERVICE

Fetch the logs of a service
```

this could be solved by checking isSupported in the `args.*` functions /cc @dnephin 