### PR TITLE
update secret command

### DIFF
--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -25,9 +25,9 @@ func newSecretCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create [name]",
+		Use:   "create [OPTIONS] SECRET",
 		Short: "Create a secret using stdin as content",
-		Args:  cli.RequiresMinArgs(1),
+		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			createOpts.name = args[0]
 			return runSecretCreate(dockerCli, createOpts)

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -16,8 +16,8 @@ type inspectOptions struct {
 func newSecretInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := inspectOptions{}
 	cmd := &cobra.Command{
-		Use:   "inspect SECRET [SECRET]",
-		Short: "Inspect a secret",
+		Use:   "inspect [OPTIONS] SECRET [SECRET...]",
+		Short: "Display detailed information on one or more secrets",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.names = args

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -21,7 +21,7 @@ func newSecretListCommand(dockerCli *command.DockerCli) *cobra.Command {
 	opts := listOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "ls",
+		Use:   "ls [OPTIONS]",
 		Short: "List secrets",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -15,8 +15,8 @@ type removeOptions struct {
 
 func newSecretRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return &cobra.Command{
-		Use:   "rm SECRET [SECRET]",
-		Short: "Remove a secret",
+		Use:   "rm SECRET [SECRET...]",
+		Short: "Remove one or more secrets",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := removeOptions{

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -16,7 +16,7 @@ keywords: ["secret, create"]
 # secret create
 
 ```Markdown
-Usage:  docker secret create [NAME]
+Usage:  docker secret create [OPTIONS] SECRET
 
 Create a secret using stdin as content
 Options:
@@ -76,5 +76,3 @@ $ docker secret inspect secret.json
 * [secret inspect](secret_inspect.md)
 * [secret ls](secret_ls.md)
 * [secret rm](secret_rm.md)
-
-<style>table tr > td:first-child { white-space: nowrap;}</style>


### PR DESCRIPTION
When I use the new feather secret, I find the secret commands and secret docs don't match well,   especially toward secret inspect command , the docs shows users can inspect one or more secrets while the command shows users can only inspect a secret. so I refine the incorrect part to make docs and commands match well.


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: erxian <evelynhsu21@gmail.com>