### PR TITLE
function setupOOMScoreAdj file close illogicality

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1230,7 +1230,7 @@ func setupOOMScoreAdj(score int) error {
 	if err != nil {
 		return err
 	}
-
+	defer f.Close()
 	stringScore := strconv.Itoa(score)
 	_, err = f.WriteString(stringScore)
 	if os.IsPermission(err) {
@@ -1242,7 +1242,7 @@ func setupOOMScoreAdj(score int) error {
 		}
 		return nil
 	}
-	f.Close()
+
 	return err
 }
 


### PR DESCRIPTION
**- What I did**
I think that the function `setupOOMScoreAdj` file close illogicality.

**- How I did it**
add `defer f.Close()` after OpenFile success,and remove  line 1237 `f.Close()`.

**- How to verify it**



Signed-off-by: chchliang <chen.chuanliang@zte.com.cn>