### PR TITLE
remove redundant file Close

### DIFF
--- a/profiles/apparmor/apparmor.go
+++ b/profiles/apparmor/apparmor.go
@@ -84,7 +84,6 @@ func InstallDefault(name string) error {
 	defer os.Remove(profilePath)
 
 	if err := p.generateDefault(f); err != nil {
-		f.Close()
 		return err
 	}
 


### PR DESCRIPTION
remove redundant file Close

As there is already a `defer f.Close()`, then I think explicit `f.Close()` will cause problem there.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


Signed-off-by: allencloud <allen.sun@daocloud.io>